### PR TITLE
feat(mcp): add review finish tool

### DIFF
--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -241,6 +241,67 @@ struct AlasActionService {
         ])
     }
 
+    func reviewFinish(
+        origin: Worktree,
+        sessionID: String?,
+        verdict: ReviewVerdict,
+        summary: String
+    ) -> AlasCLIResponse {
+        let defaultSessionID = ReviewDraftSessionID.localChanges(
+            worktreeID: origin.id,
+            worktreePath: origin.path,
+            scope: .all
+        )
+        let draftSessionID: ReviewDraftSessionID
+        if let sessionID {
+            guard let parsed = ReviewDraftSessionID(rawValue: sessionID),
+                  parsed.isFor(worktreeID: origin.id) else {
+                return .error("unknown review session id")
+            }
+            draftSessionID = parsed
+        } else {
+            draftSessionID = defaultSessionID
+        }
+        guard verdict != .requestChanges
+            || !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .error("request_changes requires a non-empty summary")
+        }
+
+        let sessions = reviewSessionStore()
+        do {
+            let record: ReviewSessionRecord
+            if let existing = try sessions.list(worktreeID: origin.id).first(where: {
+                $0.target.draftSessionID == draftSessionID
+            }) {
+                record = existing
+            } else {
+                // `review` opens local changes in the dedicated changes tab,
+                // which does not create a ReviewSessionRecord. Materialize its
+                // canonical session only when finishing that default review.
+                guard draftSessionID == defaultSessionID else {
+                    return .error("unknown review session id")
+                }
+                let target = ReviewSessionTarget.localChanges(
+                    worktreeID: origin.id,
+                    repositoryPath: origin.path,
+                    scope: .all
+                )
+                let timestamp = now()
+                record = ReviewSessionRecord(
+                    id: target.id,
+                    target: target,
+                    createdAt: timestamp,
+                    updatedAt: timestamp
+                )
+            }
+            try sessions.save(record.markedReviewed(verdict: verdict, summary: summary, now: now()))
+        } catch {
+            return .error("could not finish review: \(error.localizedDescription)")
+        }
+        notifyReviewCommentsChanged()
+        return .ok
+    }
+
     /// Worktree-relative form of `path`: absolute paths under the worktree
     /// root are relativized; already-relative paths are lexically
     /// normalized (collapsing `.`/`..`/repeated separators) and treated as

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -93,6 +93,10 @@ struct AlasCLICommandRouter {
                 origin: origin, path: path, startLine: startLine, endLine: endLine,
                 side: side, body: body, sessionID: sessionID
             )
