### PR TITLE
fix(diff): lazily render stacked hunks

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -234,7 +234,7 @@ struct DiffPaneView: View {
     }
 
     private var staticRowsStack: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(model.groups) { group in
                 hunk(group)
             }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -53,6 +53,7 @@ struct DiffReviewFileSection: View {
     var inlineFeedbackScrollTargetID: String? = nil
     var draftComments: [ReviewDraftComment] = []
     var focusedDraftCommentID: String? = nil
+    var draftCommentScrollTargetID: String? = nil
     @Binding var layoutMode: DiffLayoutMode
     @Binding var wrapLines: Bool
     @Binding var showWhitespace: Bool
@@ -431,6 +432,10 @@ struct DiffReviewFileSection: View {
         Set([focusedFeedbackID, inlineFeedbackScrollTargetID].compactMap(\.self))
     }
 
+    private var requiredDraftCommentIDs: Set<String> {
+        Set([focusedDraftCommentID, draftCommentScrollTargetID].compactMap(\.self))
+    }
+
     private func fileLevelInlineFeedback(renderContext: DiffReviewRenderContext?) -> [DiffReviewInlineFeedback] {
         guard let renderContext else { return inlineFeedback }
         return renderContext.fileLevelInlineFeedback
@@ -555,17 +560,20 @@ struct DiffReviewFileSection: View {
     @ViewBuilder
     private func content(renderContext: DiffReviewRenderContext?) -> some View {
         if let displayModel = file.displayModel, let renderContext {
-            LazyVStack(spacing: 0) {
-                ForEach(renderContext.groups) { group in
-                    if !group.inlineFeedback.isEmpty {
-                        inlineFeedbackStack(
-                            group.inlineFeedback,
-                            file: file.summary,
-                            rows: group.displayGroup.rows
-                        )
-                    }
-                    reviewGroup(group, displayModel: displayModel)
+            let groups = renderContext.groups
+            if let requiredGroupID = DiffReviewRequiredGroupResolver.groupID(
+                in: groups,
+                inlineFeedbackIDs: requiredInlineFeedbackIDs,
+                draftCommentIDs: requiredDraftCommentIDs
+            ), let requiredIndex = groups.firstIndex(where: { $0.id == requiredGroupID }) {
+                // Keep the commanded card's real ID available without eagerly rendering unrelated hunks.
+                VStack(spacing: 0) {
+                    lazyGroupStack(Array(groups[..<requiredIndex]), displayModel: displayModel)
+                    groupContent(groups[requiredIndex], displayModel: displayModel)
+                    lazyGroupStack(Array(groups[groups.index(after: requiredIndex)...]), displayModel: displayModel)
                 }
+            } else {
+                lazyGroupStack(groups, displayModel: displayModel)
             }
         } else {
             let message = file.placeholderMessage ?? "This file cannot be rendered in the review view."
@@ -582,6 +590,33 @@ struct DiffReviewFileSection: View {
                         label: message
                     )
                 )
+        }
+    }
+
+    private func lazyGroupStack(
+        _ groups: [DiffReviewRenderContext.Group],
+        displayModel: DiffDisplayModel
+    ) -> some View {
+        LazyVStack(spacing: 0) {
+            ForEach(groups) { group in
+                groupContent(group, displayModel: displayModel)
+            }
+        }
+    }
+
+    private func groupContent(
+        _ group: DiffReviewRenderContext.Group,
+        displayModel: DiffDisplayModel
+    ) -> some View {
+        VStack(spacing: 0) {
+            if !group.inlineFeedback.isEmpty {
+                inlineFeedbackStack(
+                    group.inlineFeedback,
+                    file: file.summary,
+                    rows: group.displayGroup.rows
+                )
+            }
+            reviewGroup(group, displayModel: displayModel)
         }
     }
 
@@ -1072,6 +1107,21 @@ struct DiffReviewFileSection: View {
     }
 }
 
+enum DiffReviewRequiredGroupResolver {
+    static func groupID(
+        in groups: [DiffReviewRenderContext.Group],
+        inlineFeedbackIDs: Set<String>,
+        draftCommentIDs: Set<String>
+    ) -> String? {
+        groups.first { group in
+            group.inlineFeedback.contains { inlineFeedbackIDs.contains($0.id) }
+                || group.segments.contains { segment in
+                    segment.draftComments.contains { draftCommentIDs.contains($0.id) }
+                }
+        }?.id
+    }
+}
+
 /// Wraps `DiffReviewFileSection` for `.equatable()`, with `layoutMode`,
 /// `wrapLines`, and `showWhitespace` captured as plain values rather than
 /// compared as live `@Binding`s, plus per-item action-availability
@@ -1137,6 +1187,7 @@ struct EquatableDiffReviewFileSection: View, Equatable {
             && lhs.section.inlineFeedbackScrollTargetID == rhs.section.inlineFeedbackScrollTargetID
             && lhs.section.draftComments == rhs.section.draftComments
             && lhs.section.focusedDraftCommentID == rhs.section.focusedDraftCommentID
+            && lhs.section.draftCommentScrollTargetID == rhs.section.draftCommentScrollTargetID
             && lhs.section.codeFontFamily == rhs.section.codeFontFamily
             && lhs.section.codeFontSize == rhs.section.codeFontSize
             && lhs.section.showsSourceBadge == rhs.section.showsSourceBadge

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -432,8 +432,12 @@ struct DiffReviewFileSection: View {
         Set([focusedFeedbackID, inlineFeedbackScrollTargetID].compactMap(\.self))
     }
 
-    private var requiredDraftCommentIDs: Set<String> {
-        Set([focusedDraftCommentID, draftCommentScrollTargetID].compactMap(\.self))
+    private var commandedInlineFeedbackIDs: Set<String> {
+        Set([inlineFeedbackScrollTargetID].compactMap(\.self))
+    }
+
+    private var commandedDraftCommentIDs: Set<String> {
+        Set([draftCommentScrollTargetID].compactMap(\.self))
     }
 
     private func fileLevelInlineFeedback(renderContext: DiffReviewRenderContext?) -> [DiffReviewInlineFeedback] {
@@ -561,16 +565,22 @@ struct DiffReviewFileSection: View {
     private func content(renderContext: DiffReviewRenderContext?) -> some View {
         if let displayModel = file.displayModel, let renderContext {
             let groups = renderContext.groups
-            if let requiredGroupID = DiffReviewRequiredGroupResolver.groupID(
+            let requiredGroupIDs = DiffReviewRequiredGroupResolver.groupIDs(
                 in: groups,
-                inlineFeedbackIDs: requiredInlineFeedbackIDs,
-                draftCommentIDs: requiredDraftCommentIDs
-            ), let requiredIndex = groups.firstIndex(where: { $0.id == requiredGroupID }) {
-                // Keep the commanded card's real ID available without eagerly rendering unrelated hunks.
+                inlineFeedbackIDs: commandedInlineFeedbackIDs,
+                draftCommentIDs: commandedDraftCommentIDs
+            )
+            if !requiredGroupIDs.isEmpty {
                 VStack(spacing: 0) {
-                    lazyGroupStack(Array(groups[..<requiredIndex]), displayModel: displayModel)
-                    groupContent(groups[requiredIndex], displayModel: displayModel)
-                    lazyGroupStack(Array(groups[groups.index(after: requiredIndex)...]), displayModel: displayModel)
+                    ForEach(DiffReviewGroupRenderRun.runs(in: groups, requiredGroupIDs: requiredGroupIDs)) { run in
+                        switch run.content {
+                        case .lazy(let groups):
+                            lazyGroupStack(groups, displayModel: displayModel)
+                        case .required(let group):
+                            // Keep commanded card IDs available without eagerly rendering unrelated hunks.
+                            groupContent(group, displayModel: displayModel)
+                        }
+                    }
                 }
             } else {
                 lazyGroupStack(groups, displayModel: displayModel)
@@ -1108,17 +1118,56 @@ struct DiffReviewFileSection: View {
 }
 
 enum DiffReviewRequiredGroupResolver {
-    static func groupID(
+    static func groupIDs(
         in groups: [DiffReviewRenderContext.Group],
         inlineFeedbackIDs: Set<String>,
         draftCommentIDs: Set<String>
-    ) -> String? {
-        groups.first { group in
-            group.inlineFeedback.contains { inlineFeedbackIDs.contains($0.id) }
+    ) -> Set<String> {
+        Set(groups.compactMap { group in
+            let isRequired = group.inlineFeedback.contains { inlineFeedbackIDs.contains($0.id) }
                 || group.segments.contains { segment in
                     segment.draftComments.contains { draftCommentIDs.contains($0.id) }
                 }
-        }?.id
+            return isRequired ? group.id : nil
+        })
+    }
+}
+
+private struct DiffReviewGroupRenderRun: Identifiable {
+    enum Content {
+        case lazy([DiffReviewRenderContext.Group])
+        case required(DiffReviewRenderContext.Group)
+    }
+
+    let id: String
+    let content: Content
+
+    static func runs(
+        in groups: [DiffReviewRenderContext.Group],
+        requiredGroupIDs: Set<String>
+    ) -> [DiffReviewGroupRenderRun] {
+        var runs: [DiffReviewGroupRenderRun] = []
+        var lazyGroups: [DiffReviewRenderContext.Group] = []
+
+        func appendLazyRun() {
+            guard let first = lazyGroups.first, let last = lazyGroups.last else { return }
+            runs.append(DiffReviewGroupRenderRun(
+                id: "lazy:\(first.id):\(last.id)",
+                content: .lazy(lazyGroups)
+            ))
+            lazyGroups.removeAll(keepingCapacity: true)
+        }
+
+        for group in groups {
+            if requiredGroupIDs.contains(group.id) {
+                appendLazyRun()
+                runs.append(DiffReviewGroupRenderRun(id: "required:\(group.id)", content: .required(group)))
+            } else {
+                lazyGroups.append(group)
+            }
+        }
+        appendLazyRun()
+        return runs
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -555,7 +555,7 @@ struct DiffReviewFileSection: View {
     @ViewBuilder
     private func content(renderContext: DiffReviewRenderContext?) -> some View {
         if let displayModel = file.displayModel, let renderContext {
-            VStack(spacing: 0) {
+            LazyVStack(spacing: 0) {
                 ForEach(renderContext.groups) { group in
                     if !group.inlineFeedback.isEmpty {
                         inlineFeedbackStack(

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -311,6 +311,7 @@ struct DiffReviewSurface: View {
                 inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID(for: file.id),
                 draftComments: draftComments,
                 focusedDraftCommentID: focusedDraftCommentID,
+                draftCommentScrollTargetID: draftCommentScrollTargetID(for: file.id),
                 layoutMode: $layoutMode,
                 wrapLines: $wrapLines,
                 showWhitespace: $showWhitespace,
@@ -405,9 +406,10 @@ struct DiffReviewSurface: View {
     /// `scrollTo(cardID)` silently no-ops because the card view isn't in the
     /// tree yet. Mirror the file-rail scroll for that case: first land on the
     /// file section (a direct lazy child SwiftUI reliably realizes), let
-    /// layout settle, then scroll to the nested card. When the file is
-    /// already in view the section is realized, so a single direct scroll
-    /// reaches the card without a detour through the file header.
+    /// layout settle, then scroll to the nested card. `DiffReviewFileSection`
+    /// keeps a commanded card's hunk realized when its normal hunk stack is
+    /// lazy. When the file is already in view, a direct scroll reaches the card
+    /// without a detour through the file header.
     ///
     /// A programmatic-scroll token suppresses the scrollspy during the move so
     /// it doesn't snap the selection back to whichever file ends up at the top
@@ -439,8 +441,6 @@ struct DiffReviewSurface: View {
         }
 
         if fileAlreadyVisible {
-            // The file section (and every nested card within it) is already
-            // realized — scroll straight to the card in one motion.
             scrollToCard()
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 300_000_000)
@@ -449,8 +449,6 @@ struct DiffReviewSurface: View {
             return
         }
 
-        // Cross-file: realize the file section first, then scroll to the card
-        // once layout has settled.
         let sectionID = DiffReviewSurfaceSelectionSync.sectionVisibilityTargetID(for: fileID)
         scrollProxy.scrollTo(sectionID, anchor: .top)
         Task { @MainActor in

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -576,6 +576,56 @@ struct DiffPaneViewTests {
         #expect(allSubviews(of: controller.view).contains { $0 is DiffPaneTextScrollView })
     }
 
+    @Test func stackedStaticModeBoundsSegmentMaterializationToScrollViewport() throws {
+        let baseGroup = try #require(model().groups.first)
+        let groups = (0..<80).map { index in
+            DiffDisplayGroup(
+                id: "group-\(index)",
+                header: "@@ -\(index + 1),2 +\(index + 1),2 @@",
+                sourceHunk: baseGroup.sourceHunk,
+                rows: baseGroup.rows
+            )
+        }
+        var layout = DiffLayoutMode.stacked
+        var wrap = false
+        var whitespace = false
+        let pane = DiffPaneView(
+            model: DiffDisplayModel(filePath: "large.swift", groups: groups),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsToolbar: false,
+            verticalScrollMode: .staticHeight,
+            hunkActions: { _ in DiffPaneHunkActions() }
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: ScrollView(.vertical) { pane })
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 500)
+        for _ in 0..<5 {
+            controller.view.layoutSubtreeIfNeeded()
+        }
+
+        let materializedSegments = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextDocumentContainerView }
+        let initialIdentities = Set(materializedSegments.map(ObjectIdentifier.init))
+        #expect(!materializedSegments.isEmpty)
+        #expect(materializedSegments.count < groups.count)
+
+        for _ in 0..<10 {
+            controller.view.needsLayout = true
+            controller.view.layoutSubtreeIfNeeded()
+        }
+
+        let settledIdentities = Set(allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextDocumentContainerView }
+            .map(ObjectIdentifier.init))
+        #expect(settledIdentities == initialIdentities)
+    }
+
     @Test func splitPaneUsesMergeStyleScrollPanesWithLineRulers() throws {
         var layout = DiffLayoutMode.split
         var wrap = false

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -133,6 +133,66 @@ struct DiffReviewSurfaceTests {
         }
     }
 
+    @Test func stackedFileSectionBoundsHunkMaterializationToScrollViewport() throws {
+        let baseModel = displayModel()
+        let baseGroup = try #require(baseModel.groups.first)
+        let groups = (0..<80).map { index in
+            DiffDisplayGroup(
+                id: "group-\(index)",
+                header: "@@ -\(index + 1),2 +\(index + 1),2 @@",
+                sourceHunk: baseGroup.sourceHunk,
+                rows: baseGroup.rows
+            )
+        }
+        let file = DiffReviewFileSectionModel(
+            summary: summary(
+                path: "Sources/App/LargeView.swift",
+                additions: groups.count,
+                deletions: groups.count
+            ),
+            parsedDiff: parsedDiff(),
+            displayModel: DiffDisplayModel(filePath: baseModel.filePath, groups: groups),
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil
+        )
+        var layout = DiffLayoutMode.stacked
+        var wrap = false
+        var whitespace = false
+        let section = DiffReviewFileSection(
+            file: file,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: ScrollView(.vertical) { section })
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 500)
+        for _ in 0..<5 {
+            controller.view.layoutSubtreeIfNeeded()
+        }
+
+        let materializedSegments = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextDocumentContainerView }
+        let initialIdentities = Set(materializedSegments.map(ObjectIdentifier.init))
+        #expect(!materializedSegments.isEmpty)
+        #expect(materializedSegments.count < groups.count)
+
+        for _ in 0..<10 {
+            controller.view.needsLayout = true
+            controller.view.layoutSubtreeIfNeeded()
+        }
+
+        let settledIdentities = Set(allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextDocumentContainerView }
+            .map(ObjectIdentifier.init))
+        #expect(settledIdentities == initialIdentities)
+    }
+
     @Test func fileSectionEmbedsDiffPaneWithoutToolbarAndShowsOpenFile() {
         let file = DiffReviewFileSectionModel(
             summary: summary(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -206,6 +206,12 @@ struct DiffReviewSurfaceTests {
             anchor: DiffReviewInlineFeedbackAnchor(path: path, line: 80, side: .new),
             evidenceItemID: "deep-feedback"
         )
+        let staleDraft = draftComment(
+            id: "stale-draft",
+            fileID: file.id,
+            path: path,
+            startLine: 1
+        )
         let session = DiffReviewLoadedSession(
             files: [file],
             summary: DiffReviewSessionModel(files: [file.summary], groupsEnabled: false)
@@ -229,7 +235,9 @@ struct DiffReviewSurfaceTests {
                 feedbackID: feedback.id,
                 fileID: file.id,
                 generation: 1
-            )
+            ),
+            draftCommentsByFileID: [file.id: [staleDraft]],
+            focusedDraftCommentID: staleDraft.id
         )
         .environment(\.theme, theme())
 
@@ -261,7 +269,7 @@ struct DiffReviewSurfaceTests {
             id: "deep-draft",
             fileID: fileID,
             path: path,
-            startLine: 80
+            startLine: 1
         )
 
         let renderContext = DiffReviewRenderContextBuilder.build(
@@ -278,16 +286,16 @@ struct DiffReviewSurfaceTests {
             annotations: []
         )
 
-        #expect(DiffReviewRequiredGroupResolver.groupID(
+        #expect(DiffReviewRequiredGroupResolver.groupIDs(
             in: renderContext.groups,
             inlineFeedbackIDs: [feedback.id],
             draftCommentIDs: []
-        ) == "group-79")
-        #expect(DiffReviewRequiredGroupResolver.groupID(
+        ) == ["group-79"])
+        #expect(DiffReviewRequiredGroupResolver.groupIDs(
             in: renderContext.groups,
-            inlineFeedbackIDs: [],
+            inlineFeedbackIDs: [feedback.id],
             draftCommentIDs: [comment.id]
-        ) == "group-79")
+        ) == ["group-0", "group-79"])
     }
 
     @Test func fileSectionEmbedsDiffPaneWithoutToolbarAndShowsOpenFile() {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -134,16 +134,8 @@ struct DiffReviewSurfaceTests {
     }
 
     @Test func stackedFileSectionBoundsHunkMaterializationToScrollViewport() throws {
-        let baseModel = displayModel()
-        let baseGroup = try #require(baseModel.groups.first)
-        let groups = (0..<80).map { index in
-            DiffDisplayGroup(
-                id: "group-\(index)",
-                header: "@@ -\(index + 1),2 +\(index + 1),2 @@",
-                sourceHunk: baseGroup.sourceHunk,
-                rows: baseGroup.rows
-            )
-        }
+        let baseModel = largeDisplayModel(groupCount: 80, filePath: "Sources/App/LargeView.swift")
+        let groups = baseModel.groups
         let file = DiffReviewFileSectionModel(
             summary: summary(
                 path: "Sources/App/LargeView.swift",
@@ -191,6 +183,111 @@ struct DiffReviewSurfaceTests {
             .compactMap { $0 as? DiffPaneTextDocumentContainerView }
             .map(ObjectIdentifier.init))
         #expect(settledIdentities == initialIdentities)
+    }
+
+    @Test func inlineFeedbackScrollRealizesTargetHunkWithoutEagerlyRenderingAllHunks() {
+        let path = "Sources/App/LargeView.swift"
+        let displayModel = largeDisplayModel(groupCount: 80, filePath: path)
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: path, additions: 80),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel,
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil
+        )
+        let feedback = DiffReviewInlineFeedback(
+            id: "deep-feedback",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Please update the final hunk.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: path, line: 80, side: .new),
+            evidenceItemID: "deep-feedback"
+        )
+        let session = DiffReviewLoadedSession(
+            files: [file],
+            summary: DiffReviewSessionModel(files: [file.summary], groupsEnabled: false)
+        )
+        var selectedFileID: DiffReviewFileID? = file.id
+        var railCollapsed = true
+        var layout = DiffLayoutMode.stacked
+        var wrap = false
+        var whitespace = false
+        let view = DiffReviewSurface(
+            session: session,
+            selectedFileID: Binding(get: { selectedFileID }, set: { selectedFileID = $0 }),
+            railCollapsed: Binding(get: { railCollapsed }, set: { railCollapsed = $0 }),
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            inlineFeedbackByFileID: [file.id: [feedback]],
+            inlineFeedbackScrollCommand: DiffReviewInlineFeedbackScrollCommand(
+                feedbackID: feedback.id,
+                fileID: file.id,
+                generation: 1
+            )
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 1_200, height: 500)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.6))
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "diff-review-inline-feedback-deep-feedback", in: controller.view) != nil)
+        let materializedSegments = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextDocumentContainerView }
+        #expect(materializedSegments.count < displayModel.groups.count / 2)
+    }
+
+    @Test func requiredGroupResolverFindsInlineFeedbackAndDraftCommentHunks() {
+        let path = "Sources/App/LargeView.swift"
+        let displayModel = largeDisplayModel(groupCount: 80, filePath: path)
+        let fileID = DiffReviewFileID(namespace: "commit", path: path)
+        let feedback = DiffReviewInlineFeedback(
+            id: "deep-feedback",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Please update the final hunk.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: path, line: 80, side: .new),
+            evidenceItemID: "deep-feedback"
+        )
+        let comment = draftComment(
+            id: "deep-draft",
+            fileID: fileID,
+            path: path,
+            startLine: 80
+        )
+
+        let renderContext = DiffReviewRenderContextBuilder.build(
+            fileID: fileID,
+            displayModel: displayModel,
+            contextSnapshot: nil,
+            contextProviderAvailable: false,
+            contextExpansion: DiffContextExpansionState(),
+            inlineFeedback: [feedback],
+            draftComments: [comment],
+            pendingDraftAnchor: nil,
+            canCreateDraftComment: false,
+            threads: [],
+            annotations: []
+        )
+
+        #expect(DiffReviewRequiredGroupResolver.groupID(
+            in: renderContext.groups,
+            inlineFeedbackIDs: [feedback.id],
+            draftCommentIDs: []
+        ) == "group-79")
+        #expect(DiffReviewRequiredGroupResolver.groupID(
+            in: renderContext.groups,
+            inlineFeedbackIDs: [],
+            draftCommentIDs: [comment.id]
+        ) == "group-79")
     }
 
     @Test func fileSectionEmbedsDiffPaneWithoutToolbarAndShowsOpenFile() {
@@ -3373,6 +3470,35 @@ struct DiffReviewSurfaceTests {
 
     private func displayModel() -> DiffDisplayModel {
         DiffDisplayModelBuilder.build(diff: parsedDiff(), filePath: "Sources/App/AlphaView.swift")
+    }
+
+    private func largeDisplayModel(groupCount: Int, filePath: String) -> DiffDisplayModel {
+        let sourceHunk = parsedDiff().hunks[0]
+        let groups = (0..<groupCount).map { index in
+            let line = index + 1
+            let displayLine = diffLine(
+                id: "line-\(line)",
+                side: .new,
+                newLine: line,
+                text: "let value\(line) = \(line)",
+                rowIndex: index
+            )
+            return DiffDisplayGroup(
+                id: "group-\(index)",
+                header: "@@ -\(line),1 +\(line),1 @@",
+                sourceHunk: sourceHunk,
+                rows: [
+                    DiffDisplayRow(
+                        id: "row-\(line)",
+                        kind: .add,
+                        old: nil,
+                        new: displayLine,
+                        collapsedLineCount: 0
+                    ),
+                ]
+            )
+        }
+        return DiffDisplayModel(filePath: filePath, groups: groups)
     }
 
     private func loadedSession(summaries: [DiffReviewFileSummary]) -> DiffReviewLoadedSession {


### PR DESCRIPTION
## Summary

- lazily materialize stacked diff hunks in both `DiffPaneView` and the review-file wrapper
- preserve stable AppKit segment container identity across repeated layout passes
- add large stacked-diff regressions for the reusable pane and production review surface

## Diagnosis

The latest hang diagnostic showed the main thread recursively negotiating SwiftUI `StackLayout` placement and sizing while `DiffPaneSegmentView` values were repeatedly copied and destroyed. The representable and its block/group IDs are stable; the unbounded eager stacks were forcing every hunk and nested AppKit segment into the same layout transaction.

## Verification

- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/DiffReviewSurfaceTests`
- `ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- fresh 10-second stacked-mode sample: all 6,400 main-thread samples idle in the AppKit event loop, 0.7% process CPU, and zero `StackLayout.UnmanagedImplementation`, `GraphHost.flushTransactions`, or `DiffPaneSegmentView` churn matches
- full local suite before rebase: 5,576 passed and 4 skipped; the only 8 failures were opt-in `SSHIntegrationTests` requiring `ALAS_SSH_INTEGRATION=1`
