### PR TITLE
feat(mcp): agent-facing review comment tools (Phase 1)

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A54DD8080E3395C8E7049E /* RemoteProtocol.swift */; };
 		32727E2775753CDBF02D4660 /* TreeSitterDockerfile in Frameworks */ = {isa = PBXBuildFile; productRef = B0B462D196CBF339A0F9B651 /* TreeSitterDockerfile */; };
 		3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6CCD7F7273667B5D67F821 /* SearchScope.swift */; };
+		329385662072CB658F9CA8E8 /* ReviewHandoffProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87C04CBE6911062CBE1134E /* ReviewHandoffProgress.swift */; };
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
 		32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */; };
 		32B3513F0BFC2F9B72763773 /* GitHubCLIProviderVerdictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */; };
@@ -1120,6 +1121,7 @@
 		E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */; };
 		E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */; };
 		E1EEC0425D8F30D85CDB35EE /* UpdateAvailableSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */; };
+		E2040E891927609AEFAE2EFF /* ReviewHandoffProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEA83FD24E93585D13C6A33 /* ReviewHandoffProgressTests.swift */; };
 		E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373D587E3153D902EB10208B /* MarkdownParserTests.swift */; };
 		E22E6141A5EF030F79CF8CBE /* RemotePairingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA59378FB8733DBAC67592A3 /* RemotePairingServiceTests.swift */; };
 		E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */; };
@@ -2397,6 +2399,7 @@
 		E7D9230E4E0DD70D689F40DD /* SpacePagerIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacePagerIndicatorTests.swift; sourceTree = "<group>"; };
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
 		E8272ACF30256E328519815C /* SQLiteDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabaseTests.swift; sourceTree = "<group>"; };
+		E87C04CBE6911062CBE1134E /* ReviewHandoffProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewHandoffProgress.swift; sourceTree = "<group>"; };
 		E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-new-response-with-config-options.json"; sourceTree = "<group>"; };
 		E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewInlineFeedbackActions.swift; sourceTree = "<group>"; };
 		E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteExecTests.swift; sourceTree = "<group>"; };
@@ -2516,6 +2519,7 @@
 		FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstaller.swift; sourceTree = "<group>"; };
 		FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffModeApplicabilityTests.swift; sourceTree = "<group>"; };
+		FFEA83FD24E93585D13C6A33 /* ReviewHandoffProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewHandoffProgressTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2901,6 +2905,7 @@
 				D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */,
 				67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */,
 				2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */,
+				FFEA83FD24E93585D13C6A33 /* ReviewHandoffProgressTests.swift */,
 				694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */,
 				DC73B8AC6AC57FB3A3253F40 /* ReviewScopeSelectionTests.swift */,
 				ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */,
@@ -4389,6 +4394,7 @@
 				C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */,
 				56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */,
 				B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */,
+				E87C04CBE6911062CBE1134E /* ReviewHandoffProgress.swift */,
 				2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */,
 				2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */,
 				0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */,
@@ -5495,6 +5501,7 @@
 				DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */,
 				E0F4EFE612252BDD7F999A70 /* ReviewFeedbackAgentSender.swift in Sources */,
 				D27A85DE79B3B62C6F91174A /* ReviewFeedbackBundle.swift in Sources */,
+				329385662072CB658F9CA8E8 /* ReviewHandoffProgress.swift in Sources */,
 				DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */,
 				877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */,
 				F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */,
@@ -6059,6 +6066,7 @@
 				1A6AF8939585038A3303B625 /* ReviewDraftModelsTests.swift in Sources */,
 				A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */,
 				A1252F6D967104D2B369CEA8 /* ReviewFeedbackBundleTests.swift in Sources */,
+				E2040E891927609AEFAE2EFF /* ReviewHandoffProgressTests.swift in Sources */,
 				9409E946054E7D837A479137 /* ReviewLoopDrawerTests.swift in Sources */,
 				096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */,
 				B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0C7A044AC34BF225A4149556 /* RemoteTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E25D0520B813E8AC9A7174 /* RemoteTerminalLaunchTests.swift */; };
+		0CDC1232955139B230B6600C /* ReviewDraftCommentAgentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
@@ -2081,6 +2082,7 @@
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabViewTests.swift; sourceTree = "<group>"; };
 		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
+		AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentAgentModelTests.swift; sourceTree = "<group>"; };
 		AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModelsTests.swift; sourceTree = "<group>"; };
 		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
 		ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentView.swift; sourceTree = "<group>"; };
@@ -2893,6 +2895,7 @@
 				CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */,
 				F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */,
 				FB9E78C70091168556C9669B /* ReviewChangesTabViewTests.swift */,
+				AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */,
 				D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */,
 				67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */,
 				2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */,
@@ -6047,6 +6050,7 @@
 				13928612F39D3D86ED3313AC /* ReviewChangesModelsTests.swift in Sources */,
 				B13C57CF7090C966143A6840 /* ReviewChangesScrollSpyTests.swift in Sources */,
 				ACDE5C92423E9EFBE50CAEF2 /* ReviewChangesTabViewTests.swift in Sources */,
+				0CDC1232955139B230B6600C /* ReviewDraftCommentAgentModelTests.swift in Sources */,
 				CBB3A06686A9CBFE699C08AF /* ReviewDraftCommentStoreTests.swift in Sources */,
 				1A6AF8939585038A3303B625 /* ReviewDraftModelsTests.swift in Sources */,
 				A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -755,6 +755,7 @@
 		9B51DB62236B865AB86AA0F1 /* TreeSitterTypeScript in Frameworks */ = {isa = PBXBuildFile; productRef = 1F70A188A5F7992AC8C8717E /* TreeSitterTypeScript */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */; };
+		9C03E77926427C9236E2922C /* ReviewCommentWireDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7BE909731E9D15A032A6E0 /* ReviewCommentWireDTO.swift */; };
 		9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
 		9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */; };
@@ -1814,6 +1815,7 @@
 		6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRetentionTests.swift; sourceTree = "<group>"; };
 		6D46BDE72E52818061452ECB /* CommitRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRowTests.swift; sourceTree = "<group>"; };
 		6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfoTests.swift; sourceTree = "<group>"; };
+		6D7BE909731E9D15A032A6E0 /* ReviewCommentWireDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewCommentWireDTO.swift; sourceTree = "<group>"; };
 		6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayout.swift; sourceTree = "<group>"; };
 		6D95FBEE2C9BF1AD1A602C28 /* GitLabCLIProviderVerdictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProviderVerdictTests.swift; sourceTree = "<group>"; };
 		6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagingTests.swift; sourceTree = "<group>"; };
@@ -4624,6 +4626,7 @@
 				417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */,
 				B44D759586280250330A9A04 /* FontSizeCommands.swift */,
 				7FFC9539E615699AC90A7412 /* ProjectsManager.swift */,
+				6D7BE909731E9D15A032A6E0 /* ReviewCommentWireDTO.swift */,
 				B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */,
 				69024633944E9FFF6DA76FAE /* RootView.swift */,
 				51B868809675C4110044C92E /* SpacesManager.swift */,
@@ -5482,6 +5485,7 @@
 				F2385B8730E9D1F47C7FA423 /* ReviewChangesRail.swift in Sources */,
 				5269ED23D9732680EF7F4E16 /* ReviewChangesScrollSpy.swift in Sources */,
 				72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */,
+				9C03E77926427C9236E2922C /* ReviewCommentWireDTO.swift in Sources */,
 				D1826BD546F4C8D2755D8F56 /* ReviewDraftCommentActions.swift in Sources */,
 				D9FD24854A41DF2E9214E078 /* ReviewDraftCommentController.swift in Sources */,
 				8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */,

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -229,24 +229,45 @@ struct AlasActionService {
     }
 
     /// Worktree-relative form of `path`: absolute paths under the worktree
-    /// root are relativized; already-relative paths pass through unchanged
-    /// (treated as already worktree-relative). Tries the path as given
-    /// first, then with symlinks resolved on both sides — the CLI
-    /// absolutizes against the caller's logical `$PWD`, which preserves a
-    /// symlinked checkout path, while `worktreeRoot` may be the resolved
-    /// real path Alas tracks (same two-step pattern `relativePathAndDepth`
-    /// already uses for `open`). Returns nil when an absolute path is
-    /// outside the worktree root even after symlink resolution, so callers
-    /// don't file a comment against a path that can never match a file in
-    /// the review.
+    /// root are relativized; already-relative paths are lexically
+    /// normalized (collapsing `.`/`..`/repeated separators) and treated as
+    /// already worktree-relative — MCP callers may send `./Sources/App.swift`
+    /// or `Sources/../Sources/App.swift`, and an unnormalized form would
+    /// miss the exact-match `gitStatus`/`DiffReviewFileID` lookups downstream.
+    /// Absolute paths try the path as given first, then with symlinks
+    /// resolved on both sides — the CLI absolutizes against the caller's
+    /// logical `$PWD`, which preserves a symlinked checkout path, while
+    /// `worktreeRoot` may be the resolved real path Alas tracks (same
+    /// two-step pattern `relativePathAndDepth` already uses for `open`).
+    /// Returns nil when an absolute path is outside the worktree root even
+    /// after symlink resolution, so callers don't file a comment against a
+    /// path that can never match a file in the review.
     static func worktreeRelativePath(_ path: String, worktreeRoot: URL) -> String? {
-        guard path.hasPrefix("/") else { return path }
+        guard path.hasPrefix("/") else { return normalizedRelativePath(path) }
         if let relative = relativePath(path, against: worktreeRoot.standardizedFileURL.path) {
             return relative
         }
         let resolvedRoot = worktreeRoot.resolvingSymlinksInPath().standardizedFileURL.path
         let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
         return relativePath(resolvedPath, against: resolvedRoot)
+    }
+
+    /// Collapses `.`/`..`/repeated separators in a relative path purely
+    /// lexically (no filesystem access, no process cwd involved). A leading
+    /// `..` that would climb above the path's own root is dropped rather
+    /// than followed, since this path is already meant to be worktree-root
+    /// relative.
+    private static func normalizedRelativePath(_ path: String) -> String {
+        var components: [String] = []
+        for component in path.split(separator: "/", omittingEmptySubsequences: true) {
+            if component == "." { continue }
+            if component == ".." {
+                if !components.isEmpty { components.removeLast() }
+                continue
+            }
+            components.append(String(component))
+        }
+        return components.joined(separator: "/")
     }
 
     private static func relativePath(_ path: String, against rootPath: String) -> String? {

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -138,10 +138,11 @@ struct AlasActionService {
             return .error("could not read review comments: \(error.localizedDescription)")
         }
         let scoped = all.filter { comment in
+            guard comment.sessionID.isFor(worktreeID: origin.id) else { return false }
             if let sessionID {
                 return comment.sessionID.rawValue == sessionID
             }
-            return comment.sessionID.isFor(worktreeID: origin.id)
+            return true
         }
         let filtered = scoped.filter { comment in
             switch filter {

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -355,7 +355,11 @@ struct AlasActionService {
             comment.resolvedBy = reopen ? nil : Self.cliAgentAuthor
             comment.updatedAt = timestamp
             try store.save(comment)
-            try recomputeHandoffProgress(worktreeID: origin.id, store: store, timestamp: timestamp)
+            // Best-effort: the comment mutation above already succeeded and
+            // must not be retried, so a failure recomputing handoff/session
+            // status (a separate store) is swallowed rather than reported
+            // as an overall failure a caller would retry.
+            try? recomputeHandoffProgress(worktreeID: origin.id, store: store, timestamp: timestamp)
         } catch {
             return .error("could not update review comment: \(error.localizedDescription)")
         }

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -24,6 +24,7 @@ struct AlasActionService {
     var openProviderReview: (Worktree, String) async -> AlasCLIResponse = { _, _ in
         .error("Opening provider reviews from the terminal is not available yet.")
     }
+    var draftCommentStore: () -> ReviewDraftCommentStore = { ReviewDraftCommentStore() }
     var activateApp: () -> Void
 
     /// Worktree owning `directory`: the worktree rooted exactly at
@@ -114,6 +115,30 @@ struct AlasActionService {
 
     func reviewProvider(origin: Worktree, target: String) async -> AlasCLIResponse {
         await openProviderReview(origin, target)
+    }
+
+    func reviewComments(origin: Worktree, sessionID: String?, filter: ReviewCommentWireFilter) -> AlasCLIResponse {
+        let all: [ReviewDraftComment]
+        do {
+            all = try draftCommentStore().loadAll()
+        } catch {
+            return .error("could not read review comments: \(error.localizedDescription)")
+        }
+        let scoped = all.filter { comment in
+            if let sessionID {
+                return comment.sessionID.rawValue == sessionID
+            }
+            return comment.sessionID.isFor(worktreeID: origin.id)
+        }
+        let filtered = scoped.filter { comment in
+            switch filter {
+            case .all: return true
+            case .active: return comment.state == .active
+            case .resolved: return comment.state == .resolved
+            case .dismissed: return comment.state == .dismissed
+            }
+        }
+        return .text([ReviewCommentWireDTO.jsonLine(filtered.map(ReviewCommentWireDTO.init))])
     }
 
     // MARK: - Worktree matching (moved verbatim from AlasCLICommandRouter)

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -25,6 +25,11 @@ struct AlasActionService {
         .error("Opening provider reviews from the terminal is not available yet.")
     }
     var draftCommentStore: () -> ReviewDraftCommentStore = { ReviewDraftCommentStore() }
+    var reviewSessionStore: () -> ReviewSessionStore = { ReviewSessionStore() }
+    var notifyReviewCommentsChanged: () -> Void = {
+        NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
+    }
+    var now: () -> Date = Date.init
     var activateApp: () -> Void
 
     /// Worktree owning `directory`: the worktree rooted exactly at
@@ -139,6 +144,79 @@ struct AlasActionService {
             }
         }
         return .text([ReviewCommentWireDTO.jsonLine(filtered.map(ReviewCommentWireDTO.init))])
+    }
+
+    /// The author identity CLI/MCP mutations write. Phase 2+ can thread a
+    /// real agent name through the wire; the enum already supports it.
+    static let cliAgentAuthor = ReviewDraftCommentAuthor.agent(name: "Agent")
+
+    func reviewReply(origin: Worktree, commentID: String, body: String) -> AlasCLIResponse {
+        let store = draftCommentStore()
+        do {
+            guard var comment = try store.find(commentID: commentID),
+                  comment.sessionID.isFor(worktreeID: origin.id) else {
+                return .error("unknown review comment id \"\(commentID)\"")
+            }
+            let timestamp = now()
+            var replies = comment.allReplies
+            replies.append(ReviewCommentReply(
+                id: UUID().uuidString,
+                author: Self.cliAgentAuthor,
+                bodyMarkdown: body,
+                createdAt: timestamp
+            ))
+            comment.replies = replies
+            comment.updatedAt = timestamp
+            try store.save(comment)
+        } catch {
+            return .error("could not update review comment: \(error.localizedDescription)")
+        }
+        notifyReviewCommentsChanged()
+        return .ok
+    }
+
+    func reviewResolve(origin: Worktree, commentID: String, reply: String?, reopen: Bool) -> AlasCLIResponse {
+        let store = draftCommentStore()
+        do {
+            guard var comment = try store.find(commentID: commentID),
+                  comment.sessionID.isFor(worktreeID: origin.id) else {
+                return .error("unknown review comment id \"\(commentID)\"")
+            }
+            let timestamp = now()
+            if let reply {
+                var replies = comment.allReplies
+                replies.append(ReviewCommentReply(
+                    id: UUID().uuidString,
+                    author: Self.cliAgentAuthor,
+                    bodyMarkdown: reply,
+                    createdAt: timestamp
+                ))
+                comment.replies = replies
+            }
+            comment.state = reopen ? .active : .resolved
+            comment.resolvedBy = reopen ? nil : Self.cliAgentAuthor
+            comment.updatedAt = timestamp
+            try store.save(comment)
+            if !reopen {
+                try markAddressedHandoffs(worktreeID: origin.id, store: store, timestamp: timestamp)
+            }
+        } catch {
+            return .error("could not update review comment: \(error.localizedDescription)")
+        }
+        notifyReviewCommentsChanged()
+        return .ok
+    }
+
+    private func markAddressedHandoffs(worktreeID: String, store: ReviewDraftCommentStore, timestamp: Date) throws {
+        let sessions = reviewSessionStore()
+        for record in try sessions.list(worktreeID: worktreeID) {
+            guard let updated = ReviewHandoffProgress.recomputingAddressed(
+                record: record,
+                isResolved: { id in (try? store.find(commentID: id))?.state == .resolved },
+                now: timestamp
+            ) else { continue }
+            try sessions.save(updated)
+        }
     }
 
     // MARK: - Worktree matching (moved verbatim from AlasCLICommandRouter)

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -188,9 +188,9 @@ struct AlasActionService {
         } else {
             targetSessionID = .localChanges(worktreeID: origin.id, worktreePath: origin.path, scope: .all)
         }
-        let relativePath = Self.worktreeRelativePath(path, worktreeRoot: origin.path)
-        guard !relativePath.isEmpty else {
-            return .error("review comment path must point at a file")
+        guard let relativePath = Self.worktreeRelativePath(path, worktreeRoot: origin.path),
+              !relativePath.isEmpty else {
+            return .error("review comment path must point at a file inside the worktree")
         }
         let namespace: String
         switch await fileIDNamespace(for: targetSessionID, path: relativePath, worktreePath: origin.path) {
@@ -229,23 +229,24 @@ struct AlasActionService {
     }
 
     /// Worktree-relative form of `path`: absolute paths under the worktree
-    /// root are relativized; already-relative paths pass through. Tries the
-    /// path as given first, then with symlinks resolved on both sides — the
-    /// CLI absolutizes against the caller's logical `$PWD`, which preserves
-    /// a symlinked checkout path, while `worktreeRoot` may be the resolved
+    /// root are relativized; already-relative paths pass through unchanged
+    /// (treated as already worktree-relative). Tries the path as given
+    /// first, then with symlinks resolved on both sides — the CLI
+    /// absolutizes against the caller's logical `$PWD`, which preserves a
+    /// symlinked checkout path, while `worktreeRoot` may be the resolved
     /// real path Alas tracks (same two-step pattern `relativePathAndDepth`
-    /// already uses for `open`).
-    static func worktreeRelativePath(_ path: String, worktreeRoot: URL) -> String {
+    /// already uses for `open`). Returns nil when an absolute path is
+    /// outside the worktree root even after symlink resolution, so callers
+    /// don't file a comment against a path that can never match a file in
+    /// the review.
+    static func worktreeRelativePath(_ path: String, worktreeRoot: URL) -> String? {
         guard path.hasPrefix("/") else { return path }
         if let relative = relativePath(path, against: worktreeRoot.standardizedFileURL.path) {
             return relative
         }
         let resolvedRoot = worktreeRoot.resolvingSymlinksInPath().standardizedFileURL.path
         let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
-        if let relative = relativePath(resolvedPath, against: resolvedRoot) {
-            return relative
-        }
-        return path
+        return relativePath(resolvedPath, against: resolvedRoot)
     }
 
     private static func relativePath(_ path: String, against rootPath: String) -> String? {

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -339,9 +339,7 @@ struct AlasActionService {
             comment.resolvedBy = reopen ? nil : Self.cliAgentAuthor
             comment.updatedAt = timestamp
             try store.save(comment)
-            if !reopen {
-                try markAddressedHandoffs(worktreeID: origin.id, store: store, timestamp: timestamp)
-            }
+            try recomputeHandoffProgress(worktreeID: origin.id, store: store, timestamp: timestamp)
         } catch {
             return .error("could not update review comment: \(error.localizedDescription)")
         }
@@ -349,7 +347,7 @@ struct AlasActionService {
         return .ok
     }
 
-    private func markAddressedHandoffs(worktreeID: String, store: ReviewDraftCommentStore, timestamp: Date) throws {
+    private func recomputeHandoffProgress(worktreeID: String, store: ReviewDraftCommentStore, timestamp: Date) throws {
         let sessions = reviewSessionStore()
         for record in try sessions.list(worktreeID: worktreeID) {
             guard let updated = ReviewHandoffProgress.recomputingAddressed(

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -30,6 +30,7 @@ struct AlasActionService {
         NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
     }
     var now: () -> Date = Date.init
+    var gitStatus: (URL) async throws -> [ChangedFile] = { try await GitService().status(worktreePath: $0) }
     var activateApp: () -> Void
 
     /// Worktree owning `directory`: the worktree rooted exactly at
@@ -176,7 +177,7 @@ struct AlasActionService {
         side: String?,
         body: String,
         sessionID: String?
-    ) -> AlasCLIResponse {
+    ) async -> AlasCLIResponse {
         let targetSessionID: ReviewDraftSessionID
         if let sessionID {
             guard let parsed = ReviewDraftSessionID(rawValue: sessionID),
@@ -191,11 +192,18 @@ struct AlasActionService {
         guard !relativePath.isEmpty else {
             return .error("review comment path must point at a file")
         }
+        let namespace: String
+        switch await fileIDNamespace(for: targetSessionID, path: relativePath, worktreePath: origin.path) {
+        case .resolved(let resolved):
+            namespace = resolved
+        case .failed(let message):
+            return .error(message)
+        }
         let timestamp = now()
         let comment = ReviewDraftComment(
             id: UUID().uuidString,
             sessionID: targetSessionID,
-            fileID: DiffReviewFileID(namespace: "review", path: relativePath),
+            fileID: DiffReviewFileID(namespace: namespace, path: relativePath),
             path: relativePath,
             originalPath: nil,
             side: side == "old" ? .old : .new,
@@ -230,6 +238,58 @@ struct AlasActionService {
             return String(path.dropFirst(rootPath.count + 1))
         }
         return path
+    }
+
+    /// The `DiffReviewFileID` namespace matching how each review surface
+    /// loads files for a session, so an agent-filed comment lands in the
+    /// same file bucket the UI reads from instead of becoming an orphan
+    /// (`DiffReviewSurface` matches on the exact namespace+path). Every
+    /// session kind except `.localChanges` carries enough in its own
+    /// `sourceKind` (and, for `.reviewRequest`, its encoded provider) to
+    /// resolve without touching the filesystem; local changes need a live
+    /// git-status lookup because the same path can be staged and unstaged
+    /// at once (partial staging) — unstaged wins when both are present,
+    /// since it reflects the more current working-tree state.
+    private enum FileIDNamespaceResolution {
+        case resolved(String)
+        case failed(String)
+    }
+
+    private func fileIDNamespace(
+        for sessionID: ReviewDraftSessionID,
+        path: String,
+        worktreePath: URL
+    ) async -> FileIDNamespaceResolution {
+        switch sessionID.sourceKind {
+        case .commit:
+            return .resolved("commit")
+        case .commitRange, .branch:
+            return .resolved("range")
+        case .draftCommit:
+            return .resolved(ChangeStage.staged.rawValue)
+        case .draftReviewRequest:
+            return .resolved("draft-review-request")
+        case .reviewRequest:
+            switch sessionID.reviewRequestProvider {
+            case .github: return .resolved("github-pr")
+            case .gitlab: return .resolved("gitlab-mr")
+            case nil: return .failed("could not resolve the code host for that review session")
+            }
+        case .localChanges:
+            do {
+                let files = try await gitStatus(worktreePath)
+                let stages = Set(files.filter { $0.path == path }.map(\.stage))
+                if stages.contains(.unstaged) {
+                    return .resolved(ChangeStage.unstaged.rawValue)
+                }
+                if stages.contains(.staged) {
+                    return .resolved(ChangeStage.staged.rawValue)
+                }
+                return .failed("no local changes found for \"\(path)\"")
+            } catch {
+                return .failed("could not read git status: \(error.localizedDescription)")
+            }
+        }
     }
 
     func reviewReply(origin: Worktree, commentID: String, body: String) -> AlasCLIResponse {

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -48,9 +48,9 @@ struct AlasActionService {
         // symlinks on both sides before comparing file identities, otherwise a
         // command run from a symlinked checkout root reports "not inside an
         // Alas worktree".
-        if let directoryIdentity = fileIdentity(at: url.resolvingSymlinksInPath().path),
+        if let directoryIdentity = Self.fileIdentity(at: url.resolvingSymlinksInPath().path),
            let exactMatch = visibleWorktrees().first(where: { worktree in
-               fileIdentity(at: worktree.path.resolvingSymlinksInPath().path) == directoryIdentity
+               Self.fileIdentity(at: worktree.path.resolvingSymlinksInPath().path) == directoryIdentity
            }) {
             return exactMatch
         }
@@ -240,8 +240,9 @@ struct AlasActionService {
     /// `worktreeRoot` may be the resolved real path Alas tracks (same
     /// two-step pattern `relativePathAndDepth` already uses for `open`).
     /// Returns nil when an absolute path is outside the worktree root even
-    /// after symlink resolution, so callers don't file a comment against a
-    /// path that can never match a file in the review.
+    /// after symlink resolution and a file-identity walk-up, so callers
+    /// don't file a comment against a path that can never match a file in
+    /// the review.
     static func worktreeRelativePath(_ path: String, worktreeRoot: URL) -> String? {
         guard path.hasPrefix("/") else { return normalizedRelativePath(path) }
         if let relative = relativePath(path, against: worktreeRoot.standardizedFileURL.path) {
@@ -249,7 +250,31 @@ struct AlasActionService {
         }
         let resolvedRoot = worktreeRoot.resolvingSymlinksInPath().standardizedFileURL.path
         let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
-        return relativePath(resolvedPath, against: resolvedRoot)
+        if let relative = relativePath(resolvedPath, against: resolvedRoot) {
+            return relative
+        }
+        // Falls back to comparing filesystem identity (inode + device)
+        // instead of path strings — the default case-insensitive-but-
+        // case-preserving macOS volume can give the CLI's cwd and the
+        // tracked worktree root different casing for the same directory,
+        // which a string prefix check would reject as "outside the
+        // worktree" even though it's the identical file. Mirrors the
+        // `open` command's `fileSystemRelativePathAndDepth` fallback.
+        return fileSystemRelativePath(URL(fileURLWithPath: path), worktreeRoot: worktreeRoot)
+    }
+
+    private static func fileSystemRelativePath(_ url: URL, worktreeRoot: URL) -> String? {
+        guard let rootIdentity = fileIdentity(at: worktreeRoot.path) else { return nil }
+        var ancestor = url.deletingLastPathComponent()
+        var relativeComponents = [url.lastPathComponent]
+        while ancestor.path != "/" {
+            if fileIdentity(at: ancestor.path) == rootIdentity {
+                return relativeComponents.reversed().joined(separator: "/")
+            }
+            relativeComponents.append(ancestor.lastPathComponent)
+            ancestor.deleteLastPathComponent()
+        }
+        return nil
     }
 
     /// Collapses `.`/`..`/repeated separators in a relative path purely
@@ -457,12 +482,12 @@ struct AlasActionService {
     }
 
     private func fileSystemRelativePathAndDepth(for url: URL, in rootURL: URL) -> (relativePath: String, rootComponentCount: Int)? {
-        guard let rootIdentity = fileIdentity(at: rootURL.path) else { return nil }
+        guard let rootIdentity = Self.fileIdentity(at: rootURL.path) else { return nil }
         var ancestor = url.deletingLastPathComponent()
         var relativeComponents = [url.lastPathComponent]
 
         while ancestor.path != "/" {
-            if fileIdentity(at: ancestor.path) == rootIdentity {
+            if Self.fileIdentity(at: ancestor.path) == rootIdentity {
                 return (relativeComponents.reversed().joined(separator: "/"), rootURL.pathComponents.count)
             }
             relativeComponents.append(ancestor.lastPathComponent)
@@ -471,7 +496,7 @@ struct AlasActionService {
         return nil
     }
 
-    private func fileIdentity(at path: String) -> FileIdentity? {
+    private static func fileIdentity(at path: String) -> FileIdentity? {
         guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
               let systemNumber = attributes[.systemNumber] as? NSNumber,
               let fileNumber = attributes[.systemFileNumber] as? NSNumber else { return nil }

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -229,15 +229,31 @@ struct AlasActionService {
     }
 
     /// Worktree-relative form of `path`: absolute paths under the worktree
-    /// root are relativized; already-relative paths pass through.
+    /// root are relativized; already-relative paths pass through. Tries the
+    /// path as given first, then with symlinks resolved on both sides — the
+    /// CLI absolutizes against the caller's logical `$PWD`, which preserves
+    /// a symlinked checkout path, while `worktreeRoot` may be the resolved
+    /// real path Alas tracks (same two-step pattern `relativePathAndDepth`
+    /// already uses for `open`).
     static func worktreeRelativePath(_ path: String, worktreeRoot: URL) -> String {
         guard path.hasPrefix("/") else { return path }
-        let rootPath = worktreeRoot.standardizedFileURL.path
+        if let relative = relativePath(path, against: worktreeRoot.standardizedFileURL.path) {
+            return relative
+        }
+        let resolvedRoot = worktreeRoot.resolvingSymlinksInPath().standardizedFileURL.path
+        let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+        if let relative = relativePath(resolvedPath, against: resolvedRoot) {
+            return relative
+        }
+        return path
+    }
+
+    private static func relativePath(_ path: String, against rootPath: String) -> String? {
         if path == rootPath { return "" }
         if path.hasPrefix(rootPath + "/") {
             return String(path.dropFirst(rootPath.count + 1))
         }
-        return path
+        return nil
     }
 
     /// The `DiffReviewFileID` namespace matching how each review surface

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -317,13 +317,26 @@ struct AlasActionService {
             do {
                 let files = try await gitStatus(worktreePath)
                 let stages = Set(files.filter { $0.path == path }.map(\.stage))
-                if stages.contains(.unstaged) {
-                    return .resolved(ChangeStage.unstaged.rawValue)
-                }
-                if stages.contains(.staged) {
+                switch sessionID.localChangesScope {
+                case .staged:
+                    guard stages.contains(.staged) else {
+                        return .failed("no staged changes found for \"\(path)\"")
+                    }
                     return .resolved(ChangeStage.staged.rawValue)
+                case .unstaged:
+                    guard stages.contains(.unstaged) else {
+                        return .failed("no unstaged changes found for \"\(path)\"")
+                    }
+                    return .resolved(ChangeStage.unstaged.rawValue)
+                case .all, nil:
+                    if stages.contains(.unstaged) {
+                        return .resolved(ChangeStage.unstaged.rawValue)
+                    }
+                    if stages.contains(.staged) {
+                        return .resolved(ChangeStage.staged.rawValue)
+                    }
+                    return .failed("no local changes found for \"\(path)\"")
                 }
-                return .failed("no local changes found for \"\(path)\"")
             } catch {
                 return .failed("could not read git status: \(error.localizedDescription)")
             }

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -115,7 +115,15 @@ struct AlasActionService {
     func reviewLocal(origin: Worktree) -> AlasCLIResponse {
         openReviewChanges(origin)
         activateApp()
-        return .ok
+        let sessionID = ReviewDraftSessionID.localChanges(
+            worktreeID: origin.id,
+            worktreePath: origin.path,
+            scope: .all
+        )
+        return .text([
+            "Opened review of local changes in Alas.",
+            Self.jsonLine(["session_id": sessionID.rawValue]),
+        ])
     }
 
     func reviewProvider(origin: Worktree, target: String) async -> AlasCLIResponse {
@@ -149,6 +157,79 @@ struct AlasActionService {
     /// The author identity CLI/MCP mutations write. Phase 2+ can thread a
     /// real agent name through the wire; the enum already supports it.
     static let cliAgentAuthor = ReviewDraftCommentAuthor.agent(name: "Agent")
+
+    /// One deterministic JSON line for machine-readable CLI/MCP output.
+    static func jsonLine(_ object: [String: String]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return text
+    }
+
+    func reviewCommentAdd(
+        origin: Worktree,
+        path: String,
+        startLine: Int,
+        endLine: Int?,
+        side: String?,
+        body: String,
+        sessionID: String?
+    ) -> AlasCLIResponse {
+        let targetSessionID: ReviewDraftSessionID
+        if let sessionID {
+            guard let parsed = ReviewDraftSessionID(rawValue: sessionID),
+                  parsed.isFor(worktreeID: origin.id) else {
+                return .error("unknown review session id")
+            }
+            targetSessionID = parsed
+        } else {
+            targetSessionID = .localChanges(worktreeID: origin.id, worktreePath: origin.path, scope: .all)
+        }
+        let relativePath = Self.worktreeRelativePath(path, worktreeRoot: origin.path)
+        guard !relativePath.isEmpty else {
+            return .error("review comment path must point at a file")
+        }
+        let timestamp = now()
+        let comment = ReviewDraftComment(
+            id: UUID().uuidString,
+            sessionID: targetSessionID,
+            fileID: DiffReviewFileID(namespace: "review", path: relativePath),
+            path: relativePath,
+            originalPath: nil,
+            side: side == "old" ? .old : .new,
+            startLine: startLine,
+            endLine: endLine,
+            selectedText: nil,
+            bodyMarkdown: body,
+            state: .active,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+            author: Self.cliAgentAuthor
+        )
+        do {
+            try draftCommentStore().save(comment)
+        } catch {
+            return .error("could not save review comment: \(error.localizedDescription)")
+        }
+        notifyReviewCommentsChanged()
+        return .text([
+            "Filed review comment.",
+            Self.jsonLine(["comment_id": comment.id]),
+        ])
+    }
+
+    /// Worktree-relative form of `path`: absolute paths under the worktree
+    /// root are relativized; already-relative paths pass through.
+    static func worktreeRelativePath(_ path: String, worktreeRoot: URL) -> String {
+        guard path.hasPrefix("/") else { return path }
+        let rootPath = worktreeRoot.standardizedFileURL.path
+        if path == rootPath { return "" }
+        if path.hasPrefix(rootPath + "/") {
+            return String(path.dropFirst(rootPath.count + 1))
+        }
+        return path
+    }
 
     func reviewReply(origin: Worktree, commentID: String, body: String) -> AlasCLIResponse {
         let store = draftCommentStore()

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -24,6 +24,7 @@ struct AlasCLICommandRouter {
         NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
     }
     var now: () -> Date = Date.init
+    var gitStatus: (URL) async throws -> [ChangedFile] = { try await GitService().status(worktreePath: $0) }
     var activateApp: () -> Void
 
     private var service: AlasActionService {
@@ -40,6 +41,7 @@ struct AlasCLICommandRouter {
             reviewSessionStore: reviewSessionStore,
             notifyReviewCommentsChanged: notifyReviewCommentsChanged,
             now: now,
+            gitStatus: gitStatus,
             activateApp: activateApp
         )
     }
@@ -85,7 +87,7 @@ struct AlasCLICommandRouter {
         case .review(.resolve(let commentID, let reply, let reopen)):
             return service.reviewResolve(origin: origin, commentID: commentID, reply: reply, reopen: reopen)
         case .review(.commentAdd(let path, let startLine, let endLine, let side, let body, let sessionID)):
-            return service.reviewCommentAdd(
+            return await service.reviewCommentAdd(
                 origin: origin, path: path, startLine: startLine, endLine: endLine,
                 side: side, body: body, sessionID: sessionID
             )

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -23,6 +23,7 @@ struct AlasCLICommandRouter {
     var notifyReviewCommentsChanged: () -> Void = {
         NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
     }
+    var now: () -> Date = Date.init
     var activateApp: () -> Void
 
     private var service: AlasActionService {
@@ -38,6 +39,7 @@ struct AlasCLICommandRouter {
             draftCommentStore: draftCommentStore,
             reviewSessionStore: reviewSessionStore,
             notifyReviewCommentsChanged: notifyReviewCommentsChanged,
+            now: now,
             activateApp: activateApp
         )
     }

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -18,6 +18,7 @@ struct AlasCLICommandRouter {
     var openProviderReview: (Worktree, String) async -> AlasCLIResponse = { _, _ in
         .error("Opening provider reviews from the terminal is not available yet.")
     }
+    var draftCommentStore: () -> ReviewDraftCommentStore = { ReviewDraftCommentStore() }
     var activateApp: () -> Void
 
     private var service: AlasActionService {
@@ -30,6 +31,7 @@ struct AlasCLICommandRouter {
             deleteWorktreeAction: deleteWorktree,
             openReviewChanges: openReviewChanges,
             openProviderReview: openProviderReview,
+            draftCommentStore: draftCommentStore,
             activateApp: activateApp
         )
     }
@@ -68,6 +70,8 @@ struct AlasCLICommandRouter {
             return service.reviewLocal(origin: origin)
         case .review(.provider(let target)):
             return await service.reviewProvider(origin: origin, target: target)
+        case .review(.comments(let sessionID, let state)):
+            return service.reviewComments(origin: origin, sessionID: sessionID, filter: state)
         }
     }
 }

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -84,6 +84,11 @@ struct AlasCLICommandRouter {
             return service.reviewReply(origin: origin, commentID: commentID, body: body)
         case .review(.resolve(let commentID, let reply, let reopen)):
             return service.reviewResolve(origin: origin, commentID: commentID, reply: reply, reopen: reopen)
+        case .review(.commentAdd(let path, let startLine, let endLine, let side, let body, let sessionID)):
+            return service.reviewCommentAdd(
+                origin: origin, path: path, startLine: startLine, endLine: endLine,
+                side: side, body: body, sessionID: sessionID
+            )
         }
     }
 }

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -19,6 +19,10 @@ struct AlasCLICommandRouter {
         .error("Opening provider reviews from the terminal is not available yet.")
     }
     var draftCommentStore: () -> ReviewDraftCommentStore = { ReviewDraftCommentStore() }
+    var reviewSessionStore: () -> ReviewSessionStore = { ReviewSessionStore() }
+    var notifyReviewCommentsChanged: () -> Void = {
+        NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
+    }
     var activateApp: () -> Void
 
     private var service: AlasActionService {
@@ -32,6 +36,8 @@ struct AlasCLICommandRouter {
             openReviewChanges: openReviewChanges,
             openProviderReview: openProviderReview,
             draftCommentStore: draftCommentStore,
+            reviewSessionStore: reviewSessionStore,
+            notifyReviewCommentsChanged: notifyReviewCommentsChanged,
             activateApp: activateApp
         )
     }
@@ -72,6 +78,10 @@ struct AlasCLICommandRouter {
             return await service.reviewProvider(origin: origin, target: target)
         case .review(.comments(let sessionID, let state)):
             return service.reviewComments(origin: origin, sessionID: sessionID, filter: state)
+        case .review(.reply(let commentID, let body)):
+            return service.reviewReply(origin: origin, commentID: commentID, body: body)
+        case .review(.resolve(let commentID, let reply, let reopen)):
+            return service.reviewResolve(origin: origin, commentID: commentID, reply: reply, reopen: reopen)
         }
     }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3633,7 +3633,10 @@ final class AppState {
             }
             focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
             NSApp.activate(ignoringOtherApps: true)
-            return .ok
+            return .text([
+                "Opened review for '\(target)' in Alas.",
+                AlasActionService.jsonLine(["session_id": reviewTarget.draftSessionID.rawValue]),
+            ])
         } catch {
             return .error(Self.describeCLIError(error))
         }

--- a/Alas/Sources/App/ReviewCommentWireDTO.swift
+++ b/Alas/Sources/App/ReviewCommentWireDTO.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// The agent-facing JSON shape of a review comment, as returned by the
+/// `review_comments` CLI/MCP command. Snake_cased on the wire via
+/// `jsonLine`'s key strategy.
+struct ReviewCommentWireDTO: Codable, Equatable {
+    struct Author: Codable, Equatable {
+        var kind: String
+        var name: String?
+
+        init(_ author: ReviewDraftCommentAuthor) {
+            switch author {
+            case .user:
+                kind = "user"
+                name = nil
+            case .agent(let agentName):
+                kind = "agent"
+                name = agentName
+            }
+        }
+    }
+
+    struct Reply: Codable, Equatable {
+        var id: String
+        var author: Author
+        var body: String
+        var createdAt: String
+    }
+
+    var id: String
+    var sessionId: String
+    var path: String
+    var startLine: Int
+    var endLine: Int?
+    var side: String
+    var state: String
+    var author: Author
+    var body: String
+    var selectedText: String?
+    var replies: [Reply]
+
+    init(_ comment: ReviewDraftComment) {
+        id = comment.id
+        sessionId = comment.sessionID.rawValue
+        path = comment.path
+        startLine = comment.startLine
+        endLine = comment.endLine
+        side = comment.side.rawValue
+        state = comment.state.rawValue
+        author = Author(comment.effectiveAuthor)
+        body = comment.bodyMarkdown
+        selectedText = comment.selectedText
+        replies = comment.allReplies.map { reply in
+            Reply(
+                id: reply.id,
+                author: Author(reply.author),
+                body: reply.bodyMarkdown,
+                createdAt: Self.iso8601.string(from: reply.createdAt)
+            )
+        }
+    }
+
+    private static let iso8601 = ISO8601DateFormatter()
+
+    /// One deterministic (sorted-keys, snake_case) JSON line for CLI/MCP
+    /// text output.
+    static func jsonLine<T: Encodable>(_ value: T) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        guard let data = try? encoder.encode(value),
+              let text = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return text
+    }
+}

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1786,7 +1786,7 @@ struct ReviewDraftCommentCard: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
-                    Text("Local draft")
+                    Text(draftLabel)
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(statusColor)
 
@@ -1795,7 +1795,7 @@ struct ReviewDraftCommentCard: View {
                         .foregroundColor(theme.color("fg-faint"))
 
                     if comment.state == .resolved {
-                        Text("resolved")
+                        Text(resolvedLabel)
                             .font(.system(size: 10))
                             .foregroundColor(theme.color("fg-faint"))
                     }
@@ -1827,7 +1827,25 @@ struct ReviewDraftCommentCard: View {
                     )
                     .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
                 } else {
-                    DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
+                    VStack(alignment: .leading, spacing: 6) {
+                        DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
+
+                        ForEach(comment.allReplies) { reply in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(reply.author.displayName)
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundColor(theme.color("fg-faint"))
+                                DiffReviewInlineFeedbackMarkdown.view(reply.bodyMarkdown)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .padding(.leading, 8)
+                            .overlay(alignment: .leading) {
+                                RoundedRectangle(cornerRadius: 1)
+                                    .fill(theme.color("line"))
+                                    .frame(width: 2)
+                            }
+                        }
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -2009,6 +2027,18 @@ struct ReviewDraftCommentCard: View {
             return "line \(range.lowerBound)"
         }
         return "lines \(range.lowerBound)-\(range.upperBound)"
+    }
+
+    private var draftLabel: String {
+        let author = comment.effectiveAuthor
+        return author.isAgent ? "\(author.displayName) draft" : "Local draft"
+    }
+
+    private var resolvedLabel: String {
+        if let resolvedBy = comment.resolvedBy, resolvedBy.isAgent {
+            return "resolved by \(resolvedBy.displayName)"
+        }
+        return "resolved"
     }
 
     private var accessibilityLabel: String {

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -152,6 +152,9 @@ struct DiffTabView: View {
             Task { @MainActor in draftComposerFocused = true }
         }
         .task(id: loadKey) { await load() }
+        .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
+            try? draftCommentController?.load()
+        }
         .alert(
             "Discard this hunk in \u{201C}\((relativePath as NSString).lastPathComponent)\u{201D}?",
             isPresented: Binding(

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -109,6 +109,9 @@ struct ReviewChangesTabView: View {
         .task(id: reviewDraftSessionID.rawValue) {
             loadDraftCommentController()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
+            try? draftCommentController?.load()
+        }
         .sheet(isPresented: $showScopePicker) {
             ReviewScopePicker(
                 commits: scopeCommits,

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
@@ -14,6 +14,21 @@ struct ReviewDraftCommentStore {
         return (snapshot.commentsBySessionID[sessionID.rawValue] ?? []).sorted(by: sortComments)
     }
 
+    func loadAll() throws -> [ReviewDraftComment] {
+        let snapshot = try readSnapshot()
+        return snapshot.commentsBySessionID.values.flatMap { $0 }.sorted(by: sortComments)
+    }
+
+    func find(commentID: String) throws -> ReviewDraftComment? {
+        let snapshot = try readSnapshot()
+        for comments in snapshot.commentsBySessionID.values {
+            if let match = comments.first(where: { $0.id == commentID }) {
+                return match
+            }
+        }
+        return nil
+    }
+
     func save(_ comment: ReviewDraftComment) throws {
         var snapshot = try readSnapshot()
         var comments = snapshot.commentsBySessionID[comment.sessionID.rawValue] ?? []

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -68,6 +68,14 @@ struct ReviewDraftSessionID: Codable, Equatable, Hashable, Sendable, RawRepresen
         make(.draftReviewRequest, [worktreeID, repositoryPath.standardizedFileURL.path, base, head])
     }
 
+    /// Every factory puts the worktree ID in field 1, so a session ID can be
+    /// scoped to a worktree without decoding the rest of its fields.
+    func isFor(worktreeID: String) -> Bool {
+        let parts = rawValue.split(separator: Self.separator, omittingEmptySubsequences: false).map(String.init)
+        guard parts.count >= 2 else { return false }
+        return parts[1] == Self.escape(worktreeID)
+    }
+
     private static let separator: Character = "\u{1f}"
 
     private static func make(_ kind: ReviewDraftSourceKind, _ fields: [String]) -> Self {
@@ -86,6 +94,34 @@ enum ReviewDraftCommentState: String, Codable, Equatable, Hashable, Sendable {
     case active
     case resolved
     case dismissed
+}
+
+/// Who wrote a review comment or reply. Legacy comments (no author on
+/// disk) decode as nil and are treated as `.user`.
+enum ReviewDraftCommentAuthor: Codable, Equatable, Hashable, Sendable {
+    case user
+    case agent(name: String)
+
+    var isAgent: Bool {
+        if case .agent = self { return true }
+        return false
+    }
+
+    var displayName: String {
+        switch self {
+        case .user:
+            return "You"
+        case .agent(let name):
+            return name.isEmpty ? "Agent" : name
+        }
+    }
+}
+
+struct ReviewCommentReply: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let author: ReviewDraftCommentAuthor
+    let bodyMarkdown: String
+    let createdAt: Date
 }
 
 struct ReviewDraftProviderPublish: Codable, Equatable, Sendable {
@@ -121,6 +157,9 @@ struct ReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
     var updatedAt: Date
     var providerPublish: ReviewDraftProviderPublish? = nil
     var providerError: ReviewDraftProviderError? = nil
+    var author: ReviewDraftCommentAuthor? = nil
+    var replies: [ReviewCommentReply]? = nil
+    var resolvedBy: ReviewDraftCommentAuthor? = nil
 
     var normalizedLineRange: ClosedRange<Int> {
         let end = endLine ?? startLine
@@ -128,4 +167,6 @@ struct ReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
     }
 
     var isActive: Bool { state == .active }
+    var effectiveAuthor: ReviewDraftCommentAuthor { author ?? .user }
+    var allReplies: [ReviewCommentReply] { replies ?? [] }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -86,6 +86,16 @@ struct ReviewDraftSessionID: Codable, Equatable, Hashable, Sendable, RawRepresen
         return CodeHostKind(rawValue: parts[2])
     }
 
+    /// The scope for a `.localChanges` session id, decoded from its raw
+    /// fields (`localChanges`'s third field is always `scope.rawValue`).
+    /// nil for any other `sourceKind`.
+    var localChangesScope: ReviewDraftLocalChangesScope? {
+        guard sourceKind == .localChanges else { return nil }
+        let parts = rawValue.split(separator: Self.separator, omittingEmptySubsequences: false).map(String.init)
+        guard parts.count >= 4 else { return nil }
+        return ReviewDraftLocalChangesScope(rawValue: parts[3])
+    }
+
     private static let separator: Character = "\u{1f}"
 
     private static func make(_ kind: ReviewDraftSourceKind, _ fields: [String]) -> Self {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -76,6 +76,16 @@ struct ReviewDraftSessionID: Codable, Equatable, Hashable, Sendable, RawRepresen
         return parts[1] == Self.escape(worktreeID)
     }
 
+    /// The code host for a `.reviewRequest` session id, decoded from its raw
+    /// fields (`reviewRequest`'s second field is always `provider.rawValue`).
+    /// nil for any other `sourceKind`.
+    var reviewRequestProvider: CodeHostKind? {
+        guard sourceKind == .reviewRequest else { return nil }
+        let parts = rawValue.split(separator: Self.separator, omittingEmptySubsequences: false).map(String.init)
+        guard parts.count >= 3 else { return nil }
+        return CodeHostKind(rawValue: parts[2])
+    }
+
     private static let separator: Character = "\u{1f}"
 
     private static func make(_ kind: ReviewDraftSourceKind, _ fields: [String]) -> Self {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
@@ -62,9 +62,9 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
                 let bodyLines = markdownBodyLines(comment.bodyMarkdown)
                 if bodyLines.count <= 1 {
                     let suffix = bodyLines.first.map { " — \($0)" } ?? ""
-                    lines.append("- `\(reference)`\(suffix)")
+                    lines.append("- `\(reference)` [comment-id: \(comment.id)]\(suffix)")
                 } else {
-                    lines.append("- `\(reference)`")
+                    lines.append("- `\(reference)` [comment-id: \(comment.id)]")
                     lines.append(contentsOf: bodyLines)
                 }
 
@@ -78,6 +78,11 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
                 }
             }
         }
+
+        lines.append("")
+        lines.append(
+            "When you have addressed a comment, call the alas MCP tool `review_resolve` with its comment-id and a short `reply` summarizing the change. Use `review_reply` to discuss a comment without resolving it. If the alas review tools are unavailable, report what you changed instead."
+        )
 
         return lines.joined(separator: "\n")
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewHandoffProgress.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewHandoffProgress.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension Notification.Name {
+    /// Posted after the CLI/MCP bridge mutates review draft comments so
+    /// open review panes reload their controllers.
+    static let alasReviewDraftCommentsDidChangeExternally =
+        Notification.Name("alasReviewDraftCommentsDidChangeExternally")
+}
+
+/// Pure status recomputation for review feedback handoffs: a sent handoff
+/// whose comments are all resolved becomes addressed; a sent/addressing
+/// session whose handoffs are all addressed becomes addressed.
+enum ReviewHandoffProgress {
+    /// Returns the updated record when anything changed, else nil.
+    static func recomputingAddressed(
+        record: ReviewSessionRecord,
+        isResolved: (String) -> Bool,
+        now: Date
+    ) -> ReviewSessionRecord? {
+        var changed = false
+        var updated = record
+        updated.handoffs = record.handoffs.map { handoff in
+            guard handoff.status == .sent,
+                  !handoff.commentIDs.isEmpty,
+                  handoff.commentIDs.allSatisfy(isResolved) else { return handoff }
+            var addressed = handoff
+            addressed.status = .addressed
+            changed = true
+            return addressed
+        }
+        if !updated.handoffs.isEmpty,
+           updated.handoffs.allSatisfy({ $0.status == .addressed }),
+           updated.status == .sent || updated.status == .addressing {
+            updated.status = .addressed
+            changed = true
+        }
+        guard changed else { return nil }
+        updated.updatedAt = now
+        return updated
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewHandoffProgress.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewHandoffProgress.swift
@@ -8,8 +8,13 @@ extension Notification.Name {
 }
 
 /// Pure status recomputation for review feedback handoffs: a sent handoff
-/// whose comments are all resolved becomes addressed; a sent/addressing
-/// session whose handoffs are all addressed becomes addressed.
+/// whose comments are all resolved becomes addressed, and demotes back to
+/// sent if a comment is later reopened; a sent/addressing session whose
+/// handoffs are all addressed becomes addressed, and demotes back to sent
+/// once any handoff no longer is. An archived session's own `status` is
+/// left alone either way (its individual handoffs can still flip), since
+/// archiving is a terminal, user-chosen state this recomputation shouldn't
+/// resurrect.
 enum ReviewHandoffProgress {
     /// Returns the updated record when anything changed, else nil.
     static func recomputingAddressed(
@@ -20,19 +25,31 @@ enum ReviewHandoffProgress {
         var changed = false
         var updated = record
         updated.handoffs = record.handoffs.map { handoff in
-            guard handoff.status == .sent,
-                  !handoff.commentIDs.isEmpty,
-                  handoff.commentIDs.allSatisfy(isResolved) else { return handoff }
-            var addressed = handoff
-            addressed.status = .addressed
-            changed = true
-            return addressed
+            guard !handoff.commentIDs.isEmpty else { return handoff }
+            let allResolved = handoff.commentIDs.allSatisfy(isResolved)
+            if handoff.status == .sent, allResolved {
+                var addressed = handoff
+                addressed.status = .addressed
+                changed = true
+                return addressed
+            }
+            if handoff.status == .addressed, !allResolved {
+                var reopened = handoff
+                reopened.status = .sent
+                changed = true
+                return reopened
+            }
+            return handoff
         }
-        if !updated.handoffs.isEmpty,
-           updated.handoffs.allSatisfy({ $0.status == .addressed }),
-           updated.status == .sent || updated.status == .addressing {
-            updated.status = .addressed
-            changed = true
+        if !updated.handoffs.isEmpty {
+            let allAddressed = updated.handoffs.allSatisfy { $0.status == .addressed }
+            if allAddressed, updated.status == .sent || updated.status == .addressing {
+                updated.status = .addressed
+                changed = true
+            } else if !allAddressed, updated.status == .addressed {
+                updated.status = .sent
+                changed = true
+            }
         }
         guard changed else { return nil }
         updated.updatedAt = now

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -195,6 +195,9 @@ struct ReviewSessionTabView: View {
             let token = beginLoadReviewSession()
             await loadReviewSession(token: token)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
+            try? draftCommentController?.load()
+        }
     }
 
     private var loadTaskID: String {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -166,6 +166,7 @@ struct ReviewSessionTabView: View {
     static func testView(
         record: ReviewSessionRecord,
         loaded: ReviewSessionLoadedContext,
+        sessionStore: ReviewSessionStore = ReviewSessionStore(),
         draftCommentStore: ReviewDraftCommentStore = ReviewDraftCommentStore(),
         provider: any CodeHostProvider
     ) -> some View {
@@ -173,6 +174,7 @@ struct ReviewSessionTabView: View {
             tabState: ReviewSessionTabState(worktreeId: record.target.worktreeID, record: record),
             record: record,
             loaded: loaded,
+            sessionStore: sessionStore,
             draftCommentStore: draftCommentStore,
             feedbackSender: ReviewFeedbackAgentSender(availableTargets: { [] }, send: { _, _, _ in }),
             providerRegistry: CodeHostProviderRegistry(providers: [provider.kind: provider]),
@@ -197,6 +199,9 @@ struct ReviewSessionTabView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
             try? draftCommentController?.load()
+            if let refreshed = try? sessionStore.load(id: tabState.sessionID) {
+                record = refreshed
+            }
         }
     }
 

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -35,6 +35,8 @@ struct AlasCLIRequest: Equatable {
         case localChanges
         case provider(target: String)
         case comments(sessionID: String?, state: ReviewCommentWireFilter)
+        case reply(commentID: String, body: String)
+        case resolve(commentID: String, reply: String?, reopen: Bool)
     }
 
     let version: Int
@@ -69,6 +71,17 @@ struct AlasCLIRequest: Equatable {
     private struct ReviewCommentsParams: Decodable {
         var session_id: String?
         var state: String?
+    }
+
+    private struct ReviewReplyParams: Decodable {
+        var comment_id: String
+        var body: String
+    }
+
+    private struct ReviewResolveParams: Decodable {
+        var comment_id: String
+        var reply: String?
+        var reopen: Bool?
     }
 
     /// Typed access to the `params` object new-style commands carry.
@@ -176,6 +189,19 @@ struct AlasCLIRequest: Equatable {
                 filter = .active
             }
             command = .review(.comments(sessionID: params?.session_id?.nilIfBlank, state: filter))
+        case "review_reply":
+            let params = try Self.decodeParams(ReviewReplyParams.self, from: data)
+            command = .review(.reply(
+                commentID: try requiredNonEmpty(params.comment_id),
+                body: try requiredNonEmpty(params.body)
+            ))
+        case "review_resolve":
+            let params = try Self.decodeParams(ReviewResolveParams.self, from: data)
+            command = .review(.resolve(
+                commentID: try requiredNonEmpty(params.comment_id),
+                reply: params.reply?.nilIfBlank,
+                reopen: params.reopen ?? false
+            ))
         case "resolve":
             command = .resolve
         default:

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -9,6 +9,13 @@ enum AlasCLIRequestError: Error, Equatable {
     case missingPaths
 }
 
+enum ReviewCommentWireFilter: String, Equatable {
+    case active
+    case resolved
+    case dismissed
+    case all
+}
+
 struct AlasCLIRequest: Equatable {
     enum Command: Equatable {
         case open(paths: [String])
@@ -27,6 +34,7 @@ struct AlasCLIRequest: Equatable {
     enum ReviewCommand: Equatable {
         case localChanges
         case provider(target: String)
+        case comments(sessionID: String?, state: ReviewCommentWireFilter)
     }
 
     let version: Int
@@ -56,6 +64,11 @@ struct AlasCLIRequest: Equatable {
 
     private struct ParamsEnvelope<P: Decodable>: Decodable {
         var params: P?
+    }
+
+    private struct ReviewCommentsParams: Decodable {
+        var session_id: String?
+        var state: String?
     }
 
     /// Typed access to the `params` object new-style commands carry.
@@ -151,6 +164,18 @@ struct AlasCLIRequest: Equatable {
             } else {
                 command = .review(.localChanges)
             }
+        case "review_comments":
+            let params = try Self.decodeParamsIfPresent(ReviewCommentsParams.self, from: data)
+            let filter: ReviewCommentWireFilter
+            if let rawState = params?.state?.nilIfBlank {
+                guard let parsed = ReviewCommentWireFilter(rawValue: rawState) else {
+                    throw AlasCLIRequestError.malformed
+                }
+                filter = parsed
+            } else {
+                filter = .active
+            }
+            command = .review(.comments(sessionID: params?.session_id?.nilIfBlank, state: filter))
         case "resolve":
             command = .resolve
         default:

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -59,8 +59,9 @@ struct AlasCLIRequest: Equatable {
     }
 
     /// Typed access to the `params` object new-style commands carry.
-    /// Returns nil when the request has no `params` key at all; throws
-    /// `.malformed` when `params` is present but does not match `P`.
+    /// Returns nil when `params` is absent or explicitly null (`Decodable`
+    /// synthesis treats both the same way); throws `.malformed` when
+    /// `params` is present with a non-null value that does not match `P`.
     static func decodeParamsIfPresent<P: Decodable>(_ type: P.Type, from data: Data) throws -> P? {
         do {
             return try JSONDecoder().decode(ParamsEnvelope<P>.self, from: data).params

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -37,6 +37,7 @@ struct AlasCLIRequest: Equatable {
         case comments(sessionID: String?, state: ReviewCommentWireFilter)
         case reply(commentID: String, body: String)
         case resolve(commentID: String, reply: String?, reopen: Bool)
+        case commentAdd(path: String, startLine: Int, endLine: Int?, side: String?, body: String, sessionID: String?)
     }
 
     let version: Int
@@ -82,6 +83,15 @@ struct AlasCLIRequest: Equatable {
         var comment_id: String
         var reply: String?
         var reopen: Bool?
+    }
+
+    private struct ReviewCommentAddParams: Decodable {
+        var path: String
+        var start_line: Int
+        var end_line: Int?
+        var side: String?
+        var body: String
+        var session_id: String?
     }
 
     /// Typed access to the `params` object new-style commands carry.
@@ -201,6 +211,24 @@ struct AlasCLIRequest: Equatable {
                 commentID: try requiredNonEmpty(params.comment_id),
                 reply: params.reply?.nilIfBlank,
                 reopen: params.reopen ?? false
+            ))
+        case "review_comment_add":
+            let params = try Self.decodeParams(ReviewCommentAddParams.self, from: data)
+            guard params.start_line >= 1,
+                  params.end_line.map({ $0 >= params.start_line }) ?? true else {
+                throw AlasCLIRequestError.malformed
+            }
+            let side = try params.side.map { raw -> String in
+                guard raw == "old" || raw == "new" else { throw AlasCLIRequestError.malformed }
+                return raw
+            }
+            command = .review(.commentAdd(
+                path: try requiredNonEmpty(params.path),
+                startLine: params.start_line,
+                endLine: params.end_line,
+                side: side,
+                body: try requiredNonEmpty(params.body),
+                sessionID: params.session_id?.nilIfBlank
             ))
         case "resolve":
             command = .resolve

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -54,6 +54,29 @@ struct AlasCLIRequest: Equatable {
         var keep_branch: Bool?
     }
 
+    private struct ParamsEnvelope<P: Decodable>: Decodable {
+        var params: P?
+    }
+
+    /// Typed access to the `params` object new-style commands carry.
+    /// Returns nil when the request has no `params` key at all; throws
+    /// `.malformed` when `params` is present but does not match `P`.
+    static func decodeParamsIfPresent<P: Decodable>(_ type: P.Type, from data: Data) throws -> P? {
+        do {
+            return try JSONDecoder().decode(ParamsEnvelope<P>.self, from: data).params
+        } catch {
+            throw AlasCLIRequestError.malformed
+        }
+    }
+
+    /// Like `decodeParamsIfPresent`, but the command requires arguments.
+    static func decodeParams<P: Decodable>(_ type: P.Type, from data: Data) throws -> P {
+        guard let params = try decodeParamsIfPresent(type, from: data) else {
+            throw AlasCLIRequestError.malformed
+        }
+        return params
+    }
+
     static func decode(from data: Data) throws -> AlasCLIRequest {
         func requiredNonEmpty(_ value: String?) throws -> String {
             guard let value else { throw AlasCLIRequestError.malformed }

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -128,6 +128,8 @@ pub enum Command {
     WtDelete { target: String, force: bool, keep_branch: bool },
     Review { target: Option<String> },
     ReviewComments { session_id: Option<String>, state: Option<String> },
+    ReviewReply { comment_id: String, body: String },
+    ReviewResolve { comment_id: String, reply: Option<String>, reopen: bool },
     Resolve,
 }
 
@@ -179,6 +181,24 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
             }
             if let Some(state) = state {
                 params.insert("state".into(), serde_json::Value::String(state.clone()));
+            }
+            r.params = Some(serde_json::Value::Object(params));
+            r
+        }
+        Command::ReviewReply { comment_id, body } => {
+            let mut r = Request::new("review_reply");
+            r.params = Some(serde_json::json!({ "comment_id": comment_id, "body": body }));
+            r
+        }
+        Command::ReviewResolve { comment_id, reply, reopen } => {
+            let mut r = Request::new("review_resolve");
+            let mut params = serde_json::Map::new();
+            params.insert("comment_id".into(), serde_json::Value::String(comment_id.clone()));
+            if let Some(reply) = reply {
+                params.insert("reply".into(), serde_json::Value::String(reply.clone()));
+            }
+            if *reopen {
+                params.insert("reopen".into(), serde_json::Value::Bool(true));
             }
             r.params = Some(serde_json::Value::Object(params));
             r
@@ -505,6 +525,32 @@ mod tests {
 
         let bare = build_request(&Command::ReviewComments { session_id: None, state: None }, None, Some("/wt".into()));
         assert_eq!(bare.params, Some(serde_json::json!({})));
+    }
+
+    #[test]
+    fn builds_review_reply_and_resolve_params() {
+        let reply = build_request(
+            &Command::ReviewReply { comment_id: "c1".into(), body: "done".into() },
+            None,
+            Some("/wt".into()),
+        );
+        assert_eq!(reply.command, "review_reply");
+        assert_eq!(reply.params, Some(serde_json::json!({"comment_id": "c1", "body": "done"})));
+
+        let resolve = build_request(
+            &Command::ReviewResolve { comment_id: "c1".into(), reply: Some("fixed".into()), reopen: false },
+            None,
+            Some("/wt".into()),
+        );
+        assert_eq!(resolve.command, "review_resolve");
+        assert_eq!(resolve.params, Some(serde_json::json!({"comment_id": "c1", "reply": "fixed"})));
+
+        let reopen = build_request(
+            &Command::ReviewResolve { comment_id: "c1".into(), reply: None, reopen: true },
+            None,
+            Some("/wt".into()),
+        );
+        assert_eq!(reopen.params, Some(serde_json::json!({"comment_id": "c1", "reopen": true})));
     }
 
     #[test]

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -127,6 +127,7 @@ pub enum Command {
     WtNew { branch: String, base: Option<String> },
     WtDelete { target: String, force: bool, keep_branch: bool },
     Review { target: Option<String> },
+    ReviewComments { session_id: Option<String>, state: Option<String> },
     Resolve,
 }
 
@@ -168,6 +169,18 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
         Command::Review { target } => {
             let mut r = Request::new("review");
             r.target = target.clone();
+            r
+        }
+        Command::ReviewComments { session_id, state } => {
+            let mut r = Request::new("review_comments");
+            let mut params = serde_json::Map::new();
+            if let Some(session_id) = session_id {
+                params.insert("session_id".into(), serde_json::Value::String(session_id.clone()));
+            }
+            if let Some(state) = state {
+                params.insert("state".into(), serde_json::Value::String(state.clone()));
+            }
+            r.params = Some(serde_json::Value::Object(params));
             r
         }
         Command::Resolve => Request::new("resolve"),
@@ -479,6 +492,19 @@ mod tests {
         assert!(local.target.is_none());
         let provider = build_request(&Command::Review { target: Some("123".into()) }, Some("s1".into()), None);
         assert_eq!(provider.target.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn builds_review_comments_with_params_envelope() {
+        let cmd = Command::ReviewComments { session_id: Some("sid".into()), state: Some("all".into()) };
+        let req = build_request(&cmd, None, Some("/wt".into()));
+        assert_eq!(req.command, "review_comments");
+        let params = req.params.expect("params must be set");
+        assert_eq!(params["session_id"], serde_json::json!("sid"));
+        assert_eq!(params["state"], serde_json::json!("all"));
+
+        let bare = build_request(&Command::ReviewComments { session_id: None, state: None }, None, Some("/wt".into()));
+        assert_eq!(bare.params, Some(serde_json::json!({})));
     }
 
     #[test]

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -78,6 +78,11 @@ pub struct Request {
     pub keep_branch: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paths: Option<Vec<String>>,
+    /// Command-specific arguments for commands added after the flat fields
+    /// above. New commands put ALL their arguments here; the flat fields
+    /// stay for wire compatibility with the original six commands.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
 }
 
 impl Request {
@@ -96,6 +101,7 @@ impl Request {
             force: None,
             keep_branch: None,
             paths: None,
+            params: None,
         }
     }
 }
@@ -419,6 +425,21 @@ mod tests {
             json,
             r#"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
         );
+    }
+
+    #[test]
+    fn params_envelope_serializes_only_when_present() {
+        let mut req = Request::new("review_comments");
+        req.session_id = Some("s1".into());
+        req.params = Some(serde_json::json!({ "state": "all" }));
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            json,
+            r#"{"v":1,"kind":"cli","command":"review_comments","session_id":"s1","params":{"state":"all"}}"#
+        );
+
+        let bare = serde_json::to_string(&Request::new("resolve")).unwrap();
+        assert!(!bare.contains("params"), "absent params must not serialize");
     }
 
     #[test]

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -130,6 +130,14 @@ pub enum Command {
     ReviewComments { session_id: Option<String>, state: Option<String> },
     ReviewReply { comment_id: String, body: String },
     ReviewResolve { comment_id: String, reply: Option<String>, reopen: bool },
+    ReviewCommentAdd {
+        path: String,
+        start_line: u64,
+        end_line: Option<u64>,
+        side: Option<String>,
+        body: String,
+        session_id: Option<String>,
+    },
     Resolve,
 }
 
@@ -199,6 +207,24 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
             }
             if *reopen {
                 params.insert("reopen".into(), serde_json::Value::Bool(true));
+            }
+            r.params = Some(serde_json::Value::Object(params));
+            r
+        }
+        Command::ReviewCommentAdd { path, start_line, end_line, side, body, session_id } => {
+            let mut r = Request::new("review_comment_add");
+            let mut params = serde_json::Map::new();
+            params.insert("path".into(), serde_json::Value::String(path.clone()));
+            params.insert("start_line".into(), serde_json::Value::from(*start_line));
+            if let Some(end_line) = end_line {
+                params.insert("end_line".into(), serde_json::Value::from(*end_line));
+            }
+            if let Some(side) = side {
+                params.insert("side".into(), serde_json::Value::String(side.clone()));
+            }
+            params.insert("body".into(), serde_json::Value::String(body.clone()));
+            if let Some(session_id) = session_id {
+                params.insert("session_id".into(), serde_json::Value::String(session_id.clone()));
             }
             r.params = Some(serde_json::Value::Object(params));
             r
@@ -551,6 +577,30 @@ mod tests {
             Some("/wt".into()),
         );
         assert_eq!(reopen.params, Some(serde_json::json!({"comment_id": "c1", "reopen": true})));
+    }
+
+    #[test]
+    fn builds_review_comment_add_params() {
+        let cmd = Command::ReviewCommentAdd {
+            path: "src/a.swift".into(),
+            start_line: 10,
+            end_line: Some(12),
+            side: Some("new".into()),
+            body: "consider guard".into(),
+            session_id: None,
+        };
+        let req = build_request(&cmd, None, Some("/wt".into()));
+        assert_eq!(req.command, "review_comment_add");
+        assert_eq!(
+            req.params,
+            Some(serde_json::json!({
+                "path": "src/a.swift",
+                "start_line": 10,
+                "end_line": 12,
+                "side": "new",
+                "body": "consider guard"
+            }))
+        );
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -163,6 +163,31 @@ pub fn tool_definitions() -> Vec<Value> {
                 }
             }
         }),
+        json!({
+            "name": "review_reply",
+            "description": "Reply to a review comment thread in the user's Alas review pane. Use review_resolve instead when the reply also settles the comment.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "comment_id": { "type": "string", "description": "Comment id, from review_comments." },
+                    "body": { "type": "string", "description": "Reply body, Markdown." }
+                },
+                "required": ["comment_id", "body"]
+            }
+        }),
+        json!({
+            "name": "review_resolve",
+            "description": "Resolve a review comment in the user's Alas review pane after addressing it, optionally posting a reply first. Pass state 'active' to reopen a comment instead.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "comment_id": { "type": "string", "description": "Comment id, from review_comments." },
+                    "reply": { "type": "string", "description": "Optional reply to post before changing state, e.g. a one-line summary of the fix." },
+                    "state": { "type": "string", "enum": ["resolved", "active"], "description": "Target state. Default: resolved." }
+                },
+                "required": ["comment_id"]
+            }
+        }),
     ]
 }
 
@@ -210,6 +235,22 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
                 }
             }
             Ok(Command::ReviewComments { session_id: optional_string(args, "session_id"), state })
+        }
+        "review_reply" => Ok(Command::ReviewReply {
+            comment_id: required_string(args, "comment_id")?,
+            body: required_string(args, "body")?,
+        }),
+        "review_resolve" => {
+            let reopen = match optional_string(args, "state").as_deref() {
+                None | Some("resolved") => false,
+                Some("active") => true,
+                Some(_) => return Err("review_resolve 'state' must be 'resolved' or 'active'".into()),
+            };
+            Ok(Command::ReviewResolve {
+                comment_id: required_string(args, "comment_id")?,
+                reply: optional_string(args, "reply"),
+                reopen,
+            })
         }
         other => Err(format!("unknown tool: {other}")),
     }
@@ -290,6 +331,9 @@ fn success_message(command: &Command) -> String {
         Command::Review { target: Some(target) } => format!("Opened review for '{target}' in Alas."),
         Command::Review { target: None } => "Opened review of local changes in Alas.".into(),
         Command::ReviewComments { .. } => "No review comments found.".into(),
+        Command::ReviewReply { .. } => "Reply posted.".into(),
+        Command::ReviewResolve { reopen: false, .. } => "Comment resolved.".into(),
+        Command::ReviewResolve { reopen: true, .. } => "Comment reopened.".into(),
         Command::WtList | Command::Resolve => "OK".into(),
     }
 }
@@ -418,7 +462,17 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert_eq!(
             names,
-            ["open", "worktree_list", "worktree_switch", "worktree_new", "worktree_delete", "review", "review_comments"]
+            [
+                "open",
+                "worktree_list",
+                "worktree_switch",
+                "worktree_new",
+                "worktree_delete",
+                "review",
+                "review_comments",
+                "review_reply",
+                "review_resolve"
+            ]
         );
         for tool in tools {
             assert!(tool["description"].as_str().unwrap().len() > 20);
@@ -520,6 +574,25 @@ mod tests {
             alas_client::Command::ReviewComments { session_id: Some("sid".into()), state: Some("resolved".into()) }
         );
         assert!(command_for_tool("review_comments", &json!({"state": "bogus"}), "/wt").is_err());
+    }
+
+    #[test]
+    fn review_reply_and_resolve_tools_map_to_commands() {
+        assert_eq!(
+            command_for_tool("review_reply", &json!({"comment_id": "c1", "body": "hi"}), "/wt").unwrap(),
+            alas_client::Command::ReviewReply { comment_id: "c1".into(), body: "hi".into() }
+        );
+        assert!(command_for_tool("review_reply", &json!({"comment_id": "c1"}), "/wt").is_err());
+
+        assert_eq!(
+            command_for_tool("review_resolve", &json!({"comment_id": "c1"}), "/wt").unwrap(),
+            alas_client::Command::ReviewResolve { comment_id: "c1".into(), reply: None, reopen: false }
+        );
+        assert_eq!(
+            command_for_tool("review_resolve", &json!({"comment_id": "c1", "reply": "done", "state": "active"}), "/wt").unwrap(),
+            alas_client::Command::ReviewResolve { comment_id: "c1".into(), reply: Some("done".into()), reopen: true }
+        );
+        assert!(command_for_tool("review_resolve", &json!({"comment_id": "c1", "state": "bogus"}), "/wt").is_err());
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -79,7 +79,7 @@ fn error_reply(id: Value, code: i64, message: &str) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
 }
 
-/// The six agent-facing tools, mirroring the CLI 1:1. Descriptions make
+/// The agent-facing tools, mirroring the CLI 1:1. Descriptions make
 /// explicit that these act on the user's Alas UI — that is what makes the
 /// agent-side permission prompt legible. `resolve` is internal and not
 /// exposed.
@@ -152,6 +152,17 @@ pub fn tool_definitions() -> Vec<Value> {
                 }
             }
         }),
+        json!({
+            "name": "review_comments",
+            "description": "List review comments from the user's Alas review pane for this worktree, as a JSON array. Each comment has an id, path, line range, side, state (active/resolved/dismissed), author, body, and replies. Defaults to active comments only.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "session_id": { "type": "string", "description": "Limit to one review session (from the review tool). Omit to list across the worktree's review sessions." },
+                    "state": { "type": "string", "enum": ["active", "resolved", "dismissed", "all"], "description": "Filter by comment state. Default: active." }
+                }
+            }
+        }),
     ]
 }
 
@@ -191,6 +202,15 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
             keep_branch: args.get("keep_branch").and_then(Value::as_bool).unwrap_or(false),
         }),
         "review" => Ok(Command::Review { target: review_target(args)? }),
+        "review_comments" => {
+            let state = optional_string(args, "state");
+            if let Some(state) = &state {
+                if !["active", "resolved", "dismissed", "all"].contains(&state.as_str()) {
+                    return Err("review_comments 'state' must be one of active|resolved|dismissed|all".into());
+                }
+            }
+            Ok(Command::ReviewComments { session_id: optional_string(args, "session_id"), state })
+        }
         other => Err(format!("unknown tool: {other}")),
     }
 }
@@ -269,6 +289,7 @@ fn success_message(command: &Command) -> String {
         Command::WtDelete { target, .. } => format!("Deleted worktree '{target}'."),
         Command::Review { target: Some(target) } => format!("Opened review for '{target}' in Alas."),
         Command::Review { target: None } => "Opened review of local changes in Alas.".into(),
+        Command::ReviewComments { .. } => "No review comments found.".into(),
         Command::WtList | Command::Resolve => "OK".into(),
     }
 }
@@ -390,14 +411,14 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_returns_the_six_tools() {
+    fn tools_list_returns_all_tools() {
         let line = r#"{"jsonrpc":"2.0","id":3,"method":"tools/list"}"#;
         let reply = handle_line(line, "/wt", ok_dispatch).unwrap();
         let tools = reply["result"]["tools"].as_array().unwrap();
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert_eq!(
             names,
-            ["open", "worktree_list", "worktree_switch", "worktree_new", "worktree_delete", "review"]
+            ["open", "worktree_list", "worktree_switch", "worktree_new", "worktree_delete", "review", "review_comments"]
         );
         for tool in tools {
             assert!(tool["description"].as_str().unwrap().len() > 20);
@@ -486,6 +507,19 @@ mod tests {
         );
         assert!(command_for_tool("review", &json!({"target": true}), "/wt").is_err());
         assert!(command_for_tool("review", &json!({"target": ["1"]}), "/wt").is_err());
+    }
+
+    #[test]
+    fn review_comments_tool_maps_and_validates_state() {
+        assert_eq!(
+            command_for_tool("review_comments", &json!({}), "/wt").unwrap(),
+            alas_client::Command::ReviewComments { session_id: None, state: None }
+        );
+        assert_eq!(
+            command_for_tool("review_comments", &json!({"session_id": "sid", "state": "resolved"}), "/wt").unwrap(),
+            alas_client::Command::ReviewComments { session_id: Some("sid".into()), state: Some("resolved".into()) }
+        );
+        assert!(command_for_tool("review_comments", &json!({"state": "bogus"}), "/wt").is_err());
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -144,7 +144,7 @@ pub fn tool_definitions() -> Vec<Value> {
         }),
         json!({
             "name": "review",
-            "description": "Open Alas's review pane for the user: on the current local changes when target is omitted, or on a provider pull/merge request when target (a PR/MR number or URL) is given.",
+            "description": "Open Alas's review pane for the user: on the current local changes when target is omitted, or on a provider pull/merge request when target (a PR/MR number or URL) is given. Returns the review session id for use with review_comment_add.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -186,6 +186,22 @@ pub fn tool_definitions() -> Vec<Value> {
                     "state": { "type": "string", "enum": ["resolved", "active"], "description": "Target state. Default: resolved." }
                 },
                 "required": ["comment_id"]
+            }
+        }),
+        json!({
+            "name": "review_comment_add",
+            "description": "File a review comment into the user's Alas review pane, attributed to the agent. The user sees it inline in the diff. Use after the review tool to leave findings on specific lines.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "File path relative to the worktree root." },
+                    "start_line": { "type": "integer", "minimum": 1, "description": "First line the comment refers to." },
+                    "end_line": { "type": "integer", "minimum": 1, "description": "Last line of the range, when commenting on a range." },
+                    "side": { "type": "string", "enum": ["old", "new"], "description": "Which side of the diff the lines refer to. Default: new." },
+                    "body": { "type": "string", "description": "Comment body, Markdown." },
+                    "session_id": { "type": "string", "description": "Review session to file into (returned by the review tool). Omit for the worktree's local-changes review." }
+                },
+                "required": ["path", "start_line", "body"]
             }
         }),
     ]
@@ -250,6 +266,36 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
                 comment_id: required_string(args, "comment_id")?,
                 reply: optional_string(args, "reply"),
                 reopen,
+            })
+        }
+        "review_comment_add" => {
+            let start_line = args
+                .get("start_line")
+                .and_then(Value::as_u64)
+                .filter(|line| *line >= 1)
+                .ok_or("review_comment_add requires an integer 'start_line' >= 1")?;
+            let end_line = match args.get("end_line") {
+                None | Some(Value::Null) => None,
+                Some(value) => Some(
+                    value
+                        .as_u64()
+                        .filter(|line| *line >= start_line)
+                        .ok_or("review_comment_add 'end_line' must be an integer >= start_line")?,
+                ),
+            };
+            let side = optional_string(args, "side");
+            if let Some(side) = &side {
+                if side != "old" && side != "new" {
+                    return Err("review_comment_add 'side' must be 'old' or 'new'".into());
+                }
+            }
+            Ok(Command::ReviewCommentAdd {
+                path: required_string(args, "path")?,
+                start_line,
+                end_line,
+                side,
+                body: required_string(args, "body")?,
+                session_id: optional_string(args, "session_id"),
             })
         }
         other => Err(format!("unknown tool: {other}")),
@@ -334,6 +380,7 @@ fn success_message(command: &Command) -> String {
         Command::ReviewReply { .. } => "Reply posted.".into(),
         Command::ReviewResolve { reopen: false, .. } => "Comment resolved.".into(),
         Command::ReviewResolve { reopen: true, .. } => "Comment reopened.".into(),
+        Command::ReviewCommentAdd { path, .. } => format!("Filed review comment on {path}."),
         Command::WtList | Command::Resolve => "OK".into(),
     }
 }
@@ -471,7 +518,8 @@ mod tests {
                 "review",
                 "review_comments",
                 "review_reply",
-                "review_resolve"
+                "review_resolve",
+                "review_comment_add"
             ]
         );
         for tool in tools {
@@ -593,6 +641,36 @@ mod tests {
             alas_client::Command::ReviewResolve { comment_id: "c1".into(), reply: Some("done".into()), reopen: true }
         );
         assert!(command_for_tool("review_resolve", &json!({"comment_id": "c1", "state": "bogus"}), "/wt").is_err());
+    }
+
+    #[test]
+    fn review_comment_add_tool_maps_and_validates() {
+        assert_eq!(
+            command_for_tool(
+                "review_comment_add",
+                &json!({"path": "a.swift", "start_line": 3, "body": "hm"}),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::ReviewCommentAdd {
+                path: "a.swift".into(),
+                start_line: 3,
+                end_line: None,
+                side: None,
+                body: "hm".into(),
+                session_id: None,
+            }
+        );
+        assert!(command_for_tool("review_comment_add", &json!({"path": "a.swift", "body": "hm"}), "/wt").is_err());
+        assert!(command_for_tool("review_comment_add", &json!({"path": "a.swift", "start_line": 0, "body": "hm"}), "/wt").is_err());
+        assert!(
+            command_for_tool(
+                "review_comment_add",
+                &json!({"path": "a.swift", "start_line": 3, "body": "hm", "side": "sideways"}),
+                "/wt"
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/parse.rs
+++ b/AlasCLI/crates/alas/src/parse.rs
@@ -40,7 +40,7 @@ pub fn parse(args: &[String], base: &std::path::Path) -> Result<Command, String>
         Some("wt") => parse_wt(&it.map(|s| s.as_str()).collect::<Vec<_>>()),
         Some("review") => {
             let rest: Vec<&str> = it.map(String::as_str).collect();
-            parse_review(&rest)
+            parse_review(&rest, base)
         }
         _ => Err(USAGE_ALL.into()),
     }
@@ -48,11 +48,11 @@ pub fn parse(args: &[String], base: &std::path::Path) -> Result<Command, String>
 
 pub const REVIEW_STATES: [&str; 4] = ["active", "resolved", "dismissed", "all"];
 
-fn parse_review(args: &[&str]) -> Result<Command, String> {
+fn parse_review(args: &[&str], base: &std::path::Path) -> Result<Command, String> {
     match args.first().copied() {
         None => Ok(Command::Review { target: None }),
         Some("comments") => parse_review_comments(&args[1..]),
-        Some("comment") => parse_review_comment(&args[1..]),
+        Some("comment") => parse_review_comment(&args[1..], base),
         Some("reply") => {
             const USAGE: &str = "usage: alas review reply <comment-id> <body>";
             if args.len() != 3 || args[1].starts_with("--") {
@@ -117,12 +117,15 @@ fn parse_review_comments(args: &[&str]) -> Result<Command, String> {
     Ok(Command::ReviewComments { session_id, state })
 }
 
-fn parse_review_comment(args: &[&str]) -> Result<Command, String> {
+fn parse_review_comment(args: &[&str], base: &std::path::Path) -> Result<Command, String> {
     const USAGE: &str = "usage: alas review comment <path> <line> <body> [--end-line <n>] [--side <old|new>] [--session <id>]";
     if args.len() < 3 || args[..3].iter().any(|a| a.starts_with("--")) {
         return Err(USAGE.into());
     }
-    let path = args[0].to_string();
+    // Resolved against the caller's cwd, same as `open`: the app treats an
+    // already-relative path as worktree-root-relative, which is wrong when
+    // the command is run from a subdirectory.
+    let path = alas_client::absolutize(base, args[0]);
     let start_line: u64 = args[1].parse().map_err(|_| USAGE.to_string())?;
     if start_line == 0 {
         return Err(USAGE.into());
@@ -369,7 +372,7 @@ mod tests {
         assert_eq!(
             parse(&s(&["review", "comment", "src/a.swift", "10", "fix this"]), Path::new("/b")).unwrap(),
             Command::ReviewCommentAdd {
-                path: "src/a.swift".into(),
+                path: "/b/src/a.swift".into(),
                 start_line: 10,
                 end_line: None,
                 side: None,
@@ -384,7 +387,7 @@ mod tests {
             )
             .unwrap(),
             Command::ReviewCommentAdd {
-                path: "a.swift".into(),
+                path: "/b/a.swift".into(),
                 start_line: 3,
                 end_line: Some(5),
                 side: Some("old".into()),
@@ -396,6 +399,50 @@ mod tests {
         assert!(parse(&s(&["review", "comment", "a.swift", "x", "b"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "comment", "a.swift", "3", "b", "--side", "sideways"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "comment", "a.swift"]), Path::new("/b")).is_err());
+    }
+
+    #[test]
+    fn review_comment_resolves_relative_path_against_the_callers_subdirectory() {
+        // `cd Sources && alas review comment App.swift 10 "..."` must resolve
+        // to the actual changed file `/repo/Sources/App.swift`, not
+        // `/repo/App.swift` (base is the worktree root; the caller's cwd is
+        // a subdirectory of it, same as `open`).
+        let cmd = parse(
+            &s(&["review", "comment", "App.swift", "10", "fix this"]),
+            Path::new("/repo/Sources"),
+        )
+        .unwrap();
+        assert_eq!(
+            cmd,
+            Command::ReviewCommentAdd {
+                path: "/repo/Sources/App.swift".into(),
+                start_line: 10,
+                end_line: None,
+                side: None,
+                body: "fix this".into(),
+                session_id: None,
+            }
+        );
+    }
+
+    #[test]
+    fn review_comment_keeps_an_already_absolute_path_unchanged() {
+        let cmd = parse(
+            &s(&["review", "comment", "/repo/Sources/App.swift", "10", "fix this"]),
+            Path::new("/repo/Sources"),
+        )
+        .unwrap();
+        assert_eq!(
+            cmd,
+            Command::ReviewCommentAdd {
+                path: "/repo/Sources/App.swift".into(),
+                start_line: 10,
+                end_line: None,
+                side: None,
+                body: "fix this".into(),
+                session_id: None,
+            }
+        );
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/parse.rs
+++ b/AlasCLI/crates/alas/src/parse.rs
@@ -18,7 +18,8 @@ usage: alas wt delete <name-or-branch> [--force] [--keep-branch]
 usage: alas review [pr-number-or-url]
 usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]
 usage: alas review reply <comment-id> <body>
-usage: alas review resolve <comment-id> [--reply <body>] [--reopen]";
+usage: alas review resolve <comment-id> [--reply <body>] [--reopen]
+usage: alas review comment <path> <line> <body> [--end-line <n>] [--side <old|new>] [--session <id>]";
 
 /// Parse arguments (excluding argv0) into a Command. `base` is the directory
 /// `open` paths resolve against. On misuse, returns the usage string to print.
@@ -51,6 +52,7 @@ fn parse_review(args: &[&str]) -> Result<Command, String> {
     match args.first().copied() {
         None => Ok(Command::Review { target: None }),
         Some("comments") => parse_review_comments(&args[1..]),
+        Some("comment") => parse_review_comment(&args[1..]),
         Some("reply") => {
             const USAGE: &str = "usage: alas review reply <comment-id> <body>";
             if args.len() != 3 || args[1].starts_with("--") {
@@ -113,6 +115,53 @@ fn parse_review_comments(args: &[&str]) -> Result<Command, String> {
         i += 1;
     }
     Ok(Command::ReviewComments { session_id, state })
+}
+
+fn parse_review_comment(args: &[&str]) -> Result<Command, String> {
+    const USAGE: &str = "usage: alas review comment <path> <line> <body> [--end-line <n>] [--side <old|new>] [--session <id>]";
+    if args.len() < 3 || args[..3].iter().any(|a| a.starts_with("--")) {
+        return Err(USAGE.into());
+    }
+    let path = args[0].to_string();
+    let start_line: u64 = args[1].parse().map_err(|_| USAGE.to_string())?;
+    if start_line == 0 {
+        return Err(USAGE.into());
+    }
+    let body = args[2].to_string();
+
+    let mut end_line: Option<u64> = None;
+    let mut side: Option<String> = None;
+    let mut session_id: Option<String> = None;
+    let rest = &args[3..];
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i] {
+            "--end-line" => {
+                i += 1;
+                let value = flag_value(rest, i).ok_or(USAGE)?;
+                let parsed: u64 = value.parse().map_err(|_| USAGE.to_string())?;
+                if parsed < start_line {
+                    return Err(USAGE.into());
+                }
+                end_line = Some(parsed);
+            }
+            "--side" => {
+                i += 1;
+                let value = flag_value(rest, i).ok_or(USAGE)?;
+                if value != "old" && value != "new" {
+                    return Err(USAGE.into());
+                }
+                side = Some(value.to_string());
+            }
+            "--session" => {
+                i += 1;
+                session_id = Some(flag_value(rest, i).ok_or(USAGE)?.to_string());
+            }
+            _ => return Err(USAGE.into()),
+        }
+        i += 1;
+    }
+    Ok(Command::ReviewCommentAdd { path, start_line, end_line, side, body, session_id })
 }
 
 /// Value at `i` unless it is missing or looks like another flag.
@@ -313,6 +362,40 @@ mod tests {
         assert!(parse(&s(&["review", "resolve"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "resolve", "--reopen"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "resolve", "c1", "--reply"]), Path::new("/b")).is_err());
+    }
+
+    #[test]
+    fn review_comment_parses_positionals_and_flags() {
+        assert_eq!(
+            parse(&s(&["review", "comment", "src/a.swift", "10", "fix this"]), Path::new("/b")).unwrap(),
+            Command::ReviewCommentAdd {
+                path: "src/a.swift".into(),
+                start_line: 10,
+                end_line: None,
+                side: None,
+                body: "fix this".into(),
+                session_id: None,
+            }
+        );
+        assert_eq!(
+            parse(
+                &s(&["review", "comment", "a.swift", "3", "b", "--end-line", "5", "--side", "old", "--session", "sid"]),
+                Path::new("/b")
+            )
+            .unwrap(),
+            Command::ReviewCommentAdd {
+                path: "a.swift".into(),
+                start_line: 3,
+                end_line: Some(5),
+                side: Some("old".into()),
+                body: "b".into(),
+                session_id: Some("sid".into()),
+            }
+        );
+        assert!(parse(&s(&["review", "comment", "a.swift", "0", "b"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "comment", "a.swift", "x", "b"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "comment", "a.swift", "3", "b", "--side", "sideways"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "comment", "a.swift"]), Path::new("/b")).is_err());
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/parse.rs
+++ b/AlasCLI/crates/alas/src/parse.rs
@@ -15,7 +15,8 @@ usage: alas wt list
 usage: alas wt switch <name-or-branch>
 usage: alas wt new <branch> [--base <ref>]
 usage: alas wt delete <name-or-branch> [--force] [--keep-branch]
-usage: alas review [pr-number-or-url]";
+usage: alas review [pr-number-or-url]
+usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]";
 
 /// Parse arguments (excluding argv0) into a Command. `base` is the directory
 /// `open` paths resolve against. On misuse, returns the usage string to print.
@@ -35,15 +36,55 @@ pub fn parse(args: &[String], base: &std::path::Path) -> Result<Command, String>
         }
         Some("wt") => parse_wt(&it.map(|s| s.as_str()).collect::<Vec<_>>()),
         Some("review") => {
-            let rest: Vec<&String> = it.collect();
-            match rest.len() {
-                0 => Ok(Command::Review { target: None }),
-                1 => Ok(Command::Review { target: Some(rest[0].clone()) }),
-                _ => Err("usage: alas review [pr-number-or-url]".into()),
-            }
+            let rest: Vec<&str> = it.map(String::as_str).collect();
+            parse_review(&rest)
         }
         _ => Err(USAGE_ALL.into()),
     }
+}
+
+pub const REVIEW_STATES: [&str; 4] = ["active", "resolved", "dismissed", "all"];
+
+fn parse_review(args: &[&str]) -> Result<Command, String> {
+    match args.first().copied() {
+        None => Ok(Command::Review { target: None }),
+        Some("comments") => parse_review_comments(&args[1..]),
+        Some(target) if args.len() == 1 && !target.starts_with("--") => {
+            Ok(Command::Review { target: Some(target.to_string()) })
+        }
+        _ => Err(USAGE_ALL.into()),
+    }
+}
+
+fn parse_review_comments(args: &[&str]) -> Result<Command, String> {
+    const USAGE: &str = "usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]";
+    let mut state: Option<String> = None;
+    let mut session_id: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i] {
+            "--state" => {
+                i += 1;
+                let value = flag_value(args, i).ok_or(USAGE)?;
+                if !REVIEW_STATES.contains(&value) {
+                    return Err(USAGE.into());
+                }
+                state = Some(value.to_string());
+            }
+            "--session" => {
+                i += 1;
+                session_id = Some(flag_value(args, i).ok_or(USAGE)?.to_string());
+            }
+            _ => return Err(USAGE.into()),
+        }
+        i += 1;
+    }
+    Ok(Command::ReviewComments { session_id, state })
+}
+
+/// Value at `i` unless it is missing or looks like another flag.
+fn flag_value<'a>(args: &[&'a str], i: usize) -> Option<&'a str> {
+    args.get(i).copied().filter(|v| !v.starts_with("--"))
 }
 
 fn parse_wt(args: &[&str]) -> Result<Command, String> {
@@ -198,6 +239,29 @@ mod tests {
         assert_eq!(
             parse(&s(&["review"]), Path::new("/b")).unwrap(),
             Command::Review { target: None }
+        );
+    }
+
+    #[test]
+    fn review_comments_parses_flags_and_rejects_bad_state() {
+        assert_eq!(
+            parse(&s(&["review", "comments"]), Path::new("/b")).unwrap(),
+            Command::ReviewComments { session_id: None, state: None }
+        );
+        assert_eq!(
+            parse(&s(&["review", "comments", "--state", "all", "--session", "sid"]), Path::new("/b")).unwrap(),
+            Command::ReviewComments { session_id: Some("sid".into()), state: Some("all".into()) }
+        );
+        assert!(parse(&s(&["review", "comments", "--state", "bogus"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "comments", "--session"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "comments", "extra"]), Path::new("/b")).is_err());
+    }
+
+    #[test]
+    fn plain_review_targets_still_parse() {
+        assert_eq!(
+            parse(&s(&["review", "123"]), Path::new("/b")).unwrap(),
+            Command::Review { target: Some("123".into()) }
         );
     }
 

--- a/AlasCLI/crates/alas/src/parse.rs
+++ b/AlasCLI/crates/alas/src/parse.rs
@@ -16,7 +16,9 @@ usage: alas wt switch <name-or-branch>
 usage: alas wt new <branch> [--base <ref>]
 usage: alas wt delete <name-or-branch> [--force] [--keep-branch]
 usage: alas review [pr-number-or-url]
-usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]";
+usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]
+usage: alas review reply <comment-id> <body>
+usage: alas review resolve <comment-id> [--reply <body>] [--reopen]";
 
 /// Parse arguments (excluding argv0) into a Command. `base` is the directory
 /// `open` paths resolve against. On misuse, returns the usage string to print.
@@ -49,11 +51,42 @@ fn parse_review(args: &[&str]) -> Result<Command, String> {
     match args.first().copied() {
         None => Ok(Command::Review { target: None }),
         Some("comments") => parse_review_comments(&args[1..]),
+        Some("reply") => {
+            const USAGE: &str = "usage: alas review reply <comment-id> <body>";
+            if args.len() != 3 || args[1].starts_with("--") {
+                return Err(USAGE.into());
+            }
+            Ok(Command::ReviewReply { comment_id: args[1].to_string(), body: args[2].to_string() })
+        }
+        Some("resolve") => parse_review_resolve(&args[1..]),
         Some(target) if args.len() == 1 && !target.starts_with("--") => {
             Ok(Command::Review { target: Some(target.to_string()) })
         }
         _ => Err(USAGE_ALL.into()),
     }
+}
+
+fn parse_review_resolve(args: &[&str]) -> Result<Command, String> {
+    const USAGE: &str = "usage: alas review resolve <comment-id> [--reply <body>] [--reopen]";
+    let (comment_id, rest) = match args.split_first() {
+        Some((first, rest)) if !first.starts_with("--") => (first.to_string(), rest),
+        _ => return Err(USAGE.into()),
+    };
+    let mut reply: Option<String> = None;
+    let mut reopen = false;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i] {
+            "--reply" => {
+                i += 1;
+                reply = Some(flag_value(rest, i).ok_or(USAGE)?.to_string());
+            }
+            "--reopen" => reopen = true,
+            _ => return Err(USAGE.into()),
+        }
+        i += 1;
+    }
+    Ok(Command::ReviewResolve { comment_id, reply, reopen })
 }
 
 fn parse_review_comments(args: &[&str]) -> Result<Command, String> {
@@ -255,6 +288,31 @@ mod tests {
         assert!(parse(&s(&["review", "comments", "--state", "bogus"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "comments", "--session"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "comments", "extra"]), Path::new("/b")).is_err());
+    }
+
+    #[test]
+    fn review_reply_takes_exactly_id_and_body() {
+        assert_eq!(
+            parse(&s(&["review", "reply", "c1", "looks good"]), Path::new("/b")).unwrap(),
+            Command::ReviewReply { comment_id: "c1".into(), body: "looks good".into() }
+        );
+        assert!(parse(&s(&["review", "reply", "c1"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "reply", "c1", "a", "b"]), Path::new("/b")).is_err());
+    }
+
+    #[test]
+    fn review_resolve_parses_flags() {
+        assert_eq!(
+            parse(&s(&["review", "resolve", "c1"]), Path::new("/b")).unwrap(),
+            Command::ReviewResolve { comment_id: "c1".into(), reply: None, reopen: false }
+        );
+        assert_eq!(
+            parse(&s(&["review", "resolve", "c1", "--reply", "fixed", "--reopen"]), Path::new("/b")).unwrap(),
+            Command::ReviewResolve { comment_id: "c1".into(), reply: Some("fixed".into()), reopen: true }
+        );
+        assert!(parse(&s(&["review", "resolve"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "resolve", "--reopen"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "resolve", "c1", "--reply"]), Path::new("/b")).is_err());
     }
 
     #[test]

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -635,6 +635,35 @@ struct AlasCLICommandRouterTests {
         #expect(Set(allDecoded.map(\.id)) == ["mine", "resolved"])
     }
 
+    @Test func reviewCommentsIgnoresAnExplicitSessionIDFromAnotherWorktree() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        let foreignComment = makeDraftComment(id: "foreign", worktreeID: "wt2")
+        try store.save(foreignComment)
+
+        let router = makeReviewRouter(worktree: worktree, store: store)
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.comments(sessionID: foreignComment.sessionID.rawValue, state: .all))
+        ))
+
+        guard case .text(let lines) = response, let line = lines.first else {
+            Issue.record("expected .text response, got \(response)")
+            return
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let decoded = try decoder.decode([ReviewCommentWireDTO].self, from: Data(line.utf8))
+        #expect(decoded.isEmpty)
+    }
+
     @Test func commentAddFilesAgentCommentIntoLocalChangesSession() async throws {
         let root = try makeFile("repo/a.swift").deletingLastPathComponent()
         let worktree = Worktree(

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -1012,6 +1012,42 @@ struct AlasCLICommandRouterTests {
         #expect(record.handoffs.map(\.status) == [.sent])
     }
 
+    private struct FailingReviewSessionPersistenceStore: PersistenceStoreProtocol {
+        struct Failure: Error {}
+        func write<T: Encodable>(_ value: T, to url: URL) throws { throw Failure() }
+        func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? { throw Failure() }
+    }
+
+    @Test func resolveSucceedsAndNotifiesEvenWhenHandoffRecomputationFails() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let store = ReviewDraftCommentStore(url: dir.appendingPathComponent("drafts.json"))
+        try store.save(makeDraftComment(id: "c1", worktreeID: "wt1"))
+        let brokenSessionStore = ReviewSessionStore(
+            store: FailingReviewSessionPersistenceStore(),
+            url: dir.appendingPathComponent("sessions.json")
+        )
+        var changed = 0
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store, sessionStore: brokenSessionStore, onChange: { changed += 1 }
+        )
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.resolve(commentID: "c1", reply: "fixed", reopen: false))
+        ))
+
+        #expect(response == .ok)
+        #expect(changed == 1)
+        let updated = try #require(try store.find(commentID: "c1"))
+        #expect(updated.state == .resolved)
+        #expect(updated.allReplies.map(\.bodyMarkdown) == ["fixed"])
+    }
+
     @Test func mutationsRejectCommentsFromOtherWorktrees() async throws {
         let root = try makeFile("repo/a.swift").deletingLastPathComponent()
         let worktree = Worktree(

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -914,6 +914,23 @@ struct AlasCLICommandRouterTests {
         #expect(saved[0].path == "a.swift")
     }
 
+    @Test func worktreeRelativePathResolvesCaseVariantRootOnACaseInsensitiveVolume() throws {
+        // On the default case-insensitive-but-case-preserving macOS volume,
+        // a case-variant of the tracked root's name (e.g. the shell's $PWD
+        // differs only in casing) refers to the identical directory. A
+        // string-prefix check can't see that; file identity can.
+        let realRoot = try makeFile("case-repo/Sources/App.swift")
+            .deletingLastPathComponent().deletingLastPathComponent()
+        let variantRoot = realRoot.deletingLastPathComponent()
+            .appendingPathComponent(realRoot.lastPathComponent.uppercased())
+        let variantPath = variantRoot.appendingPathComponent("Sources/App.swift").path
+
+        #expect(
+            AlasActionService.worktreeRelativePath(variantPath, worktreeRoot: realRoot)
+                == "Sources/App.swift"
+        )
+    }
+
     @Test func worktreeRelativePathResolvesSymlinkedRootAgainstTheRealWorktreePath() throws {
         // resolvingSymlinksInPath() needs the file to actually exist to
         // resolve the intermediate symlink, matching the real scenario:

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -768,6 +768,64 @@ struct AlasCLICommandRouterTests {
         #expect(try store.load(sessionID: .localChanges(worktreeID: "wt1", worktreePath: root, scope: .all)).isEmpty)
     }
 
+    @Test func worktreeRelativePathResolvesSymlinkedRootAgainstTheRealWorktreePath() throws {
+        // resolvingSymlinksInPath() needs the file to actually exist to
+        // resolve the intermediate symlink, matching the real scenario:
+        // agents comment on files that exist in the working tree.
+        let realRoot = try makeFile("repo/Sources/App.swift").deletingLastPathComponent().deletingLastPathComponent()
+        let logicalRoot = realRoot.deletingLastPathComponent().appendingPathComponent("logical-repo")
+        try FileManager.default.createSymbolicLink(at: logicalRoot, withDestinationURL: realRoot)
+
+        // The CLI absolutizes against the caller's logical $PWD, which
+        // preserves the symlink the user cd'd through.
+        let pathUnderSymlink = logicalRoot.appendingPathComponent("Sources/App.swift").path
+
+        #expect(
+            AlasActionService.worktreeRelativePath(pathUnderSymlink, worktreeRoot: realRoot)
+                == "Sources/App.swift"
+        )
+    }
+
+    @Test func commentAddFilesIntoTheCorrectSessionWhenRunFromASymlinkedWorktree() async throws {
+        let realRoot = try makeFile("repo/Sources/App.swift").deletingLastPathComponent().deletingLastPathComponent()
+        let logicalRoot = realRoot.deletingLastPathComponent().appendingPathComponent("logical-repo")
+        try FileManager.default.createSymbolicLink(at: logicalRoot, withDestinationURL: realRoot)
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: realRoot, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            gitStatus: { _ in
+                [ChangedFile(path: "Sources/App.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil)]
+            }
+        )
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: logicalRoot.appendingPathComponent("Sources/App.swift").path,
+                startLine: 1, endLine: nil, side: nil, body: "add a guard", sessionID: nil
+            ))
+        ))
+
+        guard case .text(let lines) = response, lines.count == 2 else {
+            Issue.record("expected two-line text response, got \(response)")
+            return
+        }
+        let expectedSession = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt1", worktreePath: realRoot, scope: .all
+        )
+        let saved = try store.load(sessionID: expectedSession)
+        #expect(saved.count == 1)
+        #expect(saved[0].path == "Sources/App.swift")
+        #expect(saved[0].fileID == DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"))
+    }
+
     @Test func commentAddRejectsSessionIDFromAnotherWorktree() async throws {
         let root = try makeFile("repo/a.swift").deletingLastPathComponent()
         let worktree = Worktree(

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -803,6 +803,50 @@ struct AlasCLICommandRouterTests {
         #expect(try store.load(sessionID: target.draftSessionID).isEmpty)
     }
 
+    @Test func worktreeRelativePathNormalizesAlreadyRelativePaths() {
+        #expect(AlasActionService.worktreeRelativePath("./Sources/App.swift", worktreeRoot: URL(fileURLWithPath: "/repo")) == "Sources/App.swift")
+        #expect(AlasActionService.worktreeRelativePath("Sources/../Sources/App.swift", worktreeRoot: URL(fileURLWithPath: "/repo")) == "Sources/App.swift")
+        #expect(AlasActionService.worktreeRelativePath("Sources//App.swift", worktreeRoot: URL(fileURLWithPath: "/repo")) == "Sources/App.swift")
+        #expect(AlasActionService.worktreeRelativePath("a.swift", worktreeRoot: URL(fileURLWithPath: "/repo")) == "a.swift")
+        // A leading `..` can't climb above the (already worktree-relative)
+        // root — it's dropped rather than followed.
+        #expect(AlasActionService.worktreeRelativePath("../a.swift", worktreeRoot: URL(fileURLWithPath: "/repo")) == "a.swift")
+    }
+
+    @Test func commentAddFilesAgentCommentAtNormalizedPathForDotSlashInput() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            gitStatus: { _ in
+                [ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil)]
+            }
+        )
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "./a.swift", startLine: 1, endLine: nil, side: nil, body: "add a guard", sessionID: nil
+            ))
+        ))
+
+        guard case .text = response else {
+            Issue.record("expected .text response, got \(response)")
+            return
+        }
+        let expectedSession = ReviewDraftSessionID.localChanges(worktreeID: "wt1", worktreePath: root, scope: .all)
+        let saved = try store.load(sessionID: expectedSession)
+        #expect(saved.count == 1)
+        #expect(saved[0].path == "a.swift")
+    }
+
     @Test func worktreeRelativePathResolvesSymlinkedRootAgainstTheRealWorktreePath() throws {
         // resolvingSymlinksInPath() needs the file to actually exist to
         // resolve the intermediate symlink, matching the real scenario:

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -741,6 +741,73 @@ struct AlasCLICommandRouterTests {
         #expect(saved.first?.fileID == DiffReviewFileID(namespace: "unstaged", path: "a.swift"))
     }
 
+    @Test func commentAddHonorsAStagedOnlySessionScopeOverUnstagedGitStatus() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        let stagedSession = ReviewDraftSessionID.localChanges(worktreeID: "wt1", worktreePath: root, scope: .staged)
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            gitStatus: { _ in
+                [
+                    ChangedFile(path: "a.swift", status: "M", stage: .staged, add: 1, del: 0, renameFrom: nil),
+                    ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil),
+                ]
+            }
+        )
+        _ = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "a.swift", startLine: 4, endLine: nil, side: nil, body: "add a guard",
+                sessionID: stagedSession.rawValue
+            ))
+        ))
+
+        let saved = try store.load(sessionID: stagedSession)
+        #expect(saved.first?.fileID == DiffReviewFileID(namespace: "staged", path: "a.swift"))
+    }
+
+    @Test func commentAddRejectsPathOutsideAStagedOnlySessionScope() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        let stagedSession = ReviewDraftSessionID.localChanges(worktreeID: "wt1", worktreePath: root, scope: .staged)
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            gitStatus: { _ in
+                [ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil)]
+            }
+        )
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "a.swift", startLine: 4, endLine: nil, side: nil, body: "add a guard",
+                sessionID: stagedSession.rawValue
+            ))
+        ))
+
+        guard case .error(let message) = response else {
+            Issue.record("expected error, got \(response)")
+            return
+        }
+        #expect(message.contains("no staged changes found"))
+        #expect(try store.load(sessionID: stagedSession).isEmpty)
+    }
+
     @Test func commentAddRejectsPathWithNoLocalChanges() async throws {
         let root = try makeFile("repo/a.swift").deletingLastPathComponent()
         let worktree = Worktree(

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -515,7 +515,15 @@ struct AlasCLICommandRouterTests {
 
         let response = await router.handle(.init(version: 1, sessionId: "s1", cwd: nil, command: .review(.localChanges)))
 
-        #expect(response == .ok)
+        guard case .text(let lines) = response, lines.count == 2 else {
+            Issue.record("expected two-line text response, got \(response)")
+            return
+        }
+        let expectedSession = ReviewDraftSessionID.localChanges(
+            worktreeID: current.id, worktreePath: current.path, scope: .all
+        )
+        let object = try JSONSerialization.jsonObject(with: Data(lines[1].utf8)) as? [String: String]
+        #expect(object?["session_id"] == expectedSession.rawValue)
         #expect(opened == current.id)
         #expect(activationCount == 1)
     }
@@ -625,6 +633,71 @@ struct AlasCLICommandRouterTests {
         }
         let allDecoded = try decoder.decode([ReviewCommentWireDTO].self, from: Data(allLine.utf8))
         #expect(Set(allDecoded.map(\.id)) == ["mine", "resolved"])
+    }
+
+    @Test func commentAddFilesAgentCommentIntoLocalChangesSession() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+
+        let router = makeReviewRouter(worktree: worktree, store: store)
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "a.swift", startLine: 4, endLine: nil, side: nil, body: "add a guard", sessionID: nil
+            ))
+        ))
+
+        guard case .text(let lines) = response, lines.count == 2 else {
+            Issue.record("expected two-line text response, got \(response)")
+            return
+        }
+        #expect(lines[1].contains("comment_id"))
+        let expectedSession = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt1", worktreePath: root, scope: .all
+        )
+        let saved = try store.load(sessionID: expectedSession)
+        #expect(saved.count == 1)
+        #expect(saved[0].effectiveAuthor.isAgent)
+        #expect(saved[0].path == "a.swift")
+        #expect(saved[0].side == .new)
+        #expect(saved[0].startLine == 4)
+    }
+
+    @Test func reviewLocalReturnsItsSessionID() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        var openedReview = false
+        var router = makeReviewRouter(
+            worktree: worktree,
+            store: ReviewDraftCommentStore(
+                url: FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")
+            )
+        )
+        router.openReviewChanges = { _ in openedReview = true }
+
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil, command: .review(.localChanges)
+        ))
+
+        #expect(openedReview)
+        guard case .text(let lines) = response, lines.count == 2 else {
+            Issue.record("expected two-line text response, got \(response)")
+            return
+        }
+        let expected = ReviewDraftSessionID.localChanges(worktreeID: "wt1", worktreePath: root, scope: .all)
+        #expect(lines[1].contains(#""session_id":"#))
+        let object = try JSONSerialization.jsonObject(with: Data(lines[1].utf8)) as? [String: String]
+        #expect(object?["session_id"] == expected.rawValue)
     }
 
     @Test func replyAppendsAgentReplyAndNotifies() async throws {

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -905,6 +905,55 @@ struct AlasCLICommandRouterTests {
         #expect(record.handoffs.map(\.status) == [.addressed])
     }
 
+    @Test func reopeningAResolvedCommentDemotesAnAddressedHandoff() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let store = ReviewDraftCommentStore(url: dir.appendingPathComponent("drafts.json"))
+        let sessionStore = ReviewSessionStore(url: dir.appendingPathComponent("sessions.json"))
+        var comment = makeDraftComment(id: "c1", worktreeID: "wt1", state: .resolved)
+        comment.resolvedBy = .agent(name: "Agent")
+        try store.save(comment)
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        try sessionStore.save(ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            status: .addressed,
+            handoffs: [ReviewFeedbackHandoff(
+                id: "h1",
+                sessionID: target.id,
+                commentIDs: ["c1"],
+                target: .newChat(agentID: "claude", title: "New chat"),
+                createdAt: Date(timeIntervalSince1970: 1),
+                promptRevision: "rev",
+                status: .addressed
+            )],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        ))
+
+        let router = makeReviewRouter(worktree: worktree, store: store, sessionStore: sessionStore)
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.resolve(commentID: "c1", reply: nil, reopen: true))
+        ))
+
+        #expect(response == .ok)
+        let updated = try #require(try store.find(commentID: "c1"))
+        #expect(updated.state == .active)
+        #expect(updated.resolvedBy == nil)
+        let record = try #require(try sessionStore.load(id: target.id))
+        #expect(record.status == .sent)
+        #expect(record.handoffs.map(\.status) == [.sent])
+    }
+
     @Test func mutationsRejectCommentsFromOtherWorktrees() async throws {
         let root = try makeFile("repo/a.swift").deletingLastPathComponent()
         let worktree = Worktree(

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -577,7 +577,8 @@ struct AlasCLICommandRouterTests {
         worktree: Worktree,
         store: ReviewDraftCommentStore,
         sessionStore: ReviewSessionStore? = nil,
-        onChange: @escaping () -> Void = {}
+        onChange: @escaping () -> Void = {},
+        gitStatus: @escaping (URL) async throws -> [ChangedFile] = { _ in [] }
     ) -> AlasCLICommandRouter {
         AlasCLICommandRouter(
             sessionWorktreeId: { $0 == "s1" ? worktree.id : nil },
@@ -588,6 +589,7 @@ struct AlasCLICommandRouterTests {
             draftCommentStore: { store },
             reviewSessionStore: { sessionStore ?? ReviewSessionStore(url: FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")) },
             notifyReviewCommentsChanged: onChange,
+            gitStatus: gitStatus,
             activateApp: {}
         )
     }
@@ -675,7 +677,12 @@ struct AlasCLICommandRouterTests {
             .appendingPathComponent("drafts.json")
         let store = ReviewDraftCommentStore(url: storeURL)
 
-        let router = makeReviewRouter(worktree: worktree, store: store)
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            gitStatus: { _ in
+                [ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil)]
+            }
+        )
         let response = await router.handle(.init(
             version: 1, sessionId: "s1", cwd: nil,
             command: .review(.commentAdd(
@@ -697,6 +704,68 @@ struct AlasCLICommandRouterTests {
         #expect(saved[0].path == "a.swift")
         #expect(saved[0].side == .new)
         #expect(saved[0].startLine == 4)
+        #expect(saved[0].fileID == DiffReviewFileID(namespace: "unstaged", path: "a.swift"))
+    }
+
+    @Test func commentAddPrefersUnstagedWhenPathIsBothStagedAndUnstaged() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            gitStatus: { _ in
+                [
+                    ChangedFile(path: "a.swift", status: "M", stage: .staged, add: 1, del: 0, renameFrom: nil),
+                    ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil),
+                ]
+            }
+        )
+        _ = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "a.swift", startLine: 4, endLine: nil, side: nil, body: "add a guard", sessionID: nil
+            ))
+        ))
+
+        let expectedSession = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt1", worktreePath: root, scope: .all
+        )
+        let saved = try store.load(sessionID: expectedSession)
+        #expect(saved.first?.fileID == DiffReviewFileID(namespace: "unstaged", path: "a.swift"))
+    }
+
+    @Test func commentAddRejectsPathWithNoLocalChanges() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+
+        let router = makeReviewRouter(worktree: worktree, store: store, gitStatus: { _ in [] })
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "a.swift", startLine: 4, endLine: nil, side: nil, body: "add a guard", sessionID: nil
+            ))
+        ))
+
+        guard case .error(let message) = response else {
+            Issue.record("expected error, got \(response)")
+            return
+        }
+        #expect(message.contains("no local changes found"))
+        #expect(try store.load(sessionID: .localChanges(worktreeID: "wt1", worktreePath: root, scope: .all)).isEmpty)
     }
 
     @Test func commentAddRejectsSessionIDFromAnotherWorktree() async throws {

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -768,6 +768,41 @@ struct AlasCLICommandRouterTests {
         #expect(try store.load(sessionID: .localChanges(worktreeID: "wt1", worktreePath: root, scope: .all)).isEmpty)
     }
 
+    @Test func commentAddRejectsAnAbsolutePathOutsideTheWorktree() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        // A session kind that doesn't need a git-status lookup to resolve
+        // its namespace, so an out-of-worktree path can't slip through by
+        // virtue of the local-changes git-status check happening to reject
+        // it for an unrelated reason.
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt1", repositoryPath: root, sha: "abc123", title: "Review abc123"
+        )
+
+        let router = makeReviewRouter(worktree: worktree, store: store)
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "/tmp/some-other-repo/foo.swift", startLine: 1, endLine: nil, side: nil,
+                body: "add a guard", sessionID: target.draftSessionID.rawValue
+            ))
+        ))
+
+        guard case .error(let message) = response else {
+            Issue.record("expected error, got \(response)")
+            return
+        }
+        #expect(message.contains("inside the worktree"))
+        #expect(try store.load(sessionID: target.draftSessionID).isEmpty)
+    }
+
     @Test func worktreeRelativePathResolvesSymlinkedRootAgainstTheRealWorktreePath() throws {
         // resolvingSymlinksInPath() needs the file to actually exist to
         // resolve the intermediate symlink, matching the real scenario:

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -567,7 +567,9 @@ struct AlasCLICommandRouterTests {
 
     private func makeReviewRouter(
         worktree: Worktree,
-        store: ReviewDraftCommentStore
+        store: ReviewDraftCommentStore,
+        sessionStore: ReviewSessionStore? = nil,
+        onChange: @escaping () -> Void = {}
     ) -> AlasCLICommandRouter {
         AlasCLICommandRouter(
             sessionWorktreeId: { $0 == "s1" ? worktree.id : nil },
@@ -576,6 +578,8 @@ struct AlasCLICommandRouterTests {
             openRelativeFile: { _, _ in },
             openExternalFile: { _, _ in },
             draftCommentStore: { store },
+            reviewSessionStore: { sessionStore ?? ReviewSessionStore(url: FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")) },
+            notifyReviewCommentsChanged: onChange,
             activateApp: {}
         )
     }
@@ -621,6 +625,107 @@ struct AlasCLICommandRouterTests {
         }
         let allDecoded = try decoder.decode([ReviewCommentWireDTO].self, from: Data(allLine.utf8))
         #expect(Set(allDecoded.map(\.id)) == ["mine", "resolved"])
+    }
+
+    @Test func replyAppendsAgentReplyAndNotifies() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        try store.save(makeDraftComment(id: "c1", worktreeID: "wt1"))
+        var changed = 0
+
+        let router = makeReviewRouter(worktree: worktree, store: store, onChange: { changed += 1 })
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.reply(commentID: "c1", body: "on it"))
+        ))
+
+        #expect(response == .ok)
+        #expect(changed == 1)
+        let comment = try #require(try store.find(commentID: "c1"))
+        #expect(comment.allReplies.count == 1)
+        #expect(comment.allReplies[0].bodyMarkdown == "on it")
+        #expect(comment.allReplies[0].author.isAgent)
+    }
+
+    @Test func resolveSetsStateProvenanceAndAddressesHandoffs() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let store = ReviewDraftCommentStore(url: dir.appendingPathComponent("drafts.json"))
+        let sessionStore = ReviewSessionStore(url: dir.appendingPathComponent("sessions.json"))
+        let comment = makeDraftComment(id: "c1", worktreeID: "wt1")
+        try store.save(comment)
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        try sessionStore.save(ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            status: .sent,
+            handoffs: [ReviewFeedbackHandoff(
+                id: "h1",
+                sessionID: target.id,
+                commentIDs: ["c1"],
+                target: .newChat(agentID: "claude", title: "New chat"),
+                createdAt: Date(timeIntervalSince1970: 1),
+                promptRevision: "rev",
+                status: .sent
+            )],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        ))
+
+        let router = makeReviewRouter(worktree: worktree, store: store, sessionStore: sessionStore)
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.resolve(commentID: "c1", reply: "fixed in abc123", reopen: false))
+        ))
+
+        #expect(response == .ok)
+        let updated = try #require(try store.find(commentID: "c1"))
+        #expect(updated.state == .resolved)
+        #expect(updated.resolvedBy?.isAgent == true)
+        #expect(updated.allReplies.map(\.bodyMarkdown) == ["fixed in abc123"])
+        let record = try #require(try sessionStore.load(id: target.id))
+        #expect(record.status == .addressed)
+        #expect(record.handoffs.map(\.status) == [.addressed])
+    }
+
+    @Test func mutationsRejectCommentsFromOtherWorktrees() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        try store.save(makeDraftComment(id: "foreign", worktreeID: "wt2"))
+
+        let router = makeReviewRouter(worktree: worktree, store: store)
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.resolve(commentID: "foreign", reply: nil, reopen: false))
+        ))
+
+        guard case .error(let message) = response else {
+            Issue.record("expected error, got \(response)")
+            return
+        }
+        #expect(message.contains("unknown review comment id"))
     }
 
     private static func router(

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -539,6 +539,90 @@ struct AlasCLICommandRouterTests {
         #expect(opened?.target == "123")
     }
 
+    private func makeDraftComment(
+        id: String,
+        worktreeID: String,
+        state: ReviewDraftCommentState = .active
+    ) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: id,
+            sessionID: .localChanges(
+                worktreeID: worktreeID,
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "review", path: "a.swift"),
+            path: "a.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 5,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "look at this",
+            state: state,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+    }
+
+    private func makeReviewRouter(
+        worktree: Worktree,
+        store: ReviewDraftCommentStore
+    ) -> AlasCLICommandRouter {
+        AlasCLICommandRouter(
+            sessionWorktreeId: { $0 == "s1" ? worktree.id : nil },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in },
+            openExternalFile: { _, _ in },
+            draftCommentStore: { store },
+            activateApp: {}
+        )
+    }
+
+    @Test func listsActiveReviewCommentsForTheOriginWorktree() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        try store.save(makeDraftComment(id: "mine", worktreeID: "wt1"))
+        try store.save(makeDraftComment(id: "resolved", worktreeID: "wt1", state: .resolved))
+        try store.save(makeDraftComment(id: "other", worktreeID: "wt2"))
+
+        let router = makeReviewRouter(worktree: worktree, store: store)
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.comments(sessionID: nil, state: .active))
+        ))
+
+        guard case .text(let lines) = response, let line = lines.first else {
+            Issue.record("expected .text response, got \(response)")
+            return
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let decoded = try decoder.decode([ReviewCommentWireDTO].self, from: Data(line.utf8))
+        #expect(decoded.map(\.id) == ["mine"])
+        #expect(decoded[0].author.kind == "user")
+        #expect(decoded[0].state == "active")
+
+        let all = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.comments(sessionID: nil, state: .all))
+        ))
+        guard case .text(let allLines) = all, let allLine = allLines.first else {
+            Issue.record("expected .text response")
+            return
+        }
+        let allDecoded = try decoder.decode([ReviewCommentWireDTO].self, from: Data(allLine.utf8))
+        #expect(Set(allDecoded.map(\.id)) == ["mine", "resolved"])
+    }
+
     private static func router(
         origin: Worktree,
         visibleWorktrees: [Worktree],

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -670,6 +670,37 @@ struct AlasCLICommandRouterTests {
         #expect(saved[0].startLine == 4)
     }
 
+    @Test func commentAddRejectsSessionIDFromAnotherWorktree() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        let foreignSession = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt2", worktreePath: URL(fileURLWithPath: "/other-repo"), scope: .all
+        )
+
+        let router = makeReviewRouter(worktree: worktree, store: store)
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "a.swift", startLine: 4, endLine: nil, side: nil, body: "sneaky",
+                sessionID: foreignSession.rawValue
+            ))
+        ))
+
+        guard case .error(let message) = response else {
+            Issue.record("expected error, got \(response)")
+            return
+        }
+        #expect(message.contains("unknown review session id"))
+        #expect(try store.load(sessionID: foreignSession).isEmpty)
+    }
+
     @Test func reviewLocalReturnsItsSessionID() async throws {
         let root = try makeFile("repo/a.swift").deletingLastPathComponent()
         let worktree = Worktree(

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -149,6 +149,24 @@ struct AlasCLIRequestTests {
         }
     }
 
+    @Test func decodesReviewReplyAndResolve() throws {
+        let reply = #"{"v":1,"kind":"cli","command":"review_reply","session_id":"s1","params":{"comment_id":"c1","body":"done"}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(reply.utf8)).command == .review(.reply(commentID: "c1", body: "done")))
+
+        let resolve = #"{"v":1,"kind":"cli","command":"review_resolve","session_id":"s1","params":{"comment_id":"c1"}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(resolve.utf8)).command == .review(.resolve(commentID: "c1", reply: nil, reopen: false)))
+
+        let reopen = #"{"v":1,"kind":"cli","command":"review_resolve","session_id":"s1","params":{"comment_id":"c1","reply":"oops","reopen":true}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(reopen.utf8)).command == .review(.resolve(commentID: "c1", reply: "oops", reopen: true)))
+    }
+
+    @Test func reviewReplyRequiresParams() throws {
+        let json = #"{"v":1,"kind":"cli","command":"review_reply","session_id":"s1"}"#
+        #expect(throws: AlasCLIRequestError.self) {
+            try AlasCLIRequest.decode(from: Data(json.utf8))
+        }
+    }
+
     private struct ProbeParams: Decodable, Equatable {
         var name: String
         var count: Int?

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -167,6 +167,27 @@ struct AlasCLIRequestTests {
         }
     }
 
+    @Test func decodesReviewCommentAdd() throws {
+        let json = #"{"v":1,"kind":"cli","command":"review_comment_add","session_id":"s1","params":{"path":"a.swift","start_line":3,"end_line":5,"side":"new","body":"tighten"}}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request.command == .review(.commentAdd(
+            path: "a.swift", startLine: 3, endLine: 5, side: "new", body: "tighten", sessionID: nil
+        )))
+    }
+
+    @Test func rejectsInvalidReviewCommentAdd() throws {
+        for bad in [
+            #"{"v":1,"kind":"cli","command":"review_comment_add","session_id":"s1","params":{"path":"a.swift","start_line":0,"body":"x"}}"#,
+            #"{"v":1,"kind":"cli","command":"review_comment_add","session_id":"s1","params":{"path":"a.swift","start_line":5,"end_line":3,"body":"x"}}"#,
+            #"{"v":1,"kind":"cli","command":"review_comment_add","session_id":"s1","params":{"path":"a.swift","start_line":3,"side":"sideways","body":"x"}}"#,
+            #"{"v":1,"kind":"cli","command":"review_comment_add","session_id":"s1"}"#,
+        ] {
+            #expect(throws: AlasCLIRequestError.self, "should reject: \(bad)") {
+                try AlasCLIRequest.decode(from: Data(bad.utf8))
+            }
+        }
+    }
+
     private struct ProbeParams: Decodable, Equatable {
         var name: String
         var count: Int?

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -131,4 +131,30 @@ struct AlasCLIRequestTests {
         #expect(encoded.contains(#""ok":true"#))
         #expect(encoded.contains(#""lines":["a","b"]"#))
     }
+
+    private struct ProbeParams: Decodable, Equatable {
+        var name: String
+        var count: Int?
+    }
+
+    @Test func decodesTypedParamsEnvelope() throws {
+        let json = #"{"v":1,"kind":"cli","command":"x","session_id":"s1","params":{"name":"a","count":2}}"#
+        let params = try AlasCLIRequest.decodeParams(ProbeParams.self, from: Data(json.utf8))
+        #expect(params == ProbeParams(name: "a", count: 2))
+    }
+
+    @Test func missingParamsIsNilForOptionalDecodeAndThrowsForRequired() throws {
+        let json = #"{"v":1,"kind":"cli","command":"x","session_id":"s1"}"#
+        #expect(try AlasCLIRequest.decodeParamsIfPresent(ProbeParams.self, from: Data(json.utf8)) == nil)
+        #expect(throws: AlasCLIRequestError.malformed) {
+            try AlasCLIRequest.decodeParams(ProbeParams.self, from: Data(json.utf8))
+        }
+    }
+
+    @Test func mistypedParamsThrowsMalformed() throws {
+        let json = #"{"v":1,"kind":"cli","command":"x","session_id":"s1","params":{"name":5}}"#
+        #expect(throws: AlasCLIRequestError.malformed) {
+            try AlasCLIRequest.decodeParamsIfPresent(ProbeParams.self, from: Data(json.utf8))
+        }
+    }
 }

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -132,6 +132,23 @@ struct AlasCLIRequestTests {
         #expect(encoded.contains(#""lines":["a","b"]"#))
     }
 