+        case .review(.finish(let sessionID, let verdict, let summary)):
+            return service.reviewFinish(
+                origin: origin, sessionID: sessionID, verdict: verdict, summary: summary
+            )
         }
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -286,7 +286,14 @@ enum ReviewSessionStatus: String, Codable, Equatable, Hashable, Sendable {
     case sent
     case addressing
     case addressed
+    case reviewed
     case archived
+}
+
+struct ReviewSessionVerdict: Codable, Equatable, Sendable {
+    let verdict: ReviewVerdict
+    let summary: String
+    let reviewedAt: Date
 }
 
 enum ReviewFeedbackHandoffStatus: String, Codable, Equatable, Hashable, Sendable {
@@ -329,6 +336,7 @@ struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
     var selectedFileID: DiffReviewFileID?
     var focusedCommentID: String?
     var status: ReviewSessionStatus
+    var verdict: ReviewSessionVerdict?
     var handoffs: [ReviewFeedbackHandoff]
     var lastSendError: String?
     let createdAt: Date
@@ -340,6 +348,7 @@ struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
         selectedFileID: DiffReviewFileID? = nil,
         focusedCommentID: String? = nil,
         status: ReviewSessionStatus = .active,
+        verdict: ReviewSessionVerdict? = nil,
         handoffs: [ReviewFeedbackHandoff] = [],
         lastSendError: String? = nil,
         createdAt: Date,
@@ -350,6 +359,7 @@ struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
         self.selectedFileID = selectedFileID
         self.focusedCommentID = focusedCommentID
         self.status = status
+        self.verdict = verdict
         self.handoffs = handoffs
         self.lastSendError = lastSendError
         self.createdAt = createdAt
@@ -359,7 +369,9 @@ struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
     func recording(handoff: ReviewFeedbackHandoff) -> ReviewSessionRecord {
         var record = self
         record.handoffs.append(handoff)
-        record.status = handoff.status == .failed ? .active : .sent
+        if record.status != .reviewed {
+            record.status = handoff.status == .failed ? .active : .sent
+        }
         record.lastSendError = nil
         record.updatedAt = handoff.createdAt
         return record
@@ -367,12 +379,22 @@ struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
 
     func markedAddressed(now: Date) -> ReviewSessionRecord {
         var record = self
-        record.status = .addressed
+        if record.status != .reviewed {
+            record.status = .addressed
+        }
         record.handoffs = record.handoffs.map { handoff in
             var updated = handoff
             updated.status = .addressed
             return updated
         }
+        record.updatedAt = now
+        return record
+    }
+
+    func markedReviewed(verdict: ReviewVerdict, summary: String, now: Date) -> ReviewSessionRecord {
+        var record = self
+        record.status = .reviewed
+        record.verdict = ReviewSessionVerdict(verdict: verdict, summary: summary, reviewedAt: now)
         record.updatedAt = now
         return record
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
@@ -24,7 +24,7 @@ struct ReviewSessionStore {
     func findActive(targetID: ReviewSessionID) throws -> ReviewSessionRecord? {
         let snapshot = try readSnapshot()
         return snapshot.recordsByID.values
-            .filter { $0.target.id == targetID && $0.status != .archived }
+            .filter { $0.target.id == targetID && $0.status != .archived && $0.status != .reviewed }
             .sorted(by: sortSessions)
             .first
     }

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -16,6 +16,20 @@ enum ReviewCommentWireFilter: String, Equatable {
     case all
 }
 
+enum ReviewVerdictWire: String, Equatable {
+    case approve
+    case requestChanges = "request_changes"
+    case comment
+
+    var reviewVerdict: ReviewVerdict {
+        switch self {
+        case .approve: .approve
+        case .requestChanges: .requestChanges
+        case .comment: .comment
+        }
+    }
+}
+
 struct AlasCLIRequest: Equatable {
     enum Command: Equatable {
         case open(paths: [String])
@@ -38,6 +52,7 @@ struct AlasCLIRequest: Equatable {
         case reply(commentID: String, body: String)
         case resolve(commentID: String, reply: String?, reopen: Bool)
         case commentAdd(path: String, startLine: Int, endLine: Int?, side: String?, body: String, sessionID: String?)
+        case finish(sessionID: String?, verdict: ReviewVerdict, summary: String)
     }
 
     let version: Int
@@ -92,6 +107,12 @@ struct AlasCLIRequest: Equatable {
         var side: String?
         var body: String
         var session_id: String?
+    }
+
+    private struct ReviewFinishParams: Decodable {
+        var session_id: String?
+        var verdict: String?
+        var summary: String?
     }
 
     /// Typed access to the `params` object new-style commands carry.
@@ -229,6 +250,22 @@ struct AlasCLIRequest: Equatable {
                 side: side,
                 body: try requiredNonEmpty(params.body),
                 sessionID: params.session_id?.nilIfBlank
+            ))
+        case "review_finish":
+            let params = try Self.decodeParamsIfPresent(ReviewFinishParams.self, from: data)
+            let verdict: ReviewVerdict
+            if let rawVerdict = params?.verdict?.nilIfBlank {
+                guard let parsed = ReviewVerdictWire(rawValue: rawVerdict) else {
+                    throw AlasCLIRequestError.malformed
+                }
+                verdict = parsed.reviewVerdict
+            } else {
+                verdict = .comment
+            }
+            command = .review(.finish(
+                sessionID: params?.session_id?.nilIfBlank,
+                verdict: verdict,
+                summary: params?.summary ?? ""
             ))
         case "resolve":
             command = .resolve

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -138,6 +138,7 @@ pub enum Command {
         body: String,
         session_id: Option<String>,
     },
+    ReviewFinish { session_id: Option<String>, verdict: Option<String>, summary: Option<String> },
     Resolve,
 }
 
@@ -225,6 +226,21 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
             params.insert("body".into(), serde_json::Value::String(body.clone()));
             if let Some(session_id) = session_id {
                 params.insert("session_id".into(), serde_json::Value::String(session_id.clone()));
+            }
+            r.params = Some(serde_json::Value::Object(params));
+            r
+        }
+        Command::ReviewFinish { session_id, verdict, summary } => {
+            let mut r = Request::new("review_finish");
+            let mut params = serde_json::Map::new();
+            if let Some(session_id) = session_id {
+                params.insert("session_id".into(), serde_json::Value::String(session_id.clone()));
+            }
+            if let Some(verdict) = verdict {
+                params.insert("verdict".into(), serde_json::Value::String(verdict.clone()));
+            }
+            if let Some(summary) = summary {
+                params.insert("summary".into(), serde_json::Value::String(summary.clone()));
             }
             r.params = Some(serde_json::Value::Object(params));
             r
@@ -599,6 +615,25 @@ mod tests {
                 "end_line": 12,
                 "side": "new",
                 "body": "consider guard"
+            }))
+        );
+    }
+
+    #[test]
+    fn builds_review_finish_params() {
+        let cmd = Command::ReviewFinish {
+            session_id: Some("sid".into()),
+            verdict: Some("request_changes".into()),
+            summary: Some("Fix the race.".into()),
+        };
+        let req = build_request(&cmd, None, Some("/wt".into()));
+        assert_eq!(req.command, "review_finish");
+        assert_eq!(
+            req.params,
+            Some(serde_json::json!({
+                "session_id": "sid",
+                "verdict": "request_changes",
+                "summary": "Fix the race."
             }))
         );
     }

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -204,6 +204,18 @@ pub fn tool_definitions() -> Vec<Value> {
                 "required": ["path", "start_line", "body"]
             }
         }),
