### PR TITLE
feat(mcp): Add MCP delegated ACP sessions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 		497D21A67A062CE6282008CD /* PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295319DB8544C170DDD6328D /* PathsTests.swift */; };
 		49A112CA4183D8FAEA84294A /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 0714DCAA9EC181C239773440 /* TreeSitterBash */; };
 		49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */; };
+		4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */; };
 		4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */; };
 		4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02E429B37288215EBC89571 /* CommitHeaderView.swift */; };
 		4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */; };
@@ -2123,6 +2124,7 @@
 		AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneLSPTests.swift; sourceTree = "<group>"; };
 		ADACDD363C5E4637A3113EFB /* RangeReviewLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReviewLoaderTests.swift; sourceTree = "<group>"; };
 		ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoaderTests.swift; sourceTree = "<group>"; };
+		AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelegatedSessionsPolicyTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AEAF044BC36E6083CC1529BE /* session-update-session-info-no-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-session-info-no-meta.json"; sourceTree = "<group>"; };
@@ -3464,6 +3466,7 @@
 				85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */,
 				ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */,
 				DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */,
+				AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */,
 				F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */,
 				8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */,
 				FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */,
@@ -5723,6 +5726,7 @@
 				839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */,
 				316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */,
 				DADDDA3FA289B52415EF4379 /* ACPDelayedHoverVisibilityTests.swift in Sources */,
+				4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */,
 				47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */,
 				AA19B3B2B1CE418BFD6FD134 /* ACPElicitationCoordinatorTests.swift in Sources */,
 				445DAFBF3E820823AA2779B4 /* ACPElicitationTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
 		2E386BCE2DC24809A1B68244 /* ACPSessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0349ABD94031DE1BA929C8ED /* ACPSessionPersistenceTests.swift */; };
+		2E77FDE42FBD83BBCBC8DE80 /* ACPDelegatedPromptSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F125642F0AD2F6755B5E067B /* ACPDelegatedPromptSource.swift */; };
 		2E82C412B34A091035A7DB41 /* CommitMessageEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65BEFA85B6671FDE505A30D /* CommitMessageEditorView.swift */; };
 		2E8A92496DAE35CD1F2D05AA /* ACPAdapterTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE3B261CC2B780A40B2EF4E /* ACPAdapterTargetTests.swift */; };
 		2E952C4C62784847AF4B7870 /* ZmxSessionName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */; };
@@ -2470,6 +2471,7 @@
 		F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreTests.swift; sourceTree = "<group>"; };
 		F0D567F7F894902AD192D220 /* mason-lsps.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "mason-lsps.json"; sourceTree = "<group>"; };
 		F12340A649892955245BECB7 /* DefinitionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionFeature.swift; sourceTree = "<group>"; };
+		F125642F0AD2F6755B5E067B /* ACPDelegatedPromptSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelegatedPromptSource.swift; sourceTree = "<group>"; };
 		F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffTabView.swift; sourceTree = "<group>"; };
 		F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStreamingTextTests.swift; sourceTree = "<group>"; };
 		F18E4AD4B92330FB085C821C /* FileDeviceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDeviceStore.swift; sourceTree = "<group>"; };
@@ -2690,6 +2692,7 @@
 		0C652107D8258A12E8774EF5 /* Orchestration */ = {
 			isa = PBXGroup;
 			children = (
+				F125642F0AD2F6755B5E067B /* ACPDelegatedPromptSource.swift */,
 				6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */,
 				8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */,
 				28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */,
@@ -5038,6 +5041,7 @@
 				C7EC6D85810513194F831F13 /* ACPConnection.swift in Sources */,
 				9CF654B4AB74CC1A9FBCE55F /* ACPContextRing.swift in Sources */,
 				0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */,
+				2E77FDE42FBD83BBCBC8DE80 /* ACPDelegatedPromptSource.swift in Sources */,
 				2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */,
 				16EFA072E6C91CF41269482C /* ACPElicitation.swift in Sources */,
 				9ECB0CE387C7078D238B3A15 /* ACPElicitationCoordinator.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
 		303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */; };
 		30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */; };
+		30604716147E0B9C558244F3 /* ACPSessionOrchestrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD63F297F7735AD9E1841ACF /* ACPSessionOrchestrationPolicy.swift */; };
 		30A03E2F26084723538C97BB /* SSHConfigParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2641F3E2016CE8C83E75BA5D /* SSHConfigParser.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
@@ -546,6 +547,7 @@
 		6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795056B6AD803D2B555FC866 /* RightPaneStore.swift */; };
 		6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */; };
 		6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */; };
+		6E1462FC9F25C4ED43DF8DF8 /* ACPSessionOrchestrationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F019D14D6FEFFE084FA498 /* ACPSessionOrchestrationPolicyTests.swift */; };
 		6E52521BCD52ED8DB496E74B /* CompletionDocumentationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */; };
 		6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
@@ -2092,6 +2094,7 @@
 		A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommandTests.swift; sourceTree = "<group>"; };
 		A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerTests.swift; sourceTree = "<group>"; };
 		A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServerIntegrationTests.swift; sourceTree = "<group>"; };
+		A7F019D14D6FEFFE084FA498 /* ACPSessionOrchestrationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationPolicyTests.swift; sourceTree = "<group>"; };
 		A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageChipAttachment.swift; sourceTree = "<group>"; };
 		A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailabilityTests.swift; sourceTree = "<group>"; };
 		A8EFC853C0D2EB4AC2B01D9E /* GitService+ImageDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ImageDiff.swift"; sourceTree = "<group>"; };
@@ -2110,6 +2113,7 @@
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
 		AD3B3FF5D7B8F892ED1972A8 /* DiffReviewSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewSurface.swift; sourceTree = "<group>"; };
+		AD63F297F7735AD9E1841ACF /* ACPSessionOrchestrationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationPolicy.swift; sourceTree = "<group>"; };
 		AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAttachmentMimeTypeTests.swift; sourceTree = "<group>"; };
 		AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneLSPTests.swift; sourceTree = "<group>"; };
 		ADACDD363C5E4637A3113EFB /* RangeReviewLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReviewLoaderTests.swift; sourceTree = "<group>"; };
@@ -2689,6 +2693,7 @@
 				6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */,
 				8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */,
 				28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */,
+				AD63F297F7735AD9E1841ACF /* ACPSessionOrchestrationPolicy.swift */,
 			);
 			path = Orchestration;
 			sourceTree = "<group>";
@@ -3124,6 +3129,7 @@
 			isa = PBXGroup;
 			children = (
 				331B138E37587DF6FB4139F8 /* ACPOrchestrationStoreTests.swift */,
+				A7F019D14D6FEFFE084FA498 /* ACPSessionOrchestrationPolicyTests.swift */,
 			);
 			path = Orchestration;
 			sourceTree = "<group>";
@@ -5104,6 +5110,7 @@
 				D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */,
 				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
+				30604716147E0B9C558244F3 /* ACPSessionOrchestrationPolicy.swift in Sources */,
 				8E988C41547B229AF19CBE31 /* ACPSessionPersistence.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,
 				027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */,
@@ -5770,6 +5777,7 @@
 				6C70755431CFBA41420A2F47 /* ACPSessionManagerRemoteRestoreTests.swift in Sources */,
 				095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
+				6E1462FC9F25C4ED43DF8DF8 /* ACPSessionOrchestrationPolicyTests.swift in Sources */,
 				2E386BCE2DC24809A1B68244 /* ACPSessionPersistenceTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,
 				C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */; };
 		12035048B950CE0197604F89 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CE7B4DAFDB65A79308FB63 /* GitService.swift */; };
 		1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */; };
+		12EB0B042A0225258B8A6C99 /* ACPOrchestrationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */; };
 		133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */; };
 		1339BE8F736D53991DDD19CD /* FileSearchBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */; };
 		13928612F39D3D86ED3313AC /* ReviewChangesModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */; };
@@ -305,6 +306,7 @@
 		3D561C5EDA7AAB4831CA58CF /* RemoteProjectCollisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */; };
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
+		3D90F6CD461684F6A430A190 /* ACPOrchestrationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331B138E37587DF6FB4139F8 /* ACPOrchestrationStoreTests.swift */; };
 		3D98C4F5EE2C0B1203C76752 /* ACPImageChipAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */; };
 		3DB85FF0D4965BF78AD2B010 /* MergeSidePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C55C85672956E1340B03B1 /* MergeSidePane.swift */; };
 		3DBBAB113CDB6FEEB01C588E /* ACPManagedAdapterDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */; };
@@ -462,6 +464,7 @@
 		59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
 		59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */; };
+		59F07BEDA39E5266B33DC47A /* ACPOrchestrationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */; };
 		59F39BAAD57023F090AEDA4F /* ACPImageStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */; };
 		5A0AE37CBA893BD09558C27E /* CIStatusStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FAF07CCA81D986D1C30D05 /* CIStatusStrip.swift */; };
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
@@ -906,6 +909,7 @@
 		B785053315764F42E3601F15 /* UpdateProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF766C79A3F9F004A513D4D /* UpdateProgressSheet.swift */; };
 		B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
+		B7F21BA3E994F3A0990D4C06 /* ACPOrchestrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
 		B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */; };
 		B834ADF0BB988121361AF334 /* tool-call-content-blocks.json in Resources */ = {isa = PBXBuildFile; fileRef = F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */; };
@@ -1471,6 +1475,7 @@
 		27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewFileSectionEqualityTests.swift; sourceTree = "<group>"; };
 		283613E170E25F69521F64ED /* DiffDisplaySignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplaySignatureTests.swift; sourceTree = "<group>"; };
 		28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceEmojiPickerSelectionTests.swift; sourceTree = "<group>"; };
+		28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationStore.swift; sourceTree = "<group>"; };
 		28E0789D49881A17137010D0 /* ACPRemoteAdapterInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterInstallerTests.swift; sourceTree = "<group>"; };
 		292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstallerTests.swift; sourceTree = "<group>"; };
 		29313DDC46A0CCA2FA42CDE9 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
@@ -1535,6 +1540,7 @@
 		329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionChipAttachment.swift; sourceTree = "<group>"; };
 		32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandle.swift; sourceTree = "<group>"; };
 		32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreePollTests.swift; sourceTree = "<group>"; };
+		331B138E37587DF6FB4139F8 /* ACPOrchestrationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationStoreTests.swift; sourceTree = "<group>"; };
 		333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigChangesTests.swift; sourceTree = "<group>"; };
 		336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariantsTests.swift; sourceTree = "<group>"; };
 		3375A79ACFD3567389DA855C /* FileResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileResultRow.swift; sourceTree = "<group>"; };
@@ -1834,6 +1840,7 @@
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
 		6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolverTests.swift; sourceTree = "<group>"; };
 		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
+		6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationModels.swift; sourceTree = "<group>"; };
 		6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewMutationController.swift; sourceTree = "<group>"; };
 		6F4D0EAA4C7CB45617BDD3FE /* ReadonlyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyTextView.swift; sourceTree = "<group>"; };
 		6FD359E5712BE30FF37251EE /* PaneDragMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragMathTests.swift; sourceTree = "<group>"; };
@@ -1978,6 +1985,7 @@
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		8F3F67549BDACF73DFC2E477 /* GitService+Stash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Stash.swift"; sourceTree = "<group>"; };
 		8FABF9037326B7EE23FCC040 /* FileSearchRanker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchRanker.swift; sourceTree = "<group>"; };
+		8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationPersistence.swift; sourceTree = "<group>"; };
 		906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerShell.swift; sourceTree = "<group>"; };
 		90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayoutTests.swift; sourceTree = "<group>"; };
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
@@ -2675,6 +2683,16 @@
 			path = Adapter;
 			sourceTree = "<group>";
 		};
+		0C652107D8258A12E8774EF5 /* Orchestration */ = {
+			isa = PBXGroup;
+			children = (
+				6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */,
+				8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */,
+				28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */,
+			);
+			path = Orchestration;
+			sourceTree = "<group>";
+		};
 		0F8A8BCD5083CA261EBDEC8C /* Gateway */ = {
 			isa = PBXGroup;
 			children = (
@@ -3102,6 +3120,14 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		292E48C86EB6C1E0D8A8A128 /* Orchestration */ = {
+			isa = PBXGroup;
+			children = (
+				331B138E37587DF6FB4139F8 /* ACPOrchestrationStoreTests.swift */,
+			);
+			path = Orchestration;
+			sourceTree = "<group>";
+		};
 		2DC32361E466DA20E974D106 /* Git */ = {
 			isa = PBXGroup;
 			children = (
@@ -3277,6 +3303,7 @@
 				45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */,
 				0A9B6A8C7372DB9E6C627A0E /* Adapter */,
 				22693797F2929554193802B2 /* FileWriter */,
+				0C652107D8258A12E8774EF5 /* Orchestration */,
 				3265338C21E4088B279578DE /* Permissions */,
 				4DB62FEBC3C8536A56117C23 /* Protocol */,
 				51D8A9EE658EB05F836A321A /* Session */,
@@ -3700,6 +3727,7 @@
 				E6055B84E3F6E5717B873689 /* E2E */,
 				075A0E441C47ACE7EEA52334 /* FileWriter */,
 				895189284B82DBD794D9F2F0 /* Fixtures */,
+				292E48C86EB6C1E0D8A8A128 /* Orchestration */,
 				FDD6B99A5214227965308D70 /* Permissions */,
 				28DACFA5F60339EEE14A135F /* Protocol */,
 				A72D9EE2C6FD478C41435DBA /* Session */,
@@ -5043,6 +5071,9 @@
 				552EBB79C20E7D939C7015A1 /* ACPMockClient.swift in Sources */,
 				7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */,
 				58ED3DFB6576F9B3C473D16C /* ACPNewChatEmptyStateView.swift in Sources */,
+				12EB0B042A0225258B8A6C99 /* ACPOrchestrationModels.swift in Sources */,
+				59F07BEDA39E5266B33DC47A /* ACPOrchestrationPersistence.swift in Sources */,
+				B7F21BA3E994F3A0990D4C06 /* ACPOrchestrationStore.swift in Sources */,
 				E4C6E2BE1C7F20AD29C66DF0 /* ACPPermissionDecisionLog.swift in Sources */,
 				CC30504E2DC245FD23347E33 /* ACPPermissionPolicy.swift in Sources */,
 				0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */,
@@ -5704,6 +5735,7 @@
 				BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */,
 				395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */,
 				FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */,
+				3D90F6CD461684F6A430A190 /* ACPOrchestrationStoreTests.swift in Sources */,
 				4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */,
 				57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */,
 				8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -970,6 +970,7 @@
 		C1D83EEBE3AF4ABC04B3F7EB /* GitHubCLIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */; };
 		C1EBF68A32C7C1D61ECC89AC /* LSPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */; };
 		C1F16BAC9C4B9A0457208816 /* RemoteContentSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */; };
+		C1FF6E6CE6AF5ABCF5C62115 /* ACPSessionOrchestrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728F8E1DBF9DA86092C10AD0 /* ACPSessionOrchestrationCoordinator.swift */; };
 		C245B74D0083CE00B6CD392C /* ACPAdapterVersionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */; };
 		C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2942AD875C0E7AB71E8E3CAD /* VerdictSheet.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
@@ -1252,6 +1253,7 @@
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
 		FB6FF6C91476DEE43E512E30 /* RemoteServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EACA79C819C9FBE68F9D84 /* RemoteServer.swift */; };
 		FB754FAC723CF480D3BBB101 /* RangeReviewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADACDD363C5E4637A3113EFB /* RangeReviewLoaderTests.swift */; };
+		FB8B530E472D1C22B78F12EE /* ACPDelegatedSessionsPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F2697D068C074A82959C9F /* ACPDelegatedSessionsPolicy.swift */; };
 		FB9BAF6C82A1750E41594DB7 /* SelfUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF2E2BF116094A9FEE3F8D /* SelfUpdater.swift */; };
 		FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */; };
 		FBEC59B1FD0C1DDDB6CE3100 /* RemoteNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8084388AF564A1907548C /* RemoteNetworkTests.swift */; };
@@ -1717,6 +1719,7 @@
 		53C0EBA9F81668C89977770E /* ACPLaunchPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolver.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		53EEBEEB1AC6532031BDE17F /* RemoteAccessPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAccessPolicyTests.swift; sourceTree = "<group>"; };
+		53F2697D068C074A82959C9F /* ACPDelegatedSessionsPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelegatedSessionsPolicy.swift; sourceTree = "<group>"; };
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
 		542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationState.swift; sourceTree = "<group>"; };
 		5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshotTests.swift; sourceTree = "<group>"; };
@@ -1864,6 +1867,7 @@
 		71A90560CED6562BBC313F3C /* ProjectConfigHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigHostTests.swift; sourceTree = "<group>"; };
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
 		71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefill.swift; sourceTree = "<group>"; };
+		728F8E1DBF9DA86092C10AD0 /* ACPSessionOrchestrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinator.swift; sourceTree = "<group>"; };
 		7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateView.swift; sourceTree = "<group>"; };
 		72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiffTests.swift; sourceTree = "<group>"; };
 		729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentModelTests.swift; sourceTree = "<group>"; };
@@ -2696,6 +2700,7 @@
 				6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */,
 				8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */,
 				28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */,
+				728F8E1DBF9DA86092C10AD0 /* ACPSessionOrchestrationCoordinator.swift */,
 				AD63F297F7735AD9E1841ACF /* ACPSessionOrchestrationPolicy.swift */,
 			);
 			path = Orchestration;
@@ -3811,6 +3816,7 @@
 				DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */,
 				AF522B02666DB6AC4C82339E /* ACPContextRing.swift */,
 				8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */,
+				53F2697D068C074A82959C9F /* ACPDelegatedSessionsPolicy.swift */,
 				BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */,
 				29D7631D754795D16E946440 /* ACPFileEditCard.swift */,
 				8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */,
@@ -5042,6 +5048,7 @@
 				9CF654B4AB74CC1A9FBCE55F /* ACPContextRing.swift in Sources */,
 				0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */,
 				2E77FDE42FBD83BBCBC8DE80 /* ACPDelegatedPromptSource.swift in Sources */,
+				FB8B530E472D1C22B78F12EE /* ACPDelegatedSessionsPolicy.swift in Sources */,
 				2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */,
 				16EFA072E6C91CF41269482C /* ACPElicitation.swift in Sources */,
 				9ECB0CE387C7078D238B3A15 /* ACPElicitationCoordinator.swift in Sources */,
@@ -5114,6 +5121,7 @@
 				D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */,
 				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
+				C1FF6E6CE6AF5ABCF5C62115 /* ACPSessionOrchestrationCoordinator.swift in Sources */,
 				30604716147E0B9C558244F3 /* ACPSessionOrchestrationPolicy.swift in Sources */,
 				8E988C41547B229AF19CBE31 /* ACPSessionPersistence.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1116,6 +1116,7 @@
 		DD2553E3635BFE3B15355E08 /* ACPLaunchPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */; };
 		DDAA1FF54466B7F5424D315E /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 49F7F27A9183521F9997AF49 /* TreeSitterMarkdown */; };
 		DDBEA2D41ECA8F0F28CF5DF6 /* RemoteRepoValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27192411BB5CB8F8F7AD09B2 /* RemoteRepoValidatorTests.swift */; };
+		DDEFEBB152E6AE1B0BB4D3EE /* ACPSessionOrchestrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89034A1968C6BC371826314D /* ACPSessionOrchestrationCoordinatorTests.swift */; };
 		DE207C4CFA1A45866FCB4E22 /* RemoteFileOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */; };
 		DE33366A35436471AE0DAE96 /* DiffReviewRenderBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */; };
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
@@ -1967,6 +1968,7 @@
 		883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinatorTests.swift; sourceTree = "<group>"; };
 		88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOption.swift; sourceTree = "<group>"; };
 		88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTranscriptSync.swift; sourceTree = "<group>"; };
+		89034A1968C6BC371826314D /* ACPSessionOrchestrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
 		89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionName.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
@@ -3139,6 +3141,7 @@
 			isa = PBXGroup;
 			children = (
 				331B138E37587DF6FB4139F8 /* ACPOrchestrationStoreTests.swift */,
+				89034A1968C6BC371826314D /* ACPSessionOrchestrationCoordinatorTests.swift */,
 				A7F019D14D6FEFFE084FA498 /* ACPSessionOrchestrationPolicyTests.swift */,
 			);
 			path = Orchestration;
@@ -5793,6 +5796,7 @@
 				6C70755431CFBA41420A2F47 /* ACPSessionManagerRemoteRestoreTests.swift in Sources */,
 				095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