+    @Test func decodesReviewCommentsWithAndWithoutParams() throws {
+        let bare = #"{"v":1,"kind":"cli","command":"review_comments","session_id":"s1"}"#
+        let bareRequest = try AlasCLIRequest.decode(from: Data(bare.utf8))
+        #expect(bareRequest.command == .review(.comments(sessionID: nil, state: .active)))
+
+        let full = #"{"v":1,"kind":"cli","command":"review_comments","session_id":"s1","params":{"session_id":"rsid","state":"all"}}"#
+        let fullRequest = try AlasCLIRequest.decode(from: Data(full.utf8))
+        #expect(fullRequest.command == .review(.comments(sessionID: "rsid", state: .all)))
+    }
+
+    @Test func rejectsUnknownReviewCommentsState() throws {
+        let json = #"{"v":1,"kind":"cli","command":"review_comments","session_id":"s1","params":{"state":"bogus"}}"#
+        #expect(throws: AlasCLIRequestError.self) {
+            try AlasCLIRequest.decode(from: Data(json.utf8))
+        }
+    }
+
     private struct ProbeParams: Decodable, Equatable {
         var name: String
         var count: Int?

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -481,7 +481,15 @@ struct AppStateCLIRoutingTests {
         let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in worktree.id })
         let response = await router.handle(.init(version: 1, sessionId: "s1", cwd: nil, command: .review(.localChanges)))
 
