### PR TITLE
fix(diff): Allow comments on unchanged diff lines

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -608,10 +608,15 @@ final class DiffPaneTextScrollView: NSScrollView {
     }
     var allowsReviewLineSelection: Bool = true {
         didSet {
+            textView.allowsReviewLineSelection = allowsReviewLineSelection
             (verticalRulerView as? DiffPaneLineNumberRulerView)?.allowsReviewLineSelection = allowsReviewLineSelection
         }
     }
-    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in } {
+        didSet {
+            textView.onReviewLineSelected = onReviewLineSelected
+        }
+    }
     var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in } {
         didSet {
             textView.contextExpansionHandler = onContextExpansion
@@ -657,6 +662,8 @@ final class DiffPaneTextScrollView: NSScrollView {
             self?.onReviewLineSelected(anchor)
         }
         verticalRulerView = ruler
+        textView.allowsReviewLineSelection = allowsReviewLineSelection
+        textView.onReviewLineSelected = onReviewLineSelected
 
         textView.isEditable = false
         textView.isSelectable = true
@@ -1047,6 +1054,8 @@ final class DiffPaneCodeTextView: NSTextView {
     var flagsChangedHandler: ((NSEvent) -> Void)?
     var mouseExitedHandler: (() -> Void)?
     var contextExpansionHandler: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+    var allowsReviewLineSelection = true
+    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var lspContext: DiffPaneLSPContext?
     var allowedLSPSide: DiffLineSide = .new
     var hasLSPContextForTesting: Bool { lspContext != nil }
@@ -1156,6 +1165,13 @@ final class DiffPaneCodeTextView: NSTextView {
         }
         if event.modifierFlags.contains(.command), let commandClickHandler {
             commandClickHandler(point)
+            return
+        }
+        if allowsReviewLineSelection,
+           event.clickCount == 1,
+           let anchor = reviewLineAnchor(at: point)
+        {
+            onReviewLineSelected(anchor)
             return
         }
         super.mouseDown(with: event)

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1854,6 +1854,79 @@ let second = true
         #expect(selectedAnchor == anchor)
     }
 
+    @Test @MainActor func codeTextViewInvokesReviewSelectionForContextRows() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let text = "let value = 1"
+        let sourceLine = DiffDisplayLine(
+            id: "line-12",
+            anchor: DiffLineAnchor(
+                filePath: "Sources/App.swift",
+                hunkIndex: 0,
+                rowIndex: 0,
+                side: .new,
+                oldLine: nil,
+                newLine: 12
+            ),
+            text: text,
+            lineNumber: 12,
+            kind: .context,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: text,
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .context,
+                    range: NSRange(location: 0, length: (text as NSString).length),
+                    sourceLine: sourceLine
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        let window = NSWindow(contentRect: scrollView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(scrollView)
+        var selectedAnchor: DiffReviewLineAnchor?
+        scrollView.onReviewLineSelected = { selectedAnchor = $0 }
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["12"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let textView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRect = try #require(textView.diffRowRects().first)
+        let windowPoint = textView.convert(NSPoint(x: rowRect.midX, y: rowRect.midY), to: nil)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        textView.mouseDown(with: event)
+
+        #expect(selectedAnchor?.path == "Sources/App.swift")
+        #expect(selectedAnchor?.side == .new)
+        #expect(selectedAnchor?.line == 12)
+        #expect(selectedAnchor?.selectedText == text)
+    }
+
     @Test func splitDocumentBuildsSeparateCodeAndGutterColumns() throws {
         let result = DiffPaneTextDocumentBuilder.buildSplit(
             group: try #require(model().groups.first),
@@ -2089,6 +2162,34 @@ let second = true
         #expect(result.newCode.syntaxSource == "\t/* start\nstill comment */\nlet value = 1")
         #expect(rendered.hasPrefix("→/*·start"))
         #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("fg-faint")))))
+    }
+
+    @Test func splitDocumentKeepsContextAndChangedLinesInColumnSyntaxGroup() throws {
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -1,1 +1,2 @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: [
+                    .init(kind: .context, text: "/* start", oldNumber: 1, newNumber: 1),
+                    .init(kind: .add, text: "still comment */", oldNumber: nil, newNumber: 2),
+                ]
+            ),
+        ])
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App.swift")
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.newCode.lines.count == 2)
+        #expect(result.newCode.lines[0].sourceLine?.anchor.side == .new)
+        #expect(result.newCode.lines[1].sourceLine?.anchor.side == .new)
+        #expect(result.newCode.lines[0].syntaxGroup == result.newCode.lines[1].syntaxGroup)
     }
 
     @Test func stackedDocumentDoesNotCarrySyntaxFromDeletedLinesIntoAddedLines() throws {


### PR DESCRIPTION
## Summary

- Allow unchanged/context diff lines to keep neutral review anchors in split panes.
- Preserve changed-line anchoring for added and deleted lines.
- Update the diff pane regression test to cover unchanged-line anchors.

## Testing

- `git diff --check`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests/splitTextDocumentExposesSourceLineMetadataForBothSides` *(blocked locally: missing `.build/ghostty/GhosttyKit.xcframework`; `scripts/build-ghostty.sh` started the Ghostty submodule clone but it was still slowly fetching after ~13 minutes, so it was stopped with no process left running.)*
