### PR TITLE
feat(mcp): expose the alas CLI as an MCP server auto-injected into ACP sessions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */; };
 		1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */; };
 		1ED78A36E993D85D0DD1E3CC /* ACPSessionUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */; };
+		1F3AA3B31A896A0608970906 /* AppConfigHarnessMCPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9261D66BAD364C3EEAB4DA /* AppConfigHarnessMCPTests.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		1F84796DE0ABC832C0303B27 /* ACPSessionStoreDedupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */; };
 		1F860C66D658B0DA5A0599F6 /* RemoteZmxInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */; };
@@ -1728,6 +1729,7 @@
 		5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteZmxInstaller.swift; sourceTree = "<group>"; };
 		5B72D621D704CB5B2CCA82C6 /* RemoteAppStateAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAppStateAccessTests.swift; sourceTree = "<group>"; };
 		5B7B8B82A8D4F5B1F1DF1731 /* DiffReviewRenderContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderContext.swift; sourceTree = "<group>"; };
+		5B9261D66BAD364C3EEAB4DA /* AppConfigHarnessMCPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigHarnessMCPTests.swift; sourceTree = "<group>"; };
 		5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Pull.swift"; sourceTree = "<group>"; };
 		5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabView.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
@@ -4395,6 +4397,7 @@
 		D7416CBAB1B316023E546714 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				5B9261D66BAD364C3EEAB4DA /* AppConfigHarnessMCPTests.swift */,
 				4D4F87B7B6F4A6E6ED882F1F /* HarnessConfigAutoRunTests.swift */,
 				792BD8DAE4AAED201252C9E2 /* ProjectMCPServerTests.swift */,
 			);
@@ -5760,6 +5763,7 @@
 				1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */,
 				D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */,
 				CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */,
+				1F3AA3B31A896A0608970906 /* AppConfigHarnessMCPTests.swift in Sources */,
 				8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */,
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
 				1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
 		1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
+		1BA6A97406CD857F02D81AE0 /* BuiltInAlasMCPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7A4A7B920C0E748973F282 /* BuiltInAlasMCPTests.swift */; };
 		1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */; };
 		1C2C949642E10060172AB1BA /* ACPToolCallPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */; };
 		1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */; };
@@ -464,6 +465,7 @@
 		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
 		5BB2FF7F9DFFFEF75CA508A2 /* RemoteLSPLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89D9FFAC80BDE46A651A0F /* RemoteLSPLauncherTests.swift */; };
 		5BCB202710E37EA60DCC91F0 /* ACPPlanSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */; };
+		5C15CCD6E7D896DEFA533C82 /* BuiltInAlasMCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7BEEA16E15CB254BD84F5F /* BuiltInAlasMCP.swift */; };
 		5C6F0DC6F76FC0B55F2F4051 /* DiffPaneTextDocumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E5D3E9FAA7B6B251C3883D /* DiffPaneTextDocumentBuilder.swift */; };
 		5C86AEAEA5497DBF5FD7D604 /* initialize-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 2463B784210156F489A13FAC /* initialize-response.json */; };
 		5C9791E96E80858B5A037941 /* session-update-agent-chunk.json in Resources */ = {isa = PBXBuildFile; fileRef = 4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */; };
@@ -1799,6 +1801,7 @@
 		6A190D4B29B35C457AA9829F /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
 		6AF335AB8B3061C889A348B3 /* CommitDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetails.swift; sourceTree = "<group>"; };
 		6B3F942D660C7ABA8542C77D /* ImageFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileType.swift; sourceTree = "<group>"; };
+		6B7BEEA16E15CB254BD84F5F /* BuiltInAlasMCP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltInAlasMCP.swift; sourceTree = "<group>"; };
 		6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceCreatedAtTests.swift; sourceTree = "<group>"; };
 		6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchOpsMenu.swift; sourceTree = "<group>"; };
 		6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecNpmPackageTests.swift; sourceTree = "<group>"; };
@@ -2499,6 +2502,7 @@
 		FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessionsSection.swift; sourceTree = "<group>"; };
 		FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerAction.swift; sourceTree = "<group>"; };
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
+		FE7A4A7B920C0E748973F282 /* BuiltInAlasMCPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltInAlasMCPTests.swift; sourceTree = "<group>"; };
 		FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
 		FEC68B05B719B9235865027F /* ThreePaneSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizing.swift; sourceTree = "<group>"; };
 		FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRemoteWorktreePathTests.swift; sourceTree = "<group>"; };
@@ -3479,6 +3483,7 @@
 				38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */,
 				04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */,
 				955B9084309744F3B9A44CBC /* ACPUserInput.swift */,
+				6B7BEEA16E15CB254BD84F5F /* BuiltInAlasMCP.swift */,
 				87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */,
 				AA6486CAD3FE633F9B6F4ABF /* MCPAttachmentPlanner.swift */,
 				9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */,
@@ -4057,6 +4062,7 @@
 				3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */,
 				A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */,
 				7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */,
+				FE7A4A7B920C0E748973F282 /* BuiltInAlasMCPTests.swift */,
 				336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */,
 				532AA1B8AD5E8139D2EEE948 /* MCPAttachmentPlannerTests.swift */,
 				FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */,
@@ -5122,6 +5128,7 @@
 				ACDDE4B18A94164BDFEED06B /* BranchOpsMenu.swift in Sources */,
 				9E302329243407946D47DC91 /* BranchPicker.swift in Sources */,
 				1B123A31842DDDB42C6820F1 /* BuildIdentity.swift in Sources */,
+				5C15CCD6E7D896DEFA533C82 /* BuiltInAlasMCP.swift in Sources */,
 				71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */,
 				7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */,
 				5A0AE37CBA893BD09558C27E /* CIStatusStrip.swift in Sources */,
@@ -5789,6 +5796,7 @@
 				B3240B739972444A6CB14F7C /* BaseResolutionMappingTests.swift in Sources */,
 				CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */,
 				5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */,
