### PR TITLE
fix(acp): remove transcript target visibility tracking

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -40,6 +40,7 @@ struct ACPMessageList: View {
     @State private var latestRememberedScrollAnchorIndex: Int?
     @State private var restoredRememberedAnchor: String?
     @State private var pendingTailScrollTask: Task<Void, Never>?
+    @State private var modernRowFrames: [String: CGRect] = [:]
 
     /// Height of an invisible spacer at the tail of the transcript stack. The
     /// composer pill plus its outer padding occupies roughly this much
@@ -50,6 +51,10 @@ struct ACPMessageList: View {
     /// Step the visible head back when the "Earlier messages…" marker
     /// crosses this many points from the top edge during scroll.
     private let headStepScrollThreshold: CGFloat = 200
+    /// `visibleMessageLookup.firstStableId` is safe to persist only when the
+    /// viewport is effectively at the start of the rendered window. Otherwise
+    /// it may be older than the row the user actually stopped on.
+    private let firstRenderedAnchorFallbackThreshold: CGFloat = 1
     /// Minimum gap between automatic head-back steps so a single scroll
     /// doesn't decrement multiple times before layout settles.
     private let headStepDebounceInterval: TimeInterval = 0.3
@@ -211,7 +216,6 @@ struct ACPMessageList: View {
                     .padding(.top, 24)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .environment(\.openURL, openTranscriptURLAction)
-                    .modifier(ACPScrollTargetLayoutTracking())
                 }
                 .coordinateSpace(.named(scrollSpaceName))
                 .modifier(ACPTranscriptScrollTracking(
@@ -231,9 +235,6 @@ struct ACPMessageList: View {
                             contentHeight: new.contentHeight,
                             proxy: proxy)
                     }
-                ))
-                .modifier(ACPScrollTargetVisibilityTracking(
-                    onVisibleTargetIDs: { ids in handleVisibleTargetIDs(ids, proxy: proxy) }
                 ))
                 .onAppear {
                     restoreTailIfNeeded(proxy: proxy, animated: false)
@@ -418,25 +419,34 @@ struct ACPMessageList: View {
         }
     }
 
-    private func setFollowsTranscriptTail(_ follows: Bool) {
-        guard session.followsTranscriptTail != follows else { return }
-        session.followsTranscriptTail = follows
+    private func setFollowsTranscriptTail(
+        _ follows: Bool,
+        allowFirstRenderedAnchorFallback: Bool = true
+    ) {
         if follows {
+            guard !session.followsTranscriptTail else { return }
+            session.followsTranscriptTail = true
             transcript.resetWindowToTail()
             onRememberScrollAnchor(nil, nil, true)
             latestRememberedScrollAnchorIndex = nil
         } else {
+            session.followsTranscriptTail = false
             pendingTailScrollTask?.cancel()
             pendingTailScrollTask = nil
             let lookup = visibleMessageLookup
-            let anchorIndex = lookup.transcriptIndex(for: latestTopVisibleAnchor.value)
+            let anchor = Self.rememberedAnchorWhenPausingTailFollow(
+                latestTopVisibleAnchor: latestTopVisibleAnchor.value,
+                lookup: lookup,
+                allowFirstRenderedAnchorFallback: allowFirstRenderedAnchorFallback
+            )
+            let anchorIndex = lookup.transcriptIndex(for: anchor)
             onRememberScrollAnchor(
-                latestTopVisibleAnchor.value,
+                anchor,
                 anchorIndex,
                 false
             )
             latestRememberedScrollAnchorIndex = anchorIndex
-            restoredRememberedAnchor = latestTopVisibleAnchor.value
+            restoredRememberedAnchor = anchor
         }
     }
 
@@ -468,25 +478,40 @@ struct ACPMessageList: View {
         restoredRememberedAnchor = anchor
     }
 
-    private func handleVisibleTargetIDs(_ ids: [String], proxy: ScrollViewProxy) {
+    private func handleModernRowFrame(id: String, frame: CGRect) {
         let lookup = visibleMessageLookup
-        guard let anchor = Self.topVisibleScrollTargetID(
-            in: ids,
-            visibleMessageIds: lookup.ids
-        ) else { return }
+        modernRowFrames = modernRowFrames.filter { lookup.contains($0.key) }
+        if lookup.contains(id), frame.height > 0, frame.maxY > 0 {
+            modernRowFrames[id] = frame
+        } else {
+            modernRowFrames.removeValue(forKey: id)
+        }
+        guard let anchor = Self.topVisibleAnchorID(in: modernRowFrames) else { return }
         let anchorChanged = latestTopVisibleAnchor.value != anchor
         if anchorChanged {
             latestTopVisibleAnchor.value = anchor
         }
-        guard !isRestoringTail, !session.followsTranscriptTail else { return }
+        guard !isRestoringTail else { return }
+        guard !session.followsTranscriptTail else { return }
+        guard !transcript.isBackfillingOlderMessages else { return }
         let rememberedAnchor = rememberedScrollAnchor()
         let anchorIndex = lookup.transcriptIndex(for: anchor)
         let anchorIndexChanged = rememberedAnchor == anchor && latestRememberedScrollAnchorIndex != anchorIndex
         guard anchorChanged || rememberedAnchor != anchor || anchorIndexChanged else { return }
-        guard !transcript.isBackfillingOlderMessages else { return }
         onRememberScrollAnchor(anchor, anchorIndex, false)
         latestRememberedScrollAnchorIndex = anchorIndex
         restoredRememberedAnchor = anchor
+    }
+
+    private func pauseTailFollowFromGeometry(newMinY: CGFloat) {
+        let shouldUseWindowStartFallback = Self.shouldUseFirstRenderedAnchorFallback(
+            newMinY: newMinY,
+            threshold: firstRenderedAnchorFallbackThreshold
+        )
+        setFollowsTranscriptTail(
+            false,
+            allowFirstRenderedAnchorFallback: shouldUseWindowStartFallback
+        )
     }
 
     private func stepTailForwardPreservingScroll(
@@ -498,7 +523,10 @@ struct ACPMessageList: View {
         let now = Date()
         guard now.timeIntervalSince(lastTailStepAt) > headStepDebounceInterval else { return }
         lastTailStepAt = now
-        let anchorId = latestTopVisibleAnchor.value ?? lookup.firstStableId
+        let anchorId = Self.anchorForTailForwardPreservation(
+            latestTopVisibleAnchor: latestTopVisibleAnchor.value,
+            lookup: lookup
+        )
         let anchorIndex = lookup.transcriptIndex(for: anchorId)
         isRestoringTail = true
         transcript.stepTailForward(preserving: anchorIndex)
@@ -522,14 +550,20 @@ struct ACPMessageList: View {
         }
     }
 
-    private func handleAtBottom(proxy: ScrollViewProxy, shouldPageHiddenTail: Bool) {
+    private func handleAtBottom(
+        proxy: ScrollViewProxy,
+        shouldPageHiddenTail: Bool
+    ) {
         if Self.shouldResumeTailFollowAtBottom(
             visibleTail: transcript.visibleTailBound,
             messageCount: transcript.messages.count
         ) {
             setFollowsTranscriptTail(true)
         } else if shouldPageHiddenTail {
-            stepTailForwardPreservingScroll(proxy: proxy, lookup: visibleMessageLookup)
+            stepTailForwardPreservingScroll(
+                proxy: proxy,
+                lookup: visibleMessageLookup
+            )
         }
     }
 
@@ -539,7 +573,7 @@ struct ACPMessageList: View {
             if Self.shouldUseLegacyRowFramePreferences(isModernScrollTrackingAvailable: true) {
                 legacyRowFrameReporter(id: id)
             } else {
-                EmptyView()
+                modernRowFrameReporter(id: id)
             }
         } else if Self.shouldUseLegacyRowFramePreferences(isModernScrollTrackingAvailable: false) {
             legacyRowFrameReporter(id: id)
@@ -554,6 +588,15 @@ struct ACPMessageList: View {
                 key: ACPRowFramesPreferenceKey.self,
                 value: [id: rowGeometry.frame(in: .named(scrollSpaceName))]
             )
+        }
+    }
+
+    @available(macOS 15, *)
+    private func modernRowFrameReporter(id: String) -> some View {
+        Color.clear.onGeometryChange(for: CGRect.self) { rowGeometry in
+            rowGeometry.frame(in: .named(scrollSpaceName))
+        } action: { frame in
+            handleModernRowFrame(id: id, frame: frame)
         }
     }
 
@@ -703,13 +746,6 @@ struct ACPMessageList: View {
             .key
     }
 
-    nonisolated static func topVisibleScrollTargetID(
-        in ids: [String],
-        visibleMessageIds: Set<String>
-    ) -> String? {
-        ids.first { visibleMessageIds.contains($0) }
-    }
-
     nonisolated static func shouldUseLegacyRowFramePreferences(
         isModernScrollTrackingAvailable: Bool
     ) -> Bool {
@@ -770,6 +806,31 @@ struct ACPMessageList: View {
             indexByStableId: indexByStableId,
             firstStableId: rows.first?.stableId
         )
+    }
+
+    nonisolated static func rememberedAnchorWhenPausingTailFollow(
+        latestTopVisibleAnchor: String?,
+        lookup: VisibleMessageLookup,
+        allowFirstRenderedAnchorFallback: Bool
+    ) -> String? {
+        if lookup.contains(latestTopVisibleAnchor) { return latestTopVisibleAnchor }
+        guard allowFirstRenderedAnchorFallback else { return nil }
+        return lookup.firstStableId
+    }
+
+    nonisolated static func shouldUseFirstRenderedAnchorFallback(
+        newMinY: CGFloat,
+        threshold: CGFloat
+    ) -> Bool {
+        newMinY.isFinite && newMinY <= threshold
+    }
+
+    nonisolated static func anchorForTailForwardPreservation(
+        latestTopVisibleAnchor: String?,
+        lookup: VisibleMessageLookup
+    ) -> String? {
+        if lookup.contains(latestTopVisibleAnchor) { return latestTopVisibleAnchor }
+        return lookup.firstStableId
     }
 
     nonisolated static func shouldRememberVisibleAnchor(
@@ -843,7 +904,8 @@ struct ACPMessageList: View {
             isUserDriven: isUserDriven
         )
         switch decision {
-        case .userScrolledUp: setFollowsTranscriptTail(false)
+        case .userScrolledUp:
+            pauseTailFollowFromGeometry(newMinY: newMinY)
         case .userAtBottom:
             handleAtBottom(
                 proxy: proxy,
@@ -1012,32 +1074,6 @@ private struct ACPRowFramePreferenceTracking: ViewModifier {
             }
         } else if ACPMessageList.shouldUseLegacyRowFramePreferences(isModernScrollTrackingAvailable: false) {
             content.onPreferenceChange(ACPRowFramesPreferenceKey.self, perform: onFrames)
-        } else {
-            content
-        }
-    }
-}
-
-private struct ACPScrollTargetLayoutTracking: ViewModifier {
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if #available(macOS 15, *) {
-            content.scrollTargetLayout()
-        } else {
-            content
-        }
-    }
-}
-
-private struct ACPScrollTargetVisibilityTracking: ViewModifier {
-    let onVisibleTargetIDs: ([String]) -> Void
-
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if #available(macOS 15, *) {
-            content.onScrollTargetVisibilityChange(idType: String.self, threshold: 0.01) { ids in
-                onVisibleTargetIDs(ids)
-            }
         } else {
             content
         }

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -174,22 +174,6 @@ struct ACPMessageListPaginationTests {
         #expect(ACPMessageList.topVisibleAnchorID(in: frames) == "first")
     }
 
-    @Test("top visible scroll target ignores non-message targets")
-    func topVisibleScrollTargetIgnoresNonMessageTargets() {
-        #expect(ACPMessageList.topVisibleScrollTargetID(
-            in: ["__pending_perm__", "message-2", "message-3"],
-            visibleMessageIds: ["message-1", "message-2", "message-3"]
-        ) == "message-2")
-    }
-
-    @Test("top visible scroll target returns nil without visible messages")
-    func topVisibleScrollTargetReturnsNilWithoutMessages() {
-        #expect(ACPMessageList.topVisibleScrollTargetID(
-            in: ["__pending_question__", "__composer_spacer__"],
-            visibleMessageIds: ["message-1"]
-        ) == nil)
-    }
-
     @Test("row frame preferences are legacy-only")
     func rowFramePreferencesAreLegacyOnly() {
         #expect(ACPMessageList.shouldUseLegacyRowFramePreferences(
@@ -211,6 +195,74 @@ struct ACPMessageListPaginationTests {
         #expect(!lookup.contains("message-39"))
         #expect(lookup.transcriptIndex(for: "message-41") == 41)
         #expect(lookup.firstStableId == "message-40")
+    }
+
+    @Test("tail pause anchor selection prefers sampled anchors before fallback")
+    func tailPauseAnchorSelectionUsesSampledAnchorBeforeFallback() {
+        let lookup = ACPMessageList.visibleMessageLookup(rows: [
+            (index: 40, stableId: "message-40"),
+            (index: 41, stableId: "message-41")
+        ])
+
+        #expect(ACPMessageList.rememberedAnchorWhenPausingTailFollow(
+            latestTopVisibleAnchor: "message-41",
+            lookup: lookup,
+            allowFirstRenderedAnchorFallback: true
+        ) == "message-41")
+        #expect(ACPMessageList.rememberedAnchorWhenPausingTailFollow(
+            latestTopVisibleAnchor: nil,
+            lookup: lookup,
+            allowFirstRenderedAnchorFallback: true
+        ) == "message-40")
+        #expect(ACPMessageList.rememberedAnchorWhenPausingTailFollow(
+            latestTopVisibleAnchor: "message-41",
+            lookup: lookup,
+            allowFirstRenderedAnchorFallback: false
+        ) == "message-41")
+        #expect(ACPMessageList.rememberedAnchorWhenPausingTailFollow(
+            latestTopVisibleAnchor: "stale-message",
+            lookup: lookup,
+            allowFirstRenderedAnchorFallback: true
+        ) == "message-40")
+        #expect(ACPMessageList.rememberedAnchorWhenPausingTailFollow(
+            latestTopVisibleAnchor: nil,
+            lookup: lookup,
+            allowFirstRenderedAnchorFallback: false
+        ) == nil)
+    }
+
+    @Test("first rendered anchor fallback is used only near the rendered window start")
+    func firstRenderedAnchorFallbackRequiresWindowStart() {
+        #expect(ACPMessageList.shouldUseFirstRenderedAnchorFallback(
+            newMinY: 0,
+            threshold: 1
+        ))
+        #expect(ACPMessageList.shouldUseFirstRenderedAnchorFallback(
+            newMinY: 1,
+            threshold: 1
+        ))
+        #expect(!ACPMessageList.shouldUseFirstRenderedAnchorFallback(
+            newMinY: 120,
+            threshold: 1
+        ))
+    }
+
+    @Test("tail forward preservation prefers sampled anchor before first row")
+    func tailForwardPreservationUsesSampledAnchorBeforeFallback() {
+        let lookup = ACPMessageList.visibleMessageLookup(rows: [
+            (index: 40, stableId: "message-40"),
+            (index: 41, stableId: "message-41"),
+            (index: 42, stableId: "message-42")
+        ])
+
+        #expect(ACPMessageList.anchorForTailForwardPreservation(
+            latestTopVisibleAnchor: "message-41",
+            lookup: lookup
+        ) == "message-41")
+        #expect(ACPMessageList.anchorForTailForwardPreservation(
+            latestTopVisibleAnchor: "stale-message",
+            lookup: lookup
+        ) == "message-40")
     }
 
     @Test("visible rows contain only transcript indices and stable ids")


### PR DESCRIPTION
## Summary
- remove ACPMessageList's scrollTargetLayout/onScrollTargetVisibilityChange path
- keep macOS 15+ transcript scroll state on ACPTranscriptScrollTracking/onScrollGeometryChange
- preserve tail-follow pause anchor fallback to the first rendered row when no sampled top anchor exists

## Root Cause
The beachball stack in /tmp/beachball4.log points at SwiftUI target visibility and LazySubviewPlacements work. ACPMessageList was asking SwiftUI to enumerate visible targets inside the same lazy placement machinery even though scroll geometry already owns the position signal on macOS 15+.

## Validation
- ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageListPaginationTests test