### PR TITLE
fix(search): Cmd-P search filtering reliability

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -939,6 +939,7 @@
 		BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */; };
 		BE7FA8E07C4A1FC48267C64D /* ACPAdapterUpdateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */; };
 		BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */; };
+		BEF1C5E442CA7EB29929FCC6 /* FileSearchRankerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F50B2E7675F40749566F54 /* FileSearchRankerTests.swift */; };
 		BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */; };
 		BF0A3B3A162F31E86DB13404 /* session-update-current-model.json in Resources */ = {isa = PBXBuildFile; fileRef = 02347E4D2EA79A5CB8DF82DC /* session-update-current-model.json */; };
 		BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */; };
@@ -1068,6 +1069,7 @@
 		D7201A9F55E26C033F188DE8 /* ACPRemoteAdapterInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E0789D49881A17137010D0 /* ACPRemoteAdapterInstallerTests.swift */; };
 		D76AE9874386832FF4C89E6E /* initialize-request.json in Resources */ = {isa = PBXBuildFile; fileRef = 3253B229B757C725B7747249 /* initialize-request.json */; };
 		D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */; };
+		D7C0F02B7A62097E3EF21160 /* FileSearchRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FABF9037326B7EE23FCC040 /* FileSearchRanker.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
 		D8254D678C89FC54678A1A88 /* RemoteHelperInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB9832AA15DF6888553C7E /* RemoteHelperInstallerTests.swift */; };
 		D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */; };
@@ -1964,6 +1966,7 @@
 		8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidatorTests.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		8F3F67549BDACF73DFC2E477 /* GitService+Stash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Stash.swift"; sourceTree = "<group>"; };
+		8FABF9037326B7EE23FCC040 /* FileSearchRanker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchRanker.swift; sourceTree = "<group>"; };
 		906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerShell.swift; sourceTree = "<group>"; };
 		90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayoutTests.swift; sourceTree = "<group>"; };
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
@@ -2447,6 +2450,7 @@
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalog.swift; sourceTree = "<group>"; };
 		F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesScrollSpyTests.swift; sourceTree = "<group>"; };
+		F2F50B2E7675F40749566F54 /* FileSearchRankerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchRankerTests.swift; sourceTree = "<group>"; };
 		F31E42DEC85081FEA8CA1BC3 /* ACPSessionLeaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLeaseTests.swift; sourceTree = "<group>"; };
 		F332906E17C5865856DBB90B /* ACPSessionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunner.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
@@ -2787,6 +2791,7 @@
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
 				25493E3B18A1AB94EA6985C3 /* EventHolder.swift */,
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
+				F2F50B2E7675F40749566F54 /* FileSearchRankerTests.swift */,
 				408F9FF672160D96B1C22648 /* FilesTabCompactChainTests.swift */,
 				1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */,
 				0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */,
@@ -3936,6 +3941,7 @@
 				BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */,
 				E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */,
 				5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */,
+				8FABF9037326B7EE23FCC040 /* FileSearchRanker.swift */,
 				96E7159EED1183F784104B4F /* FuzzyMatch.swift */,
 				4261E417947C1A21E77C1587 /* GitStatusCache.swift */,
 				36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */,
@@ -5256,6 +5262,7 @@
 				E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */,
 				1339BE8F736D53991DDD19CD /* FileSearchBackend.swift in Sources */,
 				DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */,
+				D7C0F02B7A62097E3EF21160 /* FileSearchRanker.swift in Sources */,
 				6AB631ACAD28A187F15282AB /* FileSnapshotTabView.swift in Sources */,
 				4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */,
 				64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */,
