### PR TITLE
ci: cache zmx/fff/helper prebuild artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,81 @@ jobs:
             .build/ghostty
           key: ${{ steps.ghostty-cache.outputs.cache-primary-key }}
 
+      - name: Compute prebuilt tools cache key inputs
+        # Same pin-file pattern as .ghostty-pin: the fingerprint inputs the
+        # build scripts consult but hashFiles can't reach (submodule HEADs,
+        # the zig binary) get dumped into a small file we can hash.
+        # The zig *binary content* hash (not `zig version`) matters because
+        # build-zmx.sh hashes the binary into its fingerprint — a Homebrew
+        # bottle rebuild with an unchanged version string must still change
+        # the key. Helper's rust toolchain is pinned inside its script, so
+        # the script hash covers it.
+        run: |
+          git -C ThirdParty/zmx rev-parse HEAD > .tools-pin
+          {
+            git -C ThirdParty/fff rev-parse HEAD
+            git rev-parse HEAD:AlasHelper
+            shasum scripts/build-zmx.sh scripts/build-fff.sh scripts/build-alas-helper.sh
+            shasum -a 256 "$(brew --prefix zig@0.15)/bin/zig"
+          } >> .tools-pin
+          cat .tools-pin
+
+      - name: Restore prebuilt tools cache
+        # zmx / fff / Alas Helper artifacts combined in one entry — each is
+        # a few MB, and only install outputs + fingerprint markers are
+        # cached (no zig/cargo intermediates). The key is an optimization
+        # hint only: each script re-validates restored artifacts against its
+        # own fingerprint (submodule SHA + dirt + arch + toolchain + script
+        # hash), so a stale restore-keys fallback can never ship a wrong
+        # binary — the changed component rebuilds while the rest fast-path.
+        # zmx's macOS slice fast-paths off the *host* cache
+        # (~/Library/Caches/Alas/zmx), not the worktree output, hence that
+        # path; the Linux slices and fff/helper check worktree markers.
+        id: tools-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/Library/Caches/Alas/zmx
+            .build/zmx/linux-*/install
+            .build/zmx/linux-*/fingerprint
+            .build/fff/*/install
+            .build/fff/*/fingerprint
+            .build/fff/include
+            .build/alas-helper/*/release/alas-helper
+            .build/alas-helper/fingerprint
+          key: tools-${{ runner.os }}-arm64-${{ hashFiles('.tools-pin') }}
+          restore-keys: |
+            tools-${{ runner.os }}-arm64-
+
+      - name: Prebuild zmx + fff + Alas Helper
+        # These normally run as pre-build script phases *inside* xcodebuild,
+        # where a cold run buries ~11 min of zig/cargo work inside the build
+        # step and a later failure throws it away. Run them as their own
+        # step so the artifacts can be cached the moment they exist; the
+        # in-xcodebuild phases then fast-path in seconds.
+        run: |
+          ./scripts/build-zmx.sh
+          ./scripts/build-fff.sh
+          ./scripts/build-alas-helper.sh
+
+      - name: Save prebuilt tools cache
+        # Save immediately after the prebuild step succeeds, BEFORE
+        # xcodebuild/tests get a chance to fail — same split restore/save
+        # rationale as the Ghostty cache above.
+        if: success() && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/Library/Caches/Alas/zmx
+            .build/zmx/linux-*/install
+            .build/zmx/linux-*/fingerprint
+            .build/fff/*/install
+            .build/fff/*/fingerprint
+            .build/fff/include
+            .build/alas-helper/*/release/alas-helper
+            .build/alas-helper/fingerprint
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
       - name: Generate Xcode project
         run: xcodegen
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,6 +117,87 @@ jobs:
             .build/ghostty
           key: ${{ steps.ghostty-cache.outputs.cache-primary-key }}
 
+      - name: Compute prebuilt tools cache key inputs
+        if: steps.skip-check.outputs.skip != 'true'
+        # Same pin-file pattern as .ghostty-pin: the fingerprint inputs the
+        # build scripts consult but hashFiles can't reach (submodule HEADs,
+        # the zig binary) get dumped into a small file we can hash.
+        # The zig *binary content* hash (not `zig version`) matters because
+        # build-zmx.sh hashes the binary into its fingerprint — a Homebrew
+        # bottle rebuild with an unchanged version string must still change
+        # the key. Helper's rust toolchain is pinned inside its script, so
+        # the script hash covers it.
+        run: |
+          git -C ThirdParty/zmx rev-parse HEAD > .tools-pin
+          {
+            git -C ThirdParty/fff rev-parse HEAD
+            git rev-parse HEAD:AlasHelper
+            shasum scripts/build-zmx.sh scripts/build-fff.sh scripts/build-alas-helper.sh
+            shasum -a 256 "$(brew --prefix zig@0.15)/bin/zig"
+          } >> .tools-pin
+          cat .tools-pin
+
+      - name: Restore prebuilt tools cache
+        if: steps.skip-check.outputs.skip != 'true'
+        # zmx / fff / Alas Helper artifacts combined in one entry — each is
+        # a few MB, and only install outputs + fingerprint markers are
+        # cached (no zig/cargo intermediates). The key is an optimization
+        # hint only: each script re-validates restored artifacts against its
+        # own fingerprint (submodule SHA + dirt + arch + toolchain + script
+        # hash), so a stale restore-keys fallback can never ship a wrong
+        # binary — the changed component rebuilds while the rest fast-path.
+        # zmx's macOS slice fast-paths off the *host* cache
+        # (~/Library/Caches/Alas/zmx), not the worktree output, hence that
+        # path; the Linux slices and fff/helper check worktree markers.
+        id: tools-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/Library/Caches/Alas/zmx
+            .build/zmx/linux-*/install
+            .build/zmx/linux-*/fingerprint
+            .build/fff/*/install
+            .build/fff/*/fingerprint
+            .build/fff/include
+            .build/alas-helper/*/release/alas-helper
+            .build/alas-helper/fingerprint
+          key: tools-${{ runner.os }}-arm64-${{ hashFiles('.tools-pin') }}
+          restore-keys: |
+            tools-${{ runner.os }}-arm64-
+
+      - name: Prebuild zmx + fff + Alas Helper
+        if: steps.skip-check.outputs.skip != 'true'
+        # These normally run as pre-build script phases *inside* xcodebuild,
+        # where a cold run buries ~11 min of zig/cargo work inside the build
+        # step and a later failure throws it away. Run them as their own
+        # step so the artifacts can be cached the moment they exist; the
+        # in-xcodebuild phases then fast-path in seconds.
+        run: |
+          ./scripts/build-zmx.sh
+          ./scripts/build-fff.sh
+          ./scripts/build-alas-helper.sh
+
+      - name: Save prebuilt tools cache (main builds only)
+        # Gate on main-built refs like the Ghostty save above — a non-main
+        # dispatch building an arbitrary tree must never seed the repo-wide
+        # cache scope with a poisoned artifact.
+        if: success()
+          && steps.skip-check.outputs.skip != 'true'
+          && steps.tools-cache.outputs.cache-hit != 'true'
+          && (inputs.ref == '' || inputs.ref == 'main')
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/Library/Caches/Alas/zmx
+            .build/zmx/linux-*/install
+            .build/zmx/linux-*/fingerprint
+            .build/fff/*/install
+            .build/fff/*/fingerprint
+            .build/fff/include
+            .build/alas-helper/*/release/alas-helper
+            .build/alas-helper/fingerprint
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
       - name: Generate project
         if: steps.skip-check.outputs.skip != 'true'
         run: xcodegen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,87 @@ jobs:
           path: ~/Library/Caches/Alas/GhosttyKit/${{ matrix.arch }}
           key: ${{ steps.ghostty-cache.outputs.cache-primary-key }}
 
+      - name: Compute prebuilt tools cache key inputs
+        # Same pin-file pattern as .ghostty-pin: the fingerprint inputs the
+        # build scripts consult but hashFiles can't reach (submodule HEADs,
+        # the zig binary) get dumped into a small file we can hash.
+        # The zig *binary content* hash (not `zig version`) matters because
+        # build-zmx.sh hashes the binary into its fingerprint — a Homebrew
+        # bottle rebuild with an unchanged version string must still change
+        # the key. Helper's rust toolchain is pinned inside its script, so
+        # the script hash covers it.
+        run: |
+          git -C ThirdParty/zmx rev-parse HEAD > .tools-pin
+          {
+            git -C ThirdParty/fff rev-parse HEAD
+            git rev-parse HEAD:AlasHelper
+            shasum scripts/build-zmx.sh scripts/build-fff.sh scripts/build-alas-helper.sh
+            shasum -a 256 "$(brew --prefix zig@0.15)/bin/zig"
+          } >> .tools-pin
+          cat .tools-pin
+
+      - name: Restore prebuilt tools cache
+        # zmx / fff / Alas Helper artifacts combined in one entry — each is
+        # a few MB, and only install outputs + fingerprint markers are
+        # cached (no zig/cargo intermediates). The key is an optimization
+        # hint only: each script re-validates restored artifacts against its
+        # own fingerprint (submodule SHA + dirt + arch + toolchain + script
+        # hash), so a stale restore-keys fallback can never ship a wrong
+        # binary — the changed component rebuilds while the rest fast-path.
+        # zmx's macOS slice fast-paths off the *host* cache
+        # (~/Library/Caches/Alas/zmx), not the worktree output, hence that
+        # path; the Linux slices and fff/helper check worktree markers.
+        id: tools-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/Library/Caches/Alas/zmx
+            .build/zmx/linux-*/install
+            .build/zmx/linux-*/fingerprint
+            .build/fff/*/install
+            .build/fff/*/fingerprint
+            .build/fff/include
+            .build/alas-helper/*/release/alas-helper
+            .build/alas-helper/fingerprint
+          key: tools-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('.tools-pin') }}
+          restore-keys: |
+            tools-${{ runner.os }}-${{ matrix.arch }}-
+
+      - name: Prebuild zmx + fff + Alas Helper (${{ matrix.arch }})
+        # These normally run as pre-build script phases *inside* xcodebuild,
+        # where a cold run buries ~11 min of zig/cargo work inside the build
+        # step and a later failure throws it away. Run them as their own
+        # step so the artifacts can be cached the moment they exist; the
+        # in-xcodebuild phases then fast-path in seconds. The arch overrides
+        # mirror ALAS_GHOSTTY_TARGET_ARCH above so the x86_64 leg populates
+        # the same per-arch paths the in-build phases will look up via
+        # CURRENT_ARCH.
+        env:
+          ALAS_ZMX_TARGET_ARCH: ${{ matrix.arch }}
+          ALAS_FFF_TARGET_ARCH: ${{ matrix.arch }}
+        run: |
+          ./scripts/build-zmx.sh
+          ./scripts/build-fff.sh
+          ./scripts/build-alas-helper.sh
+
+      - name: Save prebuilt tools cache
+        # Save immediately after the prebuild step succeeds, BEFORE
+        # xcodebuild/tests get a chance to fail — same split restore/save
+        # rationale as the Ghostty cache above.
+        if: success() && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/Library/Caches/Alas/zmx
+            .build/zmx/linux-*/install
+            .build/zmx/linux-*/fingerprint
+            .build/fff/*/install
+            .build/fff/*/fingerprint
+            .build/fff/include
+            .build/alas-helper/*/release/alas-helper
+            .build/alas-helper/fingerprint
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
       - name: Resolve SwiftPM packages
         run: |
           xcodebuild -resolvePackageDependencies \


### PR DESCRIPTION
Profiling CI run 29314937718 showed ~11.5 min of every run rebuilding the
zmx (3× zig builds), fff (cargo release), and Alas Helper (4× cargo targets)
pre-build artifacts from scratch inside xcodebuild — none of them cached,
unlike GhosttyKit.

This adds a combined "prebuilt tools" actions/cache to build/nightly/release
(same split restore/save pattern as the Ghostty cache), plus an explicit
prebuild step so the work happens outside xcodebuild and is saved the moment
it succeeds. The cache key is an optimization hint only — each script
re-validates restored artifacts against its own fingerprint, so a stale
restore just rebuilds the changed component.

Expected: PR builds ~22 → ~10-11 min warm; nightly ~32 → ~21; each release
leg −11 min.