### PR TITLE
feat(remote): ACP incremental transcript delivery + fast stop

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -917,6 +917,7 @@
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */; };
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
+		BB7A00188B3BD4C729E0D8E6 /* RemoteTranscriptSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */; };
 		BB924C35D21B87B46A47C5FA /* ACPAdapterTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818B29F6B58D4FFC80603AAD /* ACPAdapterTarget.swift */; };
 		BBACA7DCC1EFA6D55AEB38CE /* ACPMCPStatusControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1936C815E64C7DB204340469 /* ACPMCPStatusControl.swift */; };
 		BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */; };
@@ -1926,6 +1927,7 @@
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinatorTests.swift; sourceTree = "<group>"; };
 		88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOption.swift; sourceTree = "<group>"; };
+		88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTranscriptSync.swift; sourceTree = "<group>"; };
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
 		89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionName.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
@@ -2646,6 +2648,7 @@
 			children = (
 				CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */,
 				33EBE6A3E0CA30D8910E68F8 /* RemoteSessionsProvider.swift */,
+				88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */,
 				9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */,
 			);
 			path = Gateway;
@@ -5417,6 +5420,7 @@
 				A770A357750B4713AF21C0E0 /* RemoteSessionsProvider.swift in Sources */,
 				31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */,
 				FD4196C9F558CE954D94E060 /* RemoteTerminalScript.swift in Sources */,
+				BB7A00188B3BD4C729E0D8E6 /* RemoteTranscriptSync.swift in Sources */,
 				F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */,
 				8C492CBACC6D6DACE56DADA9 /* RemoteWorktreeSummaryBuilder.swift in Sources */,
 				1F860C66D658B0DA5A0599F6 /* RemoteZmxInstaller.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -736,6 +736,7 @@
 		99613CF61A0F19105D8E7A71 /* EmojiPickerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */; };
 		996B67B45E7247CDED5F98EF /* AppStateRemoteWorktreePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */; };
 		99711AA1B0FB450D32770415 /* ZmxSunPathBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */; };
+		9983414D08DCAB87919FB804 /* ACPTranscriptChangeLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */; };
 		999C8421F3610FF682CE9D0E /* ReviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500B60003934104E2CA5A895 /* ReviewTabView.swift */; };
 		99CD435501BBBAAD8C4214D8 /* ProjectMCPServerEditorPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */; };
 		99FA2F1F9D41CA81E59B20E5 /* ACPRemoteLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DC5AC55D5FF5BF7FECAD2F /* ACPRemoteLaunch.swift */; };
@@ -1192,6 +1193,7 @@
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
 		F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */; };
 		F2F75C44CD5042F209299FB9 /* InstallSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */; };
+		F3249EE6574B3C7FC9FED0B1 /* ACPTranscriptChangeLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5027B783605BE1C0189308CC /* ACPTranscriptChangeLogTests.swift */; };
 		F35B489DCC169F2B77DB6F3F /* ACPRemoteLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA0EE530F852A921942B04C /* ACPRemoteLaunchTests.swift */; };
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
@@ -1547,6 +1549,7 @@
 		380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailureTests.swift; sourceTree = "<group>"; };
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
+		38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptChangeLog.swift; sourceTree = "<group>"; };
 		389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderEligibility.swift; sourceTree = "<group>"; };
 		38C56D3A6AE256FCBDAE2FBD /* ReviewScopePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopePicker.swift; sourceTree = "<group>"; };
 		38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairKind.swift; sourceTree = "<group>"; };
@@ -1664,6 +1667,7 @@
 		4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabsManagerTests.swift; sourceTree = "<group>"; };
 		4FE58EF9CF8EC461667D9430 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		500B60003934104E2CA5A895 /* ReviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTabView.swift; sourceTree = "<group>"; };
+		5027B783605BE1C0189308CC /* ACPTranscriptChangeLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptChangeLogTests.swift; sourceTree = "<group>"; };
 		50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinatesTests.swift; sourceTree = "<group>"; };
 		50B0831638833C386E5CC9E8 /* CompletionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngine.swift; sourceTree = "<group>"; };
 		50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineRendererTests.swift; sourceTree = "<group>"; };
@@ -3460,6 +3464,7 @@
 				033CEEE92FCAFF8A177428E4 /* ACPStreamingText.swift */,
 				A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */,
 				0B0317FF3C6E6D3F149FB4F5 /* ACPTranscript.swift */,
+				38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */,
 				04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */,
 				955B9084309744F3B9A44CBC /* ACPUserInput.swift */,
 				87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */,
@@ -3647,6 +3652,7 @@
 				F31E42DEC85081FEA8CA1BC3 /* ACPSessionLeaseTests.swift */,
 				96C13707B79B7A4F4BB2608E /* ACPSessionManagerLeaseTests.swift */,
 				FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */,
+				5027B783605BE1C0189308CC /* ACPTranscriptChangeLogTests.swift */,
 				C1CE17139DAF0E60FE9D92C2 /* Adapter */,
 				E6055B84E3F6E5717B873689 /* E2E */,
 				075A0E441C47ACE7EEA52334 /* FileWriter */,
@@ -5024,6 +5030,7 @@
 				312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */,
 				303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */,
 				8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */,
+				9983414D08DCAB87919FB804 /* ACPTranscriptChangeLog.swift in Sources */,
 				C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */,
 				05AD50E71FED22187F67D33F /* ACPUserInput.swift in Sources */,
 				64DD701281B8BF9468C50C58 /* ACPUserInputFormState.swift in Sources */,
@@ -5681,6 +5688,7 @@
 				28710B18EF9FAE100B99E0A7 /* ACPThumbnailImageCacheTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
 				1C2C949642E10060172AB1BA /* ACPToolCallPresentationTests.swift in Sources */,
+				F3249EE6574B3C7FC9FED0B1 /* ACPTranscriptChangeLogTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,
 				A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */,
 				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -4,7 +4,11 @@ function listen(id, event, handler) {
   const element = $(id);
   if (element && typeof element.addEventListener === "function") element.addEventListener(event, handler);
 }
-let ws, currentSession = null, messages = new Map();
+let ws, currentSession = null, messages = new Map();   // stableId → wire message
+let messageNodes = new Map();                          // stableId → DOM node
+let transcriptMeta = null;   // {epoch, revision, firstIndex, totalCount} for the open session
+let olderFetchInFlight = false;
+let stopPending = false;
 let sessionTitles = new Map();
 let canDrive = false, canDriveKnown = false;
 let reconnectDelay = 1500;
