### PR TITLE
fix(review): recompute handoff progress when resolving comments in the UI

### DIFF
--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -419,24 +419,17 @@ struct AlasActionService {
             // must not be retried, so a failure recomputing handoff/session
             // status (a separate store) is swallowed rather than reported
             // as an overall failure a caller would retry.
-            try? recomputeHandoffProgress(worktreeID: origin.id, store: store, timestamp: timestamp)
+            try? ReviewHandoffProgress.recomputeAndPersist(
+                worktreeID: origin.id,
+                sessionStore: reviewSessionStore(),
+                isResolved: { id in (try? store.find(commentID: id))?.state == .resolved },
+                now: timestamp
+            )
         } catch {
             return .error("could not update review comment: \(error.localizedDescription)")
         }
         notifyReviewCommentsChanged()
         return .ok
-    }
-
-    private func recomputeHandoffProgress(worktreeID: String, store: ReviewDraftCommentStore, timestamp: Date) throws {
-        let sessions = reviewSessionStore()
-        for record in try sessions.list(worktreeID: worktreeID) {
-            guard let updated = ReviewHandoffProgress.recomputingAddressed(
-                record: record,
-                isResolved: { id in (try? store.find(commentID: id))?.state == .resolved },
-                now: timestamp
-            ) else { continue }
-            try sessions.save(updated)
-        }
     }
 
     // MARK: - Worktree matching (moved verbatim from AlasCLICommandRouter)

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -562,7 +562,8 @@ struct CommitReviewBody: View {
         }
         return ReviewDraftWorkspaceActions.make(
             controller: draftCommentController,
-            sender: reviewFeedbackAgentSender
+            sender: reviewFeedbackAgentSender,
+            worktreeID: worktreeId
         )
     }
 

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -499,7 +499,8 @@ struct DiffTabView: View {
     private func makeDraftCommentActions() -> ReviewDraftCommentActions {
         ReviewDraftWorkspaceActions.make(
             controller: draftCommentController,
-            sender: ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktreeId)
+            sender: ReviewFeedbackAgentSender.production(appState: appState, worktreeID: worktreeId),
+            worktreeID: worktreeId
         )
     }
 

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -541,7 +541,8 @@ struct ReviewChangesTabView: View {
     private func draftCommentActions() -> ReviewDraftCommentActions {
         ReviewDraftWorkspaceActions.make(
             controller: draftCommentController,
-            sender: reviewFeedbackAgentSender
+            sender: reviewFeedbackAgentSender,
+            worktreeID: worktree.id
         )
     }
 

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -821,7 +821,8 @@ struct DraftReviewRequestTabView: View {
     private func draftCommentActions() -> ReviewDraftCommentActions {
         ReviewDraftWorkspaceActions.make(
             controller: draftCommentController,
-            sender: reviewFeedbackAgentSender
+            sender: reviewFeedbackAgentSender,
+            worktreeID: worktreeId
         )
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
@@ -35,6 +35,16 @@ final class ReviewDraftCommentController {
         }
     }
 
+    /// Looks up a comment by id across ALL sessions in the backing store,
+    /// not just this controller's loaded `comments`. Cross-session logic —
+    /// handoff-progress recomputation spans every review session in the
+    /// worktree — must read persisted state this way, or it would treat a
+    /// comment from another session as unresolved merely because it isn't in
+    /// this controller's single-session view.
+    func persistedComment(withID id: String) -> ReviewDraftComment? {
+        try? store.find(commentID: id)
+    }
+
     func add(
         anchor: DiffReviewLineAnchor,
         fileID: DiffReviewFileID,

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -196,7 +196,7 @@ enum ReviewDraftWorkspaceActions {
                 try? ReviewHandoffProgress.recomputeAndPersist(
                     worktreeID: worktreeID,
                     sessionStore: sessionStore(),
-                    isResolved: { id in controller.comments.first(where: { $0.id == id })?.state == .resolved },
+                    isResolved: { id in controller.persistedComment(withID: id)?.state == .resolved },
                     now: now()
                 )
             },

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -165,6 +165,9 @@ enum ReviewDraftWorkspaceActions {
         worktreeID: String? = nil,
         now: @escaping () -> Date = Date.init,
         sessionStore: @escaping () -> ReviewSessionStore = { ReviewSessionStore() },
+        notifyExternalChange: @escaping () -> Void = {
+            NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
+        },
         pasteboard: @escaping (String) -> Void = { prompt in
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
@@ -199,6 +202,11 @@ enum ReviewDraftWorkspaceActions {
                     isResolved: { id in controller.persistedComment(withID: id)?.state == .resolved },
                     now: now()
                 )
+                // Mirror the CLI/MCP resolve path: notify open review panes so a
+                // tab whose in-memory record was just recomputed on disk reloads
+                // it, instead of later persisting a stale record and clobbering
+                // the freshly written addressed status back to sent.
+                notifyExternalChange()
             },
             dismiss: { comment in
                 try? controller?.dismiss(commentID: comment.id)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackAgentSender.swift
@@ -162,6 +162,9 @@ enum ReviewDraftWorkspaceActions {
         sessionID: ReviewSessionID? = nil,
         recordHandoff: ((ReviewFeedbackHandoff) -> Void)? = nil,
         recordSendFailure: ((Error) -> Void)? = nil,
+        worktreeID: String? = nil,
+        now: @escaping () -> Date = Date.init,
+        sessionStore: @escaping () -> ReviewSessionStore = { ReviewSessionStore() },
         pasteboard: @escaping (String) -> Void = { prompt in
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
@@ -189,6 +192,13 @@ enum ReviewDraftWorkspaceActions {
             },
             resolve: { comment in
                 try? controller?.resolve(commentID: comment.id)
+                guard let worktreeID, let controller else { return }
+                try? ReviewHandoffProgress.recomputeAndPersist(
+                    worktreeID: worktreeID,
+                    sessionStore: sessionStore(),
+                    isResolved: { id in controller.comments.first(where: { $0.id == id })?.state == .resolved },
+                    now: now()
+                )
             },
             dismiss: { comment in
                 try? controller?.dismiss(commentID: comment.id)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewHandoffProgress.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewHandoffProgress.swift
@@ -55,4 +55,20 @@ enum ReviewHandoffProgress {
         updated.updatedAt = now
         return updated
     }
+
+    /// Recomputes and persists addressed status for every review session
+    /// belonging to `worktreeID`. Shared by the CLI/MCP `review_resolve`
+    /// path and the UI's Resolve action, so both keep handoff/session
+    /// status consistent the same way.
+    static func recomputeAndPersist(
+        worktreeID: String,
+        sessionStore: ReviewSessionStore,
+        isResolved: (String) -> Bool,
+        now: Date
+    ) throws {
+        for record in try sessionStore.list(worktreeID: worktreeID) {
+            guard let updated = recomputingAddressed(record: record, isResolved: isResolved, now: now) else { continue }
+            try sessionStore.save(updated)
+        }
+    }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -499,7 +499,10 @@ struct ReviewSessionTabView: View {
             sender: feedbackSender,
             sessionID: tabState.sessionID,
             recordHandoff: recordSessionHandoff,
-            recordSendFailure: recordSessionSendFailure
+            recordSendFailure: recordSessionSendFailure,
+            worktreeID: persistsState ? tabState.worktreeId : nil,
+            now: now,
+            sessionStore: { sessionStore }
         )
         let baseAvailability = actions.availability
         actions.availability = { comment in

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -299,6 +299,166 @@ struct ReviewChangesTabViewTests {
         #expect(savedComments.first?.bodyMarkdown == "Updated body")
     }
 
+    @Test func draftWorkspaceActionsResolveRecomputesHandoffProgress() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-draft-comments.json")
+        )
+        let sessionStore = ReviewSessionStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-sessions.json")
+        )
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let controller = ReviewDraftCommentController(
+            sessionID: target.draftSessionID,
+            store: draftStore,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        try controller.load()
+        try controller.add(
+            anchor: DiffReviewLineAnchor(path: "Sources/App.swift", side: .new, line: 4, rowIndex: 0, selectedText: ""),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            bodyMarkdown: "Please fix this."
+        )
+        let comment = try #require(controller.comments.first)
+        try sessionStore.save(ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            status: .sent,
+            handoffs: [ReviewFeedbackHandoff(
+                id: "h1",
+                sessionID: target.id,
+                commentIDs: [comment.id],
+                target: .newChat(agentID: "claude", title: "New chat"),
+                createdAt: Date(timeIntervalSince1970: 1),
+                promptRevision: "rev",
+                status: .sent
+            )],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        ))
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [] },
+            send: { _, _, _ in Issue.record("send should not be called") }
+        )
+        let actions = ReviewDraftWorkspaceActions.make(
+            controller: controller,
+            sender: sender,
+            worktreeID: "wt-1",
+            now: { Date(timeIntervalSince1970: 200) },
+            sessionStore: { sessionStore }
+        )
+
+        actions.resolve(comment)
+
+        #expect(controller.comments.first?.state == .resolved)
+        let record = try #require(try sessionStore.load(id: target.id))
+        #expect(record.status == .addressed)
+        #expect(record.handoffs.map(\.status) == [.addressed])
+        #expect(record.updatedAt == Date(timeIntervalSince1970: 200))
+    }
+
+    @Test func draftWorkspaceActionsDismissDoesNotRecomputeHandoffProgress() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-draft-comments.json")
+        )
+        let sessionStore = ReviewSessionStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-sessions.json")
+        )
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let controller = ReviewDraftCommentController(
+            sessionID: target.draftSessionID,
+            store: draftStore,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        try controller.load()
+        try controller.add(
+            anchor: DiffReviewLineAnchor(path: "Sources/App.swift", side: .new, line: 4, rowIndex: 0, selectedText: ""),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            bodyMarkdown: "Please fix this."
+        )
+        let comment = try #require(controller.comments.first)
+        let originalRecord = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            status: .sent,
+            handoffs: [ReviewFeedbackHandoff(
+                id: "h1",
+                sessionID: target.id,
+                commentIDs: [comment.id],
+                target: .newChat(agentID: "claude", title: "New chat"),
+                createdAt: Date(timeIntervalSince1970: 1),
+                promptRevision: "rev",
+                status: .sent
+            )],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        try sessionStore.save(originalRecord)
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [] },
+            send: { _, _, _ in Issue.record("send should not be called") }
+        )
+        let actions = ReviewDraftWorkspaceActions.make(
+            controller: controller,
+            sender: sender,
+            worktreeID: "wt-1",
+            now: { Date(timeIntervalSince1970: 200) },
+            sessionStore: { sessionStore }
+        )
+
+        actions.dismiss(comment)
+
+        #expect(controller.comments.first?.state == .dismissed)
+        let record = try #require(try sessionStore.load(id: target.id))
+        #expect(record == originalRecord)
+    }
+
+    @Test func draftWorkspaceActionsResolveSkipsRecomputeWhenWorktreeIDIsNil() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-draft-comments.json")
+        )
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt-1",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let controller = ReviewDraftCommentController(sessionID: session, store: draftStore)
+        try controller.load()
+        try controller.add(
+            anchor: DiffReviewLineAnchor(path: "Sources/App.swift", side: .new, line: 4, rowIndex: 0, selectedText: ""),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            bodyMarkdown: "Please fix this."
+        )
+        let comment = try #require(controller.comments.first)
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [] },
+            send: { _, _, _ in Issue.record("send should not be called") }
+        )
+        let actions = ReviewDraftWorkspaceActions.make(controller: controller, sender: sender)
+
+        actions.resolve(comment)
+
+        #expect(controller.comments.first?.state == .resolved)
+    }
+
     @Test func draftWorkspaceActionsSendToExplicitTargetOnly() {
         let codex = ReviewFeedbackAgentTarget.newChat(agentID: "codex", title: "Codex")
         let claude = ReviewFeedbackAgentTarget.newChat(agentID: "claude", title: "Claude")

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -364,6 +364,97 @@ struct ReviewChangesTabViewTests {
         #expect(record.updatedAt == Date(timeIntervalSince1970: 200))
     }
 
+    @Test func draftWorkspaceActionsResolveDoesNotDemoteAnotherSessionInTheSameWorktree() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-draft-comments.json")
+        )
+        let sessionStore = ReviewSessionStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-sessions.json")
+        )
+
+        // Session A: a commit review, already addressed on disk, whose
+        // referenced comment is resolved in the shared draft store.
+        let targetA = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc123",
+            title: "Review abc123"
+        )
+        let controllerA = ReviewDraftCommentController(
+            sessionID: targetA.draftSessionID,
+            store: draftStore,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        try controllerA.load()
+        try controllerA.add(
+            anchor: DiffReviewLineAnchor(path: "Sources/A.swift", side: .new, line: 1, rowIndex: 0, selectedText: ""),
+            fileID: DiffReviewFileID(namespace: "commit", path: "Sources/A.swift"),
+            bodyMarkdown: "Fix A."
+        )
+        let commentA = try #require(controllerA.comments.first)
+        try controllerA.resolve(commentID: commentA.id)
+        try sessionStore.save(ReviewSessionRecord(
+            id: targetA.id,
+            target: targetA,
+            status: .addressed,
+            handoffs: [ReviewFeedbackHandoff(
+                id: "hA",
+                sessionID: targetA.id,
+                commentIDs: [commentA.id],
+                target: .newChat(agentID: "claude", title: "New chat"),
+                createdAt: Date(timeIntervalSince1970: 1),
+                promptRevision: "rev",
+                status: .addressed
+            )],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        ))
+
+        // Session B: local changes in the same worktree, sharing the draft
+        // store. The user resolves one of its comments through the UI.
+        let targetB = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let controllerB = ReviewDraftCommentController(
+            sessionID: targetB.draftSessionID,
+            store: draftStore,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        try controllerB.load()
+        try controllerB.add(
+            anchor: DiffReviewLineAnchor(path: "Sources/B.swift", side: .new, line: 1, rowIndex: 0, selectedText: ""),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/B.swift"),
+            bodyMarkdown: "Fix B."
+        )
+        let commentB = try #require(controllerB.comments.first)
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [] },
+            send: { _, _, _ in Issue.record("send should not be called") }
+        )
+        let actions = ReviewDraftWorkspaceActions.make(
+            controller: controllerB,
+            sender: sender,
+            worktreeID: "wt-1",
+            now: { Date(timeIntervalSince1970: 200) },
+            sessionStore: { sessionStore }
+        )
+
+        actions.resolve(commentB)
+
+        // Session A stays addressed — its resolved comment lives in the same
+        // draft store and must be seen as resolved even though it isn't in
+        // session B's controller.
+        let recordA = try #require(try sessionStore.load(id: targetA.id))
+        #expect(recordA.status == .addressed)
+        #expect(recordA.handoffs.map(\.status) == [.addressed])
+    }
+
     @Test func draftWorkspaceActionsDismissDoesNotRecomputeHandoffProgress() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewChangesTabViewTests.swift
