### PR TITLE
feat(mcp): add notify tool

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -46,10 +46,11 @@ final class ACPSessionManager: ObservableObject {
     private let onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)?
     private let onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)?
     private let mcpProjectContextProvider: MCPProjectContextProvider?
-    /// Builds the app-provided "alas" MCP server entry for a worktree path,
+    /// Builds the app-provided "alas" MCP server entry for a worktree path
+    /// and local ACP session id,
     /// or nil when injection is disabled/unavailable. Fetched per attach so
     /// the settings toggle applies to the next (re)connect.
-    private let builtInMCPProvider: ((String) -> BuiltInAlasMCP.Injection?)?
+    private let builtInMCPProvider: ((String, ACPSession.ID) -> BuiltInAlasMCP.Injection?)?
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     @Published private(set) var persistenceError: String?
@@ -303,7 +304,7 @@ final class ACPSessionManager: ObservableObject {
          remoteAdapterResolver: ACPRemoteAdapterResolver? = nil,
          connectionFactory: ACPConnectionFactory? = nil,
          mcpProjectContextProvider: MCPProjectContextProvider? = nil,
-         builtInMCPProvider: ((String) -> BuiltInAlasMCP.Injection?)? = nil)
+         builtInMCPProvider: ((String, ACPSession.ID) -> BuiltInAlasMCP.Injection?)? = nil)
     {
         precondition(store != nil || persistence != nil, "ACPSessionManager requires persistence")
         let resolvedPersistence = persistence ?? ACPSessionPersistence(path: store!.path)
@@ -2251,7 +2252,7 @@ extension ACPSessionManager {
             // skip it entirely instead of reporting it unavailable on every
             // connect.
             let remoteHost = RemoteHostRegistry.shared.host(forPath: worktreePath)
-            let builtInMCP = remoteHost == nil ? builtInMCPProvider?(worktreePath) : nil
+            let builtInMCP = remoteHost == nil ? builtInMCPProvider?(worktreePath, sessionId) : nil
             var plannedWireServers = mcpPlan.wireServers
             var plannedStatuses = mcpPlan.statuses
             if let builtInMCP {

--- a/Alas/Sources/ACP/Session/BuiltInAlasMCP.swift
+++ b/Alas/Sources/ACP/Session/BuiltInAlasMCP.swift
@@ -23,7 +23,8 @@ enum BuiltInAlasMCP {
         configuredServers: [ProjectMCPServer],
         binaryPath: String?,
         socketPath: String?,
-        worktreePath: String
+        worktreePath: String,
+        sessionId: String
     ) -> Injection? {
         guard enabled, let binaryPath, let socketPath else { return nil }
         let userOverride = configuredServers.contains {
@@ -38,6 +39,7 @@ enum BuiltInAlasMCP {
                 env: [
                     .init(name: "ALAS_SOCKET_PATH", value: socketPath),
                     .init(name: "ALAS_WORKTREE_DIR", value: worktreePath),
+                    .init(name: "ALAS_SESSION_ID", value: sessionId),
                 ]
             ),
             status: .init(

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -32,6 +32,9 @@ struct AlasActionService {
     var now: () -> Date = Date.init
     var gitStatus: (URL) async throws -> [ChangedFile] = { try await GitService().status(worktreePath: $0) }
     var providerReviewOriginalPath: (ReviewDraftSessionID, String) async -> String? = { _, _ in nil }
+    var notifySession: (String?, Worktree, String, String?, AlasCLINotifyLevel) -> AlasCLIResponse = { _, _, _, _, _ in
+        .error("Notifications from the terminal are not available yet.")
+    }
     var activateApp: () -> Void
 
     /// Worktree owning `directory`: the worktree rooted exactly at
@@ -97,6 +100,16 @@ struct AlasActionService {
         case .ambiguous(let labels):
             return .error("ambiguous worktree \"\(target)\"; matches: \(labels.joined(separator: ", "))")
         }
+    }
+
+    func notify(
+        sessionId: String?,
+        origin: Worktree,
+        body: String,
+        title: String?,
+        level: AlasCLINotifyLevel
+    ) -> AlasCLIResponse {
+        notifySession(sessionId, origin, body, title, level)
     }
 
     func new(origin: Worktree, branch: String, base: String?) async -> AlasCLIResponse {

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -26,6 +26,9 @@ struct AlasCLICommandRouter {
     var now: () -> Date = Date.init
     var gitStatus: (URL) async throws -> [ChangedFile] = { try await GitService().status(worktreePath: $0) }
     var providerReviewOriginalPath: (ReviewDraftSessionID, String) async -> String? = { _, _ in nil }
+    var notifySession: (String?, Worktree, String, String?, AlasCLINotifyLevel) -> AlasCLIResponse = { _, _, _, _, _ in
+        .error("Notifications from the terminal are not available yet.")
+    }
     var activateApp: () -> Void
 
     private var service: AlasActionService {
@@ -44,6 +47,7 @@ struct AlasCLICommandRouter {
             now: now,
             gitStatus: gitStatus,
             providerReviewOriginalPath: providerReviewOriginalPath,
+            notifySession: notifySession,
             activateApp: activateApp
         )
     }
@@ -70,6 +74,14 @@ struct AlasCLICommandRouter {
             return .ok
         case .open(let paths):
             return service.open(paths: paths, fallbackWorktreeId: origin.id)
+        case .notify(let body, let title, let level):
+            return service.notify(
+                sessionId: request.sessionId,
+                origin: origin,
+                body: body,
+                title: title,
+                level: level
+            )
         case .worktree(.list):
             return service.list(origin: origin, projectWorktrees: projectWorktrees)
         case .worktree(.switch(let target)):

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1774,9 +1774,18 @@ final class AppState {
             // Fall back to persisted-tab scan so `alas open` etc.
             // still resolve a worktree for zmx-persisted leaves
             // whose `TerminalSession` hasn't been restored yet.
-            return self?.persistedLeafLocation(leafId: sessionId)?.worktreeId
+            if let worktreeId = self?.persistedLeafLocation(leafId: sessionId)?.worktreeId {
+                return worktreeId
+            }
+            return self?.worktreeIdForLiveACPSession(sessionId)
         }
         return await router.handle(request)
+    }
+
+    private func worktreeIdForLiveACPSession(_ sessionId: String) -> String? {
+        acpManagers.first { _, manager in
+            manager.liveSession(for: sessionId) != nil
+        }?.key
     }
 
     /// Linear scan of persisted terminal tabs for the (projectId, worktreeId)
@@ -1880,10 +1889,62 @@ final class AppState {
             providerReviewOriginalPath: { [weak self] sessionID, relativePath in
                 await self?.reviewRequestOriginalPath(forDraftSessionID: sessionID, relativePath: relativePath) ?? nil
             },
+            notifySession: { [weak self] sessionId, origin, body, title, level in
+                guard let self else { return .error("Alas is not available.") }
+                return self.cliNotify(
+                    sessionId: sessionId,
+                    origin: origin,
+                    body: body,
+                    title: title,
+                    level: level
+                )
+            },
             activateApp: {
                 NSApp.activate(ignoringOtherApps: true)
             }
         )
+    }
+
+    private func cliNotify(
+        sessionId: String?,
+        origin: Worktree,
+        body: String,
+        title: String?,
+        level: AlasCLINotifyLevel
+    ) -> AlasCLIResponse {
+        guard let resolved = projectAndWorktree(withWorktreeId: origin.id) else {
+            return .error("Unknown worktree.")
+        }
+        let notificationSessionId = sessionId ?? origin.id
+        let agent = agentKindForNotifySession(sessionId) ?? .codex
+        harness.notifications.notifyAlas(
+            body: body,
+            title: title,
+            agent: agent,
+            projectId: resolved.project.id,
+            worktreeId: resolved.worktree.id,
+            sessionId: notificationSessionId
+        )
+        if level == .attention, let sessionId {
+            harness.setExternalActivity(sessionId: sessionId, agent: agent, state: .awaitingInput)
+        }
+        return .ok
+    }
+
+    private func agentKindForNotifySession(_ sessionId: String?) -> AgentKind? {
+        guard let sessionId else { return nil }
+        if let activity = harness.activityBySession[sessionId] {
+            return activity.agent
+        }
+        if let harnessKind = harness.activeHarnessBySession[sessionId] ?? harness.harnessBySession[sessionId] {
+            return harnessKind.asAgentKind
+        }
+        for manager in acpManagers.values {
+            if let session = manager.liveSession(for: sessionId) {
+                return ACPHarnessBridge.agentKind(for: session.agentId)
+            }
+        }
+        return nil
     }
 
     /// Activate a specific harness session: bring the app to front, select
@@ -4173,7 +4234,7 @@ final class AppState {
                     configuredServers: project.mcpServers
                 )
             },
-            builtInMCPProvider: { [weak self] worktreePath in
+            builtInMCPProvider: { [weak self] worktreePath, sessionId in
                 guard let self else { return nil }
                 // installExecutables is idempotent (byte-compares before
                 // writing); a nil binaryPath (no bundle, e.g. tests) means
@@ -4185,7 +4246,8 @@ final class AppState {
                     configuredServers: self.projects.first(where: { $0.id == worktree.projectId })?.mcpServers ?? [],
                     binaryPath: binaryPath,
                     socketPath: self.harness.socketServer.socketPath,
-                    worktreePath: worktreePath
+                    worktreePath: worktreePath,
+                    sessionId: sessionId
                 )
             }
         )

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -30,9 +30,15 @@ enum ReviewVerdictWire: String, Equatable {
     }
 }
 
+enum AlasCLINotifyLevel: String, Equatable {
+    case info
+    case attention
+}
+
 struct AlasCLIRequest: Equatable {
     enum Command: Equatable {
         case open(paths: [String])
+        case notify(body: String, title: String?, level: AlasCLINotifyLevel)
         case worktree(WorktreeCommand)
         case review(ReviewCommand)
         case resolve
@@ -115,6 +121,12 @@ struct AlasCLIRequest: Equatable {
         var summary: String?
     }
 
+    private struct NotifyParams: Decodable {
+        var body: String
+        var title: String?
+        var level: String?
+    }
+
     /// Typed access to the `params` object new-style commands carry.
     /// Returns nil when `params` is absent or explicitly null (`Decodable`
     /// synthesis treats both the same way); throws `.malformed` when
@@ -185,6 +197,22 @@ struct AlasCLIRequest: Equatable {
         switch raw.command {
         case "open":
             command = .open(paths: try validatedAbsolutePaths(raw.paths))
+        case "notify":
+            let params = try Self.decodeParams(NotifyParams.self, from: data)
+            let level: AlasCLINotifyLevel
+            if let rawLevel = params.level?.nilIfBlank {
+                guard let parsed = AlasCLINotifyLevel(rawValue: rawLevel) else {
+                    throw AlasCLIRequestError.malformed
+                }
+                level = parsed
+            } else {
+                level = .attention
+            }
+            command = .notify(
+                body: try requiredNonEmpty(params.body),
+                title: params.title?.nilIfBlank,
+                level: level
+            )
         case "wt":
             switch raw.subcommand {
             case "list":

--- a/Alas/Sources/Harness/NotificationService.swift
+++ b/Alas/Sources/Harness/NotificationService.swift
@@ -81,6 +81,24 @@ final class NotificationService {
         notificationAdder(req)
     }
 
+    func notifyAlas(body: String, title: String?, agent: AgentKind,
+                    projectId: String, worktreeId: String, sessionId: String) {
+        let content = buildContent(
+            agent: agent,
+            body: body,
+            title: title ?? "Alas",
+            projectId: projectId,
+            worktreeId: worktreeId,
+            sessionId: sessionId
+        )
+        let req = UNNotificationRequest(
+            identifier: "\(sessionId)-notify-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+        notificationAdder(req)
+    }
+
     // MARK: - Private helpers
 
     private func questionBody(_ body: String?) -> String {

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -121,15 +121,43 @@ pub struct Response {
 /// absolutized by the caller.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Command {
-    Open { paths: Vec<String> },
+    Open {
+        paths: Vec<String>,
+    },
+    Notify {
+        body: String,
+        title: Option<String>,
+        level: Option<String>,
+    },
     WtList,
-    WtSwitch { target: String },
-    WtNew { branch: String, base: Option<String> },
-    WtDelete { target: String, force: bool, keep_branch: bool },
-    Review { target: Option<String> },
-    ReviewComments { session_id: Option<String>, state: Option<String> },
-    ReviewReply { comment_id: String, body: String },
-    ReviewResolve { comment_id: String, reply: Option<String>, reopen: bool },
+    WtSwitch {
+        target: String,
+    },
+    WtNew {
+        branch: String,
+        base: Option<String>,
+    },
+    WtDelete {
+        target: String,
+        force: bool,
+        keep_branch: bool,
+    },
+    Review {
+        target: Option<String>,
+    },
+    ReviewComments {
+        session_id: Option<String>,
+        state: Option<String>,
+    },
+    ReviewReply {
+        comment_id: String,
+        body: String,
+    },
+    ReviewResolve {
+        comment_id: String,
+        reply: Option<String>,
+        reopen: bool,
+    },
     ReviewCommentAdd {
         path: String,
         start_line: u64,
@@ -138,17 +166,38 @@ pub enum Command {
         body: String,
         session_id: Option<String>,
     },
-    ReviewFinish { session_id: Option<String>, verdict: Option<String>, summary: Option<String> },
+    ReviewFinish {
+        session_id: Option<String>,
+        verdict: Option<String>,
+        summary: Option<String>,
+    },
     Resolve,
 }
 
 /// Build the wire request for a command, attaching whichever addressing the
 /// caller resolved (`session_id` inside Alas, else `cwd`).
-pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<String>) -> Request {
+pub fn build_request(
+    command: &Command,
+    session_id: Option<String>,
+    cwd: Option<String>,
+) -> Request {
     let mut req = match command {
         Command::Open { paths } => {
             let mut r = Request::new("open");
             r.paths = Some(paths.clone());
+            r
+        }
+        Command::Notify { body, title, level } => {
+            let mut r = Request::new("notify");
+            let mut params = serde_json::Map::new();
+            params.insert("body".into(), serde_json::Value::String(body.clone()));
+            if let Some(title) = title {
+                params.insert("title".into(), serde_json::Value::String(title.clone()));
+            }
+            if let Some(level) = level {
+                params.insert("level".into(), serde_json::Value::String(level.clone()));
+            }
+            r.params = Some(serde_json::Value::Object(params));
             r
         }
         Command::WtList => {
@@ -169,7 +218,11 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
             r.base = base.clone();
             r
         }
-        Command::WtDelete { target, force, keep_branch } => {
+        Command::WtDelete {
+            target,
+            force,
+            keep_branch,
+        } => {
             let mut r = Request::new("wt");
             r.subcommand = Some("delete".into());
             r.target = Some(target.clone());
@@ -186,7 +239,10 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
             let mut r = Request::new("review_comments");
             let mut params = serde_json::Map::new();
             if let Some(session_id) = session_id {
-                params.insert("session_id".into(), serde_json::Value::String(session_id.clone()));
+                params.insert(
+                    "session_id".into(),
+                    serde_json::Value::String(session_id.clone()),
+                );
             }
             if let Some(state) = state {
                 params.insert("state".into(), serde_json::Value::String(state.clone()));
@@ -199,10 +255,17 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
             r.params = Some(serde_json::json!({ "comment_id": comment_id, "body": body }));
             r
         }
-        Command::ReviewResolve { comment_id, reply, reopen } => {
+        Command::ReviewResolve {
+            comment_id,
+            reply,
+            reopen,
+        } => {
             let mut r = Request::new("review_resolve");
             let mut params = serde_json::Map::new();
-            params.insert("comment_id".into(), serde_json::Value::String(comment_id.clone()));
+            params.insert(
+                "comment_id".into(),
+                serde_json::Value::String(comment_id.clone()),
+            );
             if let Some(reply) = reply {
                 params.insert("reply".into(), serde_json::Value::String(reply.clone()));
             }
@@ -212,7 +275,14 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
             r.params = Some(serde_json::Value::Object(params));
             r
         }
-        Command::ReviewCommentAdd { path, start_line, end_line, side, body, session_id } => {
+        Command::ReviewCommentAdd {
+            path,
+            start_line,
+            end_line,
+            side,
+            body,
+            session_id,
+        } => {
             let mut r = Request::new("review_comment_add");
             let mut params = serde_json::Map::new();
             params.insert("path".into(), serde_json::Value::String(path.clone()));
@@ -225,16 +295,26 @@ pub fn build_request(command: &Command, session_id: Option<String>, cwd: Option<
             }
             params.insert("body".into(), serde_json::Value::String(body.clone()));
             if let Some(session_id) = session_id {
-                params.insert("session_id".into(), serde_json::Value::String(session_id.clone()));
+                params.insert(
+                    "session_id".into(),
+                    serde_json::Value::String(session_id.clone()),
+                );
             }
             r.params = Some(serde_json::Value::Object(params));
             r
         }
-        Command::ReviewFinish { session_id, verdict, summary } => {
+        Command::ReviewFinish {
+            session_id,
+            verdict,
+            summary,
+        } => {
             let mut r = Request::new("review_finish");
             let mut params = serde_json::Map::new();
             if let Some(session_id) = session_id {
-                params.insert("session_id".into(), serde_json::Value::String(session_id.clone()));
+                params.insert(
+                    "session_id".into(),
+                    serde_json::Value::String(session_id.clone()),
+                );
             }
             if let Some(verdict) = verdict {
                 params.insert("verdict".into(), serde_json::Value::String(verdict.clone()));
@@ -348,7 +428,11 @@ pub fn send(socket: &Path, req: &Request) -> Result<Response, TransportError> {
 
 /// `send`, parameterized on the read timeout so tests can exercise the
 /// timeout behavior without waiting on the real [`READ_TIMEOUT`].
-fn send_with_timeout(socket: &Path, req: &Request, read_timeout: Duration) -> Result<Response, TransportError> {
+fn send_with_timeout(
+    socket: &Path,
+    req: &Request,
+    read_timeout: Duration,
+) -> Result<Response, TransportError> {
     let payload = serde_json::to_vec(req).map_err(|_| TransportError::Malformed)?;
     let mut stream = UnixStream::connect(socket).map_err(|_| TransportError::Connect)?;
     stream
@@ -357,7 +441,9 @@ fn send_with_timeout(socket: &Path, req: &Request, read_timeout: Duration) -> Re
     stream.write_all(&payload).map_err(|_| TransportError::Io)?;
     stream.flush().map_err(|_| TransportError::Io)?;
     let mut buf = Vec::new();
-    stream.read_to_end(&mut buf).map_err(|_| TransportError::Io)?;
+    stream
+        .read_to_end(&mut buf)
+        .map_err(|_| TransportError::Io)?;
     serde_json::from_slice(&buf).map_err(|_| TransportError::Malformed)
 }
 
@@ -372,8 +458,12 @@ pub enum Target {
 /// Resolve the target from the environment. Inside Alas both vars are set and
 /// we address the exact session; otherwise we address the logical directory.
 pub fn resolve_target() -> Target {
-    let socket = std::env::var("ALAS_SOCKET_PATH").ok().filter(|s| !s.is_empty());
-    let session = std::env::var("ALAS_SESSION_ID").ok().filter(|s| !s.is_empty());
+    let socket = std::env::var("ALAS_SOCKET_PATH")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let session = std::env::var("ALAS_SESSION_ID")
+        .ok()
+        .filter(|s| !s.is_empty());
     if let (Some(socket), Some(session_id)) = (socket, session) {
         return Target::Session { socket, session_id };
     }
@@ -461,7 +551,6 @@ pub fn dispatch_to_sockets(
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -527,7 +616,10 @@ mod tests {
 
     #[test]
     fn builds_wt_new_with_base() {
-        let cmd = Command::WtNew { branch: "feature".into(), base: Some("main".into()) };
+        let cmd = Command::WtNew {
+            branch: "feature".into(),
+            base: Some("main".into()),
+        };
         let req = build_request(&cmd, Some("s1".into()), None);
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(
@@ -538,7 +630,11 @@ mod tests {
 
     #[test]
     fn builds_wt_delete_flags_and_cwd() {
-        let cmd = Command::WtDelete { target: "feature".into(), force: true, keep_branch: false };
+        let cmd = Command::WtDelete {
+            target: "feature".into(),
+            force: true,
+            keep_branch: false,
+        };
         let req = build_request(&cmd, None, Some("/repo".into()));
         assert_eq!(req.command, "wt");
         assert_eq!(req.subcommand.as_deref(), Some("delete"));
@@ -552,47 +648,102 @@ mod tests {
         let local = build_request(&Command::Review { target: None }, Some("s1".into()), None);
         assert_eq!(local.command, "review");
         assert!(local.target.is_none());
-        let provider = build_request(&Command::Review { target: Some("123".into()) }, Some("s1".into()), None);
+        let provider = build_request(
+            &Command::Review {
+                target: Some("123".into()),
+            },
+            Some("s1".into()),
+            None,
+        );
         assert_eq!(provider.target.as_deref(), Some("123"));
     }
 
     #[test]
+    fn builds_notify_params() {
+        let cmd = Command::Notify {
+            body: "Blocked on input".into(),
+            title: Some("Need input".into()),
+            level: Some("attention".into()),
+        };
+        let req = build_request(&cmd, Some("s1".into()), None);
+        assert_eq!(req.command, "notify");
+        assert_eq!(
+            req.params,
+            Some(serde_json::json!({
+                "body": "Blocked on input",
+                "title": "Need input",
+                "level": "attention"
+            }))
+        );
+    }
+
+    #[test]
     fn builds_review_comments_with_params_envelope() {
-        let cmd = Command::ReviewComments { session_id: Some("sid".into()), state: Some("all".into()) };
+        let cmd = Command::ReviewComments {
+            session_id: Some("sid".into()),
+            state: Some("all".into()),
+        };
         let req = build_request(&cmd, None, Some("/wt".into()));
         assert_eq!(req.command, "review_comments");
         let params = req.params.expect("params must be set");
         assert_eq!(params["session_id"], serde_json::json!("sid"));
         assert_eq!(params["state"], serde_json::json!("all"));
 
-        let bare = build_request(&Command::ReviewComments { session_id: None, state: None }, None, Some("/wt".into()));
+        let bare = build_request(
+            &Command::ReviewComments {
+                session_id: None,
+                state: None,
+            },
+            None,
+            Some("/wt".into()),
+        );
         assert_eq!(bare.params, Some(serde_json::json!({})));
     }
 
     #[test]
     fn builds_review_reply_and_resolve_params() {
         let reply = build_request(
-            &Command::ReviewReply { comment_id: "c1".into(), body: "done".into() },
+            &Command::ReviewReply {
+                comment_id: "c1".into(),
+                body: "done".into(),
+            },
             None,
             Some("/wt".into()),
         );
         assert_eq!(reply.command, "review_reply");
-        assert_eq!(reply.params, Some(serde_json::json!({"comment_id": "c1", "body": "done"})));
+        assert_eq!(
+            reply.params,
+            Some(serde_json::json!({"comment_id": "c1", "body": "done"}))
+        );
 
         let resolve = build_request(
-            &Command::ReviewResolve { comment_id: "c1".into(), reply: Some("fixed".into()), reopen: false },
+            &Command::ReviewResolve {
+                comment_id: "c1".into(),
+                reply: Some("fixed".into()),
+                reopen: false,
+            },
             None,
             Some("/wt".into()),
         );
         assert_eq!(resolve.command, "review_resolve");
-        assert_eq!(resolve.params, Some(serde_json::json!({"comment_id": "c1", "reply": "fixed"})));
+        assert_eq!(
+            resolve.params,
+            Some(serde_json::json!({"comment_id": "c1", "reply": "fixed"}))
+        );
 
         let reopen = build_request(
-            &Command::ReviewResolve { comment_id: "c1".into(), reply: None, reopen: true },
+            &Command::ReviewResolve {
+                comment_id: "c1".into(),
+                reply: None,
+                reopen: true,
+            },
             None,
             Some("/wt".into()),
         );
-        assert_eq!(reopen.params, Some(serde_json::json!({"comment_id": "c1", "reopen": true})));
+        assert_eq!(
+            reopen.params,
+            Some(serde_json::json!({"comment_id": "c1", "reopen": true}))
+        );
     }
 
     #[test]
@@ -655,7 +806,10 @@ mod tests {
 
         // A second live process we actually own, to exercise multi-entry sort
         // order (string-sorted paths, not numeric pid order).
-        let mut child = std::process::Command::new("sleep").arg("5").spawn().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
 
         // Live: our own pid and the spawned child. Dead: pid 999999999 (out of
         // range, guaranteed absent). Junk: non-`pid-` entry and a non-numeric
@@ -683,7 +837,8 @@ mod tests {
 
     #[test]
     fn discover_live_sockets_in_skips_non_positive_pids() {
-        let root = std::env::temp_dir().join(format!("alas-cli-disc-pidguard-{}", std::process::id()));
+        let root =
+            std::env::temp_dir().join(format!("alas-cli-disc-pidguard-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
         std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700)).unwrap();

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -4,7 +4,7 @@
 //! be the largest dependency in the workspace.
 
 use alas_client::{Command, Response, TransportError};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::path::PathBuf;
 
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
@@ -15,6 +15,7 @@ pub const PROTOCOL_VERSION: &str = "2025-06-18";
 pub struct McpEnv {
     pub socket: PathBuf,
     pub worktree_dir: String,
+    pub session_id: String,
 }
 
 /// Build the env from a lookup function (`std::env::var` in production,
@@ -29,7 +30,14 @@ pub fn env_from(get: impl Fn(&str) -> Option<String>) -> Result<McpEnv, String> 
     if !worktree_dir.starts_with('/') {
         return Err("ALAS_WORKTREE_DIR must be an absolute path".into());
     }
-    Ok(McpEnv { socket: PathBuf::from(socket), worktree_dir })
+    let session_id = get("ALAS_SESSION_ID")
+        .filter(|s| !s.is_empty())
+        .ok_or("alas mcp requires ALAS_SESSION_ID (it is launched by Alas, not by hand)")?;
+    Ok(McpEnv {
+        socket: PathBuf::from(socket),
+        worktree_dir,
+        session_id,
+    })
 }
 
 /// Handle one raw input line. Returns the JSON-RPC reply to write, or None
@@ -49,7 +57,10 @@ pub fn handle_line(
     }
     // Messages without an id are notifications (e.g. notifications/initialized).
     let id = msg.get("id").cloned()?;
-    let method = msg.get("method").and_then(Value::as_str).unwrap_or_default();
+    let method = msg
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     let reply = match method {
         "initialize" => Ok(initialize_result()),
         "ping" => Ok(json!({})),
@@ -99,6 +110,23 @@ pub fn tool_definitions() -> Vec<Value> {
                     }
                 },
                 "required": ["paths"]
+            }
+        }),
+        json!({
+            "name": "notify",
+            "description": "Post a macOS notification through Alas and optionally flag this session's sidebar row for attention.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "body": { "type": "string", "description": "Notification body." },
+                    "title": { "type": "string", "description": "Optional notification title." },
+                    "level": {
+                        "type": "string",
+                        "enum": ["info", "attention"],
+                        "description": "Default: attention. Attention also marks the session row as needing input."
+                    }
+                },
+                "required": ["body"]
             }
         }),
         json!({
@@ -243,8 +271,23 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
             }
             Ok(Command::Open { paths: resolved })
         }
+        "notify" => {
+            let level = optional_string(args, "level");
+            if let Some(level) = &level {
+                if level != "info" && level != "attention" {
+                    return Err("notify 'level' must be 'info' or 'attention'".into());
+                }
+            }
+            Ok(Command::Notify {
+                body: required_string(args, "body")?,
+                title: optional_string(args, "title"),
+                level,
+            })
+        }
         "worktree_list" => Ok(Command::WtList),
-        "worktree_switch" => Ok(Command::WtSwitch { target: required_string(args, "target")? }),
+        "worktree_switch" => Ok(Command::WtSwitch {
+            target: required_string(args, "target")?,
+        }),
         "worktree_new" => Ok(Command::WtNew {
             branch: required_string(args, "branch")?,
             base: optional_string(args, "base"),
@@ -252,17 +295,28 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
         "worktree_delete" => Ok(Command::WtDelete {
             target: required_string(args, "target")?,
             force: args.get("force").and_then(Value::as_bool).unwrap_or(false),
-            keep_branch: args.get("keep_branch").and_then(Value::as_bool).unwrap_or(false),
+            keep_branch: args
+                .get("keep_branch")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
         }),
-        "review" => Ok(Command::Review { target: review_target(args)? }),
+        "review" => Ok(Command::Review {
+            target: review_target(args)?,
+        }),
         "review_comments" => {
             let state = optional_string(args, "state");
             if let Some(state) = &state {
                 if !["active", "resolved", "dismissed", "all"].contains(&state.as_str()) {
-                    return Err("review_comments 'state' must be one of active|resolved|dismissed|all".into());
+                    return Err(
+                        "review_comments 'state' must be one of active|resolved|dismissed|all"
+                            .into(),
+                    );
                 }
             }
-            Ok(Command::ReviewComments { session_id: optional_string(args, "session_id"), state })
+            Ok(Command::ReviewComments {
+                session_id: optional_string(args, "session_id"),
+                state,
+            })
         }
         "review_reply" => Ok(Command::ReviewReply {
             comment_id: required_string(args, "comment_id")?,
@@ -272,7 +326,9 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
             let reopen = match optional_string(args, "state").as_deref() {
                 None | Some("resolved") => false,
                 Some("active") => true,
-                Some(_) => return Err("review_resolve 'state' must be 'resolved' or 'active'".into()),
+                Some(_) => {
+                    return Err("review_resolve 'state' must be 'resolved' or 'active'".into());
+                }
             };
             Ok(Command::ReviewResolve {
                 comment_id: required_string(args, "comment_id")?,
@@ -314,7 +370,10 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
             let verdict = optional_string(args, "verdict");
             if let Some(verdict) = &verdict {
                 if !["approve", "request_changes", "comment"].contains(&verdict.as_str()) {
-                    return Err("review_finish 'verdict' must be approve, request_changes, or comment".into());
+                    return Err(
+                        "review_finish 'verdict' must be approve, request_changes, or comment"
+                            .into(),
+                    );
                 }
             }
             Ok(Command::ReviewFinish {
@@ -335,7 +394,11 @@ fn review_target(args: &Value) -> Result<Option<String>, String> {
         None | Some(Value::Null) => Ok(None),
         Some(Value::String(s)) => {
             let s = s.trim();
-            Ok(if s.is_empty() { None } else { Some(s.to_string()) })
+            Ok(if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            })
         }
         Some(Value::Number(n)) => Ok(Some(n.to_string())),
         Some(_) => Err("review 'target' must be a string (PR/MR number or URL)".into()),
@@ -357,7 +420,11 @@ fn optional_string(args: &Value, key: &str) -> Option<String> {
 /// Send one command to the owning app instance, addressed by worktree
 /// directory (never session id — the MCP server has no terminal session).
 pub fn dispatch(env: &McpEnv, command: &Command) -> Result<Response, TransportError> {
-    let req = alas_client::build_request(command, None, Some(env.worktree_dir.clone()));
+    let req = alas_client::build_request(
+        command,
+        Some(env.session_id.clone()),
+        Some(env.worktree_dir.clone()),
+    );
     alas_client::send(&env.socket, &req)
 }
 
@@ -373,7 +440,10 @@ fn call_tool(
         .get("name")
         .and_then(Value::as_str)
         .ok_or((-32602, "tools/call requires a tool name".to_string()))?;
-    let args = params.get("arguments").cloned().unwrap_or_else(|| json!({}));
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
     let command = command_for_tool(name, &args, worktree_dir).map_err(|msg| (-32602, msg))?;
     Ok(match dispatch(&command) {
         Ok(resp) => tool_result(&command, resp),
@@ -396,10 +466,13 @@ fn tool_result(command: &Command, resp: Response) -> Value {
 fn success_message(command: &Command) -> String {
     match command {
         Command::Open { paths } => format!("Opened {} file(s) in Alas.", paths.len()),
+        Command::Notify { .. } => "Notification sent.".into(),
         Command::WtSwitch { target } => format!("Switched Alas to worktree '{target}'."),
         Command::WtNew { branch, .. } => format!("Created worktree for branch '{branch}' in Alas."),
         Command::WtDelete { target, .. } => format!("Deleted worktree '{target}'."),
-        Command::Review { target: Some(target) } => format!("Opened review for '{target}' in Alas."),
+        Command::Review {
+            target: Some(target),
+        } => format!("Opened review for '{target}' in Alas."),
         Command::Review { target: None } => "Opened review of local changes in Alas.".into(),
         Command::ReviewComments { .. } => "No review comments found.".into(),
         Command::ReviewReply { .. } => "Reply posted.".into(),
@@ -448,12 +521,16 @@ pub fn serve(env: &McpEnv) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_for_tool, dispatch, env_from, handle_line, McpEnv, PROTOCOL_VERSION};
+    use super::{McpEnv, PROTOCOL_VERSION, command_for_tool, dispatch, env_from, handle_line};
     use alas_client::Response;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     fn ok_dispatch(_: &alas_client::Command) -> Result<Response, alas_client::TransportError> {
-        Ok(Response { ok: true, lines: None, error: None })
+        Ok(Response {
+            ok: true,
+            lines: None,
+            error: None,
+        })
     }
 
     fn env<'a>(vars: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
@@ -466,17 +543,56 @@ mod tests {
 
     #[test]
     fn env_from_requires_both_vars() {
-        assert!(env_from(env(&[("ALAS_WORKTREE_DIR", "/wt")])).is_err());
-        assert!(env_from(env(&[("ALAS_SOCKET_PATH", "/tmp/s")])).is_err());
-        assert!(env_from(env(&[("ALAS_SOCKET_PATH", ""), ("ALAS_WORKTREE_DIR", "/wt")])).is_err());
-        let ok = env_from(env(&[("ALAS_SOCKET_PATH", "/tmp/s"), ("ALAS_WORKTREE_DIR", "/wt")])).unwrap();
+        assert!(
+            env_from(env(&[
+                ("ALAS_WORKTREE_DIR", "/wt"),
+                ("ALAS_SESSION_ID", "s1")
+            ]))
+            .is_err()
+        );
+        assert!(
+            env_from(env(&[
+                ("ALAS_SOCKET_PATH", "/tmp/s"),
+                ("ALAS_SESSION_ID", "s1")
+            ]))
+            .is_err()
+        );
+        assert!(
+            env_from(env(&[
+                ("ALAS_SOCKET_PATH", "/tmp/s"),
+                ("ALAS_WORKTREE_DIR", "/wt")
+            ]))
+            .is_err()
+        );
+        assert!(
+            env_from(env(&[
+                ("ALAS_SOCKET_PATH", ""),
+                ("ALAS_WORKTREE_DIR", "/wt"),
+                ("ALAS_SESSION_ID", "s1")
+            ]))
+            .is_err()
+        );
+        let ok = env_from(env(&[
+            ("ALAS_SOCKET_PATH", "/tmp/s"),
+            ("ALAS_WORKTREE_DIR", "/wt"),
+            ("ALAS_SESSION_ID", "s1"),
+        ]))
+        .unwrap();
         assert_eq!(ok.socket, std::path::PathBuf::from("/tmp/s"));
         assert_eq!(ok.worktree_dir, "/wt");
+        assert_eq!(ok.session_id, "s1");
     }
 
     #[test]
     fn env_from_rejects_relative_worktree_dir() {
-        assert!(env_from(env(&[("ALAS_SOCKET_PATH", "/tmp/s"), ("ALAS_WORKTREE_DIR", "wt")])).is_err());
+        assert!(
+            env_from(env(&[
+                ("ALAS_SOCKET_PATH", "/tmp/s"),
+                ("ALAS_WORKTREE_DIR", "wt"),
+                ("ALAS_SESSION_ID", "s1")
+            ]))
+            .is_err()
+        );
     }
 
     #[test]
@@ -502,6 +618,34 @@ mod tests {
         let reply = handle_line(line, "/wt", ok_dispatch).unwrap();
         assert_eq!(reply["id"], json!("p1"));
         assert_eq!(reply["result"], json!({}));
+    }
+
+    #[test]
+    fn command_for_notify_tool_validates_and_maps_arguments() {
+        let cmd = command_for_tool(
+            "notify",
+            &json!({ "body": "Blocked on input", "title": "Need input", "level": "attention" }),
+            "/wt",
+        )
+        .unwrap();
+        assert_eq!(
+            cmd,
+            alas_client::Command::Notify {
+                body: "Blocked on input".into(),
+                title: Some("Need input".into()),
+                level: Some("attention".into()),
+            }
+        );
+
+        assert!(
+            command_for_tool(
+                "notify",
+                &json!({ "body": "Done", "level": "urgent" }),
+                "/wt"
+            )
+            .is_err()
+        );
+        assert!(command_for_tool("notify", &json!({ "title": "Missing body" }), "/wt").is_err());
     }
 
     #[test]
@@ -537,6 +681,7 @@ mod tests {
             names,
             [
                 "open",
+                "notify",
                 "worktree_list",
                 "worktree_switch",
                 "worktree_new",
@@ -557,10 +702,13 @@ mod tests {
 
     #[test]
     fn open_maps_paths_and_absolutizes_relative_ones() {
-        let cmd = command_for_tool("open", &json!({"paths": ["a.txt", "/abs/b.txt"]}), "/wt").unwrap();
+        let cmd =
+            command_for_tool("open", &json!({"paths": ["a.txt", "/abs/b.txt"]}), "/wt").unwrap();
         assert_eq!(
             cmd,
-            alas_client::Command::Open { paths: vec!["/wt/a.txt".into(), "/abs/b.txt".into()] }
+            alas_client::Command::Open {
+                paths: vec!["/wt/a.txt".into(), "/abs/b.txt".into()]
+            }
         );
     }
 
@@ -580,15 +728,28 @@ mod tests {
         );
         assert_eq!(
             command_for_tool("worktree_switch", &json!({"target": "feat"}), "/wt").unwrap(),
-            alas_client::Command::WtSwitch { target: "feat".into() }
+            alas_client::Command::WtSwitch {
+                target: "feat".into()
+            }
         );
         assert_eq!(
-            command_for_tool("worktree_new", &json!({"branch": "feat", "base": "main"}), "/wt").unwrap(),
-            alas_client::Command::WtNew { branch: "feat".into(), base: Some("main".into()) }
+            command_for_tool(
+                "worktree_new",
+                &json!({"branch": "feat", "base": "main"}),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::WtNew {
+                branch: "feat".into(),
+                base: Some("main".into())
+            }
         );
         assert_eq!(
             command_for_tool("worktree_new", &json!({"branch": "feat"}), "/wt").unwrap(),
-            alas_client::Command::WtNew { branch: "feat".into(), base: None }
+            alas_client::Command::WtNew {
+                branch: "feat".into(),
+                base: None
+            }
         );
         assert_eq!(
             command_for_tool(
@@ -597,11 +758,19 @@ mod tests {
                 "/wt"
             )
             .unwrap(),
-            alas_client::Command::WtDelete { target: "feat".into(), force: true, keep_branch: true }
+            alas_client::Command::WtDelete {
+                target: "feat".into(),
+                force: true,
+                keep_branch: true
+            }
         );
         assert_eq!(
             command_for_tool("worktree_delete", &json!({"target": "feat"}), "/wt").unwrap(),
-            alas_client::Command::WtDelete { target: "feat".into(), force: false, keep_branch: false }
+            alas_client::Command::WtDelete {
+                target: "feat".into(),
+                force: false,
+                keep_branch: false
+            }
         );
     }
 
@@ -620,7 +789,9 @@ mod tests {
         );
         assert_eq!(
             command_for_tool("review", &json!({"target": "123"}), "/wt").unwrap(),
-            alas_client::Command::Review { target: Some("123".into()) }
+            alas_client::Command::Review {
+                target: Some("123".into())
+            }
         );
     }
 
@@ -628,7 +799,9 @@ mod tests {
     fn review_coerces_numeric_target_and_rejects_other_types() {
         assert_eq!(
             command_for_tool("review", &json!({"target": 123}), "/wt").unwrap(),
-            alas_client::Command::Review { target: Some("123".into()) }
+            alas_client::Command::Review {
+                target: Some("123".into())
+            }
         );
         assert_eq!(
             command_for_tool("review", &json!({"target": null}), "/wt").unwrap(),
@@ -642,11 +815,22 @@ mod tests {
     fn review_comments_tool_maps_and_validates_state() {
         assert_eq!(
             command_for_tool("review_comments", &json!({}), "/wt").unwrap(),
-            alas_client::Command::ReviewComments { session_id: None, state: None }
+            alas_client::Command::ReviewComments {
+                session_id: None,
+                state: None
+            }
         );
         assert_eq!(
-            command_for_tool("review_comments", &json!({"session_id": "sid", "state": "resolved"}), "/wt").unwrap(),
-            alas_client::Command::ReviewComments { session_id: Some("sid".into()), state: Some("resolved".into()) }
+            command_for_tool(
+                "review_comments",
+                &json!({"session_id": "sid", "state": "resolved"}),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::ReviewComments {
+                session_id: Some("sid".into()),
+                state: Some("resolved".into())
+            }
         );
         assert!(command_for_tool("review_comments", &json!({"state": "bogus"}), "/wt").is_err());
     }
@@ -654,20 +838,48 @@ mod tests {
     #[test]
     fn review_reply_and_resolve_tools_map_to_commands() {
         assert_eq!(
-            command_for_tool("review_reply", &json!({"comment_id": "c1", "body": "hi"}), "/wt").unwrap(),
-            alas_client::Command::ReviewReply { comment_id: "c1".into(), body: "hi".into() }
+            command_for_tool(
+                "review_reply",
+                &json!({"comment_id": "c1", "body": "hi"}),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::ReviewReply {
+                comment_id: "c1".into(),
+                body: "hi".into()
+            }
         );
         assert!(command_for_tool("review_reply", &json!({"comment_id": "c1"}), "/wt").is_err());
 
         assert_eq!(
             command_for_tool("review_resolve", &json!({"comment_id": "c1"}), "/wt").unwrap(),
-            alas_client::Command::ReviewResolve { comment_id: "c1".into(), reply: None, reopen: false }
+            alas_client::Command::ReviewResolve {
+                comment_id: "c1".into(),
+                reply: None,
+                reopen: false
+            }
         );
         assert_eq!(
-            command_for_tool("review_resolve", &json!({"comment_id": "c1", "reply": "done", "state": "active"}), "/wt").unwrap(),
-            alas_client::Command::ReviewResolve { comment_id: "c1".into(), reply: Some("done".into()), reopen: true }
+            command_for_tool(
+                "review_resolve",
+                &json!({"comment_id": "c1", "reply": "done", "state": "active"}),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::ReviewResolve {
+                comment_id: "c1".into(),
+                reply: Some("done".into()),
+                reopen: true
+            }
         );
-        assert!(command_for_tool("review_resolve", &json!({"comment_id": "c1", "state": "bogus"}), "/wt").is_err());
+        assert!(
+            command_for_tool(
+                "review_resolve",
+                &json!({"comment_id": "c1", "state": "bogus"}),
+                "/wt"
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -688,8 +900,22 @@ mod tests {
                 session_id: None,
             }
         );
-        assert!(command_for_tool("review_comment_add", &json!({"path": "a.swift", "body": "hm"}), "/wt").is_err());
-        assert!(command_for_tool("review_comment_add", &json!({"path": "a.swift", "start_line": 0, "body": "hm"}), "/wt").is_err());
+        assert!(
+            command_for_tool(
+                "review_comment_add",
+                &json!({"path": "a.swift", "body": "hm"}),
+                "/wt"
+            )
+            .is_err()
+        );
+        assert!(
+            command_for_tool(
+                "review_comment_add",
+                &json!({"path": "a.swift", "start_line": 0, "body": "hm"}),
+                "/wt"
+            )
+            .is_err()
+        );
         assert!(
             command_for_tool(
                 "review_comment_add",
@@ -704,7 +930,11 @@ mod tests {
     fn review_finish_tool_maps_and_validates_verdict() {
         assert_eq!(
             command_for_tool("review_finish", &json!({}), "/wt").unwrap(),
-            alas_client::Command::ReviewFinish { session_id: None, verdict: None, summary: None }
+            alas_client::Command::ReviewFinish {
+                session_id: None,
+                verdict: None,
+                summary: None
+            }
         );
         assert_eq!(
             command_for_tool(
@@ -739,7 +969,11 @@ mod tests {
     #[test]
     fn tools_call_returns_joined_lines_on_success() {
         let reply = handle_line(&call("worktree_list", json!({})), "/wt", |_| {
-            Ok(Response { ok: true, lines: Some(vec!["main *".into(), "feat".into()]), error: None })
+            Ok(Response {
+                ok: true,
+                lines: Some(vec!["main *".into(), "feat".into()]),
+                error: None,
+            })
         })
         .unwrap();
         let result = &reply["result"];
@@ -750,26 +984,46 @@ mod tests {
 
     #[test]
     fn tools_call_synthesizes_confirmation_when_no_lines() {
-        let reply = handle_line(&call("open", json!({"paths": ["a.txt", "b.txt"]})), "/wt", |cmd| {
-            assert_eq!(
-                cmd,
-                &alas_client::Command::Open { paths: vec!["/wt/a.txt".into(), "/wt/b.txt".into()] }
-            );
-            Ok(Response { ok: true, lines: None, error: None })
-        })
+        let reply = handle_line(
+            &call("open", json!({"paths": ["a.txt", "b.txt"]})),
+            "/wt",
+            |cmd| {
+                assert_eq!(
+                    cmd,
+                    &alas_client::Command::Open {
+                        paths: vec!["/wt/a.txt".into(), "/wt/b.txt".into()]
+                    }
+                );
+                Ok(Response {
+                    ok: true,
+                    lines: None,
+                    error: None,
+                })
+            },
+        )
         .unwrap();
         assert_eq!(reply["result"]["isError"], json!(false));
-        assert_eq!(reply["result"]["content"][0]["text"], json!("Opened 2 file(s) in Alas."));
+        assert_eq!(
+            reply["result"]["content"][0]["text"],
+            json!("Opened 2 file(s) in Alas.")
+        );
     }
 
     #[test]
     fn tools_call_maps_app_failure_to_error_result() {
         let reply = handle_line(&call("review", json!({})), "/wt", |_| {
-            Ok(Response { ok: false, lines: None, error: Some("no changes to review".into()) })
+            Ok(Response {
+                ok: false,
+                lines: None,
+                error: Some("no changes to review".into()),
+            })
         })
         .unwrap();
         assert_eq!(reply["result"]["isError"], json!(true));
-        assert_eq!(reply["result"]["content"][0]["text"], json!("no changes to review"));
+        assert_eq!(
+            reply["result"]["content"][0]["text"],
+            json!("no changes to review")
+        );
     }
 
     #[test]
@@ -779,20 +1033,30 @@ mod tests {
         })
         .unwrap();
         assert_eq!(reply["result"]["isError"], json!(true));
-        assert_eq!(reply["result"]["content"][0]["text"], json!("could not reach Alas"));
+        assert_eq!(
+            reply["result"]["content"][0]["text"],
+            json!("could not reach Alas")
+        );
 
         let reply = handle_line(&call("worktree_list", json!({})), "/wt", |_| {
             Err(alas_client::TransportError::Malformed)
         })
         .unwrap();
-        assert_eq!(reply["result"]["content"][0]["text"], json!("malformed response from Alas"));
+        assert_eq!(
+            reply["result"]["content"][0]["text"],
+            json!("malformed response from Alas")
+        );
         assert_eq!(reply["result"]["isError"], json!(true));
     }
 
     #[test]
     fn empty_lines_vec_falls_back_to_confirmation_text() {
         let reply = handle_line(&call("worktree_list", json!({})), "/wt", |_| {
-            Ok(Response { ok: true, lines: Some(vec![]), error: None })
+            Ok(Response {
+                ok: true,
+                lines: Some(vec![]),
+                error: None,
+            })
         })
         .unwrap();
         assert_eq!(reply["result"]["isError"], json!(false));
@@ -809,10 +1073,15 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_sends_cwd_addressed_request_over_the_socket() {
+    fn dispatch_sends_session_and_cwd_addressed_request_over_the_socket() {
         use std::io::{Read, Write};
 
-        let dir = std::env::temp_dir().join(format!("alas-mcp-it-{}", std::process::id()));
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::path::PathBuf::from("/private/tmp")
+            .join(format!("alas-mcp-it-{}-{unique}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("stub.sock");
@@ -822,13 +1091,18 @@ mod tests {
             let (mut stream, _) = listener.accept().unwrap();
             let mut buf = [0u8; 65536];
             let n = stream.read(&mut buf).unwrap();
-            tx.send(String::from_utf8_lossy(&buf[..n]).into_owned()).unwrap();
+            tx.send(String::from_utf8_lossy(&buf[..n]).into_owned())
+                .unwrap();
             stream
                 .write_all(br#"{"ok":true,"lines":["main *"]}"#)
                 .unwrap();
         });
 
-        let env = McpEnv { socket: path.clone(), worktree_dir: "/wt".into() };
+        let env = McpEnv {
+            socket: path.clone(),
+            worktree_dir: "/wt".into(),
+            session_id: "acp-1".into(),
+        };
         let resp = dispatch(&env, &alas_client::Command::WtList).unwrap();
         assert!(resp.ok);
         assert_eq!(resp.lines, Some(vec!["main *".into()]));
@@ -839,7 +1113,7 @@ mod tests {
         assert_eq!(seen["command"], json!("wt"));
         assert_eq!(seen["subcommand"], json!("list"));
         assert_eq!(seen["cwd"], json!("/wt"));
-        assert!(seen.get("session_id").is_none());
+        assert_eq!(seen["session_id"], json!("acp-1"));
 
         let _ = handle.join();
         let _ = std::fs::remove_dir_all(&dir);

--- a/AlasCLI/crates/alas/src/parse.rs
+++ b/AlasCLI/crates/alas/src/parse.rs
@@ -11,6 +11,7 @@ pub fn is_ao(argv0: &str) -> bool {
 /// Usage text for the whole tool (stderr on top-level misuse).
 pub const USAGE_ALL: &str = "\
 usage: alas open <path> [path...]
+usage: alas notify <body> [--title <title>] [--level <info|attention>]
 usage: alas wt list
 usage: alas wt switch <name-or-branch>
 usage: alas wt new <branch> [--base <ref>]
@@ -38,6 +39,7 @@ pub fn parse(args: &[String], base: &std::path::Path) -> Result<Command, String>
                 .collect();
             Ok(Command::Open { paths })
         }
+        Some("notify") => parse_notify(&it.map(|s| s.as_str()).collect::<Vec<_>>()),
         Some("wt") => parse_wt(&it.map(|s| s.as_str()).collect::<Vec<_>>()),
         Some("review") => {
             let rest: Vec<&str> = it.map(String::as_str).collect();
@@ -45,6 +47,36 @@ pub fn parse(args: &[String], base: &std::path::Path) -> Result<Command, String>
         }
         _ => Err(USAGE_ALL.into()),
     }
+}
+
+fn parse_notify(args: &[&str]) -> Result<Command, String> {
+    const USAGE: &str = "usage: alas notify <body> [--title <title>] [--level <info|attention>]";
+    let (body, rest) = match args.split_first() {
+        Some((first, rest)) if !first.starts_with("--") => (first.to_string(), rest),
+        _ => return Err(USAGE.into()),
+    };
+    let mut title: Option<String> = None;
+    let mut level: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i] {
+            "--title" => {
+                i += 1;
+                title = Some(flag_value(rest, i).ok_or(USAGE)?.to_string());
+            }
+            "--level" => {
+                i += 1;
+                let value = flag_value(rest, i).ok_or(USAGE)?;
+                if value != "info" && value != "attention" {
+                    return Err(USAGE.into());
+                }
+                level = Some(value.to_string());
+            }
+            _ => return Err(USAGE.into()),
+        }
+        i += 1;
+    }
+    Ok(Command::Notify { body, title, level })
 }
 
 pub const REVIEW_STATES: [&str; 4] = ["active", "resolved", "dismissed", "all"];
@@ -59,13 +91,16 @@ fn parse_review(args: &[&str], base: &std::path::Path) -> Result<Command, String
             if args.len() != 3 || args[1].starts_with("--") {
                 return Err(USAGE.into());
             }
-            Ok(Command::ReviewReply { comment_id: args[1].to_string(), body: args[2].to_string() })
+            Ok(Command::ReviewReply {
+                comment_id: args[1].to_string(),
+                body: args[2].to_string(),
+            })
         }
         Some("resolve") => parse_review_resolve(&args[1..]),
         Some("finish") => parse_review_finish(&args[1..]),
-        Some(target) if args.len() == 1 && !target.starts_with("--") => {
-            Ok(Command::Review { target: Some(target.to_string()) })
-        }
+        Some(target) if args.len() == 1 && !target.starts_with("--") => Ok(Command::Review {
+            target: Some(target.to_string()),
+        }),
         _ => Err(USAGE_ALL.into()),
     }
 }
@@ -100,7 +135,11 @@ fn parse_review_finish(args: &[&str]) -> Result<Command, String> {
         }
         i += 1;
     }
-    Ok(Command::ReviewFinish { session_id, verdict, summary })
+    Ok(Command::ReviewFinish {
+        session_id,
+        verdict,
+        summary,
+    })
 }
 
 fn parse_review_resolve(args: &[&str]) -> Result<Command, String> {
@@ -123,11 +162,16 @@ fn parse_review_resolve(args: &[&str]) -> Result<Command, String> {
         }
         i += 1;
     }
-    Ok(Command::ReviewResolve { comment_id, reply, reopen })
+    Ok(Command::ReviewResolve {
+        comment_id,
+        reply,
+        reopen,
+    })
 }
 
 fn parse_review_comments(args: &[&str]) -> Result<Command, String> {
-    const USAGE: &str = "usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]";
+    const USAGE: &str =
+        "usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]";
     let mut state: Option<String> = None;
     let mut session_id: Option<String> = None;
     let mut i = 0;
@@ -199,7 +243,14 @@ fn parse_review_comment(args: &[&str], base: &std::path::Path) -> Result<Command
         }
         i += 1;
     }
-    Ok(Command::ReviewCommentAdd { path, start_line, end_line, side, body, session_id })
+    Ok(Command::ReviewCommentAdd {
+        path,
+        start_line,
+        end_line,
+        side,
+        body,
+        session_id,
+    })
 }
 
 /// Value at `i` unless it is missing or looks like another flag.
@@ -219,7 +270,9 @@ fn parse_wt(args: &[&str]) -> Result<Command, String> {
             if args.len() != 2 {
                 return Err("usage: alas wt switch <name-or-branch>".into());
             }
-            Ok(Command::WtSwitch { target: args[1].to_string() })
+            Ok(Command::WtSwitch {
+                target: args[1].to_string(),
+            })
         }
         Some("new") => parse_wt_new(&args[1..]),
         Some("delete") => parse_wt_delete(&args[1..]),
@@ -266,7 +319,11 @@ fn parse_wt_delete(args: &[&str]) -> Result<Command, String> {
             _ => return Err(USAGE.into()),
         }
     }
-    Ok(Command::WtDelete { target, force, keep_branch })
+    Ok(Command::WtDelete {
+        target,
+        force,
+        keep_branch,
+    })
 }
 
 #[cfg(test)]
@@ -286,25 +343,88 @@ mod tests {
     #[test]
     fn open_absolutizes_relative_paths() {
         let cmd = parse(&s(&["open", "a.txt"]), Path::new("/b")).unwrap();
-        assert_eq!(cmd, Command::Open { paths: vec!["/b/a.txt".into()] });
+        assert_eq!(
+            cmd,
+            Command::Open {
+                paths: vec!["/b/a.txt".into()]
+            }
+        );
+    }
+
+    #[test]
+    fn notify_parses_body_title_and_level() {
+        let cmd = parse(
+            &s(&[
+                "notify",
+                "Blocked on input",
+                "--title",
+                "Need input",
+                "--level",
+                "attention",
+            ]),
+            Path::new("/b"),
+        )
+        .unwrap();
+        assert_eq!(
+            cmd,
+            Command::Notify {
+                body: "Blocked on input".into(),
+                title: Some("Need input".into()),
+                level: Some("attention".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn notify_rejects_missing_body_and_bad_level() {
+        assert!(parse(&s(&["notify"]), Path::new("/b")).is_err());
+        assert!(
+            parse(
+                &s(&["notify", "Done", "--level", "urgent"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
     }
 
     #[test]
     fn wt_new_parses_base_flag() {
-        let cmd = parse(&s(&["wt", "new", "feature", "--base", "main"]), Path::new("/b")).unwrap();
-        assert_eq!(cmd, Command::WtNew { branch: "feature".into(), base: Some("main".into()) });
+        let cmd = parse(
+            &s(&["wt", "new", "feature", "--base", "main"]),
+            Path::new("/b"),
+        )
+        .unwrap();
+        assert_eq!(
+            cmd,
+            Command::WtNew {
+                branch: "feature".into(),
+                base: Some("main".into())
+            }
+        );
     }
 
     #[test]
     fn wt_new_no_base_is_ok() {
         let cmd = parse(&s(&["wt", "new", "feat"]), Path::new("/b")).unwrap();
-        assert_eq!(cmd, Command::WtNew { branch: "feat".into(), base: None });
+        assert_eq!(
+            cmd,
+            Command::WtNew {
+                branch: "feat".into(),
+                base: None
+            }
+        );
     }
 
     #[test]
     fn wt_new_rejects_leading_flag() {
         assert!(parse(&s(&["wt", "new", "--base"]), Path::new("/b")).is_err());
-        assert!(parse(&s(&["wt", "new", "--base", "main", "feature-x"]), Path::new("/b")).is_err());
+        assert!(
+            parse(
+                &s(&["wt", "new", "--base", "main", "feature-x"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -319,7 +439,13 @@ mod tests {
 
     #[test]
     fn wt_new_rejects_base_value_that_is_a_flag() {
-        assert!(parse(&s(&["wt", "new", "feature", "--base", "--x"]), Path::new("/b")).is_err());
+        assert!(
+            parse(
+                &s(&["wt", "new", "feature", "--base", "--x"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -334,18 +460,38 @@ mod tests {
             Path::new("/b"),
         )
         .unwrap();
-        assert_eq!(cmd, Command::WtDelete { target: "target".into(), force: true, keep_branch: true });
+        assert_eq!(
+            cmd,
+            Command::WtDelete {
+                target: "target".into(),
+                force: true,
+                keep_branch: true
+            }
+        );
     }
 
     #[test]
     fn wt_delete_no_flags_is_ok() {
         let cmd = parse(&s(&["wt", "delete", "target"]), Path::new("/b")).unwrap();
-        assert_eq!(cmd, Command::WtDelete { target: "target".into(), force: false, keep_branch: false });
+        assert_eq!(
+            cmd,
+            Command::WtDelete {
+                target: "target".into(),
+                force: false,
+                keep_branch: false
+            }
+        );
     }
 
     #[test]
     fn wt_delete_rejects_leading_flag() {
-        assert!(parse(&s(&["wt", "delete", "--force", "some-target"]), Path::new("/b")).is_err());
+        assert!(
+            parse(
+                &s(&["wt", "delete", "--force", "some-target"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -366,13 +512,29 @@ mod tests {
     fn review_comments_parses_flags_and_rejects_bad_state() {
         assert_eq!(
             parse(&s(&["review", "comments"]), Path::new("/b")).unwrap(),
-            Command::ReviewComments { session_id: None, state: None }
+            Command::ReviewComments {
+                session_id: None,
+                state: None
+            }
         );
         assert_eq!(
-            parse(&s(&["review", "comments", "--state", "all", "--session", "sid"]), Path::new("/b")).unwrap(),
-            Command::ReviewComments { session_id: Some("sid".into()), state: Some("all".into()) }
+            parse(
+                &s(&["review", "comments", "--state", "all", "--session", "sid"]),
+                Path::new("/b")
+            )
+            .unwrap(),
+            Command::ReviewComments {
+                session_id: Some("sid".into()),
+                state: Some("all".into())
+            }
         );
-        assert!(parse(&s(&["review", "comments", "--state", "bogus"]), Path::new("/b")).is_err());
+        assert!(
+            parse(
+                &s(&["review", "comments", "--state", "bogus"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
         assert!(parse(&s(&["review", "comments", "--session"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "comments", "extra"]), Path::new("/b")).is_err());
     }
@@ -380,8 +542,15 @@ mod tests {
     #[test]
     fn review_reply_takes_exactly_id_and_body() {
         assert_eq!(
-            parse(&s(&["review", "reply", "c1", "looks good"]), Path::new("/b")).unwrap(),
-            Command::ReviewReply { comment_id: "c1".into(), body: "looks good".into() }
+            parse(
+                &s(&["review", "reply", "c1", "looks good"]),
+                Path::new("/b")
+            )
+            .unwrap(),
+            Command::ReviewReply {
+                comment_id: "c1".into(),
+                body: "looks good".into()
+            }
         );
         assert!(parse(&s(&["review", "reply", "c1"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "reply", "c1", "a", "b"]), Path::new("/b")).is_err());
@@ -391,11 +560,23 @@ mod tests {
     fn review_resolve_parses_flags() {
         assert_eq!(
             parse(&s(&["review", "resolve", "c1"]), Path::new("/b")).unwrap(),
-            Command::ReviewResolve { comment_id: "c1".into(), reply: None, reopen: false }
+            Command::ReviewResolve {
+                comment_id: "c1".into(),
+                reply: None,
+                reopen: false
+            }
         );
         assert_eq!(
-            parse(&s(&["review", "resolve", "c1", "--reply", "fixed", "--reopen"]), Path::new("/b")).unwrap(),
-            Command::ReviewResolve { comment_id: "c1".into(), reply: Some("fixed".into()), reopen: true }
+            parse(
+                &s(&["review", "resolve", "c1", "--reply", "fixed", "--reopen"]),
+                Path::new("/b")
+            )
+            .unwrap(),
+            Command::ReviewResolve {
+                comment_id: "c1".into(),
+                reply: Some("fixed".into()),
+                reopen: true
+            }
         );
         assert!(parse(&s(&["review", "resolve"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["review", "resolve", "--reopen"]), Path::new("/b")).is_err());
@@ -406,11 +587,24 @@ mod tests {
     fn review_finish_parses_flags_and_normalizes_request_changes() {
         assert_eq!(
             parse(&s(&["review", "finish"]), Path::new("/b")).unwrap(),
-            Command::ReviewFinish { session_id: None, verdict: None, summary: None }
+            Command::ReviewFinish {
+                session_id: None,
+                verdict: None,
+                summary: None
+            }
         );
         assert_eq!(
             parse(
-                &s(&["review", "finish", "--session", "sid", "--verdict", "request-changes", "--summary", "Fix it"]),
+                &s(&[
+                    "review",
+                    "finish",
+                    "--session",
+                    "sid",
+                    "--verdict",
+                    "request-changes",
+                    "--summary",
+                    "Fix it"
+                ]),
                 Path::new("/b")
             )
             .unwrap(),
@@ -420,14 +614,24 @@ mod tests {
                 summary: Some("Fix it".into()),
             }
         );
-        assert!(parse(&s(&["review", "finish", "--verdict", "reject"]), Path::new("/b")).is_err());
+        assert!(
+            parse(
+                &s(&["review", "finish", "--verdict", "reject"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
         assert!(parse(&s(&["review", "finish", "summary"]), Path::new("/b")).is_err());
     }
 
     #[test]
     fn review_comment_parses_positionals_and_flags() {
         assert_eq!(
-            parse(&s(&["review", "comment", "src/a.swift", "10", "fix this"]), Path::new("/b")).unwrap(),
+            parse(
+                &s(&["review", "comment", "src/a.swift", "10", "fix this"]),
+                Path::new("/b")
+            )
+            .unwrap(),
             Command::ReviewCommentAdd {
                 path: "/b/src/a.swift".into(),
                 start_line: 10,
@@ -439,7 +643,19 @@ mod tests {
         );
         assert_eq!(
             parse(
-                &s(&["review", "comment", "a.swift", "3", "b", "--end-line", "5", "--side", "old", "--session", "sid"]),
+                &s(&[
+                    "review",
+                    "comment",
+                    "a.swift",
+                    "3",
+                    "b",
+                    "--end-line",
+                    "5",
+                    "--side",
+                    "old",
+                    "--session",
+                    "sid"
+                ]),
                 Path::new("/b")
             )
             .unwrap(),
@@ -452,9 +668,29 @@ mod tests {
                 session_id: Some("sid".into()),
             }
         );
-        assert!(parse(&s(&["review", "comment", "a.swift", "0", "b"]), Path::new("/b")).is_err());
-        assert!(parse(&s(&["review", "comment", "a.swift", "x", "b"]), Path::new("/b")).is_err());
-        assert!(parse(&s(&["review", "comment", "a.swift", "3", "b", "--side", "sideways"]), Path::new("/b")).is_err());
+        assert!(
+            parse(
+                &s(&["review", "comment", "a.swift", "0", "b"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
+        assert!(
+            parse(
+                &s(&["review", "comment", "a.swift", "x", "b"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
+        assert!(
+            parse(
+                &s(&[
+                    "review", "comment", "a.swift", "3", "b", "--side", "sideways"
+                ]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
         assert!(parse(&s(&["review", "comment", "a.swift"]), Path::new("/b")).is_err());
     }
 
@@ -485,7 +721,13 @@ mod tests {
     #[test]
     fn review_comment_keeps_an_already_absolute_path_unchanged() {
         let cmd = parse(
-            &s(&["review", "comment", "/repo/Sources/App.swift", "10", "fix this"]),
+            &s(&[
+                "review",
+                "comment",
+                "/repo/Sources/App.swift",
+                "10",
+                "fix this",
+            ]),
             Path::new("/repo/Sources"),
         )
         .unwrap();
@@ -506,7 +748,9 @@ mod tests {
     fn plain_review_targets_still_parse() {
         assert_eq!(
             parse(&s(&["review", "123"]), Path::new("/b")).unwrap(),
-            Command::Review { target: Some("123".into()) }
+            Command::Review {
+                target: Some("123".into())
+            }
         );
     }
 

--- a/AlasTests/ACP/Session/BuiltInAlasMCPTests.swift
+++ b/AlasTests/ACP/Session/BuiltInAlasMCPTests.swift
@@ -8,14 +8,16 @@ struct BuiltInAlasMCPTests {
         configuredServers: [ProjectMCPServer] = [],
         binaryPath: String? = "/support/bin/alas",
         socketPath: String? = "/tmp/alas-501/pid-42",
-        worktreePath: String = "/repos/proj/wt"
+        worktreePath: String = "/repos/proj/wt",
+        sessionId: String = "acp-1"
     ) -> BuiltInAlasMCP.Injection? {
         BuiltInAlasMCP.injection(
             enabled: enabled,
             configuredServers: configuredServers,
             binaryPath: binaryPath,
             socketPath: socketPath,
-            worktreePath: worktreePath
+            worktreePath: worktreePath,
+            sessionId: sessionId
         )
     }
 
@@ -29,6 +31,7 @@ struct BuiltInAlasMCPTests {
             env: [
                 .init(name: "ALAS_SOCKET_PATH", value: "/tmp/alas-501/pid-42"),
                 .init(name: "ALAS_WORKTREE_DIR", value: "/repos/proj/wt"),
+                .init(name: "ALAS_SESSION_ID", value: "acp-1"),
             ]
         ))
         #expect(injection?.status == .init(

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -61,6 +61,41 @@ struct AlasCLICommandRouterTests {
         #expect(opened.first?.relativePath == "a.txt")
     }
 
+    @Test func notifyRoutesToOriginatingSessionAndWorktree() async throws {
+        let root = try makeFile("repo/a.txt").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        var captured: (sessionId: String?, worktreeId: String, body: String, title: String?, level: AlasCLINotifyLevel)?
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { $0 == "acp-1" ? "wt1" : nil },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in },
+            openExternalFile: { _, _ in },
+            notifySession: { sessionId, origin, body, title, level in
+                captured = (sessionId, origin.id, body, title, level)
+                return .ok
+            },
+            activateApp: {}
+        )
+
+        let response = await router.handle(.init(
+            version: 1,
+            sessionId: "acp-1",
+            cwd: nil,
+            command: .notify(body: "Blocked", title: "Need input", level: .attention)
+        ))
+
+        #expect(response == .ok)
+        #expect(captured?.sessionId == "acp-1")
+        #expect(captured?.worktreeId == "wt1")
+        #expect(captured?.body == "Blocked")
+        #expect(captured?.title == "Need input")
+        #expect(captured?.level == .attention)
+    }
+
     @Test func resolvesOriginFromSymlinkedWorktreeRootCwd() async throws {
         let realRoot = try makeFile("repo/a.txt").deletingLastPathComponent()
         let logicalRoot = realRoot.deletingLastPathComponent().appendingPathComponent("logical-repo")

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -86,6 +86,30 @@ struct AlasCLIRequestTests {
         #expect(request.command == .open(paths: ["/repo/a.txt"]))
     }
 
+    @Test func decodesNotifyRequestWithDefaults() throws {
+        let json = #"{"v":1,"kind":"cli","command":"notify","session_id":"s1","params":{"body":"Done, take a look"}}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request.command == .notify(body: "Done, take a look", title: nil, level: .attention))
+    }
+
+    @Test func decodesNotifyRequestWithTitleAndInfoLevel() throws {
+        let json = #"{"v":1,"kind":"cli","command":"notify","session_id":"s1","params":{"body":"Background task finished","title":"Done","level":"info"}}"#
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+        #expect(request.command == .notify(body: "Background task finished", title: "Done", level: .info))
+    }
+
+    @Test func rejectsInvalidNotifyRequests() throws {
+        for bad in [
+            #"{"v":1,"kind":"cli","command":"notify","session_id":"s1"}"#,
+            #"{"v":1,"kind":"cli","command":"notify","session_id":"s1","params":{"body":"   "}}"#,
+            #"{"v":1,"kind":"cli","command":"notify","session_id":"s1","params":{"body":"Done","level":"urgent"}}"#,
+        ] {
+            #expect(throws: AlasCLIRequestError.self, "should reject: \(bad)") {
+                try AlasCLIRequest.decode(from: Data(bad.utf8))
+            }
+        }
+    }
+
     @Test func decodesResolveRequest() throws {
         let json = #"{"v":1,"kind":"cli","command":"resolve","cwd":"/repo"}"#
         let request = try AlasCLIRequest.decode(from: Data(json.utf8))

--- a/AlasTests/NotificationServiceTests.swift
+++ b/AlasTests/NotificationServiceTests.swift
@@ -98,6 +98,31 @@ struct NotificationServiceTests {
         #expect(requests[0].content.body == "Session is waiting for an answer.")
     }
 
+    @Test func alasNotifyUsesClickableNotificationRequest() {
+        var requests: [UNNotificationRequest] = []
+        let service = NotificationService(notificationAdder: { request in
+            requests.append(request)
+        })
+
+        service.notifyAlas(
+            body: "Blocked on input",
+            title: "Need input",
+            agent: .codex,
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+            sessionId: "session-1"
+        )
+
+        #expect(requests.count == 1)
+        #expect(requests[0].identifier.hasPrefix("session-1-notify-"))
+        #expect(requests[0].content.title == "Need input")
+        #expect(requests[0].content.body == "Blocked on input")
+        #expect(requests[0].content.sound != nil)
+        #expect(requests[0].content.userInfo["projectId"] as? String == "project-1")
+        #expect(requests[0].content.userInfo["worktreeId"] as? String == "worktree-1")
+        #expect(requests[0].content.userInfo["sessionId"] as? String == "session-1")
+    }
+
     @Test func finishEnabledFlagDoesNotDisableAwaitingNotifications() {
         var requests: [UNNotificationRequest] = []
         let service = NotificationService(notificationAdder: { request in


### PR DESCRIPTION
## Summary

- Add `alas notify` with `body`, optional `title`, and `level` (`info` or `attention`).
- Expose the matching built-in MCP `notify` tool and pass the ACP session id into the built-in MCP environment.
- Route notifications through Alas so macOS notifications remain clickable and `attention` marks the session row as awaiting input.

## Validation

- `cargo test` in `AlasCLI`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AlasCLIRequestTests -only-testing:AlasTests/AlasCLICommandRouterTests -only-testing:AlasTests/NotificationServiceTests -only-testing:AlasTests/BuiltInAlasMCPTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Closes #793 