@@ -164,10 +168,10 @@ function send(obj) { ws && ws.readyState === 1 && ws.send(JSON.stringify(obj)); 
 function handle(msg) {
   switch (msg.type) {
     case "sessionList": renderSessions(msg.sessions); break;
-    case "transcriptSnapshot": messages = new Map(); msg.messages.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) { canDrive = msg.canDrive; canDriveKnown = true; renderMessages(true); renderDriveBar(msg.streamingState); } break;
-    // The server re-sends the full transcript each time, keyed by stable position
-    // ids, so replace (don't append) to avoid accumulating duplicate copies.
-    case "transcriptDelta": messages = new Map(); msg.upserts.forEach(m => messages.set(m.stableId, m)); if (msg.sessionId === currentSession) { canDrive = msg.canDrive; canDriveKnown = true; renderMessages(false); renderDriveBar(msg.streamingState); } break;
+    case "transcriptSnapshot": applySnapshot(msg); break;
+    case "transcriptDelta": applyDelta(msg); break;
+    case "transcriptPage": applyPage(msg); break;
+    case "stopPending": if (msg.sessionId === currentSession) markStopping(true); break;
     // Scope prompt events to the session currently open — a stale/in-flight
     // event for a session the user already left must not pop or close a sheet.
     case "permissionRequest": handlePromptRequest("permission", msg.sessionId, msg.payload); break;
@@ -287,8 +291,9 @@ function plural(count, singular) {
 
 function openSession(id) {
   clearSessionSheetsForOpen();
-  currentSession = id; messages = new Map(); dismissedQuestion = null; canDrive = false; canDriveKnown = false;
-  sessionConfig = null; clearAttachments();
+  currentSession = id; messages = new Map(); messageNodes = new Map(); transcriptMeta = null; olderFetchInFlight = false;
+  dismissedQuestion = null; canDrive = false; canDriveKnown = false;
+  sessionConfig = null; clearAttachments(); markStopping(false);
   $("back").classList.remove("hidden"); $("nav-title").classList.add("hidden");   // bar shows ‹ Sessions
   $("detail-title").classList.remove("hidden"); $("detail-rename").classList.remove("hidden"); setDetailTitle(id);
   $("sessions").classList.add("hidden"); $("transcript").classList.remove("hidden");
@@ -307,7 +312,8 @@ function clearSessionSheetsForOpen() {
 function showSessions() {
   if (currentSession) send({ type: "unsubscribe", sessionId: currentSession });
   currentSession = null; canDrive = false; canDriveKnown = false;
-  sessionConfig = null; clearAttachments(); hideConfig(); renderConfigAffordances();
+  messages = new Map(); messageNodes = new Map(); transcriptMeta = null; olderFetchInFlight = false;
+  sessionConfig = null; clearAttachments(); hideConfig(); renderConfigAffordances(); markStopping(false);
   hidePermission(); hideQuestion(); hideElicitation(); hideRenameSheet(); hideCreateSheet();   // never leave a sheet over the list
   $("back").classList.add("hidden"); $("nav-title").classList.remove("hidden");   // bar shows app title
   $("detail-title").classList.add("hidden"); $("detail-rename").classList.add("hidden");
@@ -589,16 +595,84 @@ function applyCreatedSession(session) {
   openSession(session.id);
 }
 
-function renderMessages(forceBottom) {
+function applySnapshot(msg) {
+  if (msg.sessionId !== currentSession) return;
+  canDrive = msg.canDrive; canDriveKnown = true;
+  transcriptMeta = { epoch: msg.epoch, revision: msg.revision, firstIndex: msg.firstIndex, totalCount: msg.totalCount };
+  olderFetchInFlight = false;
   const box = $("messages");
-  // #messages is the scroll container (fixed shell), so use its own metrics.
-  const atBottom = forceBottom || (box.scrollTop + box.clientHeight >= box.scrollHeight - 120);
-  // Preserve which tool/thought cards the user expanded across re-renders.
   const open = new Set();
   box.querySelectorAll(".m-collapsible.is-open").forEach(d => { if (d.dataset.sid) open.add(d.dataset.sid); });
   box.innerHTML = "";
-  for (const [sid, m] of messages) box.appendChild(renderMessage(m, sid, open));
+  messages = new Map(); messageNodes = new Map();
+  msg.messages.forEach(m => insertMessage(m, open));
+  requestAnimationFrame(() => { box.scrollTop = box.scrollHeight; });
+  syncStreamingState(msg.streamingState);
+}
+
+function applyDelta(msg) {
+  if (msg.sessionId !== currentSession || !transcriptMeta) return;
+  // Epoch moved or a delta was missed → the server's view diverged; resync.
+  if (msg.epoch !== transcriptMeta.epoch || msg.revision !== transcriptMeta.revision + 1) {
+    resubscribe();
+    return;
+  }
+  transcriptMeta.revision = msg.revision;
+  canDrive = msg.canDrive; canDriveKnown = true;
+  const box = $("messages");
+  const atBottom = box.scrollTop + box.clientHeight >= box.scrollHeight - 120;
+  msg.upserts.forEach(m => upsertMessage(m));
   if (atBottom) requestAnimationFrame(() => { box.scrollTop = box.scrollHeight; });
+  syncStreamingState(msg.streamingState);
+}
+
+function applyPage(msg) {
+  olderFetchInFlight = false;
+  removeLoadingRow();
+  if (msg.sessionId !== currentSession || !transcriptMeta) return;
+  if (msg.epoch !== transcriptMeta.epoch) return;   // stale page; a resync snapshot is coming
+  const box = $("messages");
+  const prevHeight = box.scrollHeight;
+  // Pages arrive oldest-first; insert in reverse so each lands at the front.
+  [...msg.messages].reverse().forEach(m => { if (!messages.has(m.stableId)) insertMessage(m, null); });
+  transcriptMeta.firstIndex = Math.min(transcriptMeta.firstIndex, msg.firstIndex);
+  box.scrollTop += box.scrollHeight - prevHeight;   // keep the viewport anchored
+}
+
+function resubscribe() {
+  if (currentSession) send({ type: "subscribe", sessionId: currentSession });
+}
+
+// Insert a message node at its index-ordered DOM position. Nodes carry
+// dataset.index; the common case (append at the tail) is O(1).
+function insertMessage(m, open) {
+  const box = $("messages");
+  const node = renderMessage(m, m.stableId, open);
+  node.dataset.sid = m.stableId;
+  node.dataset.index = m.index;
+  messages.set(m.stableId, m);
+  messageNodes.set(m.stableId, node);
+  let anchor = box.lastElementChild;
+  while (anchor && Number(anchor.dataset.index) > m.index) anchor = anchor.previousElementSibling;
+  if (anchor) anchor.after(node); else box.prepend(node);
+}
+
+function upsertMessage(m) {
+  const existing = messageNodes.get(m.stableId);
+  if (existing) {
+    const wasOpen = existing.classList.contains("is-open") ? new Set([m.stableId]) : null;
+    const node = renderMessage(m, m.stableId, wasOpen);
+    node.dataset.sid = m.stableId;
+    node.dataset.index = m.index;
+    existing.replaceWith(node);
+    messages.set(m.stableId, m);
+    messageNodes.set(m.stableId, node);
+    return;
+  }
+  // A message older than the loaded window (rare late mutation): skip —
+  // it will arrive if the user backfills that far.
+  if (transcriptMeta && m.index < transcriptMeta.firstIndex) return;
+  insertMessage(m, null);
 }
 
 function el(tag, cls, text) { const e = document.createElement(tag); if (cls) e.className = cls; if (text != null) e.textContent = text; return e; }
@@ -1949,6 +2023,23 @@ function renderDriveBar(streamingState) {
   $("stop").classList.toggle("hidden", !busy);
 }
 
+let stopFallbackTimer = null;
+function markStopping(on) {
+  stopPending = on;
+  const btn = $("stop");
+  btn.disabled = on;
+  btn.classList.toggle("is-stopping", on);
+  if (stopFallbackTimer) { clearTimeout(stopFallbackTimer); stopFallbackTimer = null; }
+  // If the cancel RPC fails and the turn keeps streaming, re-enable Stop so
+  // the user can retry instead of being stranded on a dead button.
+  if (on) stopFallbackTimer = setTimeout(() => markStopping(false), 15000);
+}
+
+function syncStreamingState(streamingState) {
+  if (streamingState === "idle" && stopPending) markStopping(false);
+  renderDriveBar(streamingState);
+}
+
 // takeOver seizes the lease synchronously server-side and messages are ordered,
 // so a follow-up action sent right after lands as the writer.
 function ensureWriter() {
@@ -2101,9 +2192,36 @@ $("file").onchange = async (e) => {
   await onFilesPicked(files);
 };
 
+const LOAD_OLDER_THRESHOLD_PX = 600;
+const OLDER_PAGE_SIZE = 90;
+
+listen("messages", "scroll", () => {
+  if (!currentSession || !transcriptMeta || olderFetchInFlight) return;
+  if (transcriptMeta.firstIndex <= 0) return;
+  if ($("messages").scrollTop > LOAD_OLDER_THRESHOLD_PX) return;
+  olderFetchInFlight = true;
+  showLoadingRow();
+  send({ type: "fetchOlder", sessionId: currentSession, beforeIndex: transcriptMeta.firstIndex, limit: OLDER_PAGE_SIZE });
+});
+
+function showLoadingRow() {
+  if ($("messages").querySelector(".load-older")) return;
+  const row = el("div", "load-older", "Loading earlier messages…");
+  row.dataset.index = "-1";
+  $("messages").prepend(row);
+}
+function removeLoadingRow() {
+  const row = $("messages").querySelector(".load-older");
+  if (row) row.remove();
+}
+
 $("takeover").onclick = () => { if (currentSession) send({ type: "takeOver", sessionId: currentSession }); };
 $("send").onclick = sendPrompt;
-$("stop").onclick = () => { if (!currentSession) return; ensureWriter(); send({ type: "stop", sessionId: currentSession }); };
+$("stop").onclick = () => {
+  if (!currentSession) return;
+  send({ type: "stop", sessionId: currentSession });   // stop is leaseless — no lease takeover first
+  markStopping(true);
+};
 listen("prompt", "input", autoGrowPrompt);
 listen("prompt", "keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendPrompt(); }

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -627,9 +627,13 @@ function applyDelta(msg) {
 }
 
 function applyPage(msg) {
+  // Check the session BEFORE touching shared in-flight state: these globals
+  // track the CURRENT session only, so a stale page for a session the user
+  // already left must not clear (or otherwise affect) whatever the current
+  // session's own in-flight backfill is doing.
+  if (msg.sessionId !== currentSession || !transcriptMeta) return;
   olderFetchInFlight = false;
   removeLoadingRow();
-  if (msg.sessionId !== currentSession || !transcriptMeta) return;
   if (msg.epoch !== transcriptMeta.epoch) return;   // stale page; a resync snapshot is coming
   const box = $("messages");
   const prevHeight = box.scrollHeight;

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -131,7 +131,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=58"></script>
+  <script src="/app.js?v=59"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=36" />
+  <link rel="stylesheet" href="/style.css?v=37" />
 </head>
 <body>
   <header id="bar">
@@ -131,7 +131,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=57"></script>
+  <script src="/app.js?v=58"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -168,6 +168,7 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 #composer-row button:active { transform: scale(0.92); }
 #send { background: var(--accent); color: var(--bg-0); }
 #stop { background: var(--del); color: var(--fg); }
+#stop.is-stopping { opacity: 0.5; cursor: not-allowed; }
 /* Secondary icon buttons (attach, config) — muted, no fill. */
 #attach, #config { background: none; color: var(--fg-dim); }
 #attach:active, #config:active { color: var(--fg-muted); }
@@ -207,6 +208,9 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .create-row-detail { margin-top: 5px; color: var(--fg-dim); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .create-row-meta { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 7px; color: var(--fg-faint); font-size: 11px; line-height: 1.3; }
 .create-empty { padding: 18px 8px; color: var(--fg-dim); font-size: 14px; text-align: center; }
+
+/* Scroll-up backfill loading row — small, centered, muted, like .create-empty. */
+.load-older { padding: 10px 8px; color: var(--fg-dim); font-size: 13px; text-align: center; }
 .sheet-error { margin: 0 0 10px; padding: 10px 12px; border: 0.5px solid color-mix(in oklab, var(--del) 55%, transparent); border-radius: 10px; background: color-mix(in oklab, var(--del) 14%, transparent); color: var(--fg); font-size: 13px; line-height: 1.35; }
 .create-actions { flex: 0 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 8px; padding-top: 8px; }
 .create-actions .btn-submit { grid-column: 1 / -1; order: -1; }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v36";
+const CACHE_NAME = "alas-remote-shell-v37";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=37",
-  "/app.js?v=58",
+  "/app.js?v=59",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v35";
+const CACHE_NAME = "alas-remote-shell-v36";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=36",
-  "/app.js?v=57",
+  "/style.css?v=37",
+  "/app.js?v=58",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1555,7 +1555,7 @@ final class ACPSession: ObservableObject, Identifiable {
             if let existingMessageId {
                 liveUserChunkMessageIds.insert(existingMessageId)
             }
-            transcript.streamingTick &+= 1
+            transcript.noteStreamingChange(at: i)
             return i
         }
 
@@ -1569,7 +1569,7 @@ final class ACPSession: ObservableObject, Identifiable {
                         text: text,
                         attachments: Self.mergingAttachments(attachments, newAttachments))
                     reconciledLocalUserPromptMessageIds.insert(messageId)
-                    transcript.streamingTick &+= 1
+                    transcript.noteStreamingChange(at: i)
                 } else {
                     reconciledLegacyLocalUserPromptIds.insert(id)
                 }
@@ -1590,7 +1590,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 messageId: existingMessageId,
                 text: mergedText,
                 attachments: mergedAttachments)
-            transcript.streamingTick &+= 1
+            transcript.noteStreamingChange(at: i)
             return i
         }
 
@@ -1747,7 +1747,7 @@ final class ACPSession: ObservableObject, Identifiable {
         default:
             return nil
         }
-        transcript.streamingTick &+= 1
+        transcript.noteStreamingChange(at: i)
         return i
     }
 
@@ -1800,7 +1800,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 switch transcript.messages[i] {
                 case .agent(_, _, let buf), .thought(_, _, let buf):
                     buf.append(Self.streamingSeparator(between: buf.value, and: addition) + addition)
-                    transcript.streamingTick &+= 1
+                    transcript.noteStreamingChange(at: i)
                     return i
                 default:
                     break

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -165,6 +165,16 @@ final class ACPSessionManager: ObservableObject {
         await runner.userCancel()
     }
 
+    /// Remote-web emergency brake: cancel this instance's in-flight turn
+    /// WITHOUT confirming the writer lease. `session/cancel` is idempotent
+    /// and only reaches this instance's own adapter — if another instance
+    /// took the lease and drives the session, our runner has no active
+    /// prompt and the cancel is a harmless no-op there.
+    func interruptBypassingLease(for id: ACPSession.ID) async {
+        guard let runner = runners[id] else { return }
+        await runner.userCancel(confirmingLease: false)
+    }
+
     /// Pending model/mode to apply once a runner registers (the writer took over
     /// but `attach` is still in flight). Keyed by session id. Applied in `attach`.
     var pendingModel: [ACPSession.ID: String] = [:]

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -987,7 +987,7 @@ final class ACPSessionRunner {
     /// any pending permission continuation, marks in-flight tool calls as
     /// canceled, posts a system notice, and flips `streamingState` back
     /// to `.idle`. Persists all mutations so they survive a reload.
-    func userCancel() async {
+    func userCancel(confirmingLease: Bool = true) async {
         flushPendingIncomingUpdates(flushQueueWhenBoundaryReady: false)
         // Capture the prompt + queue head the user INTENDED to stop
         // BEFORE awaiting `connection.cancel`. Without this snapshot, a
@@ -1017,12 +1017,14 @@ final class ACPSessionRunner {
             }
             return snapshot
         }
-        // A former writer that lost the lease must not send a cancel RPC to
-        // the agent for a session another instance now owns. The local
-        // bookkeeping above (cancelledPromptIDs insert) is fine to keep —
-        // it only affects this runner's own sendNow catch path and has no
-        // cross-instance side effects.
-        guard await hasConfirmedLeaseForSideEffect() else { return }
+        if confirmingLease {
+            // A former writer that lost the lease must not send a cancel RPC to
+            // the agent for a session another instance now owns. The local
+            // bookkeeping above (cancelledPromptIDs insert) is fine to keep —
+            // it only affects this runner's own sendNow catch path and has no
+            // cross-instance side effects.
+            guard await hasConfirmedLeaseForSideEffect() else { return }
+        }
         onUserCancel?()
         let remoteId = session.remoteSessionId ?? sessionId
         try? await connection.cancel(sessionId: remoteId)

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -11,8 +11,12 @@ final class ACPTranscript: ObservableObject {
     @Published var messages: [ACPMessage] = [] {
         didSet {
             refreshPlanCaches()
+            recordMessagesDiff(old: oldValue)
         }
     }
+    /// Mutation log consumed by remote-web gateways for incremental deltas.
+    /// Recording is enabled only while at least one gateway is subscribed.
+    let changeLog = ACPTranscriptChangeLog()
     @Published var streamingState: ACPSession.StreamingState = .idle
     @Published var pendingPermission: ACPSession.PendingPermission?
     @Published var pendingQuestion: ACPSession.PendingQuestion?
@@ -127,6 +131,45 @@ final class ACPTranscript: ObservableObject {
         }
         if latestPlan != newLatestPlan {
             latestPlan = newLatestPlan
+        }
+    }
+
+    // MARK: - Remote change tracking
+
+    /// Classify an array mutation for the change log. Index-shifting
+    /// operations (shrink, or an identity change at a surviving index —
+    /// i.e. a prepend, mid-removal, or wholesale replacement) are
+    /// structural; everything else records per-index dirty entries.
+    /// Cost is O(count) enum compares, but unchanged elements share
+    /// storage (COW) and `StreamingText` compares by identity, so the
+    /// scan is cheap — and it only runs while a remote client is
+    /// subscribed.
+    private func recordMessagesDiff(old: [ACPMessage]) {
+        guard changeLog.isTracking else { return }
+        guard messages.count >= old.count else {
+            changeLog.recordStructural()
+            return
+        }
+        for i in old.indices where old[i] != messages[i] {
+            guard old[i].stableIdentityKey == messages[i].stableIdentityKey else {
+                changeLog.recordStructural()
+                return
+            }
+            changeLog.record(index: i)
+        }
+        for i in old.count..<messages.count {
+            changeLog.record(index: i)
+        }
+    }
+
+    /// Streaming chunk appends mutate a `StreamingText` buffer in place —
+    /// the array element compares equal (identity equality), so
+    /// `messages.didSet` cannot see them. Callers pass the mutated index.
+    /// Replaces direct `streamingTick &+= 1` writes.
+    func noteStreamingChange(at index: Int) {
+        streamingTick &+= 1
+        if changeLog.isTracking, messages.indices.contains(index) {
+            changeLog.record(index: index)
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPTranscriptChangeLog.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscriptChangeLog.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Records which transcript message indices mutated so remote-web gateways
+/// can send incremental deltas instead of full re-snapshots.
+///
+/// Indices recorded here never go stale: every index-shifting operation
+/// (prepend, removal, wholesale replacement) is recorded as *structural*,
+/// which bumps `epoch`, clears the log, and forces consumers to take a
+/// fresh tail snapshot. Recording is refcount-gated so the transcript pays
+/// zero diff cost when no remote client is subscribed.
+@MainActor
+final class ACPTranscriptChangeLog {
+    enum Changes: Equatable {
+        case none
+        case resync
+        case dirty([Int])   // distinct dirty message indices, ascending
+    }
+
+    /// Transcript generation. Bumped on any structural change; a consumer
+    /// holding a stale epoch must re-snapshot.
+    private(set) var epoch: Int = 0
+    /// Monotonic mutation counter. Consumers read "changes since version".
+    private(set) var latestVersion: Int = 0
+    /// Ring of (version, index) entries; consecutive records of the same
+    /// index coalesce by bumping the tail entry's version in place, so a
+    /// streaming burst occupies one slot.
+    private var entries: [(version: Int, index: Int)] = []
+    /// Highest version dropped from `entries`; a consumer behind this
+    /// cannot be served incrementally.
+    private var prunedThrough: Int = 0
+    private var trackingRefCount = 0
+
+    static let maxEntries = 1024
+
+    var isTracking: Bool { trackingRefCount > 0 }
+
+    func retainTracking() { trackingRefCount += 1 }
+
+    func releaseTracking() {
+        trackingRefCount = max(0, trackingRefCount - 1)
+        if trackingRefCount == 0 {
+            entries.removeAll()
+            prunedThrough = latestVersion
+        }
+    }
+
+    func record(index: Int) {
+        guard isTracking else { return }
+        latestVersion += 1
+        if let last = entries.last, last.index == index {
+            entries[entries.count - 1].version = latestVersion
+        } else {
+            entries.append((latestVersion, index))
+            if entries.count > Self.maxEntries {
+                prunedThrough = entries.removeFirst().version
+            }
+        }
+    }
+
+    func recordStructural() {
+        guard isTracking else { return }
+        epoch += 1
+        latestVersion += 1
+        entries.removeAll()
+        prunedThrough = latestVersion
+    }
+
+    func changes(since: Int) -> Changes {
+        if since >= latestVersion { return .none }
+        if since < prunedThrough { return .resync }
+        let dirty = Set(entries.filter { $0.version > since }.map(\.index))
+        // Defensive: a consumer inside the retained window should always
+        // find entries; an empty result means bookkeeping drifted — resync.
+        return dirty.isEmpty ? .resync : .dirty(dirty.sorted())
+    }
+}

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4765,7 +4765,7 @@ extension AppState: RemoteSessionsProvider {
 
     func stop(for id: String) async {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
-            await mgr.interrupt(for: id)
+            await mgr.interruptBypassingLease(for: id)
             return
         }
     }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -353,7 +353,19 @@ final class RemoteSessionGateway {
         // sentVersion already covers them. Only commit once we know this
         // snapshot is actually going out.
         let newSentVersion = log.latestVersion
-        state.revision = 0
+        // Also defer resetting revision — the same hazard as sentVersion,
+        // but on the send side instead of the change-log side. A `.none`
+        // content-free delta doesn't participate in the generation ticket
+        // (it has no reason to — no message content raced it), so it can
+        // still complete and send WHILE this snapshot is suspended, bumping
+        // `state.revision` past 0. If we'd already reset it to 0 here, and
+        // this snapshot then wins (generation unaffected by a `.none`
+        // send), its wire payload hardcodes `revision: 0` while
+        // `state.revision` is left at whatever the intervening delta bumped
+        // it to — the server's internal counter desyncs from what it
+        // actually told the client, and every subsequent delta fails the
+        // client's `revision === transcriptMeta.revision + 1` check until
+        // another full resync happens. Reset it atomically with the send.
         state.generation += 1
         let capturedGeneration = state.generation
         let wire = await wireMessages(id: id, session: session, indices: Array(first..<count))
@@ -367,6 +379,7 @@ final class RemoteSessionGateway {
         // generation read fresher state and is authoritative.
         if state.generation == capturedGeneration {
             state.sentVersion = newSentVersion
+            state.revision = 0
             send(.transcriptSnapshot(sessionId: id,
                                      streamingState: Self.stateString(session.transcript.streamingState),
                                      canDrive: provider.isWriter(for: id),

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -427,7 +427,15 @@ final class RemoteSessionGateway {
                 await sendSnapshot(id: id, session: session)
                 return
             }
-            state.sentVersion = log.latestVersion
+            // Capture — but do NOT yet commit — the version this delta will
+            // cover. Committing it now (before the await) would make the
+            // change log treat `indices` as "already sent" even if this
+            // delta ends up discarded below: a later dirty mutation would
+            // then compute `changes(since:)` against an already-advanced
+            // sentVersion and never re-offer these indices, silently losing
+            // them until a full resync. Only write it once we know we're
+            // actually sending (see the guard below).
+            let newSentVersion = log.latestVersion
             // Claim a generation for this send BEFORE the async serialize
             // below — not just on sendSnapshot. Two overlapping dirty
             // deltas can race the same way a delta and a snapshot can: a
@@ -451,6 +459,7 @@ final class RemoteSessionGateway {
             }
             let wire = await wireMessages(id: id, session: session, indices: indices)
             guard state.generation == capturedGeneration else { return }
+            state.sentVersion = newSentVersion
             state.revision += 1
             send(.transcriptDelta(sessionId: id,
                                   streamingState: Self.stateString(session.transcript.streamingState),

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -173,24 +173,25 @@ final class RemoteSessionGateway {
             refreshSessionList()
         case .fetchOlder(let id, let beforeIndex, let limit):
             // Ignore pages requested before a snapshot established sync state.
-            guard let session = provider.session(for: id), syncStates[id] != nil else { return }
+            guard let session = provider.session(for: id), let state = syncStates[id] else { return }
             let clamped = min(max(limit, RemoteTranscriptSync.pageLimitRange.lowerBound),
                               RemoteTranscriptSync.pageLimitRange.upperBound)
             let count = session.transcript.messages.count
             let hi = min(max(beforeIndex, 0), count)
             let lo = max(0, hi - clamped)
-            // Capture the epoch BEFORE the async serialize below. If a
-            // structural change lands on this same session while a truncated
-            // tool call's full content is being fetched, the concurrent
-            // resync snapshot already advances the client past this page's
-            // (now stale) positions — stamping the page with the epoch read
-            // AFTER the await would make it match the client's post-resync
-            // epoch and be wrongly accepted. Drop it instead.
-            let capturedEpoch = session.transcript.changeLog.epoch
+            // Capture the generation BEFORE the async serialize below — not
+            // just the epoch, since a same-epoch concurrent snapshot (e.g.
+            // takeOver, or a client resubscribe with no structural change)
+            // also supersedes this page without moving the epoch. If a
+            // snapshot lands on this same session while a truncated tool
+            // call's full content is being fetched, stamping the page with
+            // state read AFTER the await would make it look current and be
+            // wrongly accepted instead of dropped.
+            let capturedGeneration = state.generation
             let wire = await wireMessages(id: id, session: session, indices: Array(lo..<hi))
-            guard session.transcript.changeLog.epoch == capturedEpoch else { return }
+            guard state.generation == capturedGeneration else { return }
             send(.transcriptPage(sessionId: id,
-                                 epoch: capturedEpoch,
+                                 epoch: state.epoch,
                                  firstIndex: lo,
                                  messages: wire))
         }
@@ -315,10 +316,14 @@ final class RemoteSessionGateway {
         let first = max(0, count - RemoteTranscriptSync.tailWindow)
         // Capture version/epoch BEFORE the async serialize: anything that
         // mutates during the awaits lands at a higher version and is
-        // picked up by the next delta.
+        // picked up by the next delta. Bumping `generation` here — even
+        // when `epoch` itself is unchanged (e.g. a same-epoch takeOver or
+        // client resubscribe) — lets a concurrently-suspended delta/page
+        // detect that THIS snapshot already superseded it.
         state.epoch = log.epoch
         state.sentVersion = log.latestVersion
         state.revision = 0
+        state.generation += 1
         let wire = await wireMessages(id: id, session: session, indices: Array(first..<count))
         send(.transcriptSnapshot(sessionId: id,
                                  streamingState: Self.stateString(session.transcript.streamingState),
@@ -412,16 +417,16 @@ final class RemoteSessionGateway {
                 return
             }
             state.sentVersion = log.latestVersion
-            // Capture the epoch BEFORE the async serialize below. A concurrent
-            // structural change (e.g. a takeOver-triggered snapshot, or another
-            // coalesced delta observing a prepend/removal) can call sendSnapshot
-            // on this same `state` while we're suspended, resetting its epoch
-            // and revision. If that happens, this delta's `wire` content is
-            // stale relative to the just-resynced transcript — sending it would
-            // stamp stale upserts with the new epoch/revision, which the client
-            // would wrongly accept as legitimate. Discard instead; the
-            // concurrent resync snapshot already carries the correct state.
-            let capturedEpoch = state.epoch
+            // Capture the generation BEFORE the async serialize below. A
+            // concurrent sendSnapshot on this same `state` — from a
+            // structural change, a takeOver, or a client resubscribe —
+            // resets revision/sentVersion even when `epoch` itself doesn't
+            // change, so an epoch-only check would miss it. If the
+            // generation moved, this delta's `wire` content is stale
+            // relative to whatever the concurrent snapshot already sent;
+            // sending it would let stale upserts overwrite the newer
+            // content the client just received. Discard instead.
+            let capturedGeneration = state.generation
             // A dirty tool call's persisted content may have grown past the
             // cached copy — drop it so serialization re-fetches.
             for index in indices where session.transcript.messages.indices.contains(index) {
@@ -430,7 +435,7 @@ final class RemoteSessionGateway {
                 }
             }
             let wire = await wireMessages(id: id, session: session, indices: indices)
-            guard state.epoch == capturedEpoch else { return }
+            guard state.generation == capturedGeneration else { return }
             state.revision += 1
             send(.transcriptDelta(sessionId: id,
                                   streamingState: Self.stateString(session.transcript.streamingState),

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -160,6 +160,10 @@ final class RemoteSessionGateway {
             }
             send(.sessionRenamed(sessionId: id, title: trimmed))
             refreshSessionList()
+        case .fetchOlder:
+            // Wire protocol only for now; serving historical pages from the
+            // transcript change log is a follow-up (windowing/diffing work).
+            break
         }
     }
 
@@ -261,10 +265,16 @@ final class RemoteSessionGateway {
 
     private func sendSnapshot(id: String, session: ACPSession) async {
         let wire = await wireMessages(id: id, session: session)
+        // v1: full-replay snapshot with placeholder windowing/versioning fields
+        // (real tail-window + epoch/revision tracking lands in a follow-up).
         send(.transcriptSnapshot(sessionId: id,
                                  streamingState: Self.stateString(session.transcript.streamingState),
                                  canDrive: provider.isWriter(for: id),
-                                 messages: wire))
+                                 messages: wire,
+                                 firstIndex: 0,
+                                 totalCount: wire.count,
+                                 epoch: 0,
+                                 revision: 0))
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
         emitPendingElicitationIfAny(id: id, session: session)
@@ -319,10 +329,14 @@ final class RemoteSessionGateway {
         // v1: send a full re-snapshot as the "delta" (simple + always correct).
         // A true per-message diff optimization is intentionally deferred (YAGNI).
         let wire = await wireMessages(id: id, session: session)
+        // v1: full-replay delta with placeholder epoch/revision (real per-message
+        // diffing lands in a follow-up).
         send(.transcriptDelta(sessionId: id,
                               streamingState: Self.stateString(session.transcript.streamingState),
                               canDrive: provider.isWriter(for: id),
-                              upserts: wire))
+                              upserts: wire,
+                              epoch: 0,
+                              revision: 0))
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
         emitPendingElicitationIfAny(id: id, session: session)
@@ -701,24 +715,25 @@ final class RemoteSessionGateway {
             var parts: [String] = []
             if !text.isEmpty { parts.append(text) }
             parts.append(contentsOf: attachments.map { "🖼 \($0.name ?? "Image")" })
-            return .init(stableId: sid, kind: "user", text: parts.joined(separator: "\n\n"), json: nil)
+            return .init(stableId: sid, kind: "user", text: parts.joined(separator: "\n\n"), json: nil, index: index)
         case .agent(_, _, let streaming):
-            return .init(stableId: sid, kind: "agent", text: streaming.value, json: nil)
+            return .init(stableId: sid, kind: "agent", text: streaming.value, json: nil, index: index)
         case .thought(_, _, let streaming):
-            return .init(stableId: sid, kind: "thought", text: streaming.value, json: nil)
+            return .init(stableId: sid, kind: "thought", text: streaming.value, json: nil, index: index)
         case .systemNotice(_, let text):
-            return .init(stableId: sid, kind: "systemNotice", text: text, json: nil)
+            return .init(stableId: sid, kind: "systemNotice", text: text, json: nil, index: index)
         case .toolCall(let call):
             return .init(
                 stableId: sid,
                 kind: "toolCall",
                 text: nil,
-                json: Self.encodeJSON(remoteToolCall(call, fullContent: fullToolCallContent))
+                json: Self.encodeJSON(remoteToolCall(call, fullContent: fullToolCallContent)),
+                index: index
             )
         case .fileEdit(_, let edit):
-            return .init(stableId: sid, kind: "fileEdit", text: nil, json: Self.encodeJSON(edit))
+            return .init(stableId: sid, kind: "fileEdit", text: nil, json: Self.encodeJSON(edit), index: index)
         case .plan(_, let items):
-            return .init(stableId: sid, kind: "plan", text: nil, json: Self.encodeJSON(items))
+            return .init(stableId: sid, kind: "plan", text: nil, json: Self.encodeJSON(items), index: index)
         }
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -176,26 +176,50 @@ final class RemoteSessionGateway {
             guard let session = provider.session(for: id), let state = syncStates[id] else { return }
             let clamped = min(max(limit, RemoteTranscriptSync.pageLimitRange.lowerBound),
                               RemoteTranscriptSync.pageLimitRange.upperBound)
-            let count = session.transcript.messages.count
-            let hi = min(max(beforeIndex, 0), count)
-            let lo = max(0, hi - clamped)
-            // Capture the generation BEFORE the async serialize below — not
-            // just the epoch, since a same-epoch concurrent snapshot (e.g.
-            // takeOver, or a client resubscribe with no structural change)
-            // also supersedes this page without moving the epoch. If a
-            // snapshot lands on this same session while a truncated tool
-            // call's full content is being fetched, stamping the page with
-            // state read AFTER the await would make it look current and be
-            // wrongly accepted instead of dropped.
-            let capturedGeneration = state.generation
-            let wire = await wireMessages(id: id, session: session, indices: Array(lo..<hi))
-            guard state.generation == capturedGeneration else { return }
-            send(.transcriptPage(sessionId: id,
-                                 epoch: state.epoch,
-                                 firstIndex: lo,
-                                 messages: wire))
+            // A concurrent send (snapshot OR ordinary same-epoch delta) can
+            // supersede this page mid-serialize the same way it supersedes a
+            // dirty delta — see the capturedGeneration comment below. Unlike
+            // a dropped delta/snapshot, though, the client has no fallback
+            // recovery for a silently-dropped page: only a snapshot resets
+            // its "loading earlier messages" state, and an ordinary delta
+            // (the common case here) does not, so simply returning would
+            // leave the client stuck showing a spinner forever. Retry
+            // instead — bounded so pathological continuous churn can't spin
+            // forever either; a truncated tool call's content fetched by an
+            // earlier attempt stays cached, so a retry is cheap.
+            var attempt = 0
+            while true {
+                let count = session.transcript.messages.count
+                let hi = min(max(beforeIndex, 0), count)
+                let lo = max(0, hi - clamped)
+                // Capture the generation BEFORE the async serialize below —
+                // not just the epoch, since a same-epoch concurrent
+                // snapshot (e.g. takeOver, or a client resubscribe with no
+                // structural change) also supersedes this page without
+                // moving the epoch. If a snapshot lands on this same
+                // session while a truncated tool call's full content is
+                // being fetched, stamping the page with state read AFTER
+                // the await would make it look current and be wrongly
+                // accepted instead of dropped.
+                let capturedGeneration = state.generation
+                let wire = await wireMessages(id: id, session: session, indices: Array(lo..<hi))
+                attempt += 1
+                guard state.generation == capturedGeneration || attempt > Self.maxFetchOlderAttempts else {
+                    continue
+                }
+                send(.transcriptPage(sessionId: id,
+                                     epoch: state.epoch,
+                                     firstIndex: lo,
+                                     messages: wire))
+                break
+            }
         }
     }
+
+    /// Bound on retrying a superseded `fetchOlder` page before sending
+    /// whatever was last computed anyway — the client must always get a
+    /// response, never an unbounded wait.
+    private static let maxFetchOlderAttempts = 5
 
     private func beginTracking(id: String, session: ACPSession) {
         guard !trackedSessions.contains(id) else { return }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -417,15 +417,19 @@ final class RemoteSessionGateway {
                 return
             }
             state.sentVersion = log.latestVersion
-            // Capture the generation BEFORE the async serialize below. A
-            // concurrent sendSnapshot on this same `state` — from a
-            // structural change, a takeOver, or a client resubscribe —
-            // resets revision/sentVersion even when `epoch` itself doesn't
-            // change, so an epoch-only check would miss it. If the
-            // generation moved, this delta's `wire` content is stale
-            // relative to whatever the concurrent snapshot already sent;
-            // sending it would let stale upserts overwrite the newer
-            // content the client just received. Discard instead.
+            // Claim a generation for this send BEFORE the async serialize
+            // below — not just on sendSnapshot. Two overlapping dirty
+            // deltas can race the same way a delta and a snapshot can: a
+            // still-running (cancelled-but-not-stopped) coalesce Task can
+            // suspend on a tool-content fetch while a LATER mutation spawns
+            // its own coalesce Task that completes and sends first. Without
+            // bumping generation here too, the earlier delta would resume,
+            // pass an unchanged-generation check, and send its now-stale
+            // content at a higher revision — rolling the client back after
+            // it already received the newer delta. Bumping on every send
+            // attempt (snapshot OR dirty) makes generation a strict
+            // "did anyone else claim a send after me" ticket.
+            state.generation += 1
             let capturedGeneration = state.generation
             // A dirty tool call's persisted content may have grown past the
             // cached copy — drop it so serialization re-fetches.

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -148,7 +148,10 @@ final class RemoteSessionGateway {
             }
             refusalIsSynchronous = false
         case .stop(let id):
-            guard provider.isWriter(for: id) else { return }
+            // Emergency brake: any authenticated subscriber may cancel the
+            // running turn; no writer lease required. Ack immediately so the
+            // client flips to "stopping" before the ACP round-trip completes.
+            send(.stopPending(sessionId: id))
             await provider.stop(for: id)
         case .setModel(let id, let modelId):
             guard provider.isWriter(for: id) else { return }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -405,6 +405,16 @@ final class RemoteSessionGateway {
                 return
             }
             state.sentVersion = log.latestVersion
+            // Capture the epoch BEFORE the async serialize below. A concurrent
+            // structural change (e.g. a takeOver-triggered snapshot, or another
+            // coalesced delta observing a prepend/removal) can call sendSnapshot
+            // on this same `state` while we're suspended, resetting its epoch
+            // and revision. If that happens, this delta's `wire` content is
+            // stale relative to the just-resynced transcript — sending it would
+            // stamp stale upserts with the new epoch/revision, which the client
+            // would wrongly accept as legitimate. Discard instead; the
+            // concurrent resync snapshot already carries the correct state.
+            let capturedEpoch = state.epoch
             // A dirty tool call's persisted content may have grown past the
             // cached copy — drop it so serialization re-fetches.
             for index in indices where session.transcript.messages.indices.contains(index) {
@@ -413,6 +423,7 @@ final class RemoteSessionGateway {
                 }
             }
             let wire = await wireMessages(id: id, session: session, indices: indices)
+            guard state.epoch == capturedEpoch else { return }
             state.revision += 1
             send(.transcriptDelta(sessionId: id,
                                   streamingState: Self.stateString(session.transcript.streamingState),

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -314,14 +314,21 @@ final class RemoteSessionGateway {
         let log = session.transcript.changeLog
         let count = session.transcript.messages.count
         let first = max(0, count - RemoteTranscriptSync.tailWindow)
-        // Capture version/epoch BEFORE the async serialize: anything that
-        // mutates during the awaits lands at a higher version and is
-        // picked up by the next delta. Bumping `generation` here — even
-        // when `epoch` itself is unchanged (e.g. a same-epoch takeOver or
-        // client resubscribe) — lets a concurrently-suspended delta/page
-        // detect that THIS snapshot already superseded it.
+        // Capture epoch/version BEFORE the async serialize, but do NOT yet
+        // commit sentVersion to `state` — see below. Bumping `generation`
+        // here — even when `epoch` itself is unchanged (e.g. a same-epoch
+        // takeOver or client resubscribe) — lets a concurrently-suspended
+        // delta/page detect that THIS snapshot already superseded it.
         state.epoch = log.epoch
-        state.sentVersion = log.latestVersion
+        // Defer committing sentVersion, matching the dirty-delta fix above:
+        // writing it now would make the change log treat everything dirty
+        // up to this point as "already sent" even if this snapshot ends up
+        // discarded below (superseded by a same-epoch dirty delta that
+        // raced in during the await) — the pre-snapshot dirty indices would
+        // then be silently absent from both sends, never re-offered, since
+        // sentVersion already covers them. Only commit once we know this
+        // snapshot is actually going out.
+        let newSentVersion = log.latestVersion
         state.revision = 0
         state.generation += 1
         let capturedGeneration = state.generation
@@ -335,6 +342,7 @@ final class RemoteSessionGateway {
         // unlike deltas/pages. Discard; whatever claimed the later
         // generation read fresher state and is authoritative.
         if state.generation == capturedGeneration {
+            state.sentVersion = newSentVersion
             send(.transcriptSnapshot(sessionId: id,
                                      streamingState: Self.stateString(session.transcript.streamingState),
                                      canDrive: provider.isWriter(for: id),

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -324,15 +324,26 @@ final class RemoteSessionGateway {
         state.sentVersion = log.latestVersion
         state.revision = 0
         state.generation += 1
+        let capturedGeneration = state.generation
         let wire = await wireMessages(id: id, session: session, indices: Array(first..<count))
-        send(.transcriptSnapshot(sessionId: id,
-                                 streamingState: Self.stateString(session.transcript.streamingState),
-                                 canDrive: provider.isWriter(for: id),
-                                 messages: wire,
-                                 firstIndex: first,
-                                 totalCount: count,
-                                 epoch: state.epoch,
-                                 revision: 0))
+        // If another send (a concurrent snapshot or dirty delta) claimed a
+        // later generation while this one was suspended fetching truncated
+        // tool-call content, THIS snapshot's payload is now stale relative
+        // to what the client already has or is about to receive. Sending it
+        // anyway would roll the client back — snapshots are applied
+        // unconditionally client-side (no epoch/revision ordering check),
+        // unlike deltas/pages. Discard; whatever claimed the later
+        // generation read fresher state and is authoritative.
+        if state.generation == capturedGeneration {
+            send(.transcriptSnapshot(sessionId: id,
+                                     streamingState: Self.stateString(session.transcript.streamingState),
+                                     canDrive: provider.isWriter(for: id),
+                                     messages: wire,
+                                     firstIndex: first,
+                                     totalCount: count,
+                                     epoch: state.epoch,
+                                     revision: 0))
+        }
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
         emitPendingElicitationIfAny(id: id, session: session)

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -5,8 +5,11 @@ import Combine
 ///
 /// Transport-agnostic: it consumes decoded `RemoteClientMessage`s and emits
 /// `RemoteServerMessage`s via the `send` closure, so it is fully testable
-/// without sockets. Observes the live `ACPTranscript` (Combine) and
-/// re-snapshots on change (coalesced) as a "delta". Inbound permission
+/// without sockets. Observes the live `ACPTranscript` (Combine) and, on
+/// change (coalesced), consumes `ACPTranscriptChangeLog` to emit either an
+/// incremental delta (only the messages the log marked dirty) or, when the
+/// log reports a structural change or the connection has fallen behind, a
+/// fresh tail-window snapshot under a bumped epoch. Inbound permission
 /// decisions route to the existing `ACPPermissionPolicy.userDecided(...)`
 /// after a first-wins staleness guard.
 @MainActor
@@ -22,6 +25,8 @@ final class RemoteSessionGateway {
     private var sessionListGeneration = 0
     private var worktreeListRefresh: Task<Void, Never>?
     private var worktreeListGeneration = 0
+    private var syncStates: [String: RemoteTranscriptSync] = [:]
+    private var trackedSessions: Set<String> = []
     // Per-session request id of the permission/question prompt we last surfaced,
     // so we can tell the client to dismiss it if it gets resolved elsewhere.
     private var lastPermissionReq: [String: Int] = [:]
@@ -57,6 +62,7 @@ final class RemoteSessionGateway {
                 send(.sessionClosed(sessionId: id))
                 return
             }
+            beginTracking(id: id, session: session)
             await sendSnapshot(id: id, session: session)
             if let cfg = provider.sessionConfig(for: id) {
                 send(.sessionConfig(cfg))
@@ -73,6 +79,8 @@ final class RemoteSessionGateway {
             lastPermissionReq[id] = nil
             lastQuestionReq[id] = nil
             lastElicitationReq[id] = nil
+            endTracking(id: id)
+            syncStates[id] = nil
         case .permissionDecision(let id, let requestId, let optionId, let persistScope):
             await applyDecision(sessionId: id, requestId: requestId, optionId: optionId, persistScope: persistScope)
         case .questionAnswer(let id, let requestId, let answers):
@@ -160,11 +168,33 @@ final class RemoteSessionGateway {
             }
             send(.sessionRenamed(sessionId: id, title: trimmed))
             refreshSessionList()
-        case .fetchOlder:
-            // Wire protocol only for now; serving historical pages from the
-            // transcript change log is a follow-up (windowing/diffing work).
-            break
+        case .fetchOlder(let id, let beforeIndex, let limit):
+            // Ignore pages requested before a snapshot established sync state.
+            guard let session = provider.session(for: id), syncStates[id] != nil else { return }
+            let clamped = min(max(limit, RemoteTranscriptSync.pageLimitRange.lowerBound),
+                              RemoteTranscriptSync.pageLimitRange.upperBound)
+            let count = session.transcript.messages.count
+            let hi = min(max(beforeIndex, 0), count)
+            let lo = max(0, hi - clamped)
+            let wire = await wireMessages(id: id, session: session, indices: Array(lo..<hi))
+            // Stamp with the CURRENT epoch: if it moved past the client's,
+            // the client drops the page and the pending resync wins.
+            send(.transcriptPage(sessionId: id,
+                                 epoch: session.transcript.changeLog.epoch,
+                                 firstIndex: lo,
+                                 messages: wire))
         }
+    }
+
+    private func beginTracking(id: String, session: ACPSession) {
+        guard !trackedSessions.contains(id) else { return }
+        trackedSessions.insert(id)
+        session.transcript.changeLog.retainTracking()
+    }
+
+    private func endTracking(id: String) {
+        guard trackedSessions.remove(id) != nil else { return }
+        provider.session(for: id)?.transcript.changeLog.releaseTracking()
     }
 
     private func refreshSessionList() {
@@ -259,25 +289,45 @@ final class RemoteSessionGateway {
         lastPermissionReq.removeAll()
         lastQuestionReq.removeAll()
         lastElicitationReq.removeAll()
+        for id in trackedSessions {
+            provider.session(for: id)?.transcript.changeLog.releaseTracking()
+        }
+        trackedSessions.removeAll()
+        syncStates.removeAll()
     }
 
     // MARK: snapshot / delta
 
     private func sendSnapshot(id: String, session: ACPSession) async {
-        let wire = await wireMessages(id: id, session: session)
-        // v1: full-replay snapshot with placeholder windowing/versioning fields
-        // (real tail-window + epoch/revision tracking lands in a follow-up).
+        let state = syncState(for: id)
+        let log = session.transcript.changeLog
+        let count = session.transcript.messages.count
+        let first = max(0, count - RemoteTranscriptSync.tailWindow)
+        // Capture version/epoch BEFORE the async serialize: anything that
+        // mutates during the awaits lands at a higher version and is
+        // picked up by the next delta.
+        state.epoch = log.epoch
+        state.sentVersion = log.latestVersion
+        state.revision = 0
+        let wire = await wireMessages(id: id, session: session, indices: Array(first..<count))
         send(.transcriptSnapshot(sessionId: id,
                                  streamingState: Self.stateString(session.transcript.streamingState),
                                  canDrive: provider.isWriter(for: id),
                                  messages: wire,
-                                 firstIndex: 0,
-                                 totalCount: wire.count,
-                                 epoch: 0,
+                                 firstIndex: first,
+                                 totalCount: count,
+                                 epoch: state.epoch,
                                  revision: 0))
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
         emitPendingElicitationIfAny(id: id, session: session)
+    }
+
+    private func syncState(for id: String) -> RemoteTranscriptSync {
+        if let s = syncStates[id] { return s }
+        let s = RemoteTranscriptSync()
+        syncStates[id] = s
+        return s
     }
 
     private func observe(id: String, session: ACPSession) {
@@ -325,44 +375,78 @@ final class RemoteSessionGateway {
         }
     }
 
+    /// Emits an incremental delta: only messages the change log marked
+    /// dirty since the last send. Structural transcript changes (prepend,
+    /// removal, wholesale replacement) resync via a fresh tail snapshot.
     private func sendDelta(id: String, session: ACPSession) async {
-        // v1: send a full re-snapshot as the "delta" (simple + always correct).
-        // A true per-message diff optimization is intentionally deferred (YAGNI).
-        let wire = await wireMessages(id: id, session: session)
-        // v1: full-replay delta with placeholder epoch/revision (real per-message
-        // diffing lands in a follow-up).
-        send(.transcriptDelta(sessionId: id,
-                              streamingState: Self.stateString(session.transcript.streamingState),
-                              canDrive: provider.isWriter(for: id),
-                              upserts: wire,
-                              epoch: 0,
-                              revision: 0))
+        guard let state = syncStates[id] else { return }
+        let log = session.transcript.changeLog
+        switch log.changes(since: state.sentVersion) {
+        case .resync:
+            await sendSnapshot(id: id, session: session)
+            return
+        case .none:
+            // No transcript content changed — this tick was a state flip
+            // (streamingState / pending prompt). Send a content-free delta
+            // so the client still tracks state.
+            state.revision += 1
+            send(.transcriptDelta(sessionId: id,
+                                  streamingState: Self.stateString(session.transcript.streamingState),
+                                  canDrive: provider.isWriter(for: id),
+                                  upserts: [],
+                                  epoch: state.epoch,
+                                  revision: state.revision))
+        case .dirty(let indices):
+            guard indices.count <= RemoteTranscriptSync.dirtyResnapshotThreshold else {
+                await sendSnapshot(id: id, session: session)
+                return
+            }
+            state.sentVersion = log.latestVersion
+            // A dirty tool call's persisted content may have grown past the
+            // cached copy — drop it so serialization re-fetches.
+            for index in indices where session.transcript.messages.indices.contains(index) {
+                if case .toolCall(let tc) = session.transcript.messages[index] {
+                    state.invalidateToolContent(tc.toolCallId)
+                }
+            }
+            let wire = await wireMessages(id: id, session: session, indices: indices)
+            state.revision += 1
+            send(.transcriptDelta(sessionId: id,
+                                  streamingState: Self.stateString(session.transcript.streamingState),
+                                  canDrive: provider.isWriter(for: id),
+                                  upserts: wire,
+                                  epoch: state.epoch,
+                                  revision: state.revision))
+        }
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
         emitPendingElicitationIfAny(id: id, session: session)
     }
 
-    private func wireMessages(id: String, session: ACPSession) async -> [RemoteWireMessage] {
+    private func wireMessages(id: String, session: ACPSession, indices: [Int]) async -> [RemoteWireMessage] {
         var wire: [RemoteWireMessage] = []
-        wire.reserveCapacity(session.transcript.messages.count)
-        for (index, message) in session.transcript.messages.enumerated() {
+        wire.reserveCapacity(indices.count)
+        for index in indices {
+            // Re-check across awaits: a structural mutation mid-serialize can
+            // shrink the array; the epoch bump will resync the client.
+            guard session.transcript.messages.indices.contains(index) else { continue }
+            let message = session.transcript.messages[index]
             wire.append(Self.toWire(
                 message,
                 index: index,
-                fullToolCallContent: await fullToolCallContentIfNeeded(
-                    sessionId: id,
-                    message: message
-                )
-            ))
+                fullToolCallContent: await cachedFullToolCallContent(sessionId: id, message: message)))
         }
         return wire
     }
 
-    private func fullToolCallContentIfNeeded(sessionId: String, message: ACPMessage) async -> String? {
-        guard case .toolCall(let toolCall) = message,
-              toolCall.isContentTruncated
+    private func cachedFullToolCallContent(sessionId: String, message: ACPMessage) async -> String? {
+        guard case .toolCall(let toolCall) = message, toolCall.isContentTruncated else { return nil }
+        let state = syncState(for: sessionId)
+        if let cached = state.cachedToolContent(toolCall.toolCallId) { return cached }
+        guard let full = await provider.fullToolCallContent(sessionId: sessionId, toolCallId: toolCall.toolCallId)
         else { return nil }
-        return await provider.fullToolCallContent(sessionId: sessionId, toolCallId: toolCall.toolCallId)
+        state.storeToolContent(toolCall.toolCallId, full)
+        return full
     }
 
     private func emitPendingPermissionIfAny(id: String, session: ACPSession) {
@@ -699,8 +783,13 @@ final class RemoteSessionGateway {
     /// mirror re-decodes the transcript on every refresh, minting fresh UUIDs
     /// each time (`ACPMessageWire.toMessage`), so the per-message id is not
     /// stable across our full re-snapshots. Position is — the Nth message stays
-    /// the Nth — so the client can upsert idempotently instead of accumulating
-    /// duplicate copies of the whole transcript on each refresh.
+    /// the Nth — so the client can upsert idempotently by `index` instead of
+    /// accumulating duplicate copies. Positional ids stay valid across
+    /// incremental deltas too: every index-shifting mutation (prepend,
+    /// removal, wholesale replacement) is recorded as *structural* by
+    /// `ACPTranscriptChangeLog`, which forces a fresh tail snapshot under a
+    /// bumped epoch rather than a delta that could otherwise upsert a stale
+    /// index against shifted content.
     static func toWire(
         _ message: ACPMessage,
         index: Int,

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -179,11 +179,18 @@ final class RemoteSessionGateway {
             let count = session.transcript.messages.count
             let hi = min(max(beforeIndex, 0), count)
             let lo = max(0, hi - clamped)
+            // Capture the epoch BEFORE the async serialize below. If a
+            // structural change lands on this same session while a truncated
+            // tool call's full content is being fetched, the concurrent
+            // resync snapshot already advances the client past this page's
+            // (now stale) positions — stamping the page with the epoch read
+            // AFTER the await would make it match the client's post-resync
+            // epoch and be wrongly accepted. Drop it instead.
+            let capturedEpoch = session.transcript.changeLog.epoch
             let wire = await wireMessages(id: id, session: session, indices: Array(lo..<hi))
-            // Stamp with the CURRENT epoch: if it moved past the client's,
-            // the client drops the page and the pending resync wins.
+            guard session.transcript.changeLog.epoch == capturedEpoch else { return }
             send(.transcriptPage(sessionId: id,
-                                 epoch: session.transcript.changeLog.epoch,
+                                 epoch: capturedEpoch,
                                  firstIndex: lo,
                                  messages: wire))
         }

--- a/Alas/Sources/Remote/Gateway/RemoteTranscriptSync.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteTranscriptSync.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Per-connection, per-session sync bookkeeping for incremental transcript
+/// delivery: tracks how much of the change log this connection has already
+/// been sent (`sentVersion`), which transcript epoch/outgoing delta counter
+/// the client is on, and a small FIFO cache of fetched full tool-call content
+/// so repeated dirty ticks on other messages don't re-fetch it.
+@MainActor
+final class RemoteTranscriptSync {
+    static let tailWindow = ACPTranscript.maxVisibleRows        // 90
+    static let pageLimitRange = 1...200
+    /// Above this many dirty messages, a tail re-snapshot is cheaper than a delta.
+    static let dirtyResnapshotThreshold = 200
+    static let toolContentCacheLimit = 128
+
+    var sentVersion = 0     // change-log version covered by the last send
+    var epoch = 0           // transcript epoch the client knows
+    var revision = 0        // per-connection outgoing delta counter
+    private var toolContent: [String: String] = [:]            // toolCallId → full content
+    private var toolContentOrder: [String] = []                 // FIFO eviction
+
+    func cachedToolContent(_ id: String) -> String? { toolContent[id] }
+    func storeToolContent(_ id: String, _ content: String) {
+        if toolContent[id] == nil {
+            toolContentOrder.append(id)
+            if toolContentOrder.count > Self.toolContentCacheLimit {
+                toolContent[toolContentOrder.removeFirst()] = nil
+            }
+        }
+        toolContent[id] = content
+    }
+    func invalidateToolContent(_ id: String) { toolContent[id] = nil }
+}

--- a/Alas/Sources/Remote/Gateway/RemoteTranscriptSync.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteTranscriptSync.swift
@@ -16,6 +16,14 @@ final class RemoteTranscriptSync {
     var sentVersion = 0     // change-log version covered by the last send
     var epoch = 0           // transcript epoch the client knows
     var revision = 0        // per-connection outgoing delta counter
+    /// Bumped every time `sendSnapshot` runs, regardless of whether `epoch`
+    /// itself changed. A same-epoch snapshot (e.g. from `takeOver` or a
+    /// client resubscribe with no intervening structural change) still
+    /// resets `revision`/`sentVersion` out from under a concurrently
+    /// suspended dirty delta — an epoch-only guard would miss that case, so
+    /// callers that suspend mid-serialize must capture and re-check this
+    /// instead of (or in addition to) `epoch`.
+    var generation = 0
     private var toolContent: [String: String] = [:]            // toolCallId → full content
     private var toolContentOrder: [String] = []                 // FIFO eviction
 

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -8,6 +8,7 @@ struct RemoteWireMessage: Codable, Equatable, Sendable {
     let kind: String          // "user" | "agent" | "thought" | "toolCall" | "fileEdit" | "plan" | "systemNotice"
     let text: String?
     let json: String?         // JSON string for structured kinds; nil otherwise
+    let index: Int            // transcript position; the client orders and windows by this
 }
 
 struct RemoteWorktreeSummary: Codable, Equatable, Sendable {

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -44,10 +44,11 @@ enum RemoteClientMessage: Equatable, Sendable {
     case setMode(sessionId: String, modeId: String)
     case setAutoRun(sessionId: String, enabled: Bool)
     case renameSession(sessionId: String, title: String)
+    case fetchOlder(sessionId: String, beforeIndex: Int, limit: Int)
 }
 
 extension RemoteClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId }
+    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -101,6 +102,11 @@ extension RemoteClientMessage: Codable {
             self = .renameSession(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 title: try c.decode(String.self, forKey: .title))
+        case "fetchOlder":
+            self = .fetchOlder(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                beforeIndex: try c.decode(Int.self, forKey: .beforeIndex),
+                limit: try c.decode(Int.self, forKey: .limit))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
         }
@@ -166,7 +172,23 @@ extension RemoteClientMessage: Codable {
             try c.encode("renameSession", forKey: .type)
             try c.encode(id, forKey: .sessionId)
             try c.encode(title, forKey: .title)
+        case .fetchOlder(let id, let beforeIndex, let limit):
+            try c.encode("fetchOlder", forKey: .type)
+            try c.encode(id, forKey: .sessionId)
+            try c.encode(beforeIndex, forKey: .beforeIndex)
+            try c.encode(limit, forKey: .limit)
         }
+    }
+}
+
+extension RemoteClientMessage {
+    /// Control messages bypass the per-connection serial processing chain
+    /// (RemoteConnection.dispatchMessage): they are idempotent and must not
+    /// queue behind transcript work. Everything else stays strictly ordered
+    /// (e.g. takeOver-before-sendPrompt).
+    var isControl: Bool {
+        if case .stop = self { return true }
+        return false
     }
 }
 
@@ -177,8 +199,14 @@ enum RemoteServerMessage: Equatable, Sendable {
     case agentList(agents: [RemoteAgentOption])
     case sessionCreated(session: RemoteSessionSummary)
     case createSessionFailed(message: String)
-    case transcriptSnapshot(sessionId: String, streamingState: String, canDrive: Bool, messages: [RemoteWireMessage])
-    case transcriptDelta(sessionId: String, streamingState: String, canDrive: Bool, upserts: [RemoteWireMessage])
+    case transcriptSnapshot(
+        sessionId: String, streamingState: String, canDrive: Bool, messages: [RemoteWireMessage],
+        firstIndex: Int, totalCount: Int, epoch: Int, revision: Int)
+    case transcriptDelta(
+        sessionId: String, streamingState: String, canDrive: Bool, upserts: [RemoteWireMessage],
+        epoch: Int, revision: Int)
+    case transcriptPage(sessionId: String, epoch: Int, firstIndex: Int, messages: [RemoteWireMessage])
+    case stopPending(sessionId: String)
     case permissionRequest(sessionId: String, payload: RemotePermissionPayload)
     case permissionResolved(sessionId: String, requestId: Int)
     case questionRequest(sessionId: String, payload: RemoteQuestionPayload)
@@ -200,6 +228,7 @@ extension RemoteServerMessage: Codable {
         case type, sessions, sessionId, streamingState, canDrive, messages, upserts, payload, requestId, message
         case worktrees, agents, session
         case models, modes, currentModel, currentMode, autoRunEnabled, acceptsImages, title
+        case firstIndex, totalCount, epoch, revision
     }
 
     init(from decoder: Decoder) throws {
@@ -219,13 +248,27 @@ extension RemoteServerMessage: Codable {
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 streamingState: try c.decode(String.self, forKey: .streamingState),
                 canDrive: try c.decode(Bool.self, forKey: .canDrive),
-                messages: try c.decode([RemoteWireMessage].self, forKey: .messages))
+                messages: try c.decode([RemoteWireMessage].self, forKey: .messages),
+                firstIndex: try c.decode(Int.self, forKey: .firstIndex),
+                totalCount: try c.decode(Int.self, forKey: .totalCount),
+                epoch: try c.decode(Int.self, forKey: .epoch),
+                revision: try c.decode(Int.self, forKey: .revision))
         case "transcriptDelta":
             self = .transcriptDelta(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 streamingState: try c.decode(String.self, forKey: .streamingState),
                 canDrive: try c.decode(Bool.self, forKey: .canDrive),
-                upserts: try c.decode([RemoteWireMessage].self, forKey: .upserts))
+                upserts: try c.decode([RemoteWireMessage].self, forKey: .upserts),
+                epoch: try c.decode(Int.self, forKey: .epoch),
+                revision: try c.decode(Int.self, forKey: .revision))
+        case "transcriptPage":
+            self = .transcriptPage(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                epoch: try c.decode(Int.self, forKey: .epoch),
+                firstIndex: try c.decode(Int.self, forKey: .firstIndex),
+                messages: try c.decode([RemoteWireMessage].self, forKey: .messages))
+        case "stopPending":
+            self = .stopPending(sessionId: try c.decode(String.self, forKey: .sessionId))
         case "permissionRequest":
             self = .permissionRequest(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
@@ -290,18 +333,33 @@ extension RemoteServerMessage: Codable {
         case .createSessionFailed(let message):
             try c.encode("createSessionFailed", forKey: .type)
             try c.encode(message, forKey: .message)
-        case .transcriptSnapshot(let id, let st, let cd, let m):
+        case .transcriptSnapshot(let id, let st, let cd, let m, let firstIndex, let totalCount, let epoch, let revision):
             try c.encode("transcriptSnapshot", forKey: .type)
             try c.encode(id, forKey: .sessionId)
             try c.encode(st, forKey: .streamingState)
             try c.encode(cd, forKey: .canDrive)
             try c.encode(m, forKey: .messages)
-        case .transcriptDelta(let id, let st, let cd, let u):
+            try c.encode(firstIndex, forKey: .firstIndex)
+            try c.encode(totalCount, forKey: .totalCount)
+            try c.encode(epoch, forKey: .epoch)
+            try c.encode(revision, forKey: .revision)
+        case .transcriptDelta(let id, let st, let cd, let u, let epoch, let revision):
             try c.encode("transcriptDelta", forKey: .type)
             try c.encode(id, forKey: .sessionId)
             try c.encode(st, forKey: .streamingState)
             try c.encode(cd, forKey: .canDrive)
             try c.encode(u, forKey: .upserts)
+            try c.encode(epoch, forKey: .epoch)
+            try c.encode(revision, forKey: .revision)
+        case .transcriptPage(let id, let epoch, let firstIndex, let m):
+            try c.encode("transcriptPage", forKey: .type)
+            try c.encode(id, forKey: .sessionId)
+            try c.encode(epoch, forKey: .epoch)
+            try c.encode(firstIndex, forKey: .firstIndex)
+            try c.encode(m, forKey: .messages)
+        case .stopPending(let id):
+            try c.encode("stopPending", forKey: .type)
+            try c.encode(id, forKey: .sessionId)
         case .permissionRequest(let id, let p):
             try c.encode("permissionRequest", forKey: .type)
             try c.encode(id, forKey: .sessionId)

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -190,6 +190,20 @@ extension RemoteClientMessage {
         if case .stop = self { return true }
         return false
     }
+
+    /// Messages that establish or change which turn is active, and so a
+    /// following `stop` must wait for them specifically (not the whole
+    /// ordered queue) before running — otherwise stop could land before a
+    /// still-in-flight `sendPrompt`/`takeOver` finishes, find no active turn
+    /// to cancel, and the turn the user just started would proceed anyway
+    /// right after they pressed Stop. Read/list/config verbs are excluded so
+    /// stop stays fast when a client is simply scrolled up mid-backfill.
+    var isDriveOrdering: Bool {
+        switch self {
+        case .sendPrompt, .takeOver: return true
+        default: return false
+        }
+    }
 }
 
 /// Server → client. `type` discriminates.

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -38,6 +38,12 @@ final class RemoteConnection: @unchecked Sendable {
     /// arrival order — clients rely on this (e.g. a `takeOver` must land before
     /// the `sendPrompt` that follows it). Mutated only on `queue`.
     private var processingTail: Task<Void, Never>?
+    /// Task of the most recently dispatched `isDriveOrdering` message
+    /// (sendPrompt/takeOver). A following `stop` awaits exactly this —
+    /// narrower than the full `processingTail` — so it lands after a turn
+    /// the user just started without being blocked by unrelated queued read
+    /// work (subscribe/fetchOlder/list*/etc). Mutated only on `queue`.
+    private var lastDriveActionTail: Task<Void, Never>?
     /// Reassembles fragmented WebSocket messages before they're decoded.
     private var reassembler = WebSocketReassembler()
     /// The device this connection authenticated as, set on `queue` once the WS
@@ -281,13 +287,15 @@ final class RemoteConnection: @unchecked Sendable {
               let gateway else { return }
         // Control messages (stop) are idempotent and latency-critical: they
         // don't extend `processingTail`, so messages arriving AFTER stop are
-        // never blocked behind it. They still await whatever was already
-        // in-flight before them, though — a `sendPrompt`/`takeOver` queued
-        // just before stop must be allowed to land first, or stop could find
-        // no active turn to cancel and the just-submitted prompt would go on
-        // to stream anyway after the user already pressed Stop.
+        // never blocked behind it. They still await the most recent DRIVE
+        // action (sendPrompt/takeOver) specifically — not the whole ordered
+        // queue — so a still-in-flight prompt/takeover is allowed to land
+        // first (or stop could find no active turn to cancel and the
+        // just-submitted prompt would stream anyway right after the user
+        // pressed Stop), while unrelated queued read work (subscribe,
+        // fetchOlder, list*, etc.) never blocks stop.
         if msg.isControl {
-            let previous = processingTail
+            let previous = lastDriveActionTail
             Task { @MainActor in
                 await previous?.value
                 await gateway.handle(msg)
@@ -295,9 +303,13 @@ final class RemoteConnection: @unchecked Sendable {
             return
         }
         let previous = processingTail
-        processingTail = Task { @MainActor in
+        let task = Task { @MainActor in
             await previous?.value
             await gateway.handle(msg)
+        }
+        processingTail = task
+        if msg.isDriveOrdering {
+            lastDriveActionTail = task
         }
     }
 

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -325,16 +325,26 @@ final class RemoteConnection: @unchecked Sendable {
                     // instead: whichever finishes first resumes it, and the
                     // loser keeps running independently in the background,
                     // its own eventual resume attempt becoming a no-op.
-                    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    let timedOut = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                         let resume = SingleResume(continuation)
                         Task { @MainActor in
                             await previous.value
-                            resume.fire()
+                            resume.fire(false)
                         }
                         Task { @MainActor in
                             try? await Task.sleep(nanoseconds: Self.stopDriveActionWaitNanos)
-                            resume.fire()
+                            resume.fire(true)
                         }
+                    }
+                    if timedOut {
+                        // The drive action never finished in time. It's still
+                        // queued and WILL eventually run once its own
+                        // predecessor clears — cancel it so the dispatch
+                        // below (which checks isCancelled before calling
+                        // gateway.handle) skips it instead of submitting a
+                        // prompt/takeover after the user already pressed
+                        // Stop, silently defeating the emergency brake.
+                        previous.cancel()
                     }
                 }
                 await gateway.handle(msg)
@@ -344,6 +354,12 @@ final class RemoteConnection: @unchecked Sendable {
         let previous = processingTail
         let task = Task { @MainActor in
             await previous?.value
+            // Only drive-ordering tasks are ever explicitly cancelled (by a
+            // timed-out stop, above) — this check is a no-op for every other
+            // message type, which nothing cancels.
+            if msg.isDriveOrdering {
+                guard !Task.isCancelled else { return }
+            }
             await gateway.handle(msg)
         }
         processingTail = task
@@ -398,22 +414,23 @@ final class RemoteConnection: @unchecked Sendable {
     }
 }
 
-/// Resumes a `CheckedContinuation<Void, Never>` at most once. Used to race
-/// two independent tasks (e.g. "did the prior work finish" vs. "did the
-/// timeout elapse") where whichever finishes first should win and the other
+/// Resumes a `CheckedContinuation<T, Never>` at most once with the given
+/// value. Used to race two independent tasks (e.g. "did the prior work
+/// finish" vs. "did the timeout elapse") where whichever finishes first
+/// wins — its value is what the continuation resumes with — and the other
 /// is simply abandoned rather than cancelled.
 @MainActor
-private final class SingleResume {
+private final class SingleResume<T> {
     private var fired = false
-    private let continuation: CheckedContinuation<Void, Never>
+    private let continuation: CheckedContinuation<T, Never>
 
-    init(_ continuation: CheckedContinuation<Void, Never>) {
+    init(_ continuation: CheckedContinuation<T, Never>) {
         self.continuation = continuation
     }
 
-    func fire() {
+    func fire(_ value: T) {
         guard !fired else { return }
         fired = true
-        continuation.resume()
+        continuation.resume(returning: value)
     }
 }

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -279,12 +279,19 @@ final class RemoteConnection: @unchecked Sendable {
     private func dispatchMessage(_ payload: Data) {
         guard let msg = try? JSONDecoder().decode(RemoteClientMessage.self, from: payload),
               let gateway else { return }
-        // Control messages (stop) are idempotent and latency-critical: run
-        // them immediately instead of queueing behind transcript work.
-        // Everything else keeps strict arrival order (takeOver before
-        // sendPrompt, etc.).
+        // Control messages (stop) are idempotent and latency-critical: they
+        // don't extend `processingTail`, so messages arriving AFTER stop are
+        // never blocked behind it. They still await whatever was already
+        // in-flight before them, though — a `sendPrompt`/`takeOver` queued
+        // just before stop must be allowed to land first, or stop could find
+        // no active turn to cancel and the just-submitted prompt would go on
+        // to stream anyway after the user already pressed Stop.
         if msg.isControl {
-            Task { @MainActor in await gateway.handle(msg) }
+            let previous = processingTail
+            Task { @MainActor in
+                await previous?.value
+                await gateway.handle(msg)
+            }
             return
         }
         let previous = processingTail

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -279,6 +279,14 @@ final class RemoteConnection: @unchecked Sendable {
     private func dispatchMessage(_ payload: Data) {
         guard let msg = try? JSONDecoder().decode(RemoteClientMessage.self, from: payload),
               let gateway else { return }
+        // Control messages (stop) are idempotent and latency-critical: run
+        // them immediately instead of queueing behind transcript work.
+        // Everything else keeps strict arrival order (takeOver before
+        // sendPrompt, etc.).
+        if msg.isControl {
+            Task { @MainActor in await gateway.handle(msg) }
+            return
+        }
         let previous = processingTail
         processingTail = Task { @MainActor in
             await previous?.value

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -73,6 +73,14 @@ final class RemoteConnection: @unchecked Sendable {
     private static let maxHeaderBytes = 64 * 1024
     private static let maxBodyBytes = 1 << 20   // 1 MB
 
+    /// Cap on how long a control message (stop) waits for a preceding drive
+    /// action's own task — which itself waits on whatever ordered read work
+    /// preceded IT — before running anyway regardless of whether that chain
+    /// finished. Generous for normal-speed reads/lease-confirms; short
+    /// enough that stop remains a reliable emergency brake if something
+    /// ahead of it is genuinely stuck.
+    private static let stopDriveActionWaitNanos: UInt64 = 1_000_000_000
+
     func start() {
         conn.start(queue: queue)
         receive()
@@ -292,12 +300,43 @@ final class RemoteConnection: @unchecked Sendable {
         // queue — so a still-in-flight prompt/takeover is allowed to land
         // first (or stop could find no active turn to cancel and the
         // just-submitted prompt would stream anyway right after the user
-        // pressed Stop), while unrelated queued read work (subscribe,
-        // fetchOlder, list*, etc.) never blocks stop.
+        // pressed Stop).
+        //
+        // That drive action's own task still chains behind whatever ordered
+        // read work (subscribe/fetchOlder/list*/etc.) preceded IT, though —
+        // `await previous?.value` inside its body is unavoidable, since the
+        // drive action genuinely cannot run before its predecessor. If that
+        // predecessor is stuck (not just normally slow), waiting on it here
+        // would block stop indefinitely too, defeating its purpose as an
+        // always-available emergency brake. Bound the wait: ordered read
+        // work is fast under normal conditions (Task 4/6 fixed the
+        // MainActor-saturating case), so this window is generous for the
+        // common case but still guarantees stop is never stuck for good.
         if msg.isControl {
             let previous = lastDriveActionTail
             Task { @MainActor in
-                await previous?.value
+                if let previous {
+                    // `Task<Void, Never>.value` cannot be interrupted by
+                    // cancellation (it has no error channel to abort
+                    // through), so a `withTaskGroup` race here would still
+                    // block at the group's implicit exit-reap until
+                    // `previous` itself finishes — defeating the bound
+                    // entirely. Race via a manually-resumed continuation
+                    // instead: whichever finishes first resumes it, and the
+                    // loser keeps running independently in the background,
+                    // its own eventual resume attempt becoming a no-op.
+                    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                        let resume = SingleResume(continuation)
+                        Task { @MainActor in
+                            await previous.value
+                            resume.fire()
+                        }
+                        Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: Self.stopDriveActionWaitNanos)
+                            resume.fire()
+                        }
+                    }
+                }
                 await gateway.handle(msg)
             }
             return
@@ -356,5 +395,25 @@ final class RemoteConnection: @unchecked Sendable {
         let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
         let digest = Insecure.SHA1.hash(data: Data((key + magic).utf8))
         return Data(digest).base64EncodedString()
+    }
+}
+
+/// Resumes a `CheckedContinuation<Void, Never>` at most once. Used to race
+/// two independent tasks (e.g. "did the prior work finish" vs. "did the
+/// timeout elapse") where whichever finishes first should win and the other
+/// is simply abandoned rather than cancelled.
+@MainActor
+private final class SingleResume {
+    private var fired = false
+    private let continuation: CheckedContinuation<Void, Never>
+
+    init(_ continuation: CheckedContinuation<Void, Never>) {
+        self.continuation = continuation
+    }
+
+    func fire() {
+        guard !fired else { return }
+        fired = true
+        continuation.resume()
     }
 }

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -295,9 +295,12 @@ final class RemoteConnection: @unchecked Sendable {
     }
 
     private func sendServerMessage(_ msg: RemoteServerMessage) {
-        guard let data = try? JSONEncoder().encode(msg) else { return }
+        // Encode on the connection's serial queue, not the caller's
+        // MainActor context — outbound serialization must never compete
+        // with ACP state mutation for main-thread time.
         onQueue { [weak self] in
-            self?.send(WebSocketFrame.encode(opcode: .text, payload: data)) {}
+            guard let self, let data = try? JSONEncoder().encode(msg) else { return }
+            self.send(WebSocketFrame.encode(opcode: .text, payload: data)) {}
         }
     }
 

--- a/AlasTests/ACP/ACPTranscriptChangeLogTests.swift
+++ b/AlasTests/ACP/ACPTranscriptChangeLogTests.swift
@@ -71,4 +71,69 @@ struct ACPTranscriptChangeLogTests {
         // A stale consumer from before the release must resync, not read a gap.
         #expect(log.changes(since: consumed) == .resync)
     }
+
+    // MARK: - ACPTranscript hooks
+
+    private func makeTrackedTranscript(messageCount: Int) -> ACPTranscript {
+        let t = ACPTranscript()
+        t.messages = (0..<messageCount).map { i in
+            .user(id: UUID(), messageId: "u\(i)", text: "m\(i)", attachments: [])
+        }
+        t.changeLog.retainTracking()
+        return t
+    }
+
+    @Test func appendIsRecordedAsDirtyIndex() {
+        let t = makeTrackedTranscript(messageCount: 3)
+        let consumed = t.changeLog.latestVersion
+        t.messages.append(.systemNotice(id: UUID(), text: "notice"))
+        #expect(t.changeLog.changes(since: consumed) == .dirty([3]))
+    }
+
+    @Test func inPlaceMutationKeepingIdentityIsRecordedAsDirty() {
+        let t = ACPTranscript()
+        var tc = ACPMessage.ToolCall(toolCallId: "tc1", title: "read", status: "in_progress", content: "", preview: "")
+        t.messages = [.toolCall(tc)]
+        t.changeLog.retainTracking()
+        let consumed = t.changeLog.latestVersion
+        tc.status = "completed"
+        t.messages[0] = .toolCall(tc)
+        #expect(t.changeLog.changes(since: consumed) == .dirty([0]))
+        #expect(t.changeLog.epoch == 0)
+    }
+
+    @Test func removalIsStructural() {
+        let t = makeTrackedTranscript(messageCount: 3)
+        let epochBefore = t.changeLog.epoch
+        t.messages.removeLast()
+        #expect(t.changeLog.epoch == epochBefore + 1)
+    }
+
+    @Test func identityChangeAtExistingIndexIsStructural() {
+        let t = makeTrackedTranscript(messageCount: 3)
+        let epochBefore = t.changeLog.epoch
+        // Prepending shifts every identity; the diff sees index 0's stableId change.
+        t.messages.insert(.systemNotice(id: UUID(), text: "older"), at: 0)
+        #expect(t.changeLog.epoch == epochBefore + 1)
+    }
+
+    @Test func streamingChangeIsRecordedWithoutArrayMutation() {
+        let t = ACPTranscript()
+        let buf = StreamingText("hel")
+        t.messages = [.agent(id: UUID(), messageId: "a1", buf)]
+        t.changeLog.retainTracking()
+        let consumed = t.changeLog.latestVersion
+        let tickBefore = t.streamingTick
+        buf.append("lo")                    // no didSet fires (identity equality)
+        t.noteStreamingChange(at: 0)
+        #expect(t.streamingTick == tickBefore &+ 1)
+        #expect(t.changeLog.changes(since: consumed) == .dirty([0]))
+    }
+
+    @Test func untrackedTranscriptPaysNoDiffAndRecordsNothing() {
+        let t = ACPTranscript()
+        t.messages = [.systemNotice(id: UUID(), text: "x")]
+        t.messages.append(.systemNotice(id: UUID(), text: "y"))
+        #expect(t.changeLog.latestVersion == 0)
+    }
 }

--- a/AlasTests/ACP/ACPTranscriptChangeLogTests.swift
+++ b/AlasTests/ACP/ACPTranscriptChangeLogTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct ACPTranscriptChangeLogTests {
+    @Test func recordsNothingWhileNotTracking() {
+        let log = ACPTranscriptChangeLog()
+        log.record(index: 3)
+        #expect(log.latestVersion == 0)
+        #expect(log.changes(since: 0) == .none)
+    }
+
+    @Test func recordsDirtyIndicesWhileTracking() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        log.record(index: 3)
+        log.record(index: 5)
+        #expect(log.changes(since: 0) == .dirty([3, 5]))
+        #expect(log.changes(since: log.latestVersion) == .none)
+    }
+
+    @Test func consecutiveSameIndexCoalescesIntoOneEntry() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        let consumed = log.latestVersion
+        for _ in 0..<100 { log.record(index: 7) }   // streaming burst
+        #expect(log.changes(since: consumed) == .dirty([7]))
+        // A consumer that read mid-burst still sees the entry (version was bumped in place).
+        let mid = log.latestVersion - 10
+        #expect(log.changes(since: mid) == .dirty([7]))
+    }
+
+    @Test func structuralChangeBumpsEpochAndForcesResync() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        log.record(index: 1)
+        let consumed = log.latestVersion
+        let epochBefore = log.epoch
+        log.recordStructural()
+        #expect(log.epoch == epochBefore + 1)
+        #expect(log.changes(since: consumed) == .resync)
+        #expect(log.changes(since: log.latestVersion) == .none)
+    }
+
+    @Test func prunedHistoryForcesResync() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        log.record(index: 0)
+        let consumed = log.latestVersion
+        // Overflow the ring: alternate indices so entries don't coalesce.
+        for i in 0..<(ACPTranscriptChangeLog.maxEntries + 10) {
+            log.record(index: 1 + (i % 2))
+        }
+        #expect(log.changes(since: consumed) == .resync)
+    }
+
+    @Test func releasingLastTrackerClearsEntries() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        log.retainTracking()
+        log.record(index: 2)
+        let consumed = 0
+        log.releaseTracking()
+        #expect(log.changes(since: consumed) == .dirty([2]))   // still one tracker
+        log.releaseTracking()
+        #expect(log.isTracking == false)
+        let versionBefore = log.latestVersion
+        log.record(index: 9)                                    // ignored while untracked
+        #expect(log.latestVersion == versionBefore)
+        // A stale consumer from before the release must resync, not read a gap.
+        #expect(log.changes(since: consumed) == .resync)
+    }
+}

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -454,4 +454,14 @@ struct RemoteProtocolTests {
         #expect(!RemoteClientMessage.takeOver(sessionId: "s").isControl)
         #expect(!RemoteClientMessage.fetchOlder(sessionId: "s", beforeIndex: 0, limit: 1).isControl)
     }
+
+    @Test func onlySendPromptAndTakeOverAreDriveOrdering() {
+        #expect(RemoteClientMessage.sendPrompt(sessionId: "s", text: "hi", attachments: []).isDriveOrdering)
+        #expect(RemoteClientMessage.takeOver(sessionId: "s").isDriveOrdering)
+        #expect(!RemoteClientMessage.subscribe(sessionId: "s").isDriveOrdering)
+        #expect(!RemoteClientMessage.fetchOlder(sessionId: "s", beforeIndex: 0, limit: 1).isDriveOrdering)
+        #expect(!RemoteClientMessage.stop(sessionId: "s").isDriveOrdering)
+        #expect(!RemoteClientMessage.setModel(sessionId: "s", modelId: "m").isDriveOrdering)
+        #expect(!RemoteClientMessage.listSessions.isDriveOrdering)
+    }
 }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -45,7 +45,11 @@ struct RemoteProtocolTests {
             sessionId: "s1",
             streamingState: "streaming",
             canDrive: false,
-            messages: [RemoteWireMessage(stableId: "m0", kind: "agent", text: "hi", json: nil)]
+            messages: [RemoteWireMessage(stableId: "m0", kind: "agent", text: "hi", json: nil, index: 0)],
+            firstIndex: 0,
+            totalCount: 1,
+            epoch: 0,
+            revision: 0
         )
         #expect(try roundTrip(snap) == snap)
     }
@@ -193,7 +197,9 @@ struct RemoteProtocolTests {
             sessionId: "s1",
             streamingState: "idle",
             canDrive: false,
-            upserts: [RemoteWireMessage(stableId: "m1", kind: "toolCall", text: nil, json: #"{"name":"bash"}"#)]
+            upserts: [RemoteWireMessage(stableId: "m1", kind: "toolCall", text: nil, json: #"{"name":"bash"}"#, index: 1)],
+            epoch: 0,
+            revision: 0
         )
         #expect(try roundTrip(delta) == delta)
     }
@@ -328,7 +334,9 @@ struct RemoteProtocolTests {
     }
 
     @Test func snapshotCarriesCanDrive() throws {
-        let snap = RemoteServerMessage.transcriptSnapshot(sessionId: "s1", streamingState: "idle", canDrive: true, messages: [])
+        let snap = RemoteServerMessage.transcriptSnapshot(
+            sessionId: "s1", streamingState: "idle", canDrive: true, messages: [],
+            firstIndex: 0, totalCount: 0, epoch: 0, revision: 0)
         let data = try JSONEncoder().encode(snap)
         #expect(try JSONDecoder().decode(RemoteServerMessage.self, from: data) == snap)
     }
@@ -399,5 +407,51 @@ struct RemoteProtocolTests {
             text: "look",
             attachments: [RemoteAttachment(name: "a.png", mimeType: "image/png", dataBase64: "AAAA")])
         #expect(try roundTrip(msg) == msg)
+    }
+
+    @Test func fetchOlderRoundTrips() throws {
+        let msg = RemoteClientMessage.fetchOlder(sessionId: "s1", beforeIndex: 120, limit: 90)
+        let data = try JSONEncoder().encode(msg)
+        let decoded = try JSONDecoder().decode(RemoteClientMessage.self, from: data)
+        #expect(decoded == msg)
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains(#""type":"fetchOlder""#))
+    }
+
+    @Test func windowedSnapshotRoundTrips() throws {
+        let wire = [RemoteWireMessage(stableId: "m110", kind: "agent", text: "hi", json: nil, index: 110)]
+        let msg = RemoteServerMessage.transcriptSnapshot(
+            sessionId: "s1", streamingState: "idle", canDrive: true,
+            messages: wire, firstIndex: 110, totalCount: 200, epoch: 3, revision: 0)
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: JSONEncoder().encode(msg))
+        #expect(decoded == msg)
+    }
+
+    @Test func deltaCarriesEpochAndRevision() throws {
+        let msg = RemoteServerMessage.transcriptDelta(
+            sessionId: "s1", streamingState: "streaming", canDrive: false,
+            upserts: [], epoch: 3, revision: 7)
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: JSONEncoder().encode(msg))
+        #expect(decoded == msg)
+    }
+
+    @Test func transcriptPageRoundTrips() throws {
+        let wire = [RemoteWireMessage(stableId: "m20", kind: "user", text: "old", json: nil, index: 20)]
+        let msg = RemoteServerMessage.transcriptPage(sessionId: "s1", epoch: 3, firstIndex: 20, messages: wire)
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: JSONEncoder().encode(msg))
+        #expect(decoded == msg)
+    }
+
+    @Test func stopPendingRoundTrips() throws {
+        let msg = RemoteServerMessage.stopPending(sessionId: "s1")
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: JSONEncoder().encode(msg))
+        #expect(decoded == msg)
+    }
+
+    @Test func onlyStopIsControl() {
+        #expect(RemoteClientMessage.stop(sessionId: "s").isControl)
+        #expect(!RemoteClientMessage.subscribe(sessionId: "s").isControl)
+        #expect(!RemoteClientMessage.takeOver(sessionId: "s").isControl)
+        #expect(!RemoteClientMessage.fetchOlder(sessionId: "s", beforeIndex: 0, limit: 1).isControl)
     }
 }

--- a/AlasTests/Remote/RemoteServerIntegrationTests.swift
+++ b/AlasTests/Remote/RemoteServerIntegrationTests.swift
@@ -165,6 +165,62 @@ struct RemoteServerIntegrationTests {
         server.stop()
     }
 
+    // Regression (codex review, PR #775): stop must NOT wait for unrelated
+    // queued read work (e.g. a scroll-triggered fetchOlder backfill) — only
+    // for a preceding sendPrompt/takeOver. Otherwise the original blocking-
+    // queue latency the fast lane exists to fix would reappear whenever a
+    // client scrolls up and then presses Stop.
+    @Test func stopBypassesBlockedNonDriveFetchOlder() async throws {
+        let provider = FakeSessionsProvider()
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: String(repeating: "abcdef0123456789", count: 400), preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        // 100 messages: the tail-window snapshot (last 90) excludes index 0,
+        // so subscribing never fetches its content — fetchOlder below does
+        // the first, pausable fetch.
+        s.transcript.messages = [.toolCall(toolCall)] + (0..<99).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions[s.id] = s
+        provider.fullToolCallContents["\(s.id)|old"] = "full content"
+        provider.pauseFullToolCallContentOnCall = 1   // suspends inside the gateway's own await chain
+        let pairing = RemotePairingService(store: InMemoryDeviceStore())
+        let (server, port) = try await startServer(pairing: pairing, provider: provider)
+
+        let code = pairing.beginPairing()
+        var pairReq = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/pair")!)
+        pairReq.httpMethod = "POST"
+        pairReq.httpBody = Data(#"{"code":"\#(code)","deviceName":"test"}"#.utf8)
+        let (pairData, _) = try await URLSession.shared.data(for: pairReq)
+        struct PairResp: Decodable { let token: String }
+        let token = try JSONDecoder().decode(PairResp.self, from: pairData).token
+
+        let wsURL = URL(string: "ws://127.0.0.1:\(port)/ws")!
+        let task = URLSession.shared.webSocketTask(with: wsURL, protocols: [token])
+        task.resume()
+
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.subscribe(sessionId: s.id))))
+        try await task.send(.data(JSONEncoder().encode(
+            RemoteClientMessage.fetchOlder(sessionId: s.id, beforeIndex: 10, limit: 90))))
+        for _ in 0..<100 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.stop(sessionId: s.id))))
+
+        // stop must land while fetchOlder is still parked on its continuation.
+        for _ in 0..<100 where provider.stopped.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.stopped == [s.id])
+
+        provider.resumeFullToolCallContent("full content")
+        task.cancel(with: .goingAway, reason: nil)
+        server.stop()
+    }
+
     @Test func revokingDeviceDropsLiveWebSocket() async throws {
         let provider = FakeSessionsProvider()
         let mgr = try makeManager()

--- a/AlasTests/Remote/RemoteServerIntegrationTests.swift
+++ b/AlasTests/Remote/RemoteServerIntegrationTests.swift
@@ -71,7 +71,7 @@ struct RemoteServerIntegrationTests {
         @unknown default: payload = nil
         }
         guard let data = payload,
-              case .transcriptSnapshot(_, _, _, let msgs)? = try? JSONDecoder().decode(RemoteServerMessage.self, from: data) else {
+              case .transcriptSnapshot(_, _, _, let msgs, _, _, _, _)? = try? JSONDecoder().decode(RemoteServerMessage.self, from: data) else {
             Issue.record("expected snapshot frame, got \(received)")
             task.cancel(with: .goingAway, reason: nil)
             server.stop()

--- a/AlasTests/Remote/RemoteServerIntegrationTests.swift
+++ b/AlasTests/Remote/RemoteServerIntegrationTests.swift
@@ -221,6 +221,68 @@ struct RemoteServerIntegrationTests {
         server.stop()
     }
 
+    // Regression (codex review, PR #775): the preceding fix made stop await
+    // the drive action's own task, but that task itself still chains behind
+    // whatever ordered read work preceded IT — so a drive action queued
+    // right behind a STUCK (not just slow) read still transitively blocks
+    // stop, reintroducing the "stop takes forever" failure mode the fast
+    // lane exists to prevent. Stop must give up waiting after a bounded
+    // interval and act as an emergency brake regardless.
+    @Test func stopIsBoundedWhenDriveActionIsQueuedBehindStuckReadWork() async throws {
+        let provider = FakeSessionsProvider()
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: String(repeating: "abcdef0123456789", count: 400), preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        s.transcript.messages = [.toolCall(toolCall)] + (0..<99).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions[s.id] = s
+        provider.fullToolCallContents["\(s.id)|old"] = "full content"
+        // Never resumed in this test — simulates a genuinely stuck read.
+        provider.pauseFullToolCallContentOnCall = 1
+        let pairing = RemotePairingService(store: InMemoryDeviceStore())
+        let (server, port) = try await startServer(pairing: pairing, provider: provider)
+
+        let code = pairing.beginPairing()
+        var pairReq = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/pair")!)
+        pairReq.httpMethod = "POST"
+        pairReq.httpBody = Data(#"{"code":"\#(code)","deviceName":"test"}"#.utf8)
+        let (pairData, _) = try await URLSession.shared.data(for: pairReq)
+        struct PairResp: Decodable { let token: String }
+        let token = try JSONDecoder().decode(PairResp.self, from: pairData).token
+
+        let wsURL = URL(string: "ws://127.0.0.1:\(port)/ws")!
+        let task = URLSession.shared.webSocketTask(with: wsURL, protocols: [token])
+        task.resume()
+
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.subscribe(sessionId: s.id))))
+        try await task.send(.data(JSONEncoder().encode(
+            RemoteClientMessage.fetchOlder(sessionId: s.id, beforeIndex: 10, limit: 90))))
+        for _ in 0..<100 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        // Queue a drive action right behind the stuck fetchOlder, then stop.
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.takeOver(sessionId: s.id))))
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.stop(sessionId: s.id))))
+
+        // Stop must land within the bounded wait even though fetchOlder (and
+        // thus the queued takeOver behind it) never completes.
+        for _ in 0..<150 where provider.stopped.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.stopped == [s.id])
+        // The queued takeOver never got to run — proves stop didn't wait
+        // for the full chain to actually resolve.
+        #expect(provider.takeOverCallCount == 0)
+
+        provider.resumeFullToolCallContent("full content")   // avoid a leaked continuation
+        task.cancel(with: .goingAway, reason: nil)
+        server.stop()
+    }
+
     @Test func revokingDeviceDropsLiveWebSocket() async throws {
         let provider = FakeSessionsProvider()
         let mgr = try makeManager()

--- a/AlasTests/Remote/RemoteServerIntegrationTests.swift
+++ b/AlasTests/Remote/RemoteServerIntegrationTests.swift
@@ -119,6 +119,52 @@ struct RemoteServerIntegrationTests {
         server.stop()
     }
 
+    // Regression (codex review, PR #775): the fast-lane stop dispatch must
+    // still wait for a preceding drive action (takeOver/sendPrompt) that's
+    // already in flight — otherwise stop can overtake it, find no active
+    // turn to cancel, and the queued action proceeds anyway right after the
+    // user pressed Stop.
+    @Test func stopWaitsForPrecedingTakeOverBeforeRunning() async throws {
+        let provider = FakeSessionsProvider()
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        provider.sessions[s.id] = s
+        provider.pauseTakeOver = true   // suspends inside the gateway's own await chain
+        let pairing = RemotePairingService(store: InMemoryDeviceStore())
+        let (server, port) = try await startServer(pairing: pairing, provider: provider)
+
+        let code = pairing.beginPairing()
+        var pairReq = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/pair")!)
+        pairReq.httpMethod = "POST"
+        pairReq.httpBody = Data(#"{"code":"\#(code)","deviceName":"test"}"#.utf8)
+        let (pairData, _) = try await URLSession.shared.data(for: pairReq)
+        struct PairResp: Decodable { let token: String }
+        let token = try JSONDecoder().decode(PairResp.self, from: pairData).token
+
+        let wsURL = URL(string: "ws://127.0.0.1:\(port)/ws")!
+        let task = URLSession.shared.webSocketTask(with: wsURL, protocols: [token])
+        task.resume()
+
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.takeOver(sessionId: s.id))))
+        for _ in 0..<100 where provider.takeOverCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.stop(sessionId: s.id))))
+
+        // Stop must NOT run while the preceding takeOver is still suspended.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(provider.stopped.isEmpty, "stop must wait for the preceding takeOver to land first")
+
+        provider.resumeTakeOver()
+        for _ in 0..<100 where provider.stopped.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.stopped == [s.id])
+
+        task.cancel(with: .goingAway, reason: nil)
+        server.stop()
+    }
+
     @Test func revokingDeviceDropsLiveWebSocket() async throws {
         let provider = FakeSessionsProvider()
         let mgr = try makeManager()

--- a/AlasTests/Remote/RemoteServerIntegrationTests.swift
+++ b/AlasTests/Remote/RemoteServerIntegrationTests.swift
@@ -283,6 +283,70 @@ struct RemoteServerIntegrationTests {
         server.stop()
     }
 
+    // Regression (codex review, PR #775): the bounded stop wait let stop
+    // proceed after a timeout, but the queued drive action itself was never
+    // cancelled — it was still sitting in processingTail and would run once
+    // its own predecessor eventually cleared, submitting the prompt/takeover
+    // AFTER the user already pressed Stop and silently defeating the
+    // emergency brake. A timed-out stop must cancel the queued drive action
+    // so it never actually executes once unblocked.
+    @Test func stopTimeoutCancelsQueuedDriveActionSoItNeverRuns() async throws {
+        let provider = FakeSessionsProvider()
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: String(repeating: "abcdef0123456789", count: 400), preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        s.transcript.messages = [.toolCall(toolCall)] + (0..<99).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions[s.id] = s
+        provider.fullToolCallContents["\(s.id)|old"] = "full content"
+        provider.pauseFullToolCallContentOnCall = 1
+        let pairing = RemotePairingService(store: InMemoryDeviceStore())
+        let (server, port) = try await startServer(pairing: pairing, provider: provider)
+
+        let code = pairing.beginPairing()
+        var pairReq = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/pair")!)
+        pairReq.httpMethod = "POST"
+        pairReq.httpBody = Data(#"{"code":"\#(code)","deviceName":"test"}"#.utf8)
+        let (pairData, _) = try await URLSession.shared.data(for: pairReq)
+        struct PairResp: Decodable { let token: String }
+        let token = try JSONDecoder().decode(PairResp.self, from: pairData).token
+
+        let wsURL = URL(string: "ws://127.0.0.1:\(port)/ws")!
+        let task = URLSession.shared.webSocketTask(with: wsURL, protocols: [token])
+        task.resume()
+
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.subscribe(sessionId: s.id))))
+        try await task.send(.data(JSONEncoder().encode(
+            RemoteClientMessage.fetchOlder(sessionId: s.id, beforeIndex: 10, limit: 90))))
+        for _ in 0..<100 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.takeOver(sessionId: s.id))))
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.stop(sessionId: s.id))))
+
+        // Wait past stop's bounded wait so it takes the timeout path.
+        for _ in 0..<150 where provider.stopped.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.stopped == [s.id])
+        #expect(provider.takeOverCallCount == 0)
+
+        // Now unblock the stuck predecessor — the queued takeOver's own
+        // `await previous?.value` can finally resolve. With the fix it must
+        // still never call gateway.handle (it was cancelled), so
+        // takeOverCallCount stays 0 even after everything settles.
+        provider.resumeFullToolCallContent("full content")
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(provider.takeOverCallCount == 0, "a timed-out stop must cancel the queued drive action, not just outrace it")
+
+        task.cancel(with: .goingAway, reason: nil)
+        server.stop()
+    }
+
     @Test func revokingDeviceDropsLiveWebSocket() async throws {
         let provider = FakeSessionsProvider()
         let mgr = try makeManager()

--- a/AlasTests/Remote/RemoteServerIntegrationTests.swift
+++ b/AlasTests/Remote/RemoteServerIntegrationTests.swift
@@ -83,6 +83,42 @@ struct RemoteServerIntegrationTests {
         server.stop()
     }
 
+    @Test func stopBypassesBlockedOrderedQueue() async throws {
+        let provider = FakeSessionsProvider()
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        provider.sessions[s.id] = s
+        provider.pauseSessionSummaries = true            // blocks the ordered chain
+        let pairing = RemotePairingService(store: InMemoryDeviceStore())
+        let (server, port) = try await startServer(pairing: pairing, provider: provider)
+
+        // Pair: mint a code in-process (UI would show its QR), redeem via HTTP.
+        let code = pairing.beginPairing()
+        var pairReq = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/pair")!)
+        pairReq.httpMethod = "POST"
+        pairReq.httpBody = Data(#"{"code":"\#(code)","deviceName":"test"}"#.utf8)
+        let (pairData, _) = try await URLSession.shared.data(for: pairReq)
+        struct PairResp: Decodable { let token: String }
+        let token = try JSONDecoder().decode(PairResp.self, from: pairData).token
+
+        // Connect WS with token as subprotocol.
+        let wsURL = URL(string: "ws://127.0.0.1:\(port)/ws")!
+        let task = URLSession.shared.webSocketTask(with: wsURL, protocols: [token])
+        task.resume()
+
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.listSessions)))   // parks the chain
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.stop(sessionId: s.id))))
+        // stop must land while listSessions is still parked on its continuation.
+        for _ in 0..<100 where provider.stopped.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.stopped == [s.id])
+
+        provider.resumeSessionSummaries()
+        task.cancel(with: .goingAway, reason: nil)
+        server.stop()
+    }
+
     @Test func revokingDeviceDropsLiveWebSocket() async throws {
         let provider = FakeSessionsProvider()
         let mgr = try makeManager()

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1715,10 +1715,13 @@ struct RemoteSessionGatewayTests {
 
     // Regression (codex review, PR #775): fetchOlder's page serialization has
     // the same suspend-then-stamp hazard as sendDelta — a structural resync
-    // landing while a truncated tool call's content is being fetched must not
-    // let the page go out stamped with the post-resync epoch (which the
-    // client would wrongly accept as current instead of dropping).
-    @Test func fetchOlderDropsStalePageWhenEpochChangesDuringSerialize() async throws {
+    // landing while a truncated tool call's content is being fetched must
+    // not let the FIRST attempt's page go out stamped with the post-resync
+    // epoch (which the client would wrongly accept as current). It must
+    // instead retry against the now-current state and deliver a correctly
+    // re-stamped, fresh page — not silently drop the request (see the
+    // dedicated retry test below for why silently dropping is itself a bug).
+    @Test func fetchOlderRetriesAndDeliversFreshPageWhenEpochChangesDuringSerialize() async throws {
         let provider = FakeSessionsProvider()
         let fullContent = String(repeating: "abcdef0123456789", count: 400)
         var toolCall = ACPMessage.ToolCall(
@@ -1773,11 +1776,84 @@ struct RemoteSessionGatewayTests {
         }
 
         sent.removeAll()
-        // Resume the page's suspended fetch. With the fix, it must detect the
-        // epoch moved during its await and discard rather than send a stale
-        // page stamped with the new epoch.
+        // Resume the page's suspended fetch. With the fix, it must detect
+        // the epoch moved during its await, retry against the now-current
+        // state, and still deliver a fresh page rather than leaving the
+        // client's request unanswered.
         provider.resumeFullToolCallContent(fullContent)
         await fetchTask.value
-        #expect(sent.isEmpty, "stale page must be discarded once epoch changed during serialize, got \(sent)")
+        guard case .transcriptPage(_, let pageEpoch, let pageFirst, let pageMessages)? = sent.last else {
+            Issue.record("expected a retried page after the epoch changed during serialize, got \(sent)")
+            return
+        }
+        #expect(pageEpoch != 0)   // reflects the post-resync epoch, not the stale captured one
+        #expect(pageFirst == 0)
+        #expect(pageMessages.contains { $0.stableId == "m5" })
+    }
+
+    // Regression (codex review, PR #775): unlike a dropped delta/snapshot
+    // (which the client naturally recovers from via a later resync
+    // snapshot), a fetchOlder page superseded by an ORDINARY same-epoch
+    // delta has no client-side recovery — only a snapshot clears the
+    // client's "loading earlier messages" state, and a normal delta does
+    // not. Silently dropping the page in that case would leave the client
+    // stuck forever. The gateway must retry and still deliver a page.
+    @Test func fetchOlderRetriesAndDeliversPageInsteadOfLeavingClientStuck() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        // 100 messages: the tail-window snapshot (last 90) excludes index 0,
+        // so subscribing never fetches/caches its content — fetchOlder below
+        // performs the first, pausable fetch.
+        session.transcript.messages = [.toolCall(toolCall)] + (0..<99).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))
+        sent.removeAll()
+        provider.fullToolCallContentCallCount = 0
+        provider.pauseFullToolCallContentOnCall = 1   // suspend the page's first fetch attempt
+
+        let fetchTask = Task { @MainActor in
+            await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 10, limit: 90))
+        }
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // A normal, same-epoch delta lands first (e.g. streaming continues
+        // while the user is scrolled up) — this must not leave the pending
+        // fetchOlder request unanswered.
+        session.transcript.messages.append(.systemNotice(id: UUID(), text: "notice"))
+        for _ in 0..<50 where sent.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .transcriptDelta? = sent.last else {
+            Issue.record("expected the concurrent delta to land first, got \(sent)")
+            return
+        }
+
+        sent.removeAll()
+        provider.resumeFullToolCallContent(fullContent)
+        await fetchTask.value
+        guard case .transcriptPage(_, _, let pageFirst, let pageMessages)? = sent.last else {
+            Issue.record("fetchOlder must still deliver a page after being superseded once, got \(sent)")
+            return
+        }
+        #expect(pageFirst == 0)
+        #expect(pageMessages.contains { $0.stableId == "m0" })
+        // The retry reuses the cache the first (superseded) attempt already
+        // populated — no second real fetch needed.
+        #expect(provider.fullToolCallContentCallCount == 1)
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1531,6 +1531,71 @@ struct RemoteSessionGatewayTests {
         #expect(sent.isEmpty, "stale overlapping delta must be discarded, got \(sent)")
     }
 
+    // Regression (codex review, PR #775): discarding a superseded dirty
+    // delta must not silently lose the mutation it would have carried.
+    // sentVersion used to advance BEFORE the await, so a delta that got
+    // discarded still "consumed" its indices from the change log's
+    // perspective — the next delta would never re-offer them, losing the
+    // mutation until a full resync. sentVersion must only commit once the
+    // delta is actually accepted, so a superseding delta naturally re-picks
+    // up whatever the discarded one would have sent.
+    @Test func overlappingDirtyDeltaStillDeliversDiscardedMutation() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "in_progress",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        session.transcript.messages = [.toolCall(toolCall)] + (0..<5).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))   // caches "old"'s content
+        sent.removeAll()
+        provider.fullToolCallContentCallCount = 0
+        provider.pauseFullToolCallContentOnCall = 1   // suspend mutation #1's re-fetch
+
+        // Mutation #1: the tool call — invalidates its cache and suspends
+        // its own delta while re-fetching.
+        if case .toolCall(var tc) = session.transcript.messages[0] {
+            tc.status = "completed"
+            session.transcript.messages[0] = .toolCall(tc)
+        }
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // Mutation #2: an appended message. Its own coalesced delta must
+        // include BOTH this new index AND mutation #1's index, because
+        // sentVersion was NOT prematurely advanced by the still-suspended
+        // (and about-to-be-discarded) delta from mutation #1.
+        session.transcript.messages.append(.systemNotice(id: UUID(), text: "notice"))
+        for _ in 0..<50 where sent.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .transcriptDelta(_, _, _, let upserts, _, _)? = sent.last else {
+            Issue.record("expected the overlapping dirty delta to land, got \(sent)")
+            return
+        }
+        #expect(upserts.contains { $0.kind == "systemNotice" })
+        #expect(
+            upserts.contains { $0.stableId == "m0" && ($0.json?.contains(#""status":"completed""#) ?? false) },
+            "mutation #1's tool-call status change must not be lost, got \(upserts)"
+        )
+
+        sent.removeAll()
+        provider.resumeFullToolCallContent(fullContent)
+        try await Task.sleep(nanoseconds: 250_000_000)   // > coalesce window
+        #expect(sent.isEmpty, "the superseded delta must still discard, got \(sent)")
+    }
+
     // Regression (codex review, PR #775): sendSnapshot bumps `generation`
     // but, unlike the delta/page paths, never re-checked it after its own
     // await — so a snapshot superseded by a concurrent send (another

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1402,4 +1402,72 @@ struct RemoteSessionGatewayTests {
         #expect(sent.isEmpty, "stale delta must be discarded once epoch changed during serialize, got \(sent)")
         #expect(resyncEpoch != 0)   // sanity: the resync did bump the epoch
     }
+
+    // Regression (codex review, PR #775): fetchOlder's page serialization has
+    // the same suspend-then-stamp hazard as sendDelta — a structural resync
+    // landing while a truncated tool call's content is being fetched must not
+    // let the page go out stamped with the post-resync epoch (which the
+    // client would wrongly accept as current instead of dropping).
+    @Test func fetchOlderDropsStalePageWhenEpochChangesDuringSerialize() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        // 100 messages total: the tail-window snapshot (last 90) excludes
+        // index 5, so subscribing never fetches/caches its content — the
+        // fetchOlder page below performs the FIRST fetch for it.
+        session.transcript.messages = (0..<5).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        } + [.toolCall(toolCall)] + (0..<94).map {
+            .user(id: UUID(), messageId: "v\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))
+        guard case .transcriptSnapshot(_, _, _, _, let firstIndex, _, _, _)? = sent.first else {
+            Issue.record("expected snapshot, got \(sent)")
+            return
+        }
+        #expect(firstIndex == 10)   // sanity: index 5 is outside the tail window
+        sent.removeAll()
+        provider.fullToolCallContentCallCount = 0
+        provider.pauseFullToolCallContentOnCall = 1   // suspend the page's fetch below
+
+        let fetchTask = Task { @MainActor in
+            await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 10, limit: 90))
+        }
+
+        // Wait for the fetch request to suspend on the paused tool-content call.
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // While the page is suspended, a structural change lands and its own
+        // coalesced delta resyncs via a fresh snapshot.
+        session.transcript.messages.removeLast()
+        for _ in 0..<50 where !(sent.last.map { if case .transcriptSnapshot = $0 { return true }
+        return false } ?? false) {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .transcriptSnapshot? = sent.last else {
+            Issue.record("expected a resync snapshot from the structural change, got \(sent)")
+            return
+        }
+
+        sent.removeAll()
+        // Resume the page's suspended fetch. With the fix, it must detect the
+        // epoch moved during its await and discard rather than send a stale
+        // page stamped with the new epoch.
+        provider.resumeFullToolCallContent(fullContent)
+        await fetchTask.value
+        #expect(sent.isEmpty, "stale page must be discarded once epoch changed during serialize, got \(sent)")
+    }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1713,6 +1713,89 @@ struct RemoteSessionGatewayTests {
         #expect(snapshotCount == 0, "the superseded re-subscribe snapshot must be discarded, got \(sent)")
     }
 
+    // Regression (codex review, PR #775): a same-epoch snapshot reset
+    // `state.revision = 0` synchronously up front, the same premature-commit
+    // hazard as sentVersion but on the send side. If the snapshot is then
+    // DISCARDED (superseded by a dirty delta claiming a later generation),
+    // that already-happened reset still corrupts the winning delta's own
+    // numbering: it computes `state.revision += 1` off the snapshot's
+    // premature reset (0) instead of the client's actual last-known
+    // revision, producing revision:1 when the client expects N+1 — the
+    // client rejects it and resubscribes, defeating incremental delivery
+    // right when it matters (an active resync race).
+    @Test func sendSnapshotDefersRevisionResetSoSupersedingDeltaStaysInSync() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        session.transcript.messages = (0..<5).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))   // establishes observe(); revision committed at 0
+
+        // Three uncontested dirty deltas first, to establish a non-zero
+        // baseline revision — the bug is invisible when the baseline is
+        // already 0, since a premature reset and a legitimate prior value
+        // of 0 look identical.
+        for i in 0..<3 {
+            sent.removeAll()
+            session.transcript.messages.append(.systemNotice(id: UUID(), text: "warmup \(i)"))
+            for _ in 0..<50 where sent.isEmpty {
+                try await Task.sleep(nanoseconds: 20_000_000)
+            }
+            guard case .transcriptDelta? = sent.last else {
+                Issue.record("expected warmup delta \(i) to land, got \(sent)")
+                return
+            }
+        }
+        // state.revision is now legitimately 3.
+
+        sent.removeAll()
+        provider.fullToolCallContentCallCount = 0
+        provider.pauseFullToolCallContentOnCall = 1   // suspend the re-subscribe snapshot's fetch below
+
+        session.transcript.messages.append(.toolCall(toolCall))
+        let resubscribeTask = Task { @MainActor in
+            await gw.handle(.subscribe(sessionId: "s1"))
+        }
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // The still-active observer reacts to the append with its own
+        // coalesced dirty delta, which supersedes (via generation) the
+        // suspended re-subscribe snapshot.
+        session.transcript.messages.append(.systemNotice(id: UUID(), text: "notice"))
+        for _ in 0..<50 where sent.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .transcriptDelta(_, _, _, _, _, let winningRevision)? = sent.last else {
+            Issue.record("expected the superseding delta to land, got \(sent)")
+            return
+        }
+        #expect(
+            winningRevision == 4,
+            "the superseding delta must continue from the real prior revision (3), not the discarded snapshot's premature reset, got \(winningRevision)"
+        )
+
+        sent.removeAll()
+        provider.resumeFullToolCallContent(fullContent)
+        await resubscribeTask.value
+        let snapshotCount = sent.filter { if case .transcriptSnapshot = $0 { return true }
+        return false }.count
+        #expect(snapshotCount == 0, "the superseded re-subscribe snapshot must still be discarded, got \(sent)")
+    }
+
     // Regression (codex review, PR #775): fetchOlder's page serialization has
     // the same suspend-then-stamp hazard as sendDelta — a structural resync
     // landing while a truncated tool call's content is being fetched must

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -25,6 +25,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var renameSucceeds = true
     var configs: [String: RemoteSessionConfig] = [:]
     var fullToolCallContents: [String: String] = [:]
