### PR TITLE
fix(review): fill originalPath for review_comment_add on renamed provider-review files

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		3DB85FF0D4965BF78AD2B010 /* MergeSidePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C55C85672956E1340B03B1 /* MergeSidePane.swift */; };
 		3DBBAB113CDB6FEEB01C588E /* ACPManagedAdapterDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */; };
 		3DC03A7B9F9959155AE2B60E /* DiffReviewContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */; };
+		3DC9C5782952C79AA3AA6933 /* ProviderReviewOriginalPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB817BD4764F82E765163270 /* ProviderReviewOriginalPathResolver.swift */; };
 		3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
 		3E46667F7AA794E24B04BC7F /* TerminalCLIInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */; };
@@ -1220,6 +1221,7 @@
 		F57297D50FC237F7993F7B81 /* ACPSelectChipMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */; };
+		F64E588419012161F690ACB7 /* ProviderReviewOriginalPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC7D68CD8300C0F6766AED0 /* ProviderReviewOriginalPathResolverTests.swift */; };
 		F66BDC777D0BFDE306E8880A /* ACPTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B832ED19AC178DAD77C78D37 /* ACPTabView.swift */; };
 		F6C5274BCA0B3068C6C2D36A /* ZmxSunPathBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E5107A10052A150DD8DE02 /* ZmxSunPathBudgetTests.swift */; };
 		F6CC80D1E8D2D36251C83A1D /* ShellEnvResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */; };
@@ -1420,6 +1422,7 @@
 		1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatusTests.swift; sourceTree = "<group>"; };
 		1EC659A56A08A30F7784428D /* ACPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPClient.swift; sourceTree = "<group>"; };
 		1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDeciderTests.swift; sourceTree = "<group>"; };
+		1FC7D68CD8300C0F6766AED0 /* ProviderReviewOriginalPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewOriginalPathResolverTests.swift; sourceTree = "<group>"; };
 		1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouterTests.swift; sourceTree = "<group>"; };
 		2015944331CE56AEEF534910 /* ACPStdioQuestionDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioQuestionDispatchTests.swift; sourceTree = "<group>"; };
 		20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighterTests.swift; sourceTree = "<group>"; };
@@ -2416,6 +2419,7 @@
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
 		EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabStateTests.swift; sourceTree = "<group>"; };
 		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
+		EB817BD4764F82E765163270 /* ProviderReviewOriginalPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewOriginalPathResolver.swift; sourceTree = "<group>"; };
 		EB950CFAAADD11E84E783E1F /* EditorFindRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindRequestTests.swift; sourceTree = "<group>"; };
 		EBB8043A52927E5E935E2F9B /* ImageDiffPairLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairLoaderTests.swift; sourceTree = "<group>"; };
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -2896,6 +2900,7 @@
 				CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
+				1FC7D68CD8300C0F6766AED0 /* ProviderReviewOriginalPathResolverTests.swift */,
 				ADACDD363C5E4637A3113EFB /* RangeReviewLoaderTests.swift */,
 				C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */,
 				6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */,
@@ -4332,6 +4337,7 @@
 				389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */,
 				D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */,
 				AD3B3FF5D7B8F892ED1972A8 /* DiffReviewSurface.swift */,
+				EB817BD4764F82E765163270 /* ProviderReviewOriginalPathResolver.swift */,
 			);
 			path = DiffReview;
 			sourceTree = "<group>";
@@ -5439,6 +5445,7 @@
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
 				2661C51A093174D940CB5733 /* ProviderReviewActions.swift in Sources */,
 				B9D15679A5E813254E1DDCB6 /* ProviderReviewMutationController.swift in Sources */,
+				3DC9C5782952C79AA3AA6933 /* ProviderReviewOriginalPathResolver.swift in Sources */,
 				E3D59DB020583EF3E0EB7171 /* ProviderReviewPublishConfirmationView.swift in Sources */,
 				0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */,
 				0657FD1930271CA4C1F698DD /* RangeReviewLoader.swift in Sources */,
@@ -6025,6 +6032,7 @@
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
 				DC93AED5844A56C6BA012CC3 /* ProviderReviewActionsTests.swift in Sources */,