+        json!({
+            "name": "review_finish",
+            "description": "Finish an Alas review session with its capstone verdict and optional summary after filing findings. Requesting changes requires a summary.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "session_id": { "type": "string", "description": "Review session to finish, returned by the review tool. Defaults to the current worktree's local-changes review." },
+                    "verdict": { "type": "string", "enum": ["approve", "request_changes", "comment"], "description": "Review verdict. Default: comment." },
+                    "summary": { "type": "string", "description": "Optional review summary. Required when verdict is request_changes." }
+                }
+            }
+        }),
     ]
 }
 
@@ -298,6 +310,19 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
                 session_id: optional_string(args, "session_id"),
             })
         }
+        "review_finish" => {
+            let verdict = optional_string(args, "verdict");
+            if let Some(verdict) = &verdict {
+                if !["approve", "request_changes", "comment"].contains(&verdict.as_str()) {
+                    return Err("review_finish 'verdict' must be approve, request_changes, or comment".into());
+                }
+            }
+            Ok(Command::ReviewFinish {
+                session_id: optional_string(args, "session_id"),
+                verdict,
+                summary: optional_string(args, "summary"),
+            })
+        }
         other => Err(format!("unknown tool: {other}")),
     }
 }
@@ -381,6 +406,7 @@ fn success_message(command: &Command) -> String {
         Command::ReviewResolve { reopen: false, .. } => "Comment resolved.".into(),
         Command::ReviewResolve { reopen: true, .. } => "Comment reopened.".into(),
         Command::ReviewCommentAdd { path, .. } => format!("Filed review comment on {path}."),
+        Command::ReviewFinish { .. } => "Review finished.".into(),
         Command::WtList | Command::Resolve => "OK".into(),
     }
 }
