### PR TITLE
fix(diff): align split diff feedback lanes

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -725,6 +725,7 @@
 		962361DC40B0707AB7CA6E75 /* session-update-tool-call-update-no-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 30BAC172C16C360F917B6EED /* session-update-tool-call-update-no-meta.json */; };
 		9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */; };
 		9627D6EAF83AA4B66FE09361 /* ProjectIconImageStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */; };
+		9632444ADF742653917F387D /* DiffFeedbackLane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F03EE87AC76203E09C9F1C5 /* DiffFeedbackLane.swift */; };
 		9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */; };
 		965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */; };
 		9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */; };
@@ -1191,6 +1192,7 @@
 		EE02460865C6A4ED1046B13F /* AgentLifecycleEventMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */; };
 		EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE09B83A747269494B206F23 /* UpdateThrottle.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
+		EEB1E9992AB101D398909EFA /* DiffFeedbackLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4128039056F417E483AB4DC /* DiffFeedbackLaneTests.swift */; };
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		EF276F4856AA2E82C2ECDC7E /* CodeHostModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C5E43E973803E6FD1528C /* CodeHostModels.swift */; };
@@ -1676,6 +1678,7 @@
 		4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeJSONRPCTransport.swift; sourceTree = "<group>"; };
 		4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffBuilderTests.swift; sourceTree = "<group>"; };
 		4EDBC153EAE419F270EFF948 /* ACPRemoteNodeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteNodeEnvironmentTests.swift; sourceTree = "<group>"; };
+		4F03EE87AC76203E09C9F1C5 /* DiffFeedbackLane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffFeedbackLane.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
 		4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabsManagerTests.swift; sourceTree = "<group>"; };
 		4FE58EF9CF8EC461667D9430 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
@@ -2383,6 +2386,7 @@
 		E373805AEFD068B97BC33A82 /* StashDiffTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashDiffTabView.swift; sourceTree = "<group>"; };
 		E3C49F11F34AA97B21936FC1 /* ACPElicitationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitationCoordinator.swift; sourceTree = "<group>"; };
 		E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileStatsTests.swift; sourceTree = "<group>"; };
+		E4128039056F417E483AB4DC /* DiffFeedbackLaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffFeedbackLaneTests.swift; sourceTree = "<group>"; };
 		E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderViewTests.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
 		E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPicker.swift; sourceTree = "<group>"; };
@@ -2769,6 +2773,7 @@
 				2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */,
 				6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */,
 				283613E170E25F69521F64ED /* DiffDisplaySignatureTests.swift */,
+				E4128039056F417E483AB4DC /* DiffFeedbackLaneTests.swift */,
 				729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */,
 				61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
@@ -3630,6 +3635,7 @@
 				CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */,
 				00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */,
 				5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */,
+				4F03EE87AC76203E09C9F1C5 /* DiffFeedbackLane.swift */,
 				22CF502ECFD2763E52CB022F /* DiffInlineCommentModel.swift */,
 				6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */,
 				B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */,
@@ -5221,6 +5227,7 @@
 				A630ABCDF04C36956349606C /* DiffDisplayModel.swift in Sources */,
 				E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */,
 				3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */,
+				9632444ADF742653917F387D /* DiffFeedbackLane.swift in Sources */,
 				BDEA5736B570C77CF4C965F5 /* DiffInlineAnnotationCard.swift in Sources */,
 				850D54DB270088190BA20A13 /* DiffInlineCommentCard.swift in Sources */,
 				94B884D1DB09DB562A0DCC20 /* DiffInlineCommentModel.swift in Sources */,
@@ -5868,6 +5875,7 @@
 				9DDA9F2462746F06A652973A /* DiffContextExpansionTests.swift in Sources */,
 				899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */,
 				9B00878F781FADB428684B2D /* DiffDisplaySignatureTests.swift in Sources */,
+				EEB1E9992AB101D398909EFA /* DiffFeedbackLaneTests.swift in Sources */,
 				FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */,
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,

--- a/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
+++ b/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
@@ -1,0 +1,44 @@
+enum DiffFeedbackLane: Equatable, Sendable {
+    case left
+    case right
+    case full
+}
+
+enum DiffFeedbackLaneResolver {
+    static func lane(for anchor: DiffReviewLineAnchor) -> DiffFeedbackLane {
+        let changedSides = Set(anchor.selectedLines.lazy.filter(\.isChange).map(\.side))
+
+        if changedSides.contains(.new) {
+            return .right
+        }
+        if changedSides.contains(.old) {
+            return .left
+        }
+        return lane(for: anchor.side)
+    }
+
+    static func lane(for comment: ReviewDraftComment) -> DiffFeedbackLane {
+        lane(for: comment.side)
+    }
+
+    static func lane(for feedback: DiffReviewInlineFeedback) -> DiffFeedbackLane {
+        lane(for: feedback.anchor.side)
+    }
+
+    static func lane(for thread: DiffInlineCommentThread) -> DiffFeedbackLane {
+        thread.isOldSide ? .left : .right
+    }
+
+    static func lane(for annotation: DiffInlineAnnotation) -> DiffFeedbackLane {
+        lane(for: DiffReviewInlineFeedbackSide.new)
+    }
+
+    static func lane(for side: DiffReviewInlineFeedbackSide) -> DiffFeedbackLane {
+        switch side {
+        case .old:
+            .left
+        case .new, .unknown:
+            .right
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
+++ b/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
@@ -1,3 +1,6 @@
+import AppKit
+import SwiftUI
+
 enum DiffFeedbackLane: String, Equatable, Hashable, Sendable {
     case left
     case right
@@ -40,5 +43,177 @@ enum DiffFeedbackLaneResolver {
         case .new, .unknown:
             .right
         }
+    }
+}
+
+enum DiffPaneLineNumberGutterGeometry {
+    static let minimumThickness: CGFloat = 42
+    static let horizontalPadding: CGFloat = 8
+    static var labelFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
+    }
+
+    static func thickness(labels: [String]) -> CGFloat {
+        let maxDigits = labels
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: "+- ")) }
+            .map(\.count)
+            .max() ?? 1
+        let sample = String(repeating: "8", count: max(maxDigits, 1)) as NSString
+        let width = ceil(sample.size(withAttributes: [.font: labelFont]).width)
+        return max(minimumThickness, width + horizontalPadding * 2)
+    }
+}
+
+enum DiffFeedbackLineLabels {
+    static func labels(
+        for rows: [DiffDisplayRow],
+        layoutMode: DiffLayoutMode,
+        lane: DiffFeedbackLane
+    ) -> [String] {
+        switch layoutMode {
+        case .split:
+            switch lane {
+            case .left:
+                rows.compactMap { $0.old?.lineNumber.map(String.init) }
+            case .right, .full:
+                rows.compactMap { $0.new?.lineNumber.map(String.init) }
+            }
+        case .stacked:
+            DiffPaneRowProjection.stackedLines(for: rows).compactMap {
+                $0.line.lineNumber.map(String.init)
+            }
+        }
+    }
+}
+
+enum DiffFeedbackLaneGeometry {
+    static let dividerWidth: CGFloat = 1
+
+    static func contentFrame(
+        containerWidth: CGFloat,
+        layoutMode: DiffLayoutMode,
+        lane: DiffFeedbackLane,
+        gutterWidth: CGFloat
+    ) -> CGRect {
+        let width = max(containerWidth, 0)
+        guard layoutMode == .split else {
+            let inset = min(max(gutterWidth, 0), width)
+            return CGRect(x: inset, y: 0, width: width - inset, height: 0)
+        }
+
+        let oldWidth = floor(max(width - dividerWidth, 0) / 2)
+        let newOrigin = oldWidth + min(dividerWidth, width)
+        let newWidth = max(width - newOrigin, 0)
+        if lane == .left {
+            let inset = min(max(gutterWidth, 0), oldWidth)
+            return CGRect(x: inset, y: 0, width: oldWidth - inset, height: 0)
+        }
+
+        let inset = min(max(gutterWidth, 0), newWidth)
+        return CGRect(x: newOrigin + inset, y: 0, width: newWidth - inset, height: 0)
+    }
+}
+
+private struct DiffFeedbackLaneLayout: Layout {
+    let layoutMode: DiffLayoutMode
+    let lane: DiffFeedbackLane
+    let gutterWidth: CGFloat
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        guard let subview = subviews.first else { return .zero }
+        let width = proposal.width ?? 0
+        let frame = DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: width,
+            layoutMode: layoutMode,
+            lane: lane,
+            gutterWidth: gutterWidth
+        )
+        let contentSize = subview.sizeThatFits(.init(width: frame.width, height: proposal.height))
+        return CGSize(width: width, height: contentSize.height)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        guard let subview = subviews.first else { return }
+        let frame = DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: bounds.width,
+            layoutMode: layoutMode,
+            lane: lane,
+            gutterWidth: gutterWidth
+        )
+        subview.place(
+            at: CGPoint(x: bounds.minX + frame.minX, y: bounds.minY),
+            anchor: .topLeading,
+            proposal: .init(width: frame.width, height: proposal.height)
+        )
+    }
+}
+
+struct DiffFeedbackLaneView<Content: View>: View {
+    let lane: DiffFeedbackLane
+    let layoutMode: DiffLayoutMode
+    let rows: [DiffDisplayRow]
+    private let content: Content
+
+    @Environment(\.theme) private var theme
+
+    init(
+        lane: DiffFeedbackLane,
+        layoutMode: DiffLayoutMode,
+        rows: [DiffDisplayRow],
+        @ViewBuilder content: () -> Content
+    ) {
+        self.lane = lane
+        self.layoutMode = layoutMode
+        self.rows = rows
+        self.content = content()
+    }
+
+    private var effectiveLane: DiffFeedbackLane {
+        layoutMode == .stacked ? .full : lane
+    }
+
+    var body: some View {
+        let labels = DiffFeedbackLineLabels.labels(for: rows, layoutMode: layoutMode, lane: lane)
+        let gutterWidth = DiffPaneLineNumberGutterGeometry.thickness(labels: labels)
+
+        DiffFeedbackLaneLayout(
+            layoutMode: layoutMode,
+            lane: effectiveLane,
+            gutterWidth: gutterWidth
+        ) {
+            content
+        }
+        .frame(maxWidth: .infinity)
+        .overlay {
+            if layoutMode == .split {
+                Rectangle()
+                    .fill(theme.color("line"))
+                    .frame(width: DiffFeedbackLaneGeometry.dividerWidth)
+            }
+        }
+        .background(DiffFeedbackLaneAccessibilityMarker(lane: effectiveLane))
+    }
+}
+
+private struct DiffFeedbackLaneAccessibilityMarker: NSViewRepresentable {
+    let lane: DiffFeedbackLane
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.setAccessibilityIdentifier("diff-feedback-lane-\(lane.rawValue)")
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        nsView.setAccessibilityIdentifier("diff-feedback-lane-\(lane.rawValue)")
     }
 }