@@ -5878,6 +5885,7 @@
 				51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */,
 				8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */,
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
+				BEF1C5E442CA7EB29929FCC6 /* FileSearchRankerTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
 				3910AEED9AC1888582616BEA /* FileTreeRowIndentationTests.swift in Sources */,
 				6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3128,6 +3128,7 @@ final class AppState {
 
     private func makeSearchEnvironment() -> SearchEnvironment {
         let fileSearchBackend = FffFileSearchBackend()
+        let fileSearchRanker = FileSearchRanker()
         // Invariant: the two synchronous closures below are only invoked
         // from `SearchModel`, which is `@MainActor` — so `assumeIsolated`
         // is sound. If a future caller invokes them off-main this will
@@ -3161,6 +3162,9 @@ final class AppState {
             },
             fileSearch: { query, wt in
                 try await fileSearchBackend.search(query: query, worktree: wt, limit: 50)
+            },
+            rankFiles: { query, sources in
+                try await fileSearchRanker.rank(query: query, sources: sources)
             },
             contentSearch: { [contentSearcher = ContentSearcher()] query, options, targets in
                 contentSearcher.search(query: query, options: options, worktrees: targets)

--- a/Alas/Sources/Search/FileSearchRanker.swift
+++ b/Alas/Sources/Search/FileSearchRanker.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+struct FileSearchRankingSource: Sendable {
+    let worktreeId: String
+    let projectId: String
+    let entries: [FileIndex.Entry]
+    let backendResults: [FileSearchBackendResult]?
+    let statuses: [String: GitStatusBadge]
+}
+
+actor FileSearchRanker {
+    func rank(query: String, sources: [FileSearchRankingSource]) async throws -> [FileSearchResult] {
+        var rows: [FileSearchResult] = []
+        var sinceCancelCheck = 0
+
+        for source in sources {
+            try Task.checkCancellation()
+            let backendPaths: Set<String>
+            if let backendResults = source.backendResults {
+                backendPaths = Set(backendResults.map(\.relativePath))
+                rows.append(contentsOf: backendResults.map { row in
+                    FileSearchResult(
+                        worktreeId: source.worktreeId,
+                        projectId: source.projectId,
+                        relativePath: row.relativePath,
+                        ext: (row.relativePath as NSString).pathExtension.lowercased(),
+                        statusBadge: source.statuses[row.relativePath],
+                        matchIndices: row.matchIndices,
+                        score: row.score + (source.statuses[row.relativePath] != nil ? 2 : 0)
+                    )
+                })
+            } else {
+                backendPaths = []
+            }
+
+            for entry in source.entries where !backendPaths.contains(entry.relativePath) {
+                sinceCancelCheck &+= 1
+                if sinceCancelCheck >= 256 {
+                    sinceCancelCheck = 0
+                    try Task.checkCancellation()
+                }
+
+                let badge = source.statuses[entry.relativePath]
+                if query.isEmpty {
+                    rows.append(FileSearchResult(
+                        worktreeId: source.worktreeId,
+                        projectId: source.projectId,
+                        relativePath: entry.relativePath,
+                        ext: entry.ext,
+                        statusBadge: badge,
+                        matchIndices: [],
+                        score: badge != nil ? 100 : 0
+                    ))
+                } else if let match = FuzzyMatch.score(query: query, target: entry.relativePath) {
+                    let slash = entry.relativePath.lastIndex(of: "/")
+                    let prefixLength = slash.map {
+                        entry.relativePath.distance(from: entry.relativePath.startIndex, to: $0) + 1
+                    } ?? 0
+                    let matchesFilename = match.indices.allSatisfy { $0 >= prefixLength }
+                    rows.append(FileSearchResult(
+                        worktreeId: source.worktreeId,
+                        projectId: source.projectId,
+                        relativePath: entry.relativePath,
+                        ext: entry.ext,
+                        statusBadge: badge,
+                        matchIndices: match.indices,
+                        score: match.score + (matchesFilename ? 8 : 0) + (badge != nil ? 2 : 0)
+                    ))
+                }
+            }
+        }
+
+        try Task.checkCancellation()
+        if query.isEmpty {
+            rows.sort { lhs, rhs in
+                if (lhs.statusBadge != nil) != (rhs.statusBadge != nil) {
+                    return lhs.statusBadge != nil
+                }
+                return lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
+            }
+        } else {
+            rows.sort { $0.score > $1.score }
+        }
+
+        try Task.checkCancellation()
+        return Array(rows.prefix(50))
+    }
+}

--- a/Alas/Sources/Search/SearchModel.swift
+++ b/Alas/Sources/Search/SearchModel.swift
@@ -18,6 +18,9 @@ struct SearchEnvironment: Sendable {
     var entries: @Sendable (SearchWorktree) async throws -> [FileIndex.Entry]
     var statuses: @Sendable (SearchWorktree) async throws -> [String: GitStatusBadge]
     var fileSearch: @Sendable (String, SearchWorktree) async throws -> [FileSearchBackendResult]?
+    var rankFiles: @Sendable (
+        String, [FileSearchRankingSource]
+    ) async throws -> [FileSearchResult]
     var contentSearch: @Sendable (
         String, SearchContentOptions, [SearchWorktree]
     ) -> AsyncThrowingStream<ContentSearchHit, Error>
@@ -51,7 +54,7 @@ final class SearchModel {
         didSet { if isOpen { onQueryChanged() } }
     }
     var contentOptions: SearchContentOptions = SearchContentOptions() {
-        didSet { if kind == .content { reschedule() } }
+        didSet { if isOpen && kind == .content { reschedule() } }
     }
     var kind: SearchKind = .files {
         didSet { if isOpen { reschedule() } }
@@ -114,10 +117,13 @@ final class SearchModel {
 
     func close() {
         isOpen = false
+        taskGeneration &+= 1
         searchTask?.cancel()
         searchTask = nil
+        isLoading = false
         results = SearchResults()
         query = ""
+        signalIdle()
     }
 
     func toggleKind() {
@@ -148,6 +154,7 @@ final class SearchModel {
         let snapshotKind = kind
         let snapshotScope = scope
         let snapshotQuery = trimmedQuery
+        let snapshotContentOptions = contentOptions
         taskGeneration &+= 1
         let myGeneration = taskGeneration
 
@@ -156,19 +163,25 @@ final class SearchModel {
             let debounce = (snapshotKind == .files) ? self.fileDebounce : self.contentDebounce
             try? await Task.sleep(nanoseconds: debounce)
             if Task.isCancelled { return }
-            await self.runSearch(kind: snapshotKind, scope: snapshotScope, query: snapshotQuery)
-            if Task.isCancelled { return }
-            self.signalIdle()
-            // Only clear if no newer reschedule has supplanted this one.
-            if self.taskGeneration == myGeneration {
-                self.searchTask = nil
-            }
+            await self.runSearch(
+                kind: snapshotKind,
+                scope: snapshotScope,
+                query: snapshotQuery,
+                contentOptions: snapshotContentOptions,
+                taskGeneration: myGeneration
+            )
         }
     }
 
-    private func runSearch(kind: SearchKind, scope: SearchScope, query: String) async {
+    private func runSearch(
+        kind: SearchKind,
+        scope: SearchScope,
+        query: String,
+        contentOptions: SearchContentOptions,
+        taskGeneration: Int
+    ) async {
+        guard isCurrent(taskGeneration) else { return }
         isLoading = true
-        defer { isLoading = false }
 
         let targets: [SearchWorktree]
         switch scope {
@@ -185,190 +198,64 @@ final class SearchModel {
 
         switch kind {
         case .files:
-            await runFileSearch(query: query, targets: targets)
+            await runFileSearch(query: query, targets: targets, taskGeneration: taskGeneration)
         case .content:
-            await runContentSearch(query: query, targets: targets)
+            await runContentSearch(
+                query: query,
+                options: contentOptions,
+                targets: targets,
+                taskGeneration: taskGeneration
+            )
         }
 
+        guard isCurrent(taskGeneration) else { return }
         if selectedIndex >= totalResultRows {
             moveSelection(to: 0)
         }
+        isLoading = false
+        searchTask = nil
+        signalIdle()
     }
 
-    private func runFileSearch(query: String, targets: [SearchWorktree]) async {
-        var rows: [FileSearchResult] = []
+    private func runFileSearch(
+        query: String,
+        targets: [SearchWorktree],
+        taskGeneration: Int
+    ) async {
+        var sources: [FileSearchRankingSource] = []
         var failures: [String] = []
-        var sinceCancelCheck = 0
         for wt in targets {
             do {
                 async let statusTask = env.statuses(wt)
-                async let candidateRowsTask = fileSearchCandidateRows(query: query, worktree: wt)
-
-                let candidateRows = try await candidateRowsTask
+                async let entriesTask = env.entries(wt)
+                let backendResults: [FileSearchBackendResult]?
+                if Self.canUseFileSearchBackend(query: query) {
+                    backendResults = try? await env.fileSearch(query, wt)
+                } else {
+                    backendResults = nil
+                }
+                let entries = try await entriesTask
                 let statuses = (try? await statusTask) ?? [:]
-                if case let .backend(backendRows) = candidateRows {
-                    appendBackendRows(backendRows, worktree: wt, statuses: statuses, into: &rows)
-                    try await appendBackendOmittedFallbackRows(
-                        query: query,
-                        backendRows: backendRows,
-                        worktree: wt,
-                        statuses: statuses,
-                        into: &rows,
-                        sinceCancelCheck: &sinceCancelCheck
-                    )
-                    continue
-                }
-
-                guard case let .entries(entries) = candidateRows else {
-                    continue
-                }
-                if Task.isCancelled { return }
-
-                for entry in entries {
-                    // Cooperative cancellation inside the scoring loop —
-                    // a large worktree (or `.allRepos`) can have tens of
-                    // thousands of entries; without periodic checks a
-                    // stale task keeps scoring and overwrites a newer
-                    // task's results when it eventually publishes.
-                    sinceCancelCheck &+= 1
-                    if sinceCancelCheck >= 256 {
-                        sinceCancelCheck = 0
-                        if Task.isCancelled { return }
-                    }
-                    let badge = statuses[entry.relativePath]
-                    if query.isEmpty {
-                        rows.append(FileSearchResult(
-                            worktreeId: wt.id,
-                            projectId: wt.projectId,
-                            relativePath: entry.relativePath,
-                            ext: entry.ext,
-                            statusBadge: badge,
-                            matchIndices: [],
-                            score: badge != nil ? 100 : 0
-                        ))
-                    } else if let m = FuzzyMatch.score(query: query, target: entry.relativePath) {
-                        let slash = entry.relativePath.lastIndex(of: "/")
-                        let prefixLen = slash.map { entry.relativePath.distance(from: entry.relativePath.startIndex, to: $0) + 1 } ?? 0
-                        let inName = m.indices.allSatisfy { $0 >= prefixLen }
-                        let score = m.score + (inName ? 8 : 0) + (badge != nil ? 2 : 0)
-                        rows.append(FileSearchResult(
-                            worktreeId: wt.id,
-                            projectId: wt.projectId,
-                            relativePath: entry.relativePath,
-                            ext: entry.ext,
-                            statusBadge: badge,
-                            matchIndices: m.indices,
-                            score: score
-                        ))
-                    }
-                }
+                sources.append(FileSearchRankingSource(
+                    worktreeId: wt.id,
+                    projectId: wt.projectId,
+                    entries: entries,
+                    backendResults: backendResults,
+                    statuses: statuses
+                ))
             } catch {
                 failures.append(wt.displayName)
             }
         }
 
-        if query.isEmpty {
-            // Status-tagged files first, then alphabetical.
-            rows.sort { lhs, rhs in
-                if (lhs.statusBadge != nil) != (rhs.statusBadge != nil) {
-                    return lhs.statusBadge != nil
-                }
-                return lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
-            }
-        } else {
-            rows.sort { $0.score > $1.score }
-        }
-
-        let capped = Array(rows.prefix(50))
-        // Final cancellation check before publishing — stops a stale task
-        // from clobbering a newer query's results during the time we spent
-        // sorting/capping.
-        if Task.isCancelled { return }
-        results = SearchResults(
-            fileResults: capped,
+        guard let rows = try? await env.rankFiles(query, sources) else { return }
+        publish(SearchResults(
+            fileResults: rows,
             contentGroups: [],
             partialFailureMessage: failures.isEmpty
                 ? nil
                 : "Couldn't read files for \(failures.joined(separator: ", "))"
-        )
-    }
-
-    private func appendBackendRows(
-        _ backendRows: [FileSearchBackendResult],
-        worktree wt: SearchWorktree,
-        statuses: [String: GitStatusBadge],
-        into rows: inout [FileSearchResult]
-    ) {
-        rows.append(contentsOf: backendRows.map { row in
-            let ext = (row.relativePath as NSString).pathExtension.lowercased()
-            return FileSearchResult(
-                worktreeId: wt.id,
-                projectId: wt.projectId,
-                relativePath: row.relativePath,
-                ext: ext,
-                statusBadge: statuses[row.relativePath],
-                matchIndices: row.matchIndices,
-                score: row.score + (statuses[row.relativePath] != nil ? 2 : 0)
-            )
-        })
-    }
-
-    private func appendBackendOmittedFallbackRows(
-        query: String,
-        backendRows: [FileSearchBackendResult],
-        worktree wt: SearchWorktree,
-        statuses: [String: GitStatusBadge],
-        into rows: inout [FileSearchResult],
-        sinceCancelCheck: inout Int
-    ) async throws {
-        let backendPaths = Set(backendRows.map(\.relativePath))
-        let entries = try await env.entries(wt)
-        for entry in entries where !backendPaths.contains(entry.relativePath) {
-            sinceCancelCheck &+= 1
-            if sinceCancelCheck >= 256 {
-                sinceCancelCheck = 0
-                if Task.isCancelled { return }
-            }
-
-            let badge = statuses[entry.relativePath]
-            if query.isEmpty {
-                rows.append(FileSearchResult(
-                    worktreeId: wt.id,
-                    projectId: wt.projectId,
-                    relativePath: entry.relativePath,
-                    ext: entry.ext,
-                    statusBadge: badge,
-                    matchIndices: [],
-                    score: badge != nil ? 100 : 0
-                ))
-            } else if let match = FuzzyMatch.score(query: query, target: entry.relativePath) {
-                let slash = entry.relativePath.lastIndex(of: "/")
-                let prefixLen = slash.map { entry.relativePath.distance(from: entry.relativePath.startIndex, to: $0) + 1 } ?? 0
-                let inName = match.indices.allSatisfy { $0 >= prefixLen }
-                rows.append(FileSearchResult(
-                    worktreeId: wt.id,
-                    projectId: wt.projectId,
-                    relativePath: entry.relativePath,
-                    ext: entry.ext,
-                    statusBadge: badge,
-                    matchIndices: match.indices,
-                    score: match.score + (inName ? 8 : 0) + (badge != nil ? 2 : 0)
-                ))
-            }
-        }
-    }
-
-    private enum FileSearchCandidateRows {
-        case backend([FileSearchBackendResult])
-        case entries([FileIndex.Entry])
-    }
-
-    private func fileSearchCandidateRows(query: String, worktree wt: SearchWorktree) async throws -> FileSearchCandidateRows {
-        if Self.canUseFileSearchBackend(query: query),
-           let backendRows = try? await env.fileSearch(query, wt) {
-            return .backend(backendRows)
-        }
-        return .entries(try await env.entries(wt))
+        ), taskGeneration: taskGeneration)
     }
 
     private static func canUseFileSearchBackend(query: String) -> Bool {
@@ -377,12 +264,17 @@ final class SearchModel {
             .contains { $0.count >= 2 }
     }
 
-    private func runContentSearch(query: String, targets: [SearchWorktree]) async {
+    private func runContentSearch(
+        query: String,
+        options: SearchContentOptions,
+        targets: [SearchWorktree],
+        taskGeneration: Int
+    ) async {
         // Empty content queries match everything; rg would scan the whole
         // worktree for nothing useful. Short-circuit to a clean state so the
         // empty-state copy renders instead.
         guard !query.isEmpty else {
-            results = SearchResults()
+            publish(SearchResults(), taskGeneration: taskGeneration)
             return
         }
 
@@ -393,15 +285,15 @@ final class SearchModel {
         // is ICU-regex; rg uses Rust's regex crate. Most simple patterns
         // (`[`, `(`, `\?`) are flagged identically; for exotic features
         // they may diverge, in which case this just falls through to rg.
-        if contentOptions.regex {
+        if options.regex {
             do {
                 _ = try NSRegularExpression(pattern: query, options: [])
             } catch {
-                results = SearchResults(
+                publish(SearchResults(
                     fileResults: [],
                     contentGroups: [],
                     partialFailureMessage: "Invalid regex pattern."
-                )
+                ), taskGeneration: taskGeneration)
                 return
             }
         }
@@ -418,9 +310,9 @@ final class SearchModel {
         var totalHits = 0
 
         do {
-            let stream = env.contentSearch(query, contentOptions, targets)
+            let stream = env.contentSearch(query, options, targets)
             for try await hit in stream {
-                if Task.isCancelled { return }
+                guard isCurrent(taskGeneration) else { return }
 
                 let key = hit.groupKey
                 if let idx = groupIndex[key] {
@@ -443,39 +335,35 @@ final class SearchModel {
 
                 // Push partial results every 25 hits so the UI animates.
                 if totalHits % partialEvery == 0 {
-                    results = SearchResults(
+                    publish(SearchResults(
                         fileResults: [],
                         contentGroups: groups,
                         partialFailureMessage: nil
-                    )
+                    ), taskGeneration: taskGeneration)
                 }
 
                 if totalHits >= maxHits { break }
             }
-            // Final flush — but only if we haven't been superseded by a
-            // newer query. Otherwise the about-to-be-overwritten newer
-            // task's results would be clobbered with our stale snapshot.
-            if Task.isCancelled { return }
-            results = SearchResults(
+            publish(SearchResults(
                 fileResults: [],
                 contentGroups: groups,
                 partialFailureMessage: nil
-            )
+            ), taskGeneration: taskGeneration)
         } catch ContentSearcher.SearchError.rgNotFound {
-            results = SearchResults(
+            publish(SearchResults(
                 fileResults: [],
                 contentGroups: [],
                 partialFailureMessage: "Install ripgrep (`brew install ripgrep`) to enable content search."
-            )
+            ), taskGeneration: taskGeneration)
         } catch ContentSearcher.SearchError.regexInvalid {
             // rg's stderr-detected regex parse error — covers patterns
             // that the up-front NSRegularExpression preflight accepted
             // but rg's Rust regex rejects (look-around, backrefs).
-            results = SearchResults(
+            publish(SearchResults(
                 fileResults: [],
                 contentGroups: [],
                 partialFailureMessage: "Invalid regex pattern."
-            )
+            ), taskGeneration: taskGeneration)
         } catch ContentSearcher.SearchError.rgFailed {
             // ripgrep exit 2 covers both regex-syntax errors and soft I/O
             // errors (unreadable file, permission denied, etc.) — see
@@ -486,23 +374,32 @@ final class SearchModel {
             let message = groups.isEmpty
                 ? "Content search failed."
                 : "Some files couldn't be searched."
-            results = SearchResults(
+            publish(SearchResults(
                 fileResults: [],
                 contentGroups: groups,
                 partialFailureMessage: message
-            )
+            ), taskGeneration: taskGeneration)
         } catch is CancellationError {
             // A newer keystroke superseded this query — let the new task
             // own `results`. Don't surface a banner.
             return
         } catch {
             // Flush whatever was accumulated so far.
-            results = SearchResults(
+            publish(SearchResults(
                 fileResults: [],
                 contentGroups: groups,
                 partialFailureMessage: "Content search interrupted."
-            )
+            ), taskGeneration: taskGeneration)
         }
+    }
+
+    private func isCurrent(_ generation: Int) -> Bool {
+        isOpen && taskGeneration == generation
+    }
+
+    private func publish(_ newResults: SearchResults, taskGeneration generation: Int) {
+        guard isCurrent(generation) else { return }
+        results = newResults
     }
 
     private func signalIdle() {

--- a/Alas/Sources/Search/SearchModel.swift
+++ b/Alas/Sources/Search/SearchModel.swift
@@ -225,27 +225,29 @@ final class SearchModel {
         var sources: [FileSearchRankingSource] = []
         var failures: [String] = []
         for wt in targets {
+            async let statusTask = env.statuses(wt)
+            async let entriesTask = env.entries(wt)
+            let backendResults: [FileSearchBackendResult]?
+            if Self.canUseFileSearchBackend(query: query) {
+                backendResults = try? await env.fileSearch(query, wt)
+            } else {
+                backendResults = nil
+            }
+            let entries: [FileIndex.Entry]
             do {
-                async let statusTask = env.statuses(wt)
-                async let entriesTask = env.entries(wt)
-                let backendResults: [FileSearchBackendResult]?
-                if Self.canUseFileSearchBackend(query: query) {
-                    backendResults = try? await env.fileSearch(query, wt)
-                } else {
-                    backendResults = nil
-                }
-                let entries = try await entriesTask
-                let statuses = (try? await statusTask) ?? [:]
-                sources.append(FileSearchRankingSource(
-                    worktreeId: wt.id,
-                    projectId: wt.projectId,
-                    entries: entries,
-                    backendResults: backendResults,
-                    statuses: statuses
-                ))
+                entries = try await entriesTask
             } catch {
                 failures.append(wt.displayName)
+                entries = []
             }
+            let statuses = (try? await statusTask) ?? [:]
+            sources.append(FileSearchRankingSource(
+                worktreeId: wt.id,
+                projectId: wt.projectId,
+                entries: entries,
+                backendResults: backendResults,
+                statuses: statuses
+            ))
         }
 
         guard let rows = try? await env.rankFiles(query, sources) else { return }

--- a/Alas/Sources/Search/Views/SearchInputRow.swift
+++ b/Alas/Sources/Search/Views/SearchInputRow.swift
@@ -16,6 +16,11 @@ struct SearchInputRow: View {
                 .font(.system(size: 15))
                 .foregroundColor(theme.color("fg"))
                 .autocorrectionDisabled(true)
+            if model.isLoading {
+                Spinner(lineWidth: 1.5, duration: 0.7)
+                    .frame(width: 12, height: 12)
+                    .accessibilityLabel("Searching")
+            }
             if !model.query.isEmpty {
                 Button {
                     model.query = ""

--- a/AlasTests/FileSearchRankerTests.swift
+++ b/AlasTests/FileSearchRankerTests.swift
@@ -1,0 +1,68 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct FileSearchRankerTests {
+    @Test func filteredRankingMergesBackendAndMatchingOmittedEntries() async throws {
+        let backendPath = "src/backend_needle.swift"
+        let fallbackPath = "ignored/tracked_needle.swift"
+        let backendRow = FileSearchBackendResult(
+            relativePath: backendPath,
+            score: 1_000,
+            matchIndices: [4, 5, 6]
+        )
+        let source = FileSearchRankingSource(
+            worktreeId: "worktree",
+            projectId: "project",
+            entries: [
+                .init(relativePath: backendPath, ext: "swift"),
+                .init(relativePath: fallbackPath, ext: "swift"),
+                .init(relativePath: "src/unrelated.swift", ext: "swift"),
+            ],
+            backendResults: [backendRow],
+            statuses: [
+                backendPath: .modified,
+                fallbackPath: .added,
+            ]
+        )
+
+        let results = try await FileSearchRanker().rank(query: "needle", sources: [source])
+
+        #expect(results.map(\.relativePath) == [backendPath, fallbackPath])
+        let backendResult = try #require(results.first)
+        #expect(backendResult.score == 1_002)
+        #expect(backendResult.statusBadge == .modified)
+        #expect(backendResult.matchIndices == [4, 5, 6])
+
+        let fallbackResult = try #require(results.last)
+        let fallbackMatch = try #require(FuzzyMatch.score(query: "needle", target: fallbackPath))
+        #expect(fallbackResult.score == fallbackMatch.score + 10)
+        #expect(fallbackResult.statusBadge == .added)
+        #expect(fallbackResult.matchIndices == fallbackMatch.indices)
+    }
+
+    @Test func emptyQueryRanksStatusesFirstThenAlphabeticallyAndCapsAtFifty() async throws {
+        let alphabeticalEntries = (0..<55).reversed().map {
+            FileIndex.Entry(relativePath: String(format: "file_%02d.swift", $0), ext: "swift")
+        }
+        let taggedPath = "zz_tagged.swift"
+        let source = FileSearchRankingSource(
+            worktreeId: "worktree",
+            projectId: "project",
+            entries: alphabeticalEntries + [
+                .init(relativePath: taggedPath, ext: "swift"),
+            ],
+            backendResults: nil,
+            statuses: [taggedPath: .modified]
+        )
+
+        let results = try await FileSearchRanker().rank(query: "", sources: [source])
+
+        #expect(results.count == 50)
+        #expect(results.first?.relativePath == taggedPath)
+        #expect(results.dropFirst().map(\.relativePath) == (0..<49).map {
+            String(format: "file_%02d.swift", $0)
+        })
+        #expect(results.first?.score == 100)
+    }
+}

--- a/AlasTests/SearchModelTests.swift
+++ b/AlasTests/SearchModelTests.swift
@@ -62,14 +62,19 @@ struct SearchModelTests {
         files: [String: [FileIndex.Entry]] = [:],
         statuses: [String: [String: GitStatusBadge]] = [:],
         fileSearch: (@Sendable (String, SearchWorktree) async throws -> [FileSearchBackendResult]?)? = nil,
+        rankFiles: (@Sendable (String, [FileSearchRankingSource]) async throws -> [FileSearchResult])? = nil,
         contentSearch: (@Sendable (String, SearchContentOptions, [SearchWorktree]) -> AsyncThrowingStream<ContentSearchHit, Error>)? = nil
     ) -> SearchEnvironment {
-        SearchEnvironment(
+        let ranker = FileSearchRanker()
+        return SearchEnvironment(
             currentWorktreeId: { worktrees.first?.id },
             allWorktrees: { worktrees },
             entries: { wt in files[wt.id] ?? [] },
             statuses: { wt in statuses[wt.id] ?? [:] },
             fileSearch: fileSearch ?? { _, _ in nil },
+            rankFiles: rankFiles ?? { query, sources in
+                try await ranker.rank(query: query, sources: sources)
+            },
             contentSearch: contentSearch ?? { _, _, _ in AsyncThrowingStream { $0.finish() } }
         )
     }
@@ -97,6 +102,9 @@ struct SearchModelTests {
             entries: { _ in [] },
             statuses: { _ in [:] },
             fileSearch: { _, _ in nil },
+            rankFiles: { [ranker = FileSearchRanker()] query, sources in
+                try await ranker.rank(query: query, sources: sources)
+            },
             contentSearch: { _, _, _ in AsyncThrowingStream { $0.finish() } }
         )
         let model2 = SearchModel(environment: env)
@@ -598,6 +606,146 @@ extension SearchModelTests {
         #expect(model.results.contentGroups.count == 1)
         #expect(model.results.partialFailureMessage == "Some files couldn't be searched.")
     }
+
+    @Test func staleFileRankingCannotPublishOrClearSuccessorLoading() async throws {
+        let gate = RankGate()
+        let ranker = FileSearchRanker()
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [
+                .init(relativePath: "old.swift", ext: "swift"),
+                .init(relativePath: "new.swift", ext: "swift"),
+            ]],
+            rankFiles: { query, sources in
+                guard query == "old" || query == "new" else {
+                    return try await ranker.rank(query: query, sources: sources)
+                }
+                return try await gate.rank(query: query)
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        await model.waitForIdle()
+
+        model.query = "old"
+        await gate.waitUntilStarted(query: "old")
+        model.query = "new"
+        await gate.waitUntilStarted(query: "new")
+
+        await gate.release(query: "old", results: [fileResult(path: "old.swift")])
+        await drainMainActor()
+        #expect(model.isLoading)
+        #expect(model.results.fileResults.map(\.relativePath) != ["old.swift"])
+
+        await gate.release(query: "new", results: [fileResult(path: "new.swift")])
+        await model.waitForIdle()
+        #expect(model.results.fileResults.map(\.relativePath) == ["new.swift"])
+        #expect(!model.isLoading)
+    }
+
+    @Test func staleContentPartialAndErrorCannotOverwriteCompletedSuccessor() async {
+        let streams = ContentStreamGate()
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            contentSearch: { query, _, _ in streams.stream(for: query) }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        await model.waitForIdle()
+        model.kind = .content
+        model.query = "old"
+        await streams.waitUntilStarted(query: "old")
+
+        await streams.yield(
+            query: "old",
+            hits: (0..<25).map { contentHit(path: "old.swift", line: $0 + 1) }
+        )
+        await waitUntil { model.results.contentGroups.first?.relativePath == "old.swift" }
+
+        model.query = "new"
+        await streams.waitUntilStarted(query: "new")
+        await streams.yield(query: "new", hits: [contentHit(path: "new.swift", line: 1)])
+        await streams.finish(query: "new")
+        await model.waitForIdle()
+        #expect(model.results.contentGroups.map(\.relativePath) == ["new.swift"])
+        #expect(model.results.partialFailureMessage == nil)
+
+        await streams.finish(
+            query: "old",
+            throwing: ContentSearcher.SearchError.rgFailed(exitCode: 2)
+        )
+        await drainMainActor()
+        #expect(model.results.contentGroups.map(\.relativePath) == ["new.swift"])
+        #expect(model.results.partialFailureMessage == nil)
+    }
+
+    @Test func closeInvalidatesActiveSearchAndReleasesIdleWaiters() async {
+        let gate = RankGate()
+        let ranker = FileSearchRanker()
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [.init(relativePath: "active.swift", ext: "swift")]],
+            rankFiles: { query, sources in
+                guard query == "active" else {
+                    return try await ranker.rank(query: query, sources: sources)
+                }
+                return try await gate.rank(query: query)
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        await model.waitForIdle()
+        model.query = "active"
+        await gate.waitUntilStarted(query: "active")
+        #expect(model.isLoading)
+
+        let idleWaiter = Task { @MainActor in await model.waitForIdle() }
+        model.close()
+        await idleWaiter.value
+
+        #expect(!model.isOpen)
+        #expect(!model.isLoading)
+        #expect(model.query.isEmpty)
+        #expect(model.results == SearchResults())
+
+        await gate.release(query: "active", results: [fileResult(path: "active.swift")])
+        await drainMainActor()
+        #expect(model.results == SearchResults())
+        #expect(!model.isLoading)
+    }
+
+    private func fileResult(path: String) -> FileSearchResult {
+        FileSearchResult(
+            worktreeId: "a",
+            projectId: "p1",
+            relativePath: path,
+            ext: "swift",
+            statusBadge: nil,
+            matchIndices: [],
+            score: 1
+        )
+    }
+
+    private func contentHit(path: String, line: Int) -> ContentSearchHit {
+        ContentSearchHit(
+            worktreeId: "a",
+            projectId: "p1",
+            relativePath: path,
+            line: line,
+            column: 1,
+            revealColumn: nil,
+            snippet: "match",
+            matchCharRange: nil
+        )
+    }
+
+    private func drainMainActor() async {
+        for _ in 0..<10 { await Task.yield() }
+    }
+
+    private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+        while !predicate() { await Task.yield() }
+    }
 }
 
 /// Test helper used by `invalidRegexIsCaughtBeforeBackendRuns` to flag
@@ -606,4 +754,73 @@ private actor InvocationFlag {
     private var invoked = false
     func set() { invoked = true }
     var value: Bool { invoked }
+}
+
+private actor RankGate {
+    private var startedQueries: Set<String> = []
+    private var startWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+    private var rankWaiters: [String: CheckedContinuation<[FileSearchResult], Error>] = [:]
+
+    func rank(query: String) async throws -> [FileSearchResult] {
+        startedQueries.insert(query)
+        let waiters = startWaiters.removeValue(forKey: query) ?? []
+        waiters.forEach { $0.resume() }
+        return try await withCheckedThrowingContinuation { continuation in
+            rankWaiters[query] = continuation
+        }
+    }
+
+    func waitUntilStarted(query: String) async {
+        guard !startedQueries.contains(query) else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters[query, default: []].append(continuation)
+        }
+    }
+
+    func release(query: String, results: [FileSearchResult]) {
+        rankWaiters.removeValue(forKey: query)?.resume(returning: results)
+    }
+}
+
+private actor ContentStreamGate {
+    private var continuations: [String: AsyncThrowingStream<ContentSearchHit, Error>.Continuation] = [:]
+    private var startedQueries: Set<String> = []
+    private var startWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    nonisolated func stream(for query: String) -> AsyncThrowingStream<ContentSearchHit, Error> {
+        AsyncThrowingStream { continuation in
+            Task { await self.register(continuation, for: query) }
+        }
+    }
+
+    func waitUntilStarted(query: String) async {
+        guard !startedQueries.contains(query) else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters[query, default: []].append(continuation)
+        }
+    }
+
+    func yield(query: String, hits: [ContentSearchHit]) {
+        guard let continuation = continuations[query] else { return }
+        for hit in hits { continuation.yield(hit) }
+    }
+
+    func finish(query: String, throwing error: Error? = nil) {
+        guard let continuation = continuations.removeValue(forKey: query) else { return }
+        if let error {
+            continuation.finish(throwing: error)
+        } else {
+            continuation.finish()
+        }
+    }
+
+    private func register(
+        _ continuation: AsyncThrowingStream<ContentSearchHit, Error>.Continuation,
+        for query: String
+    ) {
+        continuations[query] = continuation
+        startedQueries.insert(query)
+        let waiters = startWaiters.removeValue(forKey: query) ?? []
+        waiters.forEach { $0.resume() }
+    }
 }

--- a/AlasTests/SearchModelTests.swift
+++ b/AlasTests/SearchModelTests.swift
@@ -61,6 +61,7 @@ struct SearchModelTests {
         worktrees: [SearchWorktree] = [],
         files: [String: [FileIndex.Entry]] = [:],
         statuses: [String: [String: GitStatusBadge]] = [:],
+        entries: (@Sendable (SearchWorktree) async throws -> [FileIndex.Entry])? = nil,
         fileSearch: (@Sendable (String, SearchWorktree) async throws -> [FileSearchBackendResult]?)? = nil,
         rankFiles: (@Sendable (String, [FileSearchRankingSource]) async throws -> [FileSearchResult])? = nil,
         contentSearch: (@Sendable (String, SearchContentOptions, [SearchWorktree]) -> AsyncThrowingStream<ContentSearchHit, Error>)? = nil
@@ -69,7 +70,7 @@ struct SearchModelTests {
         return SearchEnvironment(
             currentWorktreeId: { worktrees.first?.id },
             allWorktrees: { worktrees },
-            entries: { wt in files[wt.id] ?? [] },
+            entries: entries ?? { wt in files[wt.id] ?? [] },
             statuses: { wt in statuses[wt.id] ?? [:] },
             fileSearch: fileSearch ?? { _, _ in nil },
             rankFiles: rankFiles ?? { query, sources in
@@ -174,6 +175,27 @@ struct SearchModelTests {
         #expect(model.results.fileResults.first?.statusBadge == .modified)
         #expect(model.results.fileResults.first?.score == 44)
         #expect(model.results.fileResults.first?.matchIndices == [4, 5, 6])
+    }
+
+    @Test func fileSearchPreservesBackendResultsWhenEntryEnumerationFails() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            entries: { _ in throw CocoaError(.fileReadUnknown) },
+            fileSearch: { _, _ in
+                [FileSearchBackendResult(
+                    relativePath: "src/backend_result.swift",
+                    score: 42,
+                    matchIndices: [4, 5, 6]
+                )]
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "backend"
+        await model.waitForIdle()
+
+        #expect(model.results.fileResults.map(\.relativePath) == ["src/backend_result.swift"])
+        #expect(model.results.partialFailureMessage == "Couldn't read files for wt-a")
     }
 
     @Test func fileSearchMergesDeletedFallbackRowsWithBackendResults() async {

--- a/docs/superpowers/specs/2026-07-15-cmd-p-search-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-15-cmd-p-search-filtering-design.md
@@ -1,0 +1,103 @@
+# Cmd-P Search Filtering Reliability
+
+## Problem
+
+Cmd-P file filtering can appear to stop while a large candidate set is being
+ranked. `SearchModel` is main-actor isolated, and its fallback fuzzy-scoring
+and sorting work runs synchronously on that actor. While that work is running,
+SwiftUI cannot deliver later query changes, so the active search cannot be
+cancelled promptly.
+
+Search completion also relies primarily on cooperative task cancellation.
+A superseded task can still mutate shared presentation state on a delayed or
+backend-specific completion path. In particular, every task unconditionally
+clears `isLoading`, even when a newer search is active.
+
+## Goals
+
+- Keep the search field responsive while filtering large repositories.
+- Ensure only the latest query can publish results, selection changes, errors,
+  loading state, or idle completion.
+- Preserve the current results while their replacement is loading.
+- Show the app's custom inline spinner at the right edge of the search field.
+- Cover rapid query changes and stale completion paths with regression tests.
+
+## Non-Goals
+
+- Changing fuzzy-match scoring or result caps.
+- Streaming incremental file-name results.
+- Redesigning the search dialog or content-search backend.
+- Adding new loading components or visual styles.
+
+## Design
+
+### File Ranking
+
+Move CPU-heavy file candidate scoring and sorting into a pure, sendable
+operation that does not run on the main actor. `SearchModel` remains responsible
+for capturing the query, scope, targets, backend results, and status data, then
+awaits the ranking result before publishing it.
+
+The operation retains the existing behavior:
+
+- merge indexed backend rows with tracked entries omitted by the backend;
+- apply the existing fuzzy score, filename bonus, and status bonus;
+- sort empty-query results by status and path;
+- sort filtered results by score; and
+- cap the published list at 50 rows.
+
+Cancellation checks remain in the worker so obsolete work can terminate early,
+but correctness does not depend on cancellation alone.
+
+### Search Generation Ownership
+
+Each reschedule increments a generation and captures it in the scheduled task.
+All model mutations produced by asynchronous search work must verify that the
+captured generation is still current. This includes:
+
+- final file results;
+- partial and final content results;
+- content-search error banners;
+- selection clamping;
+- `isLoading`; and
+- idle-waiter completion.
+
+The latest generation sets loading when its debounced work starts and clears it
+when that same generation settles. A stale generation may return or be cancelled
+without changing state owned by its successor. Closing the dialog invalidates
+the current generation, cancels work, clears loading, and resumes any test idle
+waiters.
+
+Existing rows remain visible between rescheduling and publication. This avoids
+an empty-state flash and makes the spinner the explicit indication that the
+visible rows are being replaced.
+
+### Loading Indicator
+
+`SearchInputRow` observes `model.isLoading`. While true, it renders the existing
+custom `Spinner` after the text field and before the clear button and mode tabs.
+The spinner uses a fixed compact frame so its appearance does not shift the
+tabs or resize the dialog. It has an accessibility label identifying search in
+progress and is absent when the latest search is idle.
+
+## Error Handling
+
+The existing user-facing content and partial-repository error messages remain
+unchanged. An error from a stale generation is discarded. An error from the
+latest generation publishes normally and clears loading when that generation
+settles.
+
+## Testing
+
+Add focused Swift Testing coverage that controls backend timing:
+
+- a slow file search is superseded by a newer query, and only the newer query
+  publishes;
+- CPU-heavy file ranking does not prevent a later query from being scheduled;
+- stale content partial/failure completion cannot overwrite newer results;
+- an older task settling cannot clear loading owned by a newer task;
+- the latest task settling clears loading and releases idle waiters; and
+- closing during a search leaves loading false and no waiter stranded.
+
+Run the focused search tests first, then the repository-required `xcodegen`,
+build, and full test commands.


### PR DESCRIPTION
## Summary

- move file ranking off the main actor so large repositories do not freeze query updates
- make the latest query authoritative for results, errors, selection, and loading state
- show the custom inline spinner in the search field while work is in progress
- preserve backend matches when fallback file enumeration fails

## Root cause

Fallback fuzzy ranking and sorting ran synchronously on the main actor. That delayed query changes and cancellation, while stale tasks could also clear loading state or publish partial results after a newer query had started.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused `SearchModelTests` and `FileSearchRankerTests`
- complete non-SSH test suite (5,400+ tests); SSH integration tests are opt-in via `ALAS_SSH_INTEGRATION=1`