+    var fullToolCallContentCallCount = 0
     var sessionSummariesCallCount = 0
     var remoteWorktreesCallCount = 0
     var remoteAgentsCallCount = 0
@@ -78,7 +79,8 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     }
 
     func fullToolCallContent(sessionId: String, toolCallId: String) async -> String? {
-        fullToolCallContents["\(sessionId)|\(toolCallId)"]
+        fullToolCallContentCallCount += 1
+        return fullToolCallContents["\(sessionId)|\(toolCallId)"]
     }
 
     func isWriter(for id: String) -> Bool { writers.contains(id) }
@@ -1156,5 +1158,151 @@ struct RemoteSessionGatewayTests {
         }
         // cleanup
         for url in provider.writtenAttachmentURLs { try? FileManager.default.removeItem(at: url) }
+    }
+
+    private func makeSessionWithUserMessages(_ count: Int) throws -> ACPSession {
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        s.transcript.messages = (0..<count).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        return s
+    }
+
+    @Test func snapshotOfLongTranscriptIsTailWindowed() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(200)
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        guard case .transcriptSnapshot(_, _, _, let msgs, let first, let total, _, let revision)? = sent.first else {
+            Issue.record("expected snapshot, got \(sent)"); return
+        }
+        #expect(total == 200)
+        #expect(first == 200 - RemoteTranscriptSync.tailWindow)
+        #expect(msgs.count == RemoteTranscriptSync.tailWindow)
+        #expect(msgs.first?.stableId == "m\(first)")
+        #expect(msgs.first?.index == first)
+        #expect(revision == 0)
+    }
+
+    @Test func deltaCarriesOnlyDirtyMessages() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(50)
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        sent.removeAll()
+        s.transcript.messages.append(.systemNotice(id: UUID(), text: "done"))
+        try await Task.sleep(nanoseconds: 250_000_000)   // > coalesce window
+        let delta = sent.compactMap { msg -> [RemoteWireMessage]? in
+            if case .transcriptDelta(_, _, _, let u, _, _) = msg { return u }
+            return nil
+        }.last
+        #expect(delta?.count == 1)
+        #expect(delta?.first?.index == 50)
+        #expect(delta?.first?.kind == "systemNotice")
+    }
+
+    @Test func structuralChangeTriggersResyncSnapshotWithBumpedEpoch() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(10)
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        guard case .transcriptSnapshot(_, _, _, _, _, _, let epoch0, _)? = sent.first else {
+            Issue.record("expected snapshot"); return
+        }
+        sent.removeAll()
+        s.transcript.messages.removeLast()               // structural
+        try await Task.sleep(nanoseconds: 250_000_000)
+        let resync = sent.last { if case .transcriptSnapshot = $0 { return true }; return false }
+        guard case .transcriptSnapshot(_, _, _, let msgs, _, let total, let epoch1, _)? = resync else {
+            Issue.record("expected resync snapshot, got \(sent)"); return
+        }
+        #expect(epoch1 == epoch0 + 1)
+        #expect(total == 9)
+        #expect(msgs.count == 9)
+    }
+
+    @Test func fetchOlderReturnsClampedPage() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(200)
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        sent.removeAll()
+        await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 110, limit: 90))
+        guard case .transcriptPage(_, _, let first, let msgs)? = sent.last else {
+            Issue.record("expected page, got \(sent)"); return
+        }
+        #expect(first == 20)
+        #expect(msgs.count == 90)
+        #expect(msgs.first?.index == 20)
+        #expect(msgs.last?.index == 109)
+
+        sent.removeAll()
+        await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 10, limit: 500))   // clamp both ends
+        guard case .transcriptPage(_, _, let first2, let msgs2)? = sent.last else {
+            Issue.record("expected page, got \(sent)"); return
+        }
+        #expect(first2 == 0)
+        #expect(msgs2.count == 10)
+    }
+
+    @Test func fetchOlderBeforeSubscribeIsIgnored() async throws {
+        let provider = FakeSessionsProvider()
+        provider.sessions["s1"] = try makeSessionWithUserMessages(5)
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 5, limit: 5))
+        #expect(sent.isEmpty)
+    }
+
+    @Test func truncatedToolContentIsFetchedOnceAcrossSnapshotAndDeltas() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let session = try makeSessionWithAgentText("tail")
+        session.transcript.messages = [.toolCall(toolCall), .agent(id: UUID(), StreamingText("tail"))]
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        #expect(provider.fullToolCallContentCallCount == 1)
+        // A dirty tick on the OTHER message must not re-fetch tool content.
+        session.transcript.messages.append(.systemNotice(id: UUID(), text: "x"))
+        try await Task.sleep(nanoseconds: 250_000_000)
+        #expect(provider.fullToolCallContentCallCount == 1)
+    }
+
+    @Test func unsubscribeReleasesChangeTracking() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(3)
+        provider.sessions["s1"] = s
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        #expect(s.transcript.changeLog.isTracking)
+        await gw.handle(.unsubscribe(sessionId: "s1"))
+        #expect(!s.transcript.changeLog.isTracking)
+    }
+
+    @Test func resubscribeDoesNotLeakTrackingRetains() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(3)
+        provider.sessions["s1"] = s
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        await gw.handle(.subscribe(sessionId: "s1"))   // client resync
+        await gw.handle(.unsubscribe(sessionId: "s1"))
+        #expect(!s.transcript.changeLog.isTracking)
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1531,6 +1531,58 @@ struct RemoteSessionGatewayTests {
         #expect(sent.isEmpty, "stale overlapping delta must be discarded, got \(sent)")
     }
 
+    // Regression (codex review, PR #775): sendSnapshot bumps `generation`
+    // but, unlike the delta/page paths, never re-checked it after its own
+    // await — so a snapshot superseded by a concurrent send (another
+    // snapshot, or a dirty delta) still went out unconditionally. Because
+    // the web client applies snapshots without any epoch/revision ordering
+    // check (unlike deltas), this could roll the client back to stale
+    // content until a later resync happened to correct it.
+    @Test func sendSnapshotDropsStaleSendWhenSupersededDuringSerialize() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        // Small transcript: the tool call is inside the tail window, so
+        // both subscribe's and takeOver's snapshots must serialize it.
+        session.transcript.messages = [.toolCall(toolCall)] + (0..<5).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        provider.pauseFullToolCallContentOnCall = 1   // only subscribe's first fetch pauses
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        let subscribeTask = Task { @MainActor in
+            await gw.handle(.subscribe(sessionId: "s1"))
+        }
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // A concurrent takeOver's own snapshot completes and sends first
+        // (its own fetch is call #2, not paused).
+        await gw.handle(.takeOver(sessionId: "s1"))
+        let snapshotsAfterTakeOver = sent.filter { if case .transcriptSnapshot = $0 { return true }
+        return false }.count
+        #expect(snapshotsAfterTakeOver == 1)
+
+        // Resume subscribe's suspended fetch. With the fix, it must detect
+        // it was superseded and NOT send a second, stale snapshot.
+        provider.resumeFullToolCallContent(fullContent)
+        await subscribeTask.value
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let snapshotCount = sent.filter { if case .transcriptSnapshot = $0 { return true }
+        return false }.count
+        #expect(snapshotCount == 1, "the superseded subscribe snapshot must be discarded, got \(sent)")
+    }
+
     // Regression (codex review, PR #775): fetchOlder's page serialization has
     // the same suspend-then-stamp hazard as sendDelta — a structural resync
     // landing while a truncated tool call's content is being fetched must not

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -32,8 +32,12 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var createRequests: [(worktreeId: String, agentId: String)] = []
     var pauseSessionSummaries = false
     var pauseRemoteWorktrees = false