+				1BA6A97406CD857F02D81AE0 /* BuiltInAlasMCPTests.swift in Sources */,
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				EAEB68B3A06AEA14BC8E2985 /* ChangesPreparationModelTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2246,9 +2246,12 @@ extension ACPSessionManager {
                 capabilities: initialized.mcpCapabilities
             ))
             // The built-in alas server composes after planning (it is not
-            // user configuration) and before the remote split (so remote
-            // hosts drop it like any other stdio server).
-            let builtInMCP = builtInMCPProvider?(worktreePath)
+            // user configuration). It is local-only by construction — its
+            // command and socket live on this machine — so remote sessions
+            // skip it entirely instead of reporting it unavailable on every
+            // connect.
+            let remoteHost = RemoteHostRegistry.shared.host(forPath: worktreePath)
+            let builtInMCP = remoteHost == nil ? builtInMCPProvider?(worktreePath) : nil
             var plannedWireServers = mcpPlan.wireServers
             var plannedStatuses = mcpPlan.statuses
             if let builtInMCP {
@@ -2259,7 +2262,7 @@ extension ACPSessionManager {
                 statuses: plannedStatuses,
                 configurationFingerprint: mcpPlan.configurationFingerprint
             )
-            let mcpSplit = RemoteHostRegistry.shared.host(forPath: worktreePath).map { _ in
+            let mcpSplit = remoteHost.map { _ in
                 ACPRemoteMCPFilter.split(plannedWireServers)
             }
             let wireMCPServers = mcpSplit?.kept ?? plannedWireServers

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -46,6 +46,10 @@ final class ACPSessionManager: ObservableObject {
     private let onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)?
     private let onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)?
     private let mcpProjectContextProvider: MCPProjectContextProvider?
+    /// Builds the app-provided "alas" MCP server entry for a worktree path,
+    /// or nil when injection is disabled/unavailable. Fetched per attach so
+    /// the settings toggle applies to the next (re)connect.
+    private let builtInMCPProvider: ((String) -> BuiltInAlasMCP.Injection?)?
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     @Published private(set) var persistenceError: String?
@@ -298,7 +302,8 @@ final class ACPSessionManager: ObservableObject {
          setupEvaluator: ACPSetupEvaluator? = nil,
          remoteAdapterResolver: ACPRemoteAdapterResolver? = nil,
          connectionFactory: ACPConnectionFactory? = nil,
-         mcpProjectContextProvider: MCPProjectContextProvider? = nil)
+         mcpProjectContextProvider: MCPProjectContextProvider? = nil,
+         builtInMCPProvider: ((String) -> BuiltInAlasMCP.Injection?)? = nil)
     {
         precondition(store != nil || persistence != nil, "ACPSessionManager requires persistence")
         let resolvedPersistence = persistence ?? ACPSessionPersistence(path: store!.path)
@@ -312,6 +317,7 @@ final class ACPSessionManager: ObservableObject {
         self.onSessionTitleUpdated = onSessionTitleUpdated
         self.onInputAwaiting = onInputAwaiting
         self.mcpProjectContextProvider = mcpProjectContextProvider
+        self.builtInMCPProvider = builtInMCPProvider
         self.changeNotifier = changeNotifier ?? DarwinChangeNotifier(worktreeId: worktreeId)
         _ = hydratorPath
         self.setupEvaluator = setupEvaluator ?? { spec in
@@ -2239,11 +2245,24 @@ extension ACPSessionManager {
                 environment: agentEnvironment,
                 capabilities: initialized.mcpCapabilities
             ))
-            session.mcpAttachmentSummary = .init(plan: mcpPlan)
-            let mcpSplit = RemoteHostRegistry.shared.host(forPath: worktreePath).map { _ in
-                ACPRemoteMCPFilter.split(mcpPlan.wireServers)
+            // The built-in alas server composes after planning (it is not
+            // user configuration) and before the remote split (so remote
+            // hosts drop it like any other stdio server).
+            let builtInMCP = builtInMCPProvider?(worktreePath)
+            var plannedWireServers = mcpPlan.wireServers
+            var plannedStatuses = mcpPlan.statuses
+            if let builtInMCP {
+                plannedWireServers.append(builtInMCP.server)
+                plannedStatuses.append(builtInMCP.status)
             }
-            let wireMCPServers = mcpSplit?.kept ?? mcpPlan.wireServers
+            session.mcpAttachmentSummary = .init(
+                statuses: plannedStatuses,
+                configurationFingerprint: mcpPlan.configurationFingerprint
+            )
+            let mcpSplit = RemoteHostRegistry.shared.host(forPath: worktreePath).map { _ in
+                ACPRemoteMCPFilter.split(plannedWireServers)
+            }
+            let wireMCPServers = mcpSplit?.kept ?? plannedWireServers
             let remoteMCPNotice: String?
             if let mcpSplit, !mcpSplit.droppedStdio.isEmpty {
                 remoteMCPNotice = "MCP servers unavailable on remote host: \(mcpSplit.droppedStdio.joined(separator: ", "))"

--- a/Alas/Sources/ACP/Session/BuiltInAlasMCP.swift
+++ b/Alas/Sources/ACP/Session/BuiltInAlasMCP.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The app-provided MCP server exposing Alas CLI actions (open files,
+/// worktrees, review) to ACP agents. Composed alongside — never inside —
+/// `MCPAttachmentPlanner`, so the planner stays a pure function of user
+/// configuration and the built-in entry never affects the configuration
+/// fingerprint.
+enum BuiltInAlasMCP {
+    static let serverName = "alas"
+    static let statusId = "builtin-alas"
+
+    struct Injection: Equatable {
+        let server: ACPMCPServer
+        let status: MCPAttachmentServerStatus
+    }
+
+    /// The wire entry + status row for the built-in server, or nil when it
+    /// must not be injected: globally disabled, the managed binary or app
+    /// socket is unavailable, or the project already configures a server
+    /// named "alas" (an intentional user override, e.g. a dev binary).
+    static func injection(
+        enabled: Bool,
+        configuredServers: [ProjectMCPServer],
+        binaryPath: String?,
+        socketPath: String?,
+        worktreePath: String
+    ) -> Injection? {
+        guard enabled, let binaryPath, let socketPath else { return nil }
+        let userOverride = configuredServers.contains {
+            $0.name.trimmingCharacters(in: .whitespacesAndNewlines) == serverName
+        }
+        guard !userOverride else { return nil }
+        return Injection(
+            server: .stdio(
+                name: serverName,
+                command: binaryPath,
+                args: ["mcp"],
+                env: [
+                    .init(name: "ALAS_SOCKET_PATH", value: socketPath),
+                    .init(name: "ALAS_WORKTREE_DIR", value: worktreePath),
+                ]
+            ),
+            status: .init(
+                id: statusId,
+                name: serverName,
+                transport: .stdio,
+                disposition: .requested
+            )
+        )
+    }
+}

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4092,6 +4092,21 @@ final class AppState {
                     projectDirectory: project.path,
                     configuredServers: project.mcpServers
                 )
+            },
+            builtInMCPProvider: { [weak self] worktreePath in
+                guard let self else { return nil }
+                // installExecutables is idempotent (byte-compares before
+                // writing); a nil binaryPath (no bundle, e.g. tests) means
+                // no injection rather than a dead command for the agent.
+                let binaryPath = (try? TerminalCLIInjection.installExecutables())?
+                    .appendingPathComponent(TerminalCLIInjection.executableName).path
+                return BuiltInAlasMCP.injection(
+                    enabled: self.config.harness.exposeAlasMCP,
+                    configuredServers: self.projects.first(where: { $0.id == worktree.projectId })?.mcpServers ?? [],
+                    binaryPath: binaryPath,
+                    socketPath: self.harness.socketServer.socketPath,
+                    worktreePath: worktreePath
+                )
             }
         )
         acpManagers[worktree.id] = mgr

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -233,11 +233,15 @@ struct AppConfig: Codable, Equatable {
         /// (the agent runs tools without asking). Seeds the per-session value
         /// only; the composer bolt still wins afterward. Default: false.
         var acpAutoRunByDefault: Bool
+        /// When true (default), every local ACP session gets the built-in
+        /// "alas" MCP server exposing CLI actions (open, worktrees, review).
+        var exposeAlasMCP: Bool
 
         enum CodingKeys: String, CodingKey {
             case notifyOnFinish, notifyOnAwaiting,
                  dismissedHookInstallNudges, dismissedACPSetupNudges,
-                 confirmCloseChatTabs, acpSendOnEnter, acpAutoRunByDefault
+                 confirmCloseChatTabs, acpSendOnEnter, acpAutoRunByDefault,
+                 exposeAlasMCP
         }
 
         init(notifyOnFinish: Bool = true, notifyOnAwaiting: Bool = true,
@@ -245,7 +249,8 @@ struct AppConfig: Codable, Equatable {
              dismissedACPSetupNudges: [String] = [],
              confirmCloseChatTabs: Bool = false,
              acpSendOnEnter: Bool = true,
-             acpAutoRunByDefault: Bool = false)
+             acpAutoRunByDefault: Bool = false,
+             exposeAlasMCP: Bool = true)
         {
             self.notifyOnFinish = notifyOnFinish
             self.notifyOnAwaiting = notifyOnAwaiting
@@ -254,6 +259,7 @@ struct AppConfig: Codable, Equatable {
             self.confirmCloseChatTabs = confirmCloseChatTabs
             self.acpSendOnEnter = acpSendOnEnter
             self.acpAutoRunByDefault = acpAutoRunByDefault
+            self.exposeAlasMCP = exposeAlasMCP
         }
 
         init(from decoder: Decoder) throws {
@@ -265,6 +271,7 @@ struct AppConfig: Codable, Equatable {
             confirmCloseChatTabs = (try? c.decode(Bool.self, forKey: .confirmCloseChatTabs)) ?? false
             acpSendOnEnter = (try? c.decode(Bool.self, forKey: .acpSendOnEnter)) ?? true
             acpAutoRunByDefault = (try? c.decode(Bool.self, forKey: .acpAutoRunByDefault)) ?? false
+            exposeAlasMCP = (try? c.decode(Bool.self, forKey: .exposeAlasMCP)) ?? true
         }
     }
 

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -60,6 +60,10 @@ struct AgentsPane: View {
                 }
 
                 SettingsGroup(title: "Harness") {
+                    SettingsRow(name: "Expose Alas tools to agents",
+                                desc: "Give chat agents an MCP server with Alas actions: open files, manage worktrees, and open reviews. Applies to newly connected sessions.") {
+                        AlasToggle(on: state.bind(\.harness.exposeAlasMCP))
+                    }
                     SettingsRow(
                         name: "Terminal / Harness",
                         desc: "Configure harness notifications and install hooks."

--- a/AlasCLI/Cargo.lock
+++ b/AlasCLI/Cargo.lock
@@ -7,6 +7,7 @@ name = "alas"
 version = "0.1.0"
 dependencies = [
  "alas-client",
+ "serde_json",
 ]
 
 [[package]]

--- a/AlasCLI/crates/alas/Cargo.toml
+++ b/AlasCLI/crates/alas/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/main.rs"
 
 [dependencies]
 alas-client = { path = "../alas-client" }
+serde_json = "1"

--- a/AlasCLI/crates/alas/src/main.rs
+++ b/AlasCLI/crates/alas/src/main.rs
@@ -17,6 +17,10 @@ fn main() -> ExitCode {
         args = rewritten;
     }
 
+    if is_mcp_invocation(&args) {
+        return run_mcp();
+    }
+
     let base = logical_base();
     let command = match parse(&args, &base) {
         Ok(command) => command,
@@ -68,6 +72,26 @@ fn describe(err: &DispatchError) -> (String, u8) {
     }
 }
 
+/// `alas mcp` takes no further arguments; anything else falls through to
+/// the normal parser, which rejects it with usage text.
+fn is_mcp_invocation(args: &[String]) -> bool {
+    args.len() == 1 && args[0] == "mcp"
+}
+
+fn run_mcp() -> ExitCode {
+    let env = match mcp::env_from(|key| std::env::var(key).ok()) {
+        Ok(env) => env,
+        Err(message) => {
+            eprintln!("alas: {message}");
+            return ExitCode::from(2);
+        }
+    };
+    match mcp::serve(&env) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(_) => ExitCode::FAILURE,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,5 +134,13 @@ mod tests {
 
         // The two must stay distinguishable from the malformed-reply case.
         assert_ne!(connect_msg, "malformed response from Alas");
+    }
+
+    #[test]
+    fn mcp_mode_is_detected_only_as_sole_argument() {
+        assert!(is_mcp_invocation(&["mcp".to_string()]));
+        assert!(!is_mcp_invocation(&["mcp".to_string(), "extra".to_string()]));
+        assert!(!is_mcp_invocation(&["open".to_string(), "mcp".to_string()]));
+        assert!(!is_mcp_invocation(&[]));
     }
 }

--- a/AlasCLI/crates/alas/src/main.rs
+++ b/AlasCLI/crates/alas/src/main.rs
@@ -1,4 +1,5 @@
 mod parse;
+mod mcp;
 
 use alas_client::{dispatch, logical_base, resolve_target, DispatchError, TransportError};
 use parse::{is_ao, parse};

--- a/AlasCLI/crates/alas/src/main.rs
+++ b/AlasCLI/crates/alas/src/main.rs
@@ -88,7 +88,10 @@ fn run_mcp() -> ExitCode {
     };
     match mcp::serve(&env) {
         Ok(()) => ExitCode::SUCCESS,
-        Err(_) => ExitCode::FAILURE,
+        Err(err) => {
+            eprintln!("alas: mcp io error: {err}");
+            ExitCode::FAILURE
+        }
     }
 }
 

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -190,8 +190,23 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
             force: args.get("force").and_then(Value::as_bool).unwrap_or(false),
             keep_branch: args.get("keep_branch").and_then(Value::as_bool).unwrap_or(false),
         }),
-        "review" => Ok(Command::Review { target: optional_string(args, "target") }),
+        "review" => Ok(Command::Review { target: review_target(args)? }),
         other => Err(format!("unknown tool: {other}")),
+    }
+}
+
+/// `review` targets are commonly numeric PR/MR ids, so JSON numbers are
+/// coerced to strings; other non-string shapes are rejected instead of being
+/// silently treated as "review local changes".
+fn review_target(args: &Value) -> Result<Option<String>, String> {
+    match args.get("target") {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => {
+            let s = s.trim();
+            Ok(if s.is_empty() { None } else { Some(s.to_string()) })
+        }
+        Some(Value::Number(n)) => Ok(Some(n.to_string())),
+        Some(_) => Err("review 'target' must be a string (PR/MR number or URL)".into()),
     }
 }
 
@@ -457,6 +472,20 @@ mod tests {
             command_for_tool("review", &json!({"target": "123"}), "/wt").unwrap(),
             alas_client::Command::Review { target: Some("123".into()) }
         );
+    }
+
+    #[test]
+    fn review_coerces_numeric_target_and_rejects_other_types() {
+        assert_eq!(
+            command_for_tool("review", &json!({"target": 123}), "/wt").unwrap(),
+            alas_client::Command::Review { target: Some("123".into()) }
+        );
+        assert_eq!(
+            command_for_tool("review", &json!({"target": null}), "/wt").unwrap(),
+            alas_client::Command::Review { target: None }
+        );
+        assert!(command_for_tool("review", &json!({"target": true}), "/wt").is_err());
+        assert!(command_for_tool("review", &json!({"target": ["1"]}), "/wt").is_err());
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -1,0 +1,146 @@
+//! MCP stdio server mode: newline-delimited JSON-RPC on stdin/stdout,
+//! translating tool calls into the same socket requests the CLI sends.
+//! Hand-rolled on purpose — the surface is five methods; an MCP SDK would
+//! be the largest dependency in the workspace.
+
+use alas_client::{Command, Response, TransportError};
+use serde_json::{json, Value};
+use std::path::PathBuf;
+
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Injected by the app in the MCP server definition. Both values are
+/// required: `alas mcp` is launched by Alas itself and deliberately has no
+/// discovery fallback (a hand-run `alas mcp` is not a supported mode).
+pub struct McpEnv {
+    pub socket: PathBuf,
+    pub worktree_dir: String,
+}
+
+/// Build the env from a lookup function (`std::env::var` in production,
+/// a fixture map in tests — process-global env mutation is racy in tests).
+pub fn env_from(get: impl Fn(&str) -> Option<String>) -> Result<McpEnv, String> {
+    let socket = get("ALAS_SOCKET_PATH")
+        .filter(|s| !s.is_empty())
+        .ok_or("alas mcp requires ALAS_SOCKET_PATH (it is launched by Alas, not by hand)")?;
+    let worktree_dir = get("ALAS_WORKTREE_DIR")
+        .filter(|s| !s.is_empty())
+        .ok_or("alas mcp requires ALAS_WORKTREE_DIR (it is launched by Alas, not by hand)")?;
+    if !worktree_dir.starts_with('/') {
+        return Err("ALAS_WORKTREE_DIR must be an absolute path".into());
+    }
+    Ok(McpEnv { socket: PathBuf::from(socket), worktree_dir })
+}
+
+/// Handle one raw input line. Returns the JSON-RPC reply to write, or None
+/// when no reply must be produced (notifications — replying to one is a
+/// protocol violation).
+pub fn handle_line(
+    line: &str,
+    worktree_dir: &str,
+    dispatch: impl FnMut(&Command) -> Result<Response, TransportError>,
+) -> Option<Value> {
+    let _ = (worktree_dir, &dispatch); // used from Task 3 on
+    let msg: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => return Some(error_reply(Value::Null, -32700, "parse error")),
+    };
+    // Messages without an id are notifications (e.g. notifications/initialized).
+    let id = msg.get("id").cloned()?;
+    let method = msg.get("method").and_then(Value::as_str).unwrap_or_default();
+    let reply = match method {
+        "initialize" => Ok(initialize_result()),
+        "ping" => Ok(json!({})),
+        other => Err((-32601, format!("method not found: {other}"))),
+    };
+    Some(match reply {
+        Ok(result) => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+        Err((code, message)) => error_reply(id, code, &message),
+    })
+}
+
+fn initialize_result() -> Value {
+    json!({
+        "protocolVersion": PROTOCOL_VERSION,
+        "capabilities": { "tools": {} },
+        "serverInfo": { "name": "alas", "version": env!("CARGO_PKG_VERSION") },
+        "instructions": "Tools that drive the user's Alas workspace UI: open files for the user to look at, manage linked worktrees, and open reviews."
+    })
+}
+
+fn error_reply(id: Value, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{env_from, handle_line, PROTOCOL_VERSION};
+    use alas_client::Response;
+    use serde_json::{json, Value};
+
+    fn ok_dispatch(_: &alas_client::Command) -> Result<Response, alas_client::TransportError> {
+        Ok(Response { ok: true, lines: None, error: None })
+    }
+
+    fn env<'a>(vars: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |key| {
+            vars.iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    #[test]
+    fn env_from_requires_both_vars() {
+        assert!(env_from(env(&[("ALAS_WORKTREE_DIR", "/wt")])).is_err());
+        assert!(env_from(env(&[("ALAS_SOCKET_PATH", "/tmp/s")])).is_err());
+        assert!(env_from(env(&[("ALAS_SOCKET_PATH", ""), ("ALAS_WORKTREE_DIR", "/wt")])).is_err());
+        let ok = env_from(env(&[("ALAS_SOCKET_PATH", "/tmp/s"), ("ALAS_WORKTREE_DIR", "/wt")])).unwrap();
+        assert_eq!(ok.socket, std::path::PathBuf::from("/tmp/s"));
+        assert_eq!(ok.worktree_dir, "/wt");
+    }
+
+    #[test]
+    fn env_from_rejects_relative_worktree_dir() {
+        assert!(env_from(env(&[("ALAS_SOCKET_PATH", "/tmp/s"), ("ALAS_WORKTREE_DIR", "wt")])).is_err());
+    }
+
+    #[test]
+    fn initialize_returns_server_info_and_tools_capability() {
+        let line = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}"#;
+        let reply = handle_line(line, "/wt", ok_dispatch).unwrap();
+        assert_eq!(reply["id"], json!(1));
+        assert_eq!(reply["result"]["protocolVersion"], json!(PROTOCOL_VERSION));
+        assert_eq!(reply["result"]["serverInfo"]["name"], json!("alas"));
+        assert!(reply["result"]["capabilities"]["tools"].is_object());
+        assert!(reply["result"]["instructions"].is_string());
+    }
+
+    #[test]
+    fn initialized_notification_gets_no_reply() {
+        let line = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+        assert_eq!(handle_line(line, "/wt", ok_dispatch), None);
+    }
+
+    #[test]
+    fn ping_returns_empty_result() {
+        let line = r#"{"jsonrpc":"2.0","id":"p1","method":"ping"}"#;
+        let reply = handle_line(line, "/wt", ok_dispatch).unwrap();
+        assert_eq!(reply["id"], json!("p1"));
+        assert_eq!(reply["result"], json!({}));
+    }
+
+    #[test]
+    fn unknown_method_is_method_not_found() {
+        let line = r#"{"jsonrpc":"2.0","id":2,"method":"resources/list"}"#;
+        let reply = handle_line(line, "/wt", ok_dispatch).unwrap();
+        assert_eq!(reply["error"]["code"], json!(-32601));
+    }
+
+    #[test]
+    fn malformed_line_is_parse_error_with_null_id() {
+        let reply = handle_line("{not json", "/wt", ok_dispatch).unwrap();
+        assert_eq!(reply["error"]["code"], json!(-32700));
+        assert_eq!(reply["id"], Value::Null);
+    }
+}

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -268,6 +268,28 @@ fn text_result(text: String, is_error: bool) -> Value {
     json!({ "content": [{ "type": "text", "text": text }], "isError": is_error })
 }
 
+/// Blocking stdio server loop: one JSON-RPC message per line in, one per
+/// line out. EOF on stdin means the agent hung up — exit cleanly.
+pub fn serve(env: &McpEnv) -> std::io::Result<()> {
+    use std::io::{BufRead, Write};
+
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Some(reply) = handle_line(&line, &env.worktree_dir, |cmd| dispatch(env, cmd)) {
+            let mut out = stdout.lock();
+            out.write_all(reply.to_string().as_bytes())?;
+            out.write_all(b"\n")?;
+            out.flush()?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{command_for_tool, dispatch, env_from, handle_line, McpEnv, PROTOCOL_VERSION};

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -38,9 +38,8 @@ pub fn env_from(get: impl Fn(&str) -> Option<String>) -> Result<McpEnv, String> 
 pub fn handle_line(
     line: &str,
     worktree_dir: &str,
-    dispatch: impl FnMut(&Command) -> Result<Response, TransportError>,
+    mut dispatch: impl FnMut(&Command) -> Result<Response, TransportError>,
 ) -> Option<Value> {
-    let _ = (worktree_dir, &dispatch); // used from Task 3 on
     let msg: Value = match serde_json::from_str(line) {
         Ok(v) => v,
         Err(_) => return Some(error_reply(Value::Null, -32700, "parse error")),
@@ -52,6 +51,10 @@ pub fn handle_line(
         "initialize" => Ok(initialize_result()),
         "ping" => Ok(json!({})),
         "tools/list" => Ok(json!({ "tools": tool_definitions() })),
+        "tools/call" => {
+            let params = msg.get("params").cloned().unwrap_or(Value::Null);
+            call_tool(&params, worktree_dir, &mut dispatch)
+        }
         other => Err((-32601, format!("method not found: {other}"))),
     };
     Some(match reply {
@@ -201,9 +204,73 @@ fn optional_string(args: &Value, key: &str) -> Option<String> {
         .map(String::from)
 }
 
+/// Send one command to the owning app instance, addressed by worktree
+/// directory (never session id — the MCP server has no terminal session).
+pub fn dispatch(env: &McpEnv, command: &Command) -> Result<Response, TransportError> {
+    let req = alas_client::build_request(command, None, Some(env.worktree_dir.clone()));
+    alas_client::send(&env.socket, &req)
+}
+
+/// Unknown tools and invalid arguments are JSON-RPC protocol errors
+/// (-32602); failures while executing a valid call are tool results with
+/// isError:true, per the MCP spec's split between the two.
+fn call_tool(
+    params: &Value,
+    worktree_dir: &str,
+    mut dispatch: impl FnMut(&Command) -> Result<Response, TransportError>,
+) -> Result<Value, (i64, String)> {
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or((-32602, "tools/call requires a tool name".to_string()))?;
+    let args = params.get("arguments").cloned().unwrap_or_else(|| json!({}));
+    let command = command_for_tool(name, &args, worktree_dir).map_err(|msg| (-32602, msg))?;
+    Ok(match dispatch(&command) {
+        Ok(resp) => tool_result(&command, resp),
+        Err(err) => transport_error_result(&err),
+    })
+}
+
+fn tool_result(command: &Command, resp: Response) -> Value {
+    if !resp.ok {
+        return text_result(resp.error.unwrap_or_else(|| "request failed".into()), true);
+    }
+    match resp.lines.filter(|lines| !lines.is_empty()) {
+        Some(lines) => text_result(lines.join("\n"), false),
+        None => text_result(success_message(command), false),
+    }
+}
+
+/// The app replies to UI-action commands with a bare ok; agents read better
+/// with an explicit confirmation than with empty content.
+fn success_message(command: &Command) -> String {
+    match command {
+        Command::Open { paths } => format!("Opened {} file(s) in Alas.", paths.len()),
+        Command::WtSwitch { target } => format!("Switched Alas to worktree '{target}'."),
+        Command::WtNew { branch, .. } => format!("Created worktree for branch '{branch}' in Alas."),
+        Command::WtDelete { target, .. } => format!("Deleted worktree '{target}'."),
+        Command::Review { target: Some(target) } => format!("Opened review for '{target}' in Alas."),
+        Command::Review { target: None } => "Opened review of local changes in Alas.".into(),
+        Command::WtList | Command::Resolve => "OK".into(),
+    }
+}
+
+fn transport_error_result(err: &TransportError) -> Value {
+    // Mirrors describe() in main.rs so agents and humans read the same words.
+    let message = match err {
+        TransportError::Malformed => "malformed response from Alas",
+        TransportError::Connect | TransportError::Io => "could not reach Alas",
+    };
+    text_result(message.into(), true)
+}
+
+fn text_result(text: String, is_error: bool) -> Value {
+    json!({ "content": [{ "type": "text", "text": text }], "isError": is_error })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{command_for_tool, env_from, handle_line, tool_definitions, PROTOCOL_VERSION};
+    use super::{command_for_tool, dispatch, env_from, handle_line, McpEnv, PROTOCOL_VERSION};
     use alas_client::Response;
     use serde_json::{json, Value};
 
@@ -362,5 +429,111 @@ mod tests {
     fn unknown_tool_is_an_error() {
         assert!(command_for_tool("resolve", &json!({}), "/wt").is_err());
         assert!(command_for_tool("nope", &json!({}), "/wt").is_err());
+    }
+
+    fn call(name: &str, arguments: Value) -> String {
+        json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": name, "arguments": arguments }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn tools_call_returns_joined_lines_on_success() {
+        let reply = handle_line(&call("worktree_list", json!({})), "/wt", |_| {
+            Ok(Response { ok: true, lines: Some(vec!["main *".into(), "feat".into()]), error: None })
+        })
+        .unwrap();
+        let result = &reply["result"];
+        assert_eq!(result["isError"], json!(false));
+        assert_eq!(result["content"][0]["type"], json!("text"));
+        assert_eq!(result["content"][0]["text"], json!("main *\nfeat"));
+    }
+
+    #[test]
+    fn tools_call_synthesizes_confirmation_when_no_lines() {
+        let reply = handle_line(&call("open", json!({"paths": ["a.txt", "b.txt"]})), "/wt", |cmd| {
+            assert_eq!(
+                cmd,
+                &alas_client::Command::Open { paths: vec!["/wt/a.txt".into(), "/wt/b.txt".into()] }
+            );
+            Ok(Response { ok: true, lines: None, error: None })
+        })
+        .unwrap();
+        assert_eq!(reply["result"]["isError"], json!(false));
+        assert_eq!(reply["result"]["content"][0]["text"], json!("Opened 2 file(s) in Alas."));
+    }
+
+    #[test]
+    fn tools_call_maps_app_failure_to_error_result() {
+        let reply = handle_line(&call("review", json!({})), "/wt", |_| {
+            Ok(Response { ok: false, lines: None, error: Some("no changes to review".into()) })
+        })
+        .unwrap();
+        assert_eq!(reply["result"]["isError"], json!(true));
+        assert_eq!(reply["result"]["content"][0]["text"], json!("no changes to review"));
+    }
+
+    #[test]
+    fn tools_call_maps_transport_failure_to_error_result() {
+        let reply = handle_line(&call("worktree_list", json!({})), "/wt", |_| {
+            Err(alas_client::TransportError::Connect)
+        })
+        .unwrap();
+        assert_eq!(reply["result"]["isError"], json!(true));
+        assert_eq!(reply["result"]["content"][0]["text"], json!("could not reach Alas"));
+
+        let reply = handle_line(&call("worktree_list", json!({})), "/wt", |_| {
+            Err(alas_client::TransportError::Malformed)
+        })
+        .unwrap();
+        assert_eq!(reply["result"]["content"][0]["text"], json!("malformed response from Alas"));
+    }
+
+    #[test]
+    fn tools_call_with_unknown_tool_or_bad_args_is_invalid_params() {
+        let reply = handle_line(&call("nope", json!({})), "/wt", ok_dispatch).unwrap();
+        assert_eq!(reply["error"]["code"], json!(-32602));
+
+        let reply = handle_line(&call("open", json!({})), "/wt", ok_dispatch).unwrap();
+        assert_eq!(reply["error"]["code"], json!(-32602));
+    }
+
+    #[test]
+    fn dispatch_sends_cwd_addressed_request_over_the_socket() {
+        use std::io::{Read, Write};
+
+        let dir = std::env::temp_dir().join(format!("alas-mcp-it-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("stub.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        let (tx, rx) = std::sync::mpsc::channel::<String>();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 65536];
+            let n = stream.read(&mut buf).unwrap();
+            tx.send(String::from_utf8_lossy(&buf[..n]).into_owned()).unwrap();
+            stream
+                .write_all(br#"{"ok":true,"lines":["main *"]}"#)
+                .unwrap();
+        });
+
+        let env = McpEnv { socket: path.clone(), worktree_dir: "/wt".into() };
+        let resp = dispatch(&env, &alas_client::Command::WtList).unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.lines, Some(vec!["main *".into()]));
+
+        let seen: Value = serde_json::from_str(&rx.recv().unwrap()).unwrap();
+        assert_eq!(seen["kind"], json!("cli"));
+        assert_eq!(seen["v"], json!(1));
+        assert_eq!(seen["command"], json!("wt"));
+        assert_eq!(seen["subcommand"], json!("list"));
+        assert_eq!(seen["cwd"], json!("/wt"));
+        assert!(seen.get("session_id").is_none());
+
+        let _ = handle.join();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -51,6 +51,7 @@ pub fn handle_line(
     let reply = match method {
         "initialize" => Ok(initialize_result()),
         "ping" => Ok(json!({})),
+        "tools/list" => Ok(json!({ "tools": tool_definitions() })),
         other => Err((-32601, format!("method not found: {other}"))),
     };
     Some(match reply {
@@ -72,9 +73,137 @@ fn error_reply(id: Value, code: i64, message: &str) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
 }
 
+/// The six agent-facing tools, mirroring the CLI 1:1. Descriptions make
+/// explicit that these act on the user's Alas UI — that is what makes the
+/// agent-side permission prompt legible. `resolve` is internal and not
+/// exposed.
+pub fn tool_definitions() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "open",
+            "description": "Open one or more files in the Alas UI for the user to look at. Paths may be relative to the worktree root or absolute.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "paths": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "description": "Files to open in Alas."
+                    }
+                },
+                "required": ["paths"]
+            }
+        }),
+        json!({
+            "name": "worktree_list",
+            "description": "List this project's worktrees in Alas. The current worktree is marked with an asterisk.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }),
+        json!({
+            "name": "worktree_switch",
+            "description": "Switch the user's Alas window focus to another worktree of this project.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": { "type": "string", "description": "Worktree name or branch name." }
+                },
+                "required": ["target"]
+            }
+        }),
+        json!({
+            "name": "worktree_new",
+            "description": "Create a new linked worktree in Alas for the given branch and focus it.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "branch": { "type": "string", "description": "Branch name for the new worktree." },
+                    "base": { "type": "string", "description": "Base ref to branch from. Defaults to the repository's default base." }
+                },
+                "required": ["branch"]
+            }
+        }),
+        json!({
+            "name": "worktree_delete",
+            "description": "Delete a linked worktree in Alas. Refuses when the worktree has uncommitted changes unless force is set.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": { "type": "string", "description": "Worktree name or branch name." },
+                    "force": { "type": "boolean", "description": "Delete even with uncommitted changes. Default false." },
+                    "keep_branch": { "type": "boolean", "description": "Keep the git branch, delete only the worktree. Default false." }
+                },
+                "required": ["target"]
+            }
+        }),
+        json!({
+            "name": "review",
+            "description": "Open Alas's review pane for the user: on the current local changes when target is omitted, or on a provider pull/merge request when target (a PR/MR number or URL) is given.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": { "type": "string", "description": "PR/MR number or URL. Omit to review local changes." }
+                }
+            }
+        }),
+    ]
+}
+
+/// Translate a tool call into the CLI command it mirrors. Relative `open`
+/// paths absolutize against the injected worktree dir — never the process
+/// cwd, which the agent controls.
+pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<Command, String> {
+    match name {
+        "open" => {
+            let paths = args
+                .get("paths")
+                .and_then(Value::as_array)
+                .ok_or("open requires a 'paths' array")?;
+            if paths.is_empty() {
+                return Err("open requires at least one path".into());
+            }
+            let base = std::path::Path::new(worktree_dir);
+            let mut resolved = Vec::new();
+            for path in paths {
+                let path = path.as_str().ok_or("open paths must be strings")?;
+                if path.trim().is_empty() {
+                    return Err("open paths must be non-empty".into());
+                }
+                resolved.push(alas_client::absolutize(base, path));
+            }
+            Ok(Command::Open { paths: resolved })
+        }
+        "worktree_list" => Ok(Command::WtList),
+        "worktree_switch" => Ok(Command::WtSwitch { target: required_string(args, "target")? }),
+        "worktree_new" => Ok(Command::WtNew {
+            branch: required_string(args, "branch")?,
+            base: optional_string(args, "base"),
+        }),
+        "worktree_delete" => Ok(Command::WtDelete {
+            target: required_string(args, "target")?,
+            force: args.get("force").and_then(Value::as_bool).unwrap_or(false),
+            keep_branch: args.get("keep_branch").and_then(Value::as_bool).unwrap_or(false),
+        }),
+        "review" => Ok(Command::Review { target: optional_string(args, "target") }),
+        other => Err(format!("unknown tool: {other}")),
+    }
+}
+
+fn required_string(args: &Value, key: &str) -> Result<String, String> {
+    optional_string(args, key).ok_or_else(|| format!("missing required argument '{key}'"))
+}
+
+fn optional_string(args: &Value, key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{env_from, handle_line, PROTOCOL_VERSION};
+    use super::{command_for_tool, env_from, handle_line, tool_definitions, PROTOCOL_VERSION};
     use alas_client::Response;
     use serde_json::{json, Value};
 
@@ -142,5 +271,96 @@ mod tests {
         let reply = handle_line("{not json", "/wt", ok_dispatch).unwrap();
         assert_eq!(reply["error"]["code"], json!(-32700));
         assert_eq!(reply["id"], Value::Null);
+    }
+
+    #[test]
+    fn tools_list_returns_the_six_tools() {
+        let line = r#"{"jsonrpc":"2.0","id":3,"method":"tools/list"}"#;
+        let reply = handle_line(line, "/wt", ok_dispatch).unwrap();
+        let tools = reply["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert_eq!(
+            names,
+            ["open", "worktree_list", "worktree_switch", "worktree_new", "worktree_delete", "review"]
+        );
+        for tool in tools {
+            assert!(tool["description"].as_str().unwrap().len() > 20);
+            assert_eq!(tool["inputSchema"]["type"], json!("object"));
+        }
+    }
+
+    #[test]
+    fn open_maps_paths_and_absolutizes_relative_ones() {
+        let cmd = command_for_tool("open", &json!({"paths": ["a.txt", "/abs/b.txt"]}), "/wt").unwrap();
+        assert_eq!(
+            cmd,
+            alas_client::Command::Open { paths: vec!["/wt/a.txt".into(), "/abs/b.txt".into()] }
+        );
+    }
+
+    #[test]
+    fn open_rejects_missing_empty_or_non_string_paths() {
+        assert!(command_for_tool("open", &json!({}), "/wt").is_err());
+        assert!(command_for_tool("open", &json!({"paths": []}), "/wt").is_err());
+        assert!(command_for_tool("open", &json!({"paths": [1]}), "/wt").is_err());
+        assert!(command_for_tool("open", &json!({"paths": ["  "]}), "/wt").is_err());
+    }
+
+    #[test]
+    fn worktree_tools_map_to_wt_commands() {
+        assert_eq!(
+            command_for_tool("worktree_list", &json!({}), "/wt").unwrap(),
+            alas_client::Command::WtList
+        );
+        assert_eq!(
+            command_for_tool("worktree_switch", &json!({"target": "feat"}), "/wt").unwrap(),
+            alas_client::Command::WtSwitch { target: "feat".into() }
+        );
+        assert_eq!(
+            command_for_tool("worktree_new", &json!({"branch": "feat", "base": "main"}), "/wt").unwrap(),
+            alas_client::Command::WtNew { branch: "feat".into(), base: Some("main".into()) }
+        );
+        assert_eq!(
+            command_for_tool("worktree_new", &json!({"branch": "feat"}), "/wt").unwrap(),
+            alas_client::Command::WtNew { branch: "feat".into(), base: None }
+        );
+        assert_eq!(
+            command_for_tool(
+                "worktree_delete",
+                &json!({"target": "feat", "force": true, "keep_branch": true}),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::WtDelete { target: "feat".into(), force: true, keep_branch: true }
+        );
+        assert_eq!(
+            command_for_tool("worktree_delete", &json!({"target": "feat"}), "/wt").unwrap(),
+            alas_client::Command::WtDelete { target: "feat".into(), force: false, keep_branch: false }
+        );
+    }
+
+    #[test]
+    fn worktree_tools_reject_missing_required_args() {
+        assert!(command_for_tool("worktree_switch", &json!({}), "/wt").is_err());
+        assert!(command_for_tool("worktree_new", &json!({}), "/wt").is_err());
+        assert!(command_for_tool("worktree_delete", &json!({}), "/wt").is_err());
+    }
+
+    #[test]
+    fn review_target_is_optional() {
+        assert_eq!(
+            command_for_tool("review", &json!({}), "/wt").unwrap(),
+            alas_client::Command::Review { target: None }
+        );
+        assert_eq!(
+            command_for_tool("review", &json!({"target": "123"}), "/wt").unwrap(),
+            alas_client::Command::Review { target: Some("123".into()) }
+        );
+    }
+
+    #[test]
+    fn unknown_tool_is_an_error() {
+        assert!(command_for_tool("resolve", &json!({}), "/wt").is_err());
+        assert!(command_for_tool("nope", &json!({}), "/wt").is_err());
     }
 }

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -44,6 +44,9 @@ pub fn handle_line(
         Ok(v) => v,
         Err(_) => return Some(error_reply(Value::Null, -32700, "parse error")),
     };
+    if !msg.is_object() {
+        return Some(error_reply(Value::Null, -32600, "invalid request"));
+    }
     // Messages without an id are notifications (e.g. notifications/initialized).
     let id = msg.get("id").cloned()?;
     let method = msg.get("method").and_then(Value::as_str).unwrap_or_default();
@@ -363,6 +366,15 @@ mod tests {
     }
 
     #[test]
+    fn non_object_json_line_is_invalid_request() {
+        for line in [r#""hello""#, "42", "[1,2]", "true", "null"] {
+            let reply = handle_line(line, "/wt", ok_dispatch).unwrap();
+            assert_eq!(reply["error"]["code"], json!(-32600), "line: {line}");
+            assert_eq!(reply["id"], Value::Null);
+        }
+    }
+
+    #[test]
     fn tools_list_returns_the_six_tools() {
         let line = r#"{"jsonrpc":"2.0","id":3,"method":"tools/list"}"#;
         let reply = handle_line(line, "/wt", ok_dispatch).unwrap();
@@ -511,6 +523,17 @@ mod tests {
         })
         .unwrap();
         assert_eq!(reply["result"]["content"][0]["text"], json!("malformed response from Alas"));
+        assert_eq!(reply["result"]["isError"], json!(true));
+    }
+
+    #[test]
+    fn empty_lines_vec_falls_back_to_confirmation_text() {
+        let reply = handle_line(&call("worktree_list", json!({})), "/wt", |_| {
+            Ok(Response { ok: true, lines: Some(vec![]), error: None })
+        })
+        .unwrap();
+        assert_eq!(reply["result"]["isError"], json!(false));
+        assert_eq!(reply["result"]["content"][0]["text"], json!("OK"));
     }
 
     #[test]

--- a/AlasTests/ACP/Session/BuiltInAlasMCPTests.swift
+++ b/AlasTests/ACP/Session/BuiltInAlasMCPTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import Alas
+
+@Suite("Built-in alas MCP injection")
+struct BuiltInAlasMCPTests {
+    private func make(
+        enabled: Bool = true,
+        configuredServers: [ProjectMCPServer] = [],
+        binaryPath: String? = "/support/bin/alas",
+        socketPath: String? = "/tmp/alas-501/pid-42",
+        worktreePath: String = "/repos/proj/wt"
+    ) -> BuiltInAlasMCP.Injection? {
+        BuiltInAlasMCP.injection(
+            enabled: enabled,
+            configuredServers: configuredServers,
+            binaryPath: binaryPath,
+            socketPath: socketPath,
+            worktreePath: worktreePath
+        )
+    }
+
+    @Test("builds the stdio entry with session-scoped env")
+    func buildsWireEntry() {
+        let injection = make()
+        #expect(injection?.server == .stdio(
+            name: "alas",
+            command: "/support/bin/alas",
+            args: ["mcp"],
+            env: [
+                .init(name: "ALAS_SOCKET_PATH", value: "/tmp/alas-501/pid-42"),
+                .init(name: "ALAS_WORKTREE_DIR", value: "/repos/proj/wt"),
+            ]
+        ))
+        #expect(injection?.status == .init(
+            id: "builtin-alas", name: "alas", transport: .stdio, disposition: .requested
+        ))
+    }
+
+    @Test("skips when disabled or prerequisites are missing")
+    func skipsWhenUnavailable() {
+        #expect(make(enabled: false) == nil)
+        #expect(make(binaryPath: nil) == nil)
+        #expect(make(socketPath: nil) == nil)
+    }
+
+    @Test("a project server named alas suppresses the built-in")
+    func userOverrideWins() {
+        #expect(make(configuredServers: [.stdio(name: "alas", command: "/dev/alas")]) == nil)
+        #expect(make(configuredServers: [.stdio(name: "  alas  ", command: "/dev/alas")]) == nil)
+        #expect(make(configuredServers: [.stdio(name: "other", command: "npx")]) != nil)
+    }
+
+    @Test("is dropped for remote sessions like any stdio server")
+    func remoteFilterDropsIt() {
+        let injection = make()!
+        let split = ACPRemoteMCPFilter.split([injection.server])
+        #expect(split.kept.isEmpty)
+        #expect(split.droppedStdio == ["alas"])
+    }
+}

--- a/AlasTests/Persistence/AppConfigHarnessMCPTests.swift
+++ b/AlasTests/Persistence/AppConfigHarnessMCPTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Harness config: exposeAlasMCP")
+struct AppConfigHarnessMCPTests {
+    @Test("defaults to true and survives absent key on decode")
+    func defaultsToTrue() throws {
+        #expect(AppConfig.Harness().exposeAlasMCP == true)
+
+        let legacy = try JSONDecoder().decode(AppConfig.Harness.self, from: Data("{}".utf8))
+        #expect(legacy.exposeAlasMCP == true)
+    }
+
+    @Test("round-trips false")
+    func roundTripsFalse() throws {
+        var harness = AppConfig.Harness()
+        harness.exposeAlasMCP = false
+        let data = try JSONEncoder().encode(harness)
+        let decoded = try JSONDecoder().decode(AppConfig.Harness.self, from: data)
+        #expect(decoded.exposeAlasMCP == false)
+    }
+}


### PR DESCRIPTION
## What

Adds an `alas mcp` mode to the Rust CLI — an MCP stdio server exposing the CLI's actions as agent tools — and auto-injects it into every local ACP session, so chat agents can drive the Alas UI (open files, manage worktrees, open reviews) through structured, permission-gated tool calls.

## How

**Rust (`AlasCLI/`)**
- `alas mcp` runs a hand-rolled newline-delimited JSON-RPC loop on stdin/stdout (`initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`; `-32700/-32600/-32601/-32602` protocol errors).
- Six tools mirroring the CLI 1:1: `open`, `worktree_list`, `worktree_switch`, `worktree_new`, `worktree_delete`, `review`. `resolve` stays internal.
- Tool calls translate to the existing `kind:"cli"` v1 socket requests via `alas-client` (untouched). Addressing is explicit — `ALAS_SOCKET_PATH` + `ALAS_WORKTREE_DIR` injected by the app; no discovery, no probe. Relative `open` paths absolutize against the worktree dir, never the process cwd.
- App failures and transport errors surface as `isError:true` tool results with the same strings the CLI prints.

**Swift**
- New `AppConfig.Harness.exposeAlasMCP` (default on) + "Expose Alas tools to agents" toggle in Settings → Agents → Harness.
- Pure `BuiltInAlasMCP.injection(...)` helper builds the stdio wire entry (managed-bin `alas mcp`, session-scoped env) and its `builtin-alas` status row. A project-configured server named `alas` suppresses the built-in (user override wins); missing binary/socket skips injection.
- `ACPSessionManager` composes the entry after `MCPAttachmentPlanner.plan` and before `ACPRemoteMCPFilter.split`, so remote (SSH) sessions drop it like any stdio server and the config fingerprint never churns.

## Testing

- Rust: 63 tests incl. a stub Unix-socket integration test asserting the wire shape (`cwd`-addressed, no `session_id`).
- Swift: `BuiltInAlasMCPTests`, `AppConfigHarnessMCPTests` (decode-compat), plus existing planner/CLI suites.
- End-to-end smoke against a live dev build: `tools/call worktree_list` returned the real worktree table; `open` popped the file in the UI; missing env → stderr + exit 2.

Design doc: `docs/superpowers/specs/2026-07-14-alas-mcp-design.md` (local, untracked).