### PR TITLE
fix(changes): Show GitLab inspect action

### DIFF
--- a/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewReadinessModel.swift
@@ -271,6 +271,10 @@ struct ReviewReadinessModel: Equatable, Sendable {
             } else if request.worstCheckBucket == .fail || request.hasActionableFeedback {
                 actions.append(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true))
             }
+            if request.provider == .gitlab,
+               !actions.contains(where: { $0.kind == .inspectReviewEvidence }) {
+                actions.append(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true))
+            }
         } else if canCreateReviewRequest(snapshot) {
             actions.append(Action(kind: .createReviewRequest, title: "Create \(requestLabel)", isEnabled: true))
         }

--- a/AlasTests/Integrations/ReviewReadinessModelTests.swift
+++ b/AlasTests/Integrations/ReviewReadinessModelTests.swift
@@ -152,6 +152,19 @@ struct ReviewReadinessModelTests {
         #expect(model.actions.contains(Action(kind: .createReviewRequest, title: "Create MR", isEnabled: true)))
     }
 
+    @Test func openGitLabRequestExposesInspectEvenWithoutAttentionState() {
+        let remote = Self.makeRemote(kind: .gitlab)
+        let request = Self.makeReviewRequest(remote: remote)
+        let model = ReviewReadinessModel(
+            snapshot: Self.makeSnapshot(remote: remote, reviewRequest: request, providerCapabilities: .gitlabCLI),
+            lastError: nil,
+            canOpenAgentHandoff: false
+        )
+
+        #expect(model.actions.contains(Action(kind: .openReviewRequest, title: "Open MR", isEnabled: true)))
+        #expect(model.actions.contains(Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true)))
+    }
+
     @Test func failedChecksExposeRerunAndInspectWhenSupported() {
         let request = Self.makeReviewRequest(checks: [Self.makeCheck(bucket: .fail)])
         let model = ReviewReadinessModel(


### PR DESCRIPTION
## Summary
The GitLab prepare card rarely exposed `Inspect` because the readiness model only emitted review evidence actions for merge-ready, failed-check, or actionable-feedback states. Ordinary open GitLab MRs only surfaced `Open MR`, so the prepare section had no inspect action to prioritize.

This PR keeps the existing higher-priority review evidence actions, and adds a GitLab fallback so existing MRs still expose `Inspect` when no attention state is present.

## Changes
- Expose an `Inspect` action for existing GitLab MRs when one was not already emitted.
- Add a regression test for a normal GitLab MR with no failed checks, feedback, or merge-ready state.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ReviewReadinessModelTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ChangesPreparationModelTests`
- Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` ran to completion; the only failures were the existing `SSHIntegrationTests` gate because `ALAS_SSH_INTEGRATION` is not set locally.