+    /// 1-indexed call number of `fullToolCallContent` to suspend on (nil = never pause).
+    /// Lets a test freeze exactly one in-flight fetch while later calls proceed normally.
+    var pauseFullToolCallContentOnCall: Int?
     private var sessionSummariesContinuation: CheckedContinuation<[RemoteSessionSummary], Never>?
     private var remoteWorktreesContinuation: CheckedContinuation<[RemoteWorktreeOption], Never>?
+    private var fullToolCallContentContinuation: CheckedContinuation<String?, Never>?
     func sessionSummaries() async -> [RemoteSessionSummary] {
         sessionSummariesCallCount += 1
         if pauseSessionSummaries {
@@ -80,7 +84,16 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
 
     func fullToolCallContent(sessionId: String, toolCallId: String) async -> String? {
         fullToolCallContentCallCount += 1
+        if pauseFullToolCallContentOnCall == fullToolCallContentCallCount {
+            return await withCheckedContinuation { continuation in
+                fullToolCallContentContinuation = continuation
+            }
+        }
         return fullToolCallContents["\(sessionId)|\(toolCallId)"]
+    }
+    func resumeFullToolCallContent(_ value: String?) {
+        fullToolCallContentContinuation?.resume(returning: value)
+        fullToolCallContentContinuation = nil
     }
 
     func isWriter(for id: String) -> Bool { writers.contains(id) }
@@ -1324,5 +1337,69 @@ struct RemoteSessionGatewayTests {
         await gw.handle(.subscribe(sessionId: "s1"))   // client resync
         await gw.handle(.unsubscribe(sessionId: "s1"))
         #expect(!s.transcript.changeLog.isTracking)
+    }
+
+    // Regression (codex review, PR #775): a dirty delta that suspends mid-
+    // serialize (awaiting truncated tool-call content) while a CONCURRENT
+    // structural resync lands on the same session must not resume and send
+    // its now-stale upserts stamped with the resync's new epoch/revision —
+    // the client would wrongly accept them as a legitimate next delta.
+    @Test func deltaDropsStaleUpsertsWhenEpochChangesDuringSerialize() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "in_progress",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        session.transcript.messages = [.toolCall(toolCall)] + (0..<5).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))   // caches "old"'s content
+        sent.removeAll()
+        provider.fullToolCallContentCallCount = 0
+        provider.pauseFullToolCallContentOnCall = 1   // suspend the delta's re-fetch below
+
+        // Mutate the tool call in place (dirty, not structural) — invalidates
+        // its cache and forces a real re-fetch in the resulting delta.
+        if case .toolCall(var tc) = session.transcript.messages[0] {
+            tc.status = "completed"
+            session.transcript.messages[0] = .toolCall(tc)
+        }
+
+        // Wait for the coalesce timer to fire and the delta to suspend on the
+        // paused fetch (call #1).
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // While that delta is suspended, a structural change lands on the
+        // SAME session and its own coalesced delta resyncs via a fresh
+        // snapshot (its tool-content fetch is call #2, not paused).
+        session.transcript.messages.removeLast()
+        for _ in 0..<50 where !(sent.last.map { if case .transcriptSnapshot = $0 { return true }
+        return false } ?? false) {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .transcriptSnapshot(_, _, _, _, _, _, let resyncEpoch, _)? = sent.last else {
+            Issue.record("expected a resync snapshot from the structural change, got \(sent)")
+            return
+        }
+
+        sent.removeAll()
+        // Resume the original delta's suspended fetch. With the fix, it must
+        // detect the epoch moved during its await and discard rather than
+        // send a stale delta stamped with the new epoch.
+        provider.resumeFullToolCallContent(fullContent)
+        try await Task.sleep(nanoseconds: 250_000_000)   // > coalesce window
+        #expect(sent.isEmpty, "stale delta must be discarded once epoch changed during serialize, got \(sent)")
+        #expect(resyncEpoch != 0)   // sanity: the resync did bump the epoch
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -320,7 +320,7 @@ struct RemoteSessionGatewayTests {
 
         await gw.handle(.subscribe(sessionId: "s1"))
         #expect(sent.contains { message in
-            if case .transcriptSnapshot(let id, _, _, _) = message {
+            if case .transcriptSnapshot(let id, _, _, _, _, _, _, _) = message {
                 return id == "s1"
             }
             return false
@@ -391,7 +391,7 @@ struct RemoteSessionGatewayTests {
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         await gw.handle(.subscribe(sessionId: "s1"))
-        guard case .transcriptSnapshot(let id, _, _, let msgs)? = sent.first else {
+        guard case .transcriptSnapshot(let id, _, _, let msgs, _, _, _, _)? = sent.first else {
             Issue.record("expected snapshot, got \(sent)")
             return
         }
@@ -419,7 +419,7 @@ struct RemoteSessionGatewayTests {
 
         await gw.handle(.subscribe(sessionId: "s1"))
 
-        guard case .transcriptSnapshot(_, _, _, let msgs)? = sent.first,
+        guard case .transcriptSnapshot(_, _, _, let msgs, _, _, _, _)? = sent.first,
               let json = msgs.first(where: { $0.kind == "toolCall" })?.json,
               let data = json.data(using: .utf8)
         else {
@@ -452,7 +452,7 @@ struct RemoteSessionGatewayTests {
             if case .transcriptSnapshot = msg { return true }
             return false
         }
-        guard case .transcriptSnapshot(let id, _, let canDrive, _)? = snap else {
+        guard case .transcriptSnapshot(let id, _, let canDrive, _, _, _, _, _)? = snap else {
             Issue.record("expected a snapshot after takeOver, got \(sent)")
             return
         }
@@ -779,7 +779,7 @@ struct RemoteSessionGatewayTests {
         s.transcript.messages.append(.agent(id: UUID(), StreamingText("more")))  // fires objectWillChange
         try await Task.sleep(nanoseconds: 250_000_000)  // > coalesce window
         let delta = sent.compactMap { msg -> [RemoteWireMessage]? in
-            if case .transcriptDelta(_, _, _, let upserts) = msg { return upserts }
+            if case .transcriptDelta(_, _, _, let upserts, _, _) = msg { return upserts }
             return nil
         }.last
         let delta2 = try #require(delta, "expected a transcriptDelta after mutation")
@@ -893,7 +893,7 @@ struct RemoteSessionGatewayTests {
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         await gw.handle(.subscribe(sessionId: "s1"))
         let drive = sent.compactMap { msg -> Bool? in
-            if case .transcriptSnapshot(_, _, let canDrive, _) = msg { return canDrive }
+            if case .transcriptSnapshot(_, _, let canDrive, _, _, _, _, _) = msg { return canDrive }
             return nil
         }.first
         #expect(drive == true)

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -97,9 +97,22 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     }
 
     func isWriter(for id: String) -> Bool { writers.contains(id) }
+    var pauseTakeOver = false   // suspends INSIDE the gateway's own await, unlike pauseSessionSummaries's detached fetch
+    var takeOverCallCount = 0
+    private var takeOverContinuation: CheckedContinuation<Void, Never>?
     func takeOver(for id: String) async {
+        takeOverCallCount += 1
         tookOver.append(id)
         writers.insert(id)
+        if pauseTakeOver {
+            await withCheckedContinuation { continuation in
+                takeOverContinuation = continuation
+            }
+        }
+    }
+    func resumeTakeOver() {
+        takeOverContinuation?.resume()
+        takeOverContinuation = nil
     }
 
     var sendPromptResultIsAsync = false   // deliver onResult on a later tick (models a late delivery failure)

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -876,14 +876,28 @@ struct RemoteSessionGatewayTests {
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
     }
 
-    @Test func stopRoutesOnlyWhenWriter() async {
+    @Test func stopWorksRegardlessOfWriterStatus() async {
+        // Stop is a fast-lane emergency brake: it no longer requires the
+        // writer lease, so it must succeed whether or not the caller is
+        // the current writer.
         let provider = FakeSessionsProvider()
         let gw = RemoteSessionGateway(provider: provider) { _ in }
         await gw.handle(.stop(sessionId: "s1"))
-        #expect(provider.stopped.isEmpty)
+        #expect(provider.stopped == ["s1"])
         provider.writers.insert("s1")
         await gw.handle(.stop(sessionId: "s1"))
+        #expect(provider.stopped == ["s1", "s1"])
+    }
+
+    @Test func stopWorksWithoutWriterLeaseAndAcksImmediately() async throws {
+        let provider = FakeSessionsProvider()
+        provider.sessions["s1"] = try makeSessionWithAgentText("hi")
+        // NOTE: provider.writers is intentionally empty — not the writer.
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.stop(sessionId: "s1"))
         #expect(provider.stopped == ["s1"])
+        #expect(sent.first == .stopPending(sessionId: "s1"))
     }
 
     @Test func snapshotCarriesCanDrive() async throws {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1191,7 +1191,8 @@ struct RemoteSessionGatewayTests {
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         await gw.handle(.subscribe(sessionId: "s1"))
         guard case .transcriptSnapshot(_, _, _, let msgs, let first, let total, _, let revision)? = sent.first else {
-            Issue.record("expected snapshot, got \(sent)"); return
+            Issue.record("expected snapshot, got \(sent)")
+            return
         }
         #expect(total == 200)
         #expect(first == 200 - RemoteTranscriptSync.tailWindow)
@@ -1228,14 +1229,17 @@ struct RemoteSessionGatewayTests {
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         await gw.handle(.subscribe(sessionId: "s1"))
         guard case .transcriptSnapshot(_, _, _, _, _, _, let epoch0, _)? = sent.first else {
-            Issue.record("expected snapshot"); return
+            Issue.record("expected snapshot")
+            return
         }
         sent.removeAll()
         s.transcript.messages.removeLast()               // structural
         try await Task.sleep(nanoseconds: 250_000_000)
-        let resync = sent.last { if case .transcriptSnapshot = $0 { return true }; return false }
+        let resync = sent.last { if case .transcriptSnapshot = $0 { return true }
+        return false }
         guard case .transcriptSnapshot(_, _, _, let msgs, _, let total, let epoch1, _)? = resync else {
-            Issue.record("expected resync snapshot, got \(sent)"); return
+            Issue.record("expected resync snapshot, got \(sent)")
+            return
         }
         #expect(epoch1 == epoch0 + 1)
         #expect(total == 9)
@@ -1252,7 +1256,8 @@ struct RemoteSessionGatewayTests {
         sent.removeAll()
         await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 110, limit: 90))
         guard case .transcriptPage(_, _, let first, let msgs)? = sent.last else {
-            Issue.record("expected page, got \(sent)"); return
+            Issue.record("expected page, got \(sent)")
+            return
         }
         #expect(first == 20)
         #expect(msgs.count == 90)
@@ -1262,7 +1267,8 @@ struct RemoteSessionGatewayTests {
         sent.removeAll()
         await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 10, limit: 500))   // clamp both ends
         guard case .transcriptPage(_, _, let first2, let msgs2)? = sent.last else {
-            Issue.record("expected page, got \(sent)"); return
+            Issue.record("expected page, got \(sent)")
+            return
         }
         #expect(first2 == 0)
         #expect(msgs2.count == 10)

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1470,6 +1470,67 @@ struct RemoteSessionGatewayTests {
         #expect(sent.isEmpty, "stale delta must be discarded once a same-epoch snapshot landed during serialize, got \(sent)")
     }
 
+    // Regression (codex review, PR #775): two overlapping DIRTY deltas race
+    // the same way a delta and a snapshot do — a still-running (cancelled-
+    // but-not-stopped) coalesce Task can suspend mid-serialize while a later
+    // mutation's own coalesce Task completes and sends first. The earlier
+    // delta must not resume, pass an unchanged-generation check, and roll
+    // the client back with its now-stale content at a higher revision.
+    @Test func deltaDropsStaleUpsertsWhenOverlappingDirtyDeltaLandsDuringSerialize() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "in_progress",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        session.transcript.messages = [.toolCall(toolCall)] + (0..<5).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))   // caches "old"'s content
+        sent.removeAll()
+        provider.fullToolCallContentCallCount = 0
+        provider.pauseFullToolCallContentOnCall = 1   // suspend the delta's re-fetch below
+
+        // Dirty mutation #1: the tool call — invalidates its cache and
+        // forces a real re-fetch that suspends.
+        if case .toolCall(var tc) = session.transcript.messages[0] {
+            tc.status = "completed"
+            session.transcript.messages[0] = .toolCall(tc)
+        }
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // Dirty mutation #2: an appended message — a non-truncated-tool-call
+        // dirty index, so its own coalesced delta completes fully (no
+        // suspension) while mutation #1's delta is still stuck above.
+        session.transcript.messages.append(.systemNotice(id: UUID(), text: "notice"))
+        for _ in 0..<50 where sent.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .transcriptDelta(_, _, _, let firstUpserts, _, _)? = sent.last else {
+            Issue.record("expected the overlapping dirty delta to land, got \(sent)")
+            return
+        }
+        #expect(firstUpserts.contains { $0.kind == "systemNotice" })
+
+        sent.removeAll()
+        // Resume mutation #1's suspended fetch. With the fix, it must detect
+        // that mutation #2's delta already claimed a newer generation and
+        // discard instead of rolling the transcript back with stale content.
+        provider.resumeFullToolCallContent(fullContent)
+        try await Task.sleep(nanoseconds: 250_000_000)   // > coalesce window
+        #expect(sent.isEmpty, "stale overlapping delta must be discarded, got \(sent)")
+    }
+
     // Regression (codex review, PR #775): fetchOlder's page serialization has
     // the same suspend-then-stamp hazard as sendDelta — a structural resync
     // landing while a truncated tool call's content is being fetched must not

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1416,6 +1416,60 @@ struct RemoteSessionGatewayTests {
         #expect(resyncEpoch != 0)   // sanity: the resync did bump the epoch
     }
 
+    // Regression (codex review, PR #775): an epoch-only guard misses a
+    // SAME-epoch snapshot (e.g. a takeOver, or a client resubscribe with no
+    // intervening structural change) landing while a dirty delta is
+    // suspended mid-serialize — the snapshot still resets revision/
+    // sentVersion, so the resumed delta's stale content would be accepted
+    // as the next legitimate delta after it. The generation counter (bumped
+    // on every snapshot regardless of epoch) must catch this too.
+    @Test func deltaDropsStaleUpsertsWhenSameEpochSnapshotLandsDuringSerialize() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "in_progress",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        session.transcript.messages = [.toolCall(toolCall)] + (0..<5).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))   // caches "old"'s content
+        sent.removeAll()
+        provider.fullToolCallContentCallCount = 0
+        provider.pauseFullToolCallContentOnCall = 1   // suspend the delta's re-fetch below
+
+        if case .toolCall(var tc) = session.transcript.messages[0] {
+            tc.status = "completed"
+            session.transcript.messages[0] = .toolCall(tc)
+        }
+
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // A SAME-epoch snapshot lands via takeOver — no structural change,
+        // so the transcript's epoch never moves.
+        await gw.handle(.takeOver(sessionId: "s1"))
+        guard case .transcriptSnapshot(_, _, _, _, _, _, let snapshotEpoch, _)? = sent.last else {
+            Issue.record("expected a snapshot from takeOver, got \(sent)")
+            return
+        }
+        #expect(snapshotEpoch == 0)   // sanity: confirms this is the same-epoch case
+
+        sent.removeAll()
+        provider.resumeFullToolCallContent(fullContent)
+        try await Task.sleep(nanoseconds: 250_000_000)   // > coalesce window
+        #expect(sent.isEmpty, "stale delta must be discarded once a same-epoch snapshot landed during serialize, got \(sent)")
+    }
+
     // Regression (codex review, PR #775): fetchOlder's page serialization has
     // the same suspend-then-stamp hazard as sendDelta — a structural resync
     // landing while a truncated tool call's content is being fetched must not

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1648,6 +1648,71 @@ struct RemoteSessionGatewayTests {
         #expect(snapshotCount == 1, "the superseded subscribe snapshot must be discarded, got \(sent)")
     }
 
+    // Regression (codex review, PR #775): sendSnapshot advanced sentVersion
+    // BEFORE its own await, the same premature-commit hazard as the dirty
+    // delta fix above. If the snapshot is later discarded because a
+    // concurrent dirty delta sent first, that delta computes its upserts
+    // against the ALREADY-advanced sentVersion and never re-offers the
+    // pre-snapshot dirty content — losing it entirely (neither send ever
+    // delivers it) until a later full resync.
+    @Test func sendSnapshotDefersSentVersionSoSupersedingDeltaStillDeliversIt() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let mgr = try makeManager()
+        let session = mgr.createSession(agentId: "claude")
+        session.transcript.messages = (0..<5).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.subscribe(sessionId: "s1"))   // establishes observe(); nothing to cache yet
+        sent.removeAll()
+        provider.fullToolCallContentCallCount = 0
+        provider.pauseFullToolCallContentOnCall = 1   // suspend the re-subscribe snapshot's fetch below
+
+        // Append the truncated tool call directly (uncached anywhere) and
+        // immediately re-subscribe — its snapshot must fetch the tool call
+        // for the first time and suspends.
+        session.transcript.messages.append(.toolCall(toolCall))
+        let resubscribeTask = Task { @MainActor in
+            await gw.handle(.subscribe(sessionId: "s1"))
+        }
+        for _ in 0..<50 where provider.fullToolCallContentCallCount == 0 {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.fullToolCallContentCallCount == 1)
+
+        // The first subscribe's still-active observer reacts to the append
+        // with its own coalesced delta, which also needs the (still
+        // uncached) tool call — its fetch is call #2, not paused.
+        for _ in 0..<50 where sent.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .transcriptDelta(_, _, _, let upserts, _, _)? = sent.last else {
+            Issue.record("expected the concurrent delta to land, got \(sent)")
+            return
+        }
+        #expect(
+            upserts.contains { $0.kind == "toolCall" },
+            "the appended tool call must not be lost, got \(upserts)"
+        )
+
+        sent.removeAll()
+        provider.resumeFullToolCallContent(fullContent)
+        await resubscribeTask.value
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let snapshotCount = sent.filter { if case .transcriptSnapshot = $0 { return true }
+        return false }.count
+        #expect(snapshotCount == 0, "the superseded re-subscribe snapshot must be discarded, got \(sent)")
+    }
+
     // Regression (codex review, PR #775): fetchOlder's page serialization has
     // the same suspend-then-stamp hazard as sendDelta — a structural resync
     // landing while a truncated tool call's content is being fetched must not

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -48,11 +48,11 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=57"#))
-        #expect(html.contains(#"/style.css?v=36"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v35";"#))
-        #expect(sw.contains(#""/app.js?v=57""#))
-        #expect(sw.contains(#""/style.css?v=36""#))
+        #expect(html.contains(#"/app.js?v=58"#))
+        #expect(html.contains(#"/style.css?v=37"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v36";"#))
+        #expect(sw.contains(#""/app.js?v=58""#))
+        #expect(sw.contains(#""/style.css?v=37""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -65,11 +65,11 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=57"#))
-        #expect(html.contains(#"/style.css?v=36"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v35";"#))
-        #expect(sw.contains(#""/app.js?v=57""#))
-        #expect(sw.contains(#""/style.css?v=36""#))
+        #expect(html.contains(#"/app.js?v=58"#))
+        #expect(html.contains(#"/style.css?v=37"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v36";"#))
+        #expect(sw.contains(#""/app.js?v=58""#))
+        #expect(sw.contains(#""/style.css?v=37""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -110,8 +110,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-state-active"))
         #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=57"))
-        #expect(html.contains("/style.css?v=36"))
+        #expect(html.contains("/app.js?v=58"))
+        #expect(html.contains("/style.css?v=37"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -136,8 +136,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=57""#))
-        #expect(sw.contains(#""/style.css?v=36""#))
+        #expect(sw.contains(#""/app.js?v=58""#))
+        #expect(sw.contains(#""/style.css?v=37""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {
@@ -267,6 +267,27 @@ struct RemoteWebAssetTests {
         #expect(css.contains(#"#new-session::before { content: "+";"#))
         #expect(css.contains("#status.chip { font-size: 0;"))
         #expect(css.contains("#status.chip::before"))
+    }
+
+    @Test func remoteWebSpeaksIncrementalTranscriptProtocol() throws {
+        let js = try asset("app.js")
+        #expect(js.contains(#"case "transcriptPage""#))
+        #expect(js.contains(#"case "stopPending""#))
+        #expect(js.contains(#"type: "fetchOlder""#))
+    }
+
+    @Test func remoteWebStopDoesNotTakeOverFirst() throws {
+        let js = try asset("app.js")
+        let stopHandler = try #require(js.range(of: #"$("stop").onclick"#).map { js[$0.lowerBound...].prefix(220) })
+        #expect(!stopHandler.contains("ensureWriter"))
+    }
+
+    @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
+        let sw = try asset("sw.js")
+        let html = try asset("index.html")
+        #expect(sw.contains("alas-remote-shell-v36"))
+        #expect(sw.contains("/app.js?v=58"))
+        #expect(html.contains("app.js?v=58"))
     }
 
     @Test func serviceWorkerKeepsControlAndDiagnosticRoutesNetworkOnly() throws {

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -48,10 +48,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=58"#))
+        #expect(html.contains(#"/app.js?v=59"#))
         #expect(html.contains(#"/style.css?v=37"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v36";"#))
-        #expect(sw.contains(#""/app.js?v=58""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v37";"#))
+        #expect(sw.contains(#""/app.js?v=59""#))
         #expect(sw.contains(#""/style.css?v=37""#))
     }
 
