### PR TITLE
fix(worktree): keep new worktrees creating until ready

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -991,6 +991,7 @@ final class AppState {
                     )
                     let gcDropped = try await projectsManager.refreshWorktrees(projectId: project.id)
                     guard projects.contains(where: { $0.id == projectId }) else { return }
+                    projectsManager.setOperationState(id: optimistic.id, state: nil)
                     if wasHidden || gcDropped {
                         saveProjects()
                     }

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -323,8 +323,9 @@ final class ProjectsManager {
         let url = URL(fileURLWithPath: project.path)
         let trees = try await worktreeSvc.list(repoPath: url, projectId: projectId)
 
-        // Reconcile optimistic rows: preserve creating rows that still aren't in git,
-        // replace them with real rows when they appear, and clear operation state.
+        // Reconcile optimistic rows: preserve creating rows until the owner
+        // task completes, while still replacing them with real rows when
+        // they appear in git.
         let previous = worktreesByProject[projectId, default: []]
         let previousById = Dictionary(uniqueKeysWithValues: previous.map { ($0.id, $0) })
         let liveIds = Set(trees.map(\.id))
@@ -339,9 +340,6 @@ final class ProjectsManager {
                     if let optimistic = previousById[id] {
                         reconciled.append(optimistic)
                     }
-                } else {
-                    // Creation succeeded; clear the pending state.
-                    clearOperationIds.append(id)
                 }
             case .deleting:
                 // If the row is gone from git, the deletion succeeded.

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -356,7 +356,7 @@ extension ProjectsManagerTests {
         #expect(mgr.worktrees(projectId: project.id).filter { $0.id == optimistic.id }.count == 1)
     }
 
-    @Test func refreshReconcilesCreatingWorktree() async throws {
+    @Test func refreshReconcilesCreatingWorktreeWithoutCompletingIt() async throws {
         let repo = try await makeRepo(name: "reconcile")
         defer { try? FileManager.default.removeItem(at: repo) }
         let mgr = ProjectsManager(persistedProjects: [])
@@ -365,24 +365,37 @@ extension ProjectsManagerTests {
 
         let svc = WorktreeService()
         let dest = repo.appendingPathComponent("wt-reconcile")
-        _ = try await svc.add(repoPath: repo, base: "main", branch: "reconcile-b", destination: dest, projectId: project.id)
+        _ = try await svc.add(
+            repoPath: repo,
+            base: "main",
+            branch: "reconcile-b",
+            destination: dest,
+            projectId: project.id
+        )
+        let live = try #require(
+            try await svc.list(repoPath: repo, projectId: project.id)
+                .first { $0.id == Worktree.makeId(path: dest) }
+        )
 
         let optimistic = Worktree(
             id: Worktree.makeId(path: dest),
             projectId: project.id,
-            name: "reconcile-b",
+            name: "optimistic-name",
             branch: "reconcile-b",
             path: dest,
             status: .clean,
-            lastActivity: Date()
+            lastActivity: Date(timeIntervalSince1970: 0)
         )
         mgr.insertOptimisticWorktree(optimistic)
         mgr.setOperationState(id: optimistic.id, state: .creating)
 
         try await mgr.refreshWorktrees(projectId: project.id)
+
         let trees = mgr.worktrees(projectId: project.id)
-        #expect(trees.contains { $0.id == optimistic.id })
-        #expect(mgr.operationState(for: optimistic.id) == nil)
+        let reconciled = try #require(trees.first { $0.id == optimistic.id })
+        #expect(reconciled.name == live.name)
+        #expect(reconciled.lastActivity == live.lastActivity)
+        #expect(mgr.operationState(for: optimistic.id) == .creating)
     }
 
     @Test func refreshKeepsCreatingWorktreeUntilGitSeesIt() async throws {

--- a/docs/superpowers/plans/2026-07-15-worktree-creation-lifecycle-implementation.md
+++ b/docs/superpowers/plans/2026-07-15-worktree-creation-lifecycle-implementation.md
@@ -1,0 +1,250 @@
+# Worktree Creation Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent the changes/files panes from querying a new worktree until the create workflow has fully completed.
+
+**Architecture:** `AppState.createWorktree` owns the `.creating` lifecycle because it is the only code path that awaits checkout, startup, and final refresh. `ProjectsManager.refreshWorktrees` continues reconciling live Git worktree rows but no longer treats Git visibility as creation completion.
+
+**Tech Stack:** Swift 5.9+, SwiftUI app state, Swift Testing, Git worktree integration.
+
+---
+
+## File Structure
+
+- Modify `AlasTests/ProjectsManagerTests.swift`
+  - Update the existing creating-reconciliation regression so topology refresh preserves `.creating` after Git lists the worktree.
+  - Assert the optimistic row is replaced by canonical live metadata.
+- Modify `Alas/Sources/App/ProjectsManager.swift`
+  - Preserve `.creating` during refresh even when the worktree is live in `git worktree list`.
+  - Keep existing `.deleting`, `.createFailed`, and `.deleteFailed` reconciliation behavior.
+- Modify `Alas/Sources/App/AppState.swift`
+  - Explicitly clear `.creating` after the successful final refresh in `createWorktree`.
+  - Keep failure paths setting `.createFailed`.
+- Modify `docs/superpowers/plans/2026-07-15-worktree-creation-lifecycle-implementation.md`
+  - Track implementation progress by checking off steps as they complete.
+
+User requested one final conventional commit, so do not create per-task commits.
+
+## Task 1: Lock Down Refresh Reconciliation
+
+**Files:**
+- Modify: `AlasTests/ProjectsManagerTests.swift`
+
+- [x] **Step 1: Update the failing regression test**
+
+Replace the existing `refreshReconcilesCreatingWorktree` test with this body:
+
+```swift
+@Test func refreshReconcilesCreatingWorktreeWithoutCompletingIt() async throws {
+    let repo = try await makeRepo(name: "reconcile")
+    defer { try? FileManager.default.removeItem(at: repo) }
+    let mgr = ProjectsManager(persistedProjects: [])
+    let project = try await mgr.addProject(path: repo, displayName: "reconcile", color: "#5fb7c4")
+    try await mgr.refreshWorktrees(projectId: project.id)
+
+    let svc = WorktreeService()
+    let dest = repo.appendingPathComponent("wt-reconcile")
+    let live = try await svc.add(
+        repoPath: repo,
+        base: "main",
+        branch: "reconcile-b",
+        destination: dest,
+        projectId: project.id
+    )
+
+    let optimistic = Worktree(
+        id: Worktree.makeId(path: dest),
+        projectId: project.id,
+        name: "optimistic-name",
+        branch: "reconcile-b",
+        path: dest,
+        status: .clean,
+        lastActivity: Date(timeIntervalSince1970: 0)
+    )
+    mgr.insertOptimisticWorktree(optimistic)
+    mgr.setOperationState(id: optimistic.id, state: .creating)
+
+    try await mgr.refreshWorktrees(projectId: project.id)
+
+    let trees = mgr.worktrees(projectId: project.id)
+    let reconciled = try #require(trees.first { $0.id == optimistic.id })
+    #expect(reconciled.name == live.name)
+    #expect(reconciled.lastActivity == live.lastActivity)
+    #expect(mgr.operationState(for: optimistic.id) == .creating)
+}
+```
+
+- [ ] **Step 2: Run the targeted test and verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ProjectsManagerTests/refreshReconcilesCreatingWorktreeWithoutCompletingIt
+```
+
+Expected: FAIL because `ProjectsManager.refreshWorktrees` still clears `.creating` when Git sees the worktree.
+
+## Task 2: Preserve Creating State During Topology Refresh
+
+**Files:**
+- Modify: `Alas/Sources/App/ProjectsManager.swift`
+- Test: `AlasTests/ProjectsManagerTests.swift`
+
+- [x] **Step 1: Implement minimal reconciliation change**
+
+In `ProjectsManager.refreshWorktrees(projectId:)`, replace the `.creating` switch branch with:
+
+```swift
+case .creating:
+    if !liveIds.contains(id) {
+        // Still pending; keep the optimistic row visible.
+        if let optimistic = previousById[id] {
+            reconciled.append(optimistic)
+        }
+    }
+```
+
+This leaves the live `trees` entry in `reconciled` when Git already lists the worktree, but preserves the operation state for `AppState.createWorktree` to clear.
+
+- [ ] **Step 2: Run the targeted reconciliation tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ProjectsManagerTests/refreshReconcilesCreatingWorktreeWithoutCompletingIt -only-testing:AlasTests/ProjectsManagerTests/refreshKeepsCreatingWorktreeUntilGitSeesIt -only-testing:AlasTests/ProjectsManagerTests/refreshClearsCreateFailedWhenWorktreeAppears
+```
+
+Expected: PASS. This verifies live creating worktrees stay `.creating`, not-yet-live creating rows remain visible, and `.createFailed` recovery still clears when Git later shows the worktree.
+
+## Task 3: Clear Creating on Successful Create Completion
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Test: `AlasTests/AppStateCleanupTests.swift`
+
+- [x] **Step 1: Add explicit success-path clearing**
+
+In `AppState.createWorktree`, after the final `refreshWorktrees(projectId:)` succeeds, after the `guard projects.contains(where:)` check, and before `if wasHidden || gcDropped`, add:
+
+```swift
+projectsManager.setOperationState(id: optimistic.id, state: nil)
+```
+
+The resulting block should be:
+
+```swift
+let gcDropped = try await projectsManager.refreshWorktrees(projectId: project.id)
+guard projects.contains(where: { $0.id == projectId }) else { return }
+projectsManager.setOperationState(id: optimistic.id, state: nil)
+if wasHidden || gcDropped {
+    saveProjects()
+}
+```
+
+- [ ] **Step 2: Run the targeted AppState create tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppStateCleanupTests/createWorktreeInsertsOptimisticRowImmediately -only-testing:AlasTests/AppStateCleanupTests/createWorktreeSelectsOptimisticRowImmediately -only-testing:AlasTests/AppStateCleanupTests/createWorktreeRetryAllowsFailedOptimisticDestination -only-testing:AlasTests/AppStateCleanupTests/createWorktreeFailureLeavesFailedRow
+```
+
+Expected: PASS. These tests cover immediate `.creating`, eventual success clearing, retry clearing, and failure preserving `.createFailed`.
+
+## Task 4: Full Verification and Regression Sweep
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-15-worktree-creation-lifecycle-implementation.md`
+
+- [x] **Step 1: Run project generation**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: exit 0. If it changes `Alas.xcodeproj`, include that generated change.
+
+- [ ] **Step 2: Run the macOS build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exit 0 with no failing tests.
+
+- [ ] **Step 4: Inspect the final diff**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat
+git diff -- Alas/Sources/App/AppState.swift Alas/Sources/App/ProjectsManager.swift AlasTests/ProjectsManagerTests.swift docs/superpowers/plans/2026-07-15-worktree-creation-lifecycle-implementation.md
+```
+
+Expected: no whitespace errors, and the diff is limited to the planned lifecycle fix, test update, and checked-off plan.
+
+## Task 5: Final Commit, Rebase, PR, CI, and Codex Review
+
+**Files:**
+- Commit all implementation changes as one final conventional commit.
+
+- [ ] **Step 1: Commit all changes as one conventional commit**
+
+Use this commit message, adjusting the body only if the final diff differs materially:
+
+```text
+fix: keep new worktrees creating until ready
+
+- Preserve creating state during topology refresh reconciliation
+- Clear creating state from the create workflow after final refresh
+- Cover live creating reconciliation and successful create completion
+```
+
+- [ ] **Step 2: Rebase on origin/main**
+
+Run:
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Expected: rebase completes cleanly. If conflicts occur, resolve them without dropping the lifecycle fix or tests, then rerun targeted tests impacted by conflict resolution.
+
+- [ ] **Step 3: Push the branch**
+
+Run:
+
+```bash
+git push --force-with-lease
+```
+
+Expected: branch updates on the remote.
+
+- [ ] **Step 4: Open or update the PR**
+
+Create or update the PR for `nacho/issue-creating-worktree` against `main`. The PR summary should mention:
+
+- The root cause: topology refresh exposed a partial checkout by clearing `.creating`.
+- The fix: refresh reconciles canonical row data but preserves `.creating`; the create task clears it after final refresh.
+- Verification: `xcodegen`, build, and full test suite results.
+
+- [ ] **Step 5: Loop until CI is green and Codex approves**
+
+Check PR CI and Codex review status. If CI fails or Codex requests changes, inspect the failure/review, implement the smallest correct fix, rerun the relevant local verification command for that fix, rerun the full final gate before pushing, amend or add to the single final commit as needed, rebase on `origin/main`, push, and repeat until CI is green and Codex gives approval.

--- a/docs/superpowers/specs/2026-07-15-worktree-creation-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-15-worktree-creation-lifecycle-design.md
@@ -1,0 +1,145 @@
+# Worktree Creation Lifecycle Design
+
+## Context
+
+Alas inserts and selects an optimistic worktree row before running `git
+worktree add`. While the row has a `.creating` operation state, the center and
+right panes show creation progress instead of querying the incomplete
+worktree.
+
+`ProjectGitWatcher` independently watches the repository Git directory. A new
+linked worktree appears in `git worktree list` early in `git worktree add`,
+before checkout has necessarily materialized every file. The watcher can call
+`ProjectsManager.refreshWorktrees` during this interval. The current
+reconciliation logic treats presence in the Git worktree list as creation
+completion and clears `.creating`, allowing `RightPaneState` to run `git
+status` and `git diff HEAD` against a partial checkout.
+
+This is highly visible in `android_stb` because its checkout takes longer than
+the project topology watcher's debounce. A measured temporary-worktree probe
+showed:
+
+- Git listed the worktree after 0.162 seconds while `git worktree add` was
+  still running.
+- At 0.198 seconds, 3,470 files existed while `git diff --numstat HEAD`
+  reported all 9,632 tracked paths as deleted, totaling 668,177 deleted
+  lines.
+- The worktree became clean around 3.2 seconds.
+- `git worktree add` returned around 4.9 seconds.
+
+Smaller repositories usually finish checkout before the 0.5-second topology
+debounce fires, which hides the race.
+
+The repository also runs asynchronous post-checkout setup, but a second probe
+confirmed the worktree remains clean after `git worktree add` returns while
+that setup runs. The false snapshot comes from exposing the worktree during
+checkout, not from the background setup phase.
+
+## Goals
+
+- Keep the creation-progress UI visible for the complete create workflow:
+  checkout, configured startup script, and final project refresh.
+- Prevent the changes and files pipelines from querying a partially checked
+  out worktree.
+- Continue allowing project topology refreshes while creation is in progress.
+- Preserve optimistic row insertion, immediate selection, failure recovery,
+  and canonical worktree metadata reconciliation.
+- Use lifecycle ownership instead of debounce intervals, delays, or
+  repository-specific heuristics.
+
+## Non-Goals
+
+- Change Git worktree creation commands or repository hooks.
+- Wait for repository-owned background post-checkout jobs after `git worktree
+  add` returns.
+- Add a new user-visible finalizing state.
+- Suppress or reinterpret legitimate large deletions outside worktree
+  creation.
+- Change delete-worktree lifecycle behavior.
+
+## Design
+
+The task started by `AppState.createWorktree` owns the `.creating` lifecycle.
+Only that task may clear `.creating` after the complete workflow succeeds.
+
+`ProjectsManager.refreshWorktrees` remains responsible for discovering live
+Git worktrees and reconciling row data. When a worktree with a `.creating`
+operation state appears in the Git list, the manager replaces the optimistic
+row with the live `Worktree` value but preserves `.creating`. Git discovery
+means the worktree exists; it does not mean the owning checkout workflow has
+completed.
+
+The successful create flow becomes:
+
+1. Insert the optimistic row, set `.creating`, and select it.
+2. Run the optional pre-create fetch.
+3. Await `git worktree add`.
+4. Await the configured worktree startup script when enabled.
+5. Refresh project worktrees so the optimistic row is replaced with canonical
+   Git metadata.
+6. Explicitly clear `.creating` in `AppState.createWorktree`.
+7. Re-select the canonical row and perform the requested launch action.
+
+The right-pane selection resolver already maps `.creating` to the progress UI.
+Preserving that state prevents `RightPaneView` and `RightPaneState` from being
+created during checkout, avoiding both the false snapshot and the expensive
+status/diff work that caused visible lag.
+
+No arbitrary settling delay is added. The owner already has the authoritative
+completion signal: return from the awaited create, startup, and refresh
+operations.
+
+## Error Handling
+
+Existing failure behavior remains:
+
+- A fetch failure remains best-effort and does not fail creation.
+- A checkout, startup orchestration, or final refresh error changes the
+  operation state to `.createFailed` with the original base branch for retry.
+- A later topology refresh may clear `.createFailed` if Git shows that the
+  worktree exists, preserving recovery from a transient final refresh failure.
+- Removing a project while creation is running continues to make the owning
+  task return without mutating removed project state.
+
+The success path clears `.creating` only after the final refresh succeeds.
+There is no fallback in generic topology reconciliation that can expose the
+worktree early.
+
+## Testing
+
+Focused Swift Testing coverage will verify:
+
+- Refreshing topology while a `.creating` worktree is already visible to Git
+  preserves the `.creating` operation state.
+- That refresh still replaces optimistic row metadata with the canonical live
+  `Worktree` data.
+- The complete `AppState.createWorktree` success path explicitly clears the
+  operation state.
+- Existing create-failure and retry behavior continues to work.
+- Existing selection resolver coverage continues to prove that `.creating`
+  renders progress rather than the active right pane.
+
+The standard project generation, build, and test commands remain the final
+verification gate.
+
+## Alternatives Considered
+
+### Add a Finalizing State
+
+A separate `.finalizing` state could distinguish Git discovery from full
+workflow completion. It would produce the same UI behavior but expand the
+operation state model and all exhaustive switches without a current product
+need.
+
+### Suppress Suspicious Diff Snapshots
+
+Alas could reject all-delete snapshots while checkout indicators such as
+`index.lock` exist. This would treat the visible symptom, still run expensive
+Git commands during checkout, and depend on Git implementation details that do
+not express the actual application lifecycle.
+
+### Delay Topology Refresh
+
+Increasing the watcher debounce or adding a fixed post-discovery delay would
+only move the race. Checkout duration varies by repository, storage, filters,
+and hooks, so no fixed interval provides a correctness guarantee.


### PR DESCRIPTION
## Summary

This fixes the transient massive changes snapshot that can appear while creating a new linked worktree in large repositories such as `android_stb`.

Root cause: topology refresh can see the new worktree in `git worktree list` before checkout has fully materialized files. `ProjectsManager.refreshWorktrees` treated that Git visibility as creation completion and cleared `.creating`, which allowed the right pane to run status/diff against a partial checkout.

## Changes

- Preserve `.creating` during topology refresh reconciliation, while still replacing optimistic row data with the canonical live Git row.
- Clear `.creating` from the owning `AppState.createWorktree` task after checkout, optional startup script, and final refresh complete.
- Add regression coverage for live creating reconciliation preserving operation state while adopting canonical metadata.
- Document the race evidence, lifecycle design, and implementation plan.

## Verification

- `xcodegen` passed locally.
- `git diff --check` passed locally.
- Source review completed with no remaining issues.
- Local `xcodebuild` build/test attempts are currently blocked before compilation by Xcode reporting `There is no XCFramework found at .build/ghostty/GhosttyKit.xcframework`, even after running `scripts/build-ghostty.sh` to populate the ignored build artifact. CI should provide the authoritative full Xcode build/test result for this branch.