### PR TITLE
fix(acp): Gate transcript tail pagination

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -219,7 +219,9 @@ struct ACPMessageList: View {
                     onResolveScrollView: { scrollViewRef.scrollView = $0 },
                     onHeadFrame: { handleHeadFramePreference($0, proxy: proxy) },
                     onPaused: { setFollowsTranscriptTail(false) },
-                    onAtBottom: { handleAtBottom(proxy: proxy) },
+                    onAtBottom: { shouldPageHiddenTail in
+                        handleAtBottom(proxy: proxy, shouldPageHiddenTail: shouldPageHiddenTail)
+                    },
                     onGeometry: { old, new in
                         handleScrollGeometry(
                             previousMinY: old.minY,
@@ -468,14 +470,6 @@ struct ACPMessageList: View {
 
     private func handleVisibleTargetIDs(_ ids: [String], proxy: ScrollViewProxy) {
         let lookup = visibleMessageLookup
-        if Self.shouldPageNewerRowsFromBottomSentinel(
-            isSentinelVisible: ids.contains(Self.bottomPaginationSentinelID),
-            isUserDriven: ACPUserScrollEvent.isUserDriven(NSApp.currentEvent?.type),
-            visibleTail: transcript.visibleTailBound,
-            messageCount: transcript.messages.count
-        ) {
-            stepTailForwardPreservingScroll(proxy: proxy, lookup: lookup)
-        }
         guard let anchor = Self.topVisibleScrollTargetID(
             in: ids,
             visibleMessageIds: lookup.ids
@@ -528,13 +522,13 @@ struct ACPMessageList: View {
         }
     }
 
-    private func handleAtBottom(proxy: ScrollViewProxy) {
+    private func handleAtBottom(proxy: ScrollViewProxy, shouldPageHiddenTail: Bool) {
         if Self.shouldResumeTailFollowAtBottom(
             visibleTail: transcript.visibleTailBound,
             messageCount: transcript.messages.count
         ) {
             setFollowsTranscriptTail(true)
-        } else {
+        } else if shouldPageHiddenTail {
             stepTailForwardPreservingScroll(proxy: proxy, lookup: visibleMessageLookup)
         }
     }
@@ -619,13 +613,18 @@ struct ACPMessageList: View {
         visibleTail >= messageCount
     }
 
-    nonisolated static func shouldPageNewerRowsFromBottomSentinel(
-        isSentinelVisible: Bool,
+    nonisolated static func shouldStepTailForwardFromBottomGeometry(
         isUserDriven: Bool,
+        isRestoring: Bool,
+        previousMinY: CGFloat,
+        newMinY: CGFloat,
         visibleTail: Int,
         messageCount: Int
     ) -> Bool {
-        isSentinelVisible && isUserDriven && visibleTail < messageCount
+        guard visibleTail < messageCount else { return false }
+        guard isUserDriven else { return false }
+        guard !isRestoring else { return false }
+        return newMinY > previousMinY + ACPScrollDirectionClassifier.upwardEpsilon
     }
 
     nonisolated static func queueHeaderCount(statuses: [QueuedPrompt.Status]) -> Int {
@@ -845,7 +844,18 @@ struct ACPMessageList: View {
         )
         switch decision {
         case .userScrolledUp: setFollowsTranscriptTail(false)
-        case .userAtBottom: handleAtBottom(proxy: proxy)
+        case .userAtBottom:
+            handleAtBottom(
+                proxy: proxy,
+                shouldPageHiddenTail: Self.shouldStepTailForwardFromBottomGeometry(
+                    isUserDriven: isUserDriven,
+                    isRestoring: isRestoringTail,
+                    previousMinY: previousMinY,
+                    newMinY: newMinY,
+                    visibleTail: transcript.visibleTailBound,
+                    messageCount: transcript.messages.count
+                )
+            )
         case .noChange: break
         }
         if Self.shouldRestoreTailAfterContentGrowth(
@@ -1048,7 +1058,7 @@ private struct ACPTranscriptScrollTracking: ViewModifier {
     let onResolveScrollView: (NSScrollView) -> Void
     let onHeadFrame: (CGRect) -> Void
     let onPaused: () -> Void
-    let onAtBottom: () -> Void
+    let onAtBottom: (Bool) -> Void
     let onGeometry: (ACPScrollProbe, ACPScrollProbe) -> Void
 
     @ViewBuilder
@@ -1089,7 +1099,7 @@ private struct ACPScrollProbe: Equatable {
 
 private struct ACPScrollEventObserver: NSViewRepresentable {
     let onPaused: () -> Void
-    let onAtBottom: () -> Void
+    let onAtBottom: (Bool) -> Void
     let isRestoring: () -> Bool
     var onScrollViewResolved: ((NSScrollView) -> Void)?
 
@@ -1116,7 +1126,7 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
     @MainActor
     final class Coordinator {
         var onPaused: () -> Void
-        var onAtBottom: () -> Void
+        var onAtBottom: (Bool) -> Void
         var isRestoring: () -> Bool
         var onScrollViewResolved: ((NSScrollView) -> Void)?
         private weak var observedScrollView: NSScrollView?
@@ -1124,7 +1134,7 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
         private var lastOffsetY: CGFloat?
 
         init(onPaused: @escaping () -> Void,
-             onAtBottom: @escaping () -> Void,
+             onAtBottom: @escaping (Bool) -> Void,
              isRestoring: @escaping () -> Bool) {
             self.onPaused = onPaused
             self.onAtBottom = onAtBottom
@@ -1169,18 +1179,20 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
             let newY = cv.bounds.origin.y
             let viewportH = cv.bounds.height
             let contentH = scrollView.documentView?.bounds.height ?? 0
+            let restoring = isRestoring()
+            let isUserDriven = Self.isUserDrivenScrollEvent
             let decision = ACPScrollDirectionClassifier.decide(
                 previousOffsetY: lastOffsetY,
                 newOffsetY: newY,
                 viewportHeight: viewportH,
                 contentHeight: contentH,
-                isRestoring: isRestoring(),
-                isUserDriven: Self.isUserDrivenScrollEvent
+                isRestoring: restoring,
+                isUserDriven: isUserDriven
             )
             lastOffsetY = newY
             switch decision {
             case .userScrolledUp: onPaused()
-            case .userAtBottom: onAtBottom()
+            case .userAtBottom: onAtBottom(isUserDriven && !restoring)
             case .noChange: break
             }
         }

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -278,30 +278,38 @@ struct ACPMessageListPaginationTests {
         ))
     }
 
-    @Test("bottom sentinel pages newer rows only during user scroll")
-    func bottomSentinelPagesNewerRowsOnlyDuringUserScroll() {
-        #expect(!ACPMessageList.shouldPageNewerRowsFromBottomSentinel(
-            isSentinelVisible: true,
-            isUserDriven: false,
+    @Test("bottom geometry pages newer rows only for fresh downward user scrolls")
+    func bottomGeometryPagesNewerRowsOnlyForFreshDownwardUserScrolls() {
+        #expect(ACPMessageList.shouldStepTailForwardFromBottomGeometry(
+            isUserDriven: true,
+            isRestoring: false,
+            previousMinY: 1_000,
+            newMinY: 1_080,
             visibleTail: 90,
             messageCount: 100
         ))
-        #expect(ACPMessageList.shouldPageNewerRowsFromBottomSentinel(
-            isSentinelVisible: true,
+        #expect(!ACPMessageList.shouldStepTailForwardFromBottomGeometry(
             isUserDriven: true,
+            isRestoring: true,
+            previousMinY: 1_000,
+            newMinY: 1_080,
             visibleTail: 90,
             messageCount: 100
         ))
-        #expect(!ACPMessageList.shouldPageNewerRowsFromBottomSentinel(
-            isSentinelVisible: true,
+        #expect(!ACPMessageList.shouldStepTailForwardFromBottomGeometry(
             isUserDriven: true,
+            isRestoring: false,
+            previousMinY: 1_080,
+            newMinY: 1_000,
+            visibleTail: 90,
+            messageCount: 100
+        ))
+        #expect(!ACPMessageList.shouldStepTailForwardFromBottomGeometry(
+            isUserDriven: true,
+            isRestoring: false,
+            previousMinY: 1_000,
+            newMinY: 1_080,
             visibleTail: 100,
-            messageCount: 100
-        ))
-        #expect(!ACPMessageList.shouldPageNewerRowsFromBottomSentinel(
-            isSentinelVisible: false,
-            isUserDriven: true,
-            visibleTail: 90,
             messageCount: 100
         ))
     }


### PR DESCRIPTION
## Summary

Fixes an ACP transcript feedback loop where hidden-tail pagination could be triggered from SwiftUI scroll target visibility/layout callbacks. Tail-window advancement now only happens from scroll geometry/bounds handling when there is a fresh downward user scroll, no restore is in progress, and newer transcript rows are actually hidden.

## Changes

- Removed hidden-tail paging from `onScrollTargetVisibilityChange` so visibility/layout updates only refresh the remembered top anchor.
- Added a geometry gate for bottom paging that requires fresh downward user movement and suppresses paging during restore.
- Preserved legacy bounds tracking behavior while passing an explicit `shouldPageHiddenTail` decision into the shared bottom handler.
- Added Swift Testing coverage for the bottom geometry gate.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageListPaginationTests test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -skip-testing:AlasTests/SSHIntegrationTests test`

Note: the unfiltered full suite fails locally only because `SSHIntegrationTests` require `ALAS_SSH_INTEGRATION=1` and localhost SSH setup.