-        #expect(response == .ok)
+        guard case .text(let lines) = response, lines.count == 2 else {
+            Issue.record("expected two-line text response, got \(response)")
+            return
+        }
+        let expectedSession = ReviewDraftSessionID.localChanges(
+            worktreeID: worktree.id, worktreePath: worktree.path, scope: .all
+        )
+        let object = try JSONSerialization.jsonObject(with: Data(lines[1].utf8)) as? [String: String]
+        #expect(object?["session_id"] == expectedSession.rawValue)
         #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
             if case .reviewChanges = $0 { return true }
             return false
@@ -503,7 +511,15 @@ struct AppStateCLIRoutingTests {
         let router = state.makeCLICommandRouter(sessionWorktreeLookup: { _ in main.id })
         let response = await router.handle(.init(version: 1, sessionId: "s1", cwd: nil, command: .review(.localChanges)))
 
-        #expect(response == .ok)
+        guard case .text(let lines) = response, lines.count == 2 else {
+            Issue.record("expected two-line text response, got \(response)")
+            return
+        }
+        let expectedSession = ReviewDraftSessionID.localChanges(
+            worktreeID: main.id, worktreePath: main.path, scope: .all
+        )
+        let object = try JSONSerialization.jsonObject(with: Data(lines[1].utf8)) as? [String: String]
+        #expect(object?["session_id"] == expectedSession.rawValue)
         #expect(state.selectedWorktreeId == main.id)
         #expect(state.tabs.tabs(forWorktree: main.id).contains {
             if case .reviewChanges = $0 { return true }

--- a/AlasTests/ReviewDraftCommentAgentModelTests.swift
+++ b/AlasTests/ReviewDraftCommentAgentModelTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Review draft comment agent model")
+struct ReviewDraftCommentAgentModelTests {
+    private func tempStoreURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-draft-comments.json")
+    }
+
+    private func makeComment(
+        id: String = "c1",
+        worktreeID: String = "wt-1",
+        author: ReviewDraftCommentAuthor? = nil
+    ) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: id,
+            sessionID: .localChanges(
+                worktreeID: worktreeID,
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "review", path: "Sources/A.swift"),
+            path: "Sources/A.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 10,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "Fix this",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1),
+            author: author
+        )
+    }
+
+    /// The exact shape ReviewDraftComment persisted before author/replies/
+    /// resolvedBy existed. Decoding it must succeed with user defaults.
+    private struct LegacyComment: Encodable {
+        var id: String
+        var sessionID: ReviewDraftSessionID
+        var fileID: DiffReviewFileID
+        var path: String
+        var side: DiffReviewInlineFeedbackSide
+        var startLine: Int
+        var bodyMarkdown: String
+        var state: ReviewDraftCommentState
+        var createdAt: Date
+        var updatedAt: Date
+    }
+
+    @Test func legacyCommentDecodesWithUserAuthorAndNoReplies() throws {
+        let legacy = LegacyComment(
+            id: "old-1",
+            sessionID: .localChanges(
+                worktreeID: "wt-1",
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "review", path: "a.swift"),
+            path: "a.swift",
+            side: .new,
+            startLine: 3,
+            bodyMarkdown: "hi",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let data = try JSONEncoder().encode(legacy)
+        let decoded = try JSONDecoder().decode(ReviewDraftComment.self, from: data)
+        #expect(decoded.effectiveAuthor == .user)
+        #expect(decoded.allReplies.isEmpty)
+        #expect(decoded.resolvedBy == nil)
+    }
+
+    @Test func agentFieldsRoundTripThroughTheStore() throws {
+        let store = ReviewDraftCommentStore(url: tempStoreURL())
+        var comment = makeComment(author: .agent(name: "Reviewer"))
+        comment.replies = [
+            ReviewCommentReply(
+                id: "r1",
+                author: .agent(name: "Reviewer"),
+                bodyMarkdown: "done",
+                createdAt: Date(timeIntervalSince1970: 2)
+            )
+        ]
+        comment.resolvedBy = .agent(name: "Reviewer")
+
+        try store.save(comment)
+
+        let loaded = try store.load(sessionID: comment.sessionID)
+        #expect(loaded == [comment])
+        #expect(loaded[0].effectiveAuthor == .agent(name: "Reviewer"))
+    }
+
+    @Test func sessionIDWorktreeScopingMatchesOnlyItsWorktree() {
+        let id = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        #expect(id.isFor(worktreeID: "wt-1"))
+        #expect(!id.isFor(worktreeID: "wt-2"))
+        #expect(!id.isFor(worktreeID: "wt"))
+    }
+
+    @Test func loadAllAndFindSpanSessions() throws {
+        let store = ReviewDraftCommentStore(url: tempStoreURL())
+        let a = makeComment(id: "a", worktreeID: "wt-1")
+        let b = makeComment(id: "b", worktreeID: "wt-2")
+        try store.save(a)
+        try store.save(b)
+
+        #expect(try store.loadAll().count == 2)
+        #expect(try store.find(commentID: "b")?.id == "b")
+        #expect(try store.find(commentID: "zzz") == nil)
+    }
+
+    @Test func authorDisplayHelpers() {
+        #expect(ReviewDraftCommentAuthor.user.isAgent == false)
+        #expect(ReviewDraftCommentAuthor.agent(name: "Claude").isAgent)
+        #expect(ReviewDraftCommentAuthor.user.displayName == "You")
+        #expect(ReviewDraftCommentAuthor.agent(name: "Claude").displayName == "Claude")
+        #expect(ReviewDraftCommentAuthor.agent(name: "").displayName == "Agent")
+    }
+}