--- a/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
+++ b/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
@@ -1,4 +1,4 @@
-enum DiffFeedbackLane: Equatable, Sendable {
+enum DiffFeedbackLane: String, Equatable, Hashable, Sendable {
     case left
     case right
     case full

--- a/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
+++ b/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
@@ -46,6 +46,7 @@ enum DiffFeedbackLaneResolver {
     }
 }
 
+@MainActor
 enum DiffPaneLineNumberGutterGeometry {
     static let minimumThickness: CGFloat = 42
     static let horizontalPadding: CGFloat = 8
@@ -61,6 +62,30 @@ enum DiffPaneLineNumberGutterGeometry {
         let sample = String(repeating: "8", count: max(maxDigits, 1)) as NSString
         let width = ceil(sample.size(withAttributes: [.font: labelFont]).width)
         return max(minimumThickness, width + horizontalPadding * 2)
+    }
+}
+
+struct DiffPaneSplitFrames: Equatable {
+    let oldPane: CGRect
+    let divider: CGRect
+    let newPane: CGRect
+}
+
+enum DiffPaneSplitGeometry {
+    static let dividerWidth: CGFloat = 1
+
+    static func frames(containerWidth: CGFloat) -> DiffPaneSplitFrames {
+        let width = max(containerWidth, 0)
+        let dividerExtent = min(dividerWidth, width)
+        let oldWidth = floor(max(width - dividerExtent, 0) / 2)
+        let newOrigin = oldWidth + dividerExtent
+        let newWidth = max(width - newOrigin, 0)
+
+        return DiffPaneSplitFrames(
+            oldPane: CGRect(x: 0, y: 0, width: oldWidth, height: 0),
+            divider: CGRect(x: oldWidth, y: 0, width: dividerExtent, height: 0),
+            newPane: CGRect(x: newOrigin, y: 0, width: newWidth, height: 0)
+        )
     }
 }
 
@@ -87,7 +112,7 @@ enum DiffFeedbackLineLabels {
 }
 
 enum DiffFeedbackLaneGeometry {
-    static let dividerWidth: CGFloat = 1
+    static let dividerWidth = DiffPaneSplitGeometry.dividerWidth
 
     static func contentFrame(
         containerWidth: CGFloat,
@@ -101,16 +126,39 @@ enum DiffFeedbackLaneGeometry {
             return CGRect(x: inset, y: 0, width: width - inset, height: 0)
         }
 
-        let oldWidth = floor(max(width - dividerWidth, 0) / 2)
-        let newOrigin = oldWidth + min(dividerWidth, width)
-        let newWidth = max(width - newOrigin, 0)
+        let splitFrames = DiffPaneSplitGeometry.frames(containerWidth: width)
         if lane == .left {
-            let inset = min(max(gutterWidth, 0), oldWidth)
-            return CGRect(x: inset, y: 0, width: oldWidth - inset, height: 0)
+            let inset = min(max(gutterWidth, 0), splitFrames.oldPane.width)
+            return CGRect(
+                x: splitFrames.oldPane.minX + inset,
+                y: 0,
+                width: splitFrames.oldPane.width - inset,
+                height: 0
+            )
         }
 
-        let inset = min(max(gutterWidth, 0), newWidth)
-        return CGRect(x: newOrigin + inset, y: 0, width: newWidth - inset, height: 0)
+        let inset = min(max(gutterWidth, 0), splitFrames.newPane.width)
+        return CGRect(
+            x: splitFrames.newPane.minX + inset,
+            y: 0,
+            width: splitFrames.newPane.width - inset,
+            height: 0
+        )
+    }
+
+    static func idealContainerWidth(
+        contentWidth: CGFloat,
+        layoutMode: DiffLayoutMode,
+        gutterWidth: CGFloat
+    ) -> CGFloat {
+        let contentWidth = max(contentWidth, 0)
+        let gutterWidth = max(gutterWidth, 0)
+        switch layoutMode {
+        case .split:
+            return (contentWidth + gutterWidth) * 2 + dividerWidth
+        case .stacked:
+            return contentWidth + gutterWidth
+        }
     }
 }
 
@@ -124,8 +172,14 @@ private struct DiffFeedbackLaneLayout: Layout {
         subviews: Subviews,
         cache: inout ()
     ) -> CGSize {
-        guard let subview = subviews.first else { return .zero }
-        let width = proposal.width ?? 0
+        guard let subview = subviews.first else {
+            return CGSize(width: proposal.width ?? 0, height: proposal.height ?? 0)
+        }
+        let width = proposal.width.map { max($0, 0) } ?? DiffFeedbackLaneGeometry.idealContainerWidth(
+            contentWidth: subview.sizeThatFits(.unspecified).width,
+            layoutMode: layoutMode,
+            gutterWidth: gutterWidth
+        )
         let frame = DiffFeedbackLaneGeometry.contentFrame(
             containerWidth: width,
             layoutMode: layoutMode,
@@ -190,30 +244,45 @@ struct DiffFeedbackLaneView<Content: View>: View {
             lane: effectiveLane,
             gutterWidth: gutterWidth
         ) {
-            content
-        }
-        .frame(maxWidth: .infinity)
-        .overlay {
-            if layoutMode == .split {
-                Rectangle()
-                    .fill(theme.color("line"))
-                    .frame(width: DiffFeedbackLaneGeometry.dividerWidth)
+            VStack(spacing: 0) {
+                content
             }
         }
-        .background(DiffFeedbackLaneAccessibilityMarker(lane: effectiveLane))
+        .frame(maxWidth: .infinity)
+        .overlay(alignment: .topLeading) {
+            if layoutMode == .split {
+                GeometryReader { geometry in
+                    let divider = DiffPaneSplitGeometry.frames(
+                        containerWidth: geometry.size.width
+                    ).divider
+
+                    Rectangle()
+                        .fill(theme.color("line"))
+                        .frame(width: divider.width, height: geometry.size.height)
+                        .background(DiffFeedbackAccessibilityMarker(
+                            identifier: "diff-feedback-divider"
+                        ))
+                        .offset(x: divider.minX)
+                }
+                .allowsHitTesting(false)
+            }
+        }
+        .background(DiffFeedbackAccessibilityMarker(
+            identifier: "diff-feedback-lane-\(effectiveLane.rawValue)"
+        ))
     }
 }
 
-private struct DiffFeedbackLaneAccessibilityMarker: NSViewRepresentable {
-    let lane: DiffFeedbackLane
+private struct DiffFeedbackAccessibilityMarker: NSViewRepresentable {
+    let identifier: String
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
-        view.setAccessibilityIdentifier("diff-feedback-lane-\(lane.rawValue)")
+        view.setAccessibilityIdentifier(identifier)
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        nsView.setAccessibilityIdentifier("diff-feedback-lane-\(lane.rawValue)")
+        nsView.setAccessibilityIdentifier(identifier)
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1814,16 +1814,13 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     private var cachedGeometry: RulerGeometry?
     private var rowGeometryComputationCount = 0
 
-    private let minimumThickness: CGFloat = 42
-    private let horizontalPadding: CGFloat = 8
-
     var rowGeometryComputationCountForTesting: Int {
         rowGeometryComputationCount
     }
 
     init(scrollView: NSScrollView) {
         super.init(scrollView: scrollView, orientation: .verticalRuler)
-        ruleThickness = minimumThickness
+        ruleThickness = DiffPaneLineNumberGutterGeometry.minimumThickness
         reservedThicknessForMarkers = 0
         reservedThicknessForAccessoryView = 0
         observe(scrollView: scrollView)
@@ -1988,11 +1985,16 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             guard !label.isEmpty else { continue }
             let sourceLabelRect = labelRects.indices.contains(index)
                 ? labelRects[index]
-                : NSRect(x: 0, y: sourceRowRect.minY, width: ruleThickness - horizontalPadding, height: textHeight)
+                : NSRect(
+                    x: 0,
+                    y: sourceRowRect.minY,
+                    width: ruleThickness - DiffPaneLineNumberGutterGeometry.horizontalPadding,
+                    height: textHeight
+                )
             let drawRect = NSRect(
                 x: sourceLabelRect.minX,
                 y: sourceLabelRect.minY - visible.minY,
-                width: ruleThickness - horizontalPadding,
+                width: ruleThickness - DiffPaneLineNumberGutterGeometry.horizontalPadding,
                 height: textHeight
             )
             NSString(string: label).draw(in: drawRect, withAttributes: labelAttributes(for: label, row: index))
@@ -2077,7 +2079,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             return NSRect(
                 x: 0,
                 y: lineRect.midY - textHeight / 2,
-                width: ruleThickness - horizontalPadding,
+                width: ruleThickness - DiffPaneLineNumberGutterGeometry.horizontalPadding,
                 height: textHeight
             )
         }
@@ -2213,13 +2215,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     }
 
     private func updateThickness() {
-        let maxDigits = labels
-            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: "+- ")) }
-            .map(\.count)
-            .max() ?? 1
-        let sample = String(repeating: "8", count: max(maxDigits, 1)) as NSString
-        let width = ceil(sample.size(withAttributes: labelAttributes(for: "", row: nil)).width)
-        ruleThickness = max(minimumThickness, width + horizontalPadding * 2)
+        ruleThickness = DiffPaneLineNumberGutterGeometry.thickness(labels: labels)
     }
 
     private func labelAttributes(for label: String, row: Int?) -> [NSAttributedString.Key: Any] {
@@ -2239,7 +2235,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             color = .secondaryLabelColor
         }
         return [
-            .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+            .font: DiffPaneLineNumberGutterGeometry.labelFont,
             .foregroundColor: color,
             .paragraphStyle: paragraph,
         ]

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -229,8 +229,6 @@ final class DiffPaneTextDocumentContainerView: NSView {
     private var lastRowsUpdateSignature: RowsUpdateSignature?
     private var pendingIntrinsicContentSizeInvalidation = false
 
-    private let dividerWidth: CGFloat = 1
-
     override var isFlipped: Bool { true }
 
     override var intrinsicContentSize: NSSize {
@@ -388,11 +386,26 @@ final class DiffPaneTextDocumentContainerView: NSView {
     }
 
     private func layoutSplit() {
-        let width = max(bounds.width, 1)
-        let paneWidth = floor((width - dividerWidth) / 2)
-        oldPane.frame = NSRect(x: 0, y: 0, width: paneWidth, height: max(bounds.height, measuredHeight))
-        dividerView.frame = NSRect(x: paneWidth, y: 0, width: dividerWidth, height: max(bounds.height, measuredHeight))
-        newPane.frame = NSRect(x: paneWidth + dividerWidth, y: 0, width: width - paneWidth - dividerWidth, height: max(bounds.height, measuredHeight))
+        let splitFrames = DiffPaneSplitGeometry.frames(containerWidth: bounds.width)
+        let height = max(bounds.height, measuredHeight)
+        oldPane.frame = NSRect(
+            x: splitFrames.oldPane.minX,
+            y: 0,
+            width: splitFrames.oldPane.width,
+            height: height
+        )
+        dividerView.frame = NSRect(
+            x: splitFrames.divider.minX,
+            y: 0,
+            width: splitFrames.divider.width,
+            height: height
+        )
+        newPane.frame = NSRect(
+            x: splitFrames.newPane.minX,
+            y: 0,
+            width: splitFrames.newPane.width,
+            height: height
+        )
 
         oldPane.layoutSubtreeIfNeeded()
         newPane.layoutSubtreeIfNeeded()

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -358,25 +358,37 @@ struct DiffPaneView: View {
                     )
                     .fixedSize(horizontal: false, vertical: true)
                 case .thread(let t):
-                    DiffInlineCommentCard(
-                        thread: t,
-                        onReply: { body in onReply(t, body) },
-                        onStageReply: { body in onStageReply(t, body) },
-                        onResolve: { onResolve(t) },
-                        onUnresolve: { onUnresolve(t) },
-                        onEdit: { comment, newBody in onEdit(t, comment, newBody) },
-                        onDelete: { comment in onDelete(t, comment) },
-                        canReply: canReply && t.viewerCanReply,
-                        canResolve: canResolve && (t.viewerCanResolve || t.viewerCanUnresolve),
-                        canAddToReview: canAddToReview,
-                        onActiveChange: { active in
-                            activeThreadID = active ? t.id : (activeThreadID == t.id ? nil : activeThreadID)
-                        }
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                case .annotation(let a):
-                    DiffInlineAnnotationCard(annotation: a)
+                    DiffFeedbackLaneView(
+                        lane: DiffFeedbackLaneResolver.lane(for: t),
+                        layoutMode: layoutMode,
+                        rows: visibleRows
+                    ) {
+                        DiffInlineCommentCard(
+                            thread: t,
+                            onReply: { body in onReply(t, body) },
+                            onStageReply: { body in onStageReply(t, body) },
+                            onResolve: { onResolve(t) },
+                            onUnresolve: { onUnresolve(t) },
+                            onEdit: { comment, newBody in onEdit(t, comment, newBody) },
+                            onDelete: { comment in onDelete(t, comment) },
+                            canReply: canReply && t.viewerCanReply,
+                            canResolve: canResolve && (t.viewerCanResolve || t.viewerCanUnresolve),
+                            canAddToReview: canAddToReview,
+                            onActiveChange: { active in
+                                activeThreadID = active ? t.id : (activeThreadID == t.id ? nil : activeThreadID)
+                            }
+                        )
                         .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                case .annotation(let a):
+                    DiffFeedbackLaneView(
+                        lane: DiffFeedbackLaneResolver.lane(for: a),
+                        layoutMode: layoutMode,
+                        rows: visibleRows
+                    ) {
+                        DiffInlineAnnotationCard(annotation: a)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
             }
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -296,27 +296,16 @@ struct DiffReviewFileSection: View {
     private func fileLevelDraftCommentStack(renderContext: DiffReviewRenderContext?) -> some View {
         let fileLevel = fileLevelDraftComments(renderContext: renderContext)
         if !fileLevel.isEmpty {
-            draftCommentStack(fileLevel)
+            fullWidthDraftCommentStack(fileLevel)
         }
     }
 
     @ViewBuilder
-    private func draftCommentStack(_ comments: [ReviewDraftComment]) -> some View {
+    private func fullWidthDraftCommentStack(_ comments: [ReviewDraftComment]) -> some View {
         if !comments.isEmpty {
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(comments) { comment in
-                    ReviewDraftCommentCard(
-                        comment: comment,
-                        file: file.summary,
-                        isFocused: comment.id == focusedDraftCommentID,
-                        actions: feedbackDraftCommentActions,
-                        reviewFeedbackTarget: effectiveReviewFeedbackTarget,
-                        onSelect: onSelectDraftComment,
-                        onHoverChange: { isHovered in
-                            hoveredDraftCommentID = isHovered ? comment.id : (hoveredDraftCommentID == comment.id ? nil : hoveredDraftCommentID)
-                        }
-                    )
-                    .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: file.id))
+                    draftCommentCard(comment)
                 }
             }
             .padding(.horizontal, 14)
@@ -324,6 +313,45 @@ struct DiffReviewFileSection: View {
             .background(theme.color("bg-1"))
             .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
         }
+    }
+
+    @ViewBuilder
+    private func draftCommentStack(
+        _ comments: [ReviewDraftComment],
+        rows: [DiffDisplayRow]
+    ) -> some View {
+        if !comments.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(comments) { comment in
+                    DiffFeedbackLaneView(
+                        lane: DiffFeedbackLaneResolver.lane(for: comment),
+                        layoutMode: layoutMode,
+                        rows: rows
+                    ) {
+                        draftCommentCard(comment)
+                            .padding(.horizontal, 14)
+                    }
+                }
+            }
+            .padding(.vertical, 10)
+            .background(theme.color("bg-1"))
+            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        }
+    }
+
+    private func draftCommentCard(_ comment: ReviewDraftComment) -> some View {
+        ReviewDraftCommentCard(
+            comment: comment,
+            file: file.summary,
+            isFocused: comment.id == focusedDraftCommentID,
+            actions: feedbackDraftCommentActions,
+            reviewFeedbackTarget: effectiveReviewFeedbackTarget,
+            onSelect: onSelectDraftComment,
+            onHoverChange: { isHovered in
+                hoveredDraftCommentID = isHovered ? comment.id : (hoveredDraftCommentID == comment.id ? nil : hoveredDraftCommentID)
+            }
+        )
+        .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: file.id))
     }
 
     @ViewBuilder
@@ -335,35 +363,68 @@ struct DiffReviewFileSection: View {
     }
 
     @ViewBuilder
-    private func inlineFeedbackStack(_ items: [DiffReviewInlineFeedback], file: DiffReviewFileSummary) -> some View {
+    private func inlineFeedbackStack(
+        _ items: [DiffReviewInlineFeedback],
+        file: DiffReviewFileSummary,
+        rows: [DiffDisplayRow]? = nil
+    ) -> some View {
         if !items.isEmpty {
             let display = DiffReviewInlineFeedbackDisplayPolicy.display(
                 for: items,
                 includingRequiredIDs: requiredInlineFeedbackIDs
             )
-            VStack(alignment: .leading, spacing: 6) {
-                ForEach(display.visibleItems) { item in
-                    DiffReviewInlineFeedbackCard(
-                        item: item,
-                        file: file,
-                        isFocused: item.id == focusedFeedbackID,
-                        actions: inlineFeedbackActions,
-                        onSelect: onSelectInlineFeedback,
-                        onHoverChange: { isHovered in
-                            hoveredInlineFeedbackID = isHovered ? item.id : (hoveredInlineFeedbackID == item.id ? nil : hoveredInlineFeedbackID)
+            if let rows {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(display.visibleItems) { item in
+                        DiffFeedbackLaneView(
+                            lane: DiffFeedbackLaneResolver.lane(for: item),
+                            layoutMode: layoutMode,
+                            rows: rows
+                        ) {
+                            inlineFeedbackCard(item, file: file)
+                                .padding(.horizontal, 14)
                         }
-                    )
-                    .id(DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: file.id))
+                    }
+                    if display.hiddenCount > 0 {
+                        DiffReviewInlineFeedbackMoreRow(hiddenCount: display.hiddenCount)
+                            .padding(.horizontal, 14)
+                    }
                 }
-                if display.hiddenCount > 0 {
-                    DiffReviewInlineFeedbackMoreRow(hiddenCount: display.hiddenCount)
+                .padding(.vertical, 10)
+                .background(theme.color("bg-1"))
+                .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(display.visibleItems) { item in
+                        inlineFeedbackCard(item, file: file)
+                    }
+                    if display.hiddenCount > 0 {
+                        DiffReviewInlineFeedbackMoreRow(hiddenCount: display.hiddenCount)
+                    }
                 }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(theme.color("bg-1"))
+                .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(theme.color("bg-1"))
-            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
         }
+    }
+
+    private func inlineFeedbackCard(
+        _ item: DiffReviewInlineFeedback,
+        file: DiffReviewFileSummary
+    ) -> some View {
+        DiffReviewInlineFeedbackCard(
+            item: item,
+            file: file,
+            isFocused: item.id == focusedFeedbackID,
+            actions: inlineFeedbackActions,
+            onSelect: onSelectInlineFeedback,
+            onHoverChange: { isHovered in
+                hoveredInlineFeedbackID = isHovered ? item.id : (hoveredInlineFeedbackID == item.id ? nil : hoveredInlineFeedbackID)
+            }
+        )
+        .id(DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: file.id))
     }
 
     private var requiredInlineFeedbackIDs: Set<String> {
@@ -497,7 +558,11 @@ struct DiffReviewFileSection: View {
             VStack(spacing: 0) {
                 ForEach(renderContext.groups) { group in
                     if !group.inlineFeedback.isEmpty {
-                        inlineFeedbackStack(group.inlineFeedback, file: file.summary)
+                        inlineFeedbackStack(
+                            group.inlineFeedback,
+                            file: file.summary,
+                            rows: group.displayGroup.rows
+                        )
                     }
                     reviewGroup(group, displayModel: displayModel)
                 }
@@ -560,33 +625,45 @@ struct DiffReviewFileSection: View {
                                 )
                                 .fixedSize(horizontal: false, vertical: true)
                             case .thread(let thread):
-                                DiffInlineCommentCard(
-                                    thread: thread,
-                                    onReply: { body in onReply(thread, body) },
-                                    onStageReply: { body in onStageReply(thread, body) },
-                                    onResolve: { onResolve(thread) },
-                                    onUnresolve: { onUnresolve(thread) },
-                                    onEdit: { comment, newBody in onEdit(thread, comment, newBody) },
-                                    onDelete: { comment in onDelete(thread, comment) },
-                                    canReply: canReply && thread.viewerCanReply,
-                                    canResolve: canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
-                                    canAddToReview: canAddToReview,
-                                    onActiveChange: { active in
-                                        activeThreadID = active ? thread.id : (activeThreadID == thread.id ? nil : activeThreadID)
-                                    }
-                                )
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            case .annotation(let annotation):
-                                DiffInlineAnnotationCard(annotation: annotation)
+                                DiffFeedbackLaneView(
+                                    lane: DiffFeedbackLaneResolver.lane(for: thread),
+                                    layoutMode: layoutMode,
+                                    rows: segment.rows
+                                ) {
+                                    DiffInlineCommentCard(
+                                        thread: thread,
+                                        onReply: { body in onReply(thread, body) },
+                                        onStageReply: { body in onStageReply(thread, body) },
+                                        onResolve: { onResolve(thread) },
+                                        onUnresolve: { onUnresolve(thread) },
+                                        onEdit: { comment, newBody in onEdit(thread, comment, newBody) },
+                                        onDelete: { comment in onDelete(thread, comment) },
+                                        canReply: canReply && thread.viewerCanReply,
+                                        canResolve: canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
+                                        canAddToReview: canAddToReview,
+                                        onActiveChange: { active in
+                                            activeThreadID = active ? thread.id : (activeThreadID == thread.id ? nil : activeThreadID)
+                                        }
+                                    )
                                     .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                            case .annotation(let annotation):
+                                DiffFeedbackLaneView(
+                                    lane: DiffFeedbackLaneResolver.lane(for: annotation),
+                                    layoutMode: layoutMode,
+                                    rows: segment.rows
+                                ) {
+                                    DiffInlineAnnotationCard(annotation: annotation)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
                             }
                         }
                     }
                     if !segment.draftComments.isEmpty {
-                        draftCommentStack(segment.draftComments)
+                        draftCommentStack(segment.draftComments, rows: segment.rows)
                     }
                     if segment.showsComposer {
-                        draftComposer
+                        draftComposer(rows: segment.rows)
                     }
                 }
             }
@@ -732,11 +809,15 @@ struct DiffReviewFileSection: View {
     }
 
     @ViewBuilder
-    private var draftComposer: some View {
-        if !allowsDraftCommentCreation {
-            EmptyView()
-        } else {
-            draftComposerBody
+    private func draftComposer(rows: [DiffDisplayRow]) -> some View {
+        if allowsDraftCommentCreation, let pendingDraftAnchor {
+            DiffFeedbackLaneView(
+                lane: DiffFeedbackLaneResolver.lane(for: pendingDraftAnchor),
+                layoutMode: layoutMode,
+                rows: rows
+            ) {
+                draftComposerBody
+            }
         }
     }
 

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -697,10 +697,10 @@ struct DiffTabView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     }
                     if !segment.draftComments.isEmpty {
-                        reviewDraftCommentStack(segment.draftComments)
+                        reviewDraftCommentStack(segment.draftComments, rows: segment.rows)
                     }
-                    if segment.showsComposer {
-                        reviewDraftComposer
+                    if segment.showsComposer, let pendingDraftAnchor {
+                        reviewDraftComposer(anchor: pendingDraftAnchor, rows: segment.rows)
                     }
                 }
             }
@@ -807,7 +807,47 @@ struct DiffTabView: View {
         }
     }
 
-    private var reviewDraftComposer: some View {
+    @ViewBuilder
+    private func reviewDraftCommentStack(_ comments: [ReviewDraftComment], rows: [DiffDisplayRow]) -> some View {
+        if !comments.isEmpty {
+            let actions = makeDraftCommentActions()
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(comments) { comment in
+                    DiffFeedbackLaneView(
+                        lane: DiffFeedbackLaneResolver.lane(for: comment),
+                        layoutMode: diffPreferences.layoutMode.wrappedValue,
+                        rows: rows
+                    ) {
+                        ReviewDraftCommentCard(
+                            comment: comment,
+                            file: fileSummary,
+                            isFocused: false,
+                            actions: actions,
+                            reviewFeedbackTarget: reviewFeedbackTarget,
+                            onSelect: { _ in }
+                        )
+                        .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: fileID))
+                        .padding(.horizontal, 14)
+                    }
+                }
+            }
+            .padding(.vertical, 10)
+            .background(theme.color("bg-1"))
+            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        }
+    }
+
+    private func reviewDraftComposer(anchor: DiffReviewLineAnchor, rows: [DiffDisplayRow]) -> some View {
+        DiffFeedbackLaneView(
+            lane: DiffFeedbackLaneResolver.lane(for: anchor),
+            layoutMode: diffPreferences.layoutMode.wrappedValue,
+            rows: rows
+        ) {
+            reviewDraftComposerContent
+        }
+    }
+
+    private var reviewDraftComposerContent: some View {
         VStack(alignment: .leading, spacing: 8) {
             ReviewDraftComposerTextEditor(
                 text: $pendingDraftBody,

--- a/AlasTests/DiffFeedbackLaneTests.swift
+++ b/AlasTests/DiffFeedbackLaneTests.swift
@@ -24,7 +24,7 @@ struct DiffFeedbackLaneTests {
 
     @Test func contextAndDeletedChangedLinesResolveLeft() {
         let anchor = makeAnchor(
-            side: .old,
+            side: .unknown,
             selectedLines: [
                 selectedLine(side: .unknown, line: 11, isChange: false),
                 selectedLine(side: .old, line: 12, isChange: true),
@@ -36,7 +36,7 @@ struct DiffFeedbackLaneTests {
 
     @Test func contextAndAddedChangedLinesResolveRight() {
         let anchor = makeAnchor(
-            side: .new,
+            side: .unknown,
             selectedLines: [
                 selectedLine(side: .unknown, line: 11, isChange: false),
                 selectedLine(side: .new, line: 12, isChange: true),
@@ -91,47 +91,16 @@ struct DiffFeedbackLaneTests {
         #expect(DiffFeedbackLaneResolver.lane(for: DiffReviewInlineFeedbackSide.unknown) == .right)
     }
 
-    @Test func savedDraftUsesItsSemanticSide() {
-        let draft = ReviewDraftComment(
-            id: "draft-1",
-            sessionID: .localChanges(
-                worktreeID: "wt-1",
-                worktreePath: URL(fileURLWithPath: "/repo"),
-                scope: .all
-            ),
-            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
-            path: "Sources/App.swift",
-            originalPath: nil,
-            side: .old,
-            startLine: 12,
-            endLine: nil,
-            selectedText: nil,
-            bodyMarkdown: "Please revisit this.",
-            state: .active,
-            createdAt: Date(timeIntervalSince1970: 1),
-            updatedAt: Date(timeIntervalSince1970: 1)
-        )
-
-        #expect(DiffFeedbackLaneResolver.lane(for: draft) == .left)
+    @Test func savedDraftUsesItsSemanticSideAndDefaultsUnknownRight() {
+        #expect(DiffFeedbackLaneResolver.lane(for: makeDraft(side: .old)) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: makeDraft(side: .new)) == .right)
+        #expect(DiffFeedbackLaneResolver.lane(for: makeDraft(side: .unknown)) == .right)
     }
 
-    @Test func actionableFeedbackUsesItsAnchorSide() {
-        let feedback = DiffReviewInlineFeedback(
-            id: "feedback-1",
-            providerName: "GitHub",
-            author: "reviewer",
-            bodyPreview: "Please revisit this.",
-            status: .actionable,
-            providerURL: nil,
-            anchor: DiffReviewInlineFeedbackAnchor(
-                path: "Sources/App.swift",
-                line: 12,
-                side: .new
-            ),
-            evidenceItemID: "evidence-1"
-        )
-
-        #expect(DiffFeedbackLaneResolver.lane(for: feedback) == .right)
+    @Test func actionableFeedbackUsesItsAnchorSideAndDefaultsUnknownRight() {
+        #expect(DiffFeedbackLaneResolver.lane(for: makeFeedback(side: .old)) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: makeFeedback(side: .new)) == .right)
+        #expect(DiffFeedbackLaneResolver.lane(for: makeFeedback(side: .unknown)) == .right)
     }
 
     @Test func inlineThreadUsesItsProviderSide() {
@@ -161,6 +130,15 @@ struct DiffFeedbackLaneTests {
         #expect(lane == .full)
     }
 
+    @Test func lanesProvideStableRawValuesAndHashabilityForLayoutMarkers() {
+        let lanes: Set<DiffFeedbackLane> = [.left, .right, .full]
+
+        #expect(lanes.count == 3)
+        #expect(DiffFeedbackLane.left.rawValue == "left")
+        #expect(DiffFeedbackLane.right.rawValue == "right")
+        #expect(DiffFeedbackLane.full.rawValue == "full")
+    }
+
     private func makeAnchor(
         side: DiffReviewInlineFeedbackSide,
         selectedLines: [DiffReviewLineAnchor.SelectedLine]
@@ -181,6 +159,45 @@ struct DiffFeedbackLaneTests {
         isChange: Bool
     ) -> DiffReviewLineAnchor.SelectedLine {
         DiffReviewLineAnchor.SelectedLine(side: side, line: line, isChange: isChange)
+    }
+
+    private func makeDraft(side: DiffReviewInlineFeedbackSide) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: "draft-\(side.rawValue)",
+            sessionID: .localChanges(
+                worktreeID: "wt-1",
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: side,
+            startLine: 12,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "Please revisit this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+    }
+
+    private func makeFeedback(side: DiffReviewInlineFeedbackSide) -> DiffReviewInlineFeedback {
+        DiffReviewInlineFeedback(
+            id: "feedback-\(side.rawValue)",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Please revisit this.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(
+                path: "Sources/App.swift",
+                line: 12,
+                side: side
+            ),
+            evidenceItemID: "evidence-\(side.rawValue)"
+        )
     }
 
     private func makeThread(id: String, isOldSide: Bool) -> DiffInlineCommentThread {

--- a/AlasTests/DiffFeedbackLaneTests.swift
+++ b/AlasTests/DiffFeedbackLaneTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Diff feedback lane resolver")
+struct DiffFeedbackLaneTests {
+    @Test func deletedChangedLinesResolveLeft() {
+        let anchor = makeAnchor(
+            side: .old,
+            selectedLines: [selectedLine(side: .old, line: 12, isChange: true)]
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor) == .left)
+    }
+
+    @Test func addedChangedLinesResolveRight() {
+        let anchor = makeAnchor(
+            side: .new,
+            selectedLines: [selectedLine(side: .new, line: 12, isChange: true)]
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor) == .right)
+    }
+
+    @Test func contextAndDeletedChangedLinesResolveLeft() {
+        let anchor = makeAnchor(
+            side: .old,
+            selectedLines: [
+                selectedLine(side: .unknown, line: 11, isChange: false),
+                selectedLine(side: .old, line: 12, isChange: true),
+            ]
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor) == .left)
+    }
+
+    @Test func contextAndAddedChangedLinesResolveRight() {
+        let anchor = makeAnchor(
+            side: .new,
+            selectedLines: [
+                selectedLine(side: .unknown, line: 11, isChange: false),
+                selectedLine(side: .new, line: 12, isChange: true),
+            ]
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor) == .right)
+    }
+
+    @Test func mixedDeletedAndAddedChangedLinesResolveRight() {
+        let anchor = makeAnchor(
+            side: .old,
+            selectedLines: [
+                selectedLine(side: .old, line: 11, isChange: true),
+                selectedLine(side: .new, line: 12, isChange: true),
+            ]
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor) == .right)
+    }
+
+    @Test func contextOnlySelectionResolvesToSelectedOldPane() {
+        let anchor = makeAnchor(
+            side: .old,
+            selectedLines: [selectedLine(side: .unknown, line: 12, isChange: false)]
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor) == .left)
+    }
+
+    @Test func contextOnlySelectionResolvesToSelectedNewPane() {
+        let anchor = makeAnchor(
+            side: .new,
+            selectedLines: [selectedLine(side: .unknown, line: 12, isChange: false)]
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor) == .right)
+    }
+
+    @Test func unknownRawSelectionDefaultsRight() {
+        let anchor = makeAnchor(
+            side: .unknown,
+            selectedLines: [selectedLine(side: .unknown, line: 12, isChange: true)]
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor) == .right)
+    }
+
+    @Test func semanticSideResolvesToMatchingLaneAndDefaultsRight() {
+        #expect(DiffFeedbackLaneResolver.lane(for: DiffReviewInlineFeedbackSide.old) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: DiffReviewInlineFeedbackSide.new) == .right)
+        #expect(DiffFeedbackLaneResolver.lane(for: DiffReviewInlineFeedbackSide.unknown) == .right)
+    }
+
+    @Test func savedDraftUsesItsSemanticSide() {
+        let draft = ReviewDraftComment(
+            id: "draft-1",
+            sessionID: .localChanges(
+                worktreeID: "wt-1",
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: .old,
+            startLine: 12,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "Please revisit this.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: draft) == .left)
+    }
+
+    @Test func actionableFeedbackUsesItsAnchorSide() {
+        let feedback = DiffReviewInlineFeedback(
+            id: "feedback-1",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Please revisit this.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(
+                path: "Sources/App.swift",
+                line: 12,
+                side: .new
+            ),
+            evidenceItemID: "evidence-1"
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: feedback) == .right)
+    }
+
+    @Test func inlineThreadUsesItsProviderSide() {
+        let oldThread = makeThread(id: "thread-old", isOldSide: true)
+        let newThread = makeThread(id: "thread-new", isOldSide: false)
+
+        #expect(DiffFeedbackLaneResolver.lane(for: oldThread) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: newThread) == .right)
+    }
+
+    @Test func annotationResolvesRight() {
+        let annotation = DiffInlineAnnotation(
+            id: "annotation-1",
+            checkName: "SwiftLint",
+            newLine: 12,
+            level: .failure,
+            message: "Line too long",
+            rawDetails: nil
+        )
+
+        #expect(DiffFeedbackLaneResolver.lane(for: annotation) == .right)
+    }
+
+    @Test func fullLaneRemainsAvailableForLayoutCallers() {
+        let lane: DiffFeedbackLane = .full
+
+        #expect(lane == .full)
+    }
+
+    private func makeAnchor(
+        side: DiffReviewInlineFeedbackSide,
+        selectedLines: [DiffReviewLineAnchor.SelectedLine]
+    ) -> DiffReviewLineAnchor {
+        DiffReviewLineAnchor(
+            path: "Sources/App.swift",
+            side: side,
+            line: 12,
+            rowIndex: 3,
+            selectedLines: selectedLines,
+            selectedText: "let value = 1"
+        )
+    }
+
+    private func selectedLine(
+        side: DiffReviewInlineFeedbackSide,
+        line: Int,
+        isChange: Bool
+    ) -> DiffReviewLineAnchor.SelectedLine {
+        DiffReviewLineAnchor.SelectedLine(side: side, line: line, isChange: isChange)
+    }
+
+    private func makeThread(id: String, isOldSide: Bool) -> DiffInlineCommentThread {
+        DiffInlineCommentThread(
+            id: id,
+            filePath: "Sources/App.swift",
+            newLine: 12,
+            isOldSide: isOldSide,
+            isResolved: false,
+            isOutdated: false,
+            comments: [DiffInlineComment(id: "\(id)-comment", author: "reviewer", body: "Please revisit this.")]
+        )
+    }
+}

--- a/AlasTests/DiffFeedbackLaneTests.swift
+++ b/AlasTests/DiffFeedbackLaneTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import Alas
 
 @Suite("Diff feedback lane resolver")
+@MainActor
 struct DiffFeedbackLaneTests {
     @Test func deletedChangedLinesResolveLeft() {
         let anchor = makeAnchor(
@@ -203,6 +204,23 @@ struct DiffFeedbackLaneTests {
                 }
             }
         }
+    }
+
+    @Test func sharedSplitFramesMatchRendererMathAtEvenAndFractionalWidths() {
+        let even = DiffPaneSplitGeometry.frames(containerWidth: 900)
+        #expect(even.oldPane == CGRect(x: 0, y: 0, width: 449, height: 0))
+        #expect(even.divider == CGRect(x: 449, y: 0, width: 1, height: 0))
+        #expect(even.newPane == CGRect(x: 450, y: 0, width: 450, height: 0))
+
+        let fractional = DiffPaneSplitGeometry.frames(containerWidth: 0.5)
+        #expect(fractional.oldPane == .zero)
+        #expect(fractional.divider == CGRect(x: 0, y: 0, width: 0.5, height: 0))
+        #expect(fractional.newPane == CGRect(x: 0.5, y: 0, width: 0, height: 0))
+
+        let zero = DiffPaneSplitGeometry.frames(containerWidth: 0)
+        #expect(zero.oldPane == .zero)
+        #expect(zero.divider == .zero)
+        #expect(zero.newPane == .zero)
     }
 
     private func makeAnchor(

--- a/AlasTests/DiffFeedbackLaneTests.swift
+++ b/AlasTests/DiffFeedbackLaneTests.swift
@@ -139,6 +139,72 @@ struct DiffFeedbackLaneTests {
         #expect(DiffFeedbackLane.full.rawValue == "full")
     }
 
+    @Test func laneFramesMatchTheDiffPaneDividerMath() {
+        #expect(DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: 901,
+            layoutMode: .split,
+            lane: .left,
+            gutterWidth: 42
+        ) == CGRect(x: 42, y: 0, width: 408, height: 0))
+        #expect(DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: 901,
+            layoutMode: .split,
+            lane: .right,
+            gutterWidth: 42
+        ) == CGRect(x: 493, y: 0, width: 408, height: 0))
+        #expect(DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: 901,
+            layoutMode: .stacked,
+            lane: .right,
+            gutterWidth: 42
+        ) == CGRect(x: 42, y: 0, width: 859, height: 0))
+    }
+
+    @Test func gutterThicknessUsesExistingMinimumAndExpandsForWideLabels() {
+        #expect(DiffPaneLineNumberGutterGeometry.thickness(labels: ["1", "22"]) == 42)
+        #expect(DiffPaneLineNumberGutterGeometry.thickness(labels: ["1234567890"]) > 42)
+    }
+
+    @Test func labelProjectionUsesTheActivePane() throws {
+        let model = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [.init(
+                header: "@@ -9,1 +99,1 @@",
+                oldStart: 9,
+                newStart: 99,
+                lines: [
+                    .init(kind: .delete, text: "old", oldNumber: 9, newNumber: nil),
+                    .init(kind: .add, text: "new", oldNumber: nil, newNumber: 99),
+                ]
+            )]),
+            filePath: "Sources/App.swift"
+        )
+        let rows = try #require(model.groups.first?.rows)
+
+        #expect(DiffFeedbackLineLabels.labels(for: rows, layoutMode: .split, lane: .left) == ["9"])
+        #expect(DiffFeedbackLineLabels.labels(for: rows, layoutMode: .split, lane: .right) == ["99"])
+        #expect(DiffFeedbackLineLabels.labels(for: rows, layoutMode: .split, lane: .full) == ["99"])
+        #expect(DiffFeedbackLineLabels.labels(for: rows, layoutMode: .stacked, lane: .right) == ["9", "99"])
+    }
+
+    @Test func laneFramesRemainNonnegativeAtNarrowAndZeroWidths() {
+        for width: CGFloat in [0, 0.5, 1, 41, 42, 84] {
+            for layoutMode in DiffLayoutMode.allCases {
+                for lane in [DiffFeedbackLane.left, .right, .full] {
+                    let frame = DiffFeedbackLaneGeometry.contentFrame(
+                        containerWidth: width,
+                        layoutMode: layoutMode,
+                        lane: lane,
+                        gutterWidth: 42
+                    )
+
+                    #expect(frame.minX >= 0)
+                    #expect(frame.width >= 0)
+                    #expect(frame.maxX <= max(width, 0))
+                }
+            }
+        }
+    }
+
     private func makeAnchor(
         side: DiffReviewInlineFeedbackSide,
         selectedLines: [DiffReviewLineAnchor.SelectedLine]

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -320,6 +320,85 @@ struct DiffPaneViewTests {
         #expect(controller.view.subviews.isEmpty == false)
     }
 
+    @Test func providerAccessoriesUseSemanticLanesAndStackedFullWidth() throws {
+        let thread = DiffInlineCommentThread(
+            id: "thread-old",
+            filePath: "a.swift",
+            newLine: 2,
+            isOldSide: true,
+            isResolved: false,
+            isOutdated: false,
+            comments: [
+                DiffInlineComment(id: "comment-old", author: "reviewer", body: "Old-side feedback"),
+            ]
+        )
+        let annotation = DiffInlineAnnotation(
+            id: "annotation-new",
+            checkName: "SwiftLint",
+            newLine: 2,
+            level: .warning,
+            message: "New-side annotation",
+            rawDetails: nil
+        )
+        var splitLayout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let splitView = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { splitLayout }, set: { splitLayout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsToolbar: false,
+            verticalScrollMode: .staticHeight,
+            threads: [thread],
+            annotations: [annotation],
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let splitController = NSHostingController(rootView: splitView)
+        splitController.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
+        splitController.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-feedback-lane-left",
+            in: splitController.view
+        ) != nil)
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-feedback-lane-right",
+            in: splitController.view
+        ) != nil)
+
+        var stackedLayout = DiffLayoutMode.stacked
+        let stackedView = DiffPaneView(
+            model: model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { stackedLayout }, set: { stackedLayout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsToolbar: false,
+            verticalScrollMode: .staticHeight,
+            threads: [thread],
+            annotations: [annotation],
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let stackedController = NSHostingController(rootView: stackedView)
+        stackedController.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
+        stackedController.view.layoutSubtreeIfNeeded()
+
+        let fullLaneMarkers = allSubviews(of: stackedController.view).filter {
+            $0.accessibilityIdentifier() == "diff-feedback-lane-full"
+        }
+        #expect(fullLaneMarkers.count == 2)
+    }
+
     @Test func defaultModeShowsDiffToolbar() {
         var layout = DiffLayoutMode.split
         var wrap = false

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -162,6 +162,107 @@ struct DiffPaneViewTests {
         #expect(context.group(id: group.id)?.segments == expectedSegments.items)
     }
 
+    @Test func diffTabDraftAccessoriesResolveSemanticLanesAndSegmentGeometry() throws {
+        let model = DiffDisplayModelBuilder.build(diff: parsedDiff(), filePath: "Sources/App.swift")
+        let group = try #require(model.groups.first)
+        let fileID = DiffReviewFileID(namespace: "diff-tab", path: "Sources/App.swift")
+        let comment = reviewDraftComment(id: "draft-new-lane", fileID: fileID)
+        let pendingAnchor = DiffReviewLineAnchor(
+            path: "Sources/App.swift",
+            side: .old,
+            line: 2,
+            rowIndex: 1,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .old, line: 2, isChange: true),
+            ],
+            selectedText: "let b = 2"
+        )
+        let context = DiffTabRenderContextBuilder.build(
+            model: model,
+            comments: [comment],
+            pendingDraftAnchor: pendingAnchor
+        )
+        let segment = try #require(context.group(id: group.id)?.segments.first {
+            !$0.draftComments.isEmpty || $0.showsComposer
+        })
+
+        #expect(DiffFeedbackLaneResolver.lane(for: comment) == .right)
+        #expect(DiffFeedbackLaneResolver.lane(for: pendingAnchor) == .left)
+        #expect(segment.rows.isEmpty == false)
+
+        let splitFrame = DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: 900,
+            layoutMode: .split,
+            lane: .left,
+            gutterWidth: 42
+        )
+        let stackedFrame = DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: 900,
+            layoutMode: .stacked,
+            lane: .left,
+            gutterWidth: 42
+        )
+        #expect(splitFrame.width == 407)
+        #expect(stackedFrame.width == 858)
+    }
+
+    @Test func pendingDraftComposerLaneUsesAnchorResolverInSplitAndStackedLayouts() throws {
+        let rows = try #require(model().groups.first?.rows)
+        let pendingAnchor = DiffReviewLineAnchor(
+            path: "Sources/App.swift",
+            side: .old,
+            line: 2,
+            rowIndex: 1,
+            selectedLines: [
+                DiffReviewLineAnchor.SelectedLine(side: .old, line: 2, isChange: true),
+            ],
+            selectedText: "let b = 2"
+        )
+        let splitController = NSHostingController(rootView:
+            DiffFeedbackLaneView(
+                lane: DiffFeedbackLaneResolver.lane(for: pendingAnchor),
+                layoutMode: .split,
+                rows: rows
+            ) {
+                FrameProbe(identifier: "diff-review-draft-composer")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 64)
+            }
+            .environment(\.theme, theme())
+        )
+        splitController.view.frame = NSRect(x: 0, y: 0, width: 900, height: 80)
+        splitController.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-feedback-lane-left",
+            in: splitController.view
+        ) != nil)
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-review-draft-composer",
+            in: splitController.view
+        ) != nil)
+
+        let stackedController = NSHostingController(rootView:
+            DiffFeedbackLaneView(
+                lane: DiffFeedbackLaneResolver.lane(for: pendingAnchor),
+                layoutMode: .stacked,
+                rows: rows
+            ) {
+                FrameProbe(identifier: "diff-review-draft-composer")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 64)
+            }
+            .environment(\.theme, theme())
+        )
+        stackedController.view.frame = NSRect(x: 0, y: 0, width: 900, height: 80)
+        stackedController.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-feedback-lane-full",
+            in: stackedController.view
+        ) != nil)
+    }
+
     @MainActor
     @Test func diffTabRenderContextCacheReusesMatchingKeyAndEvictsPastLimit() throws {
         let model = DiffDisplayModelBuilder.build(diff: parsedDiff(), filePath: "Sources/App.swift")

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1320,21 +1320,54 @@ let second = true
         #expect(scrollView.contentView.frame.minX >= rulerWidth - 0.5)
     }
 