+++ b/AlasTests/ReviewChangesTabViewTests.swift
@@ -364,6 +364,100 @@ struct ReviewChangesTabViewTests {
         #expect(record.updatedAt == Date(timeIntervalSince1970: 200))
     }
 
+    @Test func draftWorkspaceActionsResolveNotifiesOpenPanesAfterRecompute() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-draft-comments.json")
+        )
+        let sessionStore = ReviewSessionStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-sessions.json")
+        )
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let controller = ReviewDraftCommentController(
+            sessionID: target.draftSessionID,
+            store: draftStore,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        try controller.load()
+        try controller.add(
+            anchor: DiffReviewLineAnchor(path: "Sources/App.swift", side: .new, line: 4, rowIndex: 0, selectedText: ""),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            bodyMarkdown: "Please fix this."
+        )
+        let comment = try #require(controller.comments.first)
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [] },
+            send: { _, _, _ in Issue.record("send should not be called") }
+        )
+        var notifyCount = 0
+        let actions = ReviewDraftWorkspaceActions.make(
+            controller: controller,
+            sender: sender,
+            worktreeID: "wt-1",
+            now: { Date(timeIntervalSince1970: 200) },
+            sessionStore: { sessionStore },
+            notifyExternalChange: { notifyCount += 1 }
+        )
+
+        actions.resolve(comment)
+
+        // Open review panes must be told to reload after the UI recompute, so a
+        // stale in-memory record can't later clobber the persisted addressed
+        // status — the same signal the CLI/MCP resolve path emits.
+        #expect(notifyCount == 1)
+    }
+
+    @Test func draftWorkspaceActionsResolveWithoutWorktreeDoesNotNotify() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let draftStore = ReviewDraftCommentStore(
+            store: PersistenceStore(),
+            url: directory.appendingPathComponent("review-draft-comments.json")
+        )
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let controller = ReviewDraftCommentController(
+            sessionID: target.draftSessionID,
+            store: draftStore,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+        try controller.load()
+        try controller.add(
+            anchor: DiffReviewLineAnchor(path: "Sources/App.swift", side: .new, line: 4, rowIndex: 0, selectedText: ""),
+            fileID: DiffReviewFileID(namespace: "unstaged", path: "Sources/App.swift"),
+            bodyMarkdown: "Please fix this."
+        )
+        let comment = try #require(controller.comments.first)
+        let sender = ReviewFeedbackAgentSender(
+            availableTargets: { [] },
+            send: { _, _, _ in Issue.record("send should not be called") }
+        )
+        var notifyCount = 0
+        let actions = ReviewDraftWorkspaceActions.make(
+            controller: controller,
+            sender: sender,
+            now: { Date(timeIntervalSince1970: 200) },
+            notifyExternalChange: { notifyCount += 1 }
+        )
+
+        actions.resolve(comment)
+
+        // No worktree means no recompute ran, so there is nothing to reload and
+        // no notification should be emitted.
+        #expect(controller.comments.first?.state == .resolved)
+        #expect(notifyCount == 0)
+    }
+
     @Test func draftWorkspaceActionsResolveDoesNotDemoteAnotherSessionInTheSameWorktree() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewHandoffProgressTests.swift
