### PR TITLE
feat(diff): Activate selected review feedback target

### DIFF
--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -266,6 +266,7 @@ struct DiffReviewFileSection: View {
                 copyFeedback.show("Copied prompt")
             },
             publishProvider: draftCommentActions.publishProvider,
+            agent: draftCommentActions.agent,
             agentTargets: draftCommentActions.agentTargets,
             sendToAgent: draftCommentActions.sendToAgent
         )
@@ -1913,16 +1914,20 @@ struct ReviewDraftCommentCard: View {
                 let existingTargets = targets.filter { !$0.isNewChat }
                 let newChatTargets = targets.filter { $0.isNewChat }
                 ForEach(existingTargets) { target in
-                    Button(target.title) {
+                    Button {
                         actions.sendToAgent(feedbackBundle, target)
+                    } label: {
+                        sendToAgentTargetLabel(target)
                     }
                 }
                 if !existingTargets.isEmpty, !newChatTargets.isEmpty {
                     Divider()
                 }
                 ForEach(newChatTargets) { target in
-                    Button(target.title) {
+                    Button {
                         actions.sendToAgent(feedbackBundle, target)
+                    } label: {
+                        sendToAgentTargetLabel(target)
                     }
                 }
             }
@@ -1934,6 +1939,18 @@ struct ReviewDraftCommentCard: View {
             actionButton(id: "send", title: "Send", enabled: isEnabled) {
                 guard let target = targets.first else { return }
                 actions.sendToAgent(feedbackBundle, target)
+            }
+        }
+    }
+
+    private func sendToAgentTargetLabel(_ target: ReviewFeedbackAgentTarget) -> some View {
+        Label {
+            Text(target.title)
+        } icon: {
+            if let agent = actions.agent(target) {
+                Image(nsImage: AgentLogoView.menuImage(for: agent, size: 14))
+            } else {
+                Image(systemName: "sparkle")
             }
         }
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentActions.swift
@@ -50,6 +50,7 @@ struct ReviewDraftCommentActions {
     var copyPrompt: (ReviewFeedbackBundle) -> Void
     var publishProvider: (ReviewDraftComment) -> Void
     var publishReview: () -> Void
+    var agent: (ReviewFeedbackAgentTarget) -> AgentDefinition?
     var agentTargets: () -> [ReviewFeedbackAgentTarget]
     var sendToAgent: (ReviewFeedbackBundle, ReviewFeedbackAgentTarget) -> Void
 
@@ -63,6 +64,7 @@ struct ReviewDraftCommentActions {
         copyPrompt: @escaping (ReviewFeedbackBundle) -> Void = { _ in },
         publishProvider: @escaping (ReviewDraftComment) -> Void = { _ in },
         publishReview: @escaping () -> Void = {},
+        agent: @escaping (ReviewFeedbackAgentTarget) -> AgentDefinition? = { _ in nil },
         agentTargets: @escaping () -> [ReviewFeedbackAgentTarget] = { [] },
         sendToAgent: @escaping (ReviewFeedbackBundle, ReviewFeedbackAgentTarget) -> Void = { _, _ in }
     ) {
@@ -75,6 +77,7 @@ struct ReviewDraftCommentActions {
         self.copyPrompt = copyPrompt
         self.publishProvider = publishProvider
         self.publishReview = publishReview
+        self.agent = agent
         self.agentTargets = agentTargets
         self.sendToAgent = sendToAgent
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -350,16 +350,20 @@ struct ReviewDraftSummaryRail: View {
                 let existingTargets = agentTargets.filter { !$0.isNewChat }
                 let newChatTargets = agentTargets.filter { $0.isNewChat }
                 ForEach(existingTargets) { target in
-                    Button(target.title) {
+                    Button {
                         draftCommentActions.sendToAgent(bundle, target)
+                    } label: {
+                        sendToAgentTargetLabel(target)
                     }
                 }
                 if !existingTargets.isEmpty, !newChatTargets.isEmpty {
                     Divider()
                 }
                 ForEach(newChatTargets) { target in
-                    Button(target.title) {
+                    Button {
                         draftCommentActions.sendToAgent(bundle, target)
+                    } label: {
+                        sendToAgentTargetLabel(target)
                     }
                 }
             } label: {
@@ -390,16 +394,20 @@ struct ReviewDraftSummaryRail: View {
                 let existingTargets = agentTargets.filter { !$0.isNewChat }
                 let newChatTargets = agentTargets.filter { $0.isNewChat }
                 ForEach(existingTargets) { target in
-                    Button(target.title) {
+                    Button {
                         draftCommentActions.sendToAgent(bundle, target)
+                    } label: {
+                        sendToAgentTargetLabel(target)
                     }
                 }
                 if !existingTargets.isEmpty, !newChatTargets.isEmpty {
                     Divider()
                 }
                 ForEach(newChatTargets) { target in
-                    Button(target.title) {
+                    Button {
                         draftCommentActions.sendToAgent(bundle, target)
+                    } label: {
+                        sendToAgentTargetLabel(target)
                     }
                 }
             } label: {
@@ -432,6 +440,18 @@ struct ReviewDraftSummaryRail: View {
                     draftCommentActions.sendToAgent(bundle, target)
                 }
             )
+        }
+    }
+
+    private func sendToAgentTargetLabel(_ target: ReviewFeedbackAgentTarget) -> some View {
+        Label {
+            Text(target.title)
+        } icon: {
+            if let agent = draftCommentActions.agent(target) {
+                Image(nsImage: AgentLogoView.menuImage(for: agent, size: 14))
+            } else {
+                Image(systemName: "sparkle")
+            }
         }
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -37,6 +37,7 @@ enum ReviewFeedbackAgentTarget: Codable, Equatable, Hashable, Identifiable, Send
 struct ReviewFeedbackAgentSender {
     var availableTargets: () -> [ReviewFeedbackAgentTarget]
     var send: (String, ReviewFeedbackAgentTarget, @escaping @MainActor (Result<Void, Error>) -> Void) -> Void
+    var agent: (ReviewFeedbackAgentTarget) -> AgentDefinition? = { _ in nil }
 
     static func production(appState: AppState, worktreeID: String) -> ReviewFeedbackAgentSender {
         ReviewFeedbackAgentSender(
@@ -45,13 +46,13 @@ struct ReviewFeedbackAgentSender {
 
                 let sessionTargets = appState.tabs.tabs(forWorktree: worktreeID).compactMap { tab -> ReviewFeedbackAgentTarget? in
                     guard case .acpSession(let state) = tab,
-                          appState.session(for: state.sessionId) != nil,
+                          let session = appState.session(for: state.sessionId),
                           appState.isWriter(for: state.sessionId)
                     else { return nil }
                     return .existingSession(
                         worktreeID: worktreeID,
                         sessionID: state.sessionId,
-                        title: state.title.isEmpty ? "Existing chat" : state.title
+                        title: state.title.isEmpty ? appState.agent(id: session.agentId)?.displayName ?? "Existing chat" : state.title
                     )
                 }
                 targets.append(contentsOf: sessionTargets)
@@ -65,17 +66,48 @@ struct ReviewFeedbackAgentSender {
             send: { prompt, target, completion in
                 switch target {
                 case .newChat(let agentID, _):
+                    if let resolved = Self.projectAndWorktree(appState: appState, worktreeID: worktreeID) {
+                        appState.focusGlobalWorktree(id: resolved.worktree.id, projectId: resolved.project.id)
+                    }
                     appState.openNewACPSession(agentID: agentID, initialPrompt: prompt)
                     completion(.success(()))
-                case .existingSession(_, let sessionID, _):
+                case .existingSession(let targetWorktreeID, let sessionID, _):
+                    if let resolved = Self.projectAndWorktree(appState: appState, worktreeID: targetWorktreeID) {
+                        appState.activateHarnessSession(
+                            projectId: resolved.project.id,
+                            worktreeId: targetWorktreeID,
+                            sessionId: sessionID
+                        )
+                    }
                     Task { @MainActor in
                         await appState.sendPrompt(for: sessionID, text: prompt, attachments: []) { accepted in
                             completion(accepted ? .success(()) : .failure(ReviewFeedbackAgentSendError.rejected))
                         }
                     }
                 }
+            },
+            agent: { target in
+                switch target {
+                case .newChat(let agentID, _):
+                    return appState.agent(id: agentID)
+                case .existingSession(_, let sessionID, _):
+                    guard let session = appState.session(for: sessionID) else { return nil }
+                    return appState.agent(id: session.agentId)
+                }
             }
         )
+    }
+
+    private static func projectAndWorktree(
+        appState: AppState,
+        worktreeID: String
+    ) -> (project: ProjectConfig, worktree: Worktree)? {
+        for project in appState.projectsManager.projects {
+            if let worktree = appState.projectsManager.worktrees(projectId: project.id).first(where: { $0.id == worktreeID }) {
+                return (project, worktree)
+            }
+        }
+        return nil
     }
 }
 
@@ -195,6 +227,9 @@ enum ReviewDraftWorkspaceActions {
             },
             copyPrompt: { bundle in
                 ReviewFeedbackPromptActions.copyPrompt(bundle, pasteboard: pasteboard)
+            },
+            agent: { target in
+                sender.agent(target)
             },
             agentTargets: {
                 sender.availableTargets()

--- a/AlasTests/ReviewLoopHandoffRoutingTests.swift
+++ b/AlasTests/ReviewLoopHandoffRoutingTests.swift
@@ -205,6 +205,28 @@ struct ReviewLoopHandoffRoutingTests {
         #expect(sessionFor(tab: newTab, in: state)?.composerDraft == ACPComposerDraft(segments: [.text("Review feedback")]))
     }
 
+    @Test func reviewFeedbackSendActivatesSelectedExistingACPChat() throws {
+        let state = makeState()
+        state.openNewACPSession(agentID: "test-agent")
+        let first = try #require(acpTabs(in: state).first)
+        state.openNewACPSession(agentID: "other-agent")
+        let second = try #require(acpTabs(in: state).last)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        state.tabs.activate(worktreeId: worktreeId, tabId: first.id)
+
+        let sender = ReviewFeedbackAgentSender.production(appState: state, worktreeID: worktreeId)
+        let target = ReviewFeedbackAgentTarget.existingSession(
+            worktreeID: worktreeId,
+            sessionID: second.sessionId,
+            title: "Other Agent"
+        )
+
+        sender.send("Review feedback", target) { _ in }
+
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == second.id)
+        #expect(sender.agent(target)?.id == "other-agent")
+    }
+
     private func makeState() -> AppState {
         let project = ProjectConfig(
             id: UUID().uuidString,


### PR DESCRIPTION
## Summary

- Activate the selected ACP tab when review feedback is sent to an existing chat.
- Focus the review worktree before creating a new ACP chat from feedback.
- Show agent icons in the review feedback send-target menus.
- Add regression coverage for selecting an existing feedback target.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewLoopHandoffRoutingTests -quiet test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -skip-testing:AlasTests/SSHIntegrationTests test`

Note: the unfiltered full test command fails locally because `SSHIntegrationTests` require `ALAS_SSH_INTEGRATION=1`.