-    @Test func feedbackLaneWrapperExposesItsEffectiveLaneForAccessibility() throws {
+    @Test func feedbackLaneWrapperRetainsFullWidthAndHostsMultipleChildren() throws {
         let rows = try #require(model().groups.first?.rows)
         let splitController = NSHostingController(rootView:
             DiffFeedbackLaneView(lane: .left, layoutMode: .split, rows: rows) {
-                Color.clear.frame(height: 20)
+                FrameProbe(identifier: "feedback-child-first")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 10)
+                FrameProbe(identifier: "feedback-child-second")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 20)
             }
             .environment(\.theme, theme())
         )
-        splitController.view.frame = NSRect(x: 0, y: 0, width: 901, height: 20)
+        splitController.view.frame = NSRect(x: 0, y: 0, width: 900, height: 60)
         splitController.view.layoutSubtreeIfNeeded()
 
-        #expect(subview(
+        let laneMarker = try #require(subview(
             withAccessibilityIdentifier: "diff-feedback-lane-left",
             in: splitController.view
-        ) != nil)
+        ))
+        let dividerMarker = try #require(subview(
+            withAccessibilityIdentifier: "diff-feedback-divider",
+            in: splitController.view
+        ))
+        let firstChild = try #require(subview(
+            withAccessibilityIdentifier: "feedback-child-first",
+            in: splitController.view
+        ))
+        let secondChild = try #require(subview(
+            withAccessibilityIdentifier: "feedback-child-second",
+            in: splitController.view
+        ))
+        let laneFrame = laneMarker.convert(laneMarker.bounds, to: splitController.view)
+        let dividerFrame = dividerMarker.convert(dividerMarker.bounds, to: splitController.view)
+        let firstFrame = firstChild.convert(firstChild.bounds, to: splitController.view)
+        let secondFrame = secondChild.convert(secondChild.bounds, to: splitController.view)
+
+        #expect(abs(laneFrame.minX) < 0.01)
+        #expect(abs(laneFrame.width - 900) < 0.01)
+        #expect(abs(dividerFrame.minX - 449) < 0.01)
+        #expect(abs(dividerFrame.width - 1) < 0.01)
+        #expect(abs(firstFrame.minX - 42) < 0.01)
+        #expect(abs(firstFrame.width - 407) < 0.01)
+        #expect(abs(firstFrame.height - 10) < 0.01)
+        #expect(abs(secondFrame.minX - 42) < 0.01)
+        #expect(abs(secondFrame.width - 407) < 0.01)
+        #expect(abs(secondFrame.height - 20) < 0.01)
+        #expect(abs(secondFrame.minY - firstFrame.maxY) < 0.01)
 
         let stackedController = NSHostingController(rootView:
             DiffFeedbackLaneView(lane: .right, layoutMode: .stacked, rows: rows) {
@@ -2661,6 +2694,31 @@ let second = true
         #expect(nsView.intrinsicContentSize.height > 0)
     }
 
+    @Test func containerViewUsesSharedSplitFramesAtEvenAndSubDividerWidths() throws {
+        let nsView = DiffPaneTextDocumentContainerView()
+
+        nsView.setFrameSize(NSSize(width: 900, height: 20))
+        nsView.layout()
+        let oldPane = try #require(nsView.subviews.first)
+        let newPane = try #require(nsView.subviews.dropFirst().first)
+        let divider = try #require(nsView.subviews.last)
+        #expect(oldPane.frame.minX == 0)
+        #expect(oldPane.frame.width == 449)
+        #expect(divider.frame.minX == 449)
+        #expect(divider.frame.width == 1)
+        #expect(newPane.frame.minX == 450)
+        #expect(newPane.frame.width == 450)
+
+        nsView.setFrameSize(NSSize(width: 0.5, height: 20))
+        nsView.layout()
+        #expect(oldPane.frame.minX == 0)
+        #expect(oldPane.frame.width == 0)
+        #expect(divider.frame.minX == 0)
+        #expect(divider.frame.width == 0.5)
+        #expect(newPane.frame.minX == 0.5)
+        #expect(newPane.frame.width == 0)
+    }
+
     @Test func containerViewUpdateRowsProducesPositiveHeightForThreeRows() throws {
         let group = try #require(model().groups.first)
         let rows = Array(group.rows.prefix(3))
@@ -3033,6 +3091,20 @@ let second = true
                 guard needsUpdateConstraints else { return }
                 constraintInvalidationCount += 1
             }
+        }
+    }
+
+    private struct FrameProbe: NSViewRepresentable {
+        let identifier: String
+
+        func makeNSView(context: Context) -> NSView {
+            let view = NSView(frame: .zero)
+            view.setAccessibilityIdentifier(identifier)
+            return view
+        }
+
+        func updateNSView(_ nsView: NSView, context: Context) {
+            nsView.setAccessibilityIdentifier(identifier)
         }
     }
 

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1320,6 +1320,37 @@ let second = true
         #expect(scrollView.contentView.frame.minX >= rulerWidth - 0.5)
     }
 
