### PR TITLE
fix(diff): keep expand pill aligned with text

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1043,6 +1043,40 @@ final class DiffPaneCodeTextView: NSTextView {
         return 0.18
     }
 
+    nonisolated static func expandPillRect(
+        textRect: NSRect,
+        firstLineRect: NSRect,
+        rowRect: NSRect,
+        chevronSize: NSSize,
+        chevronGap: CGFloat = 5,
+        horizontalPadding: CGFloat = 12,
+        verticalInset: CGFloat = 2
+    ) -> NSRect {
+        let anchorRect = textRect.isEmpty ? (firstLineRect.isEmpty ? rowRect : firstLineRect) : textRect
+        let pillHeight = max(anchorRect.height + verticalInset * 2, 1)
+        let chevronLeftX = textRect.minX - chevronGap - chevronSize.width
+        let pillLeft = (chevronSize == .zero ? textRect.minX : chevronLeftX) - horizontalPadding
+        return NSRect(
+            x: pillLeft,
+            y: anchorRect.midY - pillHeight / 2,
+            width: textRect.maxX + horizontalPadding - pillLeft,
+            height: pillHeight
+        )
+    }
+
+    nonisolated static func expandChevronRect(
+        chevronLeftX: CGFloat,
+        chevronSize: NSSize,
+        pillRect: NSRect
+    ) -> NSRect {
+        NSRect(
+            x: chevronLeftX,
+            y: pillRect.midY - chevronSize.height / 2,
+            width: chevronSize.width,
+            height: chevronSize.height
+        )
+    }
+
     var rowGeometryComputationCountForTesting: Int {
         rowGeometryComputationCount
     }
@@ -1728,9 +1762,9 @@ final class DiffPaneCodeTextView: NSTextView {
             .offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
         guard !textRect.isEmpty else { return }
 
-        // The expandable row uses a taller fixed line height and the label is
-        // baseline-shifted to the row's vertical center (see the builder), so the
-        // pill can simply center on the row and inset a little to fit within it.
+        // Split panes can synchronize a row to be taller than its first text
+        // fragment. Keep the pill attached to the fragment where the label is
+        // drawn instead of centering it in the full synchronized row.
         // The chevron is drawn here (not baked into the text) so the backing
         // string stays a plain label for selection/copy.
         let chevronGap: CGFloat = 5
@@ -1743,15 +1777,17 @@ final class DiffPaneCodeTextView: NSTextView {
         let chevronSize = chevronImage?.size ?? .zero
         let chevronLeftX = textRect.minX - chevronGap - chevronSize.width
 
-        let horizontalPadding: CGFloat = 12
-        let verticalInset: CGFloat = 2
-        let pillHeight = max(rowRect.height - verticalInset * 2, 1)
-        let pillLeft = (chevronImage == nil ? textRect.minX : chevronLeftX) - horizontalPadding
-        let pillRect = NSRect(
-            x: pillLeft,
-            y: rowRect.midY - pillHeight / 2,
-            width: textRect.maxX + horizontalPadding - pillLeft,
-            height: pillHeight
+        let firstLineRect = firstLineFragmentRect(
+            for: range,
+            layoutManager: layoutManager,
+            origin: textContainerOrigin
+        )
+        let pillRect = Self.expandPillRect(
+            textRect: textRect,
+            firstLineRect: firstLineRect,
+            rowRect: rowRect,
+            chevronSize: chevronSize,
+            chevronGap: chevronGap
         )
         let alpha = Self.expandPillFillAlpha(
             hovered: hoverExpansionRow == row,
@@ -1762,11 +1798,10 @@ final class DiffPaneCodeTextView: NSTextView {
         path.fill()
 
         if let chevronImage {
-            let chevronRect = NSRect(
-                x: chevronLeftX,
-                y: rowRect.midY - chevronSize.height / 2,
-                width: chevronSize.width,
-                height: chevronSize.height
+            let chevronRect = Self.expandChevronRect(
+                chevronLeftX: chevronLeftX,
+                chevronSize: chevronSize,
+                pillRect: pillRect
             )
             chevronImage.draw(in: chevronRect)
         }

--- a/AlasTests/DiffPaneTextDocumentBuilderTests.swift
+++ b/AlasTests/DiffPaneTextDocumentBuilderTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Testing
 @testable import Alas
 
@@ -19,5 +20,32 @@ struct DiffPaneTextDocumentBuilderTests {
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: true, pressed: false) == 0.28)
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: true, pressed: true) == 0.36)
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: false, pressed: true) == 0.36)
+    }
+
+    @Test func expandPillStaysWithFirstTextFragmentInTallRows() {
+        let textRect = CGRect(x: 120, y: 18, width: 230, height: 16)
+        let firstLineRect = CGRect(x: 0, y: 14, width: 700, height: 72)
+        let rowRect = CGRect(x: 0, y: 14, width: 700, height: 72)
+        let chevronSize = CGSize(width: 12, height: 12)
+
+        let pillRect = DiffPaneCodeTextView.expandPillRect(
+            textRect: textRect,
+            firstLineRect: firstLineRect,
+            rowRect: rowRect,
+            chevronSize: chevronSize
+        )
+
+        #expect(pillRect.midY == textRect.midY)
+        #expect(pillRect.midY != firstLineRect.midY)
+        #expect(pillRect.midY != rowRect.midY)
+
+        let chevronRect = DiffPaneCodeTextView.expandChevronRect(
+            chevronLeftX: textRect.minX - 5 - chevronSize.width,
+            chevronSize: chevronSize,
+            pillRect: pillRect
+        )
+
+        #expect(chevronRect.midY == pillRect.midY)
+        #expect(chevronRect.midY != rowRect.midY)
     }
 }


### PR DESCRIPTION
## Summary

Fixes a diff expand-control layout bug where the `Expand 10 unchanged lines` label could appear outside its pill in tall synchronized split rows.

The root cause was that the pill background was vertically centered in the full row rect, while the label text is drawn in the first text line fragment. Split panes can inflate one side's row height to match the other side, which left the pill detached from the text.

## Changes

- Anchor expand pill geometry to the first line fragment used for text drawing, with a fallback to the row rect.
- Reuse that geometry in the AppKit drawing path so the chevron, label, and pill stay together.
- Add a regression test for tall synchronized rows where the row center differs from the text fragment center.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneTextDocumentBuilderTests/expandPillStaysWithFirstTextFragmentInTallRows -quiet test`

Full local suite was also run before rebasing; it failed outside this change on SSH integration tests requiring `ALAS_SSH_INTEGRATION=1` and `RightPaneStateBaseBranchTests/storeRefreshesWhenConfigMatchesClearedOverride()`.