--- a/AlasTests/ReviewFeedbackBundleTests.swift
+++ b/AlasTests/ReviewFeedbackBundleTests.swift
@@ -52,8 +52,8 @@ struct ReviewFeedbackBundleTests {
         let aHeader = try #require(prompt.range(of: "## Sources/A.swift")?.lowerBound)
         let bHeader = try #require(prompt.range(of: "## Sources/B.swift")?.lowerBound)
         #expect(aHeader < bHeader)
-        #expect(prompt.contains("- `Sources/A.swift:2 (new)` — Extract helper."))
-        #expect(prompt.contains("- `Sources/B.swift:9 (new)` — Rename this."))
+        #expect(prompt.contains("- `Sources/A.swift:2 (new)` [comment-id: a] — Extract helper."))
+        #expect(prompt.contains("- `Sources/B.swift:9 (new)` [comment-id: b] — Rename this."))
         #expect(!prompt.contains("Resolved body."))
     }
 
@@ -124,8 +124,8 @@ struct ReviewFeedbackBundleTests {
 
         #expect(prompt.contains("## Sources/App.swift [staged]"))
         #expect(prompt.contains("## Sources/App.swift [unstaged]"))
-        #expect(prompt.contains("- `Sources/App.swift:4 (new, staged)` — Fix the staged edit."))
-        #expect(prompt.contains("- `Sources/App.swift:4 (new, unstaged)` — Fix the working tree edit."))
+        #expect(prompt.contains("- `Sources/App.swift:4 (new, staged)` [comment-id: staged] — Fix the staged edit."))
+        #expect(prompt.contains("- `Sources/App.swift:4 (new, unstaged)` [comment-id: unstaged] — Fix the working tree edit."))
     }
 
     @Test func promptPreservesMultilineMarkdownBodies() {
@@ -233,6 +233,38 @@ struct ReviewFeedbackBundleTests {
         #expect(prompt.contains("Review session: commit deadbeef"))
         #expect(prompt.contains("Revision: deadbeef"))
         #expect(prompt.contains("Previously sent to Codex"))
+    }
+
+    @Test func promptCarriesCommentIDsAndResolveInstruction() {
+        let comment = ReviewDraftComment(
+            id: "cid-42",
+            sessionID: .localChanges(
+                worktreeID: "wt-1",
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "review", path: "a.swift"),
+            path: "a.swift",
+            originalPath: nil,
+            side: .new,
+            startLine: 5,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "tighten this",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let bundle = ReviewFeedbackBundle(
+            target: ReviewFeedbackTarget(title: "Review", sourceDescription: "Local changes"),
+            comments: [comment]
+        )
+
+        let prompt = bundle.promptMarkdown()
+
+        #expect(prompt.contains("[comment-id: cid-42]"))
+        #expect(prompt.contains("review_resolve"))
+        #expect(prompt.contains("review_reply"))
     }
 
     private func comment(

--- a/AlasTests/ReviewHandoffProgressTests.swift
+++ b/AlasTests/ReviewHandoffProgressTests.swift
@@ -82,4 +82,57 @@ struct ReviewHandoffProgressTests {
         let record = makeRecord(handoffs: [], status: .active)
         #expect(ReviewHandoffProgress.recomputingAddressed(record: record, isResolved: { _ in true }, now: Date()) == nil)
     }
+
+    @Test func reopeningACommentDemotesAnAddressedHandoffAndSession() throws {
+        let record = makeRecord(
+            handoffs: [makeHandoff(id: "h1", commentIDs: ["c1"], status: .addressed)],
+            status: .addressed
+        )
+        let now = Date(timeIntervalSince1970: 99)
+
+        let updated = ReviewHandoffProgress.recomputingAddressed(
+            record: record,
+            isResolved: { _ in false },
+            now: now
+        )
+
+        #expect(updated?.handoffs.map(\.status) == [.sent])
+        #expect(updated?.status == .sent)
+        #expect(updated?.updatedAt == now)
+    }
+
+    @Test func reopeningLeavesAnArchivedSessionsOwnStatusAlone() throws {
+        let record = makeRecord(
+            handoffs: [makeHandoff(id: "h1", commentIDs: ["c1"], status: .addressed)],
+            status: .archived
+        )
+
+        let updated = ReviewHandoffProgress.recomputingAddressed(
+            record: record,
+            isResolved: { _ in false },
+            now: Date(timeIntervalSince1970: 99)
+        )
+
+        #expect(updated?.handoffs.map(\.status) == [.sent])
+        #expect(updated?.status == .archived)
+    }
+
+    @Test func reopeningOneOfTwoAddressedHandoffsDemotesTheSessionButNotItsSibling() throws {
+        let record = makeRecord(
+            handoffs: [
+                makeHandoff(id: "h1", commentIDs: ["c1"], status: .addressed),
+                makeHandoff(id: "h2", commentIDs: ["c2"], status: .addressed),
+            ],
+            status: .addressed
+        )
+
+        let updated = ReviewHandoffProgress.recomputingAddressed(
+            record: record,
+            isResolved: { $0 == "c2" },
+            now: Date(timeIntervalSince1970: 99)
+        )
+
+        #expect(updated?.handoffs.map(\.status) == [.sent, .addressed])
+        #expect(updated?.status == .sent)
+    }
 }

--- a/AlasTests/ReviewHandoffProgressTests.swift
+++ b/AlasTests/ReviewHandoffProgressTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Review handoff progress")
+struct ReviewHandoffProgressTests {
+    private func makeRecord(handoffs: [ReviewFeedbackHandoff], status: ReviewSessionStatus) -> ReviewSessionRecord {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        return ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            status: status,
+            handoffs: handoffs,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+    }
+
+    private func makeHandoff(id: String, commentIDs: [String], status: ReviewFeedbackHandoffStatus = .sent) -> ReviewFeedbackHandoff {
+        ReviewFeedbackHandoff(
+            id: id,
+            sessionID: ReviewSessionID(rawValue: "session"),
+            commentIDs: commentIDs,
+            target: .newChat(agentID: "claude", title: "New chat"),
+            createdAt: Date(timeIntervalSince1970: 1),
+            promptRevision: "rev",
+            status: status
+        )
+    }
+
+    @Test func marksHandoffAndSessionAddressedWhenAllCommentsResolve() throws {
+        let record = makeRecord(handoffs: [makeHandoff(id: "h1", commentIDs: ["c1", "c2"])], status: .sent)
+        let now = Date(timeIntervalSince1970: 99)
+
+        let updated = ReviewHandoffProgress.recomputingAddressed(
+            record: record,
+            isResolved: { _ in true },
+            now: now
+        )
+
+        #expect(updated?.handoffs.map(\.status) == [.addressed])
+        #expect(updated?.status == .addressed)
+        #expect(updated?.updatedAt == now)
+    }
+
+    @Test func leavesPartiallyResolvedHandoffsAlone() throws {
+        let record = makeRecord(handoffs: [makeHandoff(id: "h1", commentIDs: ["c1", "c2"])], status: .sent)
+
+        let updated = ReviewHandoffProgress.recomputingAddressed(
+            record: record,
+            isResolved: { $0 == "c1" },
+            now: Date(timeIntervalSince1970: 99)
+        )
+
+        #expect(updated == nil)
+    }
+
+    @Test func sessionStaysSentWhileAnotherHandoffIsOpen() throws {
+        let record = makeRecord(
+            handoffs: [
+                makeHandoff(id: "h1", commentIDs: ["c1"]),
+                makeHandoff(id: "h2", commentIDs: ["c2"]),
+            ],
+            status: .sent
+        )
+
+        let updated = ReviewHandoffProgress.recomputingAddressed(
+            record: record,
+            isResolved: { $0 == "c1" },
+            now: Date(timeIntervalSince1970: 99)
+        )
+
+        #expect(updated?.handoffs.map(\.status) == [.addressed, .sent])
+        #expect(updated?.status == .sent)
+    }
+
+    @Test func recordsWithNoHandoffsNeverChange() throws {
+        let record = makeRecord(handoffs: [], status: .active)
+        #expect(ReviewHandoffProgress.recomputingAddressed(record: record, isResolved: { _ in true }, now: Date()) == nil)
+    }
+}

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -1311,6 +1311,67 @@ struct ReviewSessionTabViewTests {
         #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-focused-thread-1", in: host) != nil)
     }
 
+    @Test func externalCommentChangeReloadsTheSessionRecordNotJustDraftComments() throws {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let initialRecord = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-external-reload-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let sessionStore = ReviewSessionStore(url: directory.appendingPathComponent("sessions.json"))
+
+        // Simulate what an external `review_resolve` already wrote to disk
+        // (e.g. a handoff/session flipped to addressed) before this tab
+        // reacts to the change notification.
+        var externallyUpdatedRecord = initialRecord
+        externallyUpdatedRecord.lastSendError = "external change reached the disk"
+        try sessionStore.save(externallyUpdatedRecord)
+
+        let loaded = ReviewSessionLoadedContext(
+            session: DiffReviewLoadedSession(
+                files: [Self.file(path: "A.swift", namespace: "unstaged")],
+                summary: DiffReviewSessionModel(files: [Self.summary(path: "A.swift", namespace: "unstaged")], groupsEnabled: true)
+            ),
+            feedbackTarget: ReviewFeedbackTarget(
+                title: target.title,
+                repositoryPath: "/repo",
+                providerDescription: nil,
+                sourceDescription: target.sourceDescription
+            ),
+            providerContext: nil
+        )
+        let request = Self.reviewRequest(provider: .github)
+        let view = ReviewSessionTabView.testView(
+            record: initialRecord,
+            loaded: loaded,
+            sessionStore: sessionStore,
+            provider: FakeProviderReviewMutator(
+                kind: .github,
+                result: ProviderReviewPublishResult(published: [], failed: [], refreshedRequest: request, warnings: [])
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let host = NSHostingView(rootView: view.frame(width: 900, height: 700))
+        host.layoutSubtreeIfNeeded()
+        #expect(!recursiveDescription(host).contains("external change reached the disk"))
+
+        NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        host.layoutSubtreeIfNeeded()
+
+        #expect(recursiveDescription(host).contains("external change reached the disk"))
+    }
+
     @Test func providerFeedbackMatcherPrefersExactOldSidePathWhenOriginalPathIsMissing() {
         let modified = DiffReviewFileSummary(
             path: "Sources/App.swift",


### PR DESCRIPTION
## Summary

Phase 1 of the MCP toolset expansion (#787): the built-in `alas` CLI/MCP server gains a generic `params` wire envelope, then four review-comment tools built on it; closes #788, closes #789, closes #790, closes #791.

- `review_comments` — list review comments in the worktree's review pane (or a given session), filterable by state
- `review_reply` — reply to a comment thread
- `review_resolve` — resolve or reopen a comment, optionally posting a reply first, with provenance (`resolvedBy`)
- `review_comment_add` — file a new agent-authored comment; `review` now returns the session id so agents can chain into it
- `ReviewDraftComment` gains `author`/`replies`/`resolvedBy`, decoding legacy on-disk comments unchanged; agent-authored comments and resolutions are badged in the review UI
- External mutations post a notification so open review panes refresh live
- Review-feedback handoff prompts now reference `[comment-id: ...]` and instruct agents to call `review_resolve`; a handoff/session auto-flips to `addressed` once every comment it references is resolved

Every task went through an individual spec-compliance + code-quality review, plus a final whole-branch pass that caught and fixed one cross-worktree scoping gap (`review_comments` didn't enforce worktree ownership when an explicit `session_id` was supplied — now fixed and covered by a test).

## Test plan

- [x] `cd AlasCLI && cargo test` — 76/76 passing
- [x] `xcodebuild ... -quiet build` — clean
- [x] Focused Swift suites (`AlasCLIRequestTests`, `AlasCLICommandRouterTests`, `ReviewDraftCommentAgentModelTests`, `ReviewHandoffProgressTests`, `ReviewFeedbackBundleTests`, `ReviewSessionStoreTests`, `ReviewSessionTabViewTests`, `ReviewChangesTabViewTests`, `AppStateCLIRoutingTests`) — 158/158 passing
- [ ] Manual smoke: `alas review` / `alas review comments` / `alas review reply` / `alas review resolve` / `alas review comment` against a running dev build