### PR TITLE
fix(worktree): fingerprint launch crash

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
 		018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */; };
 		019D3627B3CEB44C34CC34F9 /* RemoteHelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B0D8590E0335CD31B758E0 /* RemoteHelperProtocol.swift */; };
+		019EE52A9C64CF5D15AD9AF2 /* RightPaneStateContentFingerprintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */; };
 		01C919A6F3868980D51539DD /* ACPInitializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */; };
 		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
 		01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */; };
@@ -1896,6 +1897,7 @@
 		818B29F6B58D4FFC80603AAD /* ACPAdapterTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterTarget.swift; sourceTree = "<group>"; };
 		81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServer.swift; sourceTree = "<group>"; };
 		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
+		8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateContentFingerprintTests.swift; sourceTree = "<group>"; };
 		82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBehindStatusTests.swift; sourceTree = "<group>"; };
 		82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetector.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
@@ -2887,6 +2889,7 @@
 				B87101C6F8F27B57AEDC187D /* ReviewThreadWriteTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
+				8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */,
 				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
 				3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */,
 				5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */,
@@ -6014,6 +6017,7 @@
 				1ACB56B9AA0EC3C1C2AF5E18 /* ReviewThreadWriteTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
+				019EE52A9C64CF5D15AD9AF2 /* RightPaneStateContentFingerprintTests.swift in Sources */,
 				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,
 				8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */,
 				35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */,

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -30,7 +30,7 @@ extension Process {
         stdin: String? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResult {
-        try validateLaunchConfiguration(executable: executable, cwd: cwd)
+        try validateLaunchConfiguration(executable: executable, args: args, cwd: cwd)
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
@@ -253,7 +253,7 @@ extension Process {
         env: [String: String]? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResultData {
-        try validateLaunchConfiguration(executable: executable, cwd: cwd)
+        try validateLaunchConfiguration(executable: executable, args: args, cwd: cwd)
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
@@ -338,9 +338,16 @@ extension Process {
     }
 }
 
-private func validateLaunchConfiguration(executable: String, cwd: URL?) throws {
+private let maximumFoundationProcessArgumentCount = 4096
+
+private func validateLaunchConfiguration(executable: String, args: [String], cwd: URL?) throws {
     guard FileManager.default.isExecutableFile(atPath: executable) else {
         throw ProcessError.launchFailed("Executable is not runnable: \(executable)")
+    }
+    guard args.count <= maximumFoundationProcessArgumentCount else {
+        throw ProcessError.launchFailed(
+            "Too many arguments: \(args.count) (maximum \(maximumFoundationProcessArgumentCount))"
+        )
     }
 
     try validateWorkingDirectory(cwd)

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -254,6 +254,7 @@ final class RightPaneState {
     @ObservationIgnored private var remoteHelperSession: RemoteHelperWatchSession?
     @ObservationIgnored private let remoteEventDebouncer = DebounceTimer(interval: 0.5, maxWait: 2.0)
     @ObservationIgnored private var remoteFingerprint: String?
+    nonisolated private static let hashObjectBatchSize = 256
     private static let remotePollIntervalNanos: UInt64 = 7 * 1_000_000_000
     private static let remoteHelperSafetyNetNanos: UInt64 = 5 * 60 * 1_000_000_000
 
@@ -986,21 +987,29 @@ final class RightPaneState {
 
     nonisolated private static func hashObjects(paths: [String], worktreePath: URL) async -> [String: String] {
         guard !paths.isEmpty else { return [:] }
-        if let result = try? await Process.git(["hash-object", "--"] + paths, cwd: worktreePath),
-           result.exitCode == 0 {
-            let hashes = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
-            if hashes.count == paths.count {
-                return Dictionary(uniqueKeysWithValues: zip(paths, hashes))
-            }
-        }
 
         var hashes: [String: String] = [:]
-        for path in paths {
-            guard let result = try? await Process.git(["hash-object", "--", path], cwd: worktreePath),
-                  result.exitCode == 0 else {
-                continue
+        for startIndex in stride(from: 0, to: paths.count, by: hashObjectBatchSize) {
+            let endIndex = min(startIndex + hashObjectBatchSize, paths.count)
+            let batch = Array(paths[startIndex..<endIndex])
+            if let result = try? await Process.git(["hash-object", "--"] + batch, cwd: worktreePath),
+               result.exitCode == 0 {
+                let batchHashes = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
+                if batchHashes.count == batch.count {
+                    for (path, hash) in zip(batch, batchHashes) {
+                        hashes[path] = hash
+                    }
+                    continue
+                }
             }
-            hashes[path] = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            for path in batch {
+                guard let result = try? await Process.git(["hash-object", "--", path], cwd: worktreePath),
+                      result.exitCode == 0 else {
+                    continue
+                }
+                hashes[path] = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
         }
         return hashes
     }

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -29,6 +29,17 @@ struct ProcessGitTests {
         }
     }
 
+    @Test func tooManyArgumentsThrowsLaunchFailedBeforeFoundationAbort() async throws {
+        do {
+            _ = try await Process.run("/usr/bin/true", args: Array(repeating: "x", count: 4097))
+            Issue.record("expected launch failure")
+        } catch ProcessError.launchFailed(let message) {
+            #expect(message.contains("Too many arguments"))
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
+    }
+
     @Test func gitVersionRuns() async throws {
         let result = try await Process.run("/usr/bin/env", args: ["git", "--version"])
         #expect(result.exitCode == 0)

--- a/AlasTests/RightPaneStateContentFingerprintTests.swift
+++ b/AlasTests/RightPaneStateContentFingerprintTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct RightPaneStateContentFingerprintTests {
+    @Test func untrackedContentFingerprintHandlesMorePathsThanFoundationLaunchLimit() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-fingerprint-many-paths-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let paths = (0..<4097).map { String(format: "generated-%04d.txt", $0) }
+        for path in paths {
+            try "same content\n".write(
+                to: directory.appendingPathComponent(path),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let fingerprint = await RightPaneState.untrackedContentFingerprint(paths: paths, worktreePath: directory)
+
+        #expect(fingerprint.contains("generated-0000.txt\u{0000}"))
+        #expect(fingerprint.contains("generated-4096.txt\u{0000}"))
+        #expect(!fingerprint.contains("hash-error"))
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a crash when right-pane content fingerprinting tries to hash thousands of changed paths in one `Process` launch. Foundation aborts above 4096 arguments before Swift can catch an error, so this batches `git hash-object` calls and adds a process-level launch guard.

## Changes
- Batch right-pane `git hash-object` calls in groups of 256 paths.
- Reject `Process.run` / `runData` launches with more than 4096 arguments before calling Foundation.
- Add regressions for the direct argument-limit path and a 4097-file untracked content fingerprint.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused post-rebase regressions: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProcessGitTests/tooManyArgumentsThrowsLaunchFailedBeforeFoundationAbort -only-testing:AlasTests/RightPaneStateContentFingerprintTests/untrackedContentFingerprintHandlesMorePathsThanFoundationLaunchLimit -quiet test`
- Full suite without SSH integration: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -skip-testing:AlasTests/SSHIntegrationTests test`

Note: the exact full local command `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` built successfully but failed the SSH integration tests because this environment does not set `ALAS_SSH_INTEGRATION=1`; one terminal orphan test failure passed when rerun alone.