+    @Test func feedbackLaneWrapperExposesItsEffectiveLaneForAccessibility() throws {
+        let rows = try #require(model().groups.first?.rows)
+        let splitController = NSHostingController(rootView:
+            DiffFeedbackLaneView(lane: .left, layoutMode: .split, rows: rows) {
+                Color.clear.frame(height: 20)
+            }
+            .environment(\.theme, theme())
+        )
+        splitController.view.frame = NSRect(x: 0, y: 0, width: 901, height: 20)
+        splitController.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-feedback-lane-left",
+            in: splitController.view
+        ) != nil)
+
+        let stackedController = NSHostingController(rootView:
+            DiffFeedbackLaneView(lane: .right, layoutMode: .stacked, rows: rows) {
+                Color.clear.frame(height: 20)
+            }
+            .environment(\.theme, theme())
+        )
+        stackedController.view.frame = NSRect(x: 0, y: 0, width: 901, height: 20)
+        stackedController.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-feedback-lane-full",
+            in: stackedController.view
+        ) != nil)
+    }
+
     @Test func diffPreferenceBindingsPersistLayoutAndWrapButKeepWhitespaceLocal() {
         let appState = AppState()
         appState.config.changes.diffLayoutMode = .split

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -1687,6 +1687,61 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "diff-review-draft-comment-draft-cached-inline", in: controller.view) != nil)
     }
 
