### PR TITLE
fix(acp): avoid menu tracking list invalidation

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -40,7 +40,10 @@ struct ACPMessageList: View {
     @State private var latestRememberedScrollAnchorIndex: Int?
     @State private var restoredRememberedAnchor: String?
     @State private var pendingTailScrollTask: Task<Void, Never>?
-    @State private var modernRowFrames: [String: CGRect] = [:]
+    // Geometry callbacks can run while AppKit is tracking a native menu. Keep
+    // their per-row bookkeeping out of SwiftUI-observed value state: changing
+    // a cached frame must not invalidate the entire lazy transcript list.
+    @State private var modernRowFrameCache = ACPRowFrameCache()
 
     /// Height of an invisible spacer at the tail of the transcript stack. The
     /// composer pill plus its outer padding occupies roughly this much
@@ -480,13 +483,8 @@ struct ACPMessageList: View {
 
     private func handleModernRowFrame(id: String, frame: CGRect) {
         let lookup = visibleMessageLookup
-        modernRowFrames = modernRowFrames.filter { lookup.contains($0.key) }
-        if lookup.contains(id), frame.height > 0, frame.maxY > 0 {
-            modernRowFrames[id] = frame
-        } else {
-            modernRowFrames.removeValue(forKey: id)
-        }
-        guard let anchor = Self.topVisibleAnchorID(in: modernRowFrames) else { return }
+        modernRowFrameCache.update(id: id, frame: frame, lookup: lookup)
+        guard let anchor = Self.topVisibleAnchorID(in: modernRowFrameCache.frames) else { return }
         let anchorChanged = latestTopVisibleAnchor.value != anchor
         if anchorChanged {
             latestTopVisibleAnchor.value = anchor
@@ -1046,6 +1044,41 @@ private final class ACPWeakScrollViewRef {
 
 private final class ACPMutableScrollAnchor {
     var value: String?
+}
+
+/// Non-observed cache for the modern per-row geometry callbacks. SwiftUI's
+/// `onGeometryChange` may be serviced by nested AppKit run loops (such as an
+/// open `NSMenu`), so assigning a dictionary held in `@State` here would
+/// invalidate the full list for every callback.
+final class ACPRowFrameCache {
+    private(set) var frames: [String: CGRect] = [:]
+
+    /// Returns whether the cached frame set changed. Keeping stable reports as
+    /// no-ops prevents needless work even outside nested menu tracking loops.
+    @discardableResult
+    func update(
+        id: String,
+        frame: CGRect,
+        lookup: ACPMessageList.VisibleMessageLookup
+    ) -> Bool {
+        var changed = false
+        let staleIDs = frames.keys.filter { !lookup.contains($0) }
+        for staleID in staleIDs {
+            frames.removeValue(forKey: staleID)
+            changed = true
+        }
+
+        if lookup.contains(id), frame.height > 0, frame.maxY > 0 {
+            guard frames[id] != frame else { return changed }
+            frames[id] = frame
+            return true
+        }
+
+        if frames.removeValue(forKey: id) != nil {
+            changed = true
+        }
+        return changed
+    }
 }
 
 private struct ACPHeadFramePreferenceKey: PreferenceKey {

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -184,6 +184,34 @@ struct ACPMessageListPaginationTests {
         ))
     }
 
+    @Test("modern row-frame cache ignores stable geometry reports")
+    func modernRowFrameCacheIgnoresStableGeometryReports() {
+        let lookup = ACPMessageList.visibleMessageLookup(rows: [
+            (index: 40, stableId: "message-40")
+        ])
+        let cache = ACPRowFrameCache()
+        let frame = CGRect(x: 0, y: 16, width: 100, height: 80)
+
+        #expect(cache.update(id: "message-40", frame: frame, lookup: lookup))
+        #expect(!cache.update(id: "message-40", frame: frame, lookup: lookup))
+        #expect(cache.frames == ["message-40": frame])
+    }
+
+    @Test("modern row-frame cache removes stale rows without repeated writes")
+    func modernRowFrameCachePrunesStaleRowsOnce() {
+        let cache = ACPRowFrameCache()
+        let frame = CGRect(x: 0, y: 16, width: 100, height: 80)
+        let originalLookup = ACPMessageList.visibleMessageLookup(rows: [
+            (index: 40, stableId: "message-40")
+        ])
+        let emptyLookup = ACPMessageList.visibleMessageLookup(rows: [])
+
+        #expect(cache.update(id: "message-40", frame: frame, lookup: originalLookup))
+        #expect(cache.update(id: "message-40", frame: frame, lookup: emptyLookup))
+        #expect(!cache.update(id: "message-40", frame: frame, lookup: emptyLookup))
+        #expect(cache.frames.isEmpty)
+    }
+
     @Test("visible message lookup records ids and transcript indices")
     func visibleMessageLookupRecordsIdsAndTranscriptIndices() {
         let lookup = ACPMessageList.visibleMessageLookup(rows: [


### PR DESCRIPTION
## Summary

- move modern row-frame bookkeeping out of SwiftUI-observed value state
- ignore stable geometry reports and prune stale rows once
- add regression coverage for stable and stale row-frame cache updates

## Root cause

Each modern row geometry callback assigned the top-level `modernRowFrames` `@State` dictionary, including when the effective frame set was unchanged. AppKit's nested `NSMenu` tracking loop could repeatedly service those callbacks and force a full `ACPMessageList` relayout.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test`