### PR TITLE
fix(build): use rustup toolchain for fff

### DIFF
--- a/scripts/build-fff.sh
+++ b/scripts/build-fff.sh
@@ -99,6 +99,7 @@ esac
 
 mkdir -p "${lib_dir}" "${include_root}"
 
+"${rustup_bin}" toolchain install "${rust_toolchain}" --profile minimal
 installed_targets="$("${rustup_bin}" target list --installed --toolchain "${rust_toolchain}")"
 if ! printf '%s\n' "${installed_targets}" | grep -qx "${cargo_target}"; then
     "${rustup_bin}" target add --toolchain "${rust_toolchain}" "${cargo_target}"

--- a/scripts/build-fff.sh
+++ b/scripts/build-fff.sh
@@ -11,6 +11,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 script_path="${script_dir}/$(basename "${BASH_SOURCE[0]}")"
 srcroot="${SRCROOT:-$(cd "${script_dir}/.." && pwd)}"
 fff_src="${srcroot}/ThirdParty/fff"
+rustup_bin="${ALAS_RUSTUP_BIN:-rustup}"
+rust_toolchain="${ALAS_RUST_TOOLCHAIN:-stable}"
 
 if [ -z "${ALAS_FFF_TARGET_ARCH:-}" ] && [ "${CURRENT_ARCH:-}" = "undefined_arch" ]; then
     target_arch="universal"
@@ -87,7 +89,7 @@ if [ "${target_arch}" = "universal" ]; then
 fi
 
 [ -d "${fff_src}/.git" ] || [ -f "${fff_src}/.git" ] || die "submodule missing: ${fff_src}"
-command -v cargo >/dev/null 2>&1 || die "cargo not found. Install Rust or ensure cargo is on PATH"
+command -v "${rustup_bin}" >/dev/null 2>&1 || die "rustup not found"
 
 case "${target_arch}" in
     arm64) cargo_target="aarch64-apple-darwin" ;;
@@ -97,16 +99,22 @@ esac
 
 mkdir -p "${lib_dir}" "${include_root}"
 
-if command -v rustup >/dev/null 2>&1; then
-    if ! rustup target list --installed | grep -qx "${cargo_target}"; then
-        rustup target add "${cargo_target}"
-    fi
+installed_targets="$("${rustup_bin}" target list --installed --toolchain "${rust_toolchain}")"
+if ! printf '%s\n' "${installed_targets}" | grep -qx "${cargo_target}"; then
+    "${rustup_bin}" target add --toolchain "${rust_toolchain}" "${cargo_target}"
+fi
+
+rustc_bin="$("${rustup_bin}" which --toolchain "${rust_toolchain}" rustc)"
+if [ -n "${ALAS_CARGO_BIN:-}" ]; then
+    cargo_bin="${ALAS_CARGO_BIN}"
+else
+    cargo_bin="$("${rustup_bin}" which --toolchain "${rust_toolchain}" cargo)"
 fi
 
 (
     cd "${fff_src}"
     MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}" \
-        cargo build \
+        RUSTC="${rustc_bin}" "${cargo_bin}" build \
             --package fff-c \
             --release \
             --target "${cargo_target}" \

--- a/scripts/tests/build-fff/run.sh
+++ b/scripts/tests/build-fff/run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${this_dir}/../../.." && pwd)"
+sandbox="$(mktemp -d)"
+trap 'rm -rf "${sandbox}"' EXIT
+
+srcroot="${sandbox}/repo"
+fff_src="${srcroot}/ThirdParty/fff"
+toolchain_bin="${sandbox}/toolchain/bin"
+invocations="${sandbox}/invocations"
+mkdir -p "${srcroot}/scripts" "${fff_src}/crates/fff-c/include" "${toolchain_bin}" "${sandbox}/bin"
+cp "${repo_root}/scripts/build-fff.sh" "${srcroot}/scripts/build-fff.sh"
+printf '#pragma once\n' > "${fff_src}/crates/fff-c/include/fff.h"
+: > "${invocations}"
+
+git -C "${fff_src}" init -q
+git -C "${fff_src}" add .
+git -C "${fff_src}" -c user.name=test -c user.email=test@example.com commit -qm initial
+
+cat > "${sandbox}/rustup" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+echo "rustup \$*" >> "${invocations}"
+case "\$1 \$2" in
+    "target list") exit 0 ;;
+    "target add") exit 0 ;;
+    "which --toolchain")
+        case "\${4:-}" in
+            rustc) echo "${toolchain_bin}/rustc" ;;
+            cargo) echo "${toolchain_bin}/cargo" ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    *) exit 1 ;;
+esac
+EOF
+
+cat > "${toolchain_bin}/rustc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat > "${toolchain_bin}/cargo" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+echo "cargo RUSTC=\${RUSTC:-} \$*" >> "${invocations}"
+target=""
+target_dir=""
+while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+        --target) target="\$2"; shift 2 ;;
+        --target-dir) target_dir="\$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+mkdir -p "\${target_dir}/\${target}/release"
+touch "\${target_dir}/\${target}/release/libfff_c.dylib"
+EOF
+
+cat > "${sandbox}/bin/install_name_tool" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "${sandbox}/rustup" "${toolchain_bin}/rustc" "${toolchain_bin}/cargo" "${sandbox}/bin/install_name_tool"
+
+SRCROOT="${srcroot}" \
+    ALAS_FFF_TARGET_ARCH="x86_64" \
+    ALAS_RUSTUP_BIN="${sandbox}/rustup" \
+    PATH="${sandbox}/bin:${PATH}" \
+    bash "${srcroot}/scripts/build-fff.sh"
+
+grep -qx 'rustup target list --installed --toolchain stable' "${invocations}"
+grep -qx 'rustup target add --toolchain stable x86_64-apple-darwin' "${invocations}"
+grep -qx 'rustup which --toolchain stable rustc' "${invocations}"
+grep -qx 'rustup which --toolchain stable cargo' "${invocations}"
+grep -q "^cargo RUSTC=${toolchain_bin}/rustc build " "${invocations}"
+test -f "${srcroot}/.build/fff/x86_64/install/lib/libfff_c.dylib"
+
+echo "build-fff tests passed"

--- a/scripts/tests/build-fff/run.sh
+++ b/scripts/tests/build-fff/run.sh
@@ -24,6 +24,7 @@ cat > "${sandbox}/rustup" <<EOF
 set -euo pipefail
 echo "rustup \$*" >> "${invocations}"
 case "\$1 \$2" in
+    "toolchain install") exit 0 ;;
     "target list") exit 0 ;;
     "target add") exit 0 ;;
     "which --toolchain")
@@ -72,6 +73,7 @@ SRCROOT="${srcroot}" \
     PATH="${sandbox}/bin:${PATH}" \
     bash "${srcroot}/scripts/build-fff.sh"
 
+grep -qx 'rustup toolchain install stable --profile minimal' "${invocations}"
 grep -qx 'rustup target list --installed --toolchain stable' "${invocations}"
 grep -qx 'rustup target add --toolchain stable x86_64-apple-darwin' "${invocations}"
 grep -qx 'rustup which --toolchain stable rustc' "${invocations}"


### PR DESCRIPTION
## Summary

- resolve fff cargo and rustc through the configured rustup toolchain
- install macOS targets into that same toolchain
- add a hermetic regression test for the x86_64 build path

## Root cause

`build-fff.sh` used the bare `cargo` on PATH. On Homebrew Rust installations this selected the native-only toolchain, so the x86_64 slice of universal builds could not find its standard library.

## Validation

- `bash scripts/tests/build-fff/run.sh`
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

The full Xcode test target is blocked in this worktree because `ThirdParty/ghostty` is uninitialized and `GhosttyKit.xcframework` is unavailable.

Closes #804 