+    @Test func reviewSurfaceUsesLanesForActionableFeedbackAndDrafts() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App/AlphaView.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil
+        )
+        let feedback = DiffReviewInlineFeedback(
+            id: "old-feedback",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Old-side feedback",
+            status: .actionable,
+            providerURL: nil,
+            anchor: .init(path: file.summary.path, line: 2, side: .old),
+            evidenceItemID: "old-feedback"
+        )
+        let comment = draftComment(
+            id: "new-draft",
+            fileID: file.id,
+            path: file.summary.path,
+            side: .new,
+            startLine: 2
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let makeView = {
+            DiffReviewFileSection(
+                file: file,
+                inlineFeedback: [feedback],
+                draftComments: [comment],
+                layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+                wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+                showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+                codeFontFamily: "",
+                codeFontSize: 13,
+                showsSourceBadge: false
+            )
+            .environment(\.theme, theme())
+        }
+
+        let splitController = host(makeView(), width: 900, height: 620)
+
+        #expect(subview(withAccessibilityIdentifier: "diff-feedback-lane-left", in: splitController.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-feedback-lane-right", in: splitController.view) != nil)
+
+        layout = .stacked
+        let stackedController = host(makeView(), width: 900, height: 620)
+
+        #expect(subview(withAccessibilityIdentifier: "diff-feedback-lane-full", in: stackedController.view) != nil)
+    }
+
     @Test func fileSectionDraftCommentCardShowsProviderPublishAndErrorState() {
         let file = DiffReviewFileSectionModel(
             summary: summary(path: "Sources/App.swift"),

--- a/docs/superpowers/plans/2026-07-15-split-diff-feedback-lanes.md
+++ b/docs/superpowers/plans/2026-07-15-split-diff-feedback-lanes.md
@@ -1,0 +1,961 @@
+# Split Diff Feedback Lanes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render every hunk- or row-attached diff feedback item in its semantic left or right lane in split mode, and code-aligned across the full row in stacked mode.
+
+**Architecture:** Add a pure lane resolver and a reusable SwiftUI lane wrapper backed by shared AppKit/SwiftUI gutter geometry. Keep the existing segmentation and provider models responsible for vertical placement and persistence; wrap existing composers and cards only at their current insertion sites.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, AppKit, Swift Testing, XcodeGen, Xcode 16+
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Center/Diff/DiffFeedbackLane.swift`: semantic lane resolution, line-label projection, gutter thickness, pure lane frames, and the generic SwiftUI lane wrapper.
+- Create `AlasTests/DiffFeedbackLaneTests.swift`: resolver, geometry, label projection, and direct lane-view layout tests.
+- Modify `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`: make the AppKit line ruler use the shared gutter thickness helper.
+- Modify `Alas/Sources/Center/Diff/DiffPaneView.swift`: wrap provider threads and annotations in side-local lanes.
+- Modify `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`: wrap actionable feedback, drafts, the pending composer, provider threads, and annotations without changing their vertical segmentation.
+- Modify `Alas/Sources/Center/DiffTabView.swift`: wrap standalone-diff drafts and the pending composer.
+- Modify `AlasTests/DiffPaneViewTests.swift`: integration coverage for provider thread and annotation lanes.
+- Modify `AlasTests/DiffReviewSurfaceTests.swift`: integration coverage for actionable feedback, draft, composer, and review-surface provider lanes.
+
+No `project.yml` edit is needed because both application and test targets already include their source directories recursively.
+
+### Task 1: Semantic Feedback Lane Resolver
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/DiffFeedbackLane.swift`
+- Create: `AlasTests/DiffFeedbackLaneTests.swift`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Create `AlasTests/DiffFeedbackLaneTests.swift` with the resolver matrix. The helper must retain whether selected lines are changes so context does not override the changed side:
+
+```swift
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct DiffFeedbackLaneTests {
+    @Test func pendingAnchorUsesChangedSideBeforeContext() {
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor(side: .old, lines: [
+            .init(side: .old, line: 10, isChange: true),
+            .init(side: .unknown, line: 11, isChange: false),
+        ])) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor(side: .new, lines: [
+            .init(side: .unknown, line: 10, isChange: false),
+            .init(side: .new, line: 11, isChange: true),
+        ])) == .right)
+    }
+
+    @Test func pendingAnchorDefaultsMixedChangesToRight() {
+        let mixed = anchor(side: .unknown, lines: [
+            .init(side: .old, line: 10, isChange: true),
+            .init(side: .new, line: 10, isChange: true),
+        ])
+        #expect(DiffFeedbackLaneResolver.lane(for: mixed) == .right)
+    }
+
+    @Test func pendingContextOnlyAnchorUsesSelectionPane() {
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor(side: .old, lines: [
+            .init(side: .old, line: 10, isChange: false),
+        ])) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor(side: .new, lines: [
+            .init(side: .new, line: 10, isChange: false),
+        ])) == .right)
+        #expect(DiffFeedbackLaneResolver.lane(for: anchor(side: .unknown, lines: [
+            .init(side: .unknown, line: 10, isChange: false),
+        ])) == .right)
+    }
+
+    @Test func modelAdaptersUsePersistedSemanticSide() {
+        #expect(DiffFeedbackLaneResolver.lane(for: draft(side: .old)) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: draft(side: .new)) == .right)
+        #expect(DiffFeedbackLaneResolver.lane(for: feedback(side: .old)) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: feedback(side: .new)) == .right)
+        #expect(DiffFeedbackLaneResolver.lane(for: thread(isOldSide: true)) == .left)
+        #expect(DiffFeedbackLaneResolver.lane(for: thread(isOldSide: false)) == .right)
+        #expect(DiffFeedbackLaneResolver.lane(for: annotation()) == .right)
+    }
+
+    private func anchor(
+        side: DiffReviewInlineFeedbackSide,
+        lines: [DiffReviewLineAnchor.SelectedLine]
+    ) -> DiffReviewLineAnchor {
+        DiffReviewLineAnchor(
+            path: "Sources/App.swift",
+            side: side,
+            line: lines.first?.line ?? 1,
+            endLine: lines.last?.line,
+            rowIndex: 0,
+            endRowIndex: max(lines.count - 1, 0),
+            selectedLines: lines,
+            selectedText: "selection"
+        )
+    }
+
+    private func draft(side: DiffReviewInlineFeedbackSide) -> ReviewDraftComment {
+        ReviewDraftComment(
+            id: "draft-\(side.rawValue)",
+            sessionID: .localChanges(
+                worktreeID: "worktree",
+                worktreePath: URL(fileURLWithPath: "/tmp/worktree"),
+                scope: .unstaged
+            ),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            path: "Sources/App.swift",
+            originalPath: nil,
+            side: side,
+            startLine: 10,
+            endLine: nil,
+            selectedText: nil,
+            bodyMarkdown: "Draft",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+    }
+
+    private func feedback(side: DiffReviewInlineFeedbackSide) -> DiffReviewInlineFeedback {
+        DiffReviewInlineFeedback(
+            id: "feedback-\(side.rawValue)",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Feedback",
+            status: .actionable,
+            providerURL: nil,
+            anchor: .init(path: "Sources/App.swift", line: 10, side: side),
+            evidenceItemID: "feedback-\(side.rawValue)"
+        )
+    }
+
+    private func thread(isOldSide: Bool) -> DiffInlineCommentThread {
+        DiffInlineCommentThread(
+            id: isOldSide ? "old-thread" : "new-thread",
+            filePath: "Sources/App.swift",
+            newLine: 10,
+            isOldSide: isOldSide,
+            isResolved: false,
+            isOutdated: false,
+            comments: [.init(id: "comment", author: "reviewer", body: "Feedback")]
+        )
+    }
+
+    private func annotation() -> DiffInlineAnnotation {
+        DiffInlineAnnotation(
+            id: "annotation",
+            checkName: "SwiftLint",
+            newLine: 10,
+            level: .warning,
+            message: "Warning",
+            rawDetails: nil
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: exit 0 and the generated project includes both new files.
+
+Then run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffFeedbackLaneTests
+```
+
+Expected: compilation fails because `DiffFeedbackLaneResolver` and `DiffFeedbackLane` do not exist.
+
+- [ ] **Step 3: Implement the minimal resolver**
+
+Start `Alas/Sources/Center/Diff/DiffFeedbackLane.swift` with:
+
+```swift
+import AppKit
+import SwiftUI
+
+enum DiffFeedbackLane: String, Equatable, Hashable {
+    case left
+    case right
+    case full
+}
+
+enum DiffFeedbackLaneResolver {
+    static func lane(for anchor: DiffReviewLineAnchor) -> DiffFeedbackLane {
+        let changedSides = Set(anchor.selectedLines.lazy.filter(\.isChange).map(\.side))
+        if changedSides.contains(.new) { return .right }
+        if changedSides.contains(.old) { return .left }
+        return lane(for: anchor.side)
+    }
+
+    static func lane(for comment: ReviewDraftComment) -> DiffFeedbackLane {
+        lane(for: comment.side)
+    }
+
+    static func lane(for feedback: DiffReviewInlineFeedback) -> DiffFeedbackLane {
+        lane(for: feedback.anchor.side)
+    }
+
+    static func lane(for thread: DiffInlineCommentThread) -> DiffFeedbackLane {
+        thread.isOldSide ? .left : .right
+    }
+
+    static func lane(for _: DiffInlineAnnotation) -> DiffFeedbackLane {
+        .right
+    }
+
+    static func lane(for side: DiffReviewInlineFeedbackSide) -> DiffFeedbackLane {
+        switch side {
+        case .old: .left
+        case .new, .unknown: .right
+        }
+    }
+}
+```
+
+The `.new` check intentionally precedes `.old`, which makes a mixed changed-side selection resolve right.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run the command from Step 2.
+
+Expected: `DiffFeedbackLaneTests` passes.
+
+- [ ] **Step 5: Commit the resolver**
+
+```bash
+git add Alas/Sources/Center/Diff/DiffFeedbackLane.swift AlasTests/DiffFeedbackLaneTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "Add diff feedback lane resolver"
+```
+
+### Task 2: Shared Gutter Geometry And Lane Layout
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffFeedbackLane.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift:1817-1818,2215-2223`
+- Modify: `AlasTests/DiffFeedbackLaneTests.swift`
+- Modify: `AlasTests/DiffPaneViewTests.swift:1280-1330`
+
+- [ ] **Step 1: Add failing geometry and label-projection tests**
+
+Append these tests to `DiffFeedbackLaneTests`:
+
+```swift
+@Test func laneFramesMatchTheDiffPaneDividerMath() {
+    #expect(DiffFeedbackLaneGeometry.contentFrame(
+        containerWidth: 901,
+        layoutMode: .split,
+        lane: .left,
+        gutterWidth: 42
+    ) == CGRect(x: 42, y: 0, width: 408, height: 0))
+    #expect(DiffFeedbackLaneGeometry.contentFrame(
+        containerWidth: 901,
+        layoutMode: .split,
+        lane: .right,
+        gutterWidth: 42
+    ) == CGRect(x: 493, y: 0, width: 408, height: 0))
+    #expect(DiffFeedbackLaneGeometry.contentFrame(
+        containerWidth: 901,
+        layoutMode: .stacked,
+        lane: .right,
+        gutterWidth: 42
+    ) == CGRect(x: 42, y: 0, width: 859, height: 0))
+}
+
+@Test func gutterThicknessUsesExistingMinimumAndExpandsForWideLabels() {
+    #expect(DiffPaneLineNumberGutterGeometry.thickness(labels: ["1", "22"]) == 42)
+    #expect(DiffPaneLineNumberGutterGeometry.thickness(labels: ["1234567890"]) > 42)
+}
+
+@Test func labelProjectionUsesTheActivePane() throws {
+    let model = DiffDisplayModelBuilder.build(
+        diff: ParsedDiff(hunks: [.init(
+            header: "@@ -9,1 +99,1 @@",
+            oldStart: 9,
+            newStart: 99,
+            lines: [
+                .init(kind: .delete, text: "old", oldNumber: 9, newNumber: nil),
+                .init(kind: .add, text: "new", oldNumber: nil, newNumber: 99),
+            ]
+        )]),
+        filePath: "Sources/App.swift"
+    )
+    let rows = try #require(model.groups.first?.rows)
+    #expect(DiffFeedbackLineLabels.labels(for: rows, layoutMode: .split, lane: .left) == ["9"])
+    #expect(DiffFeedbackLineLabels.labels(for: rows, layoutMode: .split, lane: .right) == ["99"])
+    #expect(DiffFeedbackLineLabels.labels(for: rows, layoutMode: .stacked, lane: .right) == ["9", "99"])
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run the Task 1 focused test command.
+
+Expected: compilation fails because the geometry and label helpers do not exist.
+
+- [ ] **Step 3: Add the shared geometry and generic lane wrapper**
+
+Append these units to `DiffFeedbackLane.swift`:
+
+```swift
+enum DiffPaneLineNumberGutterGeometry {
+    static let minimumThickness: CGFloat = 42
+    static let horizontalPadding: CGFloat = 8
+    static let labelFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
+
+    static func thickness(labels: [String]) -> CGFloat {
+        let maxDigits = labels
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: "+- ")) }
+            .map(\.count)
+            .max() ?? 1
+        let sample = String(repeating: "8", count: max(maxDigits, 1)) as NSString
+        let width = ceil(sample.size(withAttributes: [.font: labelFont]).width)
+        return max(minimumThickness, width + horizontalPadding * 2)
+    }
+}
+
+enum DiffFeedbackLineLabels {
+    static func labels(
+        for rows: [DiffDisplayRow],
+        layoutMode: DiffLayoutMode,
+        lane: DiffFeedbackLane
+    ) -> [String] {
+        switch layoutMode {
+        case .split:
+            switch lane {
+            case .left:
+                return rows.compactMap { $0.old?.lineNumber.map(String.init) }
+            case .right, .full:
+                return rows.compactMap { $0.new?.lineNumber.map(String.init) }
+            }
+        case .stacked:
+            return DiffPaneRowProjection.stackedLines(for: rows).compactMap { $0.line.lineNumber.map(String.init) }
+        }
+    }
+}
+
+enum DiffFeedbackLaneGeometry {
+    static let dividerWidth: CGFloat = 1
+
+    static func contentFrame(
+        containerWidth: CGFloat,
+        layoutMode: DiffLayoutMode,
+        lane: DiffFeedbackLane,
+        gutterWidth: CGFloat
+    ) -> CGRect {
+        let width = max(containerWidth, 0)
+        guard layoutMode == .split else {
+            let inset = min(gutterWidth, width)
+            return CGRect(x: inset, y: 0, width: width - inset, height: 0)
+        }
+        let oldWidth = floor(max(width - dividerWidth, 0) / 2)
+        let newOrigin = oldWidth + min(dividerWidth, width)
+        let newWidth = max(width - newOrigin, 0)
+        if lane == .left {
+            let inset = min(gutterWidth, oldWidth)
+            return CGRect(x: inset, y: 0, width: oldWidth - inset, height: 0)
+        }
+        let inset = min(gutterWidth, newWidth)
+        return CGRect(x: newOrigin + inset, y: 0, width: newWidth - inset, height: 0)
+    }
+}
+
+private struct DiffFeedbackLaneLayout: Layout {
+    let layoutMode: DiffLayoutMode
+    let lane: DiffFeedbackLane
+    let gutterWidth: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        guard let subview = subviews.first else { return .zero }
+        let width = proposal.width ?? 0
+        let frame = DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: width,
+            layoutMode: layoutMode,
+            lane: lane,
+            gutterWidth: gutterWidth
+        )
+        let contentSize = subview.sizeThatFits(.init(width: frame.width, height: proposal.height))
+        return CGSize(width: width, height: contentSize.height)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        guard let subview = subviews.first else { return }
+        let frame = DiffFeedbackLaneGeometry.contentFrame(
+            containerWidth: bounds.width,
+            layoutMode: layoutMode,
+            lane: lane,
+            gutterWidth: gutterWidth
+        )
+        subview.place(
+            at: CGPoint(x: bounds.minX + frame.minX, y: bounds.minY),
+            anchor: .topLeading,
+            proposal: .init(width: frame.width, height: proposal.height)
+        )
+    }
+}
+
+struct DiffFeedbackLaneView<Content: View>: View {
+    let lane: DiffFeedbackLane
+    let layoutMode: DiffLayoutMode
+    let rows: [DiffDisplayRow]
+    @ViewBuilder let content: () -> Content
+    @Environment(\.theme) private var theme
+
+    private var effectiveLane: DiffFeedbackLane {
+        layoutMode == .stacked ? .full : lane
+    }
+
+    var body: some View {
+        let labels = DiffFeedbackLineLabels.labels(for: rows, layoutMode: layoutMode, lane: lane)
+        let gutterWidth = DiffPaneLineNumberGutterGeometry.thickness(labels: labels)
+        DiffFeedbackLaneLayout(layoutMode: layoutMode, lane: effectiveLane, gutterWidth: gutterWidth) {
+            content()
+        }
+        .frame(maxWidth: .infinity)
+        .overlay {
+            if layoutMode == .split {
+                Rectangle()
+                    .fill(theme.color("line"))
+                    .frame(width: DiffFeedbackLaneGeometry.dividerWidth)
+            }
+        }
+        .background(DiffFeedbackLaneAccessibilityMarker(lane: effectiveLane))
+    }
+}
+
+private struct DiffFeedbackLaneAccessibilityMarker: NSViewRepresentable {
+    let lane: DiffFeedbackLane
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.setAccessibilityIdentifier("diff-feedback-lane-\(lane.rawValue)")
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        nsView.setAccessibilityIdentifier("diff-feedback-lane-\(lane.rawValue)")
+    }
+}
+```
+
+The environment theme's `line` color and the one-point geometry match the
+existing diff divider.
+
+- [ ] **Step 4: Make the AppKit ruler consume the shared thickness helper**
+
+In `DiffPaneLineNumberRulerView`, delete its private `minimumThickness` and `horizontalPadding` constants. Initialize and update thickness through the helper:
+
+```swift
+ruleThickness = DiffPaneLineNumberGutterGeometry.minimumThickness
+```
+
+```swift
+private func updateThickness() {
+    ruleThickness = DiffPaneLineNumberGutterGeometry.thickness(labels: labels)
+}
+```
+
+Keep drawing-only padding local by replacing drawing references to the deleted instance property with `DiffPaneLineNumberGutterGeometry.horizontalPadding`.
+
+- [ ] **Step 5: Run geometry and existing ruler tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/DiffFeedbackLaneTests \
+  -only-testing:AlasTests/DiffPaneViewTests
+```
+
+Expected: both suites pass, including the existing 42-point ruler geometry assertions.
+
+- [ ] **Step 6: Commit shared layout geometry**
+
+```bash
+git add Alas/Sources/Center/Diff/DiffFeedbackLane.swift Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift AlasTests/DiffFeedbackLaneTests.swift AlasTests/DiffPaneViewTests.swift
+git commit -m "Add diff feedback lane layout"
+```
+
+### Task 3: Provider Threads And Annotations In The Shared Diff Renderer
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPaneView.swift:330-390`
+- Modify: `AlasTests/DiffPaneViewTests.swift`
+
+- [ ] **Step 1: Add failing shared-renderer lane tests**
+
+Add a test that hosts `DiffPaneView` with one old-side thread and one new-side annotation in split mode, then asserts both accessibility markers exist. Add a second host in stacked mode and assert full-lane markers are emitted:
+
+```swift
+@Test func providerAccessoriesUseSemanticLanesAndStackedFullWidth() {
+    var layout = DiffLayoutMode.split
+    var wrap = false
+    var whitespace = false
+    let thread = DiffInlineCommentThread(
+        id: "old-thread",
+        filePath: "a.swift",
+        newLine: 2,
+        isOldSide: true,
+        isResolved: false,
+        isOutdated: false,
+        comments: [.init(id: "comment", author: "reviewer", body: "Old side")]
+    )
+    let annotation = DiffInlineAnnotation(
+        id: "new-annotation",
+        checkName: "SwiftLint",
+        newLine: 2,
+        level: .warning,
+        message: "New side",
+        rawDetails: nil
+    )
+    let makeView = {
+        DiffPaneView(
+            model: self.model(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsToolbar: false,
+            verticalScrollMode: .staticHeight,
+            threads: [thread],
+            annotations: [annotation],
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, self.theme())
+    }
+
+    let split = NSHostingController(rootView: makeView())
+    split.view.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+    split.view.layoutSubtreeIfNeeded()
+    #expect(subview(withAccessibilityIdentifier: "diff-feedback-lane-left", in: split.view) != nil)
+    #expect(subview(withAccessibilityIdentifier: "diff-feedback-lane-right", in: split.view) != nil)
+
+    layout = .stacked
+    let stacked = NSHostingController(rootView: makeView())
+    stacked.view.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+    stacked.view.layoutSubtreeIfNeeded()
+    #expect(subview(withAccessibilityIdentifier: "diff-feedback-lane-full", in: stacked.view) != nil)
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests/providerAccessoriesUseSemanticLanesAndStackedFullWidth
+```
+
+Expected: the lane accessibility markers are absent.
+
+- [ ] **Step 3: Wrap existing cards without changing block placement**
+
+In `DiffPaneView.hunk(_:)`, wrap only the `.thread` and `.annotation` card branches. Pass `visibleRows` so their gutter width is stable for the hunk:
+
+```swift
+case .thread(let thread):
+    DiffFeedbackLaneView(
+        lane: DiffFeedbackLaneResolver.lane(for: thread),
+        layoutMode: layoutMode,
+        rows: visibleRows
+    ) {
+        DiffInlineCommentCard(
+            thread: thread,
+            onReply: { body in onReply(thread, body) },
+            onStageReply: { body in onStageReply(thread, body) },
+            onResolve: { onResolve(thread) },
+            onUnresolve: { onUnresolve(thread) },
+            onEdit: { comment, newBody in onEdit(thread, comment, newBody) },
+            onDelete: { comment in onDelete(thread, comment) },
+            canReply: canReply && thread.viewerCanReply,
+            canResolve: canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
+            canAddToReview: canAddToReview,
+            onActiveChange: { active in
+                activeThreadID = active ? thread.id : (activeThreadID == thread.id ? nil : activeThreadID)
+            }
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+case .annotation(let annotation):
+    DiffFeedbackLaneView(
+        lane: DiffFeedbackLaneResolver.lane(for: annotation),
+        layoutMode: layoutMode,
+        rows: visibleRows
+    ) {
+        DiffInlineAnnotationCard(annotation: annotation)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+```
+
+Do not alter `DiffInlineCommentLayout.blocks`; it remains the source of vertical ordering.
+
+- [ ] **Step 4: Run the shared-renderer tests**
+
+Run the full `DiffPaneViewTests` suite.
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit shared-renderer integration**
+
+```bash
+git add Alas/Sources/Center/Diff/DiffPaneView.swift AlasTests/DiffPaneViewTests.swift
+git commit -m "Place provider feedback in diff lanes"
+```
+
+### Task 4: Review Surface Feedback Lanes
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift:329-365,486-505,520-610,734-805`
+- Modify: `AlasTests/DiffReviewSurfaceTests.swift`
+
+- [ ] **Step 1: Add failing review-surface integration tests**
+
+Add this focused host test through accessibility markers:
+
+```swift
+@Test func reviewSurfaceUsesLanesForActionableFeedbackAndDrafts() {
+    let file = DiffReviewFileSectionModel(
+        summary: summary(path: "Sources/App/AlphaView.swift"),
+        parsedDiff: parsedDiff(),
+        displayModel: displayModel(),
+        placeholderMessage: nil,
+        openFile: nil,
+        contextProvider: nil
+    )
+    let feedback = DiffReviewInlineFeedback(
+        id: "old-feedback",
+        providerName: "GitHub",
+        author: "reviewer",
+        bodyPreview: "Old-side feedback",
+        status: .actionable,
+        providerURL: nil,
+        anchor: .init(path: file.summary.path, line: 2, side: .old),
+        evidenceItemID: "old-feedback"
+    )
+    let comment = draftComment(
+        id: "new-draft",
+        fileID: file.id,
+        path: file.summary.path,
+        side: .new,
+        startLine: 2
+    )
+    var layout = DiffLayoutMode.split
+    var wrap = false
+    var whitespace = false
+    let view = DiffReviewFileSection(
+        file: file,
+        inlineFeedback: [feedback],
+        draftComments: [comment],
+        layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+        wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+        showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+        codeFontFamily: "",
+        codeFontSize: 13,
+        showsSourceBadge: false
+    )
+    .environment(\.theme, theme())
+
+    let controller = host(view, width: 900, height: 620)
+
+    #expect(subview(withAccessibilityIdentifier: "diff-feedback-lane-left", in: controller.view) != nil)
+    #expect(subview(withAccessibilityIdentifier: "diff-feedback-lane-right", in: controller.view) != nil)
+}
+```
+
+The pending composer uses the same resolver exercised by
+`pendingAnchorUsesChangedSideBeforeContext`,
+`pendingAnchorDefaultsMixedChangesToRight`, and
+`pendingContextOnlyAnchorUsesSelectionPane`. Existing segmentation tests remain
+the coverage for one composer and range-end insertion because the composer
+state is private to `DiffReviewFileSection`.
+
+- [ ] **Step 2: Run the focused review tests and verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffReviewSurfaceTests
+```
+
+Expected: new lane marker assertions fail while existing vertical-placement assertions pass.
+
+- [ ] **Step 3: Make actionable provider feedback side-local**
+
+Split `inlineFeedbackStack` into a file-level path that preserves today's full-width stack and a hunk-attached path that receives `rows` and wraps each visible item:
+
+```swift
+private func inlineFeedbackStack(
+    _ items: [DiffReviewInlineFeedback],
+    file: DiffReviewFileSummary,
+    rows: [DiffDisplayRow]? = nil
+) -> some View
+```
+
+At the hunk call site, pass `group.displayGroup.rows`. For every visible feedback item with rows, render:
+
+```swift
+DiffFeedbackLaneView(
+    lane: DiffFeedbackLaneResolver.lane(for: item),
+    layoutMode: layoutMode,
+    rows: rows
+) {
+    inlineFeedbackCard(item, file: file)
+        .padding(.horizontal, 14)
+}
+```
+
+Extract the existing card construction to `inlineFeedbackCard(_:file:)` so file-level and lane-local paths share focus, hover, actions, and stable IDs. Keep `DiffReviewInlineFeedbackMoreRow` outside lane resolution because it summarizes possibly mixed-side hidden items.
+
+- [ ] **Step 4: Make drafts and the pending composer side-local**
+
+Change `draftCommentStack` to accept segment rows and wrap each comment independently, preserving mixed old/new drafts on one display row:
+
+```swift
+private func draftCommentStack(
+    _ comments: [ReviewDraftComment],
+    rows: [DiffDisplayRow]
+) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+        ForEach(comments) { comment in
+            DiffFeedbackLaneView(
+                lane: DiffFeedbackLaneResolver.lane(for: comment),
+                layoutMode: layoutMode,
+                rows: rows
+            ) {
+                draftCommentCard(comment)
+                    .padding(.horizontal, 14)
+            }
+        }
+    }
+    .padding(.vertical, 10)
+    .background(theme.color("bg-1"))
+}
+```
+
+Extract the existing `ReviewDraftCommentCard` construction to `draftCommentCard(_:)` so IDs, hover, focus, selection, and actions remain identical.
+
+Change `draftComposer` to accept rows, and wrap `draftComposerBody` using the pending selection rather than the canonical saved anchor:
+
+```swift
+private func draftComposer(rows: [DiffDisplayRow]) -> some View {
+    if allowsDraftCommentCreation, let pendingDraftAnchor {
+        DiffFeedbackLaneView(
+            lane: DiffFeedbackLaneResolver.lane(for: pendingDraftAnchor),
+            layoutMode: layoutMode,
+            rows: rows
+        ) {
+            draftComposerBody
+        }
+    }
+}
+```
+
+Update segment call sites to pass `segment.rows`. Keep `savePendingDraft()` and `canonicalPendingAnchor` unchanged.
+
+- [ ] **Step 5: Wrap segmented provider threads and annotations**
+
+In `reviewGroup`, apply the Task 3 wrappers to `.thread` and `.annotation` blocks, passing `segment.rows`. Preserve every callback exactly.
+
+- [ ] **Step 6: Run review-surface and render-context regression tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/DiffReviewSurfaceTests \
+  -only-testing:AlasTests/DiffReviewRenderableContentEqualityTests \
+  -only-testing:AlasTests/DiffReviewRenderEligibilityTests
+```
+
+Expected: all selected suites pass. Existing tests still cover one composer, range-end insertion, context-only selection, focus, and block order.
+
+- [ ] **Step 7: Commit review-surface integration**
+
+```bash
+git add Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift AlasTests/DiffReviewSurfaceTests.swift
+git commit -m "Align review feedback with diff lanes"
+```
+
+### Task 5: Standalone Diff Draft Lanes
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffTabView.swift:650-835`
+- Modify: `AlasTests/DiffPaneViewTests.swift:100-260`
+
+- [ ] **Step 1: Add failing standalone diff lane tests**
+
+Extend the existing `DiffTabRenderContextBuilder` test and add a pending old-side assertion:
+
+```swift
+#expect(DiffFeedbackLaneResolver.lane(for: comment) == .right)
+let pendingOld = DiffReviewLineAnchor(
+    path: "Sources/App.swift",
+    side: .old,
+    line: 2,
+    rowIndex: 1,
+    selectedLines: [.init(side: .old, line: 2, isChange: true)],
+    selectedText: "let b = 2"
+)
+#expect(DiffFeedbackLaneResolver.lane(for: pendingOld) == .left)
+```
+
+Add a geometry assertion that demonstrates the standalone view's layout-mode
+input changes the same semantic lane from a split half to the full stacked row:
+
+```swift
+let splitFrame = DiffFeedbackLaneGeometry.contentFrame(
+    containerWidth: 900,
+    layoutMode: .split,
+    lane: DiffFeedbackLaneResolver.lane(for: pendingOld),
+    gutterWidth: 42
+)
+let stackedFrame = DiffFeedbackLaneGeometry.contentFrame(
+    containerWidth: 900,
+    layoutMode: .stacked,
+    lane: DiffFeedbackLaneResolver.lane(for: pendingOld),
+    gutterWidth: 42
+)
+#expect(splitFrame.width == 407)
+#expect(stackedFrame.width == 858)
+```
+
+- [ ] **Step 2: Run standalone diff tests and verify lane markers fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests
+```
+
+Expected: the new resolver and geometry assertions pass. The implementation
+step remains necessary because `reviewDiffGroup` still emits unwrapped,
+full-width accessories; the existing cache/layout test will exercise both
+render branches after the edit.
+
+- [ ] **Step 3: Wrap saved drafts and the composer**
+
+Change `reviewDraftCommentStack` to accept rows, wrap each comment independently, and retain existing card IDs and actions:
+
+```swift
+DiffFeedbackLaneView(
+    lane: DiffFeedbackLaneResolver.lane(for: comment),
+    layoutMode: diffPreferences.layoutMode.wrappedValue,
+    rows: rows
+) {
+    ReviewDraftCommentCard(
+        comment: comment,
+        file: fileSummary,
+        isFocused: false,
+        actions: actions,
+        reviewFeedbackTarget: reviewFeedbackTarget,
+        onSelect: { _ in }
+    )
+    .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: fileID))
+        .padding(.horizontal, 14)
+}
+```
+
+Change `reviewDraftComposer` to accept rows and wrap its existing body:
+
+```swift
+if let pendingDraftAnchor {
+    DiffFeedbackLaneView(
+        lane: DiffFeedbackLaneResolver.lane(for: pendingDraftAnchor),
+        layoutMode: diffPreferences.layoutMode.wrappedValue,
+        rows: rows
+    ) {
+        reviewDraftComposerBody
+    }
+}
+```
+
+Update `reviewDiffGroup` segment call sites to pass `segment.rows`. Extract `reviewDraftComposerBody` only to avoid recursive wrapping; keep save, cancel, focus, and accessibility identifiers unchanged.
+
+- [ ] **Step 4: Run standalone diff regression tests**
+
+Run the `DiffPaneViewTests` suite.
+
+Expected: all tests pass, including render-context cache reuse across layout changes.
+
+- [ ] **Step 5: Commit standalone diff integration**
+
+```bash
+git add Alas/Sources/Center/DiffTabView.swift AlasTests/DiffPaneViewTests.swift
+git commit -m "Align diff draft comments with lanes"
+```
+
+### Task 6: Project Regeneration And Full Verification
+
+**Files:**
+- Modify if generated output changes: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Regenerate the Xcode project**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: exit 0. The generated project includes `DiffFeedbackLane.swift` and `DiffFeedbackLaneTests.swift`. Review `git diff -- Alas.xcodeproj/project.pbxproj` and keep only deterministic XcodeGen output.
+
+- [ ] **Step 2: Run the required build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0 with no Swift compiler errors.
+
+- [ ] **Step 3: Run the complete test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exit 0 and all Swift Testing suites pass.
+
+- [ ] **Step 4: Inspect final scope**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+git log --oneline 63d058d5..HEAD
+```
+
+Expected: no unstaged implementation changes, no whitespace errors, and only the planned focused commits after the design commit.
+
+- [ ] **Step 5: Commit generated project changes if needed**
+
+If `xcodegen` changes `Alas.xcodeproj/project.pbxproj` and it was not committed in Task 1:
+
+```bash
+git add Alas.xcodeproj/project.pbxproj
+git commit -m "Regenerate project for feedback lanes"
+```
+
+If the generated project is unchanged, skip this commit.