+				F64E588419012161F690ACB7 /* ProviderReviewOriginalPathResolverTests.swift in Sources */,
 				B6580745C7EDF5AA65DB0A86 /* QueuedPromptTests.swift in Sources */,
 				FB754FAC723CF480D3BBB101 /* RangeReviewLoaderTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -31,6 +31,7 @@ struct AlasActionService {
     }
     var now: () -> Date = Date.init
     var gitStatus: (URL) async throws -> [ChangedFile] = { try await GitService().status(worktreePath: $0) }
+    var providerReviewOriginalPath: (ReviewDraftSessionID, String) async -> String? = { _, _ in nil }
     var activateApp: () -> Void
 
     /// Worktree owning `directory`: the worktree rooted exactly at
@@ -199,13 +200,19 @@ struct AlasActionService {
         case .failed(let message):
             return .error(message)
         }
+        let originalPath: String?
+        if targetSessionID.sourceKind == .reviewRequest {
+            originalPath = await providerReviewOriginalPath(targetSessionID, relativePath)
+        } else {
+            originalPath = nil
+        }
         let timestamp = now()
         let comment = ReviewDraftComment(
             id: UUID().uuidString,
             sessionID: targetSessionID,
             fileID: DiffReviewFileID(namespace: namespace, path: relativePath),
             path: relativePath,
-            originalPath: nil,
+            originalPath: originalPath,
             side: side == "old" ? .old : .new,
             startLine: startLine,
             endLine: endLine,

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -200,8 +200,14 @@ struct AlasActionService {
         case .failed(let message):
             return .error(message)
         }
+        // Only GitLab publishing consumes `originalPath` (`oldPath` for a
+        // renamed file); GitHub's review-comment API keys off the post-rename
+        // path only. Resolving it loads the provider diff, so gating to
+        // GitLab keeps `review_comment_add` on a GitHub PR from waiting on an
+        // unnecessary `gh pr diff` fetch that would publish identically.
         let originalPath: String?
-        if targetSessionID.sourceKind == .reviewRequest {
+        if targetSessionID.sourceKind == .reviewRequest,
+           targetSessionID.reviewRequestProvider == .gitlab {
             originalPath = await providerReviewOriginalPath(targetSessionID, relativePath)
         } else {
             originalPath = nil

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -25,6 +25,7 @@ struct AlasCLICommandRouter {
     }
     var now: () -> Date = Date.init
     var gitStatus: (URL) async throws -> [ChangedFile] = { try await GitService().status(worktreePath: $0) }
+    var providerReviewOriginalPath: (ReviewDraftSessionID, String) async -> String? = { _, _ in nil }
     var activateApp: () -> Void
 
     private var service: AlasActionService {
@@ -42,6 +43,7 @@ struct AlasCLICommandRouter {
             notifyReviewCommentsChanged: notifyReviewCommentsChanged,
             now: now,
             gitStatus: gitStatus,
+            providerReviewOriginalPath: providerReviewOriginalPath,
             activateApp: activateApp
         )
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3696,10 +3696,13 @@ final class AppState {
 
             let registry = CodeHostProviderRegistry.live()
             let supportedRemotes = try await cliSupportedRemotes(for: worktree, registry: registry)
-            let remote = supportedRemotes.first(where: {
+            // Require the exact remote the session was opened against. Falling
+            // back to a different remote would load that repository's PR/MR of
+            // the same number and could stamp an `originalPath` from an
+            // unrelated review; nil is the correct best-effort result instead.
+            guard let remote = supportedRemotes.first(where: {
                 $0.host == host && $0.repositorySlug.lowercased() == repositorySlug.lowercased()
-            }) ?? supportedRemotes.first
-            guard let remote, let provider = registry.provider(for: remote.kind) else { return nil }
+            }), let provider = registry.provider(for: remote.kind) else { return nil }
 
             let request = try await provider.reviewRequest(remote: remote, number: number, cwd: worktree.path)
             let loaded = try await ReviewRequestDiffLoader(provider: provider)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3680,8 +3680,12 @@ final class AppState {
         }
         do {
             // Find the persisted review session record for this draft session.
+            // Scan all worktrees, not just visible ones: the CLI resolves its
+            // origin worktree via `worktree(withId:)`, which includes hidden
+            // worktrees, so a comment filed from a hidden worktree must still
+            // find its session record here.
             let sessionStore = ReviewSessionStore()
-            let allWorktrees = projects.flatMap { projectsManager.visibleWorktrees(projectId: $0.id) }
+            let allWorktrees = projects.flatMap { projectsManager.worktrees(projectId: $0.id) }
             var record: ReviewSessionRecord?
             for worktree in allWorktrees where sessionID.isFor(worktreeID: worktree.id) {
                 record = try sessionStore.list(worktreeID: worktree.id)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1819,6 +1819,13 @@ final class AppState {
         }
     }
 
+    /// Caches the loaded file summaries of a provider review, keyed by its
+    /// draft session id, so repeated `review_comment_add` calls in the same
+    /// review share one `gh`/`glab diff` fetch. Best-effort and never
+    /// invalidated: rename mappings rarely change mid-review, and a miss
+    /// simply falls back to nil (today's behavior).
+    private var providerReviewFileSummaryCache: [ReviewDraftSessionID: [DiffReviewFileSummary]] = [:]
+
     func makeCLICommandRouter(
         sessionWorktreeLookup: @escaping (String) -> String?
     ) -> AlasCLICommandRouter {
@@ -1869,6 +1876,9 @@ final class AppState {
             openProviderReview: { [weak self] worktree, target in
                 guard let self else { return .error("Alas is not available.") }
                 return await self.cliOpenProviderReview(worktree: worktree, target: target)
+            },
+            providerReviewOriginalPath: { [weak self] sessionID, relativePath in
+                await self?.reviewRequestOriginalPath(forDraftSessionID: sessionID, relativePath: relativePath) ?? nil
             },
             activateApp: {
                 NSApp.activate(ignoringOtherApps: true)
@@ -3573,21 +3583,7 @@ final class AppState {
 
         do {
             let providerRegistry = CodeHostProviderRegistry.live()
-            let remotes = try await GitService().remotes(worktreePath: worktree.path)
-            let baseBranch = rightPaneStore.state(
-                for: worktree,
-                baseBranch: config.worktrees.baseBranch,
-                comparisonMode: config.changes.comparisonMode
-            ).baseBranch
-            let preferredRemoteName = CodeHostRemoteDetector.preferredRemoteName(
-                forBaseBranch: baseBranch,
-                remotes: remotes
-            )
-            let supportedRemotes = CodeHostRemoteDetector.detectAll(
-                from: remotes,
-                supportedKinds: providerRegistry.supportedKinds,
-                preferredRemoteName: preferredRemoteName
-            )
+            let supportedRemotes = try await cliSupportedRemotes(for: worktree, registry: providerRegistry)
             guard !supportedRemotes.isEmpty else {
                 return .error("no code host remote found for this worktree")
             }
@@ -3643,6 +3639,76 @@ final class AppState {
             ])
         } catch {
             return .error(Self.describeCLIError(error))
+        }
+    }
+
+    /// Supported code-host remotes for `worktree`, ordered with the preferred
+    /// remote (derived from the base branch) first. Shared by
+    /// `cliOpenProviderReview` and the review-comment original-path resolver.
+    private func cliSupportedRemotes(
+        for worktree: Worktree,
+        registry: CodeHostProviderRegistry
+    ) async throws -> [CodeHostRemote] {
+        let remotes = try await GitService().remotes(worktreePath: worktree.path)
+        let baseBranch = rightPaneStore.state(
+            for: worktree,
+            baseBranch: config.worktrees.baseBranch,
+            comparisonMode: config.changes.comparisonMode
+        ).baseBranch
+        let preferredRemoteName = CodeHostRemoteDetector.preferredRemoteName(
+            forBaseBranch: baseBranch,
+            remotes: remotes
+        )
+        return CodeHostRemoteDetector.detectAll(
+            from: remotes,
+            supportedKinds: registry.supportedKinds,
+            preferredRemoteName: preferredRemoteName
+        )
+    }
+
+    /// Resolves the pre-rename `originalPath` for `relativePath` in the
+    /// provider review identified by `sessionID`, by loading the review's
+    /// diff (cached per session). Returns nil on any failure — a nil
+    /// `originalPath` is exactly the prior behavior, so this never blocks or
+    /// alters filing a comment.
+    func reviewRequestOriginalPath(
+        forDraftSessionID sessionID: ReviewDraftSessionID,
+        relativePath: String
+    ) async -> String? {
+        if let cached = providerReviewFileSummaryCache[sessionID] {
+            return ProviderReviewOriginalPathResolver.originalPath(forRelativePath: relativePath, in: cached)
+        }
+        do {
+            // Find the persisted review session record for this draft session.
+            let sessionStore = ReviewSessionStore()
+            let allWorktrees = projects.flatMap { projectsManager.visibleWorktrees(projectId: $0.id) }
+            var record: ReviewSessionRecord?
+            for worktree in allWorktrees where sessionID.isFor(worktreeID: worktree.id) {
+                record = try sessionStore.list(worktreeID: worktree.id)
+                    .first(where: { $0.target.draftSessionID == sessionID })
+                if record != nil { break }
+            }
+            guard let record,
+                  case .reviewRequest(_, let host, let repositorySlug, let number, _) = record.target.payload,
+                  let worktree = worktree(withId: record.target.worktreeID) else {
+                return nil
+            }
+
+            let registry = CodeHostProviderRegistry.live()
+            let supportedRemotes = try await cliSupportedRemotes(for: worktree, registry: registry)
+            let remote = supportedRemotes.first(where: {
+                $0.host == host && $0.repositorySlug.lowercased() == repositorySlug.lowercased()
+            }) ?? supportedRemotes.first
+            guard let remote, let provider = registry.provider(for: remote.kind) else { return nil }
+
+            let request = try await provider.reviewRequest(remote: remote, number: number, cwd: worktree.path)
+            let loaded = try await ReviewRequestDiffLoader(provider: provider)
+                .load(remote: remote, request: request, cwd: worktree.path)
+            let files = loaded.summary.files
+            providerReviewFileSummaryCache[sessionID] = files
+            return ProviderReviewOriginalPathResolver.originalPath(forRelativePath: relativePath, in: files)
+        } catch {
+            return nil
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/ProviderReviewOriginalPathResolver.swift
+++ b/Alas/Sources/Center/DiffReview/ProviderReviewOriginalPathResolver.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Finds the pre-rename/pre-copy path for a file in a loaded provider review's
+/// file list, so a CLI/MCP-filed review comment can carry `originalPath` the
+/// way UI-created drafts already do (from `DiffReviewFileSummary.originalPath`).
+/// Returns nil when the path isn't in the review or the file isn't a
+/// rename/copy — in which case GitLab publishing correctly falls back to
+/// `originalPath ?? path`.
+enum ProviderReviewOriginalPathResolver {
+    static func originalPath(forRelativePath relativePath: String, in files: [DiffReviewFileSummary]) -> String? {
+        files.first(where: { $0.path == relativePath })?.originalPath
+    }
+}

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -578,7 +578,8 @@ struct AlasCLICommandRouterTests {
         store: ReviewDraftCommentStore,
         sessionStore: ReviewSessionStore? = nil,
         onChange: @escaping () -> Void = {},
-        gitStatus: @escaping (URL) async throws -> [ChangedFile] = { _ in [] }
+        gitStatus: @escaping (URL) async throws -> [ChangedFile] = { _ in [] },
+        providerReviewOriginalPath: @escaping (ReviewDraftSessionID, String) async -> String? = { _, _ in nil }
     ) -> AlasCLICommandRouter {
         AlasCLICommandRouter(
             sessionWorktreeId: { $0 == "s1" ? worktree.id : nil },
@@ -590,6 +591,7 @@ struct AlasCLICommandRouterTests {
             reviewSessionStore: { sessionStore ?? ReviewSessionStore(url: FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")) },
             notifyReviewCommentsChanged: onChange,
             gitStatus: gitStatus,
+            providerReviewOriginalPath: providerReviewOriginalPath,
             activateApp: {}
         )
     }
@@ -705,6 +707,114 @@ struct AlasCLICommandRouterTests {
         #expect(saved[0].side == .new)
         #expect(saved[0].startLine == 4)
         #expect(saved[0].fileID == DiffReviewFileID(namespace: "unstaged", path: "a.swift"))
+    }
+
+    @Test func commentAddStampsOriginalPathForProviderReviewRenamedFile() async throws {
+        let root = try makeFile("repo/Sources/New.swift").deletingLastPathComponent().deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        let session = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt1", provider: .gitlab, host: "gitlab.com", repositorySlug: "group/repo", number: 42
+        )
+        var resolverCalls: [(ReviewDraftSessionID, String)] = []
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            providerReviewOriginalPath: { sessionID, path in
+                resolverCalls.append((sessionID, path))
+                return path == "Sources/New.swift" ? "Sources/Old.swift" : nil
+            }
+        )
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "Sources/New.swift", startLine: 3, endLine: nil, side: nil,
+                body: "renamed file comment", sessionID: session.rawValue
+            ))
+        ))
+
+        guard case .text = response else {
+            Issue.record("expected .text response, got \(response)")
+            return
+        }
+        #expect(resolverCalls.count == 1)
+        #expect(resolverCalls.first?.1 == "Sources/New.swift")
+        let saved = try store.load(sessionID: session)
+        #expect(saved.count == 1)
+        #expect(saved[0].originalPath == "Sources/Old.swift")
+    }
+
+    @Test func commentAddLeavesOriginalPathNilWhenResolverReturnsNil() async throws {
+        let root = try makeFile("repo/Sources/New.swift").deletingLastPathComponent().deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        let session = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt1", provider: .github, host: "github.com", repositorySlug: "org/repo", number: 7
+        )
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            providerReviewOriginalPath: { _, _ in nil }
+        )
+        _ = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "Sources/New.swift", startLine: 3, endLine: nil, side: nil,
+                body: "unmatched", sessionID: session.rawValue
+            ))
+        ))
+
+        let saved = try store.load(sessionID: session)
+        #expect(saved.count == 1)
+        #expect(saved[0].originalPath == nil)
+    }
+
+    @Test func commentAddDoesNotResolveOriginalPathForLocalChangesSession() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        var resolverCalled = false
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            gitStatus: { _ in
+                [ChangedFile(path: "a.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil)]
+            },
+            providerReviewOriginalPath: { _, _ in
+                resolverCalled = true
+                return "Sources/Old.swift"
+            }
+        )
+        _ = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "a.swift", startLine: 1, endLine: nil, side: nil, body: "local", sessionID: nil
+            ))
+        ))
+
+        #expect(!resolverCalled)
+        let expectedSession = ReviewDraftSessionID.localChanges(worktreeID: "wt1", worktreePath: root, scope: .all)
+        let saved = try store.load(sessionID: expectedSession)
+        #expect(saved.count == 1)
+        #expect(saved[0].originalPath == nil)
     }
 
     @Test func commentAddPrefersUnstagedWhenPathIsBothStagedAndUnstaged() async throws {

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -761,7 +761,7 @@ struct AlasCLICommandRouterTests {
             .appendingPathComponent("drafts.json")
         let store = ReviewDraftCommentStore(url: storeURL)
         let session = ReviewDraftSessionID.reviewRequest(
-            worktreeID: "wt1", provider: .github, host: "github.com", repositorySlug: "org/repo", number: 7
+            worktreeID: "wt1", provider: .gitlab, host: "gitlab.com", repositorySlug: "group/repo", number: 7
         )
 
         let router = makeReviewRouter(
@@ -776,6 +776,44 @@ struct AlasCLICommandRouterTests {
             ))
         ))
 
+        let saved = try store.load(sessionID: session)
+        #expect(saved.count == 1)
+        #expect(saved[0].originalPath == nil)
+    }
+
+    @Test func commentAddDoesNotResolveOriginalPathForGitHubReview() async throws {
+        let root = try makeFile("repo/Sources/New.swift").deletingLastPathComponent().deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        let store = ReviewDraftCommentStore(url: storeURL)
+        let session = ReviewDraftSessionID.reviewRequest(
+            worktreeID: "wt1", provider: .github, host: "github.com", repositorySlug: "org/repo", number: 7
+        )
+        var resolverCalled = false
+
+        let router = makeReviewRouter(
+            worktree: worktree, store: store,
+            providerReviewOriginalPath: { _, _ in
+                resolverCalled = true
+                return "Sources/Old.swift"
+            }
+        )
+        _ = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.commentAdd(
+                path: "Sources/New.swift", startLine: 3, endLine: nil, side: nil,
+                body: "github comment", sessionID: session.rawValue
+            ))
+        ))
+
+        // GitHub publishing ignores originalPath, so the resolver (which loads
+        // the provider diff) must not run for a GitHub review.
+        #expect(!resolverCalled)
         let saved = try store.load(sessionID: session)
         #expect(saved.count == 1)
         #expect(saved[0].originalPath == nil)

--- a/AlasTests/ProviderReviewOriginalPathResolverTests.swift
+++ b/AlasTests/ProviderReviewOriginalPathResolverTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Provider review original path resolver")
+struct ProviderReviewOriginalPathResolverTests {
+    private func summary(path: String, originalPath: String?, status: DiffReviewFileStatus) -> DiffReviewFileSummary {
+        DiffReviewFileSummary(
+            path: path,
+            namespace: "github-pr",
+            groupID: nil,
+            groupTitle: nil,
+            status: status,
+            additions: 1,
+            deletions: 0,
+            isRenderable: true,
+            originalPath: originalPath
+        )
+    }
+
+    @Test func returnsOriginalPathForARenamedFile() {
+        let files = [
+            summary(path: "Sources/New.swift", originalPath: "Sources/Old.swift", status: .renamed),
+            summary(path: "Sources/Other.swift", originalPath: nil, status: .modified),
+        ]
+        #expect(
+            ProviderReviewOriginalPathResolver.originalPath(forRelativePath: "Sources/New.swift", in: files)
+                == "Sources/Old.swift"
+        )
+    }
+
+    @Test func returnsOriginalPathForACopiedFile() {
+        let files = [summary(path: "Sources/Copy.swift", originalPath: "Sources/Source.swift", status: .copied)]
+        #expect(
+            ProviderReviewOriginalPathResolver.originalPath(forRelativePath: "Sources/Copy.swift", in: files)
+                == "Sources/Source.swift"
+        )
+    }
+
+    @Test func returnsNilForANonRenamedFile() {
+        let files = [summary(path: "Sources/App.swift", originalPath: nil, status: .modified)]
+        #expect(ProviderReviewOriginalPathResolver.originalPath(forRelativePath: "Sources/App.swift", in: files) == nil)
+    }
+
+    @Test func returnsNilWhenPathIsNotInTheReview() {
+        let files = [summary(path: "Sources/New.swift", originalPath: "Sources/Old.swift", status: .renamed)]
+        #expect(ProviderReviewOriginalPathResolver.originalPath(forRelativePath: "Sources/Missing.swift", in: files) == nil)
+    }
+
+    @Test func returnsNilForAnEmptyFileList() {
+        #expect(ProviderReviewOriginalPathResolver.originalPath(forRelativePath: "Sources/New.swift", in: []) == nil)
+    }
+}


### PR DESCRIPTION
Closes #799.

## Summary

A comment filed via `review_comment_add` on a **renamed or copied** file in a **GitLab** provider review lost the pre-rename path (`originalPath` was always nil), so GitLab publishing sent the post-rename path as both `oldPath` and `newPath` — the provider could reject the position or misattach the comment. UI-created drafts already carry `originalPath` from the diff's file summary; this brings CLI/MCP-filed comments to parity.

- **Pure resolver** `ProviderReviewOriginalPathResolver.originalPath(forRelativePath:in:)` finds a file's pre-rename path in a loaded provider review's file summaries.
- **Injected closure** `providerReviewOriginalPath` on `AlasActionService`/`AlasCLICommandRouter`; `reviewCommentAdd` calls it **only** for `.reviewRequest` (provider) sessions and passes the result as `originalPath`. Best-effort: nil never blocks the comment (= prior behavior, no regression).
- **AppState glue** loads the provider review's diff (reusing an extracted `cliSupportedRemotes` helper + `provider.reviewRequest` + `ReviewRequestDiffLoader.load`), finds the file via the pure resolver, and **caches the file list per session** so N `review_comment_add` calls share one `gh`/`glab diff` fetch.

Scope is deliberately provider-only: local/commit/range sessions never publish, so filling `originalPath` there would be dead data. GitHub reviews don't read `originalPath` at all (harmless there). The GitLab/GitHub publish paths are untouched — they already do the right thing once the draft carries `originalPath`.

## Known limitation

The per-session diff cache is not invalidated for the app-session lifetime. If a provider review's rename detection materially changes mid-session (e.g. a force-push), a later comment could stamp a stale `originalPath`. This is the same snapshot-staleness class UI drafts already have (originalPath fixed at creation, published later); low blast radius. Worth a follow-up only if provider reviews become long-lived.

## Test plan

- [x] `AlasTests/ProviderReviewOriginalPathResolverTests` — rename/copy/non-rename/absent/empty
- [x] `AlasTests/AlasCLICommandRouterTests` — provider-rename stamps originalPath, nil passthrough, local-changes never invokes the resolver
- [x] `AlasTests/AppStateCLIRoutingTests` — behavior-preserving `cliOpenProviderReview` refactor still green
- [x] Full build clean; Rust suite 78/78 (unaffected)
- [ ] Manual: on a GitLab MR that renames a file, `alas review <MR>` then `alas review comment <renamed-new-path> <line> "note"`, publish, confirm the discussion position's `old_path` is the pre-rename path