+++ b/AlasTests/ReviewHandoffProgressTests.swift
@@ -32,6 +32,56 @@ struct ReviewHandoffProgressTests {
         )
     }
 
+    @Test func recomputeAndPersistSavesOnlyRecordsThatActuallyChanged() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let sessionStore = ReviewSessionStore(url: url)
+        let addressableTarget = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo-a"),
+            scope: .all
+        )
+        let untouchedTarget = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo-b"),
+            scope: .all
+        )
+        let addressableRecord = ReviewSessionRecord(
+            id: addressableTarget.id,
+            target: addressableTarget,
+            status: .sent,
+            handoffs: [makeHandoff(id: "h1", commentIDs: ["c1"])],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let untouchedRecord = ReviewSessionRecord(
+            id: untouchedTarget.id,
+            target: untouchedTarget,
+            status: .active,
+            handoffs: [],
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        try sessionStore.save(addressableRecord)
+        try sessionStore.save(untouchedRecord)
+        let now = Date(timeIntervalSince1970: 99)
+
+        try ReviewHandoffProgress.recomputeAndPersist(
+            worktreeID: "wt-1",
+            sessionStore: sessionStore,
+            isResolved: { $0 == "c1" },
+            now: now
+        )
+
+        let addressed = try #require(try sessionStore.load(id: addressableTarget.id))
+        #expect(addressed.status == .addressed)
+        #expect(addressed.handoffs.map(\.status) == [.addressed])
+        #expect(addressed.updatedAt == now)
+        let untouched = try #require(try sessionStore.load(id: untouchedTarget.id))
+        #expect(untouched.updatedAt == Date(timeIntervalSince1970: 1))
+    }
+
     @Test func marksHandoffAndSessionAddressedWhenAllCommentsResolve() throws {
         let record = makeRecord(handoffs: [makeHandoff(id: "h1", commentIDs: ["c1", "c2"])], status: .sent)
         let now = Date(timeIntervalSince1970: 99)


### PR DESCRIPTION
Closes #798.

## Summary

The CLI/MCP `review_resolve` path (from #797) auto-flips a review session's handoff/status to `addressed` once all its referenced comments are resolved. The human-driven UI "Resolve" button never did this, so resolving comments in the UI left the session stuck at `sent`/`addressing`. This wires the same recomputation into the UI resolve action.

- Extracts the CLI's private recompute-and-persist loop into a shared `ReviewHandoffProgress.recomputeAndPersist(worktreeID:sessionStore:isResolved:now:)`, and refactors the CLI path onto it (pure refactor, identical behavior).
- Adds optional `worktreeID`/`now`/`sessionStore` params to `ReviewDraftWorkspaceActions.make(...)`; its `resolve` closure now recomputes handoff progress after the comment mutation (best-effort, `try?` — a failure never blocks the resolve). `dismiss` is intentionally untouched (a dismissed comment isn't `resolved`, matching the CLI predicate).
- Wires the real worktree id at all 5 UI call sites (`ReviewSessionTabView`, `ReviewChangesTabView`, `DiffTabView`, `CommitTabView`, `DraftReviewRequestTabView`).

The recompute reads persisted comment state globally (`ReviewDraftCommentController.persistedComment(withID:)` → the store's all-sessions `find`), not the single-session in-memory list — otherwise resolving a comment in one session would spuriously demote an already-addressed *different* session in the same worktree. A regression test guards that.

## Test plan

- [x] `AlasTests/ReviewHandoffProgressTests` — shared function, only-changed-records-saved
- [x] `AlasTests/ReviewChangesTabViewTests` — resolve-recomputes, dismiss-does-not, nil-worktree-skips, cross-session-not-demoted (regression)
- [x] `AlasTests/AlasCLICommandRouterTests` — CLI `review_resolve` behavior unchanged after the refactor
- [x] Full build clean; Rust suite 78/78 (unaffected)
- [ ] Manual: resolve all comments in an open review session's handoff via the UI Resolve button, confirm the session flips to addressed without a CLI call