+				DDEFEBB152E6AE1B0BB4D3EE /* ACPSessionOrchestrationCoordinatorTests.swift in Sources */,
 				6E1462FC9F25C4ED43DF8DF8 /* ACPSessionOrchestrationPolicyTests.swift in Sources */,
 				2E386BCE2DC24809A1B68244 /* ACPSessionPersistenceTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,

--- a/Alas/Sources/ACP/Orchestration/ACPDelegatedPromptSource.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPDelegatedPromptSource.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct ACPDelegatedPromptSource: Codable, Equatable, Sendable {
+    let sessionId: String
+    let messageId: String
+}

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift
@@ -127,3 +127,49 @@ struct ACPClaimedDelegatedMessage: Equatable, Sendable {
     let message: ACPDelegatedMessage
     let claim: ACPDelegatedMessageClaim
 }
+
+struct ACPOrchestrationSessionSummary: Codable, Equatable, Sendable {
+    let sessionId: String
+    let relationship: String?
+    let agentId: String
+    let worktreeId: String
+    let state: String
+    let failure: String?
+    let createdAt: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case relationship
+        case agentId = "agent_id"
+        case worktreeId = "worktree_id"
+        case state
+        case failure
+        case createdAt = "created_at"
+    }
+}
+
+struct ACPOrchestrationListResponse: Codable, Equatable, Sendable {
+    let sessions: [ACPOrchestrationSessionSummary]
+}
+
+struct ACPOrchestrationNewResponse: Codable, Equatable, Sendable {
+    let sessionId: String
+    let state: String
+    let worktreeId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case state
+        case worktreeId = "worktree_id"
+    }
+}
+
+struct ACPOrchestrationSendResponse: Codable, Equatable, Sendable {
+    let messageId: String
+    let state: String
+
+    enum CodingKeys: String, CodingKey {
+        case messageId = "message_id"
+        case state
+    }
+}

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+struct ACPOrchestrationSessionOrigin: Equatable, Sendable {
+    let sessionId: String
+    let projectId: String
+    let worktreeId: String
+}
+
+enum ACPDelegatedSessionWorktreeTarget: Equatable, Sendable {
+    case current
+    case existing(worktreeId: String)
+    case new(branch: String, base: String?)
+}
+
+struct ACPDelegatedSessionNewRequest: Equatable, Sendable {
+    let prompt: String
+    let agentId: String?
+    let worktree: ACPDelegatedSessionWorktreeTarget
+}
+
+struct ACPDelegatedSessionMessageRequest: Equatable, Sendable {
+    let targetSessionId: String
+    let prompt: String
+}
+
 enum ACPDelegatedWorktreeRequest: Codable, Equatable, Sendable {
     case current(worktreeId: String)
     case existing(worktreeId: String)

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+enum ACPDelegatedWorktreeRequest: Codable, Equatable, Sendable {
+    case current(worktreeId: String)
+    case existing(worktreeId: String)
+    case new(branch: String, base: String?, destinationPath: String, optimisticId: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case worktreeId
+        case branch
+        case base
+        case destinationPath
+        case optimisticId
+    }
+
+    private enum Kind: String, Codable {
+        case current
+        case existing
+        case new
+    }
+
+    var worktreeId: String? {
+        switch self {
+        case .current(let id), .existing(let id): id
+        case .new(_, _, _, let id): id
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .current:
+            self = .current(worktreeId: try container.decode(String.self, forKey: .worktreeId))
+        case .existing:
+            self = .existing(worktreeId: try container.decode(String.self, forKey: .worktreeId))
+        case .new:
+            self = .new(
+                branch: try container.decode(String.self, forKey: .branch),
+                base: try container.decodeIfPresent(String.self, forKey: .base),
+                destinationPath: try container.decode(String.self, forKey: .destinationPath),
+                optimisticId: try container.decode(String.self, forKey: .optimisticId)
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .current(let worktreeId):
+            try container.encode(Kind.current, forKey: .kind)
+            try container.encode(worktreeId, forKey: .worktreeId)
+        case .existing(let worktreeId):
+            try container.encode(Kind.existing, forKey: .kind)
+            try container.encode(worktreeId, forKey: .worktreeId)
+        case .new(let branch, let base, let destinationPath, let optimisticId):
+            try container.encode(Kind.new, forKey: .kind)
+            try container.encode(branch, forKey: .branch)
+            try container.encodeIfPresent(base, forKey: .base)
+            try container.encode(destinationPath, forKey: .destinationPath)
+            try container.encode(optimisticId, forKey: .optimisticId)
+        }
+    }
+}
+
+enum ACPDelegationPhase: String, Codable, Equatable, Sendable {
+    case creatingWorktree
+    case starting
+    case ready
+    case failed
+    case closed
+}
+
+struct ACPDelegationRecord: Equatable, Sendable {
+    let childSessionId: String
+    let parentSessionId: String
+    let projectId: String
+    let parentWorktreeId: String
+    var childWorktreeId: String?
+    let agentId: String
+    let worktreeRequest: ACPDelegatedWorktreeRequest
+    var pendingInitialPrompt: String?
+    var phase: ACPDelegationPhase
+    var failureMessage: String?
+    let createdAt: Int64
+    var updatedAt: Int64
+}
+
+struct ACPDelegatedMessage: Equatable, Sendable {
+    let id: String
+    let sourceSessionId: String
+    let targetSessionId: String
+    let prompt: String
+    let createdAt: Int64
+}
+
+struct ACPDelegatedMessageClaim: Equatable, Sendable {
+    let instanceId: String
+    let token: String
+    let expiresAt: Int64
+}
+
+struct ACPClaimedDelegatedMessage: Equatable, Sendable {
+    let message: ACPDelegatedMessage
+    let claim: ACPDelegatedMessageClaim
+}

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift
@@ -50,6 +50,11 @@ enum ACPDelegatedWorktreeRequest: Codable, Equatable, Sendable {
         }
     }
 
+    var destinationPath: String? {
+        guard case .new(_, _, let path, _) = self else { return nil }
+        return path
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         switch try container.decode(Kind.self, forKey: .kind) {

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
@@ -104,4 +104,8 @@ actor ACPOrchestrationPersistence {
     func removeDeliveredMessage(id: String, claim: ACPDelegatedMessageClaim) throws {
         try openedStore().removeDeliveredMessage(id: id, claim: claim)
     }
+
+    func releaseMessageClaim(id: String, claim: ACPDelegatedMessageClaim) throws {
+        try openedStore().releaseMessageClaim(id: id, claim: claim)
+    }
 }

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
@@ -77,6 +77,14 @@ actor ACPOrchestrationPersistence {
         try openedStore().enqueue(message)
     }
 
+    func pendingMessages(targetSessionId: String) throws -> [ACPDelegatedMessage] {
+        try openedStore().pendingMessages(targetSessionId: targetSessionId)
+    }
+
+    func incompleteDelegations() throws -> [ACPDelegationRecord] {
+        try openedStore().incompleteDelegations()
+    }
+
     func claimMessage(
         id: String,
         instanceId: String,

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
@@ -36,4 +36,50 @@ actor ACPOrchestrationPersistence {
     func children(parentSessionId: String) throws -> [ACPDelegationRecord] {
         try openedStore().children(parentSessionId: parentSessionId)
     }
+
+    func parent(childSessionId: String) throws -> ACPDelegationRecord? {
+        try openedStore().parent(childSessionId: childSessionId)
+    }
+
+    func updatePhase(
+        childSessionId: String,
+        phase: ACPDelegationPhase,
+        failureMessage: String?,
+        updatedAt: Int64
+    ) throws {
+        try openedStore().updatePhase(
+            childSessionId: childSessionId,
+            phase: phase,
+            failureMessage: failureMessage,
+            updatedAt: updatedAt
+        )
+    }
+
+    func clearPendingInitialPrompt(childSessionId: String, updatedAt: Int64) throws {
+        try openedStore().clearPendingInitialPrompt(childSessionId: childSessionId, updatedAt: updatedAt)
+    }
+
+    func enqueue(_ message: ACPDelegatedMessage) throws {
+        try openedStore().enqueue(message)
+    }
+
+    func claimMessage(
+        id: String,
+        instanceId: String,
+        token: String,
+        now: Int64,
+        staleAfter: Int64
+    ) throws -> ACPClaimedDelegatedMessage? {
+        try openedStore().claimMessage(
+            id: id,
+            instanceId: instanceId,
+            token: token,
+            now: now,
+            staleAfter: staleAfter
+        )
+    }
+
+    func removeDeliveredMessage(id: String, claim: ACPDelegatedMessageClaim) throws {
+        try openedStore().removeDeliveredMessage(id: id, claim: claim)
+    }
 }

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
@@ -55,6 +55,20 @@ actor ACPOrchestrationPersistence {
         )
     }
 
+    func updateChildWorktree(
+        childSessionId: String,
+        worktreeId: String,
+        phase: ACPDelegationPhase,
+        updatedAt: Int64
+    ) throws {
+        try openedStore().updateChildWorktree(
+            childSessionId: childSessionId,
+            worktreeId: worktreeId,
+            phase: phase,
+            updatedAt: updatedAt
+        )
+    }
+
     func clearPendingInitialPrompt(childSessionId: String, updatedAt: Int64) throws {
         try openedStore().clearPendingInitialPrompt(childSessionId: childSessionId, updatedAt: updatedAt)
     }

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
@@ -81,6 +81,10 @@ actor ACPOrchestrationPersistence {
         try openedStore().pendingMessages(targetSessionId: targetSessionId)
     }
 
+    func pendingMessageTargetSessionIds() throws -> [String] {
+        try openedStore().pendingMessageTargetSessionIds()
+    }
+
     func incompleteDelegations() throws -> [ACPDelegationRecord] {
         try openedStore().incompleteDelegations()
     }

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+actor ACPOrchestrationPersistence {
+    nonisolated let path: String
+
+    private let busyTimeoutMilliseconds: Int32
+    private var store: ACPOrchestrationStore?
+
+    init(path: String = Paths.acpOrchestrationDB.path, busyTimeoutMilliseconds: Int32 = 5_000) {
+        self.path = path
+        self.busyTimeoutMilliseconds = busyTimeoutMilliseconds
+    }
+
+    private func openedStore() throws -> ACPOrchestrationStore {
+        if let store { return store }
+        let opened = try ACPOrchestrationStore(
+            path: path,
+            busyTimeoutMilliseconds: busyTimeoutMilliseconds
+        )
+        store = opened
+        return opened
+    }
+
+    func prepare() throws {
+        _ = try openedStore()
+    }
+
+    func insert(_ record: ACPDelegationRecord) throws {
+        try openedStore().insert(record)
+    }
+
+    func delegation(childSessionId: String) throws -> ACPDelegationRecord? {
+        try openedStore().delegation(childSessionId: childSessionId)
+    }
+
+    func children(parentSessionId: String) throws -> [ACPDelegationRecord] {
+        try openedStore().children(parentSessionId: parentSessionId)
+    }
+}

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
@@ -149,6 +149,15 @@ final class ACPOrchestrationStore {
         ).map(decodeMessage)
     }
 
+    func pendingMessageTargetSessionIds() throws -> [String] {
+        try db.query("""
+        SELECT target_session_id
+        FROM delegated_messages
+        GROUP BY target_session_id
+        ORDER BY MIN(created_at) ASC, MIN(rowid) ASC
+        """).compactMap { $0["target_session_id"] as? String }
+    }
+
     func incompleteDelegations() throws -> [ACPDelegationRecord] {
         try db.query(
             "SELECT * FROM delegations WHERE phase IN (?, ?)",

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
@@ -1,0 +1,307 @@
+import Foundation
+
+final class ACPOrchestrationStore {
+    enum Error: Swift.Error, Equatable {
+        case duplicateChildSession(String)
+        case malformedWorktreeRequest
+    }
+
+    static let targetSchemaVersion = 1
+
+    let path: String
+    let db: SQLiteDatabase
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    private let decoder = JSONDecoder()
+
+    init(path: String, busyTimeoutMilliseconds: Int32 = 5_000) throws {
+        self.path = path
+        try? FileManager.default.createDirectory(
+            at: URL(fileURLWithPath: path).deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        self.db = try SQLiteDatabase(path: path, busyTimeoutMilliseconds: busyTimeoutMilliseconds)
+        try migrate()
+    }
+
+    func currentSchemaVersion() throws -> Int {
+        let rows = try db.query("SELECT version FROM schema_version LIMIT 1")
+        return Int((rows.first?["version"] as? Int64) ?? 0)
+    }
+
+    func insert(_ record: ACPDelegationRecord) throws {
+        try db.exec("BEGIN IMMEDIATE")
+        do {
+            if try delegation(childSessionId: record.childSessionId) != nil {
+                throw Error.duplicateChildSession(record.childSessionId)
+            }
+            try db.exec("""
+            INSERT INTO delegations (
+                child_session_id, parent_session_id, project_id, parent_worktree_id,
+                child_worktree_id, agent_id, worktree_request, pending_initial_prompt,
+                phase, failure_message, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, bindings: [
+                record.childSessionId,
+                record.parentSessionId,
+                record.projectId,
+                record.parentWorktreeId,
+                record.childWorktreeId,
+                record.agentId,
+                try encoder.encode(record.worktreeRequest),
+                record.pendingInitialPrompt,
+                record.phase.rawValue,
+                record.failureMessage,
+                record.createdAt,
+                record.updatedAt,
+            ])
+            try db.exec("COMMIT")
+        } catch {
+            try? db.exec("ROLLBACK")
+            throw error
+        }
+    }
+
+    func delegation(childSessionId: String) throws -> ACPDelegationRecord? {
+        let rows = try db.query(
+            "SELECT * FROM delegations WHERE child_session_id = ?",
+            bindings: [childSessionId]
+        )
+        return try rows.first.map(decodeDelegation)
+    }
+
+    func parent(childSessionId: String) throws -> ACPDelegationRecord? {
+        try delegation(childSessionId: childSessionId)
+    }
+
+    func children(parentSessionId: String) throws -> [ACPDelegationRecord] {
+        try db.query(
+            """
+            SELECT * FROM delegations
+            WHERE parent_session_id = ?
+            ORDER BY created_at ASC, child_session_id ASC
+            """,
+            bindings: [parentSessionId]
+        ).map(decodeDelegation)
+    }
+
+    func updateChildWorktree(
+        childSessionId: String,
+        worktreeId: String,
+        phase: ACPDelegationPhase,
+        updatedAt: Int64
+    ) throws {
+        try db.exec("""
+        UPDATE delegations
+        SET child_worktree_id = ?, phase = ?, updated_at = ?
+        WHERE child_session_id = ?
+        """, bindings: [worktreeId, phase.rawValue, updatedAt, childSessionId])
+    }
+
+    func updatePhase(
+        childSessionId: String,
+        phase: ACPDelegationPhase,
+        failureMessage: String?,
+        updatedAt: Int64
+    ) throws {
+        try db.exec("""
+        UPDATE delegations
+        SET phase = ?, failure_message = ?, updated_at = ?
+        WHERE child_session_id = ?
+        """, bindings: [phase.rawValue, failureMessage, updatedAt, childSessionId])
+    }
+
+    func clearPendingInitialPrompt(childSessionId: String, updatedAt: Int64) throws {
+        try db.exec("""
+        UPDATE delegations
+        SET pending_initial_prompt = NULL, updated_at = ?
+        WHERE child_session_id = ?
+        """, bindings: [updatedAt, childSessionId])
+    }
+
+    func enqueue(_ message: ACPDelegatedMessage) throws {
+        try db.exec("""
+        INSERT OR IGNORE INTO delegated_messages (
+            id, source_session_id, target_session_id, prompt, created_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """, bindings: [
+            message.id,
+            message.sourceSessionId,
+            message.targetSessionId,
+            message.prompt,
+            message.createdAt,
+        ])
+    }
+
+    func pendingMessages(targetSessionId: String) throws -> [ACPDelegatedMessage] {
+        try db.query(
+            """
+            SELECT * FROM delegated_messages
+            WHERE target_session_id = ?
+            ORDER BY created_at ASC, id ASC
+            """,
+            bindings: [targetSessionId]
+        ).map(decodeMessage)
+    }
+
+    func claimMessage(
+        id: String,
+        instanceId: String,
+        token: String,
+        now: Int64,
+        staleAfter: Int64
+    ) throws -> ACPClaimedDelegatedMessage? {
+        let expiresAt = now + staleAfter
+        try db.exec("BEGIN IMMEDIATE")
+        do {
+            let changed = try db.execChanges("""
+            UPDATE delegated_messages
+            SET claim_instance_id = ?, claim_token = ?, claim_expires_at = ?
+            WHERE id = ?
+              AND (
+                claim_token IS NULL
+                OR claim_expires_at < ?
+                OR (claim_instance_id = ? AND claim_token = ?)
+              )
+            """, bindings: [instanceId, token, expiresAt, id, now, instanceId, token])
+            guard changed == 1,
+                  let row = try db.query(
+                    "SELECT * FROM delegated_messages WHERE id = ?",
+                    bindings: [id]
+                  ).first
+            else {
+                try db.exec("COMMIT")
+                return nil
+            }
+            let message = try decodeMessage(row)
+            try db.exec("COMMIT")
+            return .init(
+                message: message,
+                claim: .init(instanceId: instanceId, token: token, expiresAt: expiresAt)
+            )
+        } catch {
+            try? db.exec("ROLLBACK")
+            throw error
+        }
+    }
+
+    func claimedMessage(id: String) throws -> ACPDelegatedMessageClaim? {
+        let rows = try db.query(
+            """
+            SELECT claim_instance_id, claim_token, claim_expires_at
+            FROM delegated_messages WHERE id = ?
+            """,
+            bindings: [id]
+        )
+        guard let row = rows.first,
+              let instanceId = row["claim_instance_id"] as? String,
+              let token = row["claim_token"] as? String,
+              let expiresAt = row["claim_expires_at"] as? Int64
+        else { return nil }
+        return .init(instanceId: instanceId, token: token, expiresAt: expiresAt)
+    }
+
+    func removeDeliveredMessage(id: String, claim: ACPDelegatedMessageClaim) throws {
+        _ = try db.execChanges("""
+        DELETE FROM delegated_messages
+        WHERE id = ? AND claim_instance_id = ? AND claim_token = ?
+        """, bindings: [id, claim.instanceId, claim.token])
+    }
+
+    private func migrate() throws {
+        try db.exec("""
+        CREATE TABLE IF NOT EXISTS schema_version (
+            version INTEGER NOT NULL
+        )
+        """)
+        let current = try currentSchemaVersion()
+        if current < 1 { try migrateToV1() }
+        if current == 0 {
+            try db.exec(
+                "INSERT INTO schema_version (version) VALUES (?)",
+                bindings: [Int64(Self.targetSchemaVersion)]
+            )
+        } else if current < Self.targetSchemaVersion {
+            try db.exec(
+                "UPDATE schema_version SET version = ?",
+                bindings: [Int64(Self.targetSchemaVersion)]
+            )
+        }
+    }
+
+    private func migrateToV1() throws {
+        try db.exec("""
+        CREATE TABLE IF NOT EXISTS delegations (
+            child_session_id     TEXT PRIMARY KEY,
+            parent_session_id    TEXT NOT NULL,
+            project_id           TEXT NOT NULL,
+            parent_worktree_id   TEXT NOT NULL,
+            child_worktree_id    TEXT,
+            agent_id             TEXT NOT NULL,
+            worktree_request     BLOB NOT NULL,
+            pending_initial_prompt TEXT,
+            phase                TEXT NOT NULL,
+            failure_message      TEXT,
+            created_at           INTEGER NOT NULL,
+            updated_at           INTEGER NOT NULL
+        )
+        """)
+        try db.exec("""
+        CREATE INDEX IF NOT EXISTS delegations_parent_idx
+        ON delegations(parent_session_id, created_at, child_session_id)
+        """)
+        try db.exec("""
+        CREATE TABLE IF NOT EXISTS delegated_messages (
+            id                TEXT PRIMARY KEY,
+            source_session_id TEXT NOT NULL,
+            target_session_id TEXT NOT NULL,
+            prompt            TEXT NOT NULL,
+            created_at        INTEGER NOT NULL,
+            claim_instance_id TEXT,
+            claim_token       TEXT,
+            claim_expires_at  INTEGER
+        )
+        """)
+        try db.exec("""
+        CREATE INDEX IF NOT EXISTS delegated_messages_target_idx
+        ON delegated_messages(target_session_id, created_at, id)
+        """)
+    }
+
+    private func decodeDelegation(_ row: [String: Any?]) throws -> ACPDelegationRecord {
+        guard let requestData = row["worktree_request"] as? Data,
+              let request = try? decoder.decode(ACPDelegatedWorktreeRequest.self, from: requestData),
+              let phaseRaw = row["phase"] as? String,
+              let phase = ACPDelegationPhase(rawValue: phaseRaw)
+        else { throw Error.malformedWorktreeRequest }
+        return .init(
+            childSessionId: row["child_session_id"] as? String ?? "",
+            parentSessionId: row["parent_session_id"] as? String ?? "",
+            projectId: row["project_id"] as? String ?? "",
+            parentWorktreeId: row["parent_worktree_id"] as? String ?? "",
+            childWorktreeId: row["child_worktree_id"] as? String,
+            agentId: row["agent_id"] as? String ?? "",
+            worktreeRequest: request,
+            pendingInitialPrompt: row["pending_initial_prompt"] as? String,
+            phase: phase,
+            failureMessage: row["failure_message"] as? String,
+            createdAt: row["created_at"] as? Int64 ?? 0,
+            updatedAt: row["updated_at"] as? Int64 ?? 0
+        )
+    }
+
+    private func decodeMessage(_ row: [String: Any?]) throws -> ACPDelegatedMessage {
+        .init(
+            id: row["id"] as? String ?? "",
+            sourceSessionId: row["source_session_id"] as? String ?? "",
+            targetSessionId: row["target_session_id"] as? String ?? "",
+            prompt: row["prompt"] as? String ?? "",
+            createdAt: row["created_at"] as? Int64 ?? 0
+        )
+    }
+}

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
@@ -220,6 +220,14 @@ final class ACPOrchestrationStore {
         """, bindings: [id, claim.instanceId, claim.token])
     }
 
+    func releaseMessageClaim(id: String, claim: ACPDelegatedMessageClaim) throws {
+        _ = try db.execChanges("""
+        UPDATE delegated_messages
+        SET claim_instance_id = NULL, claim_token = NULL, claim_expires_at = NULL
+        WHERE id = ? AND claim_instance_id = ? AND claim_token = ?
+        """, bindings: [id, claim.instanceId, claim.token])
+    }
+
     private func migrate() throws {
         try db.exec("""
         CREATE TABLE IF NOT EXISTS schema_version (

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
@@ -143,7 +143,7 @@ final class ACPOrchestrationStore {
             """
             SELECT * FROM delegated_messages
             WHERE target_session_id = ?
-            ORDER BY created_at ASC, id ASC
+            ORDER BY created_at ASC, rowid ASC
             """,
             bindings: [targetSessionId]
         ).map(decodeMessage)

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
@@ -149,6 +149,13 @@ final class ACPOrchestrationStore {
         ).map(decodeMessage)
     }
 
+    func incompleteDelegations() throws -> [ACPDelegationRecord] {
+        try db.query(
+            "SELECT * FROM delegations WHERE phase IN (?, ?)",
+            bindings: [ACPDelegationPhase.creatingWorktree.rawValue, ACPDelegationPhase.starting.rawValue]
+        ).map(decodeDelegation)
+    }
+
     func claimMessage(
         id: String,
         instanceId: String,

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -183,8 +183,7 @@ final class ACPSessionOrchestrationCoordinator {
                 return .error("Could not persist delegated session.")
             }
             environment.notifyChanged()
-            Task { @MainActor [weak self] in
-                guard let self else { return }
+            Task { @MainActor in
                 let result = await self.environment.createWorktree(origin.projectId, branch, base)
                 switch result {
                 case .success(let worktree):
@@ -246,8 +245,8 @@ final class ACPSessionOrchestrationCoordinator {
             return .error("Could not queue delegated message.")
         }
         environment.notifyChanged()
-        Task { @MainActor [weak self] in
-            await self?.deliverPendingMessages(
+        Task { @MainActor in
+            await self.deliverPendingMessages(
                 to: request.targetSessionId,
                 callerParent: callerParent,
                 targetParent: targetParent
@@ -288,8 +287,8 @@ final class ACPSessionOrchestrationCoordinator {
             return .error("Could not persist delegated session.")
         }
         environment.notifyChanged()
-        Task { @MainActor [weak self] in
-            await self?.startPersistedChild(childID: childID, prompt: prompt, worktree: worktree)
+        Task { @MainActor in
+            await self.startPersistedChild(childID: childID, prompt: prompt, worktree: worktree)
         }
         return json(ACPOrchestrationNewResponse(sessionId: childID, state: "starting", worktreeId: worktree.id))
     }
@@ -399,9 +398,9 @@ final class ACPSessionOrchestrationCoordinator {
         await target.manager.attach(to: claimed.message.targetSessionId, freshlyCreated: false)
         guard target.manager.isWriter(for: claimed.message.targetSessionId) else {
             try? await environment.persistence.releaseMessageClaim(id: claimed.message.id, claim: claimed.claim)
-            Task { @MainActor [weak self] in
+            Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 5_000_000_000)
-                await self?.deliver(messageID, to: target)
+                await self.deliver(messageID, to: target)
             }
             return
         }

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -22,6 +22,7 @@ final class ACPSessionOrchestrationCoordinator {
         let sessionLocation: (String) -> SessionLocation?
         let manager: (Worktree) -> ACPSessionManager?
         let createWorktree: (String, String, String?) async -> Result<Worktree, WorktreeCreationError>
+        let rememberParent: (String, String) -> Void
         let notifyChanged: () -> Void
     }
 
@@ -249,6 +250,7 @@ final class ACPSessionOrchestrationCoordinator {
         phase: ACPDelegationPhase,
         now: Int64
     ) async -> AlasCLIResponse {
+        environment.rememberParent(childID, origin.sessionId)
         let record = ACPDelegationRecord(
             childSessionId: childID,
             parentSessionId: origin.sessionId,
@@ -263,8 +265,9 @@ final class ACPSessionOrchestrationCoordinator {
             createdAt: now,
             updatedAt: now
         )
-        do {
-            try await environment.persistence.insert(record)
+            do {
+                self.environment.rememberParent(childID, origin.sessionId)
+                try await environment.persistence.insert(record)
         } catch {
             return .error("Could not persist delegated session.")
         }

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -388,13 +388,17 @@ final class ACPSessionOrchestrationCoordinator {
         targetParent: ACPDelegationRecord?
     ) async -> SessionLocation? {
         if let target = environment.sessionLocation(sessionID) {
+            guard let row = await target.manager.persistedSessionRow(id: sessionID), !row.archived else {
+                return nil
+            }
             return target
         }
         let worktreeID = targetParent?.childWorktreeId ?? callerParent?.parentWorktreeId
         guard let worktreeID,
               let worktree = environment.worktree(worktreeID),
               let manager = environment.manager(worktree),
-              await manager.persistedSessionRow(id: sessionID) != nil
+              let row = await manager.persistedSessionRow(id: sessionID),
+              !row.archived
         else { return nil }
         _ = manager.placeholderSession(id: sessionID)
         await manager.hydrateIfNeeded(id: sessionID)

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -293,6 +293,12 @@ final class ACPSessionOrchestrationCoordinator {
             return
         }
         guard let record else { return }
+        try? await environment.persistence.updateChildWorktree(
+            childSessionId: childID,
+            worktreeId: worktree.id,
+            phase: .starting,
+            updatedAt: environment.now()
+        )
         if manager.liveSession(for: childID) == nil {
             _ = manager.createSession(id: childID, agentId: record.agentId)
         }

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -201,17 +201,18 @@ final class ACPSessionOrchestrationCoordinator {
         } catch {
             return .error("prompt must not be blank")
         }
-        guard let target = environment.sessionLocation(request.targetSessionId) else {
-            return .error("The target ACP session is not available.")
-        }
         do {
             let callerParent = try await environment.persistence.parent(childSessionId: origin.sessionId)
             let targetParent = try await environment.persistence.parent(childSessionId: request.targetSessionId)
+            let target = environment.sessionLocation(request.targetSessionId)
+            guard let targetProjectId = target?.origin.projectId ?? targetParent?.projectId ?? callerParent?.projectId else {
+                return .error("The target ACP session is not available.")
+            }
             guard case .success = ACPSessionOrchestrationPolicy.authorizeSend(
                 callerSessionId: origin.sessionId,
                 callerProjectId: origin.projectId,
                 targetSessionId: request.targetSessionId,
-                targetProjectId: target.origin.projectId,
+                targetProjectId: targetProjectId,
                 callerParent: callerParent,
                 targetParent: targetParent
             ) else {
@@ -234,8 +235,10 @@ final class ACPSessionOrchestrationCoordinator {
             return .error("Could not queue delegated message.")
         }
         environment.notifyChanged()
-        Task { @MainActor [weak self] in
-            await self?.deliver(message.id, to: target)
+        if let target = environment.sessionLocation(request.targetSessionId) {
+            Task { @MainActor [weak self] in
+                await self?.deliver(message.id, to: target)
+            }
         }
         return json(ACPOrchestrationSendResponse(messageId: message.id, state: "queued"))
     }
@@ -360,8 +363,8 @@ final class ACPSessionOrchestrationCoordinator {
             guard let session = location.manager.liveSession(for: sessionId) else { return nil }
             switch session.transcript.streamingState {
             case .idle: return .idle
-            case .sending, .streaming, .awaitingPermission: return .running
-            case .awaitingInput: return .awaitingInput
+            case .sending, .streaming: return .running
+            case .awaitingPermission, .awaitingInput: return .awaitingInput
             }
         }
         let state = ACPSessionOrchestrationPolicy.publicState(phase: phase, runtime: runtime, archived: false)

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -238,11 +238,14 @@ final class ACPSessionOrchestrationCoordinator {
             guard ACPSessionOrchestrationPolicy.acceptsMessages(target: targetParent) else {
                 return .error("The target delegated session is not available.")
             }
-            guard await resolveDeliveryTarget(
-                sessionID: request.targetSessionId,
-                callerParent: callerParent,
-                targetParent: targetParent
-            ) != nil else {
+            let targetIsStillStarting = targetParent?.phase == .creatingWorktree
+                || targetParent?.phase == .starting
+            if !targetIsStillStarting,
+               await resolveDeliveryTarget(
+                   sessionID: request.targetSessionId,
+                   callerParent: callerParent,
+                   targetParent: targetParent
+               ) == nil {
                 return .error("The target ACP session is not available.")
             }
         } catch {

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -1,0 +1,379 @@
+import Foundation
+
+@MainActor
+final class ACPSessionOrchestrationCoordinator {
+    struct WorktreeCreationError: Error {
+        let message: String
+    }
+
+    struct SessionLocation {
+        let origin: ACPOrchestrationSessionOrigin
+        let manager: ACPSessionManager
+    }
+
+    struct Environment {
+        let persistence: ACPOrchestrationPersistence
+        let instanceId: String
+        let now: () -> Int64
+        let makeID: () -> String
+        let worktree: (String) -> Worktree?
+        let existingWorktree: (String, String) -> Worktree?
+        let availableAgents: () -> [ACPOrchestrationAgent]
+        let sessionLocation: (String) -> SessionLocation?
+        let manager: (Worktree) -> ACPSessionManager?
+        let createWorktree: (String, String, String?) async -> Result<Worktree, WorktreeCreationError>
+        let notifyChanged: () -> Void
+    }
+
+    private let environment: Environment
+
+    init(environment: Environment) {
+        self.environment = environment
+    }
+
+    func list(origin: ACPOrchestrationSessionOrigin) async -> AlasCLIResponse {
+        do {
+            let parent = try await environment.persistence.parent(childSessionId: origin.sessionId)
+            let children = try await environment.persistence.children(parentSessionId: origin.sessionId)
+            let visible = ACPSessionOrchestrationPolicy.visibleSessions(
+                callerSessionId: origin.sessionId,
+                parent: parent,
+                children: children
+            )
+            let summaries = visible.compactMap { visible -> ACPOrchestrationSessionSummary? in
+                if visible.sessionId == origin.sessionId {
+                    return sessionSummary(
+                        sessionId: origin.sessionId,
+                        relationship: nil,
+                        agentId: environment.sessionLocation(origin.sessionId)?.manager.liveSession(for: origin.sessionId)?.agentId ?? parent?.agentId ?? "unknown",
+                        worktreeId: origin.worktreeId,
+                        phase: .ready,
+                        failure: nil,
+                        createdAt: 0
+                    )
+                }
+                if visible.relationship == .parent {
+                    guard let location = environment.sessionLocation(visible.sessionId) else { return nil }
+                    return sessionSummary(
+                        sessionId: visible.sessionId,
+                        relationship: "parent",
+                        agentId: location.manager.liveSession(for: visible.sessionId)?.agentId ?? "unknown",
+                        worktreeId: location.origin.worktreeId,
+                        phase: .ready,
+                        failure: nil,
+                        createdAt: 0
+                    )
+                }
+                guard let record = children.first(where: { $0.childSessionId == visible.sessionId }) else { return nil }
+                return sessionSummary(
+                    sessionId: record.childSessionId,
+                    relationship: "child",
+                    agentId: record.agentId,
+                    worktreeId: record.childWorktreeId ?? record.worktreeRequest.worktreeId ?? "",
+                    phase: record.phase,
+                    failure: record.failureMessage,
+                    createdAt: record.createdAt
+                )
+            }
+            return json(ACPOrchestrationListResponse(sessions: summaries))
+        } catch {
+            return .error("Could not load delegated sessions.")
+        }
+    }
+
+    func create(
+        origin: ACPOrchestrationSessionOrigin,
+        request: ACPDelegatedSessionNewRequest
+    ) async -> AlasCLIResponse {
+        let parentLocation = environment.sessionLocation(origin.sessionId)
+        guard let parentSession = parentLocation?.manager.liveSession(for: origin.sessionId) else {
+            return .error("The originating ACP session is no longer available.")
+        }
+
+        let parent: ACPDelegationRecord?
+        do {
+            parent = try await environment.persistence.parent(childSessionId: origin.sessionId)
+        } catch {
+            return .error("Could not verify session delegation.")
+        }
+        guard case .success = ACPSessionOrchestrationPolicy.authorizeCreate(parent: parent) else {
+            return .error("Delegated sessions cannot create child sessions.")
+        }
+
+        let prompt: String
+        let agentID: String
+        do {
+            prompt = try ACPSessionOrchestrationPolicy.validatedPrompt(request.prompt)
+            agentID = try ACPSessionOrchestrationPolicy.resolveAgent(
+                requestedId: request.agentId,
+                parentAgentId: parentSession.agentId,
+                available: environment.availableAgents()
+            )
+        } catch ACPSessionOrchestrationPolicy.Error.blankPrompt {
+            return .error("prompt must not be blank")
+        } catch ACPSessionOrchestrationPolicy.Error.agentUnavailable(let id) {
+            return .error("Agent is not enabled or ACP-capable: \(id)")
+        } catch {
+            return .error("Could not validate delegated session request.")
+        }
+
+        let childID = environment.makeID()
+        let now = environment.now()
+        switch request.worktree {
+        case .current:
+            guard let worktree = environment.worktree(origin.worktreeId) else {
+                return .error("The current worktree is no longer available.")
+            }
+            return await createChild(
+                childID: childID,
+                origin: origin,
+                prompt: prompt,
+                agentID: agentID,
+                worktree: worktree,
+                request: .current(worktreeId: worktree.id),
+                phase: .starting,
+                now: now
+            )
+        case .existing(let id):
+            guard let worktree = environment.existingWorktree(origin.projectId, id) else {
+                return .error("The requested worktree is not available in this project.")
+            }
+            return await createChild(
+                childID: childID,
+                origin: origin,
+                prompt: prompt,
+                agentID: agentID,
+                worktree: worktree,
+                request: .existing(worktreeId: worktree.id),
+                phase: .starting,
+                now: now
+            )
+        case .new(let branch, let base):
+            guard !branch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .error("new_worktree branch must not be blank")
+            }
+            let optimisticID = "pending-\(childID)"
+            let record = ACPDelegationRecord(
+                childSessionId: childID,
+                parentSessionId: origin.sessionId,
+                projectId: origin.projectId,
+                parentWorktreeId: origin.worktreeId,
+                childWorktreeId: nil,
+                agentId: agentID,
+                worktreeRequest: .new(branch: branch, base: base, destinationPath: "", optimisticId: optimisticID),
+                pendingInitialPrompt: prompt,
+                phase: .creatingWorktree,
+                failureMessage: nil,
+                createdAt: now,
+                updatedAt: now
+            )
+            do {
+                try await environment.persistence.insert(record)
+            } catch {
+                return .error("Could not persist delegated session.")
+            }
+            environment.notifyChanged()
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let result = await self.environment.createWorktree(origin.projectId, branch, base)
+                switch result {
+                case .success(let worktree):
+                    await self.startPersistedChild(childID: childID, prompt: prompt, worktree: worktree)
+                case .failure(let error):
+                    try? await self.environment.persistence.updatePhase(
+                        childSessionId: childID, phase: .failed, failureMessage: error.message, updatedAt: self.environment.now()
+                    )
+                    self.environment.notifyChanged()
+                }
+            }
+            return json(ACPOrchestrationNewResponse(sessionId: childID, state: "creating_worktree", worktreeId: nil))
+        }
+    }
+
+    func send(
+        origin: ACPOrchestrationSessionOrigin,
+        request: ACPDelegatedSessionMessageRequest
+    ) async -> AlasCLIResponse {
+        let prompt: String
+        do {
+            prompt = try ACPSessionOrchestrationPolicy.validatedPrompt(request.prompt)
+        } catch {
+            return .error("prompt must not be blank")
+        }
+        guard let target = environment.sessionLocation(request.targetSessionId) else {
+            return .error("The target ACP session is not available.")
+        }
+        do {
+            let callerParent = try await environment.persistence.parent(childSessionId: origin.sessionId)
+            let targetParent = try await environment.persistence.parent(childSessionId: request.targetSessionId)
+            guard case .success = ACPSessionOrchestrationPolicy.authorizeSend(
+                callerSessionId: origin.sessionId,
+                callerProjectId: origin.projectId,
+                targetSessionId: request.targetSessionId,
+                targetProjectId: target.origin.projectId,
+                callerParent: callerParent,
+                targetParent: targetParent
+            ) else {
+                return .error("Messages may only be sent to a direct parent or child session.")
+            }
+        } catch {
+            return .error("Could not verify session delegation.")
+        }
+
+        let message = ACPDelegatedMessage(
+            id: environment.makeID(),
+            sourceSessionId: origin.sessionId,
+            targetSessionId: request.targetSessionId,
+            prompt: prompt,
+            createdAt: environment.now()
+        )
+        do {
+            try await environment.persistence.enqueue(message)
+        } catch {
+            return .error("Could not queue delegated message.")
+        }
+        environment.notifyChanged()
+        Task { @MainActor [weak self] in
+            await self?.deliver(message.id, to: target)
+        }
+        return json(ACPOrchestrationSendResponse(messageId: message.id, state: "queued"))
+    }
+
+    private func createChild(
+        childID: String,
+        origin: ACPOrchestrationSessionOrigin,
+        prompt: String,
+        agentID: String,
+        worktree: Worktree,
+        request: ACPDelegatedWorktreeRequest,
+        phase: ACPDelegationPhase,
+        now: Int64
+    ) async -> AlasCLIResponse {
+        let record = ACPDelegationRecord(
+            childSessionId: childID,
+            parentSessionId: origin.sessionId,
+            projectId: origin.projectId,
+            parentWorktreeId: origin.worktreeId,
+            childWorktreeId: worktree.id,
+            agentId: agentID,
+            worktreeRequest: request,
+            pendingInitialPrompt: prompt,
+            phase: phase,
+            failureMessage: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+        do {
+            try await environment.persistence.insert(record)
+        } catch {
+            return .error("Could not persist delegated session.")
+        }
+        environment.notifyChanged()
+        Task { @MainActor [weak self] in
+            await self?.startPersistedChild(childID: childID, prompt: prompt, worktree: worktree)
+        }
+        return json(ACPOrchestrationNewResponse(sessionId: childID, state: "starting", worktreeId: worktree.id))
+    }
+
+    private func startPersistedChild(childID: String, prompt: String, worktree: Worktree) async {
+        guard let manager = environment.manager(worktree) else {
+            try? await environment.persistence.updatePhase(
+                childSessionId: childID, phase: .failed, failureMessage: "Could not create ACP session manager.", updatedAt: environment.now()
+            )
+            environment.notifyChanged()
+            return
+        }
+        let record: ACPDelegationRecord?
+        do {
+            record = try await environment.persistence.delegation(childSessionId: childID)
+        } catch {
+            return
+        }
+        guard let record else { return }
+        if manager.liveSession(for: childID) == nil {
+            _ = manager.createSession(id: childID, agentId: record.agentId)
+        }
+        let accepted = await manager.enqueueDelegatedPrompt(
+            text: prompt,
+            source: ACPDelegatedPromptSource(sessionId: record.parentSessionId, messageId: "initial-\(childID)"),
+            into: childID
+        )
+        guard accepted else {
+            try? await environment.persistence.updatePhase(
+                childSessionId: childID, phase: .failed, failureMessage: "Could not queue initial prompt.", updatedAt: environment.now()
+            )
+            environment.notifyChanged()
+            return
+        }
+        try? await environment.persistence.clearPendingInitialPrompt(childSessionId: childID, updatedAt: environment.now())
+        try? await environment.persistence.updatePhase(
+            childSessionId: childID, phase: .ready, failureMessage: nil, updatedAt: environment.now()
+        )
+        environment.notifyChanged()
+        Task { @MainActor [weak manager] in
+            await manager?.attach(to: childID, freshlyCreated: true)
+        }
+    }
+
+    private func deliver(_ messageID: String, to target: SessionLocation) async {
+        guard let claimed = try? await environment.persistence.claimMessage(
+            id: messageID,
+            instanceId: environment.instanceId,
+            token: environment.makeID(),
+            now: environment.now(),
+            staleAfter: 60
+        ) else { return }
+        let accepted = await target.manager.enqueueDelegatedPrompt(
+            text: claimed.message.prompt,
+            source: ACPDelegatedPromptSource(
+                sessionId: claimed.message.sourceSessionId,
+                messageId: claimed.message.id
+            ),
+            into: claimed.message.targetSessionId
+        )
+        guard accepted else { return }
+        try? await environment.persistence.removeDeliveredMessage(id: claimed.message.id, claim: claimed.claim)
+        Task { @MainActor [weak manager = target.manager] in
+            await manager?.attach(to: claimed.message.targetSessionId, freshlyCreated: false)
+        }
+        environment.notifyChanged()
+    }
+
+    private func sessionSummary(
+        sessionId: String,
+        relationship: String?,
+        agentId: String,
+        worktreeId: String,
+        phase: ACPDelegationPhase,
+        failure: String?,
+        createdAt: Int64
+    ) -> ACPOrchestrationSessionSummary {
+        let runtime = environment.sessionLocation(sessionId).flatMap { location -> ACPOrchestrationRuntimeState? in
+            guard let session = location.manager.liveSession(for: sessionId) else { return nil }
+            switch session.transcript.streamingState {
+            case .idle: return .idle
+            case .sending, .streaming, .awaitingPermission: return .running
+            case .awaitingInput: return .awaitingInput
+            }
+        }
+        let state = ACPSessionOrchestrationPolicy.publicState(phase: phase, runtime: runtime, archived: false)
+        return .init(
+            sessionId: sessionId,
+            relationship: relationship,
+            agentId: agentId,
+            worktreeId: worktreeId,
+            state: state.rawValue,
+            failure: failure,
+            createdAt: createdAt
+        )
+    }
+
+    private func json<T: Encodable>(_ value: T) -> AlasCLIResponse {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(value), let line = String(data: data, encoding: .utf8) else {
+            return .error("Could not encode session response.")
+        }
+        return .text([line])
+    }
+}

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -21,6 +21,7 @@ final class ACPSessionOrchestrationCoordinator {
         let availableAgents: () -> [ACPOrchestrationAgent]
         let sessionLocation: (String) -> SessionLocation?
         let manager: (Worktree) -> ACPSessionManager?
+        let newWorktreeDestination: (String, String) -> URL?
         let createWorktree: (String, String, String?) async -> Result<Worktree, WorktreeCreationError>
         let rememberParent: (String, String) -> Void
         let notifyChanged: () -> Void
@@ -153,6 +154,9 @@ final class ACPSessionOrchestrationCoordinator {
             guard !branch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 return .error("new_worktree branch must not be blank")
             }
+            guard let destination = environment.newWorktreeDestination(origin.projectId, branch) else {
+                return .error("The project is no longer available.")
+            }
             let optimisticID = "pending-\(childID)"
             let record = ACPDelegationRecord(
                 childSessionId: childID,
@@ -161,7 +165,12 @@ final class ACPSessionOrchestrationCoordinator {
                 parentWorktreeId: origin.worktreeId,
                 childWorktreeId: nil,
                 agentId: agentID,
-                worktreeRequest: .new(branch: branch, base: base, destinationPath: "", optimisticId: optimisticID),
+                worktreeRequest: .new(
+                    branch: branch,
+                    base: base,
+                    destinationPath: destination.path,
+                    optimisticId: optimisticID
+                ),
                 pendingInitialPrompt: prompt,
                 phase: .creatingWorktree,
                 failureMessage: nil,
@@ -388,7 +397,14 @@ final class ACPSessionOrchestrationCoordinator {
             staleAfter: 60
         ) else { return }
         await target.manager.attach(to: claimed.message.targetSessionId, freshlyCreated: false)
-        guard target.manager.isWriter(for: claimed.message.targetSessionId) else { return }
+        guard target.manager.isWriter(for: claimed.message.targetSessionId) else {
+            try? await environment.persistence.releaseMessageClaim(id: claimed.message.id, claim: claimed.claim)
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                await self?.deliver(messageID, to: target)
+            }
+            return
+        }
         let accepted = await target.manager.enqueueDelegatedPrompt(
             text: claimed.message.prompt,
             source: ACPDelegatedPromptSource(
@@ -397,7 +413,10 @@ final class ACPSessionOrchestrationCoordinator {
             ),
             into: claimed.message.targetSessionId
         )
-        guard accepted else { return }
+        guard accepted else {
+            try? await environment.persistence.releaseMessageClaim(id: claimed.message.id, claim: claimed.claim)
+            return
+        }
         try? await environment.persistence.removeDeliveredMessage(id: claimed.message.id, claim: claimed.claim)
         environment.notifyChanged()
     }

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -300,6 +300,7 @@ final class ACPSessionOrchestrationCoordinator {
             return
         }
         guard let record else { return }
+        environment.rememberParent(childID, record.parentSessionId)
         try? await environment.persistence.updateChildWorktree(
             childSessionId: childID,
             worktreeId: worktree.id,

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -332,6 +332,8 @@ final class ACPSessionOrchestrationCoordinator {
             now: environment.now(),
             staleAfter: 60
         ) else { return }
+        await target.manager.attach(to: claimed.message.targetSessionId, freshlyCreated: false)
+        guard target.manager.isWriter(for: claimed.message.targetSessionId) else { return }
         let accepted = await target.manager.enqueueDelegatedPrompt(
             text: claimed.message.prompt,
             source: ACPDelegatedPromptSource(
@@ -342,9 +344,6 @@ final class ACPSessionOrchestrationCoordinator {
         )
         guard accepted else { return }
         try? await environment.persistence.removeDeliveredMessage(id: claimed.message.id, claim: claimed.claim)
-        Task { @MainActor [weak manager = target.manager] in
-            await manager?.attach(to: claimed.message.targetSessionId, freshlyCreated: false)
-        }
         environment.notifyChanged()
     }
 

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -354,6 +354,19 @@ final class ACPSessionOrchestrationCoordinator {
             environment.notifyChanged()
             return
         }
+        await manager.attach(to: childID, freshlyCreated: true)
+        guard let session = manager.liveSession(for: childID),
+              session.agentState == .ready
+        else {
+            try? await environment.persistence.updatePhase(
+                childSessionId: childID,
+                phase: .failed,
+                failureMessage: delegatedChildStartFailureMessage(manager.liveSession(for: childID)),
+                updatedAt: environment.now()
+            )
+            environment.notifyChanged()
+            return
+        }
         try? await environment.persistence.clearPendingInitialPrompt(childSessionId: childID, updatedAt: environment.now())
         try? await environment.persistence.updatePhase(
             childSessionId: childID, phase: .ready, failureMessage: nil, updatedAt: environment.now()
@@ -364,9 +377,22 @@ final class ACPSessionOrchestrationCoordinator {
             callerParent: record,
             targetParent: record
         )
-        Task { @MainActor [weak manager] in
-            await manager?.attach(to: childID, freshlyCreated: true)
+    }
+
+    private func delegatedChildStartFailureMessage(_ session: ACPSession?) -> String {
+        guard let session else { return "Could not start delegated ACP session." }
+        switch session.setupState {
+        case .needsSetup(let reason), .setupError(let reason):
+            return reason
+        case .needsAuth(_, let reason):
+            return reason ?? "ACP session needs authentication."
+        case .checking, .ready:
+            break
         }
+        if case .failed(let reason) = session.agentState {
+            return reason
+        }
+        return "Could not start delegated ACP session."
     }
 
     private func deliverPendingMessages(

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -24,6 +24,7 @@ final class ACPSessionOrchestrationCoordinator {
         let newWorktreeDestination: (String, String) -> URL?
         let createWorktree: (String, String, String?) async -> Result<Worktree, WorktreeCreationError>
         let rememberParent: (String, String) -> Void
+        let autoRunDefault: () -> Bool
         let notifyChanged: () -> Void
     }
 
@@ -42,9 +43,10 @@ final class ACPSessionOrchestrationCoordinator {
                 parent: parent,
                 children: children
             )
-            let summaries = visible.compactMap { visible -> ACPOrchestrationSessionSummary? in
+            var summaries: [ACPOrchestrationSessionSummary] = []
+            for visible in visible {
                 if visible.sessionId == origin.sessionId {
-                    return sessionSummary(
+                    summaries.append(await sessionSummary(
                         sessionId: origin.sessionId,
                         relationship: nil,
                         agentId: environment.sessionLocation(origin.sessionId)?.manager.liveSession(for: origin.sessionId)?.agentId ?? parent?.agentId ?? "unknown",
@@ -52,11 +54,12 @@ final class ACPSessionOrchestrationCoordinator {
                         phase: .ready,
                         failure: nil,
                         createdAt: 0
-                    )
+                    ))
+                    continue
                 }
                 if visible.relationship == .parent {
                     let location = environment.sessionLocation(visible.sessionId)
-                    return sessionSummary(
+                    summaries.append(await sessionSummary(
                         sessionId: visible.sessionId,
                         relationship: "parent",
                         agentId: location?.manager.liveSession(for: visible.sessionId)?.agentId ?? "unknown",
@@ -64,10 +67,11 @@ final class ACPSessionOrchestrationCoordinator {
                         phase: .ready,
                         failure: nil,
                         createdAt: 0
-                    )
+                    ))
+                    continue
                 }
-                guard let record = children.first(where: { $0.childSessionId == visible.sessionId }) else { return nil }
-                return sessionSummary(
+                guard let record = children.first(where: { $0.childSessionId == visible.sessionId }) else { continue }
+                summaries.append(await sessionSummary(
                     sessionId: record.childSessionId,
                     relationship: "child",
                     agentId: record.agentId,
@@ -75,7 +79,7 @@ final class ACPSessionOrchestrationCoordinator {
                     phase: record.phase,
                     failure: record.failureMessage,
                     createdAt: record.createdAt
-                )
+                ))
             }
             return json(ACPOrchestrationListResponse(sessions: summaries))
         } catch {
@@ -151,8 +155,11 @@ final class ACPSessionOrchestrationCoordinator {
                 now: now
             )
         case .new(let branch, let base):
-            guard !branch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                return .error("new_worktree branch must not be blank")
+            switch GitNameValidator.validateBranchName(branch) {
+            case .valid:
+                break
+            case .invalid(let message):
+                return .error("invalid branch name: \(message)")
             }
             guard let destination = environment.newWorktreeDestination(origin.projectId, branch) else {
                 return .error("The project is no longer available.")
@@ -326,7 +333,11 @@ final class ACPSessionOrchestrationCoordinator {
             updatedAt: environment.now()
         )
         if manager.liveSession(for: childID) == nil {
-            _ = manager.createSession(id: childID, agentId: record.agentId)
+            _ = manager.createSession(
+                id: childID,
+                agentId: record.agentId,
+                autoRunDefault: environment.autoRunDefault()
+            )
         }
         let accepted = await manager.enqueueDelegatedPrompt(
             text: prompt,
@@ -435,8 +446,9 @@ final class ACPSessionOrchestrationCoordinator {
         phase: ACPDelegationPhase,
         failure: String?,
         createdAt: Int64
-    ) -> ACPOrchestrationSessionSummary {
-        let runtime = environment.sessionLocation(sessionId).flatMap { location -> ACPOrchestrationRuntimeState? in
+    ) async -> ACPOrchestrationSessionSummary {
+        let location = environment.sessionLocation(sessionId)
+        let runtime = location.flatMap { location -> ACPOrchestrationRuntimeState? in
             guard let session = location.manager.liveSession(for: sessionId) else { return nil }
             switch session.transcript.streamingState {
             case .idle: return .idle
@@ -444,7 +456,17 @@ final class ACPSessionOrchestrationCoordinator {
             case .awaitingPermission, .awaitingInput: return .awaitingInput
             }
         }
-        let state = ACPSessionOrchestrationPolicy.publicState(phase: phase, runtime: runtime, archived: false)
+        let archived: Bool
+        if location != nil {
+            archived = false
+        } else if let worktree = environment.worktree(worktreeId),
+                  let manager = environment.manager(worktree),
+                  let row = await manager.persistedSessionRow(id: sessionId) {
+            archived = row.archived
+        } else {
+            archived = true
+        }
+        let state = ACPSessionOrchestrationPolicy.publicState(phase: phase, runtime: runtime, archived: archived)
         return .init(
             sessionId: sessionId,
             relationship: relationship,

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -398,10 +398,7 @@ final class ACPSessionOrchestrationCoordinator {
         await target.manager.attach(to: claimed.message.targetSessionId, freshlyCreated: false)
         guard target.manager.isWriter(for: claimed.message.targetSessionId) else {
             try? await environment.persistence.releaseMessageClaim(id: claimed.message.id, claim: claimed.claim)
-            Task { @MainActor in
-                try? await Task.sleep(nanoseconds: 5_000_000_000)
-                await self.deliver(messageID, to: target)
-            }
+            target.manager.notifyDelegatedMessagesAvailable()
             return
         }
         let accepted = await target.manager.enqueueDelegatedPrompt(

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -228,6 +228,9 @@ final class ACPSessionOrchestrationCoordinator {
             ) else {
                 return .error("Messages may only be sent to a direct parent or child session.")
             }
+            guard ACPSessionOrchestrationPolicy.acceptsMessages(target: targetParent) else {
+                return .error("The target delegated session is not available.")
+            }
         } catch {
             return .error("Could not verify session delegation.")
         }

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -231,6 +231,13 @@ final class ACPSessionOrchestrationCoordinator {
             guard ACPSessionOrchestrationPolicy.acceptsMessages(target: targetParent) else {
                 return .error("The target delegated session is not available.")
             }
+            guard await resolveDeliveryTarget(
+                sessionID: request.targetSessionId,
+                callerParent: callerParent,
+                targetParent: targetParent
+            ) != nil else {
+                return .error("The target ACP session is not available.")
+            }
         } catch {
             return .error("Could not verify session delegation.")
         }

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -54,12 +54,12 @@ final class ACPSessionOrchestrationCoordinator {
                     )
                 }
                 if visible.relationship == .parent {
-                    guard let location = environment.sessionLocation(visible.sessionId) else { return nil }
+                    let location = environment.sessionLocation(visible.sessionId)
                     return sessionSummary(
                         sessionId: visible.sessionId,
                         relationship: "parent",
-                        agentId: location.manager.liveSession(for: visible.sessionId)?.agentId ?? "unknown",
-                        worktreeId: location.origin.worktreeId,
+                        agentId: location?.manager.liveSession(for: visible.sessionId)?.agentId ?? "unknown",
+                        worktreeId: location?.origin.worktreeId ?? parent?.parentWorktreeId ?? "",
                         phase: .ready,
                         failure: nil,
                         createdAt: 0

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift
@@ -201,9 +201,11 @@ final class ACPSessionOrchestrationCoordinator {
         } catch {
             return .error("prompt must not be blank")
         }
+        let callerParent: ACPDelegationRecord?
+        let targetParent: ACPDelegationRecord?
         do {
-            let callerParent = try await environment.persistence.parent(childSessionId: origin.sessionId)
-            let targetParent = try await environment.persistence.parent(childSessionId: request.targetSessionId)
+            callerParent = try await environment.persistence.parent(childSessionId: origin.sessionId)
+            targetParent = try await environment.persistence.parent(childSessionId: request.targetSessionId)
             let target = environment.sessionLocation(request.targetSessionId)
             guard let targetProjectId = target?.origin.projectId ?? targetParent?.projectId ?? callerParent?.projectId else {
                 return .error("The target ACP session is not available.")
@@ -235,10 +237,12 @@ final class ACPSessionOrchestrationCoordinator {
             return .error("Could not queue delegated message.")
         }
         environment.notifyChanged()
-        if let target = environment.sessionLocation(request.targetSessionId) {
-            Task { @MainActor [weak self] in
-                await self?.deliver(message.id, to: target)
-            }
+        Task { @MainActor [weak self] in
+            await self?.deliverPendingMessages(
+                to: request.targetSessionId,
+                callerParent: callerParent,
+                targetParent: targetParent
+            )
         }
         return json(ACPOrchestrationSendResponse(messageId: message.id, state: "queued"))
     }
@@ -322,9 +326,56 @@ final class ACPSessionOrchestrationCoordinator {
             childSessionId: childID, phase: .ready, failureMessage: nil, updatedAt: environment.now()
         )
         environment.notifyChanged()
+        await deliverPendingMessages(
+            to: childID,
+            callerParent: record,
+            targetParent: record
+        )
         Task { @MainActor [weak manager] in
             await manager?.attach(to: childID, freshlyCreated: true)
         }
+    }
+
+    private func deliverPendingMessages(
+        to sessionID: String,
+        callerParent: ACPDelegationRecord?,
+        targetParent: ACPDelegationRecord?
+    ) async {
+        guard let target = await resolveDeliveryTarget(
+            sessionID: sessionID,
+            callerParent: callerParent,
+            targetParent: targetParent
+        ), let messages = try? await environment.persistence.pendingMessages(targetSessionId: sessionID)
+        else { return }
+        for message in messages {
+            await deliver(message.id, to: target)
+        }
+    }
+
+    private func resolveDeliveryTarget(
+        sessionID: String,
+        callerParent: ACPDelegationRecord?,
+        targetParent: ACPDelegationRecord?
+    ) async -> SessionLocation? {
+        if let target = environment.sessionLocation(sessionID) {
+            return target
+        }
+        let worktreeID = targetParent?.childWorktreeId ?? callerParent?.parentWorktreeId
+        guard let worktreeID,
+              let worktree = environment.worktree(worktreeID),
+              let manager = environment.manager(worktree),
+              await manager.persistedSessionRow(id: sessionID) != nil
+        else { return nil }
+        _ = manager.placeholderSession(id: sessionID)
+        await manager.hydrateIfNeeded(id: sessionID)
+        return .init(
+            origin: ACPOrchestrationSessionOrigin(
+                sessionId: sessionID,
+                projectId: worktree.projectId,
+                worktreeId: worktree.id
+            ),
+            manager: manager
+        )
     }
 
     private func deliver(_ messageID: String, to target: SessionLocation) async {

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+enum ACPOrchestrationRelationship: String, Equatable, Sendable {
+    case parent
+    case child
+}
+
+enum ACPOrchestrationPublicState: String, Equatable, Sendable {
+    case creatingWorktree
+    case starting
+    case idle
+    case running
+    case awaitingInput
+    case failed
+    case closed
+}
+
+enum ACPOrchestrationRuntimeState: Equatable, Sendable {
+    case idle
+    case running
+    case awaitingInput
+    case closed
+}
+
+struct ACPOrchestrationVisibleSession: Equatable, Sendable {
+    let sessionId: String
+    let relationship: ACPOrchestrationRelationship?
+}
+
+struct ACPOrchestrationAgent: Equatable, Sendable {
+    let id: String
+    let isEnabled: Bool
+    let isACPCapable: Bool
+}
+
+enum ACPSessionOrchestrationPolicy {
+    enum Error: Swift.Error, Equatable {
+        case delegatedSessionCannotCreateChild
+        case crossProjectTarget
+        case targetIsNotDirectRelative
+        case agentUnavailable(String)
+        case blankPrompt
+    }
+
+    static func authorizeCreate(parent: ACPDelegationRecord?) -> Result<Void, Error> {
+        guard parent == nil else {
+            return .failure(.delegatedSessionCannotCreateChild)
+        }
+
+        return .success(())
+    }
+
+    static func authorizeSend(
+        callerSessionId: String,
+        callerProjectId: String,
+        targetSessionId: String,
+        targetProjectId: String,
+        callerParent: ACPDelegationRecord?,
+        targetParent: ACPDelegationRecord?
+    ) -> Result<ACPOrchestrationRelationship, Error> {
+        guard callerProjectId == targetProjectId,
+              callerParent?.projectId == nil || callerParent?.projectId == callerProjectId,
+              targetParent?.projectId == nil || targetParent?.projectId == targetProjectId else {
+            return .failure(.crossProjectTarget)
+        }
+
+        if targetParent?.parentSessionId == callerSessionId {
+            return .success(.child)
+        }
+
+        if callerParent?.parentSessionId == targetSessionId {
+            return .success(.parent)
+        }
+
+        return .failure(.targetIsNotDirectRelative)
+    }
+
+    static func visibleSessions(
+        callerSessionId: String,
+        parent: ACPDelegationRecord?,
+        children: [ACPDelegationRecord]
+    ) -> [ACPOrchestrationVisibleSession] {
+        var sessions = [ACPOrchestrationVisibleSession(sessionId: callerSessionId, relationship: nil)]
+
+        if let parent {
+            sessions.append(.init(sessionId: parent.parentSessionId, relationship: .parent))
+        }
+
+        sessions.append(contentsOf: children.map {
+            ACPOrchestrationVisibleSession(sessionId: $0.childSessionId, relationship: .child)
+        })
+
+        return sessions
+    }
+
+    static func resolveAgent(
+        requestedAgentId: String?,
+        parentAgentId: String,
+        availableAgents: [ACPOrchestrationAgent]
+    ) throws -> String {
+        let requestedId = requestedAgentId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let agentId = requestedId?.isEmpty == false ? requestedId! : parentAgentId
+
+        guard availableAgents.contains(where: {
+            $0.id == agentId && $0.isEnabled && $0.isACPCapable
+        }) else {
+            throw Error.agentUnavailable(agentId)
+        }
+
+        return agentId
+    }
+
+    static func validatedPrompt(_ prompt: String) throws -> String {
+        let prompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw Error.blankPrompt
+        }
+
+        return prompt
+    }
+
+    static func publicState(
+        phase: ACPDelegationPhase,
+        runtime: ACPOrchestrationRuntimeState?,
+        archived: Bool
+    ) -> ACPOrchestrationPublicState {
+        if archived || phase == .closed || runtime == .closed {
+            return .closed
+        }
+
+        switch phase {
+        case .creatingWorktree:
+            return .creatingWorktree
+        case .starting:
+            return .starting
+        case .failed:
+            return .failed
+        case .ready:
+            switch runtime {
+            case .running:
+                return .running
+            case .awaitingInput:
+                return .awaitingInput
+            case .idle, .none:
+                return .idle
+            case .closed:
+                return .closed
+            }
+        case .closed:
+            return .closed
+        }
+    }
+}

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
@@ -129,10 +129,6 @@ enum ACPSessionOrchestrationPolicy {
         runtime: ACPOrchestrationRuntimeState?,
         archived: Bool
     ) -> ACPOrchestrationPublicState {
-        if archived || phase == .closed || runtime == .closed {
-            return .closed
-        }
-
         switch phase {
         case .creatingWorktree:
             return .creatingWorktree
@@ -141,6 +137,9 @@ enum ACPSessionOrchestrationPolicy {
         case .failed:
             return .failed
         case .ready:
+            if archived || runtime == .closed {
+                return .closed
+            }
             switch runtime {
             case .running:
                 return .running

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
@@ -6,11 +6,11 @@ enum ACPOrchestrationRelationship: String, Equatable, Sendable {
 }
 
 enum ACPOrchestrationPublicState: String, Equatable, Sendable {
-    case creatingWorktree
+    case creatingWorktree = "creating_worktree"
     case starting
     case idle
     case running
-    case awaitingInput
+    case awaitingInput = "awaiting_input"
     case failed
     case closed
 }

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
@@ -94,14 +94,14 @@ enum ACPSessionOrchestrationPolicy {
     }
 
     static func resolveAgent(
-        requestedAgentId: String?,
+        requestedId: String?,
         parentAgentId: String,
-        availableAgents: [ACPOrchestrationAgent]
+        available: [ACPOrchestrationAgent]
     ) throws -> String {
-        let requestedId = requestedAgentId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let requestedId = requestedId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let agentId = requestedId?.isEmpty == false ? requestedId! : parentAgentId
 
-        guard availableAgents.contains(where: {
+        guard available.contains(where: {
             $0.id == agentId && $0.isEnabled && $0.isACPCapable
         }) else {
             throw Error.agentUnavailable(agentId)

--- a/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift
@@ -75,6 +75,11 @@ enum ACPSessionOrchestrationPolicy {
         return .failure(.targetIsNotDirectRelative)
     }
 
+    static func acceptsMessages(target: ACPDelegationRecord?) -> Bool {
+        guard let target else { return true }
+        return target.phase != .failed && target.phase != .closed
+    }
+
     static func visibleSessions(
         callerSessionId: String,
         parent: ACPDelegationRecord?,

--- a/Alas/Sources/ACP/Session/ACPChangeNotifier.swift
+++ b/Alas/Sources/ACP/Session/ACPChangeNotifier.swift
@@ -17,20 +17,21 @@ final class DarwinChangeNotifier: ACPChangeNotifier {
     // off the main thread — callers must hop to MainActor as needed.
     private let deliveryQueue = DispatchQueue(label: "io.alas.acp.notify")
 
-    init(worktreeId: String) {
-        self.name = Self.channelName(worktreeId: worktreeId)
+    init(worktreeId: String, channel: String? = nil) {
+        self.name = Self.channelName(worktreeId: worktreeId, channel: channel)
     }
 
     /// notify(3) names must be short, ASCII, and reverse-DNS-ish. Hash
     /// the (possibly long, space-containing) worktree id into a stable
     /// 64-bit suffix so any worktree maps to one safe channel.
-    static func channelName(worktreeId: String) -> String {
+    static func channelName(worktreeId: String, channel: String? = nil) -> String {
         var hash: UInt64 = 1469598103934665603   // FNV-1a offset basis
         for byte in worktreeId.utf8 {
             hash ^= UInt64(byte)
             hash = hash &* 1099511628211
         }
-        return "io.alas.acp." + String(hash, radix: 16)
+        let name = "io.alas.acp." + String(hash, radix: 16)
+        return channel.map { name + "." + $0 } ?? name
     }
 
     func post() {

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum ACPMessage: Equatable {
-    case user(id: UUID, messageId: String?, text: String, attachments: [Attachment])
+    case user(id: UUID, messageId: String?, text: String, attachments: [Attachment], delegatedSource: ACPDelegatedPromptSource? = nil)
     case agent(id: UUID, messageId: String?, StreamingText)
     case thought(id: UUID, messageId: String?, StreamingText)
     case toolCall(ToolCall)
@@ -36,7 +36,7 @@ enum ACPMessage: Equatable {
 
     var stableIdentityKey: StableIdentityKey {
         switch self {
-        case .user(let id, let messageId, _, _):
+        case .user(let id, let messageId, _, _, _):
             messageId.map(StableIdentityKey.userMessageId) ?? .userUUID(id)
         case .agent(let id, let messageId, _):
             messageId.map(StableIdentityKey.agentMessageId) ?? .agentUUID(id)
@@ -76,7 +76,7 @@ enum ACPMessage: Equatable {
     @MainActor
     var contentUTF8Length: Int {
         switch self {
-        case .user(_, _, let text, _):
+        case .user(_, _, let text, _, _):
             text.utf8.count
         case .agent(_, _, let text), .thought(_, _, let text):
             text.utf8Length
@@ -372,7 +372,7 @@ enum ACPMessageCodec {
     @MainActor
     static func encode(_ m: ACPMessage) throws -> Data {
         switch m {
-        case .user(_, let messageId, let text, let atts): return try encoder.encode(UserPayload(messageId: messageId, text: text, attachments: atts))
+        case .user(_, let messageId, let text, let atts, let delegatedSource): return try encoder.encode(UserPayload(messageId: messageId, text: text, attachments: atts, delegatedSource: delegatedSource))
         case .agent(_, let messageId, let buf):            return try encoder.encode(TextPayload(messageId: messageId, text: buf.value))
         case .thought(_, let messageId, let buf):          return try encoder.encode(TextPayload(messageId: messageId, text: buf.value))
         case .toolCall(let tc):             return try encoder.encode(tc)
@@ -387,7 +387,7 @@ enum ACPMessageCodec {
         switch kind {
         case "user":
             let p = try JSONDecoder().decode(UserPayload.self, from: payload)
-            return .user(id: UUID(), messageId: p.messageId, text: p.text, attachments: p.attachments)
+            return .user(id: UUID(), messageId: p.messageId, text: p.text, attachments: p.attachments, delegatedSource: p.delegatedSource)
         case "agent":
             let p = try JSONDecoder().decode(TextPayload.self, from: payload)
             return .agent(id: UUID(), messageId: p.messageId, StreamingText(p.text))
@@ -420,11 +420,13 @@ enum ACPMessageCodec {
         let messageId: String?
         let text: String
         let attachments: [ACPMessage.Attachment]
+        let delegatedSource: ACPDelegatedPromptSource?
 
-        init(messageId: String? = nil, text: String, attachments: [ACPMessage.Attachment]) {
+        init(messageId: String? = nil, text: String, attachments: [ACPMessage.Attachment], delegatedSource: ACPDelegatedPromptSource? = nil) {
             self.messageId = messageId
             self.text = text
             self.attachments = attachments
+            self.delegatedSource = delegatedSource
         }
     }
     private struct PlanPayload: Codable { let items: [ACPMessage.PlanItem] }

--- a/Alas/Sources/ACP/Session/ACPMessageWire.swift
+++ b/Alas/Sources/ACP/Session/ACPMessageWire.swift
@@ -6,7 +6,7 @@ import Foundation
 /// converts each variant into a full `ACPMessage`, which is the only
 /// place we allocate `StreamingText` (a `@MainActor` class).
 enum ACPMessageWire: Sendable {
-    case user(messageId: String?, text: String, attachments: [ACPMessage.Attachment])
+    case user(messageId: String?, text: String, attachments: [ACPMessage.Attachment], delegatedSource: ACPDelegatedPromptSource?)
     case agent(messageId: String?, text: String)
     case thought(messageId: String?, text: String)
     case toolCall(ACPMessage.ToolCall)
@@ -39,7 +39,7 @@ enum ACPMessageWire: Sendable {
         switch kind {
         case "user":
             let p = try decoder.decode(UserPayload.self, from: payload)
-            return .user(messageId: p.messageId, text: p.text, attachments: p.attachments)
+            return .user(messageId: p.messageId, text: p.text, attachments: p.attachments, delegatedSource: p.delegatedSource)
         case "agent":
             let p = try decoder.decode(TextPayload.self, from: payload)
             return .agent(messageId: p.messageId, text: p.text)
@@ -64,8 +64,8 @@ enum ACPMessageWire: Sendable {
     @MainActor
     func toMessage() -> ACPMessage {
         switch self {
-        case .user(let messageId, let text, let attachments):
-            return .user(id: UUID(), messageId: messageId, text: text, attachments: attachments)
+        case .user(let messageId, let text, let attachments, let delegatedSource):
+            return .user(id: UUID(), messageId: messageId, text: text, attachments: attachments, delegatedSource: delegatedSource)
         case .agent(let messageId, let text):
             return .agent(id: UUID(), messageId: messageId, StreamingText(text))
         case .thought(let messageId, let text):
@@ -89,6 +89,7 @@ enum ACPMessageWire: Sendable {
         let messageId: String?
         let text: String
         let attachments: [ACPMessage.Attachment]
+        let delegatedSource: ACPDelegatedPromptSource?
     }
     private struct PlanPayload: Decodable { let items: [ACPMessage.PlanItem] }
 }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -285,7 +285,7 @@ final class ACPSession: ObservableObject, Identifiable {
         _ = flushPendingReplayCandidates()
         transcript.messages.append(.user(
             id: UUID(),
-            messageId: delegatedSource?.messageId,
+            messageId: nil,
             text: text,
             attachments: attachments,
             delegatedSource: delegatedSource

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -210,7 +210,7 @@ final class ACPSession: ObservableObject, Identifiable {
     var hasConversationTranscript: Bool {
         transcript.messages.contains { message in
             switch message {
-            case .user(_, _, let text, _):
+            case .user(_, _, let text, _, _):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             case .agent(_, _, let buffer):
                 return !buffer.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -273,13 +273,23 @@ final class ACPSession: ObservableObject, Identifiable {
         Task { @MainActor in host.killAll() }
     }
 
-    func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
+    func recordUserPrompt(
+        text: String,
+        attachments: [ACPMessage.Attachment],
+        delegatedSource: ACPDelegatedPromptSource? = nil
+    ) {
         // Materialise any held replay candidate before the new prompt so
         // stranded live text from the just-ended turn keeps its place ahead
         // of the user message instead of being dropped. The runner persists
         // from the pre-call message count, so the flushed rows are saved too.
         _ = flushPendingReplayCandidates()
-        transcript.messages.append(.user(id: UUID(), messageId: nil, text: text, attachments: attachments))
+        transcript.messages.append(.user(
+            id: UUID(),
+            messageId: delegatedSource?.messageId,
+            text: text,
+            attachments: attachments,
+            delegatedSource: delegatedSource
+        ))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         if titleSource == .placeholder {
@@ -765,8 +775,12 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Append a new pending item to the tail of the queue. Used by the
     /// runner when the user submits while the agent is busy (or while
     /// the queue is already non-empty — see ACPSubmitRoute).
-    func enqueue(blocks: [ACPContentBlock], draft: ACPComposerDraft? = nil) {
-        queue.append(QueuedPrompt(blocks: blocks, draft: draft))
+    func enqueue(
+        blocks: [ACPContentBlock],
+        draft: ACPComposerDraft? = nil,
+        delegatedSource: ACPDelegatedPromptSource? = nil
+    ) {
+        queue.append(QueuedPrompt(blocks: blocks, draft: draft, delegatedSource: delegatedSource))
     }
 
     /// Remove a specific item by id. The drag-handle X on the bubble
@@ -1509,7 +1523,7 @@ final class ACPSession: ObservableObject, Identifiable {
     private func messageIndex(messageId: String, kind: TextMessageKind) -> Int? {
         transcript.messages.firstIndex { message in
             switch (kind, message) {
-            case (.user, .user(_, let existing, _, _)),
+            case (.user, .user(_, let existing, _, _, _)),
                  (.agent, .agent(_, let existing, _)),
                  (.thought, .thought(_, let existing, _)):
                 return existing == messageId
@@ -1522,7 +1536,7 @@ final class ACPSession: ObservableObject, Identifiable {
     private func appendUserChunk(text addition: String, attachments newAttachments: [ACPMessage.Attachment], messageId: String?, flushedReplayIndices: inout Set<Int>) -> Int? {
         let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
         if let i = located,
-           case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
+           case .user(let id, let existingMessageId, let text, let attachments, let delegatedSource) = transcript.messages[i] {
             let mergedAttachments = Self.mergingAttachments(attachments, newAttachments)
             let mergedText = text + Self.streamingSeparator(between: text, and: addition) + addition
             if text == mergedText && attachments == mergedAttachments {
@@ -1551,7 +1565,8 @@ final class ACPSession: ObservableObject, Identifiable {
                 id: id,
                 messageId: existingMessageId,
                 text: mergedText,
-                attachments: mergedAttachments)
+                attachments: mergedAttachments,
+                delegatedSource: delegatedSource)
             if let existingMessageId {
                 liveUserChunkMessageIds.insert(existingMessageId)
             }
@@ -1560,14 +1575,15 @@ final class ACPSession: ObservableObject, Identifiable {
         }
 
         if let i = lastEchoedLocalUserPromptIndex(matching: addition, attachments: newAttachments),
-           case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
+           case .user(let id, let existingMessageId, let text, let attachments, let delegatedSource) = transcript.messages[i] {
             if existingMessageId == nil {
                 if let messageId {
                     transcript.messages[i] = .user(
                         id: id,
                         messageId: messageId,
                         text: text,
-                        attachments: Self.mergingAttachments(attachments, newAttachments))
+                        attachments: Self.mergingAttachments(attachments, newAttachments),
+                        delegatedSource: delegatedSource)
                     reconciledLocalUserPromptMessageIds.insert(messageId)
                     transcript.noteStreamingChange(at: i)
                 } else {
@@ -1579,7 +1595,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
         if messageId == nil,
            let i = lastLegacyUserChunkIndex(),
-           case .user(let id, let existingMessageId, let text, let attachments) = transcript.messages[i] {
+           case .user(let id, let existingMessageId, let text, let attachments, let delegatedSource) = transcript.messages[i] {
             let mergedText = text + Self.streamingSeparator(between: text, and: addition) + addition
             let mergedAttachments = Self.mergingAttachments(attachments, newAttachments)
             if text == mergedText && attachments == mergedAttachments {
@@ -1589,7 +1605,8 @@ final class ACPSession: ObservableObject, Identifiable {
                 id: id,
                 messageId: existingMessageId,
                 text: mergedText,
-                attachments: mergedAttachments)
+                attachments: mergedAttachments,
+                delegatedSource: delegatedSource)
             transcript.noteStreamingChange(at: i)
             return i
         }
@@ -1645,7 +1662,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     private func lastLegacyUserChunkIndex() -> Int? {
         guard let index = transcript.messages.indices.last else { return nil }
-        if case .user(let id, let messageId, _, _) = transcript.messages[index],
+        if case .user(let id, let messageId, _, _, _) = transcript.messages[index],
            messageId == nil,
            legacyUserChunkMessageIds.contains(id) {
             return index
@@ -1656,7 +1673,7 @@ final class ACPSession: ObservableObject, Identifiable {
     private func lastEchoedLocalUserPromptIndex(matching text: String, attachments: [ACPMessage.Attachment]) -> Int? {
         guard !text.isEmpty || !attachments.isEmpty else { return nil }
         return transcript.messages.indices.reversed().first { index in
-            if case .user(let id, let messageId, let existing, let existingAttachments) = transcript.messages[index] {
+            if case .user(let id, let messageId, let existing, let existingAttachments, _) = transcript.messages[index] {
                 guard messageId == nil,
                       !legacyUserChunkMessageIds.contains(id) else { return false }
                 if !text.isEmpty {
@@ -1754,7 +1771,7 @@ final class ACPSession: ObservableObject, Identifiable {
     private func userMessageExists(containing text: String, attachments: [ACPMessage.Attachment]) -> Bool {
         guard !text.isEmpty || !attachments.isEmpty else { return false }
         return transcript.messages.contains { message in
-            guard case .user(_, _, let existing, let existingAttachments) = message else { return false }
+            guard case .user(_, _, let existing, let existingAttachments, _) = message else { return false }
             if !text.isEmpty, existing.contains(text) {
                 return true
             }

--- a/Alas/Sources/ACP/Session/ACPSessionByteAccounting.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionByteAccounting.swift
@@ -10,7 +10,7 @@ extension ACPSession {
         var total: UInt64 = 0
         for m in transcript.messages {
             switch m {
-            case .user(_, _, let text, let atts):
+            case .user(_, _, let text, let atts, _):
                 total &+= UInt64(text.utf8.count)
                 for a in atts {
                     total &+= UInt64(a.uri.utf8.count)

--- a/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
@@ -64,7 +64,7 @@ actor ACPSessionHydrator {
                 }
                 if let storedDraft,
                    storedDraft.submittedRecovery,
-                   case .user(_, let text, let attachments) = w,
+                   case .user(_, let text, let attachments, _) = w,
                    storedDraft.draft.matchesSubmittedRecoveryPrompt(
                     seq: m.seq,
                     text: text,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2717,6 +2717,9 @@ extension ACPSessionManager {
         into sessionId: ACPSession.ID
     ) async -> Bool {
         guard let session = sessions[sessionId] else { return false }
+        guard !session.queue.contains(where: { $0.delegatedSource?.messageId == source.messageId }) else {
+            return true
+        }
         let blocks = ACPSessionRunner.blocks(text: text, attachments: [])
         session.enqueue(blocks: blocks, delegatedSource: source)
         let fence = leaseFence(sessionId: sessionId)
@@ -2725,6 +2728,7 @@ extension ACPSessionManager {
             _ = try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
         await task.value
+        runners[sessionId]?.flushQueueIfIdle()
         return true
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -28,6 +28,10 @@ final class ACPSessionManager: ObservableObject {
         _ worktreePath: String
     ) throws -> ACPConnection
     typealias MCPProjectContextProvider = @MainActor () -> MCPProjectContext?
+    typealias BuiltInMCPProvider = @MainActor (
+        _ worktreePath: String,
+        _ sessionId: ACPSession.ID
+    ) async -> BuiltInAlasMCP.Injection?
 
     let instanceId: String
     let pid: Int64
@@ -50,7 +54,7 @@ final class ACPSessionManager: ObservableObject {
     /// and local ACP session id,
     /// or nil when injection is disabled/unavailable. Fetched per attach so
     /// the settings toggle applies to the next (re)connect.
-    private let builtInMCPProvider: ((String, ACPSession.ID) -> BuiltInAlasMCP.Injection?)?
+    private let builtInMCPProvider: BuiltInMCPProvider?
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     @Published private(set) var persistenceError: String?
@@ -304,7 +308,7 @@ final class ACPSessionManager: ObservableObject {
          remoteAdapterResolver: ACPRemoteAdapterResolver? = nil,
          connectionFactory: ACPConnectionFactory? = nil,
          mcpProjectContextProvider: MCPProjectContextProvider? = nil,
-         builtInMCPProvider: ((String, ACPSession.ID) -> BuiltInAlasMCP.Injection?)? = nil)
+         builtInMCPProvider: BuiltInMCPProvider? = nil)
     {
         precondition(store != nil || persistence != nil, "ACPSessionManager requires persistence")
         let resolvedPersistence = persistence ?? ACPSessionPersistence(path: store!.path)
@@ -2257,7 +2261,7 @@ extension ACPSessionManager {
             // skip it entirely instead of reporting it unavailable on every
             // connect.
             let remoteHost = RemoteHostRegistry.shared.host(forPath: worktreePath)
-            let builtInMCP = remoteHost == nil ? builtInMCPProvider?(worktreePath, sessionId) : nil
+            let builtInMCP = remoteHost == nil ? await builtInMCPProvider?(worktreePath, sessionId) : nil
             var plannedWireServers = mcpPlan.wireServers
             var plannedStatuses = mcpPlan.statuses
             if let builtInMCP {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -39,6 +39,7 @@ final class ACPSessionManager: ObservableObject {
     let worktreePath: String
     let persistence: ACPSessionPersistence
     let changeNotifier: ACPChangeNotifier
+    private let delegatedMessageNotifier: ACPChangeNotifier
     /// Called by each runner's write handler to check whether the target path
     /// has an open, dirty editor buffer. `nil` disables the check (no notices).
     let onDirtyCheck: ((String) -> Bool)?
@@ -49,6 +50,7 @@ final class ACPSessionManager: ObservableObject {
     let onLiveBufferRead: ((String) -> String?)?
     private let onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)?
     private let onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)?
+    private let onDelegatedMessageAvailable: ((ACPSession.ID) -> Void)?
     private let mcpProjectContextProvider: MCPProjectContextProvider?
     /// Builds the app-provided "alas" MCP server entry for a worktree path
     /// and local ACP session id,
@@ -293,6 +295,7 @@ final class ACPSessionManager: ObservableObject {
     /// release the lease after `connection.shutdown` — preserving the
     /// correct shutdown order (connection down before lease freed).
     private var attachingSessions: Set<ACPSession.ID> = []
+    private var delegatedMessageWatchTokens: [ACPSession.ID: Int32] = [:]
 
     init(worktreeId: String, worktreePath: String, store: ACPSessionStore? = nil,
          persistence: ACPSessionPersistence? = nil,
@@ -303,7 +306,9 @@ final class ACPSessionManager: ObservableObject {
          onLiveBufferRead: ((String) -> String?)? = nil,
          onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)? = nil,
          onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)? = nil,
+         onDelegatedMessageAvailable: ((ACPSession.ID) -> Void)? = nil,
          changeNotifier: ACPChangeNotifier? = nil,
+         delegatedMessageNotifier: ACPChangeNotifier? = nil,
          setupEvaluator: ACPSetupEvaluator? = nil,
          remoteAdapterResolver: ACPRemoteAdapterResolver? = nil,
          connectionFactory: ACPConnectionFactory? = nil,
@@ -321,9 +326,12 @@ final class ACPSessionManager: ObservableObject {
         self.onLiveBufferRead = onLiveBufferRead
         self.onSessionTitleUpdated = onSessionTitleUpdated
         self.onInputAwaiting = onInputAwaiting
+        self.onDelegatedMessageAvailable = onDelegatedMessageAvailable
         self.mcpProjectContextProvider = mcpProjectContextProvider
         self.builtInMCPProvider = builtInMCPProvider
         self.changeNotifier = changeNotifier ?? DarwinChangeNotifier(worktreeId: worktreeId)
+        self.delegatedMessageNotifier = delegatedMessageNotifier
+            ?? DarwinChangeNotifier(worktreeId: worktreeId, channel: "delegated-inbox")
         _ = hydratorPath
         self.setupEvaluator = setupEvaluator ?? { spec in
             let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
@@ -1713,6 +1721,13 @@ extension ACPSessionManager {
             }
         }
         writerWatchTokens[sessionId] = token
+        let delegatedMessageToken = delegatedMessageNotifier.subscribe { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self._ownedLeases.contains(sessionId) else { return }
+                self.onDelegatedMessageAvailable?(sessionId)
+            }
+        }
+        delegatedMessageWatchTokens[sessionId] = delegatedMessageToken
     }
 
     private func scheduleWriterOwnershipCheck(sessionId: ACPSession.ID) {
@@ -1730,7 +1745,17 @@ extension ACPSessionManager {
 
     private func stopWriterWatch(sessionId: ACPSession.ID) {
         if let t = writerWatchTokens.removeValue(forKey: sessionId) { changeNotifier.unsubscribe(t) }
+        if let t = delegatedMessageWatchTokens.removeValue(forKey: sessionId) {
+            delegatedMessageNotifier.unsubscribe(t)
+        }
         writerWatchDebounce.removeValue(forKey: sessionId)?.cancel()
+    }
+
+    /// Wake the active owner of this worktree to drain delegated messages.
+    /// This uses a dedicated channel so normal transcript persistence does not
+    /// trigger inbox scans.
+    func notifyDelegatedMessagesAvailable() {
+        delegatedMessageNotifier.post()
     }
 
     // MARK: - Test accessors for writer watch
@@ -2722,6 +2747,12 @@ extension ACPSessionManager {
     ) async -> Bool {
         guard let session = sessions[sessionId] else { return false }
         guard !session.queue.contains(where: { $0.delegatedSource?.messageId == source.messageId }) else {
+            return true
+        }
+        guard !session.transcript.messages.contains(where: { message in
+            guard case .user(_, _, _, _, let recordedSource) = message else { return false }
+            return recordedSource == source
+        }) else {
             return true
         }
         let blocks = ACPSessionRunner.blocks(text: text, attachments: [])

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2759,10 +2759,13 @@ extension ACPSessionManager {
         session.enqueue(blocks: blocks, delegatedSource: source)
         let fence = leaseFence(sessionId: sessionId)
         let items = session.queue
-        let task = enqueuePersistence { persistence in
-            _ = try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
+        let task = enqueuePersistenceResult { persistence in
+            try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
-        await task.value
+        guard await task.value == true else {
+            session.queue.removeAll { $0.delegatedSource == source }
+            return false
+        }
         runners[sessionId]?.flushQueueIfIdle()
         return true
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -401,6 +401,11 @@ final class ACPSessionManager: ObservableObject {
 
     func createSession(agentId: String, autoRunDefault: Bool = false) -> ACPSession {
         let id = UUID().uuidString
+        return createSession(id: id, agentId: agentId, autoRunDefault: autoRunDefault)
+    }
+
+    func createSession(id: String, agentId: String, autoRunDefault: Bool = false) -> ACPSession {
+        precondition(sessions[id] == nil && persistedRows[id] == nil, "ACP session id already exists")
         let now = Int64(Date().timeIntervalSince1970)
         let row = ACPSessionRow(
             id: id, agentId: agentId, title: "New session",
@@ -651,7 +656,7 @@ final class ACPSessionManager: ObservableObject {
     private static func wireMessagesHaveConversation(_ wires: [ACPMessageWire]) -> Bool {
         wires.contains { wire in
             switch wire {
-            case let .user(_, text, _):
+            case let .user(_, text, _, _):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             case let .agent(_, text):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -2703,6 +2708,24 @@ extension ACPSessionManager {
                 fence: fence
             )
         }
+    }
+
+    @discardableResult
+    func enqueueDelegatedPrompt(
+        text: String,
+        source: ACPDelegatedPromptSource,
+        into sessionId: ACPSession.ID
+    ) async -> Bool {
+        guard let session = sessions[sessionId] else { return false }
+        let blocks = ACPSessionRunner.blocks(text: text, attachments: [])
+        session.enqueue(blocks: blocks, delegatedSource: source)
+        let fence = leaseFence(sessionId: sessionId)
+        let items = session.queue
+        let task = enqueuePersistence { persistence in
+            _ = try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
+        }
+        await task.value
+        return true
     }
 
     /// Composer submit. Returns `true` if the prompt was accepted (either

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1308,7 +1308,7 @@ extension ACPSessionRunner {
         if case .needsAuth = session.setupState { return }
         session.markQueueHeadSending()
         persistQueue()
-        sendNow(blocks: head.blocks, queuedItemId: head.id)
+        sendNow(blocks: head.blocks, queuedItemId: head.id, delegatedSource: head.delegatedSource)
     }
 
     /// User clicked the row-local "send now" affordance for a queued item.
@@ -1447,6 +1447,7 @@ extension ACPSessionRunner {
     func sendNow(
         blocks: [ACPContentBlock],
         queuedItemId: UUID?,
+        delegatedSource: ACPDelegatedPromptSource? = nil,
         recordUserPrompt: Bool = true,
         draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
@@ -1516,7 +1517,8 @@ extension ACPSessionRunner {
                         self.onResumeTranscriptTail?()
                     }
                     self.session.recordUserPrompt(text: Self.textPreview(of: blocks),
-                                                  attachments: Self.attachments(of: blocks))
+                                                  attachments: Self.attachments(of: blocks),
+                                                  delegatedSource: delegatedSource)
                     self.persistFromIndex(before)
                     if self.session.title != titleBefore {
                         self.persistGeneratedTitleIfStoredPlaceholder()

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1339,7 +1339,11 @@ extension ACPSessionRunner {
 
         let item = session.queue.remove(at: idx)
         persistQueue()
-        steer(blocks: item.blocks, recordUserPrompt: !item.transcriptRecorded)
+        steer(
+            blocks: item.blocks,
+            delegatedSource: item.delegatedSource,
+            recordUserPrompt: !item.transcriptRecorded
+        )
     }
 
     /// Cancel the in-flight turn (if any), discard the ENTIRE queue
@@ -1353,6 +1357,7 @@ extension ACPSessionRunner {
     /// resolves to a no-op.
     func steer(
         blocks: [ACPContentBlock],
+        delegatedSource: ACPDelegatedPromptSource? = nil,
         recordUserPrompt: Bool = true,
         draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
@@ -1403,6 +1408,7 @@ extension ACPSessionRunner {
                 self.sendNow(
                     blocks: blocks,
                     queuedItemId: nil,
+                    delegatedSource: delegatedSource,
                     recordUserPrompt: recordUserPrompt,
                     draft: draft,
                     onPromptFinished: onPromptFinished

--- a/Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift
@@ -22,7 +22,7 @@ enum ACPTranscriptMarkdown {
         var sections: [String] = ["# \(headerTitle(title))"]
         for message in messages {
             switch message {
-            case .user(_, _, let text, _):
+            case .user(_, _, let text, _, _):
                 sections.append("## You\n\n\(serializedBody(text))")
             case .agent(_, _, let buffer):
                 sections.append("## \(agentHeading)\n\n\(serializedBody(buffer.value))")
@@ -37,7 +37,7 @@ enum ACPTranscriptMarkdown {
     @MainActor
     static func messageBody(_ message: ACPMessage) -> String? {
         switch message {
-        case .user(_, _, let text, _): return serializedBody(text)
+        case .user(_, _, let text, _, _): return serializedBody(text)
         case .agent(_, _, let buffer): return serializedBody(buffer.value)
         default: return nil
         }

--- a/Alas/Sources/ACP/Session/BuiltInAlasMCP.swift
+++ b/Alas/Sources/ACP/Session/BuiltInAlasMCP.swift
@@ -24,7 +24,8 @@ enum BuiltInAlasMCP {
         binaryPath: String?,
         socketPath: String?,
         worktreePath: String,
-        sessionId: String
+        sessionId: String,
+        parentSessionId: String? = nil
     ) -> Injection? {
         guard enabled, let binaryPath, let socketPath else { return nil }
         let userOverride = configuredServers.contains {
@@ -40,7 +41,7 @@ enum BuiltInAlasMCP {
                     .init(name: "ALAS_SOCKET_PATH", value: socketPath),
                     .init(name: "ALAS_WORKTREE_DIR", value: worktreePath),
                     .init(name: "ALAS_SESSION_ID", value: sessionId),
-                ]
+                ] + (parentSessionId.map { [.init(name: "ALAS_PARENT_SESSION_ID", value: $0)] } ?? [])
             ),
             status: .init(
                 id: statusId,

--- a/Alas/Sources/ACP/Session/QueuedPrompt.swift
+++ b/Alas/Sources/ACP/Session/QueuedPrompt.swift
@@ -21,6 +21,9 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
     /// rolled-back direct sends) — those fall back to the heuristic via
     /// `restorableDraft`. Not sent to the agent; `blocks` remains the wire form.
     var draft: ACPComposerDraft?
+    /// Present only for prompts delivered by a direct delegated-session edge.
+    /// It is intentionally omitted from ordinary prompt JSON for compatibility.
+    let delegatedSource: ACPDelegatedPromptSource?
 
     init(id: UUID = UUID(),
          blocks: [ACPContentBlock],
@@ -28,6 +31,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
          status: Status = .pending,
          lastError: String? = nil,
          draft: ACPComposerDraft? = nil,
+         delegatedSource: ACPDelegatedPromptSource? = nil,
          transcriptRecorded: Bool = false)
     {
         self.id = id
@@ -36,11 +40,12 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
         self.status = status
         self.lastError = lastError
         self.draft = draft
+        self.delegatedSource = delegatedSource
         self.transcriptRecorded = transcriptRecorded
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, blocks, enqueuedAt, status, lastError, draft, transcriptRecorded
+        case id, blocks, enqueuedAt, status, lastError, draft, delegatedSource, transcriptRecorded
     }
 
     init(from decoder: Decoder) throws {
@@ -51,6 +56,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
         status = try c.decode(Status.self, forKey: .status)
         lastError = try? c.decode(String.self, forKey: .lastError)
         draft = try? c.decode(ACPComposerDraft.self, forKey: .draft)
+        delegatedSource = try? c.decode(ACPDelegatedPromptSource.self, forKey: .delegatedSource)
         transcriptRecorded = (try? c.decode(Bool.self, forKey: .transcriptRecorded)) ?? false
     }
 

--- a/Alas/Sources/ACP/UI/ACPDelegatedSessionsPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPDelegatedSessionsPolicy.swift
@@ -3,10 +3,10 @@ import Foundation
 enum ACPDelegatedSessionsPolicy {
     static func statusLabel(for state: String) -> String {
         switch state {
-        case "creatingWorktree": return "Creating worktree"
+        case "creating_worktree": return "Creating worktree"
         case "starting": return "Starting"
         case "running": return "Working"
-        case "awaitingInput": return "Needs input"
+        case "awaiting_input": return "Needs input"
         case "failed": return "Failed"
         case "closed": return "Closed"
         default: return "Idle"

--- a/Alas/Sources/ACP/UI/ACPDelegatedSessionsPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPDelegatedSessionsPolicy.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum ACPDelegatedSessionsPolicy {
+    static func statusLabel(for state: String) -> String {
+        switch state {
+        case "creatingWorktree": return "Creating worktree"
+        case "starting": return "Starting"
+        case "running": return "Working"
+        case "awaitingInput": return "Needs input"
+        case "failed": return "Failed"
+        case "closed": return "Closed"
+        default: return "Idle"
+        }
+    }
+
+    static func ordered(_ sessions: [ACPOrchestrationSessionSummary]) -> [ACPOrchestrationSessionSummary] {
+        sessions.sorted {
+            if $0.relationship != $1.relationship { return $0.relationship == "parent" }
+            if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+            return $0.sessionId < $1.sessionId
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -999,11 +999,12 @@ struct ACPMessageList: View {
     @ViewBuilder
     private func row(for m: ACPMessage, stableId: String) -> some View {
         switch m {
-        case .user(_, _, let text, let attachments, _):
+        case .user(_, _, let text, let attachments, let delegatedSource):
             ACPMessageGutter(copySource: .text(text)) {
                 UserMessageRow(
                     text: text,
                     attachments: attachments,
+                    isDelegated: delegatedSource != nil,
                     contentMaxWidth: contentMaxWidth,
                     typography: typography
                 )
@@ -1369,6 +1370,7 @@ final class ACPDelayedHoverVisibility: ObservableObject {
 private struct UserMessageRow: View {
     let text: String
     let attachments: [ACPMessage.Attachment]
+    let isDelegated: Bool
     let contentMaxWidth: CGFloat
     let typography: ACPChatTypography
     @Environment(\.theme) private var theme
@@ -1376,6 +1378,11 @@ private struct UserMessageRow: View {
         HStack {
             Spacer(minLength: 40)
             VStack(alignment: .trailing, spacing: 4) {
+                if isDelegated {
+                    Text("Delegated prompt")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(theme.color("fg-faint"))
+                }
                 if !attachments.isEmpty {
                     let images = attachments.filter { ($0.mimeType?.hasPrefix("image/")) == true }
                     let others = attachments.filter { ($0.mimeType?.hasPrefix("image/")) != true }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -999,7 +999,7 @@ struct ACPMessageList: View {
     @ViewBuilder
     private func row(for m: ACPMessage, stableId: String) -> some View {
         switch m {
-        case .user(_, _, let text, let attachments):
+        case .user(_, _, let text, let attachments, _):
             ACPMessageGutter(copySource: .text(text)) {
                 UserMessageRow(
                     text: text,

--- a/Alas/Sources/ACP/UI/ACPSessionsButton.swift
+++ b/Alas/Sources/ACP/UI/ACPSessionsButton.swift
@@ -63,6 +63,7 @@ private struct SessionsPopover: View {
     let agentLookup: (String) -> AgentDefinition?
     let onPick: () -> Void
     @Environment(\.theme) private var theme
+    @State private var delegatedSessions: [ACPOrchestrationSessionSummary] = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -84,10 +85,20 @@ private struct SessionsPopover: View {
                     .padding(.vertical, 4)
                 }
             }
+            if !delegatedSessions.isEmpty {
+                Divider().background(theme.color("line"))
+                delegatedHeader
+                ForEach(delegatedSessions, id: \.sessionId) { summary in
+                    delegatedRow(summary)
+                }
+            }
         }
         .frame(width: 320)
         .frame(maxHeight: 420)
         .background(theme.color("bg-1"))
+        .task(id: session.id) {
+            delegatedSessions = await state.delegatedSessionSummaries(for: session.id)
+        }
     }
 
     @ViewBuilder
@@ -136,6 +147,49 @@ private struct SessionsPopover: View {
             .foregroundStyle(theme.color("fg-faint"))
             .padding(.horizontal, 12).padding(.vertical, 16)
             .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var delegatedHeader: some View {
+        HStack {
+            Text("Delegated sessions")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .textCase(.uppercase)
+                .foregroundStyle(theme.color("fg-faint"))
+            Spacer()
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(theme.color("bg-2").opacity(0.4))
+    }
+
+    private func delegatedRow(_ summary: ACPOrchestrationSessionSummary) -> some View {
+        Button {
+            Task {
+                await state.openDelegatedACPSession(summary)
+                onPick()
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: summary.relationship == "parent" ? "arrow.up.left" : "arrow.down.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(theme.color("fg-faint"))
+                    .frame(width: 14)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(summary.relationship == "parent" ? "Delegated by parent" : "Child session")
+                        .font(.system(size: 12))
+                        .foregroundStyle(theme.color("fg"))
+                    Text(ACPDelegatedSessionsPolicy.statusLabel(for: summary.state))
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(summary.state == "failed" ? theme.color("del") : theme.color("fg-faint"))
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10).padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 6)
+        .help(summary.failure ?? ACPDelegatedSessionsPolicy.statusLabel(for: summary.state))
     }
 
     @ViewBuilder

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -37,6 +37,15 @@ struct AlasActionService {
     var notifySession: (String?, Worktree, String, String?, AlasCLINotifyLevel) -> AlasCLIResponse = { _, _, _, _, _ in
         .error("Notifications from the terminal are not available yet.")
     }
+    var listDelegatedSessions: (ACPOrchestrationSessionOrigin) async -> AlasCLIResponse = { _ in
+        .error("Session orchestration is not available yet.")
+    }
+    var createDelegatedSession: (ACPOrchestrationSessionOrigin, ACPDelegatedSessionNewRequest) async -> AlasCLIResponse = { _, _ in
+        .error("Session orchestration is not available yet.")
+    }
+    var sendDelegatedSessionMessage: (ACPOrchestrationSessionOrigin, ACPDelegatedSessionMessageRequest) async -> AlasCLIResponse = { _, _ in
+        .error("Session orchestration is not available yet.")
+    }
     var activateApp: () -> Void
 
     /// Worktree owning `directory`: the worktree rooted exactly at
@@ -137,6 +146,24 @@ struct AlasActionService {
         level: AlasCLINotifyLevel
     ) -> AlasCLIResponse {
         notifySession(sessionId, origin, body, title, level)
+    }
+
+    func sessionList(origin: ACPOrchestrationSessionOrigin) async -> AlasCLIResponse {
+        await listDelegatedSessions(origin)
+    }
+
+    func sessionNew(
+        origin: ACPOrchestrationSessionOrigin,
+        request: ACPDelegatedSessionNewRequest
+    ) async -> AlasCLIResponse {
+        await createDelegatedSession(origin, request)
+    }
+
+    func sessionSend(
+        origin: ACPOrchestrationSessionOrigin,
+        request: ACPDelegatedSessionMessageRequest
+    ) async -> AlasCLIResponse {
+        await sendDelegatedSessionMessage(origin, request)
     }
 
     func new(origin: Worktree, branch: String, base: String?) async -> AlasCLIResponse {

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -3,6 +3,7 @@ import Foundation
 @MainActor
 struct AlasCLICommandRouter {
     var sessionWorktreeId: (String) -> String?
+    var resolveACPSessionOrigin: (String) -> ACPOrchestrationSessionOrigin? = { _ in nil }
     var originatingWorktree: (String) -> Worktree?
     var visibleWorktrees: () -> [Worktree]
     var openRelativeFile: (String, String) -> Void
@@ -31,6 +32,15 @@ struct AlasCLICommandRouter {
     var notifySession: (String?, Worktree, String, String?, AlasCLINotifyLevel) -> AlasCLIResponse = { _, _, _, _, _ in
         .error("Notifications from the terminal are not available yet.")
     }
+    var listDelegatedSessions: (ACPOrchestrationSessionOrigin) async -> AlasCLIResponse = { _ in
+        .error("Session orchestration is not available yet.")
+    }
+    var createDelegatedSession: (ACPOrchestrationSessionOrigin, ACPDelegatedSessionNewRequest) async -> AlasCLIResponse = { _, _ in
+        .error("Session orchestration is not available yet.")
+    }
+    var sendDelegatedSessionMessage: (ACPOrchestrationSessionOrigin, ACPDelegatedSessionMessageRequest) async -> AlasCLIResponse = { _, _ in
+        .error("Session orchestration is not available yet.")
+    }
     var activateApp: () -> Void
 
     private var service: AlasActionService {
@@ -52,12 +62,58 @@ struct AlasCLICommandRouter {
             gitStatus: gitStatus,
             providerReviewOriginalPath: providerReviewOriginalPath,
             notifySession: notifySession,
+            listDelegatedSessions: listDelegatedSessions,
+            createDelegatedSession: createDelegatedSession,
+            sendDelegatedSessionMessage: sendDelegatedSessionMessage,
             activateApp: activateApp
         )
     }
 
     func handle(_ request: AlasCLIRequest) async -> AlasCLIResponse {
         let service = self.service
+        switch request.command {
+        case .sessionList, .sessionNew, .sessionSend:
+            guard let sessionId = request.sessionId,
+                  let acpOrigin = resolveACPSessionOrigin(sessionId) else {
+                return .error("session commands require an originating ACP session")
+            }
+
+            switch request.command {
+            case .sessionList:
+                return await service.sessionList(origin: acpOrigin)
+            case .sessionNew(let prompt, let agentID, let worktree):
+                let target: ACPDelegatedSessionWorktreeTarget
+                switch worktree {
+                case .current:
+                    target = .current
+                case .existing(let worktreeID):
+                    target = .existing(worktreeId: worktreeID)
+                case .new(let branch, let base):
+                    target = .new(branch: branch, base: base)
+                }
+                return await service.sessionNew(
+                    origin: acpOrigin,
+                    request: ACPDelegatedSessionNewRequest(
+                        prompt: prompt,
+                        agentId: agentID,
+                        worktree: target
+                    )
+                )
+            case .sessionSend(let sessionID, let prompt):
+                return await service.sessionSend(
+                    origin: acpOrigin,
+                    request: ACPDelegatedSessionMessageRequest(
+                        targetSessionId: sessionID,
+                        prompt: prompt
+                    )
+                )
+            default:
+                preconditionFailure("Session command switch must be exhaustive")
+            }
+        default:
+            break
+        }
+
         // Resolve the origin worktree: exact session first, else cwd.
         let origin: Worktree
         if let sessionId = request.sessionId,
@@ -120,6 +176,8 @@ struct AlasCLICommandRouter {
             return service.reviewFinish(
                 origin: origin, sessionID: sessionID, verdict: verdict, summary: summary
             )
+        case .sessionList, .sessionNew, .sessionSend:
+            preconditionFailure("Session commands are handled before generic origin resolution")
         }
     }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4480,6 +4480,14 @@ final class AppState {
                 // no injection rather than a dead command for the agent.
                 let binaryPath = (try? TerminalCLIInjection.installExecutables())?
                     .appendingPathComponent(TerminalCLIInjection.executableName).path
+                let persistedParent = try? await self.acpOrchestrationPersistence.parent(
+                    childSessionId: sessionId
+                )
+                let parentSessionId = self.delegatedSessionParents[sessionId]
+                    ?? persistedParent?.parentSessionId
+                if let parentSessionId {
+                    self.delegatedSessionParents[sessionId] = parentSessionId
+                }
                 return BuiltInAlasMCP.injection(
                     enabled: self.config.harness.exposeAlasMCP,
                     configuredServers: self.projects.first(where: { $0.id == worktree.projectId })?.mcpServers ?? [],
@@ -4487,7 +4495,7 @@ final class AppState {
                     socketPath: self.harness.socketServer.socketPath,
                     worktreePath: worktreePath,
                     sessionId: sessionId,
-                    parentSessionId: self.delegatedSessionParents[sessionId]
+                    parentSessionId: parentSessionId
                 )
             }
         )
@@ -4706,7 +4714,11 @@ final class AppState {
                 relationship: "child",
                 agentId: record.agentId,
                 worktreeId: record.childWorktreeId ?? "",
-                state: record.phase.rawValue,
+                state: ACPSessionOrchestrationPolicy.publicState(
+                    phase: record.phase,
+                    runtime: nil,
+                    archived: false
+                ).rawValue,
                 failure: record.failureMessage,
                 createdAt: record.createdAt
             )

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4742,6 +4742,15 @@ final class AppState {
         let parent = try? await acpOrchestrationPersistence.parent(childSessionId: sessionId)
         let children = (try? await acpOrchestrationPersistence.children(parentSessionId: sessionId)) ?? []
         var summaries = children.map { record in
+            let runtime = record.childWorktreeId
+                .flatMap { acpManagers[$0]?.liveSession(for: record.childSessionId) }
+                .map { session -> ACPOrchestrationRuntimeState in
+                    switch session.transcript.streamingState {
+                    case .idle: return .idle
+                    case .sending, .streaming: return .running
+                    case .awaitingPermission, .awaitingInput: return .awaitingInput
+                    }
+                }
             ACPOrchestrationSessionSummary(
                 sessionId: record.childSessionId,
                 relationship: "child",
@@ -4749,7 +4758,7 @@ final class AppState {
                 worktreeId: record.childWorktreeId ?? "",
                 state: ACPSessionOrchestrationPolicy.publicState(
                     phase: record.phase,
-                    runtime: nil,
+                    runtime: runtime,
                     archived: false
                 ).rawValue,
                 failure: record.failureMessage,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2039,12 +2039,17 @@ final class AppState {
                     guard let self,
                           let project = self.projects.first(where: { $0.id == projectId })
                     else { return nil }
-                    return WorktreePathTemplateRenderer.render(
+                    let destination = WorktreePathTemplateRenderer.render(
                         template: self.config.worktrees.pathTemplate,
                         worktreeRoot: self.config.worktrees.rootPath,
                         repoName: project.name,
                         branch: branch
                     )
+                    guard !URL(fileURLWithPath: project.path).isRemoteAlasPath else { return destination }
+                    return destination
+                        .deletingLastPathComponent()
+                        .resolvingSymlinksInPath()
+                        .appendingPathComponent(destination.lastPathComponent)
                 },
                 createWorktree: { [weak self] projectId, branch, base in
                     guard let self else {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4660,6 +4660,7 @@ final class AppState {
             title = "ACP session"
         }
         _ = mgr.placeholderSession(id: sessionId)
+        await mgr.hydrateIfNeeded(id: sessionId)
         await deliverPendingDelegatedMessages(to: sessionId, manager: mgr)
         let state = ACPSessionTabState(sessionId: sessionId, title: title)
         tabs.append(acpSession: state, to: worktree.id)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1941,6 +1941,9 @@ final class AppState {
                     }
                     return await self.createDelegatedWorktree(projectId: projectId, branch: branch, base: base)
                 },
+                rememberParent: { [weak self] childID, parentID in
+                    self?.delegatedSessionParents[childID] = parentID
+                },
                 notifyChanged: { }
             )
         )
@@ -4282,6 +4285,9 @@ final class AppState {
     @ObservationIgnored
     private let acpOrchestrationPersistence = ACPOrchestrationPersistence()
 
+    @ObservationIgnored
+    private var delegatedSessionParents: [String: String] = [:]
+
     /// Force-flush every per-session debounced composer-draft write across
     /// all live managers. Called from app-will-terminate so an in-flight
     /// typing burst doesn't lose its last ~300ms of input to the
@@ -4403,7 +4409,8 @@ final class AppState {
                     binaryPath: binaryPath,
                     socketPath: self.harness.socketServer.socketPath,
                     worktreePath: worktreePath,
-                    sessionId: sessionId
+                    sessionId: sessionId,
+                    parentSessionId: self.delegatedSessionParents[sessionId]
                 )
             }
         )

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4777,7 +4777,9 @@ final class AppState {
         let children = (try? await acpOrchestrationPersistence.children(parentSessionId: sessionId)) ?? []
         var summaries: [ACPOrchestrationSessionSummary] = []
         for record in children {
-            let manager = record.childWorktreeId.flatMap { acpManagers[$0] }
+            let manager = record.childWorktreeId
+                .flatMap { worktree(withId: $0) }
+                .flatMap { acpManager(for: $0) }
             let runtime = manager?.liveSession(for: record.childSessionId)
                 .map { session -> ACPOrchestrationRuntimeState in
                     switch session.transcript.streamingState {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1166,7 +1166,16 @@ final class AppState {
         if FileManager.default.fileExists(atPath: destination.path) {
             return .failure(.init(message: "A worktree already exists at this path."))
         }
-        let selectedBase = base ?? config.worktrees.baseBranch
+        let selectedBase: String
+        if let base {
+            selectedBase = base
+        } else {
+            let branches = (try? await GitService().branches(at: URL(fileURLWithPath: project.path))) ?? []
+            selectedBase = NewWorktreeDialog.preferredBaseBranch(
+                availableBranches: branches,
+                configuredDefault: config.worktrees.baseBranch
+            )
+        }
         let id = await createWorktree(
             projectId: projectId,
             base: selectedBase,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4762,6 +4762,12 @@ final class AppState {
                     id: claimed.message.id,
                     claim: claimed.claim
                 )
+            } else {
+                try? await acpOrchestrationPersistence.releaseMessageClaim(
+                    id: claimed.message.id,
+                    claim: claimed.claim
+                )
+                manager.notifyDelegatedMessagesAvailable()
             }
         }
     }
@@ -4769,9 +4775,10 @@ final class AppState {
     func delegatedSessionSummaries(for sessionId: String) async -> [ACPOrchestrationSessionSummary] {
         let parent = try? await acpOrchestrationPersistence.parent(childSessionId: sessionId)
         let children = (try? await acpOrchestrationPersistence.children(parentSessionId: sessionId)) ?? []
-        var summaries: [ACPOrchestrationSessionSummary] = children.map { record in
-            let runtime = record.childWorktreeId
-                .flatMap { acpManagers[$0]?.liveSession(for: record.childSessionId) }
+        var summaries: [ACPOrchestrationSessionSummary] = []
+        for record in children {
+            let manager = record.childWorktreeId.flatMap { acpManagers[$0] }
+            let runtime = manager?.liveSession(for: record.childSessionId)
                 .map { session -> ACPOrchestrationRuntimeState in
                     switch session.transcript.streamingState {
                     case .idle: return .idle
@@ -4779,7 +4786,15 @@ final class AppState {
                     case .awaitingPermission, .awaitingInput: return .awaitingInput
                     }
                 }
-            return ACPOrchestrationSessionSummary(
+            let archived: Bool
+            if let manager, let row = await manager.persistedSessionRow(id: record.childSessionId) {
+                archived = row.archived
+            } else if record.childWorktreeId != nil {
+                archived = true
+            } else {
+                archived = false
+            }
+            summaries.append(ACPOrchestrationSessionSummary(
                 sessionId: record.childSessionId,
                 relationship: "child",
                 agentId: record.agentId,
@@ -4787,11 +4802,11 @@ final class AppState {
                 state: ACPSessionOrchestrationPolicy.publicState(
                     phase: record.phase,
                     runtime: runtime,
-                    archived: false
+                    archived: archived
                 ).rawValue,
                 failure: record.failureMessage,
                 createdAt: record.createdAt
-            )
+            ))
         }
         if let parent {
             summaries.append(.init(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -625,6 +625,18 @@ final class AppState {
                 preferredWorktreeId: childRecord?.childWorktreeId ?? childRecord?.worktreeRequest.worktreeId
             ) else { continue }
             await deliverPendingDelegatedMessages(to: sessionId, manager: manager)
+            await scheduleRecoveredDelegatedMessageRetry(to: sessionId, manager: manager)
+        }
+    }
+
+    private func scheduleRecoveredDelegatedMessageRetry(to sessionId: String, manager: ACPSessionManager) async {
+        guard let remaining = try? await acpOrchestrationPersistence.pendingMessages(targetSessionId: sessionId),
+              !remaining.isEmpty
+        else { return }
+        Task { @MainActor [weak self, weak manager] in
+            try? await Task.sleep(nanoseconds: 61_000_000_000)
+            guard let self, let manager else { return }
+            await self.deliverPendingDelegatedMessages(to: sessionId, manager: manager)
         }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -603,10 +603,51 @@ final class AppState {
                 failureMessage: nil,
                 updatedAt: Int64(Date().timeIntervalSince1970)
             )
+            await deliverPendingDelegatedMessages(to: record.childSessionId, manager: manager)
             Task { @MainActor [weak manager] in
                 await manager?.attach(to: record.childSessionId, freshlyCreated: false)
             }
         }
+        await drainRecoveredDelegatedMessageTargets()
+    }
+
+    private func drainRecoveredDelegatedMessageTargets() async {
+        guard let targetSessionIds = try? await acpOrchestrationPersistence.pendingMessageTargetSessionIds() else {
+            return
+        }
+        for sessionId in targetSessionIds {
+            let childRecord = try? await acpOrchestrationPersistence.parent(childSessionId: sessionId)
+            if let childRecord {
+                delegatedSessionParents[childRecord.childSessionId] = childRecord.parentSessionId
+            }
+            guard let manager = await acpManagerForPersistedSession(
+                sessionId: sessionId,
+                preferredWorktreeId: childRecord?.childWorktreeId ?? childRecord?.worktreeRequest.worktreeId
+            ) else { continue }
+            await deliverPendingDelegatedMessages(to: sessionId, manager: manager)
+        }
+    }
+
+    private func acpManagerForPersistedSession(
+        sessionId: String,
+        preferredWorktreeId: String?
+    ) async -> ACPSessionManager? {
+        var worktreeIds: [String] = []
+        if let preferredWorktreeId {
+            worktreeIds.append(preferredWorktreeId)
+        }
+        worktreeIds.append(contentsOf: allWorktreeIds().filter { $0 != preferredWorktreeId }.sorted())
+        for worktreeId in worktreeIds {
+            guard let worktree = worktree(withId: worktreeId),
+                  let manager = acpManager(for: worktree),
+                  let row = await manager.persistedSessionRow(id: sessionId),
+                  !row.archived
+            else { continue }
+            _ = manager.placeholderSession(id: sessionId)
+            await manager.hydrateIfNeeded(id: sessionId)
+            return manager
+        }
+        return nil
     }
 
     func toggleRightPaneVisibility() {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -932,13 +932,16 @@ final class AppState {
             status: .clean,
             lastActivity: Date()
         )
-        if let containing = spacesManager.containingSpaceId(forProjectId: projectId),
+        if launchSurface != .delegated,
+           let containing = spacesManager.containingSpaceId(forProjectId: projectId),
            containing != spacesManager.activeSpaceId {
             _ = switchToSpace(id: containing)
         }
         projectsManager.insertOptimisticWorktree(optimistic)
         projectsManager.setOperationState(id: optimistic.id, state: .creating)
-        selectWorktree(id: optimistic.id)
+        if launchSurface != .delegated {
+            selectWorktree(id: optimistic.id)
+        }
 
         let startupScript = StartupScriptResolver.worktreeCreateScript(
             global: config.terminal,
@@ -995,7 +998,9 @@ final class AppState {
                         saveProjects()
                     }
 
-                    selectWorktree(id: newWorktree.id)
+                    if launchSurface != .delegated {
+                        selectWorktree(id: newWorktree.id)
+                    }
 
                     switch launchSurface {
                     case .none:
@@ -1013,6 +1018,8 @@ final class AppState {
                         )
                     case .acp(let agentId):
                         openNewACPSession(agentID: agentId)
+                    case .delegated:
+                        break
                     }
                 } catch {
                     projectsManager.setOperationState(
@@ -1072,6 +1079,60 @@ final class AppState {
             return .error("A worktree already exists at this path.")
         }
         return .text(["creating \(branch) at \(destination.path)"])
+    }
+
+    /// Creates a worktree for delegated ACP work without changing the visible
+    /// project/worktree selection. The existing creation path remains the
+    /// single owner of validation, startup, refresh, and failure handling.
+    private func createDelegatedWorktree(
+        projectId: String,
+        branch: String,
+        base: String?
+    ) async -> Result<Worktree, ACPSessionOrchestrationCoordinator.WorktreeCreationError> {
+        guard let project = projects.first(where: { $0.id == projectId }) else {
+            return .failure(.init(message: "The project is no longer available."))
+        }
+        switch GitNameValidator.validateBranchName(branch) {
+        case .valid:
+            break
+        case .invalid(let message):
+            return .failure(.init(message: "invalid branch name: \(message)"))
+        }
+        let destination = WorktreePathTemplateRenderer.render(
+            template: config.worktrees.pathTemplate,
+            worktreeRoot: config.worktrees.rootPath,
+            repoName: project.name,
+            branch: branch
+        )
+        if FileManager.default.fileExists(atPath: destination.path) {
+            return .failure(.init(message: "A worktree already exists at this path."))
+        }
+        let selectedBase = base ?? config.worktrees.baseBranch
+        let id = await createWorktree(
+            projectId: projectId,
+            base: selectedBase,
+            branch: branch,
+            destination: destination,
+            runStartup: true,
+            launchSurface: .delegated
+        )
+        guard !id.isEmpty else { return .failure(.init(message: "Could not start worktree creation.")) }
+        for _ in 0..<1_200 {
+            switch projectsManager.operationState(for: id) {
+            case .createFailed(let message, _):
+                return .failure(.init(message: message))
+            case .creating:
+                try? await Task.sleep(for: .milliseconds(250))
+            case .deleting, .deleteFailed:
+                return .failure(.init(message: "Worktree creation was interrupted."))
+            case nil:
+                if let worktree = worktree(withId: id) {
+                    return .success(worktree)
+                }
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+        }
+        return .failure(.init(message: "Timed out waiting for worktree creation."))
     }
 
     func agentStartupCommand(for agent: AgentDefinition, project: ProjectConfig) -> String {
@@ -1838,7 +1899,52 @@ final class AppState {
     func makeCLICommandRouter(
         sessionWorktreeLookup: @escaping (String) -> String?
     ) -> AlasCLICommandRouter {
-        AlasCLICommandRouter(
+        let orchestration = ACPSessionOrchestrationCoordinator(
+            environment: .init(
+                persistence: acpOrchestrationPersistence,
+                instanceId: instanceId,
+                now: { Int64(Date().timeIntervalSince1970) },
+                makeID: { UUID().uuidString },
+                worktree: { [weak self] id in self?.worktree(withId: id) },
+                existingWorktree: { [weak self] projectId, worktreeId in
+                    guard let self else { return nil }
+                    return self.projectsManager.visibleWorktrees(projectId: projectId)
+                        .first(where: { $0.id == worktreeId })
+                },
+                availableAgents: { [weak self] in
+                    guard let self else { return [] }
+                    let acpIDs = Set(ACPLaunchCatalog.specs.map(\.agentID))
+                    return self.agentRegistry.enabled().map {
+                        ACPOrchestrationAgent(id: $0.id, isEnabled: true, isACPCapable: acpIDs.contains($0.id))
+                    }
+                },
+                sessionLocation: { [weak self] sessionId in
+                    guard let self,
+                          let (worktreeId, manager) = self.acpManagers.first(where: { _, manager in
+                              manager.liveSession(for: sessionId) != nil
+                          }),
+                          let worktree = self.worktree(withId: worktreeId)
+                    else { return nil }
+                    return .init(
+                        origin: ACPOrchestrationSessionOrigin(
+                            sessionId: sessionId,
+                            projectId: worktree.projectId,
+                            worktreeId: worktree.id
+                        ),
+                        manager: manager
+                    )
+                },
+                manager: { [weak self] worktree in self?.acpManager(for: worktree) },
+                createWorktree: { [weak self] projectId, branch, base in
+                    guard let self else {
+                        return .failure(.init(message: "Alas is not available."))
+                    }
+                    return await self.createDelegatedWorktree(projectId: projectId, branch: branch, base: base)
+                },
+                notifyChanged: { }
+            )
+        )
+        return AlasCLICommandRouter(
             sessionWorktreeId: sessionWorktreeLookup,
             resolveACPSessionOrigin: { [weak self] sessionId in
                 guard let self,
@@ -1934,6 +2040,15 @@ final class AppState {
                     title: title,
                     level: level
                 )
+            },
+            listDelegatedSessions: { origin in
+                await orchestration.list(origin: origin)
+            },
+            createDelegatedSession: { origin, request in
+                await orchestration.create(origin: origin, request: request)
+            },
+            sendDelegatedSessionMessage: { origin, request in
+                await orchestration.send(origin: origin, request: request)
             },
             activateApp: {
                 NSApp.activate(ignoringOtherApps: true)
@@ -4164,6 +4279,9 @@ final class AppState {
     @ObservationIgnored
     private var acpManagers: [String: ACPSessionManager] = [:]
 
+    @ObservationIgnored
+    private let acpOrchestrationPersistence = ACPOrchestrationPersistence()
+
     /// Force-flush every per-session debounced composer-draft write across
     /// all live managers. Called from app-will-terminate so an in-flight
     /// typing burst doesn't lose its last ~300ms of input to the
@@ -4460,6 +4578,40 @@ final class AppState {
         _ = mgr.placeholderSession(id: sessionId)
         let state = ACPSessionTabState(sessionId: sessionId, title: title)
         tabs.append(acpSession: state, to: worktree.id)
+    }
+
+    func delegatedSessionSummaries(for sessionId: String) async -> [ACPOrchestrationSessionSummary] {
+        let parent = try? await acpOrchestrationPersistence.parent(childSessionId: sessionId)
+        let children = (try? await acpOrchestrationPersistence.children(parentSessionId: sessionId)) ?? []
+        var summaries = children.map { record in
+            ACPOrchestrationSessionSummary(
+                sessionId: record.childSessionId,
+                relationship: "child",
+                agentId: record.agentId,
+                worktreeId: record.childWorktreeId ?? "",
+                state: record.phase.rawValue,
+                failure: record.failureMessage,
+                createdAt: record.createdAt
+            )
+        }
+        if let parent {
+            summaries.append(.init(
+                sessionId: parent.parentSessionId,
+                relationship: "parent",
+                agentId: "",
+                worktreeId: parent.parentWorktreeId,
+                state: "idle",
+                failure: nil,
+                createdAt: parent.createdAt
+            ))
+        }
+        return ACPDelegatedSessionsPolicy.ordered(summaries)
+    }
+
+    func openDelegatedACPSession(_ summary: ACPOrchestrationSessionSummary) async {
+        guard let worktree = worktree(withId: summary.worktreeId) else { return }
+        focusGlobalWorktree(id: worktree.id, projectId: worktree.projectId)
+        await openExistingACPSession(sessionId: summary.sessionId)
     }
 
     @discardableResult

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1840,6 +1840,19 @@ final class AppState {
     ) -> AlasCLICommandRouter {
         AlasCLICommandRouter(
             sessionWorktreeId: sessionWorktreeLookup,
+            resolveACPSessionOrigin: { [weak self] sessionId in
+                guard let self,
+                      let (worktreeId, manager) = self.acpManagers.first(where: { _, manager in
+                          manager.liveSession(for: sessionId) != nil
+                      }),
+                      let worktree = self.worktree(withId: worktreeId)
+                else { return nil }
+                return ACPOrchestrationSessionOrigin(
+                    sessionId: sessionId,
+                    projectId: worktree.projectId,
+                    worktreeId: worktree.id
+                )
+            },
             originatingWorktree: { [weak self] worktreeId in
                 self?.worktree(withId: worktreeId)
             },

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -520,9 +520,6 @@ final class AppState {
         // hasn't finished by the first git command, gitEnv() falls back to the
         // process PATH (same behaviour as before).
         ShellEnvResolver.shared.resolve()
-        Task { [weak self] in
-            await self?.reconcileInterruptedDelegations()
-        }
     }
 
     /// All worktree IDs currently known to the projects manager (including
@@ -535,14 +532,57 @@ final class AppState {
 
     private func reconcileInterruptedDelegations() async {
         guard let records = try? await acpOrchestrationPersistence.incompleteDelegations() else { return }
-        let now = Int64(Date().timeIntervalSince1970)
         for record in records {
+            guard let worktreeId = record.childWorktreeId,
+                  let worktree = worktree(withId: worktreeId),
+                  let prompt = record.pendingInitialPrompt,
+                  let manager = acpManager(for: worktree)
+            else {
+                try? await acpOrchestrationPersistence.updatePhase(
+                    childSessionId: record.childSessionId,
+                    phase: .failed,
+                    failureMessage: "Alas stopped before delegated session setup completed.",
+                    updatedAt: Int64(Date().timeIntervalSince1970)
+                )
+                continue
+            }
+            delegatedSessionParents[record.childSessionId] = record.parentSessionId
+            if await manager.persistedSessionRow(id: record.childSessionId) != nil {
+                _ = manager.placeholderSession(id: record.childSessionId)
+                await manager.hydrateIfNeeded(id: record.childSessionId)
+            } else {
+                _ = manager.createSession(id: record.childSessionId, agentId: record.agentId)
+            }
+            let accepted = await manager.enqueueDelegatedPrompt(
+                text: prompt,
+                source: ACPDelegatedPromptSource(
+                    sessionId: record.parentSessionId,
+                    messageId: "initial-\(record.childSessionId)"
+                ),
+                into: record.childSessionId
+            )
+            guard accepted else {
+                try? await acpOrchestrationPersistence.updatePhase(
+                    childSessionId: record.childSessionId,
+                    phase: .failed,
+                    failureMessage: "Could not restore delegated session prompt.",
+                    updatedAt: Int64(Date().timeIntervalSince1970)
+                )
+                continue
+            }
+            try? await acpOrchestrationPersistence.clearPendingInitialPrompt(
+                childSessionId: record.childSessionId,
+                updatedAt: Int64(Date().timeIntervalSince1970)
+            )
             try? await acpOrchestrationPersistence.updatePhase(
                 childSessionId: record.childSessionId,
-                phase: .failed,
-                failureMessage: "Alas stopped before delegated session setup completed. Retry from the session menu.",
-                updatedAt: now
+                phase: .ready,
+                failureMessage: nil,
+                updatedAt: Int64(Date().timeIntervalSince1970)
             )
+            Task { @MainActor [weak manager] in
+                await manager?.attach(to: record.childSessionId, freshlyCreated: false)
+            }
         }
     }
 
@@ -602,6 +642,9 @@ final class AppState {
         // TerminalTabView.task) to fire when the user opens the tab.
         refreshPersistedHookSymlinks()
         sweepOrphanZmxSessions(worktreeIds: allWorktreeIds)
+        Task { [weak self] in
+            await self?.reconcileInterruptedDelegations()
+        }
     }
 
     /// Compute (knownWorktreeIds, knownLeafIds) from in-memory state and

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -536,7 +536,6 @@ final class AppState {
             let worktree = record.childWorktreeId.flatMap(worktree(withId:))
                 ?? worktree(atPersistedDestinationPath: record.worktreeRequest.destinationPath)
             guard let worktree,
-                  let prompt = record.pendingInitialPrompt,
                   let manager = acpManager(for: worktree)
             else {
                 try? await acpOrchestrationPersistence.updatePhase(
@@ -556,21 +555,36 @@ final class AppState {
                 )
             }
             delegatedSessionParents[record.childSessionId] = record.parentSessionId
-            if await manager.persistedSessionRow(id: record.childSessionId) != nil {
+            let sessionAlreadyPersisted = await manager.persistedSessionRow(id: record.childSessionId) != nil
+            if sessionAlreadyPersisted {
                 _ = manager.placeholderSession(id: record.childSessionId)
                 await manager.hydrateIfNeeded(id: record.childSessionId)
             } else {
                 _ = manager.createSession(id: record.childSessionId, agentId: record.agentId)
             }
-            let accepted = await manager.enqueueDelegatedPrompt(
-                text: prompt,
-                source: ACPDelegatedPromptSource(
-                    sessionId: record.parentSessionId,
-                    messageId: "initial-\(record.childSessionId)"
-                ),
-                into: record.childSessionId
-            )
-            guard accepted else {
+            if let prompt = record.pendingInitialPrompt {
+                let accepted = await manager.enqueueDelegatedPrompt(
+                    text: prompt,
+                    source: ACPDelegatedPromptSource(
+                        sessionId: record.parentSessionId,
+                        messageId: "initial-\(record.childSessionId)"
+                    ),
+                    into: record.childSessionId
+                )
+                guard accepted else {
+                    try? await acpOrchestrationPersistence.updatePhase(
+                        childSessionId: record.childSessionId,
+                        phase: .failed,
+                        failureMessage: "Could not restore delegated session prompt.",
+                        updatedAt: Int64(Date().timeIntervalSince1970)
+                    )
+                    continue
+                }
+                try? await acpOrchestrationPersistence.clearPendingInitialPrompt(
+                    childSessionId: record.childSessionId,
+                    updatedAt: Int64(Date().timeIntervalSince1970)
+                )
+            } else if !sessionAlreadyPersisted {
                 try? await acpOrchestrationPersistence.updatePhase(
                     childSessionId: record.childSessionId,
                     phase: .failed,
@@ -579,10 +593,6 @@ final class AppState {
                 )
                 continue
             }
-            try? await acpOrchestrationPersistence.clearPendingInitialPrompt(
-                childSessionId: record.childSessionId,
-                updatedAt: Int64(Date().timeIntervalSince1970)
-            )
             try? await acpOrchestrationPersistence.updatePhase(
                 childSessionId: record.childSessionId,
                 phase: .ready,
@@ -4497,6 +4507,12 @@ final class AppState {
                     requestId: self.notificationRequestId(for: request)
                 )
             },
+            onDelegatedMessageAvailable: { [weak self] sessionId in
+                Task { @MainActor [weak self] in
+                    guard let self, let manager = self.acpManagers[worktree.id] else { return }
+                    await self.deliverPendingDelegatedMessages(to: sessionId, manager: manager)
+                }
+            },
             mcpProjectContextProvider: { [weak self] in
                 guard let project = self?.projects.first(where: { $0.id == worktree.projectId }) else {
                     return nil
@@ -4741,7 +4757,7 @@ final class AppState {
     func delegatedSessionSummaries(for sessionId: String) async -> [ACPOrchestrationSessionSummary] {
         let parent = try? await acpOrchestrationPersistence.parent(childSessionId: sessionId)
         let children = (try? await acpOrchestrationPersistence.children(parentSessionId: sessionId)) ?? []
-        var summaries = children.map { record in
+        var summaries: [ACPOrchestrationSessionSummary] = children.map { record in
             let runtime = record.childWorktreeId
                 .flatMap { acpManagers[$0]?.liveSession(for: record.childSessionId) }
                 .map { session -> ACPOrchestrationRuntimeState in
@@ -4751,7 +4767,7 @@ final class AppState {
                     case .awaitingPermission, .awaitingInput: return .awaitingInput
                     }
                 }
-            ACPOrchestrationSessionSummary(
+            return ACPOrchestrationSessionSummary(
                 sessionId: record.childSessionId,
                 relationship: "child",
                 agentId: record.agentId,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -533,8 +533,9 @@ final class AppState {
     private func reconcileInterruptedDelegations() async {
         guard let records = try? await acpOrchestrationPersistence.incompleteDelegations() else { return }
         for record in records {
-            guard let worktreeId = record.childWorktreeId,
-                  let worktree = worktree(withId: worktreeId),
+            let worktree = record.childWorktreeId.flatMap(worktree(withId:))
+                ?? worktree(atPersistedDestinationPath: record.worktreeRequest.destinationPath)
+            guard let worktree,
                   let prompt = record.pendingInitialPrompt,
                   let manager = acpManager(for: worktree)
             else {
@@ -545,6 +546,14 @@ final class AppState {
                     updatedAt: Int64(Date().timeIntervalSince1970)
                 )
                 continue
+            }
+            if record.childWorktreeId != worktree.id {
+                try? await acpOrchestrationPersistence.updateChildWorktree(
+                    childSessionId: record.childSessionId,
+                    worktreeId: worktree.id,
+                    phase: .starting,
+                    updatedAt: Int64(Date().timeIntervalSince1970)
+                )
             }
             delegatedSessionParents[record.childSessionId] = record.parentSessionId
             if await manager.persistedSessionRow(id: record.childSessionId) != nil {
@@ -2012,6 +2021,17 @@ final class AppState {
                     )
                 },
                 manager: { [weak self] worktree in self?.acpManager(for: worktree) },
+                newWorktreeDestination: { [weak self] projectId, branch in
+                    guard let self,
+                          let project = self.projects.first(where: { $0.id == projectId })
+                    else { return nil }
+                    return WorktreePathTemplateRenderer.render(
+                        template: self.config.worktrees.pathTemplate,
+                        worktreeRoot: self.config.worktrees.rootPath,
+                        repoName: project.name,
+                        branch: branch
+                    )
+                },
                 createWorktree: { [weak self] projectId, branch, base in
                     guard let self else {
                         return .failure(.init(message: "Alas is not available."))
@@ -3259,6 +3279,19 @@ final class AppState {
     private func worktree(withId id: String) -> Worktree? {
         for project in projects {
             if let worktree = projectsManager.worktrees(projectId: project.id).first(where: { $0.id == id }) {
+                return worktree
+            }
+        }
+        return nil
+    }
+
+    private func worktree(atPersistedDestinationPath path: String?) -> Worktree? {
+        guard let path, !path.isEmpty else { return nil }
+        let targetPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        for project in projects {
+            if let worktree = projectsManager.worktrees(projectId: project.id).first(where: {
+                $0.path.standardizedFileURL.path == targetPath
+            }) {
                 return worktree
             }
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -520,6 +520,9 @@ final class AppState {
         // hasn't finished by the first git command, gitEnv() falls back to the
         // process PATH (same behaviour as before).
         ShellEnvResolver.shared.resolve()
+        Task { [weak self] in
+            await self?.reconcileInterruptedDelegations()
+        }
     }
 
     /// All worktree IDs currently known to the projects manager (including
@@ -528,6 +531,19 @@ final class AppState {
         Set(projectsManager.projects.flatMap {
             projectsManager.worktrees(projectId: $0.id).map(\.id)
         })
+    }
+
+    private func reconcileInterruptedDelegations() async {
+        guard let records = try? await acpOrchestrationPersistence.incompleteDelegations() else { return }
+        let now = Int64(Date().timeIntervalSince1970)
+        for record in records {
+            try? await acpOrchestrationPersistence.updatePhase(
+                childSessionId: record.childSessionId,
+                phase: .failed,
+                failureMessage: "Alas stopped before delegated session setup completed. Retry from the session menu.",
+                updatedAt: now
+            )
+        }
     }
 
     func toggleRightPaneVisibility() {
@@ -4592,8 +4608,40 @@ final class AppState {
             title = "ACP session"
         }
         _ = mgr.placeholderSession(id: sessionId)
+        await deliverPendingDelegatedMessages(to: sessionId, manager: mgr)
         let state = ACPSessionTabState(sessionId: sessionId, title: title)
         tabs.append(acpSession: state, to: worktree.id)
+    }
+
+    private func deliverPendingDelegatedMessages(to sessionId: String, manager: ACPSessionManager) async {
+        guard let messages = try? await acpOrchestrationPersistence.pendingMessages(targetSessionId: sessionId) else {
+            return
+        }
+        await manager.attach(to: sessionId, freshlyCreated: false)
+        guard manager.isWriter(for: sessionId) else { return }
+        for message in messages {
+            guard let claimed = try? await acpOrchestrationPersistence.claimMessage(
+                id: message.id,
+                instanceId: instanceId,
+                token: UUID().uuidString,
+                now: Int64(Date().timeIntervalSince1970),
+                staleAfter: 60
+            ) else { continue }
+            let accepted = await manager.enqueueDelegatedPrompt(
+                text: claimed.message.prompt,
+                source: ACPDelegatedPromptSource(
+                    sessionId: claimed.message.sourceSessionId,
+                    messageId: claimed.message.id
+                ),
+                into: sessionId
+            )
+            if accepted {
+                try? await acpOrchestrationPersistence.removeDeliveredMessage(
+                    id: claimed.message.id,
+                    claim: claimed.claim
+                )
+            }
+        }
     }
 
     func delegatedSessionSummaries(for sessionId: String) async -> [ACPOrchestrationSessionSummary] {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -566,6 +566,7 @@ final class AppState {
                     autoRunDefault: config.harness.acpAutoRunByDefault
                 )
             }
+            let restoredPendingPrompt = record.pendingInitialPrompt != nil
             if let prompt = record.pendingInitialPrompt {
                 let accepted = await manager.enqueueDelegatedPrompt(
                     text: prompt,
@@ -584,10 +585,6 @@ final class AppState {
                     )
                     continue
                 }
-                try? await acpOrchestrationPersistence.clearPendingInitialPrompt(
-                    childSessionId: record.childSessionId,
-                    updatedAt: Int64(Date().timeIntervalSince1970)
-                )
             } else if !sessionAlreadyPersisted {
                 try? await acpOrchestrationPersistence.updatePhase(
                     childSessionId: record.childSessionId,
@@ -597,6 +594,24 @@ final class AppState {
                 )
                 continue
             }
+            await manager.attach(to: record.childSessionId, freshlyCreated: !sessionAlreadyPersisted)
+            guard let session = manager.liveSession(for: record.childSessionId),
+                  session.agentState == .ready
+            else {
+                try? await acpOrchestrationPersistence.updatePhase(
+                    childSessionId: record.childSessionId,
+                    phase: .failed,
+                    failureMessage: recoveredDelegatedSessionFailureMessage(manager.liveSession(for: record.childSessionId)),
+                    updatedAt: Int64(Date().timeIntervalSince1970)
+                )
+                continue
+            }
+            if restoredPendingPrompt {
+                try? await acpOrchestrationPersistence.clearPendingInitialPrompt(
+                    childSessionId: record.childSessionId,
+                    updatedAt: Int64(Date().timeIntervalSince1970)
+                )
+            }
             try? await acpOrchestrationPersistence.updatePhase(
                 childSessionId: record.childSessionId,
                 phase: .ready,
@@ -604,11 +619,24 @@ final class AppState {
                 updatedAt: Int64(Date().timeIntervalSince1970)
             )
             await deliverPendingDelegatedMessages(to: record.childSessionId, manager: manager)
-            Task { @MainActor [weak manager] in
-                await manager?.attach(to: record.childSessionId, freshlyCreated: false)
-            }
         }
         await drainRecoveredDelegatedMessageTargets()
+    }
+
+    private func recoveredDelegatedSessionFailureMessage(_ session: ACPSession?) -> String {
+        guard let session else { return "Could not restore delegated ACP session." }
+        switch session.setupState {
+        case .needsSetup(let reason), .setupError(let reason):
+            return reason
+        case .needsAuth(_, let reason):
+            return reason ?? "ACP session needs authentication."
+        case .checking, .ready:
+            break
+        }
+        if case .failed(let reason) = session.agentState {
+            return reason
+        }
+        return "Could not restore delegated ACP session."
     }
 
     private func drainRecoveredDelegatedMessageTargets() async {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1908,8 +1908,17 @@ final class AppState {
                 worktree: { [weak self] id in self?.worktree(withId: id) },
                 existingWorktree: { [weak self] projectId, worktreeId in
                     guard let self else { return nil }
-                    return self.projectsManager.visibleWorktrees(projectId: projectId)
-                        .first(where: { $0.id == worktreeId })
+                    let worktrees = self.projectsManager.visibleWorktrees(projectId: projectId)
+                    if let exactID = worktrees.first(where: { $0.id == worktreeId }) {
+                        return exactID
+                    }
+                    if case .matched(let worktree) = AlasCLIWorktreeResolver.resolve(
+                        target: worktreeId,
+                        worktrees: worktrees
+                    ) {
+                        return worktree
+                    }
+                    return nil
                 },
                 availableAgents: { [weak self] in
                     guard let self else { return [] }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -560,7 +560,11 @@ final class AppState {
                 _ = manager.placeholderSession(id: record.childSessionId)
                 await manager.hydrateIfNeeded(id: record.childSessionId)
             } else {
-                _ = manager.createSession(id: record.childSessionId, agentId: record.agentId)
+                _ = manager.createSession(
+                    id: record.childSessionId,
+                    agentId: record.agentId,
+                    autoRunDefault: config.harness.acpAutoRunByDefault
+                )
             }
             if let prompt = record.pendingInitialPrompt {
                 let accepted = await manager.enqueueDelegatedPrompt(
@@ -2050,6 +2054,9 @@ final class AppState {
                 },
                 rememberParent: { [weak self] childID, parentID in
                     self?.delegatedSessionParents[childID] = parentID
+                },
+                autoRunDefault: { [weak self] in
+                    self?.config.harness.acpAutoRunByDefault ?? false
                 },
                 notifyChanged: { }
             )

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4793,7 +4793,10 @@ final class AppState {
             return
         }
         await manager.attach(to: sessionId, freshlyCreated: false)
-        guard manager.isWriter(for: sessionId) else { return }
+        guard manager.isWriter(for: sessionId) else {
+            manager.notifyDelegatedMessagesAvailable()
+            return
+        }
         for message in messages {
             guard let claimed = try? await acpOrchestrationPersistence.claimMessage(
                 id: message.id,

--- a/Alas/Sources/App/WorktreeLaunchSurface.swift
+++ b/Alas/Sources/App/WorktreeLaunchSurface.swift
@@ -12,4 +12,6 @@ enum WorktreeLaunchSurface: Equatable {
     /// An ACP chat session tab is opened for `agentId`. The agent must be
     /// ACP-capable (present in `ACPLaunchCatalog.specs`).
     case acp(agentId: String)
+    /// An API-created worktree. It must not alter selection or open a tab.
+    case delegated
 }

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -42,6 +42,9 @@ struct AlasCLIRequest: Equatable {
         case notify(body: String, title: String?, level: AlasCLINotifyLevel)
         case worktree(WorktreeCommand)
         case review(ReviewCommand)
+        case sessionList
+        case sessionNew(prompt: String, agentID: String?, worktree: SessionWorktreeSelector)
+        case sessionSend(sessionID: String, prompt: String)
         case resolve
     }
 
@@ -60,6 +63,12 @@ struct AlasCLIRequest: Equatable {
         case resolve(commentID: String, reply: String?, reopen: Bool)
         case commentAdd(path: String, startLine: Int, endLine: Int?, side: String?, body: String, sessionID: String?)
         case finish(sessionID: String?, verdict: ReviewVerdict, summary: String)
+    }
+
+    enum SessionWorktreeSelector: Equatable {
+        case current
+        case existing(worktreeID: String)
+        case new(branch: String, base: String?)
     }
 
     let version: Int
@@ -137,6 +146,25 @@ struct AlasCLIRequest: Equatable {
         var body: String
         var title: String?
         var level: String?
+    }
+
+    private struct SessionListParams: Decodable {}
+
+    private struct SessionNewParams: Decodable {
+        struct NewWorktree: Decodable {
+            var branch: String
+            var base: String?
+        }
+
+        var prompt: String
+        var agent: String?
+        var worktree: String?
+        var new_worktree: NewWorktree?
+    }
+
+    private struct SessionSendParams: Decodable {
+        var session_id: String
+        var prompt: String
     }
 
     /// Typed access to the `params` object new-style commands carry.
@@ -319,6 +347,37 @@ struct AlasCLIRequest: Equatable {
                 verdict: verdict,
                 summary: params?.summary ?? ""
             ))
+        case "session_list":
+            _ = try Self.decodeParams(SessionListParams.self, from: data)
+            command = .sessionList
+        case "session_new":
+            let params = try Self.decodeParams(SessionNewParams.self, from: data)
+            let worktree: SessionWorktreeSelector
+            let existingWorktree = try params.worktree.map(requiredNonEmpty)
+            if let newWorktree = params.new_worktree {
+                guard existingWorktree == nil else {
+                    throw AlasCLIRequestError.malformed
+                }
+                worktree = .new(
+                    branch: try requiredNonEmpty(newWorktree.branch),
+                    base: newWorktree.base?.nilIfBlank
+                )
+            } else if let existingWorktree {
+                worktree = .existing(worktreeID: existingWorktree)
+            } else {
+                worktree = .current
+            }
+            command = .sessionNew(
+                prompt: try requiredNonEmpty(params.prompt),
+                agentID: try params.agent.map(requiredNonEmpty),
+                worktree: worktree
+            )
+        case "session_send":
+            let params = try Self.decodeParams(SessionSendParams.self, from: data)
+            command = .sessionSend(
+                sessionID: try requiredNonEmpty(params.session_id),
+                prompt: try requiredNonEmpty(params.prompt)
+            )
         case "resolve":
             command = .resolve
         default:

--- a/Alas/Sources/Persistence/Paths.swift
+++ b/Alas/Sources/Persistence/Paths.swift
@@ -41,6 +41,10 @@ extension Paths {
     static func acpSessionsDB(forWorktreeId id: String) -> URL {
         acpSessionsRoot.appendingPathComponent("\(id).sqlite")
     }
+
+    static var acpOrchestrationDB: URL {
+        appSupportRoot.appendingPathComponent("acp-orchestration.sqlite")
+    }
 }
 
 extension Paths {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -892,7 +892,7 @@ final class RemoteSessionGateway {
     ) -> RemoteWireMessage {
         let sid = "m\(index)"
         switch message {
-        case .user(_, _, let text, let attachments):
+        case .user(_, _, let text, let attachments, _):
             // The wire carries user text only; surface attachments as a labelled
             // placeholder so an image-only prompt isn't a blank bubble on the
             // phone (we don't serve the image bytes to the client in v1).

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -176,7 +176,29 @@ pub enum Command {
         verdict: Option<String>,
         summary: Option<String>,
     },
+    SessionList,
+    SessionNew {
+        prompt: String,
+        agent: Option<String>,
+        worktree: SessionWorktreeTarget,
+    },
+    SessionSend {
+        session_id: String,
+        prompt: String,
+    },
     Resolve,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SessionWorktreeTarget {
+    Current,
+    Existing {
+        worktree: String,
+    },
+    New {
+        branch: String,
+        base: Option<String>,
+    },
 }
 
 /// Build the wire request for a command, attaching whichever addressing the
@@ -192,7 +214,11 @@ pub fn build_request(
             r.paths = Some(paths.clone());
             r
         }
-        Command::OpenAt { path, line, end_line } => {
+        Command::OpenAt {
+            path,
+            line,
+            end_line,
+        } => {
             let mut r = Request::new("open");
             r.paths = Some(vec![path.clone()]);
             let mut params = serde_json::Map::new();
@@ -339,6 +365,47 @@ pub fn build_request(
                 params.insert("summary".into(), serde_json::Value::String(summary.clone()));
             }
             r.params = Some(serde_json::Value::Object(params));
+            r
+        }
+        Command::SessionList => {
+            let mut r = Request::new("session_list");
+            r.params = Some(serde_json::json!({}));
+            r
+        }
+        Command::SessionNew {
+            prompt,
+            agent,
+            worktree,
+        } => {
+            let mut r = Request::new("session_new");
+            let mut params = serde_json::Map::new();
+            params.insert("prompt".into(), serde_json::Value::String(prompt.clone()));
+            if let Some(agent) = agent {
+                params.insert("agent".into(), serde_json::Value::String(agent.clone()));
+            }
+            match worktree {
+                SessionWorktreeTarget::Current => {}
+                SessionWorktreeTarget::Existing { worktree } => {
+                    params.insert(
+                        "worktree".into(),
+                        serde_json::Value::String(worktree.clone()),
+                    );
+                }
+                SessionWorktreeTarget::New { branch, base } => {
+                    let mut target = serde_json::Map::new();
+                    target.insert("branch".into(), serde_json::Value::String(branch.clone()));
+                    if let Some(base) = base {
+                        target.insert("base".into(), serde_json::Value::String(base.clone()));
+                    }
+                    params.insert("new_worktree".into(), serde_json::Value::Object(target));
+                }
+            }
+            r.params = Some(serde_json::Value::Object(params));
+            r
+        }
+        Command::SessionSend { session_id, prompt } => {
+            let mut r = Request::new("session_send");
+            r.params = Some(serde_json::json!({ "session_id": session_id, "prompt": prompt }));
             r
         }
         Command::Resolve => Request::new("resolve"),
@@ -650,6 +717,43 @@ mod tests {
 
         let bare = serde_json::to_string(&Request::new("resolve")).unwrap();
         assert!(!bare.contains("params"), "absent params must not serialize");
+    }
+
+    #[test]
+    fn session_commands_use_params_and_preserve_the_injected_session_id() {
+        let new = Command::SessionNew {
+            prompt: "Task".into(),
+            agent: Some("codex".into()),
+            worktree: SessionWorktreeTarget::New {
+                branch: "child".into(),
+                base: Some("origin/main".into()),
+            },
+        };
+        let request = build_request(&new, Some("acp-1".into()), None);
+        assert_eq!(request.session_id.as_deref(), Some("acp-1"));
+        assert_eq!(
+            request.params,
+            Some(serde_json::json!({
+                "prompt": "Task",
+                "agent": "codex",
+                "new_worktree": { "branch": "child", "base": "origin/main" }
+            }))
+        );
+
+        let send = build_request(
+            &Command::SessionSend {
+                session_id: "child".into(),
+                prompt: "Follow up".into(),
+            },
+            Some("acp-1".into()),
+            None,
+        );
+        assert_eq!(send.command, "session_send");
+        assert_eq!(send.session_id.as_deref(), Some("acp-1"));
+        assert_eq!(
+            send.params,
+            Some(serde_json::json!({ "session_id": "child", "prompt": "Follow up" }))
+        );
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -4,7 +4,7 @@
 //! be the largest dependency in the workspace.
 
 use alas_client::{Command, Response, TransportError};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::path::PathBuf;
 
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
@@ -16,6 +16,7 @@ pub struct McpEnv {
     pub socket: PathBuf,
     pub worktree_dir: String,
     pub session_id: String,
+    pub parent_session_id: Option<String>,
 }
 
 /// Build the env from a lookup function (`std::env::var` in production,
@@ -37,6 +38,7 @@ pub fn env_from(get: impl Fn(&str) -> Option<String>) -> Result<McpEnv, String> 
         socket: PathBuf::from(socket),
         worktree_dir,
         session_id,
+        parent_session_id: get("ALAS_PARENT_SESSION_ID").filter(|s| !s.is_empty()),
     })
 }
 
@@ -46,6 +48,15 @@ pub fn env_from(get: impl Fn(&str) -> Option<String>) -> Result<McpEnv, String> 
 pub fn handle_line(
     line: &str,
     worktree_dir: &str,
+    mut dispatch: impl FnMut(&Command) -> Result<Response, TransportError>,
+) -> Option<Value> {
+    handle_line_with_parent(line, worktree_dir, None, dispatch)
+}
+
+fn handle_line_with_parent(
+    line: &str,
+    worktree_dir: &str,
+    parent_session_id: Option<&str>,
     mut dispatch: impl FnMut(&Command) -> Result<Response, TransportError>,
 ) -> Option<Value> {
     let msg: Value = match serde_json::from_str(line) {
@@ -62,7 +73,7 @@ pub fn handle_line(
         .and_then(Value::as_str)
         .unwrap_or_default();
     let reply = match method {
-        "initialize" => Ok(initialize_result()),
+        "initialize" => Ok(initialize_result(parent_session_id)),
         "ping" => Ok(json!({})),
         "tools/list" => Ok(json!({ "tools": tool_definitions() })),
         "tools/call" => {
@@ -77,12 +88,16 @@ pub fn handle_line(
     })
 }
 
-fn initialize_result() -> Value {
+fn initialize_result(parent_session_id: Option<&str>) -> Value {
+    let instructions = match parent_session_id {
+        Some(_) => "Tools that drive the user's Alas workspace UI. This session was delegated by a parent session: it cannot create descendants; return results or questions through session_send.",
+        None => "Tools that drive the user's Alas workspace UI: open files for the user to look at, manage linked worktrees, and open reviews. Root ACP sessions may delegate direct child sessions.",
+    };
     json!({
         "protocolVersion": PROTOCOL_VERSION,
         "capabilities": { "tools": {} },
         "serverInfo": { "name": "alas", "version": env!("CARGO_PKG_VERSION") },
-        "instructions": "Tools that drive the user's Alas workspace UI: open files for the user to look at, manage linked worktrees, and open reviews."
+        "instructions": instructions
     })
 }
 
@@ -677,7 +692,12 @@ pub fn serve(env: &McpEnv) -> std::io::Result<()> {
         if line.trim().is_empty() {
             continue;
         }
-        if let Some(reply) = handle_line(&line, &env.worktree_dir, |cmd| dispatch(env, cmd)) {
+        if let Some(reply) = handle_line_with_parent(
+            &line,
+            &env.worktree_dir,
+            env.parent_session_id.as_deref(),
+            |cmd| dispatch(env, cmd),
+        ) {
             let mut out = stdout.lock();
             out.write_all(reply.to_string().as_bytes())?;
             out.write_all(b"\n")?;
@@ -689,9 +709,9 @@ pub fn serve(env: &McpEnv) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{McpEnv, PROTOCOL_VERSION, command_for_tool, dispatch, env_from, handle_line};
+    use super::{command_for_tool, dispatch, env_from, handle_line, McpEnv, PROTOCOL_VERSION};
     use alas_client::Response;
-    use serde_json::{Value, json};
+    use serde_json::{json, Value};
 
     fn ok_dispatch(_: &alas_client::Command) -> Result<Response, alas_client::TransportError> {
         Ok(Response {
@@ -711,35 +731,27 @@ mod tests {
 
     #[test]
     fn env_from_requires_both_vars() {
-        assert!(
-            env_from(env(&[
-                ("ALAS_WORKTREE_DIR", "/wt"),
-                ("ALAS_SESSION_ID", "s1")
-            ]))
-            .is_err()
-        );
-        assert!(
-            env_from(env(&[
-                ("ALAS_SOCKET_PATH", "/tmp/s"),
-                ("ALAS_SESSION_ID", "s1")
-            ]))
-            .is_err()
-        );
-        assert!(
-            env_from(env(&[
-                ("ALAS_SOCKET_PATH", "/tmp/s"),
-                ("ALAS_WORKTREE_DIR", "/wt")
-            ]))
-            .is_err()
-        );
-        assert!(
-            env_from(env(&[
-                ("ALAS_SOCKET_PATH", ""),
-                ("ALAS_WORKTREE_DIR", "/wt"),
-                ("ALAS_SESSION_ID", "s1")
-            ]))
-            .is_err()
-        );
+        assert!(env_from(env(&[
+            ("ALAS_WORKTREE_DIR", "/wt"),
+            ("ALAS_SESSION_ID", "s1")
+        ]))
+        .is_err());
+        assert!(env_from(env(&[
+            ("ALAS_SOCKET_PATH", "/tmp/s"),
+            ("ALAS_SESSION_ID", "s1")
+        ]))
+        .is_err());
+        assert!(env_from(env(&[
+            ("ALAS_SOCKET_PATH", "/tmp/s"),
+            ("ALAS_WORKTREE_DIR", "/wt")
+        ]))
+        .is_err());
+        assert!(env_from(env(&[
+            ("ALAS_SOCKET_PATH", ""),
+            ("ALAS_WORKTREE_DIR", "/wt"),
+            ("ALAS_SESSION_ID", "s1")
+        ]))
+        .is_err());
         let ok = env_from(env(&[
             ("ALAS_SOCKET_PATH", "/tmp/s"),
             ("ALAS_WORKTREE_DIR", "/wt"),
@@ -753,14 +765,12 @@ mod tests {
 
     #[test]
     fn env_from_rejects_relative_worktree_dir() {
-        assert!(
-            env_from(env(&[
-                ("ALAS_SOCKET_PATH", "/tmp/s"),
-                ("ALAS_WORKTREE_DIR", "wt"),
-                ("ALAS_SESSION_ID", "s1")
-            ]))
-            .is_err()
-        );
+        assert!(env_from(env(&[
+            ("ALAS_SOCKET_PATH", "/tmp/s"),
+            ("ALAS_WORKTREE_DIR", "wt"),
+            ("ALAS_SESSION_ID", "s1")
+        ]))
+        .is_err());
     }
 
     #[test]
@@ -805,14 +815,12 @@ mod tests {
             }
         );
 
-        assert!(
-            command_for_tool(
-                "notify",
-                &json!({ "body": "Done", "level": "urgent" }),
-                "/wt"
-            )
-            .is_err()
-        );
+        assert!(command_for_tool(
+            "notify",
+            &json!({ "body": "Done", "level": "urgent" }),
+            "/wt"
+        )
+        .is_err());
         assert!(command_for_tool("notify", &json!({ "title": "Missing body" }), "/wt").is_err());
     }
 
@@ -930,14 +938,12 @@ mod tests {
             "/wt"
         )
         .is_err());
-        assert!(
-            command_for_tool(
-                "session_send",
-                &json!({ "session_id": "child", "prompt": "  " }),
-                "/wt"
-            )
-            .is_err()
-        );
+        assert!(command_for_tool(
+            "session_send",
+            &json!({ "session_id": "child", "prompt": "  " }),
+            "/wt"
+        )
+        .is_err());
     }
 
     #[test]
@@ -973,14 +979,12 @@ mod tests {
     fn open_rejects_invalid_line_targets() {
         assert!(command_for_tool("open", &json!({"path": "a", "line": 0}), "/wt").is_err());
         assert!(command_for_tool("open", &json!({"path": "a", "end_line": 2}), "/wt").is_err());
-        assert!(
-            command_for_tool(
-                "open",
-                &json!({"path": "a", "line": 3, "end_line": 2}),
-                "/wt"
-            )
-            .is_err()
-        );
+        assert!(command_for_tool(
+            "open",
+            &json!({"path": "a", "line": 3, "end_line": 2}),
+            "/wt"
+        )
+        .is_err());
         assert!(command_for_tool("open", &json!({"paths": ["a", "b"], "line": 2}), "/wt").is_err());
         assert!(command_for_tool("open", &json!({"path": "a", "paths": ["a"]}), "/wt").is_err());
     }
@@ -1137,14 +1141,12 @@ mod tests {
                 reopen: true
             }
         );
-        assert!(
-            command_for_tool(
-                "review_resolve",
-                &json!({"comment_id": "c1", "state": "bogus"}),
-                "/wt"
-            )
-            .is_err()
-        );
+        assert!(command_for_tool(
+            "review_resolve",
+            &json!({"comment_id": "c1", "state": "bogus"}),
+            "/wt"
+        )
+        .is_err());
     }
 
     #[test]
@@ -1165,30 +1167,24 @@ mod tests {
                 session_id: None,
             }
         );
-        assert!(
-            command_for_tool(
-                "review_comment_add",
-                &json!({"path": "a.swift", "body": "hm"}),
-                "/wt"
-            )
-            .is_err()
-        );
-        assert!(
-            command_for_tool(
-                "review_comment_add",
-                &json!({"path": "a.swift", "start_line": 0, "body": "hm"}),
-                "/wt"
-            )
-            .is_err()
-        );
-        assert!(
-            command_for_tool(
-                "review_comment_add",
-                &json!({"path": "a.swift", "start_line": 3, "body": "hm", "side": "sideways"}),
-                "/wt"
-            )
-            .is_err()
-        );
+        assert!(command_for_tool(
+            "review_comment_add",
+            &json!({"path": "a.swift", "body": "hm"}),
+            "/wt"
+        )
+        .is_err());
+        assert!(command_for_tool(
+            "review_comment_add",
+            &json!({"path": "a.swift", "start_line": 0, "body": "hm"}),
+            "/wt"
+        )
+        .is_err());
+        assert!(command_for_tool(
+            "review_comment_add",
+            &json!({"path": "a.swift", "start_line": 3, "body": "hm", "side": "sideways"}),
+            "/wt"
+        )
+        .is_err());
     }
 
     #[test]
@@ -1367,6 +1363,7 @@ mod tests {
             socket: path.clone(),
             worktree_dir: "/wt".into(),
             session_id: "acp-1".into(),
+            parent_session_id: None,
         };
         let resp = dispatch(&env, &alas_client::Command::WtList).unwrap();
         assert!(resp.ok);

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -132,6 +132,45 @@ pub fn tool_definitions() -> Vec<Value> {
             }
         }),
         json!({
+            "name": "session_list",
+            "description": "List this ACP session and its direct parent or children only. Returns structured state summaries without transcript content.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }),
+        json!({
+            "name": "session_new",
+            "description": "Asynchronously ask Alas to create a direct child ACP session. The child may use the current worktree, an existing project worktree, or a new linked worktree. The prompt is text-only and Alas does not automatically focus the child.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "prompt": { "type": "string", "description": "Initial text-only task for the child session." },
+                    "agent": { "type": "string", "description": "Optional enabled ACP-capable agent id. Defaults to this session's agent." },
+                    "worktree": { "type": "string", "description": "Existing project worktree name or branch. Mutually exclusive with new_worktree." },
+                    "new_worktree": {
+                        "type": "object",
+                        "description": "New linked worktree selector. Mutually exclusive with worktree.",
+                        "properties": {
+                            "branch": { "type": "string", "description": "Branch for the new linked worktree." },
+                            "base": { "type": "string", "description": "Optional base ref." }
+                        },
+                        "required": ["branch"]
+                    }
+                },
+                "required": ["prompt"]
+            }
+        }),
+        json!({
+            "name": "session_send",
+            "description": "Queue a text-only prompt for this session's direct parent or child. Delivery is asynchronous and does not automatically focus either session.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "session_id": { "type": "string", "description": "Direct parent or child session id." },
+                    "prompt": { "type": "string", "description": "Text-only prompt to queue." }
+                },
+                "required": ["session_id", "prompt"]
+            }
+        }),
+        json!({
             "name": "worktree_list",
             "description": "List this project's worktrees in Alas. The current worktree is marked with an asterisk.",
             "inputSchema": { "type": "object", "properties": {} }
@@ -326,6 +365,42 @@ pub fn command_for_tool(name: &str, args: &Value, worktree_dir: &str) -> Result<
                 level,
             })
         }
+        "session_list" => Ok(Command::SessionList),
+        "session_new" => {
+            let worktree = optional_non_blank_string(args, "worktree")?;
+            let agent = optional_non_blank_string(args, "agent")?;
+            let new_worktree = match args.get("new_worktree") {
+                None => None,
+                Some(Value::Object(new_worktree)) => {
+                    let branch = required_object_string(new_worktree, "branch", "new_worktree")?;
+                    let base = optional_object_string(new_worktree, "base", "new_worktree")?;
+                    Some((branch, base))
+                }
+                Some(_) => return Err("session_new 'new_worktree' must be an object".into()),
+            };
+            if worktree.is_some() && new_worktree.is_some() {
+                return Err(
+                    "session_new accepts either 'worktree' or 'new_worktree', not both".into(),
+                );
+            }
+            let worktree = match (worktree, new_worktree) {
+                (Some(worktree), None) => alas_client::SessionWorktreeTarget::Existing { worktree },
+                (None, Some((branch, base))) => {
+                    alas_client::SessionWorktreeTarget::New { branch, base }
+                }
+                (None, None) => alas_client::SessionWorktreeTarget::Current,
+                (Some(_), Some(_)) => unreachable!("mutual exclusion checked above"),
+            };
+            Ok(Command::SessionNew {
+                prompt: required_string(args, "prompt")?,
+                agent,
+                worktree,
+            })
+        }
+        "session_send" => Ok(Command::SessionSend {
+            session_id: required_string(args, "session_id")?,
+            prompt: required_string(args, "prompt")?,
+        }),
         "worktree_list" => Ok(Command::WtList),
         "worktree_switch" => Ok(Command::WtSwitch {
             target: required_string(args, "target")?,
@@ -459,6 +534,53 @@ fn optional_string(args: &Value, key: &str) -> Option<String> {
         .map(String::from)
 }
 
+fn optional_non_blank_string(args: &Value, key: &str) -> Result<Option<String>, String> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if !value.trim().is_empty() => {
+            Ok(Some(value.trim().to_string()))
+        }
+        Some(Value::String(_)) => Err(format!("{key} must be non-empty")),
+        Some(_) => Err(format!("{key} must be a string")),
+    }
+}
+
+fn required_object_string(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+    object_name: &str,
+) -> Result<String, String> {
+    match object.get(key) {
+        Some(Value::String(value)) if !value.trim().is_empty() => Ok(value.trim().to_string()),
+        Some(Value::String(_)) => Err(format!(
+            "session_new '{object_name}.{key}' must be non-empty"
+        )),
+        Some(_) => Err(format!(
+            "session_new '{object_name}.{key}' must be a string"
+        )),
+        None => Err(format!("session_new requires '{object_name}.{key}'")),
+    }
+}
+
+fn optional_object_string(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+    object_name: &str,
+) -> Result<Option<String>, String> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if !value.trim().is_empty() => {
+            Ok(Some(value.trim().to_string()))
+        }
+        Some(Value::String(_)) => Err(format!(
+            "session_new '{object_name}.{key}' must be non-empty"
+        )),
+        Some(_) => Err(format!(
+            "session_new '{object_name}.{key}' must be a string"
+        )),
+    }
+}
+
 /// Send one command to the owning app instance, addressed by worktree
 /// directory (never session id — the MCP server has no terminal session).
 pub fn dispatch(env: &McpEnv, command: &Command) -> Result<Response, TransportError> {
@@ -523,6 +645,9 @@ fn success_message(command: &Command) -> String {
         Command::ReviewResolve { reopen: true, .. } => "Comment reopened.".into(),
         Command::ReviewCommentAdd { path, .. } => format!("Filed review comment on {path}."),
         Command::ReviewFinish { .. } => "Review finished.".into(),
+        Command::SessionList => "No delegated sessions found.".into(),
+        Command::SessionNew { .. } => "Delegated session creation accepted.".into(),
+        Command::SessionSend { .. } => "Delegated prompt queued.".into(),
         Command::WtList | Command::Resolve => "OK".into(),
     }
 }
@@ -725,6 +850,9 @@ mod tests {
             [
                 "open",
                 "notify",
+                "session_list",
+                "session_new",
+                "session_send",
                 "worktree_list",
                 "worktree_switch",
                 "worktree_new",
@@ -755,6 +883,60 @@ mod tests {
             alas_client::Command::Open {
                 paths: vec!["/wt/a.txt".into(), "/abs/b.txt".into()]
             }
+        );
+    }
+
+    #[test]
+    fn session_tools_validate_and_map_arguments() {
+        assert_eq!(
+            command_for_tool("session_list", &json!({}), "/wt").unwrap(),
+            alas_client::Command::SessionList
+        );
+        assert_eq!(
+            command_for_tool(
+                "session_new",
+                &json!({
+                    "prompt": "Task",
+                    "agent": "codex",
+                    "new_worktree": { "branch": "child", "base": "origin/main" }
+                }),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::SessionNew {
+                prompt: "Task".into(),
+                agent: Some("codex".into()),
+                worktree: alas_client::SessionWorktreeTarget::New {
+                    branch: "child".into(),
+                    base: Some("origin/main".into())
+                }
+            }
+        );
+        assert_eq!(
+            command_for_tool(
+                "session_send",
+                &json!({ "session_id": "child", "prompt": "Follow up" }),
+                "/wt"
+            )
+            .unwrap(),
+            alas_client::Command::SessionSend {
+                session_id: "child".into(),
+                prompt: "Follow up".into()
+            }
+        );
+        assert!(command_for_tool(
+            "session_new",
+            &json!({ "prompt": "Task", "worktree": "main", "new_worktree": { "branch": "child" } }),
+            "/wt"
+        )
+        .is_err());
+        assert!(
+            command_for_tool(
+                "session_send",
+                &json!({ "session_id": "child", "prompt": "  " }),
+                "/wt"
+            )
+            .is_err()
         );
     }
 
@@ -791,24 +973,16 @@ mod tests {
     fn open_rejects_invalid_line_targets() {
         assert!(command_for_tool("open", &json!({"path": "a", "line": 0}), "/wt").is_err());
         assert!(command_for_tool("open", &json!({"path": "a", "end_line": 2}), "/wt").is_err());
-        assert!(command_for_tool(
-            "open",
-            &json!({"path": "a", "line": 3, "end_line": 2}),
-            "/wt"
-        )
-        .is_err());
-        assert!(command_for_tool(
-            "open",
-            &json!({"paths": ["a", "b"], "line": 2}),
-            "/wt"
-        )
-        .is_err());
-        assert!(command_for_tool(
-            "open",
-            &json!({"path": "a", "paths": ["a"]}),
-            "/wt"
-        )
-        .is_err());
+        assert!(
+            command_for_tool(
+                "open",
+                &json!({"path": "a", "line": 3, "end_line": 2}),
+                "/wt"
+            )
+            .is_err()
+        );
+        assert!(command_for_tool("open", &json!({"paths": ["a", "b"], "line": 2}), "/wt").is_err());
+        assert!(command_for_tool("open", &json!({"path": "a", "paths": ["a"]}), "/wt").is_err());
     }
 
     #[test]

--- a/AlasCLI/crates/alas/src/parse.rs
+++ b/AlasCLI/crates/alas/src/parse.rs
@@ -17,6 +17,9 @@ usage: alas wt list
 usage: alas wt switch <name-or-branch>
 usage: alas wt new <branch> [--base <ref>]
 usage: alas wt delete <name-or-branch> [--force] [--keep-branch]
+usage: alas session list
+usage: alas session new --prompt <text> [--agent <id>] [--worktree <name-or-branch> | --new-worktree <branch> [--base <ref>]]
+usage: alas session send <session-id> <prompt>
 usage: alas review [pr-number-or-url]
 usage: alas review comments [--state <active|resolved|dismissed|all>] [--session <id>]
 usage: alas review reply <comment-id> <body>
@@ -35,12 +38,79 @@ pub fn parse(args: &[String], base: &std::path::Path) -> Result<Command, String>
         }
         Some("notify") => parse_notify(&it.map(|s| s.as_str()).collect::<Vec<_>>()),
         Some("wt") => parse_wt(&it.map(|s| s.as_str()).collect::<Vec<_>>()),
+        Some("session") => parse_session(&it.map(|s| s.as_str()).collect::<Vec<_>>()),
         Some("review") => {
             let rest: Vec<&str> = it.map(String::as_str).collect();
             parse_review(&rest, base)
         }
         _ => Err(USAGE_ALL.into()),
     }
+}
+
+fn parse_session(args: &[&str]) -> Result<Command, String> {
+    match args.first().copied() {
+        Some("list") if args.len() == 1 => Ok(Command::SessionList),
+        Some("new") => parse_session_new(&args[1..]),
+        Some("send") => {
+            const USAGE: &str = "usage: alas session send <session-id> <prompt>";
+            if args.len() != 3 || args[1].trim().is_empty() || args[2].trim().is_empty() {
+                return Err(USAGE.into());
+            }
+            Ok(Command::SessionSend {
+                session_id: args[1].to_string(),
+                prompt: args[2].to_string(),
+            })
+        }
+        _ => Err(USAGE_ALL.into()),
+    }
+}
+
+fn parse_session_new(args: &[&str]) -> Result<Command, String> {
+    const USAGE: &str = "usage: alas session new --prompt <text> [--agent <id>] [--worktree <name-or-branch> | --new-worktree <branch> [--base <ref>]]";
+    let mut prompt = None;
+    let mut agent = None;
+    let mut existing_worktree = None;
+    let mut new_worktree = None;
+    let mut base = None;
+    let mut i = 0;
+    while i < args.len() {
+        let value = match args[i] {
+            "--prompt" => &mut prompt,
+            "--agent" => &mut agent,
+            "--worktree" => &mut existing_worktree,
+            "--new-worktree" => &mut new_worktree,
+            "--base" => &mut base,
+            _ => return Err(USAGE.into()),
+        };
+        if value.is_some() {
+            return Err(USAGE.into());
+        }
+        i += 1;
+        let Some(argument) = flag_value(args, i).filter(|argument| !argument.trim().is_empty())
+        else {
+            return Err(USAGE.into());
+        };
+        *value = Some(argument.to_string());
+        i += 1;
+    }
+    let prompt = prompt.ok_or(USAGE)?;
+    if existing_worktree.is_some() && new_worktree.is_some() {
+        return Err(USAGE.into());
+    }
+    if base.is_some() && new_worktree.is_none() {
+        return Err(USAGE.into());
+    }
+    let worktree = match (existing_worktree, new_worktree) {
+        (Some(worktree), None) => alas_client::SessionWorktreeTarget::Existing { worktree },
+        (None, Some(branch)) => alas_client::SessionWorktreeTarget::New { branch, base },
+        (None, None) => alas_client::SessionWorktreeTarget::Current,
+        (Some(_), Some(_)) => unreachable!("mutual exclusion checked above"),
+    };
+    Ok(Command::SessionNew {
+        prompt,
+        agent,
+        worktree,
+    })
 }
 
 fn parse_notify(args: &[&str]) -> Result<Command, String> {
@@ -90,8 +160,14 @@ usage: alas open <path> --line <n> [--end-line <n>]";
         return Ok(Command::Open { paths });
     }
     let (first, rest) = args.split_first().ok_or(USAGE)?;
-    if rest.iter().all(|arg| !matches!(*arg, "--line" | "--end-line")) {
-        let paths = args.iter().map(|path| alas_client::absolutize(base, path)).collect();
+    if rest
+        .iter()
+        .all(|arg| !matches!(*arg, "--line" | "--end-line"))
+    {
+        let paths = args
+            .iter()
+            .map(|path| alas_client::absolutize(base, path))
+            .collect();
         return Ok(Command::Open { paths });
     }
 
@@ -105,14 +181,24 @@ usage: alas open <path> --line <n> [--end-line <n>]";
                     return Err(USAGE.into());
                 }
                 i += 1;
-                line = Some(flag_value(rest, i).ok_or(USAGE)?.parse::<u64>().map_err(|_| USAGE)?);
+                line = Some(
+                    flag_value(rest, i)
+                        .ok_or(USAGE)?
+                        .parse::<u64>()
+                        .map_err(|_| USAGE)?,
+                );
             }
             "--end-line" => {
                 if end_line.is_some() {
                     return Err(USAGE.into());
                 }
                 i += 1;
-                end_line = Some(flag_value(rest, i).ok_or(USAGE)?.parse::<u64>().map_err(|_| USAGE)?);
+                end_line = Some(
+                    flag_value(rest, i)
+                        .ok_or(USAGE)?
+                        .parse::<u64>()
+                        .map_err(|_| USAGE)?,
+                );
             }
             _ => return Err(USAGE.into()),
         }
@@ -440,15 +526,27 @@ mod tests {
     #[test]
     fn open_preserves_flag_shaped_legacy_paths() {
         let cmd = parse(&s(&["open", "--notes"]), Path::new("/b")).unwrap();
-        assert_eq!(cmd, Command::Open { paths: vec!["/b/--notes".into()] });
+        assert_eq!(
+            cmd,
+            Command::Open {
+                paths: vec!["/b/--notes".into()]
+            }
+        );
 
         let cmd = parse(&s(&["open", "--"]), Path::new("/b")).unwrap();
-        assert_eq!(cmd, Command::Open { paths: vec!["/b/--".into()] });
+        assert_eq!(
+            cmd,
+            Command::Open {
+                paths: vec!["/b/--".into()]
+            }
+        );
 
         let cmd = parse(&s(&["open", "a.txt", "--", "--line"]), Path::new("/b")).unwrap();
         assert_eq!(
             cmd,
-            Command::Open { paths: vec!["/b/a.txt".into(), "/b/--line".into()] }
+            Command::Open {
+                paths: vec!["/b/a.txt".into(), "/b/--line".into()]
+            }
         );
     }
 
@@ -473,21 +571,27 @@ mod tests {
     fn open_rejects_invalid_line_targets() {
         assert!(parse(&s(&["open", "a.txt", "--line", "0"]), Path::new("/b")).is_err());
         assert!(parse(&s(&["open", "a.txt", "--end-line", "12"]), Path::new("/b")).is_err());
-        assert!(parse(
-            &s(&["open", "a.txt", "--line", "15", "--end-line", "12"]),
-            Path::new("/b")
-        )
-        .is_err());
-        assert!(parse(
-            &s(&["open", "a.txt", "b.txt", "--line", "12"]),
-            Path::new("/b")
-        )
-        .is_err());
-        assert!(parse(
-            &s(&["open", "a.txt", "--line", "12", "--line", "13"]),
-            Path::new("/b")
-        )
-        .is_err());
+        assert!(
+            parse(
+                &s(&["open", "a.txt", "--line", "15", "--end-line", "12"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
+        assert!(
+            parse(
+                &s(&["open", "a.txt", "b.txt", "--line", "12"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
+        assert!(
+            parse(
+                &s(&["open", "a.txt", "--line", "12", "--line", "13"]),
+                Path::new("/b")
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -855,6 +959,98 @@ mod tests {
                 target: Some("123".into())
             }
         );
+    }
+
+    #[test]
+    fn session_commands_parse_and_validate() {
+        assert_eq!(
+            parse(&s(&["session", "list"]), Path::new("/b")).unwrap(),
+            Command::SessionList
+        );
+        assert_eq!(
+            parse(
+                &s(&[
+                    "session",
+                    "new",
+                    "--prompt",
+                    "Task",
+                    "--agent",
+                    "codex",
+                    "--worktree",
+                    "feature",
+                ]),
+                Path::new("/b"),
+            )
+            .unwrap(),
+            Command::SessionNew {
+                prompt: "Task".into(),
+                agent: Some("codex".into()),
+                worktree: alas_client::SessionWorktreeTarget::Existing {
+                    worktree: "feature".into()
+                }
+            }
+        );
+        assert_eq!(
+            parse(
+                &s(&[
+                    "session",
+                    "new",
+                    "--prompt",
+                    "Task",
+                    "--new-worktree",
+                    "child",
+                    "--base",
+                    "origin/main",
+                ]),
+                Path::new("/b"),
+            )
+            .unwrap(),
+            Command::SessionNew {
+                prompt: "Task".into(),
+                agent: None,
+                worktree: alas_client::SessionWorktreeTarget::New {
+                    branch: "child".into(),
+                    base: Some("origin/main".into())
+                }
+            }
+        );
+        assert_eq!(
+            parse(
+                &s(&["session", "send", "child", "Follow-up"]),
+                Path::new("/b"),
+            )
+            .unwrap(),
+            Command::SessionSend {
+                session_id: "child".into(),
+                prompt: "Follow-up".into()
+            }
+        );
+        for invalid in [
+            ["session", "new", "--prompt", "Task", "--prompt", "Again"].as_slice(),
+            [
+                "session",
+                "new",
+                "--prompt",
+                "Task",
+                "--worktree",
+                "main",
+                "--new-worktree",
+                "child",
+            ]
+            .as_slice(),
+            [
+                "session",
+                "new",
+                "--prompt",
+                "Task",
+                "--base",
+                "origin/main",
+            ]
+            .as_slice(),
+            ["session", "send", "child"].as_slice(),
+        ] {
+            assert!(parse(&s(invalid), Path::new("/b")).is_err());
+        }
     }
 
     #[test]

--- a/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
+++ b/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
@@ -227,6 +227,32 @@ import Foundation
                 "writer must be able to persist the queue when it holds the lease")
     }
 
+    @Test("delegated delivery is not acknowledged when its fenced queue write fails")
+    func delegatedPromptRejectsFailedFencedQueueWrite() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("delegated-fenced-queue-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = tempManager(instanceId: "A", store: store)
+        let session = manager.createSession(agentId: "claude")
+        #expect(await manager.acquireWriterLease(sessionId: session.id))
+
+        try store.seizeLease(
+            sessionId: session.id,
+            instanceId: "B",
+            pid: Int64(getpid()),
+            now: Int64(Date().timeIntervalSince1970)
+        )
+
+        let accepted = await manager.enqueueDelegatedPrompt(
+            text: "retry through the active writer",
+            source: .init(sessionId: "parent", messageId: "message"),
+            into: session.id
+        )
+        #expect(!accepted)
+        #expect(session.queue.isEmpty)
+        #expect(try store.loadQueue(sessionId: session.id).isEmpty)
+    }
+
     // MARK: - P1: Stale-owner write block (store re-read)
 
     @Test("a former owner whose lease was seized cannot persist (store-lease re-read)")

--- a/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
+++ b/AlasTests/ACP/ACPSessionManagerLeaseTests.swift
@@ -583,7 +583,7 @@ import Foundation
         await mgrB.refreshMirror(sessionId: "s")
 
         #expect(mirrorSession.transcript.messages.count == ACPTranscript.tailWindow)
-        if case .user(_, _, let text, _) = mirrorSession.transcript.messages.first {
+        if case .user(_, _, let text, _, _) = mirrorSession.transcript.messages.first {
             #expect(text == "m\(total - ACPTranscript.tailWindow)")
         } else {
             Issue.record("expected first tail message")
@@ -591,7 +591,7 @@ import Foundation
 
         await mgrB.awaitBackfill(id: "s")
         #expect(mirrorSession.transcript.messages.count == total)
-        if case .user(_, _, let text, _) = mirrorSession.transcript.messages.first {
+        if case .user(_, _, let text, _, _) = mirrorSession.transcript.messages.first {
             #expect(text == "m0")
         } else {
             Issue.record("expected first backfilled message")

--- a/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
@@ -172,6 +172,34 @@ struct ACPOrchestrationStoreTests {
         #expect(try store.pendingMessages(targetSessionId: "child").map(\.id) == ["z-message", "a-message"])
     }
 
+    @Test("pending message targets are returned once in first-message order")
+    func pendingMessageTargetsAreDistinctAndOrdered() throws {
+        let store = try ACPOrchestrationStore(path: temporaryPath())
+        try store.enqueue(.init(
+            id: "child-2-first",
+            sourceSessionId: "parent",
+            targetSessionId: "child-2",
+            prompt: "second target",
+            createdAt: 110
+        ))
+        try store.enqueue(.init(
+            id: "child-1-first",
+            sourceSessionId: "parent",
+            targetSessionId: "child-1",
+            prompt: "first target",
+            createdAt: 100
+        ))
+        try store.enqueue(.init(
+            id: "child-1-second",
+            sourceSessionId: "parent",
+            targetSessionId: "child-1",
+            prompt: "same target",
+            createdAt: 120
+        ))
+
+        #expect(try store.pendingMessageTargetSessionIds() == ["child-1", "child-2"])
+    }
+
     @Test("released inbox claim can be immediately reclaimed")
     func releasesMessageClaim() throws {
         let store = try ACPOrchestrationStore(path: temporaryPath())

--- a/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
@@ -151,6 +151,27 @@ struct ACPOrchestrationStoreTests {
         #expect(try b.claimedMessage(id: "message")?.instanceId == "instance-a")
     }
 
+    @Test("messages with the same timestamp preserve insertion order")
+    func messagesWithSameTimestampPreserveInsertionOrder() throws {
+        let store = try ACPOrchestrationStore(path: temporaryPath())
+        try store.enqueue(.init(
+            id: "z-message",
+            sourceSessionId: "parent",
+            targetSessionId: "child",
+            prompt: "first",
+            createdAt: 100
+        ))
+        try store.enqueue(.init(
+            id: "a-message",
+            sourceSessionId: "parent",
+            targetSessionId: "child",
+            prompt: "second",
+            createdAt: 100
+        ))
+
+        #expect(try store.pendingMessages(targetSessionId: "child").map(\.id) == ["z-message", "a-message"])
+    }
+
     @Test("released inbox claim can be immediately reclaimed")
     func releasesMessageClaim() throws {
         let store = try ACPOrchestrationStore(path: temporaryPath())

--- a/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
@@ -99,7 +99,7 @@ struct ACPOrchestrationStoreTests {
         )
         try store.clearPendingInitialPrompt(childSessionId: "child", updatedAt: 130)
 
-        let record = try #require(store.delegation(childSessionId: "child"))
+        let record = try #require(try store.delegation(childSessionId: "child"))
         #expect(record.childWorktreeId == "real-worktree")
         #expect(record.phase == .failed)
         #expect(record.failureMessage == "Could not create worktree.")
@@ -170,7 +170,7 @@ struct ACPOrchestrationStoreTests {
             staleAfter: 10
         )
 
-        let claim = try #require(store.claimMessage(
+        let claim = try #require(try store.claimMessage(
             id: "message",
             instanceId: "new-instance",
             token: "new-token",

--- a/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP orchestration store")
+struct ACPOrchestrationStoreTests {
+    private func temporaryPath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-orchestration-\(UUID().uuidString).sqlite")
+            .path
+    }
+
+    private func newRecord(
+        childSessionId: String = "child",
+        parentSessionId: String = "parent",
+        request: ACPDelegatedWorktreeRequest = .current(worktreeId: "parent-worktree")
+    ) -> ACPDelegationRecord {
+        .init(
+            childSessionId: childSessionId,
+            parentSessionId: parentSessionId,
+            projectId: "project",
+            parentWorktreeId: "parent-worktree",
+            childWorktreeId: request.worktreeId,
+            agentId: "codex",
+            worktreeRequest: request,
+            pendingInitialPrompt: "Investigate the parser.",
+            phase: .starting,
+            failureMessage: nil,
+            createdAt: 100,
+            updatedAt: 100
+        )
+    }
+
+    @Test("creates schema and preserves delegation records across reopen")
+    func persistsDelegationAcrossReopen() throws {
+        let path = temporaryPath()
+        let record = newRecord()
+
+        do {
+            let store = try ACPOrchestrationStore(path: path)
+            #expect(try store.currentSchemaVersion() == ACPOrchestrationStore.targetSchemaVersion)
+            try store.insert(record)
+            #expect(try store.delegation(childSessionId: "child") == record)
+            #expect(try store.children(parentSessionId: "parent") == [record])
+            #expect(try store.parent(childSessionId: "child") == record)
+        }
+
+        let reopened = try ACPOrchestrationStore(path: path)
+        #expect(try reopened.delegation(childSessionId: "child") == record)
+    }
+
+    @Test("round trips every worktree request")
+    func roundTripsWorktreeRequests() throws {
+        let path = temporaryPath()
+        let store = try ACPOrchestrationStore(path: path)
+        let requests: [ACPDelegatedWorktreeRequest] = [
+            .current(worktreeId: "current"),
+            .existing(worktreeId: "existing"),
+            .new(
+                branch: "delegate/parser",
+                base: "origin/main",
+                destinationPath: "/tmp/alas-delegate-parser",
+                optimisticId: "optimistic"
+            ),
+        ]
+
+        for (index, request) in requests.enumerated() {
+            let record = newRecord(
+                childSessionId: "child-\(index)",
+                request: request
+            )
+            try store.insert(record)
+            #expect(try store.delegation(childSessionId: record.childSessionId) == record)
+        }
+    }
+
+    @Test("updates creation phase, worktree, failure, and pending prompt")
+    func updatesDelegationLifecycle() throws {
+        let path = temporaryPath()
+        let store = try ACPOrchestrationStore(path: path)
+        try store.insert(newRecord(request: .new(
+            branch: "delegate/parser",
+            base: nil,
+            destinationPath: "/tmp/alas-delegate-parser",
+            optimisticId: "optimistic"
+        )))
+
+        try store.updateChildWorktree(
+            childSessionId: "child",
+            worktreeId: "real-worktree",
+            phase: .starting,
+            updatedAt: 110
+        )
+        try store.updatePhase(
+            childSessionId: "child",
+            phase: .failed,
+            failureMessage: "Could not create worktree.",
+            updatedAt: 120
+        )
+        try store.clearPendingInitialPrompt(childSessionId: "child", updatedAt: 130)
+
+        let record = try #require(store.delegation(childSessionId: "child"))
+        #expect(record.childWorktreeId == "real-worktree")
+        #expect(record.phase == .failed)
+        #expect(record.failureMessage == "Could not create worktree.")
+        #expect(record.pendingInitialPrompt == nil)
+        #expect(record.updatedAt == 130)
+    }
+
+    @Test("rejects a duplicate child session id")
+    func rejectsDuplicateChild() throws {
+        let store = try ACPOrchestrationStore(path: temporaryPath())
+        try store.insert(newRecord())
+
+        #expect(throws: ACPOrchestrationStore.Error.duplicateChildSession("child")) {
+            try store.insert(newRecord(parentSessionId: "different-parent"))
+        }
+    }
+
+    @Test("stores and atomically claims a delegated message")
+    func claimsMessageOnceAcrossHandles() throws {
+        let path = temporaryPath()
+        let a = try ACPOrchestrationStore(path: path)
+        let b = try ACPOrchestrationStore(path: path)
+        let message = ACPDelegatedMessage(
+            id: "message",
+            sourceSessionId: "parent",
+            targetSessionId: "child",
+            prompt: "Please check malformed UTF-8.",
+            createdAt: 100
+        )
+        try a.enqueue(message)
+
+        let claimedByA = try a.claimMessage(
+            id: "message",
+            instanceId: "instance-a",
+            token: "token-a",
+            now: 110,
+            staleAfter: 30
+        )
+        let claimedByB = try b.claimMessage(
+            id: "message",
+            instanceId: "instance-b",
+            token: "token-b",
+            now: 110,
+            staleAfter: 30
+        )
+
+        #expect(claimedByA?.message == message)
+        #expect(claimedByB == nil)
+        #expect(try b.claimedMessage(id: "message")?.instanceId == "instance-a")
+    }
+
+    @Test("expired inbox claim can be reclaimed and delivery removes message")
+    func reclaimsExpiredMessageAndRemovesItAfterDelivery() throws {
+        let store = try ACPOrchestrationStore(path: temporaryPath())
+        let message = ACPDelegatedMessage(
+            id: "message",
+            sourceSessionId: "child",
+            targetSessionId: "parent",
+            prompt: "The parser accepts malformed UTF-8.",
+            createdAt: 100
+        )
+        try store.enqueue(message)
+        _ = try store.claimMessage(
+            id: "message",
+            instanceId: "stale-instance",
+            token: "stale-token",
+            now: 100,
+            staleAfter: 10
+        )
+
+        let claim = try #require(store.claimMessage(
+            id: "message",
+            instanceId: "new-instance",
+            token: "new-token",
+            now: 111,
+            staleAfter: 10
+        ))
+        try store.removeDeliveredMessage(id: "message", claim: claim.claim)
+
+        #expect(try store.pendingMessages(targetSessionId: "parent") == [])
+    }
+}

--- a/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
@@ -151,6 +151,36 @@ struct ACPOrchestrationStoreTests {
         #expect(try b.claimedMessage(id: "message")?.instanceId == "instance-a")
     }
 
+    @Test("released inbox claim can be immediately reclaimed")
+    func releasesMessageClaim() throws {
+        let store = try ACPOrchestrationStore(path: temporaryPath())
+        let message = ACPDelegatedMessage(
+            id: "message",
+            sourceSessionId: "parent",
+            targetSessionId: "child",
+            prompt: "Please retry delivery.",
+            createdAt: 100
+        )
+        try store.enqueue(message)
+        let claim = try #require(try store.claimMessage(
+            id: "message",
+            instanceId: "mirror-instance",
+            token: "mirror-token",
+            now: 110,
+            staleAfter: 60
+        ))
+
+        try store.releaseMessageClaim(id: message.id, claim: claim.claim)
+
+        #expect(try store.claimMessage(
+            id: "message",
+            instanceId: "writer-instance",
+            token: "writer-token",
+            now: 110,
+            staleAfter: 60
+        )?.message == message)
+    }
+
     @Test("expired inbox claim can be reclaimed and delivery removes message")
     func reclaimsExpiredMessageAndRemovesItAfterDelivery() throws {
         let store = try ACPOrchestrationStore(path: temporaryPath())

--- a/AlasTests/ACP/Orchestration/ACPSessionOrchestrationCoordinatorTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPSessionOrchestrationCoordinatorTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP session orchestration coordinator")
+struct ACPSessionOrchestrationCoordinatorTests {
+    @Test("child remains failed when initial attach needs setup")
+    func childStartPersistsAttachSetupFailure() async throws {
+        let orchestrationPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-orchestration-coordinator-\(UUID().uuidString).sqlite")
+            .path
+        let sessionPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-orchestration-coordinator-session-\(UUID().uuidString).sqlite")
+            .path
+        let persistence = ACPOrchestrationPersistence(path: orchestrationPath)
+        let sessionStore = try ACPSessionStore(path: sessionPath)
+        let manager = ACPSessionManager(
+            worktreeId: "worktree",
+            worktreePath: "/tmp/worktree",
+            store: sessionStore,
+            setupEvaluator: { _ in .missing(reason: "Install Codex") }
+        )
+        _ = manager.createSession(id: "parent", agentId: "codex", autoRunDefault: false)
+        let worktree = Worktree(
+            id: "worktree",
+            projectId: "project",
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/worktree"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        var now = 100
+        let coordinator = ACPSessionOrchestrationCoordinator(environment: .init(
+            persistence: persistence,
+            instanceId: "instance",
+            now: {
+                now += 1
+                return Int64(now)
+            },
+            makeID: { "child" },
+            worktree: { $0 == worktree.id ? worktree : nil },
+            existingWorktree: { _, _ in nil },
+            availableAgents: {
+                [ACPOrchestrationAgent(id: "codex", isEnabled: true, isACPCapable: true)]
+            },
+            sessionLocation: { sessionId in
+                sessionId == "parent"
+                    ? .init(origin: .init(sessionId: "parent", projectId: "project", worktreeId: "worktree"), manager: manager)
+                    : nil
+            },
+            manager: { _ in manager },
+            newWorktreeDestination: { _, _ in nil },
+            createWorktree: { _, _, _ in .failure(.init(message: "unused")) },
+            rememberParent: { _, _ in },
+            autoRunDefault: { false },
+            notifyChanged: {}
+        ))
+
+        let response = await coordinator.create(
+            origin: .init(sessionId: "parent", projectId: "project", worktreeId: "worktree"),
+            request: .init(prompt: "Investigate the parser.", agentId: nil, worktree: .current)
+        )
+
+        guard case .text = response else {
+            Issue.record("Expected delegated session creation response")
+            return
+        }
+        let record = try await eventuallyLoadDelegation(
+            persistence: persistence,
+            childSessionId: "child",
+            matching: { $0.phase == .failed }
+        )
+        #expect(record.failureMessage == "Install Codex")
+        #expect(record.pendingInitialPrompt == "Investigate the parser.")
+    }
+
+    private func eventuallyLoadDelegation(
+        persistence: ACPOrchestrationPersistence,
+        childSessionId: String,
+        matching predicate: (ACPDelegationRecord) -> Bool
+    ) async throws -> ACPDelegationRecord {
+        for _ in 0..<50 {
+            if let record = try await persistence.delegation(childSessionId: childSessionId),
+               predicate(record) {
+                return record
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        return try #require(try await persistence.delegation(childSessionId: childSessionId))
+    }
+}

--- a/AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
@@ -1,0 +1,199 @@
+import Testing
+@testable import Alas
+
+@Suite("ACP session orchestration policy")
+struct ACPSessionOrchestrationPolicyTests {
+    private let child = ACPDelegationRecord(
+        childSessionId: "child",
+        parentSessionId: "parent",
+        projectId: "project",
+        parentWorktreeId: "parent-worktree",
+        childWorktreeId: "child-worktree",
+        agentId: "codex",
+        worktreeRequest: .existing(worktreeId: "child-worktree"),
+        pendingInitialPrompt: nil,
+        phase: .ready,
+        failureMessage: nil,
+        createdAt: 10,
+        updatedAt: 20
+    )
+
+    @Test("root sessions may create children but delegated children may not")
+    func createAuthorization() {
+        #expect(ACPSessionOrchestrationPolicy.authorizeCreate(parent: nil) == .success(()))
+        #expect(
+            ACPSessionOrchestrationPolicy.authorizeCreate(parent: child)
+                == .failure(.delegatedSessionCannotCreateChild)
+        )
+    }
+
+    @Test("only direct parent-child edges may send prompts")
+    func sendAuthorization() {
+        #expect(
+            ACPSessionOrchestrationPolicy.authorizeSend(
+                callerSessionId: "parent",
+                callerProjectId: "project",
+                targetSessionId: "child",
+                targetProjectId: "project",
+                callerParent: nil,
+                targetParent: child
+            ) == .success(.child)
+        )
+        #expect(
+            ACPSessionOrchestrationPolicy.authorizeSend(
+                callerSessionId: "child",
+                callerProjectId: "project",
+                targetSessionId: "parent",
+                targetProjectId: "project",
+                callerParent: child,
+                targetParent: nil
+            ) == .success(.parent)
+        )
+        #expect(
+            ACPSessionOrchestrationPolicy.authorizeSend(
+                callerSessionId: "child",
+                callerProjectId: "project",
+                targetSessionId: "sibling",
+                targetProjectId: "project",
+                callerParent: child,
+                targetParent: ACPDelegationRecord(
+                    childSessionId: "sibling",
+                    parentSessionId: "parent",
+                    projectId: "project",
+                    parentWorktreeId: "parent-worktree",
+                    childWorktreeId: "sibling-worktree",
+                    agentId: "codex",
+                    worktreeRequest: .existing(worktreeId: "sibling-worktree"),
+                    pendingInitialPrompt: nil,
+                    phase: .ready,
+                    failureMessage: nil,
+                    createdAt: 10,
+                    updatedAt: 20
+                )
+            ) == .failure(.targetIsNotDirectRelative)
+        )
+    }
+
+    @Test("cross-project targets are rejected before edge evaluation")
+    func crossProjectSendIsRejected() {
+        #expect(
+            ACPSessionOrchestrationPolicy.authorizeSend(
+                callerSessionId: "parent",
+                callerProjectId: "project-a",
+                targetSessionId: "child",
+                targetProjectId: "project-b",
+                callerParent: nil,
+                targetParent: child
+            ) == .failure(.crossProjectTarget)
+        )
+    }
+
+    @Test("list visibility contains only self and direct relatives")
+    func visibility() {
+        let sibling = ACPDelegationRecord(
+            childSessionId: "other-child",
+            parentSessionId: "parent",
+            projectId: "project",
+            parentWorktreeId: "parent-worktree",
+            childWorktreeId: "other-worktree",
+            agentId: "claude",
+            worktreeRequest: .existing(worktreeId: "other-worktree"),
+            pendingInitialPrompt: nil,
+            phase: .ready,
+            failureMessage: nil,
+            createdAt: 30,
+            updatedAt: 30
+        )
+
+        #expect(
+            ACPSessionOrchestrationPolicy.visibleSessions(
+                callerSessionId: "parent",
+                parent: nil,
+                children: [child, sibling]
+            ).map(\.sessionId) == ["parent", "child", "other-child"]
+        )
+        #expect(
+            ACPSessionOrchestrationPolicy.visibleSessions(
+                callerSessionId: "child",
+                parent: child,
+                children: []
+            ).map(\.sessionId) == ["child", "parent"]
+        )
+    }
+
+    @Test("agent resolution inherits parent and rejects unavailable choices")
+    func resolvesAgent() {
+        let agents = [
+            ACPOrchestrationAgent(id: "codex", isEnabled: true, isACPCapable: true),
+            ACPOrchestrationAgent(id: "claude", isEnabled: false, isACPCapable: true),
+            ACPOrchestrationAgent(id: "terminal", isEnabled: true, isACPCapable: false),
+        ]
+
+        #expect(try ACPSessionOrchestrationPolicy.resolveAgent(
+            requestedId: nil,
+            parentAgentId: "codex",
+            available: agents
+        ) == "codex")
+        #expect(throws: ACPSessionOrchestrationPolicy.Error.agentUnavailable("claude")) {
+            _ = try ACPSessionOrchestrationPolicy.resolveAgent(
+                requestedId: "claude",
+                parentAgentId: "codex",
+                available: agents
+            )
+        }
+        #expect(throws: ACPSessionOrchestrationPolicy.Error.agentUnavailable("terminal")) {
+            _ = try ACPSessionOrchestrationPolicy.resolveAgent(
+                requestedId: "terminal",
+                parentAgentId: "codex",
+                available: agents
+            )
+        }
+    }
+
+    @Test("prompt validation rejects blank text")
+    func promptValidation() {
+        #expect(try ACPSessionOrchestrationPolicy.validatedPrompt("  Task\n") == "Task")
+        #expect(throws: ACPSessionOrchestrationPolicy.Error.blankPrompt) {
+            _ = try ACPSessionOrchestrationPolicy.validatedPrompt(" \n\t ")
+        }
+    }
+
+    @Test("projects persisted and runtime state into the public states")
+    func publicStateProjection() {
+        #expect(ACPSessionOrchestrationPolicy.publicState(
+            phase: .creatingWorktree,
+            runtime: nil,
+            archived: false
+        ) == .creatingWorktree)
+        #expect(ACPSessionOrchestrationPolicy.publicState(
+            phase: .starting,
+            runtime: .idle,
+            archived: false
+        ) == .starting)
+        #expect(ACPSessionOrchestrationPolicy.publicState(
+            phase: .ready,
+            runtime: .running,
+            archived: false
+        ) == .running)
+        #expect(ACPSessionOrchestrationPolicy.publicState(
+            phase: .ready,
+            runtime: .awaitingInput,
+            archived: false
+        ) == .awaitingInput)
+        #expect(ACPSessionOrchestrationPolicy.publicState(
+            phase: .ready,
+            runtime: .idle,
+            archived: false
+        ) == .idle)
+        #expect(ACPSessionOrchestrationPolicy.publicState(
+            phase: .failed,
+            runtime: .running,
+            archived: false
+        ) == .failed)
+        #expect(ACPSessionOrchestrationPolicy.publicState(
+            phase: .ready,
+            runtime: .idle,
+            archived: true
+        ) == .closed)
+    }
+}

--- a/AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
@@ -20,11 +20,14 @@ struct ACPSessionOrchestrationPolicyTests {
 
     @Test("root sessions may create children but delegated children may not")
     func createAuthorization() {
-        #expect(ACPSessionOrchestrationPolicy.authorizeCreate(parent: nil) == .success(()))
-        #expect(
-            ACPSessionOrchestrationPolicy.authorizeCreate(parent: child)
-                == .failure(.delegatedSessionCannotCreateChild)
-        )
+        guard case .success = ACPSessionOrchestrationPolicy.authorizeCreate(parent: nil) else {
+            Issue.record("Expected root session creation to succeed")
+            return
+        }
+        guard case .failure(.delegatedSessionCannotCreateChild) = ACPSessionOrchestrationPolicy.authorizeCreate(parent: child) else {
+            Issue.record("Expected delegated child creation to be rejected")
+            return
+        }
     }
 
     @Test("only direct parent-child edges may send prompts")
@@ -122,18 +125,19 @@ struct ACPSessionOrchestrationPolicyTests {
     }
 
     @Test("agent resolution inherits parent and rejects unavailable choices")
-    func resolvesAgent() {
+    func resolvesAgent() throws {
         let agents = [
             ACPOrchestrationAgent(id: "codex", isEnabled: true, isACPCapable: true),
             ACPOrchestrationAgent(id: "claude", isEnabled: false, isACPCapable: true),
             ACPOrchestrationAgent(id: "terminal", isEnabled: true, isACPCapable: false),
         ]
 
-        #expect(try ACPSessionOrchestrationPolicy.resolveAgent(
+        let inherited = try ACPSessionOrchestrationPolicy.resolveAgent(
             requestedId: nil,
             parentAgentId: "codex",
             available: agents
-        ) == "codex")
+        )
+        #expect(inherited == "codex")
         #expect(throws: ACPSessionOrchestrationPolicy.Error.agentUnavailable("claude")) {
             _ = try ACPSessionOrchestrationPolicy.resolveAgent(
                 requestedId: "claude",
@@ -151,8 +155,9 @@ struct ACPSessionOrchestrationPolicyTests {
     }
 
     @Test("prompt validation rejects blank text")
-    func promptValidation() {
-        #expect(try ACPSessionOrchestrationPolicy.validatedPrompt("  Task\n") == "Task")
+    func promptValidation() throws {
+        let prompt = try ACPSessionOrchestrationPolicy.validatedPrompt("  Task\n")
+        #expect(prompt == "Task")
         #expect(throws: ACPSessionOrchestrationPolicy.Error.blankPrompt) {
             _ = try ACPSessionOrchestrationPolicy.validatedPrompt(" \n\t ")
         }

--- a/AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
@@ -91,6 +91,19 @@ struct ACPSessionOrchestrationPolicyTests {
         )
     }
 
+    @Test("failed and closed delegated targets reject messages")
+    func failedAndClosedTargetsRejectMessages() {
+        var failedChild = child
+        failedChild.phase = .failed
+        var closedChild = child
+        closedChild.phase = .closed
+
+        #expect(!ACPSessionOrchestrationPolicy.acceptsMessages(target: failedChild))
+        #expect(!ACPSessionOrchestrationPolicy.acceptsMessages(target: closedChild))
+        #expect(ACPSessionOrchestrationPolicy.acceptsMessages(target: child))
+        #expect(ACPSessionOrchestrationPolicy.acceptsMessages(target: nil))
+    }
+
     @Test("list visibility contains only self and direct relatives")
     func visibility() {
         let sibling = ACPDelegationRecord(

--- a/AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
@@ -165,6 +165,8 @@ struct ACPSessionOrchestrationPolicyTests {
 
     @Test("projects persisted and runtime state into the public states")
     func publicStateProjection() {
+        #expect(ACPOrchestrationPublicState.creatingWorktree.rawValue == "creating_worktree")
+        #expect(ACPOrchestrationPublicState.awaitingInput.rawValue == "awaiting_input")
         #expect(ACPSessionOrchestrationPolicy.publicState(
             phase: .creatingWorktree,
             runtime: nil,

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -57,7 +57,7 @@ struct ACPMessageStableIdTests {
         s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text(" world"))))
 
         #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1", "acp-agent:agent-1"])
-        if case .user(_, _, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, _, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(text == "hello world")
             #expect(attachments.isEmpty)
         } else {
@@ -73,7 +73,7 @@ struct ACPMessageStableIdTests {
         s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("a"))))
 
         #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
-        if case .user(_, _, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, _, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(text == "aaa")
             #expect(attachments.isEmpty)
         } else {
@@ -90,7 +90,7 @@ struct ACPMessageStableIdTests {
 
         #expect(changed == [0])
         #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == "user-1")
             #expect(text == "hello world")
             #expect(attachments.isEmpty)
@@ -108,7 +108,7 @@ struct ACPMessageStableIdTests {
             content: .resourceLink(uri: "file:///tmp/example.swift", name: "example.swift"))))
 
         #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == "user-1")
             #expect(text == "")
             #expect(attachments == [
@@ -140,7 +140,7 @@ struct ACPMessageStableIdTests {
         s.apply(.userMessageChunk(.init(messageId: "user-1", content: .text("please"))))
 
         #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == "user-1")
             #expect(text == "see please")
             #expect(attachments == [
@@ -163,7 +163,7 @@ struct ACPMessageStableIdTests {
             content: .resourceLink(uri: "file:///tmp/example.swift", name: "example.swift"))))
 
         #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == "user-1")
             #expect(text == "see this")
             #expect(attachments == [attachment])
@@ -187,7 +187,7 @@ struct ACPMessageStableIdTests {
 
         #expect(changed == [0])
         #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == "user-1")
             #expect(text == "")
             #expect(attachments == [attachment])
@@ -215,7 +215,7 @@ struct ACPMessageStableIdTests {
         #expect(attachmentChanged == [0])
         #expect(textChanged == [0])
         #expect(s.transcript.messages.map(\.stableId) == ["acp-user:user-1"])
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == "user-1")
             #expect(text == "see this")
             #expect(attachments == [attachment])
@@ -245,7 +245,7 @@ struct ACPMessageStableIdTests {
         #expect(changed == [0])
         #expect(s.transcript.messages.count == 1)
         #expect(s.transcript.messages[0].stableId == "acp-user:user-1")
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == "user-1")
             #expect(text == "hello")
             #expect(attachments.isEmpty)
@@ -266,7 +266,7 @@ struct ACPMessageStableIdTests {
         #expect(secondChanged == [0])
         #expect(s.transcript.messages.count == 1)
         #expect(s.transcript.messages[0].stableId == "acp-user:user-1")
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == "user-1")
             #expect(text == "hello world")
             #expect(attachments.isEmpty)
@@ -284,7 +284,7 @@ struct ACPMessageStableIdTests {
 
         #expect(changed == [0])
         #expect(s.transcript.messages.count == 1)
-        if case .user(_, let messageId, let text, _) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, _, _) = s.transcript.messages[0] {
             #expect(messageId == nil)
             #expect(text == "hello")
         } else {
@@ -303,7 +303,7 @@ struct ACPMessageStableIdTests {
         #expect(firstChanged == [0])
         #expect(secondChanged == [0])
         #expect(s.transcript.messages.count == 1)
-        if case .user(_, let messageId, let text, _) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, _, _) = s.transcript.messages[0] {
             #expect(messageId == nil)
             #expect(text == "hello world")
         } else {
@@ -324,7 +324,7 @@ struct ACPMessageStableIdTests {
         #expect(firstChanged == [0])
         #expect(secondChanged == [0])
         #expect(s.transcript.messages.count == 1)
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == nil)
             #expect(text == "see ")
             #expect(attachments == [attachment])
@@ -343,7 +343,7 @@ struct ACPMessageStableIdTests {
         #expect(firstChanged == [0])
         #expect(secondChanged == [0])
         #expect(s.transcript.messages.count == 1)
-        if case .user(_, let messageId, let text, let attachments) = s.transcript.messages[0] {
+        if case .user(_, let messageId, let text, let attachments, _) = s.transcript.messages[0] {
             #expect(messageId == nil)
             #expect(text == "haha")
             #expect(attachments.isEmpty)

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -10,7 +10,7 @@ struct ACPMessageTests {
         let m = ACPMessage.user(id: UUID(), text: "hello", attachments: [.init(uri: "file:///a.swift", name: "a.swift")])
         let payload = try ACPMessageCodec.encode(m)
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
-        guard case .user(_, _, let text, let atts) = back else {
+        guard case .user(_, _, let text, let atts, _) = back else {
             Issue.record("expected user message")
             return
         }

--- a/AlasTests/ACP/Session/ACPMessageWireTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageWireTests.swift
@@ -13,12 +13,28 @@ struct ACPMessageWireTests {
             attachments: [.init(uri: "file:///x.txt", name: "x.txt")])
         let payload = try ACPMessageCodec.encode(original)
         let wire = try ACPMessageWire.decode(kind: "user", payload: payload)
-        guard case let .user(_, text, attachments) = wire else {
+        guard case let .user(_, text, attachments, source) = wire else {
             #expect(Bool(false), "expected .user, got \(wire)")
             return
         }
         #expect(text == "hello")
         #expect(attachments == [.init(uri: "file:///x.txt", name: "x.txt")])
+        #expect(source == nil)
+    }
+
+    @Test("delegated user provenance round-trips through the wire payload")
+    func delegatedUserRoundTrip() throws {
+        let source = ACPDelegatedPromptSource(sessionId: "parent", messageId: "message-1")
+        let original: ACPMessage = .user(
+            id: UUID(), messageId: "message-1", text: "delegate", attachments: [], delegatedSource: source)
+        let wire = try ACPMessageWire.decode(kind: "user", payload: try ACPMessageCodec.encode(original))
+        guard case let .user(messageId, text, _, decodedSource) = wire else {
+            Issue.record("expected user wire payload")
+            return
+        }
+        #expect(messageId == "message-1")
+        #expect(text == "delegate")
+        #expect(decodedSource == source)
     }
 
     @Test("decode round-trips agent text")

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -157,7 +157,7 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(client.sent.map(\.method) == ["initialize", "session/load"])
         #expect(session.transcript.messages.count == 3)
         #expect(try store.loadMessages(sessionId: "local").count == 3)
-        guard case .user(_, _, let text, let attachments) = session.transcript.messages[0] else {
+        guard case .user(_, _, let text, let attachments, _) = session.transcript.messages[0] else {
             Issue.record("Expected hydrated user message to remain first")
             return
         }
@@ -385,7 +385,7 @@ struct ACPSessionManagerAttachRestoreTests {
                 && session.queue.isEmpty
         }
         #expect(session.transcript.messages.count == 2)
-        guard case .user(_, _, let text, _) = session.transcript.messages[1] else {
+        guard case .user(_, _, let text, _, _) = session.transcript.messages[1] else {
             Issue.record("Expected queued prompt to append after hydrated transcript")
             return
         }

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -66,7 +66,7 @@ struct ACPSessionManagerHydrationTests {
 
         #expect(s.hydrationState == .ready)
         #expect(s.transcript.messages.count == 1)
-        if case .user(_, _, let text, _) = s.transcript.messages.first! {
+        if case .user(_, _, let text, _, _) = s.transcript.messages.first! {
             #expect(text == "hi")
         } else {
             #expect(Bool(false), "expected user message")
@@ -550,12 +550,12 @@ struct ACPSessionManagerHydrationTests {
         #expect(s.hydrationState == .ready)
         #expect(s.transcript.messages.count == ACPTranscript.tailWindow)
         #expect(s.transcript.visibleHead == 0)
-        if case .user(_, _, let text, _) = s.transcript.messages.first {
+        if case .user(_, _, let text, _, _) = s.transcript.messages.first {
             #expect(text == "m70")
         } else {
             #expect(Bool(false), "expected first visible message to be .user m70")
         }
-        if case .user(_, _, let text, _) = s.transcript.messages.last {
+        if case .user(_, _, let text, _, _) = s.transcript.messages.last {
             #expect(text == "m99")
         } else {
             #expect(Bool(false), "expected last visible message to be .user m99")
@@ -566,17 +566,17 @@ struct ACPSessionManagerHydrationTests {
         await mgr.awaitBackfill(id: "s")
         #expect(s.transcript.messages.count == 100)
         #expect(s.transcript.visibleHead == 100 - ACPTranscript.tailWindow)
-        if case .user(_, _, let text, _) = s.transcript.messages.first {
+        if case .user(_, _, let text, _, _) = s.transcript.messages.first {
             #expect(text == "m0")
         } else {
             #expect(Bool(false), "expected first message to be .user m0 after backfill")
         }
-        if case .user(_, _, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+        if case .user(_, _, let text, _, _) = s.transcript.messages[s.transcript.visibleHead] {
             #expect(text == "m70")
         } else {
             #expect(Bool(false), "expected message at visibleHead to be .user m70")
         }
-        if case .user(_, _, let text, _) = s.transcript.messages.last {
+        if case .user(_, _, let text, _, _) = s.transcript.messages.last {
             #expect(text == "m99")
         } else {
             #expect(Bool(false), "expected last message to be .user m99 after backfill")
@@ -612,7 +612,7 @@ struct ACPSessionManagerHydrationTests {
 
         #expect(s.transcript.messages.count == ACPTranscript.tailWindow)
         #expect(s.transcript.visibleHead == 0)
-        if case .user(_, _, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+        if case .user(_, _, let text, _, _) = s.transcript.messages[s.transcript.visibleHead] {
             #expect(text == "m70")
         } else {
             #expect(Bool(false), "expected first tail message before backfill")
@@ -622,7 +622,7 @@ struct ACPSessionManagerHydrationTests {
 
         #expect(s.transcript.messages.count == 100)
         #expect(s.transcript.visibleHead == 5)
-        if case .user(_, _, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+        if case .user(_, _, let text, _, _) = s.transcript.messages[s.transcript.visibleHead] {
             #expect(text == "m5")
         } else {
             #expect(Bool(false), "expected remembered absolute index after backfill")
@@ -667,7 +667,7 @@ struct ACPSessionManagerHydrationTests {
         await mgr.hydrateIfNeeded(id: "s")
         await mgr.awaitBackfill(id: "s")
 
-        if case .user(_, _, let text, _) = reopened.transcript.messages[reopened.transcript.visibleHead] {
+        if case .user(_, _, let text, _, _) = reopened.transcript.messages[reopened.transcript.visibleHead] {
             #expect(text == "m40")
         } else {
             #expect(Bool(false), "expected remembered anchor row to be a user message")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -5,6 +5,29 @@ import Testing
 @MainActor
 @Suite("ACPSessionManager")
 struct ACPSessionManagerTests {
+    @Test("delegated prompt already recorded in the transcript is not requeued")
+    func delegatedPromptRecordedInTranscriptIsNotRequeued() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-delegated-dedupe-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = manager.createSession(agentId: "claude")
+        let source = ACPDelegatedPromptSource(sessionId: "parent", messageId: "message")
+        session.transcript.messages.append(.user(
+            id: UUID(),
+            messageId: nil,
+            text: "already sent",
+            attachments: [],
+            delegatedSource: source
+        ))
+
+        #expect(await manager.enqueueDelegatedPrompt(
+            text: "already sent",
+            source: source,
+            into: session.id
+        ))
+        #expect(session.queue.isEmpty)
+    }
+
     @Test("creating a session inserts it and persists the row")
     func create() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRecoveryIntegrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRecoveryIntegrationTests.swift
@@ -73,7 +73,7 @@ struct ACPSessionRecoveryIntegrationTests {
 
         #expect(session.hydrationState == .ready)
         #expect(session.transcript.messages.count == 1)
-        if case .user(_, _, let text, _) = session.transcript.messages.first! {
+        if case .user(_, _, let text, _, _) = session.transcript.messages.first! {
             #expect(text == "persisted hello")
         } else {
             Issue.record("expected hydrated transcript head to be a user message")

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -290,7 +290,7 @@ struct ACPSessionRunnerQueueTests {
         #expect(session.queue[0].transcriptRecorded == true)
         var userTexts: [String] = []
         for msg in session.transcript.messages {
-            if case .user(_, _, let text, _) = msg { userTexts.append(text) }
+            if case .user(_, _, let text, _, _) = msg { userTexts.append(text) }
         }
         #expect(userTexts == ["queued-q"])
     }
@@ -375,7 +375,7 @@ struct ACPSessionRunnerQueueTests {
         #expect(prompts.count == 1)
         var userTexts: [String] = []
         for msg in session.transcript.messages {
-            if case .user(_, _, let text, _) = msg { userTexts.append(text) }
+            if case .user(_, _, let text, _, _) = msg { userTexts.append(text) }
         }
         #expect(userTexts == ["selected"])
         #expect(session.queue.isEmpty)
@@ -404,7 +404,7 @@ struct ACPSessionRunnerQueueTests {
         #expect(prompts.count == 1)
         var userTexts: [String] = []
         for msg in session.transcript.messages {
-            if case .user(_, _, let text, _) = msg { userTexts.append(text) }
+            if case .user(_, _, let text, _, _) = msg { userTexts.append(text) }
         }
         #expect(userTexts == ["selected"])
     }

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -362,7 +362,8 @@ struct ACPSessionRunnerQueueTests {
         session.agentState = .ready
         session.transcript.streamingState = .streaming
         session.enqueue(blocks: [.text("first")])
-        session.enqueue(blocks: [.text("selected")])
+        let source = ACPDelegatedPromptSource(sessionId: "parent", messageId: "delegated-message")
+        session.enqueue(blocks: [.text("selected")], delegatedSource: source)
         session.enqueue(blocks: [.text("third")])
         let selectedId = session.queue[1].id
         runner.persistQueue()
@@ -374,10 +375,15 @@ struct ACPSessionRunnerQueueTests {
         let prompts = mock.sent.filter { $0.method == "session/prompt" }
         #expect(prompts.count == 1)
         var userTexts: [String] = []
+        var delegatedSources: [ACPDelegatedPromptSource?] = []
         for msg in session.transcript.messages {
-            if case .user(_, _, let text, _, _) = msg { userTexts.append(text) }
+            if case .user(_, _, let text, _, let delegatedSource) = msg {
+                userTexts.append(text)
+                delegatedSources.append(delegatedSource)
+            }
         }
         #expect(userTexts == ["selected"])
+        #expect(delegatedSources == [source])
         #expect(session.queue.isEmpty)
         #expect(runner.steerUndoSnapshot()?.map { $0.blocks } == [[.text("first")], [.text("third")]])
         #expect(try store.loadQueue(sessionId: "s").isEmpty)

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -107,9 +107,9 @@ struct ACPSessionRunnerTests {
 
         try await waitUntil {
             session.transcript.messages.contains {
-                    if case .user(_, _, "hello", _, _, _) = -e { return true }
-                    return false
-                }
+                if case .user(_, _, "hello", _, _, _) = $0 { return true }
+                return false
+            }
         }
         #expect(try store.loadComposerDraft(sessionId: "s") == submitted)
         #expect(completion == nil)

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -106,10 +106,10 @@ struct ACPSessionRunnerTests {
         }
 
         try await waitUntil {
-            session.transcript.messages.contains {
-                if case .user(_, _, "hello", _, _, _) = $0 { return true }
+            session.transcript.messages.contains(where: {
+                if case .user(_, _, "hello", _, _) = $0 { return true }
                 return false
-            }
+            })
         }
         #expect(try store.loadComposerDraft(sessionId: "s") == submitted)
         #expect(completion == nil)

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -107,7 +107,7 @@ struct ACPSessionRunnerTests {
 
         try await waitUntil {
             session.transcript.messages.contains {
-                    if case .user(_, _, "hello", _) = $0 { return true }
+                    if case .user(_, _, "hello", _, _, _) = -e { return true }
                     return false
                 }
         }
@@ -208,9 +208,9 @@ struct ACPSessionRunnerTests {
                 && session.transcript.messages.count >= 3
         }
 
-        if case .user(_, _, let firstUser, _) = session.transcript.messages[0],
+        if case .user(_, _, let firstUser, _, _) = session.transcript.messages[0],
            case .agent(_, _, let firstAnswer) = session.transcript.messages[1],
-           case .user(_, _, let secondUser, _) = session.transcript.messages[2] {
+           case .user(_, _, let secondUser, _, _) = session.transcript.messages[2] {
             #expect(firstUser == "hello")
             #expect(firstAnswer.value == "first second")
             #expect(secondUser == "next")
@@ -1408,7 +1408,7 @@ struct ACPSessionRunnerTests {
             session.transcript.messages.count >= 2
         }
         guard case .agent(_, _, let text) = session.transcript.messages[0],
-              case .user(_, _, let prompt, _) = session.transcript.messages[1]
+              case .user(_, _, let prompt, _, _) = session.transcript.messages[1]
         else {
             Issue.record("expected buffered agent text before the next user prompt")
             return

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -939,7 +939,7 @@ struct ACPSessionTests {
 
         #expect(changed.isEmpty)
         #expect(session.transcript.messages.count == 2)
-        if case .user(_, _, let text, let attachments) = session.transcript.messages[0] {
+        if case .user(_, _, let text, let attachments, _) = session.transcript.messages[0] {
             #expect(text == "earlier prompt")
             #expect(attachments.isEmpty)
         } else {
@@ -1027,7 +1027,7 @@ struct ACPSessionTests {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         session.recordUserPrompt(text: "hi", attachments: [])
         #expect(session.transcript.messages.count == 1)
-        if case .user(_, _, let text, _) = session.transcript.messages[0] { #expect(text == "hi") }
+        if case .user(_, _, let text, _, _) = session.transcript.messages[0] { #expect(text == "hi") }
         else { Issue.record("expected user message") }
     }
 

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -371,7 +371,7 @@ struct ACPSessionTests {
         let texts: [String] = session.transcript.messages.compactMap { message in
             switch message {
             case .agent(_, _, let t): return "agent:\(t.value)"
-            case .user(_, _, let t, _): return "user:\(t)"
+            case .user(_, _, let t, _, _): return "user:\(t)"
             default: return nil
             }
         }
@@ -437,7 +437,7 @@ struct ACPSessionTests {
         let texts: [String] = session.transcript.messages.compactMap { message in
             switch message {
             case .agent(_, _, let t): return "agent:\(t.value)"
-            case .user(_, _, let t, _): return "user:\(t)"
+            case .user(_, _, let t, _, _): return "user:\(t)"
             default: return nil
             }
         }

--- a/AlasTests/ACP/Session/QueuedPromptTests.swift
+++ b/AlasTests/ACP/Session/QueuedPromptTests.swift
@@ -72,6 +72,18 @@ struct QueuedPromptTests {
         #expect(decoded.draft == nil)
     }
 
+    @Test("delegated provenance round-trips while legacy JSON remains valid")
+    func delegatedProvenanceRoundTrip() throws {
+        let source = ACPDelegatedPromptSource(sessionId: "parent", messageId: "message-1")
+        let prompt = QueuedPrompt(
+            id: UUID(), blocks: [.text("delegate")], enqueuedAt: .init(), delegatedSource: source)
+        let data = try JSONEncoder().encode(prompt)
+        #expect(try JSONDecoder().decode(QueuedPrompt.self, from: data).delegatedSource == source)
+
+        let legacy = #"{"id":"00000000-0000-0000-0000-000000000001","blocks":[{"type":"text","text":"legacy"}],"enqueuedAt":0,"status":"pending"}"#
+        #expect(try JSONDecoder().decode(QueuedPrompt.self, from: Data(legacy.utf8)).delegatedSource == nil)
+    }
+
     @Test("restorableDraft prefers the stored draft, else falls back to the blocks heuristic")
     func restorableDraftFallback() {
         let draft = ACPComposerDraft(segments: [.text("kept")])

--- a/AlasTests/ACP/UI/ACPDelegatedSessionsPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPDelegatedSessionsPolicyTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import Alas
+
+@Suite("Delegated ACP session status labels")
+struct ACPDelegatedSessionsPolicyTests {
+    @Test("renders public creating-worktree state")
+    func creatingWorktreeState() {
+        #expect(ACPDelegatedSessionsPolicy.statusLabel(for: "creating_worktree") == "Creating worktree")
+    }
+}

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -1487,6 +1487,96 @@ struct AlasCLICommandRouterTests {
         #expect(message.contains("unknown review comment id"))
     }
 
+    @Test func sessionCommandsForwardTheirResolvedACPOrigin() async throws {
+        let worktree = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        let origin = ACPOrchestrationSessionOrigin(
+            sessionId: "acp-1",
+            projectId: "p1",
+            worktreeId: worktree.id
+        )
+        var listedOrigin: ACPOrchestrationSessionOrigin?
+        var created: (origin: ACPOrchestrationSessionOrigin, request: ACPDelegatedSessionNewRequest)?
+        var sent: (origin: ACPOrchestrationSessionOrigin, request: ACPDelegatedSessionMessageRequest)?
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in worktree.id },
+            resolveACPSessionOrigin: { $0 == "acp-1" ? origin : nil },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in },
+            openExternalFile: { _, _ in },
+            listDelegatedSessions: { resolvedOrigin in
+                listedOrigin = resolvedOrigin
+                return .text([#"{"sessions":[]}"#])
+            },
+            createDelegatedSession: { resolvedOrigin, request in
+                created = (resolvedOrigin, request)
+                return .text([#"{"session_id":"child"}"#])
+            },
+            sendDelegatedSessionMessage: { resolvedOrigin, request in
+                sent = (resolvedOrigin, request)
+                return .text([#"{"queued":true}"#])
+            },
+            activateApp: {}
+        )
+
+        let list = await router.handle(.init(version: 1, sessionId: "acp-1", cwd: nil, command: .sessionList))
+        let create = await router.handle(.init(
+            version: 1,
+            sessionId: "acp-1",
+            cwd: nil,
+            command: .sessionNew(
+                prompt: "Implement this",
+                agentID: "codex",
+                worktree: .new(branch: "child", base: "origin/main")
+            )
+        ))
+        let send = await router.handle(.init(
+            version: 1,
+            sessionId: "acp-1",
+            cwd: nil,
+            command: .sessionSend(sessionID: "child", prompt: "Please continue")
+        ))
+
+        #expect(listedOrigin == origin)
+        #expect(created?.origin == origin)
+        #expect(created?.request == ACPDelegatedSessionNewRequest(
+            prompt: "Implement this",
+            agentId: "codex",
+            worktree: .new(branch: "child", base: "origin/main")
+        ))
+        #expect(sent?.origin == origin)
+        #expect(sent?.request == ACPDelegatedSessionMessageRequest(
+            targetSessionId: "child",
+            prompt: "Please continue"
+        ))
+        #expect(list == .text([#"{"sessions":[]}"#]))
+        #expect(create == .text([#"{"session_id":"child"}"#]))
+        #expect(send == .text([#"{"queued":true}"#]))
+    }
+
+    @Test func sessionCommandsRequireAnOriginatingACPSession() async throws {
+        let worktree = Self.worktree(branch: "main", path: "/tmp/repo", projectId: "p1")
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { $0 == "terminal-1" ? worktree.id : nil },
+            resolveACPSessionOrigin: { _ in nil },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in },
+            openExternalFile: { _, _ in },
+            activateApp: {}
+        )
+
+        let terminal = await router.handle(.init(
+            version: 1, sessionId: "terminal-1", cwd: nil, command: .sessionList
+        ))
+        let directory = await router.handle(.init(
+            version: 1, sessionId: nil, cwd: worktree.path.path, command: .sessionList
+        ))
+
+        #expect(terminal == .error("session commands require an originating ACP session"))
+        #expect(directory == .error("session commands require an originating ACP session"))
+    }
+
     private static func router(
         origin: Worktree,
         visibleWorktrees: [Worktree],

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -130,6 +130,47 @@ struct AlasCLIRequestTests {
         #expect(request.command == .notify(body: "Background task finished", title: "Done", level: .info))
     }
 
+    @Test func decodesSessionOrchestrationRequests() throws {
+        let list = #"{"v":1,"kind":"cli","command":"session_list","session_id":"s1","future_transport_field":true,"params":{"future_param":true}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(list.utf8)).command == .sessionList)
+
+        let current = #"{"v":1,"kind":"cli","command":"session_new","session_id":"s1","params":{"prompt":"Task"}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(current.utf8)).command == .sessionNew(
+            prompt: "Task", agentID: nil, worktree: .current
+        ))
+
+        let existing = #"{"v":1,"kind":"cli","command":"session_new","session_id":"s1","params":{"prompt":"Task","agent":"codex","worktree":"feature"}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(existing.utf8)).command == .sessionNew(
+            prompt: "Task", agentID: "codex", worktree: .existing(worktreeID: "feature")
+        ))
+
+        let fresh = #"{"v":1,"kind":"cli","command":"session_new","session_id":"s1","params":{"prompt":"Task","new_worktree":{"branch":"child","base":"origin/main"}}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(fresh.utf8)).command == .sessionNew(
+            prompt: "Task", agentID: nil, worktree: .new(branch: "child", base: "origin/main")
+        ))
+
+        let send = #"{"v":1,"kind":"cli","command":"session_send","session_id":"s1","params":{"session_id":"child","prompt":"Follow up"}}"#
+        #expect(try AlasCLIRequest.decode(from: Data(send.utf8)).command == .sessionSend(
+            sessionID: "child", prompt: "Follow up"
+        ))
+    }
+
+    @Test func rejectsInvalidSessionOrchestrationRequests() throws {
+        for invalid in [
+            #"{"v":1,"kind":"cli","command":"session_list","session_id":"s1"}"#,
+            #"{"v":1,"kind":"cli","command":"session_new","session_id":"s1","params":{"prompt":"   "}}"#,
+            #"{"v":1,"kind":"cli","command":"session_new","session_id":"s1","params":{"prompt":"Task","agent":"  "}}"#,
+            #"{"v":1,"kind":"cli","command":"session_new","session_id":"s1","params":{"prompt":"Task","worktree":"  "}}"#,
+            #"{"v":1,"kind":"cli","command":"session_new","session_id":"s1","params":{"prompt":"Task","worktree":"feature","new_worktree":{"branch":"child"}}}"#,
+            #"{"v":1,"kind":"cli","command":"session_new","session_id":"s1","params":{"prompt":"Task","new_worktree":{"branch":"  "}}}"#,
+            #"{"v":1,"kind":"cli","command":"session_send","session_id":"s1","params":{"session_id":"child","prompt":3}}"#,
+        ] {
+            #expect(throws: AlasCLIRequestError.malformed, "should reject: \(invalid)") {
+                try AlasCLIRequest.decode(from: Data(invalid.utf8))
+            }
+        }
+    }
+
     @Test func rejectsInvalidNotifyRequests() throws {
         for bad in [
             #"{"v":1,"kind":"cli","command":"notify","session_id":"s1"}"#,

--- a/docs/superpowers/plans/2026-07-15-mcp-agent-session-orchestration.md
+++ b/docs/superpowers/plans/2026-07-15-mcp-agent-session-orchestration.md
@@ -1,0 +1,923 @@
+# MCP Agent Session Orchestration Implementation Plan
+
+> **For implementers:** Execute this plan task-by-task. Keep each task
+> independently tested and commit at the listed boundary before moving on.
+
+**Goal:** Add `session_list`, `session_new`, and `session_send` to the built-in
+Alas MCP server and CLI so a root ACP session can delegate work to direct child
+sessions in current, existing, or newly created worktrees while Alas preserves
+authorization, writer leases, durable delivery, honest UI attribution, and
+user-owned lifecycle.
+
+**Design:**
+[`2026-07-15-mcp-agent-session-orchestration-design.md`](../specs/2026-07-15-mcp-agent-session-orchestration-design.md)
+
+**Architecture:** Add an app-level SQLite orchestration store and a main-actor
+coordinator. The store owns only parent-child edges, asynchronous creation
+phase, pending initial prompts, and a short-lived message inbox. Existing
+per-worktree ACP databases remain authoritative for sessions, queues,
+transcripts, and writer leases. Swift enforces graph permissions and routes
+operations; Rust keeps CLI and MCP parsing in parity over the existing socket
+request.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Foundation, SQLite3, Swift Testing, Rust,
+Serde/serde_json, MCP JSON-RPC, XcodeGen.
+
+---
+
+## File Structure
+
+Create focused orchestration files:
+
+- `Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift`
+  - Persisted edge, worktree request, phase, inbox message, public state, and
+    stable response DTOs.
+- `Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift`
+  - Synchronous SQLite schema and transactional operations.
+- `Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift`
+  - Lazy, actor-isolated store owner matching `ACPSessionPersistence`.
+- `Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift`
+  - Pure graph authorization, request validation, and public-state projection.
+- `Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift`
+  - App-level creation, routing, reconciliation, and observable summaries.
+- `Alas/Sources/ACP/Orchestration/ACPDelegatedPromptSource.swift`
+  - Codable prompt/message provenance shared by queues and transcript rows.
+- `Alas/Sources/ACP/UI/ACPDelegatedSessionsPolicy.swift`
+  - Pure row ordering, labels, status, and navigation policy for SwiftUI.
+
+Create focused tests:
+
+- `AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift`
+- `AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift`
+- `AlasTests/ACP/Orchestration/ACPSessionOrchestrationCoordinatorTests.swift`
+- `AlasTests/ACP/Orchestration/ACPDelegatedMessageDeliveryTests.swift`
+- `AlasTests/ACP/UI/ACPDelegatedSessionsPolicyTests.swift`
+
+Modify these existing ownership points:
+
+- `Alas/Sources/Persistence/Paths.swift`
+- `Alas/Sources/Harness/AlasCLIRequest.swift`
+- `Alas/Sources/App/AlasActionService.swift`
+- `Alas/Sources/App/AlasCLICommandRouter.swift`
+- `Alas/Sources/App/AppState.swift`
+- `Alas/Sources/App/WorktreeLaunchSurface.swift`
+- `Alas/Sources/ACP/Session/ACPSession.swift`
+- `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- `Alas/Sources/ACP/Session/ACPSessionPersistence.swift`
+- `Alas/Sources/ACP/Session/ACPMessage.swift`
+- `Alas/Sources/ACP/Session/ACPMessageWire.swift`
+- `Alas/Sources/ACP/Session/QueuedPrompt.swift`
+- `Alas/Sources/ACP/Session/BuiltInAlasMCP.swift`
+- `Alas/Sources/ACP/UI/ACPMessageList.swift`
+- `Alas/Sources/ACP/UI/ACPSessionsButton.swift`
+- `Alas/Sources/ACP/UI/ACPToolbar.swift`
+- `AlasCLI/crates/alas-client/src/lib.rs`
+- `AlasCLI/crates/alas/src/parse.rs`
+- `AlasCLI/crates/alas/src/mcp.rs`
+
+New files are picked up by recursive source groups. Regenerate
+`Alas.xcodeproj` with `xcodegen`; do not edit `project.yml` unless source-group
+behavior proves otherwise.
+
+## Shared Verification Notes
+
+- Prefix every command with `rtk`.
+- Run Xcode test invocations serially; do not overlap them against the same
+  build database.
+- Use `ALAS_FFF_TARGET_ARCH=arm64` if the local Ghostty/fff build requests an
+  unavailable x86_64 Rust target.
+- Focused Swift tests use `-only-testing:AlasTests/<SuiteName>`.
+- Run Rust tests from `AlasCLI` or with `--manifest-path AlasCLI/Cargo.toml`.
+
+### Task 1: Add Durable Orchestration Models And Store
+
+**Files:**
+- Create: `Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift`
+- Create: `Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift`
+- Create: `Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift`
+- Modify: `Alas/Sources/Persistence/Paths.swift`
+- Test: `AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing store tests**
+
+Cover:
+
+- schema creation on a new database;
+- delegation insert/load/list by parent/list by child;
+- unique child ID and one-parent constraints;
+- current, existing, and new-worktree request round trips;
+- phase, child worktree, failure, and timestamp updates;
+- pending initial prompt retention and atomic clear;
+- inbox insert/load and source/target edge fields;
+- atomic message claim by one instance/token;
+- delivered-message tombstone or ID deduplication;
+- reopening the same file preserves all records; and
+- an older/empty database migrates without main-actor I/O.
+
+Use a temporary SQLite path per test and a short busy timeout. Assert typed
+records, not raw SQL rows.
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPOrchestrationStoreTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+Expected: compilation fails because orchestration types do not exist.
+
+- [ ] **Step 3: Implement the persisted model**
+
+Define:
+
+```swift
+enum ACPDelegatedWorktreeRequest: Codable, Equatable, Sendable {
+    case current(worktreeId: String)
+    case existing(worktreeId: String)
+    case new(branch: String, base: String?, destinationPath: String, optimisticId: String)
+}
+
+enum ACPDelegationPhase: String, Codable, Equatable, Sendable {
+    case creatingWorktree
+    case starting
+    case ready
+    case failed
+    case closed
+}
+
+struct ACPDelegationRecord: Equatable, Sendable {
+    let childSessionId: String
+    let parentSessionId: String
+    let projectId: String
+    let parentWorktreeId: String
+    var childWorktreeId: String?
+    let agentId: String
+    let worktreeRequest: ACPDelegatedWorktreeRequest
+    var pendingInitialPrompt: String?
+    var phase: ACPDelegationPhase
+    var failureMessage: String?
+    let createdAt: Int64
+    var updatedAt: Int64
+}
+```
+
+Add an inbox record with stable message ID, source/target IDs, prompt, creation
+time, optional claim owner/token/time, and delivery marker. Do not store
+transcript excerpts, agent output, or permission data.
+
+- [ ] **Step 4: Implement SQLite and actor ownership**
+
+Follow `ACPSessionStore`/`ACPSessionPersistence` conventions:
+
+- lazy open on an actor executor;
+- WAL and busy timeout;
+- explicit schema version/migrations;
+- parameterized statements only;
+- transactional claim/delivery operations; and
+- deterministic row decoding with typed errors.
+
+Add:
+
+```swift
+static var acpOrchestrationDB: URL {
+    appSupportRoot.appendingPathComponent("acp-orchestration.sqlite")
+}
+```
+
+The claim transaction must make two consumers racing for one inbox message
+produce exactly one winner.
+
+- [ ] **Step 5: Run focused tests and inspect SQL safety**
+
+Run Step 2 again, then:
+
+```bash
+rtk rg -n 'exec\(|query\(|prepare\(' Alas/Sources/ACP/Orchestration
+```
+
+Review every match to confirm user values are bindings, not SQL interpolation.
+
+- [ ] **Step 6: Commit the store**
+
+```bash
+rtk git add Alas/Sources/ACP/Orchestration \
+  Alas/Sources/Persistence/Paths.swift \
+  AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift \
+  Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(acp): persist session delegation state"
+```
+
+### Task 2: Add Pure Authorization And State Projection
+
+**Files:**
+- Create: `Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift`
+- Test: `AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift`
+
+- [ ] **Step 1: Write the authorization matrix first**
+
+Test pure inputs for:
+
+- root creation accepted;
+- child creation rejected;
+- parent-to-child send accepted;
+- child-to-parent send accepted;
+- sibling, unrelated, cross-project, missing, failed, and closed send rejected;
+- forged target/worktree IDs rejected even when names collide;
+- list visibility limited to self, parent, and direct children;
+- omitted agent inherits the parent agent;
+- explicit agent must be enabled and ACP-capable;
+- blank prompts rejected;
+- `worktree` and `new_worktree` mutual exclusion; and
+- auto-run state has no effect on graph authorization.
+
+Write state-projection tests for every public state:
+
+- stored creation/start/failure/closed phases;
+- ready plus idle/sending/streaming/permission/question/elicitation runtime;
+- missing archived endpoint; and
+- last activity as the maximum safe timestamp.
+
+- [ ] **Step 2: Verify the policy suite fails**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPSessionOrchestrationPolicyTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+- [ ] **Step 3: Implement a side-effect-free policy**
+
+Keep the policy independent of AppState, SQLite, SwiftUI, and live managers.
+Use small snapshots for caller, edge, agent capability, worktree availability,
+and target runtime state. Return typed failures that later map to stable error
+strings.
+
+Define stable public DTOs for list/new/send responses here or in the models
+file. Encode them with sorted keys and snake_case field names.
+
+- [ ] **Step 4: Run focused tests and commit**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPSessionOrchestrationPolicyTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+rtk git add Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationPolicy.swift \
+  Alas/Sources/ACP/Orchestration/ACPOrchestrationModels.swift \
+  AlasTests/ACP/Orchestration/ACPSessionOrchestrationPolicyTests.swift
+rtk git commit -m "feat(acp): define session orchestration policy"
+```
+
+### Task 3: Add Swift Request Decoding And App Router Boundaries
+
+**Files:**
+- Modify: `Alas/Sources/Harness/AlasCLIRequest.swift`
+- Modify: `Alas/Sources/App/AlasActionService.swift`
+- Modify: `Alas/Sources/App/AlasCLICommandRouter.swift`
+- Test: `AlasTests/AlasCLIRequestTests.swift`
+- Test: `AlasTests/AlasCLICommandRouterTests.swift`
+
+- [ ] **Step 1: Add failing request tests**
+
+Cover params-envelope decoding for:
+
+```json
+{"command":"session_list","params":{}}
+{"command":"session_new","params":{"prompt":"Task"}}
+{"command":"session_new","params":{"prompt":"Task","agent":"codex","worktree":"feature"}}
+{"command":"session_new","params":{"prompt":"Task","new_worktree":{"branch":"child","base":"origin/main"}}}
+{"command":"session_send","params":{"session_id":"child","prompt":"Follow up"}}
+```
+
+Also cover missing/wrong-typed/blank values, mutually exclusive worktree
+selectors, unknown extra transport fields, and preservation of every existing
+request decoder.
+
+- [ ] **Step 2: Add failing router tests**
+
+Inject orchestration closures into `AlasCLICommandRouter` and verify:
+
+- each typed command forwards the resolved ACP origin;
+- directory-only and regular terminal origins return
+  `session commands require an originating ACP session`;
+- existing open/worktree/review/notify routing remains unchanged; and
+- responses contain one deterministic JSON line.
+
+- [ ] **Step 3: Run the two suites and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/AlasCLIRequestTests \
+  -only-testing:AlasTests/AlasCLICommandRouterTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+- [ ] **Step 4: Implement typed request and service cases**
+
+Add `sessionList`, `sessionNew`, and `sessionSend` command cases. Decode every
+new argument from `params`; do not add legacy flat fields. Keep origin lookup in
+the router and add a narrow `resolveACPSessionOrigin` dependency rather than
+making `AlasActionService` search managers.
+
+The action service should expose async typed closures and remain ignorant of
+SQLite and SwiftUI.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/AlasCLIRequestTests \
+  -only-testing:AlasTests/AlasCLICommandRouterTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+rtk git add Alas/Sources/Harness/AlasCLIRequest.swift \
+  Alas/Sources/App/AlasActionService.swift \
+  Alas/Sources/App/AlasCLICommandRouter.swift \
+  AlasTests/AlasCLIRequestTests.swift AlasTests/AlasCLICommandRouterTests.swift
+rtk git commit -m "feat(cli): route session orchestration commands"
+```
+
+### Task 4: Add Rust CLI And MCP Parity
+
+**Files:**
+- Modify: `AlasCLI/crates/alas-client/src/lib.rs`
+- Modify: `AlasCLI/crates/alas/src/parse.rs`
+- Modify: `AlasCLI/crates/alas/src/mcp.rs`
+- Test: colocated Rust unit tests and existing transport tests
+
+- [ ] **Step 1: Add failing command/request tests**
+
+Add `Command::SessionList`, `Command::SessionNew`, and
+`Command::SessionSend`. Test exact params objects and verify the surrounding
+request still carries the injected local ACP `session_id`.
+
+- [ ] **Step 2: Add failing CLI parser tests**
+
+Cover:
+
+```text
+alas session list
+alas session new --prompt Task
+alas session new --prompt Task --agent codex --worktree feature
+alas session new --prompt Task --new-worktree child --base origin/main
+alas session send CHILD Follow-up
+```
+
+Cover missing values, duplicate flags, unknown flags, mutual exclusion, blank
+strings, and trailing arguments. Update `USAGE_ALL`.
+
+- [ ] **Step 3: Add failing MCP tests**
+
+Assert the three tool definitions, required fields, descriptions, and
+`command_for_tool` validation. Descriptions must state direct parent/child
+scope, asynchronous acceptance, text-only prompts, and no automatic focus.
+
+- [ ] **Step 4: Verify Rust tests fail**
+
+```bash
+rtk cargo test --manifest-path AlasCLI/Cargo.toml
+```
+
+- [ ] **Step 5: Implement commands, parser, and MCP translation**
+
+Use the params envelope for every new argument. Keep worktree resolution and
+authorization in Swift. Rust performs only shape, non-blank, enum, and mutual
+exclusion validation.
+
+MCP results should forward the app's JSON text as normal text content. Do not
+parse and reserialize app responses in Rust.
+
+- [ ] **Step 6: Run Rust tests and commit**
+
+```bash
+rtk cargo fmt --manifest-path AlasCLI/Cargo.toml -- --check
+rtk cargo test --manifest-path AlasCLI/Cargo.toml
+rtk git add AlasCLI/crates/alas-client/src/lib.rs \
+  AlasCLI/crates/alas/src/parse.rs AlasCLI/crates/alas/src/mcp.rs
+rtk git commit -m "feat(mcp): add session orchestration tools"
+```
+
+### Task 5: Add Preallocated Session IDs And Delegated Prompt Provenance
+
+**Files:**
+- Create: `Alas/Sources/ACP/Orchestration/ACPDelegatedPromptSource.swift`
+- Modify: `Alas/Sources/ACP/Session/QueuedPrompt.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPMessage.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPMessageWire.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSession.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- Test: `AlasTests/ACP/Session/QueuedPromptTests.swift`
+- Test: `AlasTests/ACP/Session/ACPMessageTests.swift`
+- Test: `AlasTests/ACP/Session/ACPMessageWireTests.swift`
+- Test: `AlasTests/ACP/Session/ACPSessionManagerTests.swift`
+
+- [ ] **Step 1: Write provenance compatibility tests**
+
+Test:
+
+- legacy queued prompts/messages decode with nil provenance;
+- delegated source round-trips through queue JSON and user-message payload;
+- message ID/source session survive hydration;
+- stable message identity remains based on existing message ID/UUID rules;
+- Markdown export keeps message text and does not leak internal IDs; and
+- retries do not duplicate a delegated user bubble.
+
+- [ ] **Step 2: Write manager tests for preallocated creation and enqueue**
+
+Test:
+
+- `createSession(id:agentId:autoRunDefault:)` uses the exact supplied ID;
+- the UUID-generating convenience remains unchanged;
+- duplicate supplied IDs are rejected without replacing a live/persisted row;
+- delegated enqueue persists before its completion returns;
+- delegated enqueue always preserves FIFO while ready/busy/recovering;
+- completion does not wait for the ACP turn response; and
+- the queue kicks attach/reconnect exactly once where needed.
+
+- [ ] **Step 3: Run focused tests and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/QueuedPromptTests \
+  -only-testing:AlasTests/ACPMessageTests \
+  -only-testing:AlasTests/ACPMessageWireTests \
+  -only-testing:AlasTests/ACPSessionManagerTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+- [ ] **Step 4: Implement backward-compatible provenance**
+
+Add an optional `ACPDelegatedPromptSource` to `QueuedPrompt` and the user
+message payload. Update the `ACPMessage.user` associated value and all
+exhaustive pattern matches mechanically. Do not encode nil provenance, so old
+payload shape remains valid and ordinary prompts remain unchanged.
+
+Use a stable delegated message ID as the queue item's transfer/deduplication
+identity. Do not encode parent/child labels into prompt text or ACP wire
+content.
+
+- [ ] **Step 5: Implement the manager API**
+
+Add an internal preallocated-ID creation overload and an async
+`enqueueDelegatedPrompt` that returns after the queue write is durable. It must
+not reuse `sendPrompt` completion because ACP `session/prompt` can remain open
+for the full agent turn.
+
+- [ ] **Step 6: Run tests and commit**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/QueuedPromptTests \
+  -only-testing:AlasTests/ACPMessageTests \
+  -only-testing:AlasTests/ACPMessageWireTests \
+  -only-testing:AlasTests/ACPSessionManagerTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+rtk git add Alas/Sources/ACP/Orchestration/ACPDelegatedPromptSource.swift \
+  Alas/Sources/ACP/Session/QueuedPrompt.swift \
+  Alas/Sources/ACP/Session/ACPMessage.swift \
+  Alas/Sources/ACP/Session/ACPMessageWire.swift \
+  Alas/Sources/ACP/Session/ACPSession.swift \
+  Alas/Sources/ACP/Session/ACPSessionManager.swift \
+  AlasTests/ACP/Session/QueuedPromptTests.swift \
+  AlasTests/ACP/Session/ACPMessageTests.swift \
+  AlasTests/ACP/Session/ACPMessageWireTests.swift \
+  AlasTests/ACP/Session/ACPSessionManagerTests.swift
+rtk git commit -m "feat(acp): persist delegated prompt provenance"
+```
+
+### Task 6: Build The Coordinator For Current And Existing Worktrees
+
+**Files:**
+- Create: `Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/App/AlasActionService.swift`
+- Modify: `Alas/Sources/App/AlasCLICommandRouter.swift`
+- Test: `AlasTests/ACP/Orchestration/ACPSessionOrchestrationCoordinatorTests.swift`
+- Test: `AlasTests/AlasCLICommandRouterTests.swift`
+
+- [ ] **Step 1: Define an injected coordinator environment**
+
+Keep tests independent of a full AppState by injecting closures for:
+
+- current project/worktree snapshots;
+- ACP origin lookup;
+- enabled ACP agent lookup;
+- existing worktree resolution;
+- manager lookup/creation;
+- session row/runtime snapshot lookup;
+- app instance ID and clock; and
+- orchestration change notification.
+
+- [ ] **Step 2: Write failing creation/list tests**
+
+Cover:
+
+- current worktree child creation;
+- existing worktree child creation;
+- omitted agent inheritance;
+- explicit valid agent;
+- durable record written before response;
+- child created with preallocated ID;
+- initial prompt persisted then cleared from orchestration storage;
+- attach/flush begins without opening a tab;
+- no worktree/window focus callback fires;
+- all agreed validation/authorization failures; and
+- list DTO ordering and transcript-free contents.
+
+- [ ] **Step 3: Run the focused suite and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPSessionOrchestrationCoordinatorTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+- [ ] **Step 4: Implement current/existing creation**
+
+The coordinator flow is:
+
+1. Resolve caller and root authority.
+2. Validate prompt, agent, and target within the project.
+3. Allocate child ID.
+4. Persist `starting` record plus pending initial prompt.
+5. Return/encode the accepted response.
+6. Create the target manager/session asynchronously.
+7. Enqueue the prompt with parent provenance.
+8. Clear pending prompt and set `ready`.
+9. Notify observers.
+
+Do not require an ACP tab to exist. Add AppState wiring at the existing
+`AlasCLICommandRouter` construction point and preserve every existing closure.
+
+- [ ] **Step 5: Run tests and commit**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPSessionOrchestrationCoordinatorTests \
+  -only-testing:AlasTests/AlasCLICommandRouterTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+rtk git add Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift \
+  Alas/Sources/App/AppState.swift Alas/Sources/App/AlasActionService.swift \
+  Alas/Sources/App/AlasCLICommandRouter.swift \
+  AlasTests/ACP/Orchestration/ACPSessionOrchestrationCoordinatorTests.swift \
+  AlasTests/AlasCLICommandRouterTests.swift
+rtk git commit -m "feat(acp): create delegated sessions"
+```
+
+### Task 7: Add Atomic Fresh-Worktree Creation Without Focus
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/App/WorktreeLaunchSurface.swift`
+- Modify: `Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift`
+- Test: `AlasTests/AppStateCreateWorktreeLaunchSurfaceTests.swift`
+- Test: `AlasTests/AppStateCreateWorktreeSymlinkTests.swift`
+- Test: `AlasTests/ACP/Orchestration/ACPSessionOrchestrationCoordinatorTests.swift`
+
+- [ ] **Step 1: Write failing worktree completion tests**
+
+Cover a shared creation primitive that:
+
+- returns optimistic ID/path immediately;
+- exposes one completion result for the real Git operation;
+- supports a no-focus policy;
+- preserves existing UI/CLI focus behavior for current callers;
+- reuses branch validation, base selection, path templates, fetch, startup
+  scripts, remote destination handling, and project refresh; and
+- reports a typed failure without requiring published-state polling.
+
+- [ ] **Step 2: Write coordinator fresh-worktree tests**
+
+Cover accepted `creating_worktree` response, later session startup, no focus,
+failure persistence, optimistic/real worktree reconciliation, and initial
+prompt exactly-once delivery.
+
+- [ ] **Step 3: Verify tests fail**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/AppStateCreateWorktreeLaunchSurfaceTests \
+  -only-testing:AlasTests/AppStateCreateWorktreeSymlinkTests \
+  -only-testing:AlasTests/ACPSessionOrchestrationCoordinatorTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+- [ ] **Step 4: Refactor the shared creation core**
+
+Do not duplicate `performCreateWorktree` or create a second project-refresh
+path. Return a small handle/result from the shared coordinator or add a
+completion hook that is completed exactly once. Existing callers may continue
+to ignore the completion.
+
+Delegated creation passes no-focus/no-tab behavior. After success, bind the
+resolved worktree to the delegation and continue Task 6's child creation.
+
+- [ ] **Step 5: Add relaunch reconciliation**
+
+For `creatingWorktree`/`starting` rows:
+
+- continue if the planned worktree or child session can be proven to exist;
+- resume initial prompt transfer using its stable ID; and
+- otherwise mark `failed` with an interruption reason rather than repeating a
+  Git mutation.
+
+- [ ] **Step 6: Run tests and commit**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/AppStateCreateWorktreeLaunchSurfaceTests \
+  -only-testing:AlasTests/AppStateCreateWorktreeSymlinkTests \
+  -only-testing:AlasTests/ACPSessionOrchestrationCoordinatorTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+rtk git add Alas/Sources/App/AppState.swift \
+  Alas/Sources/App/WorktreeLaunchSurface.swift \
+  Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift \
+  AlasTests/AppStateCreateWorktreeLaunchSurfaceTests.swift \
+  AlasTests/AppStateCreateWorktreeSymlinkTests.swift \
+  AlasTests/ACP/Orchestration/ACPSessionOrchestrationCoordinatorTests.swift
+rtk git commit -m "feat(acp): launch delegated worktrees"
+```
+
+### Task 8: Deliver `session_send` Through The Durable Inbox
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift`
+- Modify: `Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift`
+- Modify: `Alas/Sources/ACP/Orchestration/ACPSessionOrchestrationCoordinator.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- Test: `AlasTests/ACP/Orchestration/ACPDelegatedMessageDeliveryTests.swift`
+- Test: `AlasTests/ACP/Session/ACPSessionManagerLeaseTests.swift`
+
+- [ ] **Step 1: Write end-to-end delivery tests with controlled stores**
+
+Cover:
+
+- parent-to-child and child-to-parent accepted;
+- unauthorized sends leave no inbox row;
+- accepted response occurs after inbox persistence but before ACP turn finish;
+- target busy/starting/disconnected preserves FIFO;
+- prompt reaches transcript with source provenance;
+- source instance without target lease cannot mutate the target queue;
+- target owner consumes and deletes the inbox row;
+- crash after target queue persistence but before inbox cleanup does not
+  duplicate the prompt;
+- competing instances produce one delivery; and
+- failed/closed targets return stable errors.
+
+- [ ] **Step 2: Verify delivery tests fail**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPDelegatedMessageDeliveryTests \
+  -only-testing:AlasTests/ACPSessionManagerLeaseTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+- [ ] **Step 3: Implement inbox observation and claim**
+
+Use a short-name `ACPChangeNotifier`-style notification plus a bounded polling
+fallback. A consumer must:
+
+1. atomically claim an inbox row;
+2. resolve/lazily load the target worktree manager;
+3. acquire or confirm the target writer lease;
+4. enqueue using the inbox message ID and source session;
+5. confirm target persistence; and
+6. mark delivered/remove the inbox row.
+
+Release or expire claims when delivery cannot proceed. Never bypass the target
+lease merely because the graph edge is valid.
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPDelegatedMessageDeliveryTests \
+  -only-testing:AlasTests/ACPSessionManagerLeaseTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+rtk git add Alas/Sources/ACP/Orchestration \
+  Alas/Sources/ACP/Session/ACPSessionManager.swift \
+  AlasTests/ACP/Orchestration/ACPDelegatedMessageDeliveryTests.swift \
+  AlasTests/ACP/Session/ACPSessionManagerLeaseTests.swift
+rtk git commit -m "feat(acp): route delegated session prompts"
+```
+
+### Task 9: Add Delegation-Aware MCP Instructions
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/BuiltInAlasMCP.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `AlasCLI/crates/alas/src/mcp.rs`
+- Test: `AlasTests/ACP/Session/BuiltInAlasMCPTests.swift`
+- Test: Rust MCP/env unit tests
+
+- [ ] **Step 1: Add failing injection tests**
+
+Test root injection unchanged and child injection containing a validated
+`ALAS_PARENT_SESSION_ID`. Ensure user-configured `alas` MCP override behavior
+and disabled/unavailable cases remain unchanged.
+
+- [ ] **Step 2: Add failing dynamic-instructions tests**
+
+For child env, MCP initialize instructions must identify the parent, state that
+the caller cannot spawn descendants, and direct results/questions through
+`session_send`. Root instructions describe direct-child fan-out. No prompt or
+transcript content appears in instructions.
+
+- [ ] **Step 3: Implement metadata lookup at attach**
+
+Expose a cheap in-memory parent lookup from the coordinator to the built-in MCP
+provider. Do not synchronously open SQLite from `ACPSessionManager.attach` or
+the main actor. Refresh coordinator cache from persisted changes/relaunch
+reconciliation.
+
+Extend Rust `McpEnv` and `initialize_result` to produce role-aware instructions.
+Swift remains authoritative if stale metadata causes a child to attempt
+`session_new`.
+
+- [ ] **Step 4: Run Swift and Rust tests, then commit**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/BuiltInAlasMCPTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+rtk cargo test --manifest-path AlasCLI/Cargo.toml
+rtk git add Alas/Sources/ACP/Session/BuiltInAlasMCP.swift \
+  Alas/Sources/ACP/Session/ACPSessionManager.swift Alas/Sources/App/AppState.swift \
+  AlasCLI/crates/alas/src/mcp.rs AlasTests/ACP/Session/BuiltInAlasMCPTests.swift
+rtk git commit -m "feat(mcp): describe delegated session context"
+```
+
+### Task 10: Add Parent/Child UI And Honest Message Attribution
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPDelegatedSessionsPolicy.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPSessionsButton.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPToolbar.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPMessageList.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Test: `AlasTests/ACP/UI/ACPDelegatedSessionsPolicyTests.swift`
+- Test: relevant ACP message-list policy/snapshot tests
+
+- [ ] **Step 1: Write pure presentation-policy tests**
+
+Cover:
+
+- section visibility for root/child/unrelated sessions;
+- child row ordering by active attention then last activity;
+- labels for creating, starting, idle, running, awaiting, failed, and closed;
+- safe failure tooltip truncation;
+- retry visibility only for retryable creation failure;
+- parent backlink label/fallback title; and
+- delegated source label without exposing raw internal IDs when title/worktree
+  metadata is available.
+
+- [ ] **Step 2: Add navigation and retry tests around AppState helpers**
+
+Test cross-worktree navigation opens/focuses the exact target session, does not
+create another session, and activates only on user click. Retry reuses the
+recorded child ID and pending prompt.
+
+- [ ] **Step 3: Implement existing-surface UI**
+
+- Add **Delegated sessions** to the existing sessions popover.
+- Render agent, branch/worktree, live status, unread/awaiting/failure state.
+- Show rows immediately during `creating_worktree`.
+- Add **Delegated by [parent]** backlink for children.
+- Hide descendant creation affordance for child context where applicable.
+- Add Retry for failed child creation.
+- Keep all creation/send operations non-focusing.
+
+Do not add a dashboard, page-level card, nested card, or modal completion
+surface.
+
+- [ ] **Step 4: Render delegated prompt provenance**
+
+Update the existing user-message branch in `ACPMessageList` to show a compact
+source label/backlink when provenance exists. Preserve ordinary user bubbles,
+copy behavior, markdown rendering, pagination, and stable row identity.
+
+- [ ] **Step 5: Run focused tests and inspect at two widths**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPDelegatedSessionsPolicyTests \
+  -only-testing:AlasTests/ACPMessageTests \
+  -only-testing:AlasTests/ACPMessageListPaginationTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+Manually verify normal and narrow center-pane widths. Confirm row text wraps or
+truncates without overlapping icons/status, and keyboard/VoiceOver labels name
+navigation and retry actions.
+
+- [ ] **Step 6: Commit the UI**
+
+```bash
+rtk git add Alas/Sources/ACP/UI/ACPDelegatedSessionsPolicy.swift \
+  Alas/Sources/ACP/UI/ACPSessionsButton.swift \
+  Alas/Sources/ACP/UI/ACPToolbar.swift \
+  Alas/Sources/ACP/UI/ACPMessageList.swift \
+  Alas/Sources/App/AppState.swift \
+  AlasTests/ACP/UI/ACPDelegatedSessionsPolicyTests.swift \
+  AlasTests/ACP/Session/ACPMessageTests.swift
+rtk git commit -m "feat(acp): show delegated session activity"
+```
+
+### Task 11: Integration, Compatibility, And Final Verification
+
+**Files:**
+- Test: `AlasTests/ACP/Orchestration/ACPSessionOrchestrationIntegrationTests.swift`
+- Modify: implementation files only for failures found by this task
+
+- [ ] **Step 1: Add one complete socket-path integration test**
+
+Exercise MCP/CLI-shaped requests through Swift decoding/router/coordinator:
+
+1. Root lists itself.
+2. Root creates a child in an existing worktree.
+3. Child receives its initial prompt.
+4. Parent sends a follow-up while child is busy.
+5. Child sends a result to parent.
+6. Both list calls see only the authorized graph.
+7. Child creation of a grandchild fails.
+
+Assert stable JSON keys and no focus callbacks.
+
+- [ ] **Step 2: Run all focused orchestration coverage**
+
+```bash
+rtk cargo test --manifest-path AlasCLI/Cargo.toml
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPOrchestrationStoreTests \
+  -only-testing:AlasTests/ACPSessionOrchestrationPolicyTests \
+  -only-testing:AlasTests/ACPSessionOrchestrationCoordinatorTests \
+  -only-testing:AlasTests/ACPDelegatedMessageDeliveryTests \
+  -only-testing:AlasTests/ACPDelegatedSessionsPolicyTests \
+  -only-testing:AlasTests/AlasCLIRequestTests \
+  -only-testing:AlasTests/AlasCLICommandRouterTests \
+  -only-testing:AlasTests/BuiltInAlasMCPTests test \
+  ALAS_FFF_TARGET_ARCH=arm64
+```
+
+- [ ] **Step 3: Run repository-required generation and build**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -quiet build ALAS_FFF_TARGET_ARCH=arm64
+```
+
+- [ ] **Step 4: Run the full Swift test suite serially**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  test ALAS_FFF_TARGET_ARCH=arm64
+```
+
+Do not run another Xcode build/test concurrently. If the broad suite stalls,
+capture the concrete process/build state before deciding whether CI must be the
+broad gate.
+
+- [ ] **Step 5: Manual end-to-end verification**
+
+With the built-in Alas MCP enabled:
+
+1. Open a root ACP session and call `session_list`.
+2. Create a child in the same worktree and verify no focus change.
+3. Create a child in a fresh worktree and observe `creating_worktree` then
+   `starting`/`running`.
+4. Send a follow-up while the child is active and verify FIFO delivery.
+5. Have the child report through `session_send`; verify the parent bubble is
+   attributed to the child, not the user.
+6. Click parent/child navigation in both directions.
+7. Trigger a worktree failure and verify persistent failure plus user Retry.
+8. Attempt grandchild and unrelated-session operations and verify rejection.
+9. Close/relaunch Alas during creation and verify honest reconciliation.
+10. Repeat a send across two Alas instances to verify writer-safe delivery.
+
+- [ ] **Step 6: Review scope and final diff**
+
+```bash
+rtk git diff --check origin/main...HEAD
+rtk git status --short --branch
+rtk git log --oneline origin/main..HEAD
+```
+
+Confirm the branch contains only issue #795 orchestration work, the approved
+spec/plan, generated project changes required by new files, and focused tests.
+
+- [ ] **Step 7: Commit final integration fixes when needed**
+
+```bash
+rtk git status --short
+rtk git add AlasTests/ACP/Orchestration/ACPSessionOrchestrationIntegrationTests.swift
+rtk git commit -m "test(acp): cover session orchestration flow"
+```
+
+Stage any implementation fixes individually after reviewing `git status`; do
+not replace the exact add above with a broad source-directory add. Skip this
+commit when the integration task required no code or test changes.

--- a/docs/superpowers/specs/2026-07-15-mcp-agent-session-orchestration-design.md
+++ b/docs/superpowers/specs/2026-07-15-mcp-agent-session-orchestration-design.md
@@ -1,0 +1,649 @@
+# MCP Agent Session Orchestration Design
+
+**Status:** Design approved, ready for implementation planning
+
+## Context
+
+[Issue #795](https://github.com/mrmans0n/alas/issues/795) is Phase 4 of the
+[MCP toolset expansion](https://github.com/mrmans0n/alas/issues/787). It adds
+agent-facing session tools to the built-in `alas` MCP server so one ACP session
+can delegate work to other ACP sessions, including sessions launched in fresh
+linked worktrees.
+
+The current built-in MCP server is injected into each ACP session with the
+local Alas session ID, worktree path, and app socket. MCP calls therefore have
+a precise originating session, and Swift remains the authority for projects,
+worktrees, sessions, permissions, and UI state. The Rust `alas` CLI and MCP
+server are thin, matching front ends over the same Unix-socket request model.
+
+ACP session persistence is currently one SQLite database per worktree. That is
+the correct ownership boundary for transcripts, queues, drafts, permissions,
+and runner leases, but it cannot answer a cross-worktree question such as
+"which session delegated this child?" without opening and scanning every
+worktree database. Orchestration therefore needs a small app-level index while
+leaving session content in the existing per-worktree stores.
+
+The design is intentionally a bounded delegation model rather than a general
+multi-agent workflow engine. A user-created root may fan work out to direct
+children. Children may report to their parent, but cannot recursively spawn
+more sessions.
+
+## Goals
+
+- Let a root ACP session list its delegated children, create a child, and send
+  follow-up prompts to a child.
+- Let a delegated child inspect its parent and send results or questions back.
+- Support children in the current worktree, an existing project worktree, or a
+  newly created linked worktree.
+- Make fresh-worktree creation and child launch one atomic user intent, without
+  racing separate `worktree_new` and `session_new` calls.
+- Persist the delegation relationship and asynchronous creation state across
+  UI navigation and app relaunches.
+- Preserve ACP writer-lease rules when routing prompts across worktrees or Alas
+  instances.
+- Keep agent-created sessions and messages visibly distinct from user-created
+  content in the UI.
+- Keep MCP and CLI command surfaces in 1:1 parity and return stable JSON.
+- Avoid changing window/worktree focus as a side effect of agent orchestration.
+
+## Non-Goals
+
+- No recursive delegation or configurable delegation depth.
+- No messaging between unrelated sessions, even within the same project.
+- No transcript reading, transcript copying, or automatic result summarizing.
+- No automatic definition of "done" from an idle agent or completed turn.
+- No agent-driven session close, archive, delete, or worktree cleanup.
+- No prompt attachments in orchestration tools in the first version.
+- No agent-selected auto-run, permission, model, or mode overrides.
+- No orchestration of terminal-only or non-ACP agent sessions.
+- No standalone root-session creation from an external/directory-only CLI
+  context. Session commands require an originating ACP session in v1.
+- No new orchestration dashboard, graph canvas, scheduler, budgets, or numeric
+  concurrency controls.
+
+## Delegation Model
+
+Every orchestration relationship is one directed parent-child edge.
+
+- A session with no parent edge is a root.
+- A root may create any number of direct children.
+- A child may not call `session_new`.
+- A root may send only to its children.
+- A child may send only to its parent.
+- Both endpoints must remain in the project recorded on the edge.
+- A session ID that is not one endpoint of an authorized edge is never exposed
+  or accepted as a target.
+
+The absence of recursive creation is the loop-prevention rule for v1. It is
+enforced by Swift from persisted delegation data, not by prompt instructions or
+the Rust client. The persisted model can support a deeper tree later without a
+wire-format change, but v1 rejects `session_new` whenever the caller already
+has a parent.
+
+The originating session's normal ACP MCP-tool permission policy remains the
+user-consent surface. Auto-run may approve these calls just as it may approve
+other Alas MCP tools. Alas does not add a second confirmation dialog, but it
+always performs graph authorization, project scoping, agent validation, and
+worktree validation after the tool call reaches the app.
+
+## Tool And CLI Surface
+
+### `session_list`
+
+MCP:
+
+```json
+{
+  "name": "session_list",
+  "arguments": {}
+}
+```
+
+CLI:
+
+```sh
+alas session list
+```
+
+The result is a JSON array containing only the caller, its parent when one
+exists, and its direct children. A root has no parent; a child has no children
+under the v1 authorization model.
+
+Each entry has this stable shape:
+
+```json
+{
+  "session_id": "UUID",
+  "relationship": "self",
+  "title": "Investigate parser failures",
+  "agent_id": "codex",
+  "worktree": {
+    "id": "WORKTREE_ID",
+    "path": "/path/to/worktree",
+    "branch": "feature/parser"
+  },
+  "state": "running",
+  "last_activity_at": 1784149200,
+  "error": null
+}
+```
+
+`relationship` is `self`, `parent`, or `child`. `state` is one of:
+
+- `creating_worktree`
+- `starting`
+- `idle`
+- `running`
+- `awaiting_input`
+- `failed`
+- `closed`
+
+`awaiting_input` includes an ACP permission, question, elicitation, or other
+user-input wait. `error` is present only for `failed` and contains a short safe
+reason. Entries never contain prompts, transcript excerpts, tool output, or
+permission details.
+
+### `session_new`
+
+MCP:
+
+```json
+{
+  "name": "session_new",
+  "arguments": {
+    "prompt": "Investigate the parser failures and report back.",
+    "agent": "codex",
+    "new_worktree": {
+      "branch": "investigate/parser",
+      "base": "origin/main"
+    }
+  }
+}
+```
+
+Supported arguments:
+
+- `prompt` is required and must be non-blank.
+- `agent` is optional. Omission inherits the parent's agent ID.
+- `worktree` optionally names an existing visible worktree by the same project
+  resolver used by other CLI worktree commands.
+- `new_worktree` optionally contains required `branch` and optional `base`.
+- `worktree` and `new_worktree` are mutually exclusive.
+- Omitting both worktree arguments uses the parent's current worktree.
+
+CLI:
+
+```sh
+alas session new --prompt "Investigate the parser failures and report back."
+alas session new --prompt "Fix the tests." --agent claude --worktree feature/tests
+alas session new --prompt "Try the migration." --new-worktree spike/migration --base origin/main
+```
+
+The command validates and persists the intent, allocates the child session ID,
+and returns without waiting for worktree creation or an agent turn:
+
+```json
+{
+  "session_id": "CHILD_UUID",
+  "parent_session_id": "PARENT_UUID",
+  "agent_id": "codex",
+  "state": "creating_worktree",
+  "worktree": {
+    "id": "OPTIMISTIC_WORKTREE_ID",
+    "path": "/path/to/planned-worktree",
+    "branch": "spike/migration"
+  }
+}
+```
+
+For a current or existing worktree, the initial state is normally `starting`.
+The response means the operation is durably accepted, not that worktree
+creation, adapter setup, authentication, or the initial agent turn succeeded.
+Callers use `session_list` for subsequent state.
+
+The selected agent must be enabled and have an `ACPLaunchCatalog` entry. The
+child uses the user's normal new-ACP-session auto-run default; the parent may
+not pass or inherit a more permissive per-session setting.
+
+### `session_send`
+
+MCP:
+
+```json
+{
+  "name": "session_send",
+  "arguments": {
+    "session_id": "CHILD_OR_PARENT_UUID",
+    "prompt": "Please also cover malformed UTF-8 input."
+  }
+}
+```
+
+CLI:
+
+```sh
+alas session send CHILD_OR_PARENT_UUID "Please also cover malformed UTF-8 input."
+```
+
+Both fields are required and `prompt` must be non-blank. The target must be the
+caller's direct parent or child. On success:
+
+```json
+{
+  "session_id": "CHILD_OR_PARENT_UUID",
+  "accepted": true,
+  "delivery": "queued"
+}
+```
+
+`accepted` means the prompt is durably stored for the authorized target. It
+does not wait for the target agent to begin or finish the turn. Delivery uses
+FIFO queue semantics while the target is busy, starting, disconnected, or
+recovering. It never activates the target worktree, opens a tab, or changes
+window focus.
+
+Sending to a `failed` or `closed` target returns an error with the target's safe
+failure reason where available. A transient lack of an attached runner is not
+an error when the session remains recoverable.
+
+### CLI Context Requirement
+
+The Rust parser exposes all three commands for CLI/MCP parity. Swift requires
+the request's `session_id` to resolve to an ACP session. Calls from an external
+shell, directory-only dispatch, or an Alas terminal unrelated to an ACP session
+fail with:
+
+```text
+alas: session commands require an originating ACP session
+```
+
+The MCP server always satisfies this requirement because Alas injects its local
+ACP session ID through `ALAS_SESSION_ID`.
+
+## App-Level Orchestration Store
+
+Add one SQLite store under Application Support, separate from every worktree's
+ACP session database:
+
+```text
+~/Library/Application Support/Alas/acp-orchestration.sqlite
+```
+
+The store contains relationship and delivery metadata only. Transcripts,
+normal ACP queue state, drafts, permissions, and leases remain in the existing
+per-worktree databases.
+
+### Delegation Records
+
+Conceptually, each child record contains:
+
+```swift
+struct ACPDelegationRecord: Equatable, Sendable {
+    let childSessionId: String
+    let parentSessionId: String
+    let projectId: String
+    let parentWorktreeId: String
+    var childWorktreeId: String?
+    let agentId: String
+    let worktreeRequest: ACPDelegatedWorktreeRequest
+    var pendingInitialPrompt: String?
+    var phase: ACPDelegationPhase
+    var failureMessage: String?
+    let createdAt: Int64
+    var updatedAt: Int64
+}
+```
+
+`ACPDelegatedWorktreeRequest` records current, existing, or new-worktree intent
+and enough resolved destination metadata to render progress and reconcile an
+interrupted creation. `ACPDelegationPhase` persists only orchestration-owned
+phases: `creatingWorktree`, `starting`, `ready`, `failed`, and `closed`.
+`session_list` projects `ready` into `idle`, `running`, or `awaiting_input` from
+the target session's live/persisted state.
+
+The initial prompt remains in this store only until it is durably inserted into
+the child's normal ACP queue. It is then cleared. This makes creation crash-safe
+without creating a second permanent transcript.
+
+### Delegated Message Inbox
+
+`session_send` writes an authorized message to a short-lived durable inbox in
+the orchestration database. Conceptually:
+
+```swift
+struct ACPDelegatedMessage: Equatable, Sendable {
+    let id: String
+    let sourceSessionId: String
+    let targetSessionId: String
+    let prompt: String
+    let createdAt: Int64
+}
+```
+
+The coordinator validates the edge before insertion. An Alas instance that can
+legitimately drive the target claims the inbox item, persists it into the
+target session's FIFO queue with the message ID and source provenance, and only
+then removes the inbox row. The message ID makes the transfer idempotent if the
+app stops between the target write and inbox cleanup.
+
+This inbox preserves the existing per-session writer lease as the authority for
+ACP queue mutation. It also lets `session_send` return after durable acceptance
+when another Alas instance currently owns the target. Store changes use a
+lightweight cross-process notifier plus a bounded polling fallback, following
+the existing ACP persistence pattern.
+
+Prompt text is never logged or included in orchestration errors. Once delivery
+is confirmed, the orchestration database retains no copy.
+
+## Coordinator And App Boundaries
+
+Add an app-level `ACPSessionOrchestrationCoordinator` that owns the
+orchestration store and coordinates AppState-owned capabilities. It does not
+replace `ACPSessionManager`.
+
+Responsibilities:
+
+1. Resolve the originating ACP session and worktree.
+2. Authorize list, create, and send operations from the persisted graph.
+3. Validate agent selection and worktree requests against current AppState.
+4. Allocate child IDs and persist delegation records.
+5. Run new-worktree creation asynchronously without changing focus.
+6. Lazily obtain the child worktree's `ACPSessionManager`.
+7. Create the child session using the preallocated ID.
+8. Persist the initial prompt with delegated provenance and start attach/queue
+   flushing without requiring a visible tab.
+9. Route durable inbox messages to whichever instance owns the target writer
+   lease.
+10. Publish relationship and state summaries for MCP responses and SwiftUI.
+
+`AlasActionService` gains narrow injected closures for these three operations,
+and `AlasCLICommandRouter` continues to resolve the origin before dispatching.
+The service and router speak typed domain requests rather than reaching into
+SQLite or SwiftUI.
+
+`ACPSessionManager.createSession` gains an internal form that accepts a
+preallocated local ID. Ordinary UI creation continues using its UUID-generating
+convenience method. The manager also gains a delegated-prompt enqueue operation
+that:
+
+- always persists before reporting acceptance;
+- records source session and message ID provenance;
+- preserves FIFO order when the target is busy;
+- starts or reconnects the runner when appropriate; and
+- does not wait for the ACP `session/prompt` turn to finish.
+
+The existing worktree creation path currently returns an optimistic row while
+Git work continues in an unstructured task. Extract or extend its shared core
+so orchestration receives a completion result without polling published UI
+state. UI-created worktrees retain their current focus behavior; delegated
+creation passes a no-focus policy and still reuses branch validation, path
+templates, base selection, fetch behavior, startup scripts, remote handling,
+project refresh, and failure cleanup.
+
+## Creation Flow
+
+### Current Or Existing Worktree
+
+1. Validate root authority, prompt, agent, and target worktree.
+2. Allocate the child session ID.
+3. Persist a `starting` delegation record and pending initial prompt.
+4. Return the accepted `session_new` response.
+5. Get or create the target worktree's session manager.
+6. Create the child with the preallocated ID and normal auto-run default.
+7. Persist the initial prompt into the child's queue with parent provenance.
+8. Clear `pendingInitialPrompt`, mark the record `ready`, and start attach/flush.
+9. Publish state changes to MCP list callers and SwiftUI observers.
+
+### New Worktree
+
+1. Validate root authority, prompt, agent, branch, base, and destination.
+2. Allocate both the optimistic worktree ID and child session ID.
+3. Persist a `creatingWorktree` record and pending initial prompt.
+4. Return the accepted `session_new` response.
+5. Run the shared worktree creation path with no focus or tab activation.
+6. Reconcile the project and bind the real worktree ID to the delegation.
+7. Continue with steps 5 through 9 of the existing-worktree flow.
+
+The delegated session starts independently of `ACPTabView`; opening a tab is a
+presentation action, not the trigger for attach. Setup or authentication needs
+after the child exists are represented through normal ACP state rather than
+being treated as worktree-creation failure.
+
+### Relaunch Reconciliation
+
+At startup, reconcile nonterminal records:
+
+- If a planned worktree now exists and resolves to the recorded project,
+  continue child creation and initial-prompt delivery.
+- If a `starting` child already exists in its per-worktree store, resume prompt
+  transfer idempotently.
+- If neither condition can be proven, mark the record `failed` with an
+  interruption reason rather than repeating a Git mutation automatically.
+
+The UI offers Retry for a failed creation. Retry reuses the same child session
+ID and pending initial prompt after revalidation. There is no MCP
+`session_retry` tool in v1; an agent sees the failure through `session_list` and
+can inform the user or continue with another child.
+
+## Session State Projection
+
+The coordinator derives public state in this order:
+
+1. Persisted orchestration `failed` or `closed` wins.
+2. `creatingWorktree` maps to `creating_worktree`.
+3. `starting` or an attach/setup transition maps to `starting` unless it has a
+   terminal safe failure.
+4. A pending permission, question, or elicitation maps to `awaiting_input`.
+5. Sending or streaming maps to `running`.
+6. A ready/recoverable session without active work maps to `idle`.
+7. A missing or archived session/worktree that cannot be recovered maps to
+   `closed`.
+
+`last_activity_at` is the maximum of orchestration updates and the target
+session's persisted activity. State projection must not hydrate or decode a
+full transcript.
+
+## Prompt Provenance And Reporting
+
+Prompts transferred by `session_new` or `session_send` are ACP user prompts on
+the wire because they instruct the target agent. They are not authored by the
+human user, so Alas persists optional delegated provenance alongside the queue
+item and resulting transcript message:
+
+```swift
+struct ACPDelegatedPromptSource: Codable, Equatable, Sendable {
+    let messageId: String
+    let sourceSessionId: String
+}
+```
+
+The target transcript labels these bubbles as coming from a delegated session
+rather than presenting them as ordinary user-authored text. Older rows decode
+without provenance and retain current rendering.
+
+For a delegated child, the built-in Alas MCP injection includes parent
+metadata, for example `ALAS_PARENT_SESSION_ID`. The MCP `initialize`
+instructions explain that the session is a delegated child, identify its
+parent, and direct it to report results or blocking questions with
+`session_send`. `session_list` supplies the same relationship through normal
+tool data.
+
+Alas does not rewrite the initial prompt, inject a hidden transcript message,
+or automatically copy the child's final response to the parent. Reporting is
+an explicit child action. If the child becomes idle without reporting, the
+parent can observe `idle` through `session_list` and send a follow-up.
+
+## UI Design
+
+Extend existing ACP session surfaces rather than adding a dashboard.
+
+### Parent
+
+The existing session popover gains a **Delegated sessions** section below the
+current-session header. Each child row shows:
+
+- agent icon/name;
+- worktree name or branch;
+- live state;
+- unread activity, awaiting-input, or failure indication; and
+- a short safe error tooltip for failures.
+
+The row appears immediately after `session_new` is accepted, including while
+the worktree is being created. Clicking it switches to the child's worktree and
+opens or focuses that ACP session. Creation itself never changes focus.
+
+### Child
+
+A child session shows a compact **Delegated by [parent title]** backlink in the
+existing session/toolbar area. Activating it switches to and opens the parent.
+The child does not show a creation affordance for grandchildren; server-side
+authorization remains authoritative even if a stale client still attempts the
+call.
+
+### Failure And Activity
+
+Failed child creation remains visible with Retry. Retry is a user action and
+does not create a second child identity. Closing a parent tab does not stop its
+children. Idle children do not auto-close, auto-archive, or delete their
+worktrees.
+
+An incoming delegated prompt uses the existing transcript bubble structure
+with a compact source label/backlink. It is not placed in a new nested card.
+Unread delegated activity reuses the session activity styling already used by
+Alas rather than adding modal alerts or automatically activating the app.
+
+## Lifecycle Ownership
+
+Delegated sessions are ordinary persistent ACP sessions once created:
+
+- The user owns their tabs, archive state, permissions, and worktrees.
+- Parent archival or tab closure does not cascade.
+- Child idle state is not completion and causes no cleanup.
+- Agents cannot close, archive, delete, or retry sessions through these tools.
+- Relationship records remain available when either endpoint is archived so
+  provenance is not silently lost.
+- A permanently removed endpoint projects as `closed`; the other endpoint may
+  still show the historical relationship until normal user cleanup removes it.
+
+## Rust And Swift Wire Changes
+
+Rust changes preserve the umbrella issue's params-envelope rule:
+
+- Add `SessionList`, `SessionNew`, and `SessionSend` to `alas_client::Command`.
+- Encode all new arguments under `Request.params`; add no new legacy flat
+  fields.
+- Add `alas session ...` parsing and usage text.
+- Add matching MCP definitions and strict argument validation.
+- Keep path/worktree authority in Swift; Rust validates only shape, required
+  values, mutual exclusion, and non-blank strings.
+- Treat the app's JSON line as opaque command output for CLI and MCP content.
+
+Swift changes:
+
+- Add typed params decoding in `AlasCLIRequest`.
+- Add typed commands to `AlasCLICommandRouter` and `AlasActionService`.
+- Resolve and require an ACP origin before any orchestration action.
+- Return one deterministic JSON line for each command.
+- Keep authorization and target resolution in the coordinator/service layer,
+  never in SwiftUI or the Rust front end.
+
+## Error Handling
+
+Errors are short, stable enough for agents, and contain no prompt or transcript
+content. Expected cases include:
+
+```text
+session commands require an originating ACP session
+delegated sessions cannot create child sessions
+target session is not the caller's parent or child
+target session is closed
+agent is not enabled or ACP-capable
+unknown worktree "..."
+worktree and new_worktree are mutually exclusive
+invalid branch name: ...
+could not create worktree: ...
+could not start delegated session: ...
+```
+
+Validation failures do not allocate a child record. Failures after durable
+acceptance update the existing record to `failed`. A session setup/auth need is
+not collapsed into a generic orchestration failure; it remains visible through
+the target ACP session's normal state and UI.
+
+## Testing
+
+### Rust
+
+- CLI parsing for list, new, and send forms.
+- Mutual exclusion and required/non-blank argument validation.
+- Command-to-params request encoding.
+- MCP tool definitions and tool-call translation.
+- Stable MCP errors for invalid argument shapes.
+
+### Swift Request And Routing
+
+- Params decoding for all session commands.
+- ACP-origin requirement versus directory/terminal origins.
+- Router forwarding and deterministic JSON response encoding.
+- Unknown/disabled/non-ACP agent rejection.
+- Current, existing, and new-worktree request resolution.
+
+### Authorization
+
+- A root can create direct children.
+- A child cannot create a child.
+- Parent-to-child and child-to-parent sends succeed.
+- Sibling, unrelated, cross-project, missing, failed, and closed targets fail.
+- Forged session/worktree IDs cannot widen the graph.
+- Auto-run changes no server-side authorization result.
+
+### Persistence And Concurrency
+
+- Delegation records and pending prompts survive store reopen.
+- Initial prompt transfer clears the orchestration copy only after target queue
+  persistence succeeds.
+- Inbox claim and message-ID deduplication prevent duplicate prompts.
+- A writer takeover cannot let the stale instance mutate the target queue.
+- Another Alas instance can consume a durable message after acquiring the
+  legitimate target lease.
+- Relaunch reconciliation continues proven worktrees/sessions and honestly
+  fails ambiguous interrupted operations.
+
+### Session And Worktree Flow
+
+- Existing-worktree creation allocates the requested child ID, queues the
+  prompt, attaches without a tab, and does not focus.
+- New-worktree creation uses shared validation/startup behavior and does not
+  focus.
+- Worktree failure persists a retryable failed child.
+- Retry reuses the same child ID and does not duplicate the prompt.
+- `session_send` accepts while idle, busy, disconnected, or starting and
+  preserves FIFO order.
+- Delegated provenance round-trips through queue and transcript persistence.
+
+### State And UI Policy
+
+- Public state projection covers every persisted/runtime combination.
+- List output contains only self, parent, and direct children.
+- List output never includes transcript or prompt data.
+- Parent rows expose creation, activity, awaiting-input, failure, and retry.
+- Child backlink resolves across worktrees.
+- Delegated prompt rows are visibly attributed and remain backward-compatible
+  with ordinary transcript rows.
+
+After focused tests, run the repository-required `xcodegen`, quiet macOS build,
+and full test suite. Rust workspace tests cover the CLI/MCP side.
+
+## Implementation Sequence
+
+1. Add the orchestration store, models, graph authorization, and pure state
+   projection tests.
+2. Add Swift request types, action-service boundaries, and router tests.
+3. Add Rust CLI/MCP commands and wire tests.
+4. Add preallocated session creation, delegated queue provenance, and durable
+   inbox transfer.
+5. Add no-focus worktree completion plumbing and asynchronous child creation.
+6. Add dynamic MCP delegation instructions.
+7. Add parent/child UI surfaces, retry, navigation, and unread activity.
+8. Run focused integration tests, standard project generation/build/tests, and
+   manual end-to-end verification with two agents in separate worktrees.


### PR DESCRIPTION
## Summary
- add durable parent/child ACP delegation state and routed session CLI/MCP commands
- create child sessions in current, existing, or background-created worktrees without stealing focus
- preserve delegated prompt provenance and surface delegated activity in the existing session menu

## Verification
- `cargo test --manifest-path AlasCLI/Cargo.toml`
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build ALAS_FFF_TARGET_ARCH=arm64`\n- focused router, policy, request, and store Swift tests\n\nThe broader local Swift test batch hits an existing compiler diagnostic-generation failure while compiling unrelated test files; CI will run the full matrix.
- 
closes #795 