@@ -519,7 +545,8 @@ mod tests {
                 "review_comments",
                 "review_reply",
                 "review_resolve",
-                "review_comment_add"
+                "review_comment_add",
+                "review_finish"
             ]
         );
         for tool in tools {
@@ -671,6 +698,28 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn review_finish_tool_maps_and_validates_verdict() {
+        assert_eq!(
+            command_for_tool("review_finish", &json!({}), "/wt").unwrap(),
+            alas_client::Command::ReviewFinish { session_id: None, verdict: None, summary: None }
+        );
+        assert_eq!(
+            command_for_tool(
+                "review_finish",
+                &json!({"session_id": "sid", "verdict": "approve", "summary": "Looks good."}),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::ReviewFinish {
+                session_id: Some("sid".into()),
+                verdict: Some("approve".into()),
+                summary: Some("Looks good.".into()),
+            }
+        );
+        assert!(command_for_tool("review_finish", &json!({"verdict": "reject"}), "/wt").is_err());
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/parse.rs
+++ b/AlasCLI/crates/alas/src/parse.rs
@@ -19,7 +19,8 @@ usage: alas review [pr-number-or-url]
 usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]
 usage: alas review reply <comment-id> <body>
 usage: alas review resolve <comment-id> [--reply <body>] [--reopen]
-usage: alas review comment <path> <line> <body> [--end-line <n>] [--side <old|new>] [--session <id>]";
+usage: alas review comment <path> <line> <body> [--end-line <n>] [--side <old|new>] [--session <id>]
+usage: alas review finish [--session <id>] [--verdict <approve|request-changes|comment>] [--summary <body>]";
 
 /// Parse arguments (excluding argv0) into a Command. `base` is the directory
 /// `open` paths resolve against. On misuse, returns the usage string to print.
@@ -61,11 +62,45 @@ fn parse_review(args: &[&str], base: &std::path::Path) -> Result<Command, String
             Ok(Command::ReviewReply { comment_id: args[1].to_string(), body: args[2].to_string() })
         }
         Some("resolve") => parse_review_resolve(&args[1..]),
+        Some("finish") => parse_review_finish(&args[1..]),
         Some(target) if args.len() == 1 && !target.starts_with("--") => {
             Ok(Command::Review { target: Some(target.to_string()) })
         }
         _ => Err(USAGE_ALL.into()),
     }
+}
+
+fn parse_review_finish(args: &[&str]) -> Result<Command, String> {
+    const USAGE: &str = "usage: alas review finish [--session <id>] [--verdict <approve|request-changes|comment>] [--summary <body>]";
+    let mut session_id: Option<String> = None;
+    let mut verdict: Option<String> = None;
+    let mut summary: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i] {
+            "--session" => {
+                i += 1;
+                session_id = Some(flag_value(args, i).ok_or(USAGE)?.to_string());
+            }
+            "--verdict" => {
+                i += 1;
+                let value = flag_value(args, i).ok_or(USAGE)?;
+                let wire_value = match value {
+                    "approve" | "comment" => value,
+                    "request-changes" => "request_changes",
+                    _ => return Err(USAGE.into()),
+                };
+                verdict = Some(wire_value.to_string());
+            }
+            "--summary" => {
+                i += 1;
+                summary = Some(flag_value(args, i).ok_or(USAGE)?.to_string());
+            }
+            _ => return Err(USAGE.into()),
+        }
+        i += 1;
+    }
+    Ok(Command::ReviewFinish { session_id, verdict, summary })
 }
 
 fn parse_review_resolve(args: &[&str]) -> Result<Command, String> {
@@ -365,6 +400,28 @@ mod tests {
         assert!(parse(&s(&["review", "resolve"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "resolve", "--reopen"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "resolve", "c1", "--reply"]), Path::new("/b")).is_err());
+    }
+
+    #[test]
+    fn review_finish_parses_flags_and_normalizes_request_changes() {
+        assert_eq!(
+            parse(&s(&["review", "finish"]), Path::new("/b")).unwrap(),
+            Command::ReviewFinish { session_id: None, verdict: None, summary: None }
+        );
+        assert_eq!(
+            parse(
+                &s(&["review", "finish", "--session", "sid", "--verdict", "request-changes", "--summary", "Fix it"]),
+                Path::new("/b")
+            )
+            .unwrap(),
+            Command::ReviewFinish {
+                session_id: Some("sid".into()),
+                verdict: Some("request_changes".into()),
+                summary: Some("Fix it".into()),
+            }
+        );
+        assert!(parse(&s(&["review", "finish", "--verdict", "reject"]), Path::new("/b")).is_err());
+        assert!(parse(&s(&["review", "finish", "summary"]), Path::new("/b")).is_err());
     }
 
     #[test]

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -1198,6 +1198,74 @@ struct AlasCLICommandRouterTests {
         #expect(object?["session_id"] == expected.rawValue)
     }
 
+    @Test func reviewFinishRecordsVerdictForTheRequestedSession() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let sessionStore = ReviewSessionStore(url: directory.appendingPathComponent("sessions.json"))
+        let target = ReviewSessionTarget.localChanges(worktreeID: "wt1", repositoryPath: root, scope: .all)
+        try sessionStore.save(ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        ))
+        var changed = 0
+        let router = makeReviewRouter(
+            worktree: worktree,
+            store: ReviewDraftCommentStore(url: directory.appendingPathComponent("drafts.json")),
+            sessionStore: sessionStore,
+            onChange: { changed += 1 }
+        )
+
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.finish(
+                sessionID: target.draftSessionID.rawValue,
+                verdict: .requestChanges,
+                summary: "Fix the race."
+            ))
+        ))
+
+        #expect(response == .ok)
+        #expect(changed == 1)
+        let record = try #require(try sessionStore.load(id: target.id))
+        #expect(record.status == .reviewed)
+        #expect(record.verdict?.verdict == .requestChanges)
+        #expect(record.verdict?.summary == "Fix the race.")
+        #expect(try sessionStore.findActive(targetID: target.id) == nil)
+    }
+
+    @Test func reviewFinishRejectsChangeRequestWithoutSummary() async throws {
+        let root = try makeFile("repo/a.swift").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let sessionStore = ReviewSessionStore(
+            url: FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")
+        )
+        let router = makeReviewRouter(
+            worktree: worktree,
+            store: ReviewDraftCommentStore(
+                url: FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")
+            ),
+            sessionStore: sessionStore
+        )
+
+        let response = await router.handle(.init(
+            version: 1, sessionId: "s1", cwd: nil,
+            command: .review(.finish(sessionID: nil, verdict: .requestChanges, summary: "  "))
+        ))
+
+        #expect(response == .error("request_changes requires a non-empty summary"))
+        let target = ReviewSessionTarget.localChanges(worktreeID: "wt1", repositoryPath: root, scope: .all)
+        #expect(try sessionStore.load(id: target.id) == nil)
+    }
+
     @Test func replyAppendsAgentReplyAndNotifies() async throws {
         let root = try makeFile("repo/a.swift").deletingLastPathComponent()
         let worktree = Worktree(

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -188,6 +188,25 @@ struct AlasCLIRequestTests {
         }
     }
 
+    @Test func decodesReviewFinishWithDefaultsAndVerdict() throws {
+        let bare = #"{"v":1,"kind":"cli","command":"review_finish","session_id":"s1"}"#
+        #expect(try AlasCLIRequest.decode(from: Data(bare.utf8)).command == .review(.finish(
+            sessionID: nil, verdict: .comment, summary: ""
+        )))
+
+        let full = #"{"v":1,"kind":"cli","command":"review_finish","session_id":"s1","params":{"session_id":"rs1","verdict":"request_changes","summary":"Fix the race."}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(full.utf8)).command == .review(.finish(
+            sessionID: "rs1", verdict: .requestChanges, summary: "Fix the race."
+        )))
+    }
+
+    @Test func rejectsUnknownReviewFinishVerdict() throws {
+        let json = #"{"v":1,"kind":"cli","command":"review_finish","session_id":"s1","params":{"verdict":"reject"}}"#
+        #expect(throws: AlasCLIRequestError.malformed) {
+            try AlasCLIRequest.decode(from: Data(json.utf8))
+        }
+    }
+
     private struct ProbeParams: Decodable, Equatable {
         var name: String
         var count: Int?

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -152,4 +152,33 @@ struct ReviewSessionModelsTests {
         #expect(focused.focusedCommentID == "comment-1")
         #expect(focused.updatedAt == Date(timeIntervalSince1970: 30))
     }
+
+    @Test func markingReviewedStoresTheVerdictAndEndsTheSession() {
+        let target = ReviewSessionTarget.localChanges(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+
+        let reviewed = record.markedReviewed(
+            verdict: .approve,
+            summary: "Looks good.",
+            now: Date(timeIntervalSince1970: 20)
+        )
+
+        #expect(reviewed.status == .reviewed)
+        #expect(reviewed.verdict == ReviewSessionVerdict(
+            verdict: .approve,
+            summary: "Looks good.",
+            reviewedAt: Date(timeIntervalSince1970: 20)
+        ))
+        #expect(reviewed.updatedAt == Date(timeIntervalSince1970: 20))
+        #expect(reviewed.markedAddressed(now: Date(timeIntervalSince1970: 30)).status == .reviewed)
+    }
 }


### PR DESCRIPTION
## Summary
- add `review_finish` MCP tool and `alas review finish` CLI command
- persist terminal review verdicts and summaries in the review session model
- cover wire parsing, routing, persistence, and MCP/CLI parity

## Verification
- `cargo test` (AlasCLI)
- focused macOS Swift tests for CLI request/router and review session models
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-review-792-derived -quiet build`

Closes #792 