### PR TITLE
fix(diff): focus review comment composers

### DIFF
--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -125,7 +125,7 @@ struct CommitEditorTabView: View {
         GeometryReader { proxy in
             let total = proxy.size.width
             let ratio = max(0.15, min(0.7, appState.config.commitDetailSplitRatio))
-            let leftWidth = transientFilesWidth ?? max(Self.minPaneWidth, total * ratio)
+            let leftWidth: CGFloat = transientFilesWidth ?? max(Self.minPaneWidth, total * ratio)
             HStack(spacing: 0) {
                 CommitFilesListView(
                     files: details.files,
@@ -138,7 +138,7 @@ struct CommitEditorTabView: View {
                     axis: .horizontal,
                     onDragChanged: { translation in
                         guard total > Self.minPaneWidth * 2 else { return }
-                        let start = filesDragStartWidth ?? leftWidth
+                        let start: CGFloat = filesDragStartWidth ?? leftWidth
                         filesDragStartWidth = start
                         transientFilesWidth = CGFloat(PaneDragMath.resolvedWidth(
                             startWidth: Double(start),

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1127,10 +1127,13 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         textView.autoresizingMask = [.width]
         textView.string = text
         textView.onKeyboardAction = context.coordinator.perform
+        textView.onWindowChanged = { [weak coordinator = context.coordinator] in
+            coordinator?.requestFocusIfNeeded()
+        }
         scrollView.documentView = textView
         context.coordinator.textView = textView
         applyTheme(to: scrollView, textView: textView)
-        requestFocusIfNeeded(textView)
+        context.coordinator.requestFocusIfNeeded()
         return scrollView
     }
 
@@ -1141,8 +1144,11 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
             textView.string = text
         }
         textView.onKeyboardAction = context.coordinator.perform
+        textView.onWindowChanged = { [weak coordinator = context.coordinator] in
+            coordinator?.requestFocusIfNeeded()
+        }
         applyTheme(to: scrollView, textView: textView)
-        requestFocusIfNeeded(textView)
+        context.coordinator.requestFocusIfNeeded()
     }
 
     private func applyTheme(to scrollView: NSScrollView, textView: NSTextView) {
@@ -1151,16 +1157,6 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         textView.font = .systemFont(ofSize: 12)
         textView.textColor = NSColor(theme.color("fg"))
         textView.insertionPointColor = NSColor(theme.color("accent"))
-    }
-
-    private func requestFocusIfNeeded(_ textView: NSTextView) {
-        guard isFocused.wrappedValue else { return }
-        DispatchQueue.main.async {
-            guard let window = textView.window,
-                  window.firstResponder !== textView
-            else { return }
-            window.makeFirstResponder(textView)
-        }
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
@@ -1185,6 +1181,16 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         }
 
         @MainActor
+        func requestFocusIfNeeded() {
+            guard parent.isFocused.wrappedValue,
+                  let textView,
+                  let window = textView.window,
+                  window.firstResponder !== textView
+            else { return }
+            window.makeFirstResponder(textView)
+        }
+
+        @MainActor
         func perform(_ action: ReviewDraftComposerKeyboardAction) {
             switch action {
             case .save:
@@ -1198,6 +1204,12 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
 
 private final class ReviewDraftComposerNSTextView: NSTextView {
     var onKeyboardAction: (@MainActor (ReviewDraftComposerKeyboardAction) -> Void)?
+    var onWindowChanged: (@MainActor () -> Void)?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        onWindowChanged?()
+    }
 
     override func keyDown(with event: NSEvent) {
         let key = event.charactersIgnoringModifiers ?? event.characters ?? ""

--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 
 struct DiffInlineCommentCard: View {
+    private enum FocusedEditor: Hashable {
+        case reply
+        case edit(String)
+    }
+
     let thread: DiffInlineCommentThread
     var onReply: (String) -> Void = { _ in }
     var onResolve: () -> Void = {}
@@ -20,6 +25,7 @@ struct DiffInlineCommentCard: View {
     @State private var editDraft = ""
     @State private var isHovered = false
     @FocusState private var isCardFocused: Bool
+    @FocusState private var focusedEditor: FocusedEditor?
 
     init(
         thread: DiffInlineCommentThread,
@@ -160,16 +166,21 @@ struct DiffInlineCommentCard: View {
                     }
                     TextEditor(text: $replyDraft)
                         .font(.system(size: 11))
+                        .focused($focusedEditor, equals: .reply)
                         .frame(minHeight: 60)
                         .overlay(
                             RoundedRectangle(cornerRadius: 4)
                                 .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                         )
+                        .onAppear {
+                            focusedEditor = .reply
+                        }
                     HStack(spacing: 8) {
                         Button("Comment") {
                             onReply(replyDraft)
                             replyDraft = ""
                             isComposerOpen = false
+                            focusedEditor = nil
                         }
                         .buttonStyle(.plain)
                         .font(.system(size: 11, weight: .semibold))
@@ -180,6 +191,7 @@ struct DiffInlineCommentCard: View {
                                 onStageReply(replyDraft)
                                 replyDraft = ""
                                 isComposerOpen = false
+                                focusedEditor = nil
                             }
                             .buttonStyle(.plain)
                             .font(.system(size: 11, weight: .semibold))
@@ -189,6 +201,7 @@ struct DiffInlineCommentCard: View {
                         Button("Cancel") {
                             replyDraft = ""
                             isComposerOpen = false
+                            focusedEditor = nil
                         }
                         .buttonStyle(.plain)
                         .font(.system(size: 11))
@@ -204,7 +217,10 @@ struct DiffInlineCommentCard: View {
             // Action buttons
             HStack(spacing: 8) {
                 if canReply {
-                    Button("Reply") { isComposerOpen.toggle() }
+                    Button("Reply") {
+                        isComposerOpen.toggle()
+                        focusedEditor = isComposerOpen ? .reply : nil
+                    }
                         .buttonStyle(.plain)
                         .font(.system(size: 11))
                         .foregroundColor(.accentColor)
@@ -249,16 +265,21 @@ struct DiffInlineCommentCard: View {
                     .foregroundColor(.primary)
                 TextEditor(text: $editDraft)
                     .font(.system(size: 11))
+                    .focused($focusedEditor, equals: .edit(comment.id))
                     .frame(minHeight: 60)
                     .overlay(
                         RoundedRectangle(cornerRadius: 4)
                             .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                     )
+                    .onAppear {
+                        focusedEditor = .edit(comment.id)
+                    }
                 HStack(spacing: 8) {
                     Button("Save") {
                         onEdit(comment, editDraft)
                         editingCommentID = nil
                         editDraft = ""
+                        focusedEditor = nil
                     }
                     .buttonStyle(.plain)
                     .font(.system(size: 11, weight: .semibold))
@@ -267,6 +288,7 @@ struct DiffInlineCommentCard: View {
                     Button("Cancel") {
                         editingCommentID = nil
                         editDraft = ""
+                        focusedEditor = nil
                     }
                     .buttonStyle(.plain)
                     .font(.system(size: 11))
@@ -286,6 +308,7 @@ struct DiffInlineCommentCard: View {
                         Button {
                             editingCommentID = comment.id
                             editDraft = comment.body
+                            focusedEditor = .edit(comment.id)
                         } label: {
                             Image(systemName: "pencil")
                                 .font(.system(size: 10))

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -127,7 +127,7 @@ struct MarkdownTabView: View {
             preview
         case .split:
             GeometryReader { proxy in
-                let leftWidth = transientEditorWidth ?? max(120, proxy.size.width * splitFraction)
+                let leftWidth: CGFloat = transientEditorWidth ?? max(120, proxy.size.width * splitFraction)
                 HStack(spacing: 0) {
                     codeEditor.frame(width: leftWidth)
                     DragHandle(
@@ -135,7 +135,7 @@ struct MarkdownTabView: View {
                         onDragChanged: { translation in
                             let total = proxy.size.width
                             guard total > 240 else { return }
-                            let start = editorDragStartWidth ?? leftWidth
+                            let start: CGFloat = editorDragStartWidth ?? leftWidth
                             editorDragStartWidth = start
                             transientEditorWidth = CGFloat(PaneDragMath.resolvedWidth(
                                 startWidth: Double(start),


### PR DESCRIPTION
## Summary

- Focus the shared draft review composer after its underlying `NSTextView` attaches to a window.
- Add explicit SwiftUI focus state for inline review reply and edit text boxes.
- Fix two post-rebase split-view drag width inference issues exposed by the current main branch/Xcode toolchain.

## Root cause

The draft composer could request first responder status before the AppKit text view had a window, so the request was dropped in panes that mount the composer asynchronously, including "Review current changes".

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full local `xcodebuild ... test` was run before the rebase; it executed 5,383 tests and only failed the SSH integration tests that require `ALAS_SSH_INTEGRATION=1`.