--- a/docs/superpowers/specs/2026-07-15-split-diff-feedback-lanes-design.md
+++ b/docs/superpowers/specs/2026-07-15-split-diff-feedback-lanes-design.md
@@ -1,0 +1,190 @@
+# Split Diff Feedback Lanes Design
+
+## Context
+
+Inline feedback currently renders as a full-width row below its anchored diff
+line. In split mode, that makes a comment on only the added side look detached
+from the right pane, and a comment on only the deleted side look detached from
+the left pane. The selection and review models already preserve old/new side
+information for local drafts and provider threads, but the SwiftUI accessory
+rows do not use it for horizontal placement.
+
+This change makes all row- or hunk-attached inline feedback follow the diff
+pane it belongs to while retaining the existing vertical insertion point.
+
+## Goals
+
+- Place deleted-side feedback in the left split pane and added-side feedback
+  in the right split pane.
+- Apply the same placement to pending composers, saved local drafts, actionable
+  provider feedback cards, provider comment threads, and check annotations.
+- Align feedback content with source code by insetting it past the line-number
+  gutter.
+- Keep stacked feedback full-width while applying the same code-aligned gutter
+  inset.
+- Preserve comment anchoring, publishing, editing, focus, highlighting,
+  resolving, and reply behavior.
+
+## Non-Goals
+
+- Changing how review comments are persisted or published to providers.
+- Moving feedback vertically or changing range-end insertion behavior.
+- Redesigning comment cards, composer controls, or provider thread content.
+- Changing file-level or outdated feedback that has no visible row attachment.
+- Embedding SwiftUI feedback views inside the AppKit text renderer.
+
+## Behavior
+
+Vertical placement remains unchanged: feedback renders immediately after its
+selected or provider-anchored row.
+
+In split mode, horizontal placement follows this matrix:
+
+| Feedback anchor | Lane |
+|---|---|
+| Deleted changed lines only | Left |
+| Deleted changed lines plus unchanged lines | Left |
+| Added changed lines only | Right |
+| Added changed lines plus unchanged lines | Right |
+| Both deleted and added changed lines | Right |
+| Unchanged lines only | Pane where selection began |
+| Saved draft or provider thread with old side | Left |
+| Saved draft or provider thread with new side | Right |
+| Actionable provider feedback with old/new side | Left/right respectively |
+| Check annotation | Right |
+| Unknown or incomplete side metadata | Right |
+
+The selected lane occupies one split half. Its feedback content begins after
+that pane's line-number gutter and uses the existing card padding toward the
+center divider or outer edge. The opposite half stays empty. The center divider
+continues through the feedback row.
+
+In stacked mode, all lane-eligible feedback occupies the full row and begins
+after the single line-number gutter. Switching between split and stacked modes
+changes presentation only and does not rewrite anchors or persisted comments.
+
+Narrow split panes retain the resolved lane and allow card content to wrap
+vertically. They do not silently fall back to a full-width row.
+
+## Architecture
+
+Add two shared units to the diff UI layer:
+
+- `DiffFeedbackLaneResolver` maps semantic feedback information to `.left`,
+  `.right`, or `.full`.
+- `DiffFeedbackLaneView` places arbitrary SwiftUI content using the resolved
+  lane, current `DiffLayoutMode`, and shared gutter geometry.
+
+The resolver remains a pure model with overloads or adapters for the existing
+feedback types:
+
+- pending `DiffReviewLineAnchor`
+- saved `ReviewDraftComment`
+- `DiffReviewInlineFeedback`
+- `DiffInlineCommentThread`
+- `DiffInlineAnnotation`
+- other row- or hunk-attached inline feedback with an old/new anchor
+
+For a pending range, the resolver inspects changed sides before context lines.
+An old-only changed range resolves left, a new-only changed range resolves
+right, and a range containing both changed sides resolves right. A context-only
+range uses the pane side recorded by the selection anchor. This presentation
+decision is separate from `canonicalPendingAnchor`, which continues to control
+the provider-facing saved anchor.
+
+The lane view is a reusable wrapper, not a new card. It receives content and
+computes only its horizontal frame and inset. In split mode it uses the same
+one-point divider and half-width calculation as
+`DiffPaneTextDocumentContainerView`. In stacked mode it uses the full available
+width.
+
+## Shared Gutter Geometry
+
+`DiffPaneLineNumberRulerView` currently calculates its thickness from a
+42-point minimum, the maximum visible label width, and horizontal padding.
+Extract that calculation into a small shared geometry helper that accepts the
+line labels and resolved code font.
+
+Both the AppKit ruler and `DiffFeedbackLaneView` use this helper. Feedback
+therefore remains aligned with source text for ordinary and high line numbers,
+and when the configured code font changes. The geometry helper also exposes a
+pure lane-frame calculation so its split and stacked output can be tested
+without rendering a window.
+
+The relevant display group or row segment supplies old/new line labels to the
+lane wrapper. Left feedback uses old-side gutter metrics, right feedback uses
+new-side gutter metrics, and stacked feedback uses the stacked projection's
+gutter metrics.
+
+## Integration Points
+
+Apply the shared lane wrapper at every lane-eligible feedback insertion site:
+
+- `DiffPaneView` for provider threads and check annotations in the shared diff
+  renderer.
+- `DiffReviewFileSection` for pending composers, saved local drafts, actionable
+  provider feedback cards, provider threads, and annotations in the review
+  surface. Hunk-attached actionable feedback keeps its current position above
+  the matching hunk; only each card's horizontal lane changes.
+- `DiffTabView` for pending composers and saved local drafts in standalone diff
+  tabs.
+
+The existing segmentation and block builders continue to decide vertical
+placement. Render-context segment data gains only the lane or anchor data
+needed for deterministic presentation. It must not duplicate comment
+placement logic or introduce a second vertical segmentation pass.
+
+File-level fallbacks remain full-width in their existing location because they
+do not have a visible diff row or reliable pane geometry.
+
+## Data Flow
+
+1. Existing selection, draft, actionable feedback, provider thread, or
+   annotation loading produces its current semantic anchor.
+2. Existing row segmentation places the accessory after the matching row.
+3. `DiffFeedbackLaneResolver` derives the presentation lane from that anchor.
+4. The active layout mode and relevant row labels produce shared gutter and
+   lane geometry.
+5. `DiffFeedbackLaneView` renders the existing composer or card in the computed
+   code-aligned frame.
+6. Existing actions and persistence callbacks flow through unchanged.
+
+Changing layout mode re-runs steps 3 through 5 from the same underlying model.
+
+## Fallbacks And Compatibility
+
+- Unknown split-side metadata resolves to the right lane so feedback remains
+  visible and compact.
+- Unknown stacked-side metadata has no special case because stacked feedback
+  always uses the full row.
+- Missing or non-visible row anchors continue through the existing file-level
+  fallback instead of attempting lane placement.
+- The feature changes no stored schema and requires no migration.
+- GitHub and GitLab provider payload construction remains unchanged.
+
+## Testing
+
+Use Swift Testing for focused coverage:
+
+- Lane resolver tests cover old-only, new-only, old-plus-context,
+  new-plus-context, old-plus-new, context-only selection origin, saved draft
+  sides, actionable feedback sides, provider thread sides, annotations, and
+  unknown metadata.
+- Geometry tests cover left, right, and full frames; the one-point split
+  divider; code-gutter insets; narrow widths; and ruler expansion for wide line
+  numbers and different code fonts.
+- Render-context tests verify that composers and persisted feedback receive the
+  same lane data without changing their row segment.
+- Regression tests retain one pending composer, range-end insertion, mixed-side
+  right fallback, context selection origin, focus behavior, and split/stacked
+  layout switching.
+- Existing provider thread, annotation, draft comment, and active-highlight
+  tests continue to pass.
+
+Final verification remains:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```

--- a/docs/superpowers/specs/2026-07-15-split-diff-feedback-lanes-design.md
+++ b/docs/superpowers/specs/2026-07-15-split-diff-feedback-lanes-design.md
@@ -103,13 +103,13 @@ width.
 `DiffPaneLineNumberRulerView` currently calculates its thickness from a
 42-point minimum, the maximum visible label width, and horizontal padding.
 Extract that calculation into a small shared geometry helper that accepts the
-line labels and resolved code font.
+line labels and uses the ruler's existing 10-point monospaced label font.
 
 Both the AppKit ruler and `DiffFeedbackLaneView` use this helper. Feedback
 therefore remains aligned with source text for ordinary and high line numbers,
-and when the configured code font changes. The geometry helper also exposes a
-pure lane-frame calculation so its split and stacked output can be tested
-without rendering a window.
+without relying on a duplicated width constant. The geometry helper also
+exposes a pure lane-frame calculation so its split and stacked output can be
+tested without rendering a window.
 
 The relevant display group or row segment supplies old/new line labels to the
 lane wrapper. Left feedback uses old-side gutter metrics, right feedback uses
@@ -172,7 +172,7 @@ Use Swift Testing for focused coverage:
   unknown metadata.
 - Geometry tests cover left, right, and full frames; the one-point split
   divider; code-gutter insets; narrow widths; and ruler expansion for wide line
-  numbers and different code fonts.
+  numbers.
 - Render-context tests verify that composers and persisted feedback receive the
   same lane data without changing their row segment.
 - Regression tests retain one pending composer, range-end insertion, mixed-side


### PR DESCRIPTION
## Summary
- Split diff feedback comments into old/new-side lanes so side-specific comments stay visually attached to the correct pane.
- Reuse the same lane resolver across provider feedback, review threads, annotations, standalone diff drafts, and review-surface composers.
- Keep mixed/unknown changed-side feedback on the right/full-width fallback path depending on view context.

## Test Plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (local run completed 5,516 passing tests and failed only the opt-in `SSHIntegrationTests` gate because `ALAS_SSH_INTEGRATION=1` was not set)