@@ -65,10 +65,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=58"#))
+        #expect(html.contains(#"/app.js?v=59"#))
         #expect(html.contains(#"/style.css?v=37"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v36";"#))
-        #expect(sw.contains(#""/app.js?v=58""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v37";"#))
+        #expect(sw.contains(#""/app.js?v=59""#))
         #expect(sw.contains(#""/style.css?v=37""#))
     }
 
@@ -110,7 +110,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-state-active"))
         #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=58"))
+        #expect(html.contains("/app.js?v=59"))
         #expect(html.contains("/style.css?v=37"))
     }
 
@@ -136,7 +136,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=58""#))
+        #expect(sw.contains(#""/app.js?v=59""#))
         #expect(sw.contains(#""/style.css?v=37""#))
     }
 
@@ -285,9 +285,26 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v36"))
-        #expect(sw.contains("/app.js?v=58"))
-        #expect(html.contains("app.js?v=58"))
+        #expect(sw.contains("alas-remote-shell-v37"))
+        #expect(sw.contains("/app.js?v=59"))
+        #expect(html.contains("app.js?v=59"))
+    }
+
+    // Regression (codex review, PR #775): applyPage used to clear the
+    // shared (single-session) olderFetchInFlight/loading-row state BEFORE
+    // checking whether the page belonged to the currently open session —
+    // so a stale page for a session the user already left could clear the
+    // CURRENT session's own in-flight backfill indicator and allow a
+    // duplicate fetch while the real request was still pending.
+    @Test func applyPageChecksSessionBeforeClearingSharedInFlightState() throws {
+        let js = try asset("app.js")
+        let body = try #require(js.range(of: "function applyPage(msg) {").map { js[$0.lowerBound...].prefix(400) })
+        let sessionCheckIndex = try #require(body.range(of: "msg.sessionId !== currentSession")?.lowerBound)
+        let clearInFlightIndex = try #require(body.range(of: "olderFetchInFlight = false")?.lowerBound)
+        #expect(
+            sessionCheckIndex < clearInFlightIndex,
+            "the sessionId check must run before clearing shared in-flight state"
+        )
     }
 
     @Test func serviceWorkerKeepsControlAndDiagnosticRoutesNetworkOnly() throws {

--- a/docs/superpowers/plans/2026-07-14-acp-remote-web-perf.md
+++ b/docs/superpowers/plans/2026-07-14-acp-remote-web-perf.md
@@ -1,0 +1,1362 @@
+# ACP Remote Web Incremental Transcript & Fast Stop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the remote web's full-transcript-replay wire protocol with windowed snapshots + true incremental deltas, and make Stop land in under a second by fast-laning it past the serial queue and the writer-lease round-trips.
+
+**Architecture:** A change log on `ACPTranscript` records which message indices mutated (array-diff in `messages.didSet` + explicit hooks at the streaming-buffer tick sites). Each gateway consumes the log per connection: snapshots carry only a ~90-message tail window; deltas carry only dirty messages; older history is served by a new `fetchOlder` page request. Index-shifting mutations (prepend/removal/wholesale replace) bump an epoch and force a tail re-snapshot — the correctness fallback is always "resync the tail", never "diff harder". Stop becomes a control-class message that skips the per-connection serial chain and the lease confirmation.
+
+**Tech Stack:** Swift 5.9 / SwiftUI macOS app, Network.framework WebSocket server, vanilla-JS web client (`Alas/Resources/RemoteWeb/`), Swift Testing (`import Testing`).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-acp-remote-web-perf-design.md`
+
+## Global Constraints
+
+- All code, comments, logs, UI strings in English.
+- Tests use Swift Testing (`import Testing`, `@Test`, `#expect`, `#require`) — never XCTest.
+- New source files require regenerating the Xcode project: run `xcodegen` and commit `Alas.xcodeproj` alongside the new files.
+- No agent attributions anywhere: no `Co-Authored-By`, no "Generated with" footers, no 🤖 markers in commits/PRs/code.
+- Build: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
+- Test (scoped): `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/<SuiteName>`
+- Full test suite must pass before finishing: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
+- Web assets: any change to `app.js`/`style.css` must bump the matching `?v=` in `Alas/Resources/RemoteWeb/index.html` **and** in `sw.js` `SHELL_ASSETS`, and bump `CACHE_NAME` in `sw.js` (currently `alas-remote-shell-v35`, `app.js?v=57`, `style.css?v=36`).
+- Both wire endpoints (Swift server + bundled JS client) ship together; no wire backward compatibility is required.
+
+## Design invariants (read before any task)
+
+1. **Message indices are stable under append and in-place mutation.** The only operations that shift indices — prepend during hydration backfill, removals, wholesale array replacement (mirror refresh) — are detected as *structural* changes, bump the `epoch`, clear the log, and force subscribers to re-snapshot. Therefore positional wire ids (`"m<index>"`) remain valid client map keys, and indices recorded in the change log never go stale.
+2. **Streaming chunk appends do not fire `messages.didSet`.** `StreamingText` is a reference type with identity equality (`ACPStreamingText.swift:36`), so appends mutate the buffer in place and only bump `transcript.streamingTick`. Every `streamingTick &+= 1` site in `ACPSession.swift` has the mutated index `i` in hand — those sites are the explicit dirty hooks.
+3. **The change log is per-transcript; consumption state is per-connection.** Multiple browsers each hold their own `sentVersion`/`revision`; the log is append-only with pruning, and a consumer that falls behind the pruned window gets `.resync`.
+4. **Two deliberate refinements vs. the spec:** (a) deltas carry no `removals` field — every removal shifts indices, so it is structural and resolves as a tail re-snapshot (the fallback the spec explicitly allows); (b) the `stopPending` ack goes to the connection that pressed Stop — other subscribers learn via the normal state delta when the cancel lands.
+
+---
+
+### Task 1: `ACPTranscriptChangeLog`
+
+**Files:**
+- Create: `Alas/Sources/ACP/Session/ACPTranscriptChangeLog.swift`
+- Test: `AlasTests/ACP/ACPTranscriptChangeLogTests.swift`
+
+**Interfaces:**
+- Consumes: nothing (pure model).
+- Produces: `@MainActor final class ACPTranscriptChangeLog` with:
+  - `enum Changes: Equatable { case none, resync, dirty([Int]) }`
+  - `private(set) var epoch: Int`, `private(set) var latestVersion: Int`
+  - `var isTracking: Bool`, `func retainTracking()`, `func releaseTracking()`
+  - `func record(index: Int)`, `func recordStructural()`
+  - `func changes(since: Int) -> Changes`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `AlasTests/ACP/ACPTranscriptChangeLogTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct ACPTranscriptChangeLogTests {
+    @Test func recordsNothingWhileNotTracking() {
+        let log = ACPTranscriptChangeLog()
+        log.record(index: 3)
+        #expect(log.latestVersion == 0)
+        #expect(log.changes(since: 0) == .none)
+    }
+
+    @Test func recordsDirtyIndicesWhileTracking() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        log.record(index: 3)
+        log.record(index: 5)
+        #expect(log.changes(since: 0) == .dirty([3, 5]))
+        #expect(log.changes(since: log.latestVersion) == .none)
+    }
+
+    @Test func consecutiveSameIndexCoalescesIntoOneEntry() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        let consumed = log.latestVersion
+        for _ in 0..<100 { log.record(index: 7) }   // streaming burst
+        #expect(log.changes(since: consumed) == .dirty([7]))
+        // A consumer that read mid-burst still sees the entry (version was bumped in place).
+        let mid = log.latestVersion - 10
+        #expect(log.changes(since: mid) == .dirty([7]))
+    }
+
+    @Test func structuralChangeBumpsEpochAndForcesResync() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        log.record(index: 1)
+        let consumed = log.latestVersion
+        let epochBefore = log.epoch
+        log.recordStructural()
+        #expect(log.epoch == epochBefore + 1)
+        #expect(log.changes(since: consumed) == .resync)
+        #expect(log.changes(since: log.latestVersion) == .none)
+    }
+
+    @Test func prunedHistoryForcesResync() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        log.record(index: 0)
+        let consumed = log.latestVersion
+        // Overflow the ring: alternate indices so entries don't coalesce.
+        for i in 0..<(ACPTranscriptChangeLog.maxEntries + 10) {
+            log.record(index: 1 + (i % 2))
+        }
+        #expect(log.changes(since: consumed) == .resync)
+    }
+
+    @Test func releasingLastTrackerClearsEntries() {
+        let log = ACPTranscriptChangeLog()
+        log.retainTracking()
+        log.retainTracking()
+        log.record(index: 2)
+        let consumed = 0
+        log.releaseTracking()
+        #expect(log.changes(since: consumed) == .dirty([2]))   // still one tracker
+        log.releaseTracking()
+        #expect(log.isTracking == false)
+        let versionBefore = log.latestVersion
+        log.record(index: 9)                                    // ignored while untracked
+        #expect(log.latestVersion == versionBefore)
+        // A stale consumer from before the release must resync, not read a gap.
+        #expect(log.changes(since: consumed) == .resync)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPTranscriptChangeLogTests 2>&1 | tail -20`
+Expected: BUILD FAILURE — `cannot find 'ACPTranscriptChangeLog' in scope`. (You must run `xcodegen` first for the new test file to be seen; it will then fail to compile, which is the expected "red".)
+
+- [ ] **Step 3: Implement the change log**
+
+Create `Alas/Sources/ACP/Session/ACPTranscriptChangeLog.swift`:
+
+```swift
+import Foundation
+
+/// Records which transcript message indices mutated so remote-web gateways
+/// can send incremental deltas instead of full re-snapshots.
+///
+/// Indices recorded here never go stale: every index-shifting operation
+/// (prepend, removal, wholesale replacement) is recorded as *structural*,
+/// which bumps `epoch`, clears the log, and forces consumers to take a
+/// fresh tail snapshot. Recording is refcount-gated so the transcript pays
+/// zero diff cost when no remote client is subscribed.
+@MainActor
+final class ACPTranscriptChangeLog {
+    enum Changes: Equatable {
+        case none
+        case resync
+        case dirty([Int])   // distinct dirty message indices, ascending
+    }
+
+    /// Transcript generation. Bumped on any structural change; a consumer
+    /// holding a stale epoch must re-snapshot.
+    private(set) var epoch: Int = 0
+    /// Monotonic mutation counter. Consumers read "changes since version".
+    private(set) var latestVersion: Int = 0
+    /// Ring of (version, index) entries; consecutive records of the same
+    /// index coalesce by bumping the tail entry's version in place, so a
+    /// streaming burst occupies one slot.
+    private var entries: [(version: Int, index: Int)] = []
+    /// Highest version dropped from `entries`; a consumer behind this
+    /// cannot be served incrementally.
+    private var prunedThrough: Int = 0
+    private var trackingRefCount = 0
+
+    static let maxEntries = 1024
+
+    var isTracking: Bool { trackingRefCount > 0 }
+
+    func retainTracking() { trackingRefCount += 1 }
+
+    func releaseTracking() {
+        trackingRefCount = max(0, trackingRefCount - 1)
+        if trackingRefCount == 0 {
+            entries.removeAll()
+            prunedThrough = latestVersion
+        }
+    }
+
+    func record(index: Int) {
+        guard isTracking else { return }
+        latestVersion += 1
+        if let last = entries.last, last.index == index {
+            entries[entries.count - 1].version = latestVersion
+        } else {
+            entries.append((latestVersion, index))
+            if entries.count > Self.maxEntries {
+                prunedThrough = entries.removeFirst().version
+            }
+        }
+    }
+
+    func recordStructural() {
+        guard isTracking else { return }
+        epoch += 1
+        latestVersion += 1
+        entries.removeAll()
+        prunedThrough = latestVersion
+    }
+
+    func changes(since: Int) -> Changes {
+        if since >= latestVersion { return .none }
+        if since < prunedThrough { return .resync }
+        let dirty = Set(entries.filter { $0.version > since }.map(\.index))
+        // Defensive: a consumer inside the retained window should always
+        // find entries; an empty result means bookkeeping drifted — resync.
+        return dirty.isEmpty ? .resync : .dirty(dirty.sorted())
+    }
+}
+```
+
+- [ ] **Step 4: Regenerate project, run tests to verify they pass**
+
+Run: `xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPTranscriptChangeLogTests 2>&1 | tail -20`
+Expected: `** TEST SUCCEEDED **` with 6 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/ACP/Session/ACPTranscriptChangeLog.swift AlasTests/ACP/ACPTranscriptChangeLogTests.swift Alas.xcodeproj
+git commit -m "feat(acp): add transcript change log for incremental remote sync"
+```
+
+---
+
+### Task 2: Transcript dirty-tracking hooks
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/ACPTranscript.swift` (add change log + didSet diff + `noteStreamingChange`)
+- Modify: `Alas/Sources/ACP/Session/ACPSession.swift` (replace the five `transcript.streamingTick &+= 1` sites)
+- Test: `AlasTests/ACP/ACPTranscriptChangeLogTests.swift` (extend)
+
+**Interfaces:**
+- Consumes: `ACPTranscriptChangeLog` from Task 1.
+- Produces: `ACPTranscript.changeLog: ACPTranscriptChangeLog` (a `let` property) and `ACPTranscript.noteStreamingChange(at index: Int)`. Gateways call `transcript.changeLog.retainTracking()` / `.releaseTracking()` / `.changes(since:)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the suite in `AlasTests/ACP/ACPTranscriptChangeLogTests.swift`:
+
+```swift
+    // MARK: - ACPTranscript hooks
+
+    private func makeTrackedTranscript(messageCount: Int) -> ACPTranscript {
+        let t = ACPTranscript()
+        t.messages = (0..<messageCount).map { i in
+            .user(id: UUID(), messageId: "u\(i)", text: "m\(i)", attachments: [])
+        }
+        t.changeLog.retainTracking()
+        return t
+    }
+
+    @Test func appendIsRecordedAsDirtyIndex() {
+        let t = makeTrackedTranscript(messageCount: 3)
+        let consumed = t.changeLog.latestVersion
+        t.messages.append(.systemNotice(id: UUID(), text: "notice"))
+        #expect(t.changeLog.changes(since: consumed) == .dirty([3]))
+    }
+
+    @Test func inPlaceMutationKeepingIdentityIsRecordedAsDirty() {
+        let t = ACPTranscript()
+        var tc = ACPMessage.ToolCall(toolCallId: "tc1", title: "read", status: "in_progress", content: "", preview: "")
+        t.messages = [.toolCall(tc)]
+        t.changeLog.retainTracking()
+        let consumed = t.changeLog.latestVersion
+        tc.status = "completed"
+        t.messages[0] = .toolCall(tc)
+        #expect(t.changeLog.changes(since: consumed) == .dirty([0]))
+        #expect(t.changeLog.epoch == 0)
+    }
+
+    @Test func removalIsStructural() {
+        let t = makeTrackedTranscript(messageCount: 3)
+        let epochBefore = t.changeLog.epoch
+        t.messages.removeLast()
+        #expect(t.changeLog.epoch == epochBefore + 1)
+    }
+
+    @Test func identityChangeAtExistingIndexIsStructural() {
+        let t = makeTrackedTranscript(messageCount: 3)
+        let epochBefore = t.changeLog.epoch
+        // Prepending shifts every identity; the diff sees index 0's stableId change.
+        t.messages.insert(.systemNotice(id: UUID(), text: "older"), at: 0)
+        #expect(t.changeLog.epoch == epochBefore + 1)
+    }
+
+    @Test func streamingChangeIsRecordedWithoutArrayMutation() {
+        let t = ACPTranscript()
+        let buf = StreamingText("hel")
+        t.messages = [.agent(id: UUID(), messageId: "a1", buf)]
+        t.changeLog.retainTracking()
+        let consumed = t.changeLog.latestVersion
+        let tickBefore = t.streamingTick
+        buf.append("lo")                    // no didSet fires (identity equality)
+        t.noteStreamingChange(at: 0)
+        #expect(t.streamingTick == tickBefore &+ 1)
+        #expect(t.changeLog.changes(since: consumed) == .dirty([0]))
+    }
+
+    @Test func untrackedTranscriptPaysNoDiffAndRecordsNothing() {
+        let t = ACPTranscript()
+        t.messages = [.systemNotice(id: UUID(), text: "x")]
+        t.messages.append(.systemNotice(id: UUID(), text: "y"))
+        #expect(t.changeLog.latestVersion == 0)
+    }
+```
+
+Note: check `ACPMessage.ToolCall`'s real initializer before using the stub above — mirror the parameters used in `RemoteSessionGatewayTests.swift` (`snapshotRestoresFullTruncatedToolCallContent` builds one with `toolCallId/title/status/content/preview`).
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPTranscriptChangeLogTests 2>&1 | tail -20`
+Expected: compile error — `value of type 'ACPTranscript' has no member 'changeLog'`.
+
+- [ ] **Step 3: Implement the transcript hooks**
+
+In `Alas/Sources/ACP/Session/ACPTranscript.swift`:
+
+1. Add the property (near the top, after the `@Published` block):
+
+```swift
+    /// Mutation log consumed by remote-web gateways for incremental deltas.
+    /// Recording is enabled only while at least one gateway is subscribed.
+    let changeLog = ACPTranscriptChangeLog()
+```
+
+2. Extend the existing `messages` `didSet`:
+
+```swift
+    @Published var messages: [ACPMessage] = [] {
+        didSet {
+            refreshPlanCaches()
+            recordMessagesDiff(old: oldValue)
+        }
+    }
+```
+
+3. Add the diff + streaming hook (new section near the render-window helpers):
+
+```swift
+    // MARK: - Remote change tracking
+
+    /// Classify an array mutation for the change log. Index-shifting
+    /// operations (shrink, or an identity change at a surviving index —
+    /// i.e. a prepend, mid-removal, or wholesale replacement) are
+    /// structural; everything else records per-index dirty entries.
+    /// Cost is O(count) enum compares, but unchanged elements share
+    /// storage (COW) and `StreamingText` compares by identity, so the
+    /// scan is cheap — and it only runs while a remote client is
+    /// subscribed.
+    private func recordMessagesDiff(old: [ACPMessage]) {
+        guard changeLog.isTracking else { return }
+        guard messages.count >= old.count else {
+            changeLog.recordStructural()
+            return
+        }
+        for i in old.indices where old[i] != messages[i] {
+            guard old[i].stableIdentityKey == messages[i].stableIdentityKey else {
+                changeLog.recordStructural()
+                return
+            }
+            changeLog.record(index: i)
+        }
+        for i in old.count..<messages.count {
+            changeLog.record(index: i)
+        }
+    }
+
+    /// Streaming chunk appends mutate a `StreamingText` buffer in place —
+    /// the array element compares equal (identity equality), so
+    /// `messages.didSet` cannot see them. Callers pass the mutated index.
+    /// Replaces direct `streamingTick &+= 1` writes.
+    func noteStreamingChange(at index: Int) {
+        streamingTick &+= 1
+        if changeLog.isTracking, messages.indices.contains(index) {
+            changeLog.record(index: index)
+        }
+    }
+```
+
+4. In `Alas/Sources/ACP/Session/ACPSession.swift`, replace every `transcript.streamingTick &+= 1` with `transcript.noteStreamingChange(at: i)`. Find them with `grep -n 'streamingTick &+= 1' Alas/Sources/ACP/Session/ACPSession.swift` (five sites, currently near lines 1558, 1572, 1593, 1750, 1803). Each site already has the mutated index in a local named `i` — verify the local's name at each site before substituting. Do NOT touch the `streamingTick` declaration in `ACPTranscript.swift`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPTranscriptChangeLogTests 2>&1 | tail -20`
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 5: Run the ACP test directory to catch regressions in streaming behavior**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests 2>&1 | tail -30`
+
+(If the full AlasTests run is prohibitively slow here, run at minimum every suite whose name contains `Session`, `Transcript`, or `Streaming`.)
+Expected: no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/ACP/Session/ACPTranscript.swift Alas/Sources/ACP/Session/ACPSession.swift AlasTests/ACP/ACPTranscriptChangeLogTests.swift
+git commit -m "feat(acp): record transcript mutations for incremental remote sync"
+```
+
+---
+
+### Task 3: Wire protocol — windowed snapshots, true deltas, pages, stopPending
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Protocol/RemoteProtocol.swift`
+- Modify: `Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift` (`RemoteWireMessage` gains `index`)
+- Test: `AlasTests/Remote/RemoteProtocolTests.swift` (extend)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (exact shapes later tasks rely on):
+  - `RemoteClientMessage.fetchOlder(sessionId: String, beforeIndex: Int, limit: Int)` — wire type `"fetchOlder"`.
+  - `RemoteServerMessage.transcriptSnapshot(sessionId: String, streamingState: String, canDrive: Bool, messages: [RemoteWireMessage], firstIndex: Int, totalCount: Int, epoch: Int, revision: Int)`
+  - `RemoteServerMessage.transcriptDelta(sessionId: String, streamingState: String, canDrive: Bool, upserts: [RemoteWireMessage], epoch: Int, revision: Int)`
+  - `RemoteServerMessage.transcriptPage(sessionId: String, epoch: Int, firstIndex: Int, messages: [RemoteWireMessage])` — wire type `"transcriptPage"`.
+  - `RemoteServerMessage.stopPending(sessionId: String)` — wire type `"stopPending"`.
+  - `RemoteWireMessage.index: Int` (required, synthesized Codable).
+  - `RemoteClientMessage.isControl: Bool` — true only for `.stop` (used by Task 5; define it here so the protocol file owns classification).
+
+- [ ] **Step 1: Write the failing round-trip tests**
+
+Add to `AlasTests/Remote/RemoteProtocolTests.swift`, following the file's existing encode→decode round-trip idiom (read a couple of existing tests first and match them):
+
+```swift
+    @Test func fetchOlderRoundTrips() throws {
+        let msg = RemoteClientMessage.fetchOlder(sessionId: "s1", beforeIndex: 120, limit: 90)
+        let data = try JSONEncoder().encode(msg)
+        let decoded = try JSONDecoder().decode(RemoteClientMessage.self, from: data)
+        #expect(decoded == msg)
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains(#""type":"fetchOlder""#))
+    }
+
+    @Test func windowedSnapshotRoundTrips() throws {
+        let wire = [RemoteWireMessage(stableId: "m110", kind: "agent", text: "hi", json: nil, index: 110)]
+        let msg = RemoteServerMessage.transcriptSnapshot(
+            sessionId: "s1", streamingState: "idle", canDrive: true,
+            messages: wire, firstIndex: 110, totalCount: 200, epoch: 3, revision: 0)
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: JSONEncoder().encode(msg))
+        #expect(decoded == msg)
+    }
+
+    @Test func deltaCarriesEpochAndRevision() throws {
+        let msg = RemoteServerMessage.transcriptDelta(
+            sessionId: "s1", streamingState: "streaming", canDrive: false,
+            upserts: [], epoch: 3, revision: 7)
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: JSONEncoder().encode(msg))
+        #expect(decoded == msg)
+    }
+
+    @Test func transcriptPageRoundTrips() throws {
+        let wire = [RemoteWireMessage(stableId: "m20", kind: "user", text: "old", json: nil, index: 20)]
+        let msg = RemoteServerMessage.transcriptPage(sessionId: "s1", epoch: 3, firstIndex: 20, messages: wire)
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: JSONEncoder().encode(msg))
+        #expect(decoded == msg)
+    }
+
+    @Test func stopPendingRoundTrips() throws {
+        let msg = RemoteServerMessage.stopPending(sessionId: "s1")
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: JSONEncoder().encode(msg))
+        #expect(decoded == msg)
+    }
+
+    @Test func onlyStopIsControl() {
+        #expect(RemoteClientMessage.stop(sessionId: "s").isControl)
+        #expect(!RemoteClientMessage.subscribe(sessionId: "s").isControl)
+        #expect(!RemoteClientMessage.takeOver(sessionId: "s").isControl)
+        #expect(!RemoteClientMessage.fetchOlder(sessionId: "s", beforeIndex: 0, limit: 1).isControl)
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteProtocolTests 2>&1 | tail -20`
+Expected: compile errors (`fetchOlder` not a member, extra arguments to `transcriptSnapshot`, missing `index:`).
+
+- [ ] **Step 3: Implement the protocol changes**
+
+In `RemoteMessageWireJSON.swift`, add the field:
+
+```swift
+struct RemoteWireMessage: Codable, Equatable, Sendable {
+    let stableId: String
+    let kind: String          // "user" | "agent" | "thought" | "toolCall" | "fileEdit" | "plan" | "systemNotice"
+    let text: String?
+    let json: String?         // JSON string for structured kinds; nil otherwise
+    let index: Int            // transcript position; the client orders and windows by this
+}
+```
+
+In `RemoteProtocol.swift`:
+
+1. `RemoteClientMessage`: add case `fetchOlder(sessionId: String, beforeIndex: Int, limit: Int)`; add `beforeIndex`, `limit` to `CodingKeys`; wire both `init(from:)` (`case "fetchOlder"`) and `encode(to:)`. Add:
+
+```swift
+extension RemoteClientMessage {
+    /// Control messages bypass the per-connection serial processing chain
+    /// (RemoteConnection.dispatchMessage): they are idempotent and must not
+    /// queue behind transcript work. Everything else stays strictly ordered
+    /// (e.g. takeOver-before-sendPrompt).
+    var isControl: Bool {
+        if case .stop = self { return true }
+        return false
+    }
+}
+```
+
+2. `RemoteServerMessage`: extend `transcriptSnapshot`/`transcriptDelta` with the new associated values, add `transcriptPage` and `stopPending` cases, add `firstIndex`, `totalCount`, `epoch`, `revision` to `CodingKeys`, and wire codable paths for all four. Follow the file's existing hand-rolled Codable style exactly.
+
+3. Fix every non-test construction/pattern-match of the changed cases so the target compiles — they are all in `RemoteSessionGateway.swift` (`sendSnapshot`/`sendDelta`/`toWire`). For this task only, thread placeholder values so behavior is unchanged: snapshot sends the full array with `firstIndex: 0, totalCount: wire.count, epoch: 0, revision: 0`; delta keeps full upserts with `epoch: 0, revision: 0`; `toWire` passes its existing `index` parameter into `RemoteWireMessage(index:)`. Task 4 replaces these placeholders with real logic.
+
+- [ ] **Step 4: Fix existing test pattern-matches and run**
+
+Existing tests pattern-match the old arities (e.g. `case .transcriptSnapshot(let id, _, _, let msgs)` in `RemoteSessionGatewayTests`, `RemoteServerIntegrationTests`, `RemoteProtocolTests`). Update every match/construction mechanically (`grep -rn "transcriptSnapshot\|transcriptDelta" AlasTests/`).
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteProtocolTests -only-testing:AlasTests/RemoteSessionGatewayTests -only-testing:AlasTests/RemoteServerIntegrationTests 2>&1 | tail -20`
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Remote/Protocol/ AlasTests/Remote/
+git commit -m "feat(remote): wire protocol for windowed snapshots, deltas, pages, stopPending"
+```
+
+---
+
+### Task 4: Gateway — tail-window snapshots, incremental deltas, fetchOlder, tool-content cache
+
+**Files:**
+- Create: `Alas/Sources/Remote/Gateway/RemoteTranscriptSync.swift`
+- Modify: `Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift`
+- Test: `AlasTests/Remote/RemoteSessionGatewayTests.swift` (extend + update stale expectations)
+
+**Interfaces:**
+- Consumes: `ACPTranscriptChangeLog` (Task 2), protocol shapes (Task 3), `RemoteSessionsProvider.fullToolCallContent(sessionId:toolCallId:)` (existing).
+- Produces: per-session, per-connection sync state:
+
+```swift
+@MainActor
+final class RemoteTranscriptSync {
+    static let tailWindow = ACPTranscript.maxVisibleRows        // 90
+    static let pageLimitRange = 1...200
+    /// Above this many dirty messages, a tail re-snapshot is cheaper than a delta.
+    static let dirtyResnapshotThreshold = 200
+    static let toolContentCacheLimit = 128
+
+    var sentVersion = 0     // change-log version covered by the last send
+    var epoch = 0           // transcript epoch the client knows
+    var revision = 0        // per-connection outgoing delta counter
+    private var toolContent: [String: String] = [:]            // toolCallId → full content
+    private var toolContentOrder: [String] = []                 // FIFO eviction
+
+    func cachedToolContent(_ id: String) -> String? { toolContent[id] }
+    func storeToolContent(_ id: String, _ content: String) {
+        if toolContent[id] == nil {
+            toolContentOrder.append(id)
+            if toolContentOrder.count > Self.toolContentCacheLimit {
+                toolContent[toolContentOrder.removeFirst()] = nil
+            }
+        }
+        toolContent[id] = content
+    }
+    func invalidateToolContent(_ id: String) { toolContent[id] = nil }
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `AlasTests/Remote/RemoteSessionGatewayTests.swift`. Extend `FakeSessionsProvider` first with a call counter:
+
+```swift
+    var fullToolCallContentCallCount = 0
+    // in fullToolCallContent(sessionId:toolCallId:): fullToolCallContentCallCount += 1
+```
+
+Then the tests (the 250ms sleeps mirror the file's existing `> coalesce window` idiom):
+
+```swift
+    private func makeSessionWithUserMessages(_ count: Int) throws -> ACPSession {
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        s.transcript.messages = (0..<count).map {
+            .user(id: UUID(), messageId: "u\($0)", text: "msg \($0)", attachments: [])
+        }
+        return s
+    }
+
+    @Test func snapshotOfLongTranscriptIsTailWindowed() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(200)
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        guard case .transcriptSnapshot(_, _, _, let msgs, let first, let total, _, let revision)? = sent.first else {
+            Issue.record("expected snapshot, got \(sent)"); return
+        }
+        #expect(total == 200)
+        #expect(first == 200 - RemoteTranscriptSync.tailWindow)
+        #expect(msgs.count == RemoteTranscriptSync.tailWindow)
+        #expect(msgs.first?.stableId == "m\(first)")
+        #expect(msgs.first?.index == first)
+        #expect(revision == 0)
+    }
+
+    @Test func deltaCarriesOnlyDirtyMessages() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(50)
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        sent.removeAll()
+        s.transcript.messages.append(.systemNotice(id: UUID(), text: "done"))
+        try await Task.sleep(nanoseconds: 250_000_000)   // > coalesce window
+        let delta = sent.compactMap { msg -> [RemoteWireMessage]? in
+            if case .transcriptDelta(_, _, _, let u, _, _) = msg { return u }
+            return nil
+        }.last
+        #expect(delta?.count == 1)
+        #expect(delta?.first?.index == 50)
+        #expect(delta?.first?.kind == "systemNotice")
+    }
+
+    @Test func structuralChangeTriggersResyncSnapshotWithBumpedEpoch() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(10)
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        guard case .transcriptSnapshot(_, _, _, _, _, _, let epoch0, _)? = sent.first else {
+            Issue.record("expected snapshot"); return
+        }
+        sent.removeAll()
+        s.transcript.messages.removeLast()               // structural
+        try await Task.sleep(nanoseconds: 250_000_000)
+        let resync = sent.last { if case .transcriptSnapshot = $0 { return true }; return false }
+        guard case .transcriptSnapshot(_, _, _, let msgs, _, let total, let epoch1, _)? = resync else {
+            Issue.record("expected resync snapshot, got \(sent)"); return
+        }
+        #expect(epoch1 == epoch0 + 1)
+        #expect(total == 9)
+        #expect(msgs.count == 9)
+    }
+
+    @Test func fetchOlderReturnsClampedPage() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(200)
+        provider.sessions["s1"] = s
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        sent.removeAll()
+        await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 110, limit: 90))
+        guard case .transcriptPage(_, _, let first, let msgs)? = sent.last else {
+            Issue.record("expected page, got \(sent)"); return
+        }
+        #expect(first == 20)
+        #expect(msgs.count == 90)
+        #expect(msgs.first?.index == 20)
+        #expect(msgs.last?.index == 109)
+
+        sent.removeAll()
+        await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 10, limit: 500))   // clamp both ends
+        guard case .transcriptPage(_, _, let first2, let msgs2)? = sent.last else {
+            Issue.record("expected page, got \(sent)"); return
+        }
+        #expect(first2 == 0)
+        #expect(msgs2.count == 10)
+    }
+
+    @Test func fetchOlderBeforeSubscribeIsIgnored() async throws {
+        let provider = FakeSessionsProvider()
+        provider.sessions["s1"] = try makeSessionWithUserMessages(5)
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.fetchOlder(sessionId: "s1", beforeIndex: 5, limit: 5))
+        #expect(sent.isEmpty)
+    }
+
+    @Test func truncatedToolContentIsFetchedOnceAcrossSnapshotAndDeltas() async throws {
+        let provider = FakeSessionsProvider()
+        let fullContent = String(repeating: "abcdef0123456789", count: 400)
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "old", title: "read", status: "completed",
+            content: fullContent, preview: "abcdef")
+        toolCall.truncateForOffWindow()
+        let session = try makeSessionWithAgentText("tail")
+        session.transcript.messages = [.toolCall(toolCall), .agent(id: UUID(), StreamingText("tail"))]
+        provider.sessions["s1"] = session
+        provider.fullToolCallContents["s1|old"] = fullContent
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        #expect(provider.fullToolCallContentCallCount == 1)
+        // A dirty tick on the OTHER message must not re-fetch tool content.
+        session.transcript.messages.append(.systemNotice(id: UUID(), text: "x"))
+        try await Task.sleep(nanoseconds: 250_000_000)
+        #expect(provider.fullToolCallContentCallCount == 1)
+    }
+
+    @Test func unsubscribeReleasesChangeTracking() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(3)
+        provider.sessions["s1"] = s
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        #expect(s.transcript.changeLog.isTracking)
+        await gw.handle(.unsubscribe(sessionId: "s1"))
+        #expect(!s.transcript.changeLog.isTracking)
+    }
+
+    @Test func resubscribeDoesNotLeakTrackingRetains() async throws {
+        let provider = FakeSessionsProvider()
+        let s = try makeSessionWithUserMessages(3)
+        provider.sessions["s1"] = s
+        let gw = RemoteSessionGateway(provider: provider) { _ in }
+        await gw.handle(.subscribe(sessionId: "s1"))
+        await gw.handle(.subscribe(sessionId: "s1"))   // client resync
+        await gw.handle(.unsubscribe(sessionId: "s1"))
+        #expect(!s.transcript.changeLog.isTracking)
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteSessionGatewayTests 2>&1 | tail -20`
+Expected: compile error (`RemoteTranscriptSync` unknown) or assertion failures on the placeholder full-window snapshot.
+
+- [ ] **Step 3: Implement**
+
+Create `Alas/Sources/Remote/Gateway/RemoteTranscriptSync.swift` with the class from the Interfaces block (add a short doc comment: per-connection, per-session sync bookkeeping for incremental transcript delivery).
+
+In `RemoteSessionGateway.swift`:
+
+1. Add state: `private var syncStates: [String: RemoteTranscriptSync] = [:]` and `private var trackedSessions: Set<String> = []`.
+
+2. Tracking lifecycle. In `.subscribe`, BEFORE calling `sendSnapshot`: `beginTracking(id: id, session: session)`. Add helpers:
+
+```swift
+    private func beginTracking(id: String, session: ACPSession) {
+        guard !trackedSessions.contains(id) else { return }
+        trackedSessions.insert(id)
+        session.transcript.changeLog.retainTracking()
+    }
+
+    private func endTracking(id: String) {
+        guard trackedSessions.remove(id) != nil else { return }
+        provider.session(for: id)?.transcript.changeLog.releaseTracking()
+    }
+```
+
+In `.unsubscribe`, call `endTracking(id: id)` and `syncStates[id] = nil` alongside the existing cleanup. In `close()`, iterate `trackedSessions` calling `endTracking`, then clear `syncStates`.
+
+3. Rewrite `sendSnapshot` to a tail window:
+
+```swift
+    private func sendSnapshot(id: String, session: ACPSession) async {
+        let state = syncState(for: id)
+        let log = session.transcript.changeLog
+        let count = session.transcript.messages.count
+        let first = max(0, count - RemoteTranscriptSync.tailWindow)
+        // Capture version/epoch BEFORE the async serialize: anything that
+        // mutates during the awaits lands at a higher version and is
+        // picked up by the next delta.
+        state.epoch = log.epoch
+        state.sentVersion = log.latestVersion
+        state.revision = 0
+        let wire = await wireMessages(id: id, session: session, indices: Array(first..<count))
+        send(.transcriptSnapshot(sessionId: id,
+                                 streamingState: Self.stateString(session.transcript.streamingState),
+                                 canDrive: provider.isWriter(for: id),
+                                 messages: wire,
+                                 firstIndex: first,
+                                 totalCount: count,
+                                 epoch: state.epoch,
+                                 revision: 0))
+        emitPendingPermissionIfAny(id: id, session: session)
+        emitPendingQuestionIfAny(id: id, session: session)
+        emitPendingElicitationIfAny(id: id, session: session)
+    }
+
+    private func syncState(for id: String) -> RemoteTranscriptSync {
+        if let s = syncStates[id] { return s }
+        let s = RemoteTranscriptSync()
+        syncStates[id] = s
+        return s
+    }
+```
+
+4. Rewrite `sendDelta` (replace the "v1 full re-snapshot" comment and body):
+
+```swift
+    /// Emits an incremental delta: only messages the change log marked
+    /// dirty since the last send. Structural transcript changes (prepend,
+    /// removal, wholesale replacement) resync via a fresh tail snapshot.
+    private func sendDelta(id: String, session: ACPSession) async {
+        guard let state = syncStates[id] else { return }
+        let log = session.transcript.changeLog
+        switch log.changes(since: state.sentVersion) {
+        case .resync:
+            await sendSnapshot(id: id, session: session)
+            return
+        case .none:
+            // No transcript content changed — this tick was a state flip
+            // (streamingState / pending prompt). Send a content-free delta
+            // so the client still tracks state.
+            state.revision += 1
+            send(.transcriptDelta(sessionId: id,
+                                  streamingState: Self.stateString(session.transcript.streamingState),
+                                  canDrive: provider.isWriter(for: id),
+                                  upserts: [],
+                                  epoch: state.epoch,
+                                  revision: state.revision))
+        case .dirty(let indices):
+            guard indices.count <= RemoteTranscriptSync.dirtyResnapshotThreshold else {
+                await sendSnapshot(id: id, session: session)
+                return
+            }
+            state.sentVersion = log.latestVersion
+            // A dirty tool call's persisted content may have grown past the
+            // cached copy — drop it so serialization re-fetches.
+            for index in indices where session.transcript.messages.indices.contains(index) {
+                if case .toolCall(let tc) = session.transcript.messages[index] {
+                    state.invalidateToolContent(tc.toolCallId)
+                }
+            }
+            let wire = await wireMessages(id: id, session: session, indices: indices)
+            state.revision += 1
+            send(.transcriptDelta(sessionId: id,
+                                  streamingState: Self.stateString(session.transcript.streamingState),
+                                  canDrive: provider.isWriter(for: id),
+                                  upserts: wire,
+                                  epoch: state.epoch,
+                                  revision: state.revision))
+        }
+        emitPendingPermissionIfAny(id: id, session: session)
+        emitPendingQuestionIfAny(id: id, session: session)
+        emitPendingElicitationIfAny(id: id, session: session)
+    }
+```
+
+5. Generalize `wireMessages` to serialize arbitrary indices with the cache:
+
+```swift
+    private func wireMessages(id: String, session: ACPSession, indices: [Int]) async -> [RemoteWireMessage] {
+        var wire: [RemoteWireMessage] = []
+        wire.reserveCapacity(indices.count)
+        for index in indices {
+            // Re-check across awaits: a structural mutation mid-serialize can
+            // shrink the array; the epoch bump will resync the client.
+            guard session.transcript.messages.indices.contains(index) else { continue }
+            let message = session.transcript.messages[index]
+            wire.append(Self.toWire(
+                message,
+                index: index,
+                fullToolCallContent: await cachedFullToolCallContent(sessionId: id, message: message)))
+        }
+        return wire
+    }
+
+    private func cachedFullToolCallContent(sessionId: String, message: ACPMessage) async -> String? {
+        guard case .toolCall(let toolCall) = message, toolCall.isContentTruncated else { return nil }
+        let state = syncState(for: sessionId)
+        if let cached = state.cachedToolContent(toolCall.toolCallId) { return cached }
+        guard let full = await provider.fullToolCallContent(sessionId: sessionId, toolCallId: toolCall.toolCallId)
+        else { return nil }
+        state.storeToolContent(toolCall.toolCallId, full)
+        return full
+    }
+```
+
+Delete the old `fullToolCallContentIfNeeded`.
+
+6. Add the `fetchOlder` handler in `handle(_:)`:
+
+```swift
+        case .fetchOlder(let id, let beforeIndex, let limit):
+            // Ignore pages requested before a snapshot established sync state.
+            guard let session = provider.session(for: id), syncStates[id] != nil else { return }
+            let clamped = min(max(limit, RemoteTranscriptSync.pageLimitRange.lowerBound),
+                              RemoteTranscriptSync.pageLimitRange.upperBound)
+            let count = session.transcript.messages.count
+            let hi = min(max(beforeIndex, 0), count)
+            let lo = max(0, hi - clamped)
+            let wire = await wireMessages(id: id, session: session, indices: Array(lo..<hi))
+            // Stamp with the CURRENT epoch: if it moved past the client's,
+            // the client drops the page and the pending resync wins.
+            send(.transcriptPage(sessionId: id,
+                                 epoch: session.transcript.changeLog.epoch,
+                                 firstIndex: lo,
+                                 messages: wire))
+```
+
+7. Update `toWire`'s doc comment: positional ids stay (`"m\(index)"`) — note they remain valid because every index-shifting mutation is structural and forces a tail re-snapshot under a new epoch. Set `index: index` in every `RemoteWireMessage` init inside `toWire`.
+
+8. Update the class doc comment (lines 4–11): it no longer "re-snapshots on change"; describe change-log consumption + tail-window snapshots.
+
+- [ ] **Step 4: Run gateway tests; update stale expectations**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteSessionGatewayTests 2>&1 | tail -40`
+
+Some pre-existing tests assert full-transcript deltas or snapshot shapes; update them to the new semantics (they should still pass conceptually — short transcripts fit entirely inside the tail window, so most assertions hold). Iterate until green.
+
+- [ ] **Step 5: Run the remote suites**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteSessionGatewayTests -only-testing:AlasTests/RemoteServerIntegrationTests -only-testing:AlasTests/RemoteAppStateAccessTests 2>&1 | tail -20`
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/Remote/Gateway/ AlasTests/Remote/RemoteSessionGatewayTests.swift Alas.xcodeproj
+git commit -m "feat(remote): incremental transcript deltas with windowed snapshots and paging"
+```
+
+---
+
+### Task 5: Fast-lane stop — dispatch bypass, lease bypass, stopPending ack
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Server/RemoteConnection.swift` (control-class dispatch)
+- Modify: `Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift` (`.stop` case)
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift` (add `interruptBypassingLease`)
+- Modify: `Alas/Sources/ACP/Session/ACPSessionRunner.swift` (`userCancel(confirmingLease:)`)
+- Modify: `Alas/Sources/App/AppState.swift` (`stop(for:)` routes to the bypass)
+- Test: `AlasTests/Remote/RemoteSessionGatewayTests.swift`, `AlasTests/Remote/RemoteServerIntegrationTests.swift`
+
+**Interfaces:**
+- Consumes: `RemoteClientMessage.isControl` (Task 3), `RemoteServerMessage.stopPending` (Task 3).
+- Produces:
+  - `ACPSessionManager.interruptBypassingLease(for id: ACPSession.ID) async`
+  - `ACPSessionRunner.userCancel(confirmingLease: Bool = true) async` (existing callers unchanged)
+
+- [ ] **Step 1: Write the failing tests**
+
+Gateway-level (in `RemoteSessionGatewayTests.swift`):
+
+```swift
+    @Test func stopWorksWithoutWriterLeaseAndAcksImmediately() async throws {
+        let provider = FakeSessionsProvider()
+        provider.sessions["s1"] = try makeSessionWithAgentText("hi")
+        // NOTE: provider.writers is intentionally empty — not the writer.
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gw.handle(.stop(sessionId: "s1"))
+        #expect(provider.stopped == ["s1"])
+        #expect(sent.first == .stopPending(sessionId: "s1"))
+    }
+```
+
+Integration-level (in `RemoteServerIntegrationTests.swift`, using the existing `startServer(pairing:provider:)` + pair + WS helpers — copy the connection boilerplate from `pairThenWebSocketSubscribeReceivesSnapshot`):
+
+```swift
+    @Test func stopBypassesBlockedOrderedQueue() async throws {
+        let provider = FakeSessionsProvider()
+        let mgr = try makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        provider.sessions[s.id] = s
+        provider.pauseSessionSummaries = true            // blocks the ordered chain
+        let pairing = RemotePairingService(store: InMemoryDeviceStore())
+        let (server, port) = try await startServer(pairing: pairing, provider: provider)
+        defer { server.stop() }
+        // ... pair + open WS exactly as pairThenWebSocketSubscribeReceivesSnapshot ...
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.listSessions)))   // parks the chain
+        try await task.send(.data(JSONEncoder().encode(RemoteClientMessage.stop(sessionId: s.id))))
+        // stop must land while listSessions is still parked on its continuation.
+        for _ in 0..<100 where provider.stopped.isEmpty {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(provider.stopped == [s.id])
+        provider.resumeSessionSummaries()
+        task.cancel(with: .goingAway, reason: nil)
+    }
+```
+
+(Adapt names/boilerplate to the file's existing helpers; the assertion that matters is `provider.stopped` becoming non-empty while `pauseSessionSummaries` is still holding the ordered chain.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteSessionGatewayTests -only-testing:AlasTests/RemoteServerIntegrationTests 2>&1 | tail -20`
+Expected: `stopWorksWithoutWriterLease...` fails (`provider.stopped == []` — writer guard rejects), `stopBypassesBlockedOrderedQueue` times out.
+
+- [ ] **Step 3: Implement**
+
+1. `RemoteConnection.dispatchMessage` — control messages skip the chain:
+
+```swift
+    private func dispatchMessage(_ payload: Data) {
+        guard let msg = try? JSONDecoder().decode(RemoteClientMessage.self, from: payload),
+              let gateway else { return }
+        // Control messages (stop) are idempotent and latency-critical: run
+        // them immediately instead of queueing behind transcript work.
+        // Everything else keeps strict arrival order (takeOver before
+        // sendPrompt, etc.).
+        if msg.isControl {
+            Task { @MainActor in await gateway.handle(msg) }
+            return
+        }
+        let previous = processingTail
+        processingTail = Task { @MainActor in
+            await previous?.value
+            await gateway.handle(msg)
+        }
+    }
+```
+
+2. Gateway `.stop` — drop the writer guard, ack first:
+
+```swift
+        case .stop(let id):
+            // Emergency brake: any authenticated subscriber may cancel the
+            // running turn; no writer lease required. Ack immediately so the
+            // client flips to "stopping" before the ACP round-trip completes.
+            send(.stopPending(sessionId: id))
+            await provider.stop(for: id)
+```
+
+3. `ACPSessionRunner.userCancel` — parameterize the lease confirmation. Change the signature to `func userCancel(confirmingLease: Bool = true) async` and wrap the existing guard:
+
+```swift
+        if confirmingLease {
+            // A former writer that lost the lease must not send a cancel RPC
+            // ... (keep existing comment)
+            guard await hasConfirmedLeaseForSideEffect() else { return }
+        }
+```
+
+4. `ACPSessionManager` — add next to `interrupt(for:)`:
+
+```swift
+    /// Remote-web emergency brake: cancel this instance's in-flight turn
+    /// WITHOUT confirming the writer lease. `session/cancel` is idempotent
+    /// and only reaches this instance's own adapter — if another instance
+    /// took the lease and drives the session, our runner has no active
+    /// prompt and the cancel is a harmless no-op there.
+    func interruptBypassingLease(for id: ACPSession.ID) async {
+        guard let runner = runners[id] else { return }
+        await runner.userCancel(confirmingLease: false)
+    }
+```
+
+5. `AppState.stop(for:)` (RemoteSessionsProvider extension, ~line 4766): call `mgr.interruptBypassingLease(for: id)` instead of `mgr.interrupt(for: id)`.
+
+6. `app.js` stop handler loses `ensureWriter()` in Task 6 (client side) — do not touch JS here.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteSessionGatewayTests -only-testing:AlasTests/RemoteServerIntegrationTests 2>&1 | tail -20`
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Remote/ Alas/Sources/ACP/Session/ACPSessionManager.swift Alas/Sources/ACP/Session/ACPSessionRunner.swift Alas/Sources/App/AppState.swift AlasTests/Remote/
+git commit -m "feat(remote): fast-lane stop past the ordered queue and writer lease"
+```
+
+---
+
+### Task 6: Move outbound JSON encoding off the MainActor
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Server/RemoteConnection.swift` (`sendServerMessage`)
+
+**Interfaces:**
+- Consumes: `RemoteServerMessage: Sendable` (already true).
+- Produces: no API change; encoding happens on the connection's serial `queue` instead of the caller's (MainActor) context.
+
+- [ ] **Step 1: Implement (no new test — covered by every existing wire test)**
+
+```swift
+    private func sendServerMessage(_ msg: RemoteServerMessage) {
+        // Encode on the connection's serial queue, not the caller's
+        // MainActor context — outbound serialization must never compete
+        // with ACP state mutation for main-thread time.
+        onQueue { [weak self] in
+            guard let self, let data = try? JSONEncoder().encode(msg) else { return }
+            self.send(WebSocketFrame.encode(opcode: .text, payload: data)) {}
+        }
+    }
+```
+
+- [ ] **Step 2: Build and run the remote suites**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteServerIntegrationTests -only-testing:AlasTests/RemoteSessionGatewayTests 2>&1 | tail -10`
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Alas/Sources/Remote/Server/RemoteConnection.swift
+git commit -m "perf(remote): encode outbound frames off the main actor"
+```
+
+---
+
+### Task 7: Web client — keyed rendering, scroll backfill, leaseless stop
+
+**Files:**
+- Modify: `Alas/Resources/RemoteWeb/app.js`
+- Modify: `Alas/Resources/RemoteWeb/index.html` (bump `app.js?v=57` → `?v=58`; `style.css?v=36` → `?v=37` if CSS changes)
+- Modify: `Alas/Resources/RemoteWeb/style.css` (loading-row + stopping-state styles)
+- Modify: `Alas/Resources/RemoteWeb/sw.js` (bump `CACHE_NAME` to `alas-remote-shell-v36`; sync `SHELL_ASSETS` versions)
+- Test: `AlasTests/Remote/RemoteWebAssetTests.swift` (extend)
+
+**Interfaces:**
+- Consumes: wire messages from Task 3 (`transcriptSnapshot` with `firstIndex`/`totalCount`/`epoch`/`revision`, `transcriptDelta` with `upserts`/`epoch`/`revision`, `transcriptPage`, `stopPending`) and `fetchOlder` client message.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the failing asset tests**
+
+Add to `AlasTests/Remote/RemoteWebAssetTests.swift` (follow the file's `asset(_:)` string-inspection idiom):
+
+```swift
+    @Test func remoteWebSpeaksIncrementalTranscriptProtocol() throws {
+        let js = try asset("app.js")
+        #expect(js.contains(#"case "transcriptPage""#))
+        #expect(js.contains(#"case "stopPending""#))
+        #expect(js.contains(#"type: "fetchOlder""#))
+    }
+
+    @Test func remoteWebStopDoesNotTakeOverFirst() throws {
+        let js = try asset("app.js")
+        let stopHandler = try #require(js.range(of: #"$("stop").onclick"#).map { js[$0.lowerBound...].prefix(220) })
+        #expect(!stopHandler.contains("ensureWriter"))
+    }
+
+    @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
+        let sw = try asset("sw.js")
+        let html = try asset("index.html")
+        #expect(sw.contains("alas-remote-shell-v36"))
+        #expect(sw.contains("/app.js?v=58"))
+        #expect(html.contains("app.js?v=58"))
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteWebAssetTests 2>&1 | tail -10`
+Expected: the three new tests FAIL.
+
+- [ ] **Step 3: Implement app.js**
+
+All changes in `Alas/Resources/RemoteWeb/app.js`:
+
+1. **State** (top of file, replacing `messages = new Map()` usage semantics):
+
+```js
+let ws, currentSession = null, messages = new Map();   // stableId → wire message
+let messageNodes = new Map();                          // stableId → DOM node
+let transcriptMeta = null;   // {epoch, revision, firstIndex, totalCount} for the open session
+let olderFetchInFlight = false;
+let stopPending = false;
+```
+
+Reset all of these in `openSession` and `showSessions` (where `messages = new Map()` is reset today).
+
+2. **handle() cases** — replace the two transcript cases and add two:
+
+```js
+    case "transcriptSnapshot": applySnapshot(msg); break;
+    case "transcriptDelta": applyDelta(msg); break;
+    case "transcriptPage": applyPage(msg); break;
+    case "stopPending": if (msg.sessionId === currentSession) markStopping(true); break;
+```
+
+3. **Snapshot / delta / page application:**
+
+```js
+function applySnapshot(msg) {
+  if (msg.sessionId !== currentSession) return;
+  canDrive = msg.canDrive; canDriveKnown = true;
+  transcriptMeta = { epoch: msg.epoch, revision: msg.revision, firstIndex: msg.firstIndex, totalCount: msg.totalCount };
+  olderFetchInFlight = false;
+  const box = $("messages");
+  const open = new Set();
+  box.querySelectorAll(".m-collapsible.is-open").forEach(d => { if (d.dataset.sid) open.add(d.dataset.sid); });
+  box.innerHTML = "";
+  messages = new Map(); messageNodes = new Map();
+  msg.messages.forEach(m => insertMessage(m, open));
+  requestAnimationFrame(() => { box.scrollTop = box.scrollHeight; });
+  syncStreamingState(msg.streamingState);
+}
+
+function applyDelta(msg) {
+  if (msg.sessionId !== currentSession || !transcriptMeta) return;
+  // Epoch moved or a delta was missed → the server's view diverged; resync.
+  if (msg.epoch !== transcriptMeta.epoch || msg.revision !== transcriptMeta.revision + 1) {
+    resubscribe();
+    return;
+  }
+  transcriptMeta.revision = msg.revision;
+  canDrive = msg.canDrive; canDriveKnown = true;
+  const box = $("messages");
+  const atBottom = box.scrollTop + box.clientHeight >= box.scrollHeight - 120;
+  msg.upserts.forEach(m => upsertMessage(m));
+  if (atBottom) requestAnimationFrame(() => { box.scrollTop = box.scrollHeight; });
+  syncStreamingState(msg.streamingState);
+}
+
+function applyPage(msg) {
+  olderFetchInFlight = false;
+  removeLoadingRow();
+  if (msg.sessionId !== currentSession || !transcriptMeta) return;
+  if (msg.epoch !== transcriptMeta.epoch) return;   // stale page; a resync snapshot is coming
+  const box = $("messages");
+  const prevHeight = box.scrollHeight;
+  // Pages arrive oldest-first; insert in reverse so each lands at the front.
+  [...msg.messages].reverse().forEach(m => { if (!messages.has(m.stableId)) insertMessage(m, null); });
+  transcriptMeta.firstIndex = Math.min(transcriptMeta.firstIndex, msg.firstIndex);
+  box.scrollTop += box.scrollHeight - prevHeight;   // keep the viewport anchored
+}
+
+function resubscribe() {
+  if (currentSession) send({ type: "subscribe", sessionId: currentSession });
+}
+```
+
+4. **Keyed insert/upsert** (replaces `renderMessages`; delete `renderMessages`):
+
+```js
+// Insert a message node at its index-ordered DOM position. Nodes carry
+// dataset.index; the common case (append at the tail) is O(1).
+function insertMessage(m, open) {
+  const box = $("messages");
+  const node = renderMessage(m, m.stableId, open);
+  node.dataset.sid = m.stableId;
+  node.dataset.index = m.index;
+  messages.set(m.stableId, m);
+  messageNodes.set(m.stableId, node);
+  let anchor = box.lastElementChild;
+  while (anchor && Number(anchor.dataset.index) > m.index) anchor = anchor.previousElementSibling;
+  if (anchor) anchor.after(node); else box.prepend(node);
+}
+
+function upsertMessage(m) {
+  const existing = messageNodes.get(m.stableId);
+  if (existing) {
+    const wasOpen = existing.classList.contains("is-open") ? new Set([m.stableId]) : null;
+    const node = renderMessage(m, m.stableId, wasOpen);
+    node.dataset.sid = m.stableId;
+    node.dataset.index = m.index;
+    existing.replaceWith(node);
+    messages.set(m.stableId, m);
+    messageNodes.set(m.stableId, node);
+    return;
+  }
+  // A message older than the loaded window (rare late mutation): skip —
+  // it will arrive if the user backfills that far.
+  if (transcriptMeta && m.index < transcriptMeta.firstIndex) return;
+  insertMessage(m, null);
+}
+```
+
+Note `renderMessage` already sets `dataset.sid` only for collapsibles — setting it for every node here is fine and needed for the open-state scan in `applySnapshot`.
+
+5. **Scroll backfill** (register once at startup, next to the other listeners):
+
+```js
+const LOAD_OLDER_THRESHOLD_PX = 600;
+const OLDER_PAGE_SIZE = 90;
+
+listen("messages", "scroll", () => {
+  if (!currentSession || !transcriptMeta || olderFetchInFlight) return;
+  if (transcriptMeta.firstIndex <= 0) return;
+  if ($("messages").scrollTop > LOAD_OLDER_THRESHOLD_PX) return;
+  olderFetchInFlight = true;
+  showLoadingRow();
+  send({ type: "fetchOlder", sessionId: currentSession, beforeIndex: transcriptMeta.firstIndex, limit: OLDER_PAGE_SIZE });
+});
+
+function showLoadingRow() {
+  if ($("messages").querySelector(".load-older")) return;
+  const row = el("div", "load-older", "Loading earlier messages…");
+  row.dataset.index = "-1";
+  $("messages").prepend(row);
+}
+function removeLoadingRow() {
+  const row = $("messages").querySelector(".load-older");
+  if (row) row.remove();
+}
+```
+
+Add `.load-older` styling to `style.css` (small, centered, muted — match `.create-empty`'s look).
+
+6. **Stop UX** — replace the stop handler and hook state resets:
+
+```js
+$("stop").onclick = () => {
+  if (!currentSession) return;
+  send({ type: "stop", sessionId: currentSession });   // no ensureWriter: stop is leaseless
+  markStopping(true);
+};
+
+let stopFallbackTimer = null;
+function markStopping(on) {
+  stopPending = on;
+  const btn = $("stop");
+  btn.disabled = on;
+  btn.classList.toggle("is-stopping", on);
+  if (stopFallbackTimer) { clearTimeout(stopFallbackTimer); stopFallbackTimer = null; }
+  // If the cancel RPC fails and the turn keeps streaming, re-enable Stop so
+  // the user can retry instead of being stranded on a dead button.
+  if (on) stopFallbackTimer = setTimeout(() => markStopping(false), 15000);
+}
+
+function syncStreamingState(streamingState) {
+  if (streamingState === "idle" && stopPending) markStopping(false);
+  renderDriveBar(streamingState);
+}
+```
+
+Add `#stop.is-stopping { opacity: 0.5; }` (or similar) to `style.css`. Reset `markStopping(false)` in `openSession`/`showSessions`.
+
+7. **Bump versions:** `index.html` `app.js?v=58` (+ `style.css?v=37`); `sw.js` `CACHE_NAME = "alas-remote-shell-v36"` and matching `SHELL_ASSETS` entries.
+
+- [ ] **Step 4: Run asset tests**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteWebAssetTests 2>&1 | tail -10`
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 5: Manual browser verification**
+
+Launch Alas, enable Remote, open the web client on a long ACP session (or seed one). Verify: (1) the transcript paints the tail instantly; (2) scrolling to the top loads older pages and preserves scroll position; (3) streaming updates only mutate the tail; (4) pressing Stop during a turn dims the button immediately and the turn cancels promptly; (5) expanded tool cards stay expanded across streaming ticks.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Resources/RemoteWeb/ AlasTests/Remote/RemoteWebAssetTests.swift
+git commit -m "feat(remote-web): keyed incremental rendering, scroll backfill, instant stop"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Regenerate + full build + full test suite**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test 2>&1 | tail -30
+```
+
+Expected: `** TEST SUCCEEDED **`. Fix any stragglers (most likely: remaining pattern-matches of the widened `transcriptSnapshot`/`transcriptDelta` cases somewhere outside the remote tests — `grep -rn "transcriptSnapshot(\|transcriptDelta(" Alas/ AlasTests/`).
+
+- [ ] **Step 2: Commit any remaining fixes; confirm clean tree**
+
+```bash
+git status
+```

--- a/docs/superpowers/specs/2026-07-14-acp-remote-web-perf-design.md
+++ b/docs/superpowers/specs/2026-07-14-acp-remote-web-perf-design.md
@@ -1,0 +1,173 @@
+# ACP Remote Web: Incremental Transcript Delivery & Fast Stop
+
+**Date:** 2026-07-14
+**Status:** Approved
+
+## Problem
+
+Long ACP sessions make the remote web client nearly unusable:
+
+1. **Slow transcript population.** Opening a session sends the entire
+   transcript history as one `transcriptSnapshot`. Worse, every "delta" is a
+   full re-snapshot: `RemoteSessionGateway.sendDelta` re-serializes the whole
+   `session.transcript.messages` array on every 80 ms coalesce tick during
+   streaming, on the MainActor, per connected browser, with a SQLite read per
+   truncated tool call inside the loop. The browser then discards its message
+   map, clears the DOM (`innerHTML = ""`), and re-markdown-renders every
+   message on each delta.
+2. **Stop takes minutes.** Client messages on a connection are processed
+   strictly serially (`RemoteConnection.processingTail`). The web Stop button
+   first sends a `takeOver` (writer-lease seize + forced full snapshot) and
+   then `stop`, so the cancel queues behind full-transcript encodes on a
+   saturated MainActor. The server stop path adds two more lease loads before
+   the ACP `session/cancel` is sent.
+
+The recent native fix (#771, "Bound ACP transcript restore window") bounds
+only the SwiftUI render window; the web wire still serializes the full array.
+
+Both symptoms share one root cause: the wire protocol has no incremental
+delivery, no pagination, and no prioritization — everything is a full replay
+serialized on the MainActor.
+
+## Decisions
+
+- **Full incremental protocol redesign.** Web assets and the Swift server
+  ship together in the app build; no external wire compatibility to preserve.
+- **Initial load = tail window + lazy backfill** on scroll-up, mirroring the
+  native transcript's bounded window.
+- **Fast-lane control messages** on the existing socket (no second
+  WebSocket).
+- **Stop bypasses the writer lease.** Cancel is a safe, idempotent emergency
+  brake available to any authenticated subscriber; prompting still requires
+  the lease.
+
+## Section 1: Wire protocol
+
+The `RemoteServerMessage` transcript vocabulary moves from
+"snapshot + full-resnapshot-as-delta" to a versioned incremental model:
+
+- **`transcriptSnapshot`** — carries only a tail window (last ~90 messages,
+  matching the native `maxVisibleRows`), plus `totalCount` and `firstIndex`
+  so the client knows how much older history exists. Sent on subscribe and on
+  resync.
+- **`transcriptDelta`** — a true delta:
+  `{ upserts: [changed messages], removals: [ids], revision: n }`. During
+  streaming this is typically one message. The gateway tracks per-message
+  dirty state instead of re-emitting everything.
+- **`transcriptPage`** — response to a new client request
+  **`fetchOlder(sessionId, beforeIndex, limit)`** for lazy backfill. Pages
+  come from the in-memory transcript (already fully loaded in the session
+  manager): pure serialization, no new persistence.
+- **Revision counter + resync.** Each delta carries a monotonically
+  increasing `revision`. On a detected gap the client re-subscribes and gets
+  a fresh tail snapshot. Correctness strategy is always "resync the tail
+  window", never "diff harder".
+- **Epoch.** Snapshots (and pages) carry an `epoch` identifying the
+  transcript generation. The gateway bumps it on wholesale transcript
+  replacement; a client holding a stale epoch resyncs.
+
+**Dirty tracking.** `ACPTranscript` messages get a cheap monotonic `version`
+stamp bumped on mutation (chunk append, status change, …). The gateway keeps
+`lastSentVersion` per message id and, on each 80 ms tick, emits only messages
+with `version > lastSentVersion`. Tracking is by id, not position, so late
+mutations to older messages (e.g. tool-call completion) are still caught.
+
+**Tool-call content caching.** Full tool-call content
+(`fullToolCallContent` → SQLite) is fetched once when a tool call is first
+serialized, cached on the gateway, and only re-fetched if that message's
+version bumps. No more per-tick disk reads.
+
+## Section 2: Server-side execution
+
+**Serialization off the MainActor.** The gateway (MainActor) collects dirty
+ids and copies the corresponding `ACPMessage` values (value types), then
+hands them to a background serialization task that performs JSON encoding and
+frame writing. Per-tick MainActor work becomes O(dirty), not O(N), per
+connection.
+
+**Fast-lane control dispatch.** `RemoteConnection.dispatchMessage` splits
+incoming client messages into two classes:
+
+- **Control** (`stop`, `ping`): executed immediately on arrival, bypassing
+  the serial queue. Idempotent; no ordering dependency on transcript work.
+- **Ordered** (everything else — `subscribe`, `prompt`, `takeOver`,
+  `fetchOlder`, …): keeps the existing serial `processingTail` chain, which
+  protects prompt/lease ordering semantics.
+
+**Stop bypasses the lease.** The gateway's `.stop` handler drops the writer
+check. `AppState.stop` → `ACPSessionManager.interrupt` gains a path that
+skips `confirmedWriterLease`, and `ACPSessionRunner.userCancel` skips
+`hasConfirmedLeaseForSideEffect` for the cancel case. Client side, `app.js`
+drops the `ensureWriter()` call before `stop` — the takeOver-forced snapshot
+disappears from the critical path.
+
+**Immediate UI ack.** On receiving `stop`, the server pushes a lightweight
+`stopping` state update to all subscribers before the ACP round-trip
+completes, so the web UI flips to "stopping…" instantly.
+
+## Section 3: Web client
+
+**Keyed incremental rendering.** The client keeps `Map(id → message)` and
+`Map(id → DOM node)`. On `transcriptDelta`, only upserted messages get their
+node re-rendered (single-message markdown render); new nodes insert at the
+correct position; removals drop their nodes. Untouched messages keep their
+DOM. On `transcriptSnapshot` (subscribe/resync) a full rebuild is fine — it
+is a bounded tail window.
+
+**Scroll-up backfill.** Near the top with `firstIndex > 0`, the client sends
+`fetchOlder(beforeIndex, limit≈90)`, shows a loading indicator, prepends the
+page, and preserves scroll position by anchoring to the previously-topmost
+node. An in-flight flag prevents duplicate page requests.
+
+**Stop UX.** Stop button sends `stop` immediately (no `ensureWriter`), flips
+locally to "stopping…", and reconciles when the server's state update
+arrives.
+
+**Streaming tail behavior** (auto-follow at bottom) is unchanged, just
+cheaper: only the streaming message's node updates per tick.
+
+## Section 4: Error handling & edge cases
+
+**Resync correctness.** The single fallback for any inconsistency is
+re-subscribe → fresh tail snapshot:
+
+- Revision gap detected by the client → re-subscribe.
+- WebSocket reconnect → re-subscribe (existing behavior, now cheap).
+- Removals ride in deltas; if a change can't be expressed cheaply as
+  upserts+removals (wholesale transcript replacement, e.g. session restore),
+  the gateway bumps an epoch and pushes a fresh tail snapshot instead.
+
+**Backfill edges.** `fetchOlder` clamps `beforeIndex`/`limit` server-side.
+If the transcript changed underneath (epoch mismatch), the response says so
+and the client resyncs. Pages are positional but messages are keyed by id, so
+overlap upserts harmlessly.
+
+**Stop edges.** `stop` on an idle session is a no-op ack; duplicate stops are
+idempotent. If the ACP `session/cancel` round-trip fails, the still-running
+session state reaches the client and the button reverts from "stopping…".
+
+## Testing
+
+Swift Testing (`import Testing`), per repo convention:
+
+- **Gateway:** dirty tracking emits only changed messages; tail-window
+  snapshot bounds; `fetchOlder` paging math (clamping, epoch mismatch);
+  tool-call content cached across deltas (single persistence hit).
+- **Dispatch:** control messages execute while an ordered message is blocked
+  in the serial queue.
+- **Stop path:** stop reaches `interrupt` without a writer lease.
+- **Web assets:** extend `RemoteWebAssetTests` where the JS surface is
+  checkable; manual browser verification for scroll backfill and stopping UX.
+
+## Key files
+
+| File | Change |
+| --- | --- |
+| `Alas/Sources/Remote/Protocol/RemoteProtocol.swift` | New wire messages: windowed snapshot metadata, true deltas with revision, `fetchOlder`/`transcriptPage`, `stopping` state |
+| `Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift` | Dirty tracking, tail-window snapshot, paging, tool-call content cache, off-main serialization, lease-free stop |
+| `Alas/Sources/Remote/Server/RemoteConnection.swift` | Control vs ordered message dispatch classes |
+| `Alas/Sources/ACP/Session/ACPTranscript.swift` | Per-message monotonic version stamp |
+| `Alas/Sources/ACP/Session/ACPSessionManager.swift` | Lease-free interrupt entry point |
+| `Alas/Sources/ACP/Session/ACPSessionRunner.swift` | Skip lease check on cancel |
+| `Alas/Sources/App/AppState.swift` | Route lease-free stop |
+| `Alas/Resources/RemoteWeb/app.js` | Keyed DOM reconciliation, scroll backfill, leaseless stop with local "stopping…" state |


### PR DESCRIPTION
## Summary
- Replaces full-transcript-replay on the remote web wire with genuinely incremental delivery: a mutation change-log with epoch/version tracking, windowed initial snapshots (~90-message tail) with lazy scroll-up backfill (`fetchOlder`/`transcriptPage`), and true per-message deltas instead of full re-snapshots on every ~80ms coalesce tick.
- Fixes the multi-minute Stop-button latency: Stop now bypasses the per-connection ordered message queue (fast-lane dispatch for control messages) and no longer requires the writer lease — it's a leaseless "emergency brake" any authenticated subscriber can pull, acked immediately via `stopPending`. All other write actions (`sendPrompt`/`setModel`/`setMode`/`setAutoRun`) remain lease-gated, unchanged.
- Moves outbound WebSocket JSON encoding off the MainActor onto the connection's serial queue.
- Web client (`app.js`) does keyed DOM reconciliation instead of full `innerHTML` rebuilds on every update, and the Stop button no longer takes over the writer lease first.

Design spec: `docs/superpowers/specs/2026-07-14-acp-remote-web-perf-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-14-acp-remote-web-perf.md`

Built and reviewed task-by-task (8 tasks) via subagent-driven development, plus a final whole-branch review. No Critical or Important findings in either the per-task or final review.

## Test plan
- [x] Full Swift test suite: 5390 tests / 547 suites — passing except the 8 pre-existing, env-gated `SSHIntegrationTests` failures (confirmed present on `main` too, unrelated to this branch)
- [x] Final whole-branch code review: architecture, cross-task integration, security boundary (Stop lease bypass), and off-main encoding all traced and confirmed correct
- [ ] **Manual browser verification — outstanding.** No implementer or reviewer in this process had browser access; the web client changes (keyed rendering, scroll backfill, leaseless-stop UX) have only been read/traced by hand and checked via string-based asset tests, never executed. Before merging, verify against a real long-running ACP session:
  - [ ] Transcript tail paints instantly on open (no full-history wait)
  - [ ] Scrolling to the top backfills older messages and preserves scroll position
  - [ ] Streaming updates only mutate the active message's DOM node
  - [ ] Stop dims immediately and cancels within ~1s, even mid-turn
  - [ ] Expanded tool/thought cards stay expanded across streaming ticks