### PR TITLE
feat(diff): context expansion controls

### DIFF
--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -152,7 +152,7 @@ enum DiffContextExpandedDisplayBuilder {
         groups.enumerated().map { index, group in
             var rows: [DiffDisplayRow] = []
 
-            if providerAvailable {
+            if providerAvailable, index == 0 {
                 rows.append(contentsOf: expansionRows(
                     for: group,
                     groupIndex: index,
@@ -165,9 +165,35 @@ enum DiffContextExpandedDisplayBuilder {
                 ))
             }
 
+            if providerAvailable, index > 0 {
+                rows.append(contentsOf: sharedExpansionRows(
+                    upperGroup: groups[index - 1],
+                    lowerGroup: group,
+                    upperGroupIndex: index - 1,
+                    lowerGroupIndex: index,
+                    groups: groups,
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    filePath: filePath,
+                    edge: .bottom
+                ))
+            }
+
             rows.append(contentsOf: group.rows)
 
-            if providerAvailable {
+            if providerAvailable, index + 1 < groups.count {
+                rows.append(contentsOf: sharedExpansionRows(
+                    upperGroup: group,
+                    lowerGroup: groups[index + 1],
+                    upperGroupIndex: index,
+                    lowerGroupIndex: index + 1,
+                    groups: groups,
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    filePath: filePath,
+                    edge: .top
+                ))
+            } else if providerAvailable {
                 rows.append(contentsOf: expansionRows(
                     for: group,
                     groupIndex: index,
@@ -194,22 +220,135 @@ enum DiffContextExpandedDisplayBuilder {
         groups: [DiffDisplayGroup],
         snapshot: DiffReviewFileContextSnapshot?
     ) -> Int {
-        guard
-            let snapshot,
-            let groupIndex = groups.firstIndex(where: { $0.id == key.groupID })
-        else {
+        guard let snapshot else {
             return 0
         }
-        guard ownsBoundary(groupIndex: groupIndex, boundary: key.boundary) else {
-            return 0
+
+        switch key.kind {
+        case let .external(groupID, boundary):
+            guard let groupIndex = groups.firstIndex(where: { $0.id == groupID }) else {
+                return 0
+            }
+            guard ownsBoundary(groupIndex: groupIndex, boundary: boundary) else {
+                return 0
+            }
+            return boundaryRange(
+                for: groups[groupIndex],
+                groupIndex: groupIndex,
+                boundary: boundary,
+                groups: groups,
+                snapshot: snapshot
+            ).lineCount
+        case let .shared(upperGroupID, lowerGroupID):
+            guard
+                let upperIndex = groups.firstIndex(where: { $0.id == upperGroupID }),
+                upperIndex + 1 < groups.count,
+                groups[upperIndex + 1].id == lowerGroupID
+            else {
+                return 0
+            }
+            return boundaryRange(
+                for: groups[upperIndex],
+                groupIndex: upperIndex,
+                boundary: .below,
+                groups: groups,
+                snapshot: snapshot
+            ).lineCount
         }
-        return boundaryRange(
-            for: groups[groupIndex],
-            groupIndex: groupIndex,
-            boundary: key.boundary,
+    }
+
+    private static func sharedExpansionRows(
+        upperGroup: DiffDisplayGroup,
+        lowerGroup: DiffDisplayGroup,
+        upperGroupIndex: Int,
+        lowerGroupIndex: Int,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?,
+        expansion: DiffContextExpansionState,
+        filePath: String,
+        edge: DiffContextExpansionEdge
+    ) -> [DiffDisplayRow] {
+        let key = DiffContextExpansionKey.shared(upperGroupID: upperGroup.id, lowerGroupID: lowerGroup.id)
+        let attachedGroup = edge == .top ? upperGroup : lowerGroup
+        let attachedGroupIndex = edge == .top ? upperGroupIndex : lowerGroupIndex
+        let attachedBoundary: DiffContextBoundary = edge == .top ? .below : .above
+
+        guard let snapshot else {
+            guard optimisticBoundaryAvailable(
+                for: upperGroup,
+                groupIndex: upperGroupIndex,
+                boundary: .below,
+                groups: groups
+            ) else {
+                return []
+            }
+            return [expandableRow(
+                group: attachedGroup,
+                boundary: attachedBoundary,
+                remaining: 0,
+                key: key,
+                edge: edge
+            )]
+        }
+
+        let range = boundaryRange(
+            for: upperGroup,
+            groupIndex: upperGroupIndex,
+            boundary: .below,
             groups: groups,
             snapshot: snapshot
-        ).lineCount
+        )
+        let available = range.lineCount
+        guard available > 0 else {
+            return []
+        }
+
+        let topExpanded = min(expansion.expandedLineCount(for: key, edge: .top), available)
+        let bottomExpanded = min(
+            expansion.expandedLineCount(for: key, edge: .bottom),
+            max(0, available - topExpanded)
+        )
+        let expandedCount = edge == .top ? topExpanded : bottomExpanded
+        let remaining = expansion.remainingLineCount(for: key, available: available)
+        let offsets: Range<Int>
+        switch edge {
+        case .top:
+            offsets = 0..<expandedCount
+        case .bottom:
+            offsets = (available - expandedCount)..<available
+        }
+
+        var rows = offsets.map {
+            expandedContextRow(
+                group: attachedGroup,
+                groupIndex: attachedGroupIndex,
+                boundary: attachedBoundary,
+                range: range,
+                offset: $0,
+                totalCount: available,
+                snapshot: snapshot,
+                filePath: filePath
+            )
+        }
+
+        guard remaining > 0 else {
+            return rows
+        }
+
+        let expandable = expandableRow(
+            group: attachedGroup,
+            boundary: attachedBoundary,
+            remaining: remaining,
+            key: key,
+            edge: edge
+        )
+        switch edge {
+        case .top:
+            rows.insert(expandable, at: rows.endIndex)
+        case .bottom:
+            rows.insert(expandable, at: rows.startIndex)
+        }
+        return rows
     }
 
     private static func expansionRows(
@@ -469,10 +608,12 @@ enum DiffContextExpandedDisplayBuilder {
         group: DiffDisplayGroup,
         boundary: DiffContextBoundary,
         remaining: Int,
-        key: DiffContextExpansionKey
+        key: DiffContextExpansionKey,
+        edge: DiffContextExpansionEdge? = nil
     ) -> DiffDisplayRow {
-        DiffDisplayRow(
-            id: "\(group.id)-expand-\(boundary.rawValue)",
+        let edgeID = edge.map { "-\($0.rawValue)" } ?? ""
+        return DiffDisplayRow(
+            id: "\(group.id)-expand-\(boundary.rawValue)\(edgeID)",
             kind: .expandableContext,
             old: nil,
             new: nil,
@@ -480,7 +621,8 @@ enum DiffContextExpandedDisplayBuilder {
             contextExpansion: DiffContextExpansionRow(
                 key: key,
                 boundary: boundary,
-                remainingLineCount: remaining
+                remainingLineCount: remaining,
+                edge: edge
             )
         )
     }

--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -210,9 +210,88 @@ enum DiffContextExpandedDisplayBuilder {
                 id: group.id,
                 header: group.header,
                 sourceHunk: group.sourceHunk,
-                rows: rows
+                rows: rows,
+                sharedContextBefore: sharedContextBefore(
+                    forGroupAt: index,
+                    groups: groups,
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    providerAvailable: providerAvailable
+                ),
+                sharedContextAfter: sharedContextAfter(
+                    forGroupAt: index,
+                    groups: groups,
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    providerAvailable: providerAvailable
+                )
             )
         }
+    }
+
+    private static func sharedContextBefore(
+        forGroupAt index: Int,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?,
+        expansion: DiffContextExpansionState,
+        providerAvailable: Bool
+    ) -> DiffContextExpansionKey? {
+        guard providerAvailable, index > 0 else { return nil }
+        return exhaustedSharedContextKey(
+            upperGroupIndex: index - 1,
+            groups: groups,
+            snapshot: snapshot,
+            expansion: expansion
+        )
+    }
+
+    private static func sharedContextAfter(
+        forGroupAt index: Int,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?,
+        expansion: DiffContextExpansionState,
+        providerAvailable: Bool
+    ) -> DiffContextExpansionKey? {
+        guard providerAvailable, index + 1 < groups.count else { return nil }
+        return exhaustedSharedContextKey(
+            upperGroupIndex: index,
+            groups: groups,
+            snapshot: snapshot,
+            expansion: expansion
+        )
+    }
+
+    private static func exhaustedSharedContextKey(
+        upperGroupIndex: Int,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?,
+        expansion: DiffContextExpansionState
+    ) -> DiffContextExpansionKey? {
+        guard upperGroupIndex + 1 < groups.count else { return nil }
+
+        let upperGroup = groups[upperGroupIndex]
+        let lowerGroup = groups[upperGroupIndex + 1]
+        let key = DiffContextExpansionKey.shared(upperGroupID: upperGroup.id, lowerGroupID: lowerGroup.id)
+        guard let snapshot else {
+            return optimisticBoundaryAvailable(
+                for: upperGroup,
+                groupIndex: upperGroupIndex,
+                boundary: .below,
+                groups: groups
+            ) ? nil : key
+        }
+        guard boundaryContextIsAvailable(for: upperGroup, boundary: .below, snapshot: snapshot) else {
+            return nil
+        }
+
+        let available = boundaryRange(
+            for: upperGroup,
+            groupIndex: upperGroupIndex,
+            boundary: .below,
+            groups: groups,
+            snapshot: snapshot
+        ).lineCount
+        return expansion.remainingLineCount(for: key, available: available) == 0 ? key : nil
     }
 
     static func availableLineCount(
@@ -318,6 +397,30 @@ enum DiffContextExpandedDisplayBuilder {
             offsets = (available - expandedCount)..<available
         }
 
+        let excludedOldLineNumbers: Set<Int>
+        let excludedNewLineNumbers: Set<Int>
+        switch edge {
+        case .top:
+            excludedOldLineNumbers = []
+            excludedNewLineNumbers = []
+        case .bottom:
+            let topOffsets = 0..<topExpanded
+            excludedOldLineNumbers = lineNumbers(
+                start: range.oldStart,
+                count: range.oldCount,
+                offsets: topOffsets,
+                totalCount: available,
+                boundary: .below
+            )
+            excludedNewLineNumbers = lineNumbers(
+                start: range.newStart,
+                count: range.newCount,
+                offsets: topOffsets,
+                totalCount: available,
+                boundary: .below
+            )
+        }
+
         var rows = offsets.map {
             expandedContextRow(
                 group: attachedGroup,
@@ -327,7 +430,9 @@ enum DiffContextExpandedDisplayBuilder {
                 offset: $0,
                 totalCount: available,
                 snapshot: snapshot,
-                filePath: filePath
+                filePath: filePath,
+                excludedOldLineNumbers: excludedOldLineNumbers,
+                excludedNewLineNumbers: excludedNewLineNumbers
             )
         }
 
@@ -345,6 +450,17 @@ enum DiffContextExpandedDisplayBuilder {
         switch edge {
         case .top:
             rows.insert(expandable, at: rows.endIndex)
+            rows.insert(
+                expandableRow(
+                    group: attachedGroup,
+                    boundary: attachedBoundary,
+                    remaining: remaining,
+                    key: key,
+                    edge: nil,
+                    defaultsEdgeFromBoundary: false
+                ),
+                at: rows.endIndex
+            )
         case .bottom:
             rows.insert(expandable, at: rows.startIndex)
         }
@@ -527,12 +643,48 @@ enum DiffContextExpandedDisplayBuilder {
         }
     }
 
+    private static func boundaryContextIsAvailable(
+        for group: DiffDisplayGroup,
+        boundary: DiffContextBoundary,
+        snapshot: DiffReviewFileContextSnapshot
+    ) -> Bool {
+        let currentOld = hunkSideExtent(in: group, side: .old)
+        let currentNew = hunkSideExtent(in: group, side: .new)
+
+        switch boundary {
+        case .above:
+            return snapshot.old.hasLine(currentOld.lineBefore)
+                || snapshot.new.hasLine(currentNew.lineBefore)
+        case .below:
+            return snapshot.old.hasLine(currentOld.lineAfter)
+                || snapshot.new.hasLine(currentNew.lineAfter)
+        }
+    }
+
     private static func lineCount(start: Int, end: Int?, snapshotLines: Int?) -> Int {
         guard let snapshotLines, let end else { return 0 }
         let clampedStart = max(1, start)
         let clampedEnd = min(end, snapshotLines)
         guard clampedStart <= clampedEnd else { return 0 }
         return clampedEnd - clampedStart + 1
+    }
+
+    private static func lineNumbers(
+        start: Int?,
+        count: Int,
+        offsets: Range<Int>,
+        totalCount: Int,
+        boundary: DiffContextBoundary
+    ) -> Set<Int> {
+        Set(offsets.compactMap {
+            lineNumber(
+                start: start,
+                count: count,
+                offset: $0,
+                totalCount: totalCount,
+                boundary: boundary
+            )
+        })
     }
 
     private static func hunkSideExtent(in group: DiffDisplayGroup, side: DiffLineSide) -> HunkSideExtent {
@@ -560,22 +712,26 @@ enum DiffContextExpandedDisplayBuilder {
         offset: Int,
         totalCount: Int,
         snapshot: DiffReviewFileContextSnapshot,
-        filePath: String
+        filePath: String,
+        excludedOldLineNumbers: Set<Int> = [],
+        excludedNewLineNumbers: Set<Int> = []
     ) -> DiffDisplayRow {
-        let oldNumber = lineNumber(
+        let candidateOldNumber = lineNumber(
             start: range.oldStart,
             count: range.oldCount,
             offset: offset,
             totalCount: totalCount,
             boundary: boundary
         )
-        let newNumber = lineNumber(
+        let candidateNewNumber = lineNumber(
             start: range.newStart,
             count: range.newCount,
             offset: offset,
             totalCount: totalCount,
             boundary: boundary
         )
+        let oldNumber = candidateOldNumber.flatMap { excludedOldLineNumbers.contains($0) ? nil : $0 }
+        let newNumber = candidateNewNumber.flatMap { excludedNewLineNumbers.contains($0) ? nil : $0 }
         let rowIndex = syntheticRowIndex(boundary: boundary, offset: offset)
         let anchorSide = anchorSide(oldNumber: oldNumber, newNumber: newNumber)
         let anchor = DiffLineAnchor(
@@ -609,7 +765,8 @@ enum DiffContextExpandedDisplayBuilder {
         boundary: DiffContextBoundary,
         remaining: Int,
         key: DiffContextExpansionKey,
-        edge: DiffContextExpansionEdge? = nil
+        edge: DiffContextExpansionEdge? = nil,
+        defaultsEdgeFromBoundary: Bool = true
     ) -> DiffDisplayRow {
         let edgeID = edge.map { "-\($0.rawValue)" } ?? ""
         return DiffDisplayRow(
@@ -622,7 +779,8 @@ enum DiffContextExpandedDisplayBuilder {
                 key: key,
                 boundary: boundary,
                 remainingLineCount: remaining,
-                edge: edge
+                edge: edge,
+                defaultsEdgeFromBoundary: defaultsEdgeFromBoundary
             )
         )
     }
@@ -684,6 +842,11 @@ private extension DiffReviewFileContextLines {
         case let .available(lines):
             return lines.count
         }
+    }
+
+    func hasLine(_ number: Int) -> Bool {
+        guard let lineCount else { return false }
+        return number >= 1 && number <= lineCount
     }
 
     func line(at number: Int) -> String? {

--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -16,13 +16,51 @@ enum DiffContextExpansionMode: Equatable {
 }
 
 struct DiffContextExpansionState: Equatable {
+    private struct SharedExpansion: Equatable {
+        var top: Int = 0
+        var bottom: Int = 0
+    }
+
     private var expandedLineCounts: [DiffContextExpansionKey: Int] = [:]
+    private var sharedExpandedLineCounts: [DiffContextExpansionKey: SharedExpansion] = [:]
 
     func expandedLineCount(for key: DiffContextExpansionKey) -> Int {
-        expandedLineCounts[key, default: 0]
+        if key.isShared {
+            return expandedLineCount(for: key, edge: .top)
+        }
+        return expandedLineCounts[key, default: 0]
+    }
+
+    func expandedLineCount(for key: DiffContextExpansionKey, edge: DiffContextExpansionEdge) -> Int {
+        guard key.isShared else {
+            return expandedLineCount(for: key)
+        }
+
+        let shared = sharedExpandedLineCounts[key, default: SharedExpansion()]
+        switch edge {
+        case .top:
+            return shared.top
+        case .bottom:
+            return shared.bottom
+        }
+    }
+
+    func remainingLineCount(for key: DiffContextExpansionKey, available: Int) -> Int {
+        let available = max(0, available)
+        guard key.isShared else {
+            return max(0, available - expandedLineCount(for: key))
+        }
+
+        let shared = sharedExpandedLineCounts[key, default: SharedExpansion()]
+        return max(0, available - shared.top - shared.bottom)
     }
 
     mutating func expand(_ key: DiffContextExpansionKey, available: Int, mode: DiffContextExpansionMode) {
+        if key.isShared {
+            expand(key, available: available, mode: mode, edge: .top)
+            return
+        }
+
         let available = max(0, available)
         let current = expandedLineCounts[key, default: 0]
         let next: Int
@@ -33,6 +71,48 @@ struct DiffContextExpansionState: Equatable {
             next = available
         }
         expandedLineCounts[key] = min(next, available)
+    }
+
+    mutating func expand(
+        _ key: DiffContextExpansionKey,
+        available: Int,
+        mode: DiffContextExpansionMode,
+        edge: DiffContextExpansionEdge
+    ) {
+        guard key.isShared else {
+            expand(key, available: available, mode: mode)
+            return
+        }
+
+        let available = max(0, available)
+        var shared = sharedExpandedLineCounts[key, default: SharedExpansion()]
+        let current: Int
+        let other: Int
+        switch edge {
+        case .top:
+            current = shared.top
+            other = shared.bottom
+        case .bottom:
+            current = shared.bottom
+            other = shared.top
+        }
+
+        let requested: Int
+        switch mode {
+        case let .chunk(size):
+            requested = current + max(0, size)
+        case .all:
+            requested = available - other
+        }
+
+        let clamped = min(max(0, requested), max(0, available - other))
+        switch edge {
+        case .top:
+            shared.top = clamped
+        case .bottom:
+            shared.bottom = clamped
+        }
+        sharedExpandedLineCounts[key] = shared
     }
 }
 

--- a/Alas/Sources/Center/Diff/DiffDisplayModel.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModel.swift
@@ -177,18 +177,19 @@ struct DiffContextExpansionRow: Codable, Equatable, Hashable, Sendable {
     let key: DiffContextExpansionKey
     let boundary: DiffContextBoundary
     let remainingLineCount: Int
-    let edge: DiffContextExpansionEdge
+    let edge: DiffContextExpansionEdge?
 
     init(
         key: DiffContextExpansionKey,
         boundary: DiffContextBoundary,
         remainingLineCount: Int,
-        edge: DiffContextExpansionEdge? = nil
+        edge: DiffContextExpansionEdge? = nil,
+        defaultsEdgeFromBoundary: Bool = true
     ) {
         self.key = key
         self.boundary = boundary
         self.remainingLineCount = remainingLineCount
-        self.edge = edge ?? (boundary == .above ? .bottom : .top)
+        self.edge = edge ?? (defaultsEdgeFromBoundary ? (boundary == .above ? .bottom : .top) : nil)
     }
 
     init(from decoder: Decoder) throws {
@@ -208,7 +209,7 @@ struct DiffContextExpansionRow: Codable, Equatable, Hashable, Sendable {
         try container.encode(key, forKey: .key)
         try container.encode(boundary, forKey: .boundary)
         try container.encode(remainingLineCount, forKey: .remainingLineCount)
-        try container.encode(edge, forKey: .edge)
+        try container.encodeIfPresent(edge, forKey: .edge)
     }
 }
 
@@ -255,6 +256,8 @@ struct DiffDisplayGroup: Identifiable, Equatable {
     let header: String
     let sourceHunk: ParsedDiff.Hunk
     let rows: [DiffDisplayRow]
+    let sharedContextBefore: DiffContextExpansionKey?
+    let sharedContextAfter: DiffContextExpansionKey?
 
     /// Full-fidelity content fingerprint (row/line identity, text, kinds,
     /// inline spans, collapse structure). Precomputed once at build time and
@@ -270,15 +273,26 @@ struct DiffDisplayGroup: Identifiable, Equatable {
     let oldSideExtent: DiffHunkSideExtent
     let newSideExtent: DiffHunkSideExtent
 
-    init(id: String, header: String, sourceHunk: ParsedDiff.Hunk, rows: [DiffDisplayRow]) {
+    init(
+        id: String,
+        header: String,
+        sourceHunk: ParsedDiff.Hunk,
+        rows: [DiffDisplayRow],
+        sharedContextBefore: DiffContextExpansionKey? = nil,
+        sharedContextAfter: DiffContextExpansionKey? = nil
+    ) {
         self.id = id
         self.header = header
         self.sourceHunk = sourceHunk
         self.rows = rows
+        self.sharedContextBefore = sharedContextBefore
+        self.sharedContextAfter = sharedContextAfter
 
         var content = Hasher()
         content.combine(id)
         content.combine(header)
+        content.combine(sharedContextBefore)
+        content.combine(sharedContextAfter)
         for row in rows {
             DiffDisplaySignatureBuilder.combineContent(row, into: &content)
         }
@@ -286,6 +300,8 @@ struct DiffDisplayGroup: Identifiable, Equatable {
 
         var structural = Hasher()
         structural.combine(id)
+        structural.combine(sharedContextBefore)
+        structural.combine(sharedContextAfter)
         for row in rows {
             structural.combine(row.id)
             structural.combine(row.old?.lineNumber)

--- a/Alas/Sources/Center/Diff/DiffDisplayModel.swift
+++ b/Alas/Sources/Center/Diff/DiffDisplayModel.swift
@@ -80,20 +80,136 @@ struct DiffDisplayLine: Identifiable, Equatable {
     let noTrailingNewline: Bool
 }
 
-struct DiffContextExpansionKey: Codable, Equatable, Hashable, Sendable {
-    let groupID: String
-    let boundary: DiffContextBoundary
-}
-
 enum DiffContextBoundary: String, Codable, Equatable, Hashable, Sendable {
     case above
     case below
 }
 
+enum DiffContextExpansionEdge: String, Codable, Equatable, Hashable, Sendable {
+    case top
+    case bottom
+}
+
+struct DiffContextExpansionKey: Codable, Equatable, Hashable, Sendable {
+    enum Kind: Codable, Equatable, Hashable, Sendable {
+        case external(groupID: String, boundary: DiffContextBoundary)
+        case shared(upperGroupID: String, lowerGroupID: String)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case groupID
+        case boundary
+    }
+
+    let kind: Kind
+
+    init(groupID: String, boundary: DiffContextBoundary) {
+        kind = .external(groupID: groupID, boundary: boundary)
+    }
+
+    static func shared(upperGroupID: String, lowerGroupID: String) -> DiffContextExpansionKey {
+        DiffContextExpansionKey(kind: .shared(upperGroupID: upperGroupID, lowerGroupID: lowerGroupID))
+    }
+
+    private init(kind: Kind) {
+        self.kind = kind
+    }
+
+    var groupID: String {
+        switch kind {
+        case let .external(groupID, _):
+            return groupID
+        case let .shared(upperGroupID, lowerGroupID):
+            return "\(upperGroupID)..\(lowerGroupID)"
+        }
+    }
+
+    var boundary: DiffContextBoundary {
+        switch kind {
+        case let .external(_, boundary):
+            return boundary
+        case .shared:
+            return .below
+        }
+    }
+
+    var isShared: Bool {
+        if case .shared = kind {
+            return true
+        }
+        return false
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let kind = try container.decodeIfPresent(Kind.self, forKey: .kind) {
+            self.kind = kind
+            return
+        }
+
+        kind = .external(
+            groupID: try container.decode(String.self, forKey: .groupID),
+            boundary: try container.decode(DiffContextBoundary.self, forKey: .boundary)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch kind {
+        case let .external(groupID, boundary):
+            try container.encode(groupID, forKey: .groupID)
+            try container.encode(boundary, forKey: .boundary)
+        case .shared:
+            try container.encode(kind, forKey: .kind)
+        }
+    }
+}
+
 struct DiffContextExpansionRow: Codable, Equatable, Hashable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case boundary
+        case remainingLineCount
+        case edge
+    }
+
     let key: DiffContextExpansionKey
     let boundary: DiffContextBoundary
     let remainingLineCount: Int
+    let edge: DiffContextExpansionEdge
+
+    init(
+        key: DiffContextExpansionKey,
+        boundary: DiffContextBoundary,
+        remainingLineCount: Int,
+        edge: DiffContextExpansionEdge? = nil
+    ) {
+        self.key = key
+        self.boundary = boundary
+        self.remainingLineCount = remainingLineCount
+        self.edge = edge ?? (boundary == .above ? .bottom : .top)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let key = try container.decode(DiffContextExpansionKey.self, forKey: .key)
+        let boundary = try container.decode(DiffContextBoundary.self, forKey: .boundary)
+        self.init(
+            key: key,
+            boundary: boundary,
+            remainingLineCount: try container.decode(Int.self, forKey: .remainingLineCount),
+            edge: try container.decodeIfPresent(DiffContextExpansionEdge.self, forKey: .edge)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(key, forKey: .key)
+        try container.encode(boundary, forKey: .boundary)
+        try container.encode(remainingLineCount, forKey: .remainingLineCount)
+        try container.encode(edge, forKey: .edge)
+    }
 }
 
 struct DiffDisplayRow: Identifiable, Equatable {
@@ -242,9 +358,10 @@ enum DiffDisplaySignatureBuilder {
         }
         if let expansion = row.contextExpansion {
             hasher.combine(true)
-            hasher.combine(expansion.key.groupID)
+            hasher.combine(expansion.key.kind)
             hasher.combine(expansion.boundary)
             hasher.combine(expansion.remainingLineCount)
+            hasher.combine(expansion.edge)
         } else {
             hasher.combine(false)
         }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -11,6 +11,7 @@ struct DiffPaneTextDocumentBuilder {
         var syntaxGroup: Int? = nil
         var expansionKey: DiffContextExpansionKey? = nil
         var expansionBoundary: DiffContextBoundary? = nil
+        var expansionEdge: DiffContextExpansionEdge? = nil
     }
 
     struct CodeDocument {
@@ -301,7 +302,8 @@ struct DiffPaneTextDocumentBuilder {
                 kind: row.kind,
                 range: NSRange(location: start, length: output.length - start),
                 expansionKey: row.contextExpansion?.key,
-                expansionBoundary: row.contextExpansion?.boundary
+                expansionBoundary: row.contextExpansion?.boundary,
+                expansionEdge: row.contextExpansion?.edge
             ))
         }
 
@@ -336,7 +338,8 @@ struct DiffPaneTextDocumentBuilder {
                     kind: row.kind,
                     range: NSRange(location: start, length: output.length - start),
                     expansionKey: row.contextExpansion?.key,
-                    expansionBoundary: row.contextExpansion?.boundary
+                    expansionBoundary: row.contextExpansion?.boundary,
+                    expansionEdge: row.contextExpansion?.edge
                 ))
                 index += 1
                 continue
@@ -390,7 +393,8 @@ struct DiffPaneTextDocumentBuilder {
                 sourceLine: line,
                 sourceRange: NSRange(location: start + prefixLength, length: (line.text as NSString).length),
                 expansionKey: row.contextExpansion?.key,
-                expansionBoundary: row.contextExpansion?.boundary
+                expansionBoundary: row.contextExpansion?.boundary,
+                expansionEdge: row.contextExpansion?.edge
             ))
         }
     }
@@ -963,7 +967,8 @@ private struct ColumnAccumulator {
             sourceRange: sourceLine.map { _ in NSRange(location: start, length: line.length) },
             syntaxGroup: lineSyntaxGroup,
             expansionKey: expansion?.key,
-            expansionBoundary: expansion?.boundary
+            expansionBoundary: expansion?.boundary,
+            expansionEdge: expansion?.edge
         ))
     }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -551,6 +551,12 @@ struct DiffPaneTextDocumentBuilder {
     }
 
     static func expandableContextLabel(_ row: DiffDisplayRow) -> String {
+        if row.contextExpansion?.key.isShared == true, row.contextExpansion?.edge == nil {
+            guard row.collapsedLineCount > 0 else {
+                return "Expand all context"
+            }
+            return "Expand all \(row.collapsedLineCount) unchanged lines"
+        }
         let boundaryText = row.contextExpansion?.boundary == .below ? "below" : "above"
         guard row.collapsedLineCount > 0 else {
             return "Expand context \(boundaryText)"

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 private let diffContextExpansionChunkSize = 10
 
+typealias DiffContextExpansionHandler = (DiffContextExpansionKey, DiffContextExpansionMode, DiffContextExpansionEdge?) -> Void
+
 struct DiffReviewLineAnchor: Equatable, Hashable, Sendable {
     struct SelectedLine: Equatable, Hashable, Sendable {
         let side: DiffReviewInlineFeedbackSide
@@ -115,7 +117,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
     let activeCommentHighlight: DiffReviewCommentHighlight?
     var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
-    var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+    var onContextExpansion: DiffContextExpansionHandler = { _, _, _ in }
 
     init(
         group: DiffDisplayGroup,
@@ -131,7 +133,7 @@ struct DiffPaneTextDocumentView: NSViewRepresentable {
         activeCommentHighlight: DiffReviewCommentHighlight? = nil,
         allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
-        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+        onContextExpansion: @escaping DiffContextExpansionHandler = { _, _, _ in }
     ) {
         self.group = group
         self.expandedCollapsedRowIDs = expandedCollapsedRowIDs
@@ -191,7 +193,7 @@ struct DiffPaneSegmentView: NSViewRepresentable {
     var activeCommentHighlight: DiffReviewCommentHighlight? = nil
     var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
-    let onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void
+    let onContextExpansion: DiffContextExpansionHandler
 
     func makeNSView(context: Context) -> DiffPaneTextDocumentContainerView {
         DiffPaneTextDocumentContainerView()
@@ -261,7 +263,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
         activeCommentHighlight: DiffReviewCommentHighlight? = nil,
         allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
-        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+        onContextExpansion: @escaping DiffContextExpansionHandler = { _, _, _ in }
     ) {
         oldPane.allowsReviewLineSelection = allowsReviewLineSelection
         newPane.allowsReviewLineSelection = allowsReviewLineSelection
@@ -462,7 +464,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
         activeCommentHighlight: DiffReviewCommentHighlight? = nil,
         allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
-        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+        onContextExpansion: @escaping DiffContextExpansionHandler = { _, _, _ in }
     ) {
         oldPane.allowsReviewLineSelection = allowsReviewLineSelection
         newPane.allowsReviewLineSelection = allowsReviewLineSelection
@@ -605,7 +607,7 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var lineLabels: [String] = []
     private var rowKinds: [DiffDisplayRow.Kind] = []
     private var lineTones: [DiffPaneLineTone] = []
-    private var expansionKeys: [DiffContextExpansionKey?] = []
+    private var expansionRequests: [(key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?)?] = []
     private var baseDocument: DiffPaneTextDocumentBuilder.CodeDocument?
     private var synchronizedRowHeights: [CGFloat] = []
     private var synchronizedRowLineHeights: [CGFloat?] = []
@@ -630,7 +632,7 @@ final class DiffPaneTextScrollView: NSScrollView {
             textView.onReviewLineSelected = onReviewLineSelected
         }
     }
-    var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in } {
+    var onContextExpansion: DiffContextExpansionHandler = { _, _, _ in } {
         didSet {
             textView.contextExpansionHandler = onContextExpansion
             (verticalRulerView as? DiffPaneLineNumberRulerView)?.onContextExpansion = onContextExpansion
@@ -709,7 +711,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         theme: Theme,
         lspContext: DiffPaneLSPContext?,
         allowedLSPSide: DiffLineSide,
-        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+        onContextExpansion: @escaping DiffContextExpansionHandler = { _, _, _ in }
     ) {
         self.lineLabels = lineLabels
         self.rowKinds = document.lines.map(\.kind)
@@ -719,7 +721,9 @@ final class DiffPaneTextScrollView: NSScrollView {
                 rowKind: line.kind
             )
         }
-        self.expansionKeys = document.lines.map(\.expansionKey)
+        self.expansionRequests = document.lines.map { metadata in
+            metadata.expansionKey.map { (key: $0, edge: metadata.expansionEdge) }
+        }
         self.baseDocument = document
         self.synchronizedRowHeights = []
         self.synchronizedRowLineHeights = []
@@ -749,7 +753,7 @@ final class DiffPaneTextScrollView: NSScrollView {
                 rowHeight: lineHeight(),
                 contentTopInset: textView.textContainerInset.height,
                 theme: theme,
-                expansionKeys: expansionKeys,
+                expansionRequests: expansionRequests,
                 activeCommentHighlight: activeCommentHighlight,
                 onContextExpansion: onContextExpansion
             )
@@ -1100,7 +1104,7 @@ final class DiffPaneCodeTextView: NSTextView {
     var commandClickHandler: ((NSPoint) -> Void)?
     var flagsChangedHandler: ((NSEvent) -> Void)?
     var mouseExitedHandler: (() -> Void)?
-    var contextExpansionHandler: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+    var contextExpansionHandler: DiffContextExpansionHandler = { _, _, _ in }
     var allowsReviewLineSelection = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var lspContext: DiffPaneLSPContext?
@@ -1243,8 +1247,8 @@ final class DiffPaneCodeTextView: NSTextView {
         let optionKey = armedExpansionOptionKey
         pressedExpansionRow = nil
         armedExpansionRow = nil
-        if releasedInside, let key = expansionKey(atRow: armed) {
-            invokeExpansion(key: key, optionKey: optionKey)
+        if releasedInside, let request = expansionRequest(atRow: armed) {
+            invokeExpansion(request: request, optionKey: optionKey)
         }
     }
 
@@ -1555,27 +1559,29 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     func invokeExpansionForTesting(row: Int, optionKey: Bool) {
-        guard let key = expansionKey(atRow: row) else { return }
-        invokeExpansion(key: key, optionKey: optionKey)
+        guard let request = expansionRequest(atRow: row) else { return }
+        invokeExpansion(request: request, optionKey: optionKey)
     }
 
     /// Row index of the expandable-context button under `point`, if any.
     private func expansionRow(at point: NSPoint) -> Int? {
         let rowRects = diffRowRects()
         guard let row = rowRects.binarySearchRow(containing: point),
-              expansionKey(atRow: row) != nil
+              expansionRequest(atRow: row) != nil
         else { return nil }
         return row
     }
 
-    private func expansionKey(atRow row: Int) -> DiffContextExpansionKey? {
-        guard lineMetadata.indices.contains(row) else { return nil }
-        return lineMetadata[row].expansionKey
+    private func expansionRequest(atRow row: Int) -> (key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?)? {
+        guard lineMetadata.indices.contains(row),
+              let key = lineMetadata[row].expansionKey
+        else { return nil }
+        return (key, lineMetadata[row].expansionEdge)
     }
 
-    private func invokeExpansion(key: DiffContextExpansionKey, optionKey: Bool) {
+    private func invokeExpansion(request: (key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?), optionKey: Bool) {
         let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: diffContextExpansionChunkSize)
-        contextExpansionHandler(key, mode)
+        contextExpansionHandler(request.key, mode, request.edge)
     }
 
     private func drawLineBackgrounds(in dirtyRect: NSRect) {
@@ -1838,7 +1844,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
 
     private var labels: [String] = []
     private var lineTones: [DiffPaneLineTone] = []
-    private var expansionKeys: [DiffContextExpansionKey?] = []
+    private var expansionRequests: [(key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?)?] = []
     private var theme: Theme?
     private var hoverRowIndex: Int? {
         didSet {
@@ -1851,7 +1857,7 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     var rowHeight: CGFloat = 16
     var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
-    var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+    var onContextExpansion: DiffContextExpansionHandler = { _, _, _ in }
     var activeCommentHighlight: DiffReviewCommentHighlight? {
         didSet { needsDisplay = true }
     }
@@ -1886,16 +1892,16 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
         rowHeight: CGFloat,
         contentTopInset: CGFloat,
         theme: Theme,
-        expansionKeys: [DiffContextExpansionKey?],
+        expansionRequests: [(key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?)?],
         activeCommentHighlight: DiffReviewCommentHighlight?,
-        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void
+        onContextExpansion: @escaping DiffContextExpansionHandler
     ) {
         self.labels = labels
         self.lineTones = lineTones
         self.rowHeight = rowHeight
         self.contentTopInset = contentTopInset
         self.theme = theme
-        self.expansionKeys = expansionKeys
+        self.expansionRequests = expansionRequests
         self.activeCommentHighlight = activeCommentHighlight
         self.onContextExpansion = onContextExpansion
         updateThickness()
@@ -2176,14 +2182,14 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     }
 
     private func invokeExpansion(row: Int, optionKey: Bool) -> Bool {
-        guard expansionKeys.indices.contains(row),
-              let key = expansionKeys[row]
+        guard expansionRequests.indices.contains(row),
+              let request = expansionRequests[row]
         else {
             return false
         }
 
         let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: diffContextExpansionChunkSize)
-        onContextExpansion(key, mode)
+        onContextExpansion(request.key, mode, request.edge)
         return true
     }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1580,8 +1580,18 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     private func invokeExpansion(request: (key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?), optionKey: Bool) {
-        let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: diffContextExpansionChunkSize)
+        let mode = expansionMode(for: request, optionKey: optionKey)
         contextExpansionHandler(request.key, mode, request.edge)
+    }
+
+    private func expansionMode(
+        for request: (key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?),
+        optionKey: Bool
+    ) -> DiffContextExpansionMode {
+        if optionKey || (request.key.isShared && request.edge == nil) {
+            return .all
+        }
+        return .chunk(size: diffContextExpansionChunkSize)
     }
 
     private func drawLineBackgrounds(in dirtyRect: NSRect) {
@@ -2188,9 +2198,19 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
             return false
         }
 
-        let mode: DiffContextExpansionMode = optionKey ? .all : .chunk(size: diffContextExpansionChunkSize)
+        let mode = expansionMode(for: request, optionKey: optionKey)
         onContextExpansion(request.key, mode, request.edge)
         return true
+    }
+
+    private func expansionMode(
+        for request: (key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?),
+        optionKey: Bool
+    ) -> DiffContextExpansionMode {
+        if optionKey || (request.key.isShared && request.edge == nil) {
+            return .all
+        }
+        return .chunk(size: diffContextExpansionChunkSize)
     }
 
     static func selectionOutlineRect(

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -104,6 +104,79 @@ enum DiffPaneVerticalScrollMode {
     case staticHeight
 }
 
+struct DiffPaneHunkFusionState: Equatable {
+    static let none = DiffPaneHunkFusionState(fusedWithPrevious: false, fusedWithNext: false)
+
+    let fusedWithPrevious: Bool
+    let fusedWithNext: Bool
+
+    var bottomPadding: CGFloat {
+        fusedWithNext ? 0 : 10
+    }
+
+    var outerTopPadding: CGFloat {
+        fusedWithPrevious ? 0 : 10
+    }
+
+    var outerBottomPadding: CGFloat {
+        fusedWithNext ? 0 : 10
+    }
+}
+
+enum DiffPaneHunkFusionResolver {
+    static func states(for groups: [DiffDisplayGroup]) -> [DiffPaneHunkFusionState] {
+        guard !groups.isEmpty else { return [] }
+        var states = Array(repeating: DiffPaneHunkFusionState.none, count: groups.count)
+        guard groups.count > 1 else { return states }
+
+        for index in groups.indices.dropLast() {
+            guard
+                let endingKey = sharedBridgeKeyEnding(groups[index]),
+                let startingKey = sharedBridgeKeyStarting(groups[index + 1]),
+                endingKey == startingKey
+            else {
+                continue
+            }
+            states[index] = DiffPaneHunkFusionState(
+                fusedWithPrevious: states[index].fusedWithPrevious,
+                fusedWithNext: true
+            )
+            states[index + 1] = DiffPaneHunkFusionState(
+                fusedWithPrevious: true,
+                fusedWithNext: states[index + 1].fusedWithNext
+            )
+        }
+        return states
+    }
+
+    private static func sharedBridgeKeyEnding(_ group: DiffDisplayGroup) -> DiffContextExpansionKey? {
+        group.sharedContextAfter
+    }
+
+    private static func sharedBridgeKeyStarting(_ group: DiffDisplayGroup) -> DiffContextExpansionKey? {
+        group.sharedContextBefore
+    }
+}
+
+struct DiffPaneHunkCardShape: Shape {
+    let fusion: DiffPaneHunkFusionState
+
+    func path(in rect: CGRect) -> Path {
+        let topRadius: CGFloat = fusion.fusedWithPrevious ? 0 : 7
+        let bottomRadius: CGFloat = fusion.fusedWithNext ? 0 : 7
+        return UnevenRoundedRectangle(
+            cornerRadii: RectangleCornerRadii(
+                topLeading: topRadius,
+                bottomLeading: bottomRadius,
+                bottomTrailing: bottomRadius,
+                topTrailing: topRadius
+            ),
+            style: .continuous
+        )
+        .path(in: rect)
+    }
+}
+
 struct DiffPaneView: View {
     let model: DiffDisplayModel
     let fileExtension: String
@@ -130,6 +203,7 @@ struct DiffPaneView: View {
     var canResolve: Bool = false
     var onStageReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
     var canAddToReview: Bool = false
+    var hunkFusionStates: [DiffPaneHunkFusionState]? = nil
     let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
 
     @Environment(\.theme) private var theme
@@ -162,6 +236,7 @@ struct DiffPaneView: View {
         canResolve: Bool = false,
         onStageReply: @escaping (DiffInlineCommentThread, String) -> Void = { _, _ in },
         canAddToReview: Bool = false,
+        hunkFusionStates: [DiffPaneHunkFusionState]? = nil,
         hunkActions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions
     ) {
         self.model = model
@@ -189,6 +264,7 @@ struct DiffPaneView: View {
         self.canResolve = canResolve
         self.onStageReply = onStageReply
         self.canAddToReview = canAddToReview
+        self.hunkFusionStates = hunkFusionStates
         self.hunkActions = hunkActions
     }
 
@@ -224,23 +300,44 @@ struct DiffPaneView: View {
     }
 
     private var lazyRowsStack: some View {
-        LazyVStack(alignment: .leading, spacing: 0) {
-            ForEach(model.groups) { group in
-                hunk(group)
+        let indexedGroups = Array(model.groups.enumerated())
+        let fusionStates = resolvedHunkFusionStates
+        return LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(indexedGroups, id: \.element.id) { index, group in
+                hunk(group, fusion: fusionStates[index])
             }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 10)
+        .padding(.top, outerTopPadding(for: fusionStates))
+        .padding(.bottom, outerBottomPadding(for: fusionStates))
     }
 
     private var staticRowsStack: some View {
-        LazyVStack(alignment: .leading, spacing: 0) {
-            ForEach(model.groups) { group in
-                hunk(group)
+        let indexedGroups = Array(model.groups.enumerated())
+        let fusionStates = resolvedHunkFusionStates
+        return LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(indexedGroups, id: \.element.id) { index, group in
+                hunk(group, fusion: fusionStates[index])
             }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 10)
+        .padding(.top, outerTopPadding(for: fusionStates))
+        .padding(.bottom, outerBottomPadding(for: fusionStates))
+    }
+
+    private var resolvedHunkFusionStates: [DiffPaneHunkFusionState] {
+        if let hunkFusionStates, hunkFusionStates.count == model.groups.count {
+            return hunkFusionStates
+        }
+        return DiffPaneHunkFusionResolver.states(for: model.groups)
+    }
+
+    private func outerTopPadding(for fusionStates: [DiffPaneHunkFusionState]) -> CGFloat {
+        fusionStates.first?.outerTopPadding ?? 10
+    }
+
+    private func outerBottomPadding(for fusionStates: [DiffPaneHunkFusionState]) -> CGFloat {
+        fusionStates.last?.outerBottomPadding ?? 10
     }
 
     private var toolbar: some View {
@@ -323,7 +420,7 @@ struct DiffPaneView: View {
         .help(tooltip)
     }
 
-    private func hunk(_ group: DiffDisplayGroup) -> some View {
+    private func hunk(_ group: DiffDisplayGroup, fusion: DiffPaneHunkFusionState) -> some View {
         let visibleRows = DiffPaneRowProjection.visibleRows(
             in: group,
             expandedCollapsedRowIDs: expandedCollapsedRowIDs
@@ -393,12 +490,12 @@ struct DiffPaneView: View {
             }
         }
         .background(theme.color("bg-1"))
-        .clipShape(RoundedRectangle(cornerRadius: 7))
+        .clipShape(DiffPaneHunkCardShape(fusion: fusion))
         .overlay(
-            RoundedRectangle(cornerRadius: 7)
+            DiffPaneHunkCardShape(fusion: fusion)
                 .stroke(theme.color("line"), lineWidth: 0.75)
         )
-        .padding(.bottom, 10)
+        .padding(.bottom, fusion.bottomPadding)
     }
 
     private func threadsForVisibleRows(_ visibleRows: [DiffDisplayRow]) -> [DiffInlineCommentThread] {

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -118,7 +118,7 @@ struct DiffPaneView: View {
     var activeCommentHighlight: DiffReviewCommentHighlight? = nil
     var allowsReviewLineSelection: Bool = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
-    var onContextExpansion: (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in }
+    var onContextExpansion: DiffContextExpansionHandler = { _, _, _ in }
     var threads: [DiffInlineCommentThread] = []
     var annotations: [DiffInlineAnnotation] = []
     var onReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
@@ -150,7 +150,7 @@ struct DiffPaneView: View {
         activeCommentHighlight: DiffReviewCommentHighlight? = nil,
         allowsReviewLineSelection: Bool = true,
         onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in },
-        onContextExpansion: @escaping (DiffContextExpansionKey, DiffContextExpansionMode) -> Void = { _, _ in },
+        onContextExpansion: @escaping DiffContextExpansionHandler = { _, _, _ in },
         threads: [DiffInlineCommentThread] = [],
         annotations: [DiffInlineAnnotation] = [],
         onReply: @escaping (DiffInlineCommentThread, String) -> Void = { _, _ in },

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -29,6 +29,34 @@ enum DiffReviewActiveCommentCandidate: Equatable {
     case thread(String)
 }
 
+enum DiffReviewHunkFusionResolver {
+    static func states(for groups: [DiffReviewRenderContext.Group]) -> [DiffPaneHunkFusionState] {
+        var states = DiffPaneHunkFusionResolver.states(for: groups.map(\.displayGroup))
+        guard states.count == groups.count else { return states }
+
+        for index in groups.indices.dropLast()
+            where states[index].fusedWithNext && !groups[index + 1].inlineFeedback.isEmpty {
+            states[index] = DiffPaneHunkFusionState(
+                fusedWithPrevious: states[index].fusedWithPrevious,
+                fusedWithNext: false
+            )
+            states[index + 1] = DiffPaneHunkFusionState(
+                fusedWithPrevious: false,
+                fusedWithNext: states[index + 1].fusedWithNext
+            )
+        }
+
+        return states
+    }
+}
+
+private struct DiffReviewRenderableGroup: Identifiable {
+    let group: DiffReviewRenderContext.Group
+    let fusion: DiffPaneHunkFusionState
+
+    var id: String { group.id }
+}
+
 struct DiffReviewActiveCommentIDs {
     var hoveredDraftCommentID: String?
     var focusedDraftCommentID: String?
@@ -566,6 +594,11 @@ struct DiffReviewFileSection: View {
     private func content(renderContext: DiffReviewRenderContext?) -> some View {
         if let displayModel = file.displayModel, let renderContext {
             let groups = renderContext.groups
+            let fusionStates = DiffReviewHunkFusionResolver.states(for: groups)
+            let renderableGroups = zip(groups, fusionStates).map { pair in
+                DiffReviewRenderableGroup(group: pair.0, fusion: pair.1)
+            }
+            let renderableGroupsByID = Dictionary(uniqueKeysWithValues: renderableGroups.map { ($0.id, $0) })
             let requiredGroupIDs = DiffReviewRequiredGroupResolver.groupIDs(
                 in: groups,
                 inlineFeedbackIDs: commandedInlineFeedbackIDs,
@@ -576,15 +609,20 @@ struct DiffReviewFileSection: View {
                     ForEach(DiffReviewGroupRenderRun.runs(in: groups, requiredGroupIDs: requiredGroupIDs)) { run in
                         switch run.content {
                         case .lazy(let groups):
-                            lazyGroupStack(groups, displayModel: displayModel)
+                            lazyGroupStack(
+                                groups.compactMap { renderableGroupsByID[$0.id] },
+                                displayModel: displayModel
+                            )
                         case .required(let group):
                             // Keep commanded card IDs available without eagerly rendering unrelated hunks.
-                            groupContent(group, displayModel: displayModel)
+                            if let renderableGroup = renderableGroupsByID[group.id] {
+                                groupContent(renderableGroup, displayModel: displayModel)
+                            }
                         }
                     }
                 }
             } else {
-                lazyGroupStack(groups, displayModel: displayModel)
+                lazyGroupStack(renderableGroups, displayModel: displayModel)
             }
         } else {
             let message = file.placeholderMessage ?? "This file cannot be rendered in the review view."
@@ -605,7 +643,7 @@ struct DiffReviewFileSection: View {
     }
 
     private func lazyGroupStack(
-        _ groups: [DiffReviewRenderContext.Group],
+        _ groups: [DiffReviewRenderableGroup],
         displayModel: DiffDisplayModel
     ) -> some View {
         LazyVStack(spacing: 0) {
@@ -616,10 +654,11 @@ struct DiffReviewFileSection: View {
     }
 
     private func groupContent(
-        _ group: DiffReviewRenderContext.Group,
+        _ renderableGroup: DiffReviewRenderableGroup,
         displayModel: DiffDisplayModel
     ) -> some View {
-        VStack(spacing: 0) {
+        let group = renderableGroup.group
+        return VStack(spacing: 0) {
             if !group.inlineFeedback.isEmpty {
                 inlineFeedbackStack(
                     group.inlineFeedback,
@@ -627,14 +666,15 @@ struct DiffReviewFileSection: View {
                     rows: group.displayGroup.rows
                 )
             }
-            reviewGroup(group, displayModel: displayModel)
+            reviewGroup(group, displayModel: displayModel, fusion: renderableGroup.fusion)
         }
     }
 
     @ViewBuilder
     private func reviewGroup(
         _ group: DiffReviewRenderContext.Group,
-        displayModel: DiffDisplayModel
+        displayModel: DiffDisplayModel,
+        fusion: DiffPaneHunkFusionState
     ) -> some View {
         let displayGroup = group.displayGroup
         if group.containsLocalAccessories {
@@ -714,12 +754,12 @@ struct DiffReviewFileSection: View {
                 }
             }
             .background(theme.color("bg-1"))
-            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .clipShape(DiffPaneHunkCardShape(fusion: fusion))
             .overlay(
-                RoundedRectangle(cornerRadius: 7)
+                DiffPaneHunkCardShape(fusion: fusion)
                     .stroke(theme.color("line"), lineWidth: 0.75)
             )
-            .padding(.bottom, 10)
+            .padding(.bottom, fusion.bottomPadding)
         } else {
             DiffPaneView(
                 model: DiffDisplayModel(filePath: displayModel.filePath, groups: [displayGroup]),
@@ -750,6 +790,7 @@ struct DiffReviewFileSection: View {
                 canResolve: canResolve,
                 onStageReply: onStageReply,
                 canAddToReview: canAddToReview,
+                hunkFusionStates: [fusion],
                 hunkActions: { hunk in
                     let enabled = file.stagedMutationActions?.isHunkUnstageEnabled?(hunk) ?? false
                     return DiffPaneHunkActions(

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -4,6 +4,7 @@ import SwiftUI
 private struct PendingContextExpansion {
     let key: DiffContextExpansionKey
     let mode: DiffContextExpansionMode
+    let edge: DiffContextExpansionEdge?
 }
 
 /// O(1) signal that clears a pending draft when the file's structural layout
@@ -998,14 +999,18 @@ struct DiffReviewFileSection: View {
         )
     }
 
-    private func loadContextAndExpand(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {
+    private func loadContextAndExpand(
+        _ key: DiffContextExpansionKey,
+        mode: DiffContextExpansionMode,
+        edge: DiffContextExpansionEdge?
+    ) {
         guard let provider = file.contextProvider else { return }
         onContextExpansionActivated()
         if contextSnapshot != nil {
-            applyContextExpansion(key, mode: mode)
+            applyContextExpansion(key, mode: mode, edge: edge)
             return
         }
-        pendingContextExpansions.append(PendingContextExpansion(key: key, mode: mode))
+        pendingContextExpansions.append(PendingContextExpansion(key: key, mode: mode, edge: edge))
         guard contextLoadTask == nil else { return }
         let fileID = file.id
         let loadSignature = contextStateSignature
@@ -1030,7 +1035,7 @@ struct DiffReviewFileSection: View {
                     let pendingExpansions = pendingContextExpansions
                     pendingContextExpansions = []
                     for expansion in pendingExpansions {
-                        applyContextExpansion(expansion.key, mode: expansion.mode)
+                        applyContextExpansion(expansion.key, mode: expansion.mode, edge: expansion.edge)
                     }
                 }
             } catch {
@@ -1049,14 +1054,22 @@ struct DiffReviewFileSection: View {
         }
     }
 
-    private func applyContextExpansion(_ key: DiffContextExpansionKey, mode: DiffContextExpansionMode) {
+    private func applyContextExpansion(
+        _ key: DiffContextExpansionKey,
+        mode: DiffContextExpansionMode,
+        edge: DiffContextExpansionEdge?
+    ) {
         guard let displayModel = file.displayModel else { return }
         let available = DiffContextExpandedDisplayBuilder.availableLineCount(
             key: key,
             groups: displayModel.groups,
             snapshot: contextSnapshot
         )
-        contextExpansion.expand(key, available: available, mode: mode)
+        if let edge {
+            contextExpansion.expand(key, available: available, mode: mode, edge: edge)
+        } else {
+            contextExpansion.expand(key, available: available, mode: mode)
+        }
     }
 
     private func resetContextState() {

--- a/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
@@ -230,44 +230,140 @@ private struct ContextExpansionStateSignature: Hashable {
             return
         }
 
+        var signatures: [BoundarySignature] = []
         var expandedLines: [ExpandedSnapshotLineSignature] = []
-        boundaries = groups.enumerated().flatMap { groupIndex, group in
-            [DiffContextBoundary.above, .below].map { boundary in
-                let key = DiffContextExpansionKey(groupID: group.id, boundary: boundary)
-                let range = BoundaryRange(
+
+        for groupIndex in groups.indices {
+            let group = groups[groupIndex]
+            if groupIndex == groups.startIndex {
+                signatures.append(Self.externalSignature(
                     group: group,
                     groupIndex: groupIndex,
-                    boundary: boundary,
+                    boundary: .above,
                     groups: groups,
-                    snapshot: snapshot
-                )
-                let available = range.lineCount
-                let expanded = min(expansion.expandedLineCount(for: key), available)
-                if expanded > 0 {
-                    expandedLines.append(contentsOf: range.expandedLineSignatures(
-                        groupID: group.id,
-                        boundary: boundary,
-                        expandedCount: expanded,
-                        snapshot: snapshot
-                    ))
-                }
-                return BoundarySignature(
-                    groupID: group.id,
-                    boundary: boundary.rawValue,
-                    availableLineCount: available,
-                    expandedLineCount: expanded
-                )
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    expandedLines: &expandedLines
+                ))
+            }
+
+            if groupIndex + 1 < groups.endIndex {
+                signatures.append(Self.sharedSignature(
+                    upperGroup: group,
+                    lowerGroup: groups[groupIndex + 1],
+                    upperGroupIndex: groupIndex,
+                    groups: groups,
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    expandedLines: &expandedLines
+                ))
+            } else {
+                signatures.append(Self.externalSignature(
+                    group: group,
+                    groupIndex: groupIndex,
+                    boundary: .below,
+                    groups: groups,
+                    snapshot: snapshot,
+                    expansion: expansion,
+                    expandedLines: &expandedLines
+                ))
             }
         }
+        boundaries = signatures
         expandedSnapshotContent = expandedLines
+    }
+
+    private static func externalSignature(
+        group: DiffDisplayGroup,
+        groupIndex: Int,
+        boundary: DiffContextBoundary,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?,
+        expansion: DiffContextExpansionState,
+        expandedLines: inout [ExpandedSnapshotLineSignature]
+    ) -> BoundarySignature {
+        let key = DiffContextExpansionKey(groupID: group.id, boundary: boundary)
+        let range = BoundaryRange(
+            group: group,
+            groupIndex: groupIndex,
+            boundary: boundary,
+            groups: groups,
+            snapshot: snapshot
+        )
+        let available = range.lineCount
+        let expanded = min(expansion.expandedLineCount(for: key), available)
+        if expanded > 0 {
+            expandedLines.append(contentsOf: range.expandedLineSignatures(
+                groupID: group.id,
+                boundary: boundary,
+                expandedCount: expanded,
+                snapshot: snapshot
+            ))
+        }
+        return BoundarySignature(
+            key: key,
+            boundary: boundary.rawValue,
+            availableLineCount: available,
+            topExpandedLineCount: expanded,
+            bottomExpandedLineCount: 0
+        )
+    }
+
+    private static func sharedSignature(
+        upperGroup: DiffDisplayGroup,
+        lowerGroup: DiffDisplayGroup,
+        upperGroupIndex: Int,
+        groups: [DiffDisplayGroup],
+        snapshot: DiffReviewFileContextSnapshot?,
+        expansion: DiffContextExpansionState,
+        expandedLines: inout [ExpandedSnapshotLineSignature]
+    ) -> BoundarySignature {
+        let key = DiffContextExpansionKey.shared(upperGroupID: upperGroup.id, lowerGroupID: lowerGroup.id)
+        let range = BoundaryRange(
+            group: upperGroup,
+            groupIndex: upperGroupIndex,
+            boundary: .below,
+            groups: groups,
+            snapshot: snapshot
+        )
+        let available = range.lineCount
+        let topExpanded = min(expansion.expandedLineCount(for: key, edge: .top), available)
+        let bottomExpanded = min(
+            expansion.expandedLineCount(for: key, edge: .bottom),
+            max(0, available - topExpanded)
+        )
+        if topExpanded > 0 {
+            expandedLines.append(contentsOf: range.expandedLineSignatures(
+                groupID: key.groupID,
+                boundary: .below,
+                expandedCount: topExpanded,
+                snapshot: snapshot
+            ))
+        }
+        if bottomExpanded > 0 {
+            expandedLines.append(contentsOf: range.expandedLineSignatures(
+                groupID: key.groupID,
+                boundary: .above,
+                expandedCount: bottomExpanded,
+                snapshot: snapshot
+            ))
+        }
+        return BoundarySignature(
+            key: key,
+            boundary: DiffContextBoundary.below.rawValue,
+            availableLineCount: available,
+            topExpandedLineCount: topExpanded,
+            bottomExpandedLineCount: bottomExpanded
+        )
     }
 }
 
 private struct BoundarySignature: Hashable {
-    let groupID: String
+    let key: DiffContextExpansionKey
     let boundary: String
     let availableLineCount: Int
-    let expandedLineCount: Int
+    let topExpandedLineCount: Int
+    let bottomExpandedLineCount: Int
 }
 
 private struct SnapshotSignature: Hashable {

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -25,6 +25,15 @@ struct DiffContextExpansionTests {
         )
     }
 
+    private func twoSeparatedGroups() -> [DiffDisplayGroup] {
+        let first = group()
+        let secondHunk = ParsedDiff.Hunk(header: "@@ -9,1 +9,1 @@", oldStart: 9, newStart: 9, lines: [
+            .init(kind: .context, text: "line 9", oldNumber: 9, newNumber: 9),
+        ])
+        let second = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [secondHunk]), filePath: "a.swift").groups[0]
+        return [first, second]
+    }
+
     @Test func sharedBoundaryTracksExpansionFromBothSides() {
         let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
         var state = DiffContextExpansionState()
@@ -96,6 +105,61 @@ struct DiffContextExpansionTests {
         #expect(row.edge == .bottom)
     }
 
+    @Test func derivesSharedBridgeBetweenNeighboringHunks() throws {
+        let groups = twoSeparatedGroups()
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: groups,
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: DiffContextExpansionState(),
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        let firstBridge = try #require(expanded[0].rows.last?.contextExpansion)
+        let secondBridge = expanded[1].rows.first?.contextExpansion
+        #expect(firstBridge.key == .shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id))
+        #expect(firstBridge.edge == .top)
+        #expect(secondBridge?.key == firstBridge.key)
+        #expect(secondBridge?.edge == .bottom)
+    }
+
+    @Test func sharedBridgeAvailableLineCountUsesInterHunkGap() {
+        let groups = twoSeparatedGroups()
+        let key = DiffContextExpansionKey.shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id)
+
+        let available = DiffContextExpandedDisplayBuilder.availableLineCount(
+            key: key,
+            groups: groups,
+            snapshot: snapshot()
+        )
+
+        #expect(available == 2)
+    }
+
+    @Test func sharedBridgeRevealsFromBothSidesWithoutDuplicatingLines() {
+        let groups = twoSeparatedGroups()
+        let key = DiffContextExpansionKey.shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id)
+        var state = DiffContextExpansionState()
+        state.expand(key, available: 2, mode: .chunk(size: 1), edge: .top)
+        state.expand(key, available: 2, mode: .chunk(size: 1), edge: .bottom)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: groups,
+            snapshot: snapshot(),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        let numbers = expanded.flatMap(\.rows).compactMap { $0.old?.lineNumber }
+        #expect(numbers.filter { $0 == 7 }.count == 1)
+        #expect(numbers.filter { $0 == 8 }.count == 1)
+        #expect(expanded.flatMap(\.rows).contains { $0.contextExpansion?.key == key } == false)
+    }
+
     @Test func derivesAboveBoundaryAndChunkedRows() throws {
         let base = group()
         let snapshot = snapshot()
@@ -157,8 +221,8 @@ struct DiffContextExpansionTests {
         ])
         let second = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [secondHunk]), filePath: "a.swift").groups[0]
         var state = DiffContextExpansionState()
-        state.expand(.init(groupID: first.id, boundary: .below), available: 10, mode: .all)
-        state.expand(.init(groupID: second.id, boundary: .above), available: 10, mode: .all)
+        let key = DiffContextExpansionKey.shared(upperGroupID: first.id, lowerGroupID: second.id)
+        state.expand(key, available: 1, mode: .all, edge: .top)
 
         let expanded = DiffContextExpandedDisplayBuilder.derive(
             groups: [first, second],
@@ -187,7 +251,12 @@ struct DiffContextExpansionTests {
         ])
         let model = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [insertHunk, adjacentHunk]), filePath: "a.swift")
         var state = DiffContextExpansionState()
-        state.expand(.init(groupID: model.groups[0].id, boundary: .below), available: 2, mode: .all)
+        state.expand(
+            .shared(upperGroupID: model.groups[0].id, lowerGroupID: model.groups[1].id),
+            available: 2,
+            mode: .all,
+            edge: .top
+        )
 
         let expanded = DiffContextExpandedDisplayBuilder.derive(
             groups: model.groups,

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -22,6 +23,77 @@ struct DiffContextExpansionTests {
             old: .available((1...10).map { "old \($0)" }),
             new: .available((1...12).map { "new \($0)" })
         )
+    }
+
+    @Test func sharedBoundaryTracksExpansionFromBothSides() {
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        var state = DiffContextExpansionState()
+
+        state.expand(key, available: 5, mode: .chunk(size: 2), edge: .top)
+        state.expand(key, available: 5, mode: .chunk(size: 2), edge: .bottom)
+
+        #expect(state.expandedLineCount(for: key, edge: .top) == 2)
+        #expect(state.expandedLineCount(for: key, edge: .bottom) == 2)
+        #expect(state.remainingLineCount(for: key, available: 5) == 1)
+    }
+
+    @Test func sharedBoundaryExpansionClampsWhenEdgesMeet() {
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        var state = DiffContextExpansionState()
+
+        state.expand(key, available: 3, mode: .chunk(size: 2), edge: .top)
+        state.expand(key, available: 3, mode: .chunk(size: 2), edge: .bottom)
+
+        #expect(state.expandedLineCount(for: key, edge: .top) == 2)
+        #expect(state.expandedLineCount(for: key, edge: .bottom) == 1)
+        #expect(state.remainingLineCount(for: key, available: 3) == 0)
+    }
+
+    @Test func sharedBoundaryLegacyExpansionAccessReadsTopEdge() {
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        var state = DiffContextExpansionState()
+
+        state.expand(key, available: 5, mode: .chunk(size: 2))
+
+        #expect(state.expandedLineCount(for: key) == 2)
+        #expect(state.expandedLineCount(for: key, edge: .top) == 2)
+        #expect(state.expandedLineCount(for: key, edge: .bottom) == 0)
+    }
+
+    @Test func edgeAwareExpansionDelegatesExternalKeysToBoundaryState() {
+        let key = DiffContextExpansionKey(groupID: "hunk-0", boundary: .below)
+        var state = DiffContextExpansionState()
+
+        state.expand(key, available: 5, mode: .chunk(size: 2), edge: .top)
+
+        #expect(state.expandedLineCount(for: key) == 2)
+        #expect(state.expandedLineCount(for: key, edge: .top) == 2)
+        #expect(state.remainingLineCount(for: key, available: 5) == 3)
+    }
+
+    @Test func decodesLegacyExternalExpansionKeyShape() throws {
+        let data = try #require("""
+        {"groupID":"hunk-0","boundary":"above"}
+        """.data(using: .utf8))
+
+        let key = try JSONDecoder().decode(DiffContextExpansionKey.self, from: data)
+
+        #expect(key == DiffContextExpansionKey(groupID: "hunk-0", boundary: .above))
+    }
+
+    @Test func decodesExpansionRowWithoutEdgeUsingBoundaryDefault() throws {
+        let data = try #require("""
+        {
+          "key": {"groupID":"hunk-0","boundary":"above"},
+          "boundary": "above",
+          "remainingLineCount": 4
+        }
+        """.data(using: .utf8))
+
+        let row = try JSONDecoder().decode(DiffContextExpansionRow.self, from: data)
+
+        #expect(row.key == DiffContextExpansionKey(groupID: "hunk-0", boundary: .above))
+        #expect(row.edge == .bottom)
     }
 
     @Test func derivesAboveBoundaryAndChunkedRows() throws {

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -117,12 +117,18 @@ struct DiffContextExpansionTests {
             chunkSize: 2
         )
 
-        let firstBridge = try #require(expanded[0].rows.last?.contextExpansion)
+        let key = DiffContextExpansionKey.shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id)
+        let firstBridge = try #require(expanded[0].rows.compactMap(\.contextExpansion).first { $0.key == key && $0.edge == .top })
+        let allBridge = try #require(expanded[0].rows.compactMap(\.contextExpansion).first { $0.key == key && $0.edge == nil })
         let secondBridge = expanded[1].rows.first?.contextExpansion
-        #expect(firstBridge.key == .shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id))
+        #expect(firstBridge.key == key)
         #expect(firstBridge.edge == .top)
-        #expect(secondBridge?.key == firstBridge.key)
+        #expect(allBridge.key == key)
+        #expect(allBridge.edge == nil)
+        #expect(secondBridge?.key == key)
         #expect(secondBridge?.edge == .bottom)
+        #expect(expanded[0].sharedContextAfter == nil)
+        #expect(expanded[1].sharedContextBefore == nil)
     }
 
     @Test func sharedBridgeAvailableLineCountUsesInterHunkGap() {
@@ -158,6 +164,67 @@ struct DiffContextExpansionTests {
         #expect(numbers.filter { $0 == 7 }.count == 1)
         #expect(numbers.filter { $0 == 8 }.count == 1)
         #expect(expanded.flatMap(\.rows).contains { $0.contextExpansion?.key == key } == false)
+        #expect(expanded[0].sharedContextAfter == key)
+        #expect(expanded[1].sharedContextBefore == key)
+    }
+
+    @Test func unavailableSharedBridgeContextDoesNotMarkGapExhausted() {
+        let groups = twoSeparatedGroups()
+        let key = DiffContextExpansionKey.shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id)
+        var state = DiffContextExpansionState()
+        state.expand(key, available: 0, mode: .all, edge: .top)
+        state.expand(key, available: 0, mode: .all, edge: .bottom)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: groups,
+            snapshot: DiffReviewFileContextSnapshot(old: .unavailable, new: .unavailable),
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        #expect(expanded[0].rows.last?.contextExpansion == nil)
+        #expect(expanded[1].rows.first?.contextExpansion == nil)
+        #expect(expanded[0].sharedContextAfter == nil)
+        #expect(expanded[1].sharedContextBefore == nil)
+    }
+
+    @Test func sharedBridgeDoesNotDuplicateShortSideLineWhenGapLengthsDiffer() {
+        let firstHunk = ParsedDiff.Hunk(header: "@@ -1,1 +1,1 @@", oldStart: 1, newStart: 1, lines: [
+            .init(kind: .context, text: "line 1", oldNumber: 1, newNumber: 1),
+        ])
+        let secondHunk = ParsedDiff.Hunk(header: "@@ -12,1 +3,1 @@", oldStart: 12, newStart: 3, lines: [
+            .init(kind: .context, text: "line end", oldNumber: 12, newNumber: 3),
+        ])
+        let groups = DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [firstHunk, secondHunk]),
+            filePath: "a.swift"
+        ).groups
+        let snapshot = DiffReviewFileContextSnapshot(
+            old: .available((1...12).map { "old \($0)" }),
+            new: .available((1...3).map { "new \($0)" })
+        )
+        let key = DiffContextExpansionKey.shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id)
+        var state = DiffContextExpansionState()
+        state.expand(key, available: 10, mode: .chunk(size: 1), edge: .top)
+        state.expand(key, available: 10, mode: .chunk(size: 9), edge: .bottom)
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: groups,
+            snapshot: snapshot,
+            providerAvailable: true,
+            expansion: state,
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        let newNumbers = expanded.flatMap(\.rows).compactMap { $0.new?.lineNumber }
+        #expect(newNumbers.filter { $0 == 2 }.count == 1)
+        let oldNumbers = expanded.flatMap(\.rows).compactMap { $0.old?.lineNumber }
+        for number in 2...11 {
+            #expect(oldNumbers.filter { $0 == number }.count == 1)
+        }
     }
 
     @Test func derivesAboveBoundaryAndChunkedRows() throws {

--- a/AlasTests/DiffDisplaySignatureTests.swift
+++ b/AlasTests/DiffDisplaySignatureTests.swift
@@ -24,6 +24,30 @@ struct DiffDisplaySignatureTests {
         DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk(lines: lines)]), filePath: "a.swift")
     }
 
+    private func twoSeparatedHunkModel() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                hunk(lines: sampleLines()),
+                hunk(
+                    header: "@@ -9,1 +9,1 @@",
+                    oldStart: 9,
+                    newStart: 9,
+                    lines: [
+                        .init(kind: .context, text: "old/new 9", oldNumber: 9, newNumber: 9),
+                    ]
+                ),
+            ]),
+            filePath: "a.swift"
+        )
+    }
+
+    private func snapshot() -> DiffReviewFileContextSnapshot {
+        DiffReviewFileContextSnapshot(
+            old: .available((1...10).map { "old \($0)" }),
+            new: .available((1...10).map { "new \($0)" })
+        )
+    }
+
     // MARK: - contentHash
 
     @Test func contentHashEqualForIdenticalModels() {
@@ -133,6 +157,37 @@ struct DiffDisplaySignatureTests {
             )
         }
         #expect(key(a) != key(b))
+    }
+
+    @Test func renderContextKeyDiffersWhenSharedExpansionEdgeChanges() {
+        let model = twoSeparatedHunkModel()
+        let key = DiffContextExpansionKey.shared(
+            upperGroupID: model.groups[0].id,
+            lowerGroupID: model.groups[1].id
+        )
+        var topExpansion = DiffContextExpansionState()
+        topExpansion.expand(key, available: 2, mode: .chunk(size: 1), edge: .top)
+        var bottomExpansion = DiffContextExpansionState()
+        bottomExpansion.expand(key, available: 2, mode: .chunk(size: 1), edge: .bottom)
+        let fileID = DiffReviewFileID(namespace: "commit", path: "a.swift")
+
+        func renderKey(_ expansion: DiffContextExpansionState) -> DiffReviewRenderContextKey {
+            DiffReviewRenderContextKey(
+                fileID: fileID,
+                displayModel: model,
+                contextSnapshot: snapshot(),
+                contextProviderAvailable: true,
+                contextExpansion: expansion,
+                inlineFeedback: [],
+                draftComments: [],
+                pendingDraftAnchor: nil,
+                canCreateDraftComment: true,
+                threads: [],
+                annotations: []
+            )
+        }
+
+        #expect(renderKey(topExpansion) != renderKey(bottomExpansion))
     }
 
     @Test func diffTabRenderContextKeyDiffersWhenModelTextChanges() {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -96,6 +96,40 @@ struct DiffPaneViewTests {
         )
     }
 
+    private func sharedExpandableContextGroup(
+        edge: DiffContextExpansionEdge,
+        collapsedLineCount: Int
+    ) -> DiffDisplayGroup {
+        let upperGroupID = "hunk-0"
+        let lowerGroupID = "hunk-1"
+        let boundary: DiffContextBoundary = edge == .top ? .below : .above
+        return DiffDisplayGroup(
+            id: edge == .top ? upperGroupID : lowerGroupID,
+            header: "@@ -2,1 +2,1 @@",
+            sourceHunk: ParsedDiff.Hunk(
+                header: "@@ -2,1 +2,1 @@",
+                oldStart: 2,
+                newStart: 2,
+                lines: []
+            ),
+            rows: [
+                DiffDisplayRow(
+                    id: "shared-expand-\(edge.rawValue)",
+                    kind: .expandableContext,
+                    old: nil,
+                    new: nil,
+                    collapsedLineCount: collapsedLineCount,
+                    contextExpansion: DiffContextExpansionRow(
+                        key: .shared(upperGroupID: upperGroupID, lowerGroupID: lowerGroupID),
+                        boundary: boundary,
+                        remainingLineCount: collapsedLineCount,
+                        edge: edge
+                    )
+                ),
+            ]
+        )
+    }
+
     private func diffLine(id: String, side: DiffLineSide, oldLine: Int? = nil, newLine: Int? = nil, text: String) -> DiffDisplayLine {
         DiffDisplayLine(
             id: id,
@@ -1892,7 +1926,7 @@ let second = true
             theme: theme,
             lspContext: nil,
             allowedLSPSide: .old,
-            onContextExpansion: { key, mode in captured = (key, mode) }
+            onContextExpansion: { key, mode, _ in captured = (key, mode) }
         )
 
         let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
@@ -1931,7 +1965,7 @@ let second = true
             theme: theme,
             lspContext: nil,
             allowedLSPSide: .new,
-            onContextExpansion: { key, mode in captured = (key, mode) }
+            onContextExpansion: { key, mode, _ in captured = (key, mode) }
         )
 
         let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
@@ -1939,6 +1973,47 @@ let second = true
 
         #expect(captured?.0 == key)
         #expect(captured?.1 == .all)
+    }
+
+    @Test @MainActor func lineNumberRulerInvokesSharedBottomExpansionEdge() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "2 unchanged lines above",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: key,
+                    expansionBoundary: .above,
+                    expansionEdge: .bottom
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode, DiffContextExpansionEdge?)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode, edge in captured = (key, mode, edge) }
+        )
+
+        let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+        ruler.invokeExpansionForTesting(row: 0, optionKey: false)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .chunk(size: 10))
+        #expect(captured?.2 == .bottom)
     }
 
     @Test @MainActor func codeTextViewInvokesExpansionActionForExpandableRows() throws {
@@ -1972,7 +2047,7 @@ let second = true
             theme: theme,
             lspContext: nil,
             allowedLSPSide: .old,
-            onContextExpansion: { key, mode in captured = (key, mode) }
+            onContextExpansion: { key, mode, _ in captured = (key, mode) }
         )
         scrollView.layoutSubtreeIfNeeded()
 
@@ -2042,7 +2117,7 @@ let second = true
             theme: theme,
             lspContext: nil,
             allowedLSPSide: .new,
-            onContextExpansion: { key, mode in captured = (key, mode) }
+            onContextExpansion: { key, mode, _ in captured = (key, mode) }
         )
         scrollView.layoutSubtreeIfNeeded()
 
@@ -2079,6 +2154,76 @@ let second = true
 
         #expect(captured?.0 == key)
         #expect(captured?.1 == .all)
+    }
+
+    @Test @MainActor func codeTextViewInvokesSharedBottomExpansionEdge() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "2 unchanged lines above",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: key,
+                    expansionBoundary: .above,
+                    expansionEdge: .bottom
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        let window = NSWindow(contentRect: scrollView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(scrollView)
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode, DiffContextExpansionEdge?)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode, edge in captured = (key, mode, edge) }
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let textView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRect = try #require(textView.diffRowRects().first)
+        let windowPoint = textView.convert(NSPoint(x: rowRect.midX, y: rowRect.midY), to: nil)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let upEvent = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        textView.mouseDown(with: event)
+        textView.mouseUp(with: upEvent)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .chunk(size: 10))
+        #expect(captured?.2 == .bottom)
     }
 
     @Test @MainActor func lineNumberRulerKeepsReviewSelectionForNonExpandableRows() throws {
@@ -2137,7 +2282,7 @@ let second = true
             theme: theme,
             lspContext: nil,
             allowedLSPSide: .new,
-            onContextExpansion: { _, _ in expansionInvocations += 1 }
+            onContextExpansion: { _, _, _ in expansionInvocations += 1 }
         )
 
         let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
@@ -2270,6 +2415,22 @@ let second = true
         #expect(result.newCode.lines.first?.expansionBoundary == .above)
     }
 
+    @Test func splitDocumentPreservesSharedExpansionEdge() throws {
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            group: sharedExpandableContextGroup(edge: .bottom, collapsedLineCount: 2),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.oldCode.lines.first?.expansionKey == .shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1"))
+        #expect(result.oldCode.lines.first?.expansionBoundary == .above)
+        #expect(result.oldCode.lines.first?.expansionEdge == .bottom)
+        #expect(result.newCode.lines.first?.expansionEdge == .bottom)
+    }
+
     @Test func stackedDocumentRendersExpandableContextBoundaryRows() throws {
         let result = DiffPaneTextDocumentBuilder.buildStacked(
             group: expandableContextGroup(boundary: .below, collapsedLineCount: 7),
@@ -2285,6 +2446,21 @@ let second = true
         #expect(result.code.lines.count == result.gutter.string.components(separatedBy: "\n").count)
         #expect(result.code.lines.first?.expansionKey == DiffContextExpansionKey(groupID: "hunk-0", boundary: .below))
         #expect(result.code.lines.first?.expansionBoundary == .below)
+    }
+
+    @Test func stackedDocumentPreservesSharedExpansionEdge() throws {
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: sharedExpandableContextGroup(edge: .top, collapsedLineCount: 2),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.code.lines.first?.expansionKey == .shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1"))
+        #expect(result.code.lines.first?.expansionBoundary == .below)
+        #expect(result.code.lines.first?.expansionEdge == .top)
     }
 
     @Test func singleDocumentPreservesExpandableContextMetadata() throws {
@@ -3033,7 +3209,7 @@ let second = true
             codeFontSize: 13,
             theme: theme,
             lspContext: nil,
-            onContextExpansion: { _, _ in }
+            onContextExpansion: { _, _, _ in }
         )
 
         let controller = NSHostingController(rootView: view)

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -97,14 +97,14 @@ struct DiffPaneViewTests {
     }
 
     private func sharedExpandableContextGroup(
-        edge: DiffContextExpansionEdge,
+        edge: DiffContextExpansionEdge?,
         collapsedLineCount: Int
     ) -> DiffDisplayGroup {
         let upperGroupID = "hunk-0"
         let lowerGroupID = "hunk-1"
-        let boundary: DiffContextBoundary = edge == .top ? .below : .above
+        let boundary: DiffContextBoundary = edge == .bottom ? .above : .below
         return DiffDisplayGroup(
-            id: edge == .top ? upperGroupID : lowerGroupID,
+            id: edge == .bottom ? lowerGroupID : upperGroupID,
             header: "@@ -2,1 +2,1 @@",
             sourceHunk: ParsedDiff.Hunk(
                 header: "@@ -2,1 +2,1 @@",
@@ -114,7 +114,7 @@ struct DiffPaneViewTests {
             ),
             rows: [
                 DiffDisplayRow(
-                    id: "shared-expand-\(edge.rawValue)",
+                    id: "shared-expand-\(edge?.rawValue ?? "all")",
                     kind: .expandableContext,
                     old: nil,
                     new: nil,
@@ -123,7 +123,8 @@ struct DiffPaneViewTests {
                         key: .shared(upperGroupID: upperGroupID, lowerGroupID: lowerGroupID),
                         boundary: boundary,
                         remainingLineCount: collapsedLineCount,
-                        edge: edge
+                        edge: edge,
+                        defaultsEdgeFromBoundary: edge != nil
                     )
                 ),
             ]
@@ -152,6 +153,147 @@ struct DiffPaneViewTests {
     private struct MemoryStore: PersistenceStoreProtocol {
         func write<T: Encodable>(_: T, to _: URL) throws {}
         func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    private func reviewGroup(
+        _ displayGroup: DiffDisplayGroup,
+        inlineFeedback: [DiffReviewInlineFeedback] = []
+    ) -> DiffReviewRenderContext.Group {
+        DiffReviewRenderContext.Group(
+            displayGroup: displayGroup,
+            inlineFeedback: inlineFeedback,
+            segments: [
+                DiffReviewRenderContext.Segment(
+                    id: "\(displayGroup.id)-segment",
+                    rows: displayGroup.rows,
+                    draftComments: [],
+                    showsComposer: false,
+                    blocks: []
+                ),
+            ]
+        )
+    }
+
+    private func inlineFeedback(path: String = "a.swift", line: Int = 1) -> DiffReviewInlineFeedback {
+        DiffReviewInlineFeedback(
+            id: "feedback-\(line)",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Review this.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: path, line: line, side: .new),
+            evidenceItemID: "feedback-\(line)"
+        )
+    }
+
+    @Test func hunkFusionResolverDoesNotFuseHiddenSharedBridgeRows() throws {
+        let upper = sharedExpandableContextGroup(edge: .top, collapsedLineCount: 8)
+        let lower = sharedExpandableContextGroup(edge: .bottom, collapsedLineCount: 8)
+
+        let states = DiffPaneHunkFusionResolver.states(for: [upper, lower])
+
+        #expect(states == [.none, .none])
+    }
+
+    @Test func hunkFusionResolverFusesFullyExpandedSharedBoundaryWithoutBridgeRows() throws {
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        let upper = DiffDisplayGroup(
+            id: "hunk-0",
+            header: "@@ -2,1 +2,1 @@",
+            sourceHunk: ParsedDiff.Hunk(
+                header: "@@ -2,1 +2,1 @@",
+                oldStart: 2,
+                newStart: 2,
+                lines: []
+            ),
+            rows: [],
+            sharedContextAfter: key
+        )
+        let lower = DiffDisplayGroup(
+            id: "hunk-1",
+            header: "@@ -4,1 +4,1 @@",
+            sourceHunk: ParsedDiff.Hunk(
+                header: "@@ -4,1 +4,1 @@",
+                oldStart: 4,
+                newStart: 4,
+                lines: []
+            ),
+            rows: [],
+            sharedContextBefore: key
+        )
+
+        let states = DiffPaneHunkFusionResolver.states(for: [upper, lower])
+
+        #expect(states[0] == DiffPaneHunkFusionState(fusedWithPrevious: false, fusedWithNext: true))
+        #expect(states[1] == DiffPaneHunkFusionState(fusedWithPrevious: true, fusedWithNext: false))
+    }
+
+    @Test func hunkFusionResolverDoesNotFuseDifferentSharedBridgeKeys() throws {
+        let upper = sharedExpandableContextGroup(edge: .top, collapsedLineCount: 8)
+        let lower = DiffDisplayGroup(
+            id: "hunk-2",
+            header: "@@ -20,1 +20,1 @@",
+            sourceHunk: ParsedDiff.Hunk(
+                header: "@@ -20,1 +20,1 @@",
+                oldStart: 20,
+                newStart: 20,
+                lines: []
+            ),
+            rows: [
+                DiffDisplayRow(
+                    id: "shared-expand-bottom-other",
+                    kind: .expandableContext,
+                    old: nil,
+                    new: nil,
+                    collapsedLineCount: 8,
+                    contextExpansion: DiffContextExpansionRow(
+                        key: .shared(upperGroupID: "hunk-1", lowerGroupID: "hunk-2"),
+                        boundary: .above,
+                        remainingLineCount: 8,
+                        edge: .bottom
+                    )
+                ),
+            ]
+        )
+
+        let states = DiffPaneHunkFusionResolver.states(for: [upper, lower])
+
+        #expect(states == [.none, .none])
+    }
+
+    @Test func hunkFusionResolverDoesNotFuseWhenOnlyOneSideHasSharedBridge() throws {
+        let upper = sharedExpandableContextGroup(edge: .top, collapsedLineCount: 8)
+        let lower = expandableContextGroup(boundary: .above, collapsedLineCount: 8)
+
+        let states = DiffPaneHunkFusionResolver.states(for: [upper, lower])
+
+        #expect(states == [.none, .none])
+    }
+
+    @Test func hunkFusionStateBottomPaddingIsZeroOnlyWhenFusedWithNext() {
+        #expect(DiffPaneHunkFusionState.none.bottomPadding == 10)
+        #expect(DiffPaneHunkFusionState(fusedWithPrevious: false, fusedWithNext: true).bottomPadding == 0)
+        #expect(DiffPaneHunkFusionState(fusedWithPrevious: true, fusedWithNext: false).bottomPadding == 10)
+    }
+
+    @Test func hunkFusionStateOuterPaddingIsZeroAtFusedEdges() {
+        #expect(DiffPaneHunkFusionState.none.outerTopPadding == 10)
+        #expect(DiffPaneHunkFusionState.none.outerBottomPadding == 10)
+        #expect(DiffPaneHunkFusionState(fusedWithPrevious: true, fusedWithNext: false).outerTopPadding == 0)
+        #expect(DiffPaneHunkFusionState(fusedWithPrevious: false, fusedWithNext: true).outerBottomPadding == 0)
+    }
+
+    @Test func reviewHunkFusionResolverDoesNotFuseAcrossLowerInlineFeedback() throws {
+        let upper = sharedExpandableContextGroup(edge: .top, collapsedLineCount: 8)
+        let lower = sharedExpandableContextGroup(edge: .bottom, collapsedLineCount: 8)
+
+        let states = DiffReviewHunkFusionResolver.states(for: [
+            reviewGroup(upper),
+            reviewGroup(lower, inlineFeedback: [inlineFeedback(line: 2)]),
+        ])
+
+        #expect(states == [.none, .none])
     }
 
     @Test func diffTabRenderContextMatchesDraftPlacementAndSegmentationHelpers() throws {
@@ -2016,6 +2158,47 @@ let second = true
         #expect(captured?.2 == .bottom)
     }
 
+    @Test @MainActor func lineNumberRulerInvokesSharedExpandAllWithoutOption() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "Expand all 14 unchanged lines",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 29),
+                    expansionKey: key,
+                    expansionBoundary: .below,
+                    expansionEdge: nil
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 260, height: 80))
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode, DiffContextExpansionEdge?)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode, edge in captured = (key, mode, edge) }
+        )
+
+        let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+        ruler.invokeExpansionForTesting(row: 0, optionKey: false)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .all)
+        #expect(captured?.2 == nil)
+    }
+
     @Test @MainActor func codeTextViewInvokesExpansionActionForExpandableRows() throws {
         let theme = theme()
         let font = CenterTypography.resolveCodeFont(family: "", size: 13)
@@ -2226,6 +2409,76 @@ let second = true
         #expect(captured?.2 == .bottom)
     }
 
+    @Test @MainActor func codeTextViewInvokesSharedExpandAllWithoutOption() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "Expand all 14 unchanged lines",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 29),
+                    expansionKey: key,
+                    expansionBoundary: .below,
+                    expansionEdge: nil
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 260, height: 80))
+        let window = NSWindow(contentRect: scrollView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(scrollView)
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode, DiffContextExpansionEdge?)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode, edge in captured = (key, mode, edge) }
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let textView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRect = try #require(textView.diffRowRects().first)
+        let windowPoint = textView.convert(NSPoint(x: rowRect.midX, y: rowRect.midY), to: nil)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let upEvent = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        textView.mouseDown(with: event)
+        textView.mouseUp(with: upEvent)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .all)
+        #expect(captured?.2 == nil)
+    }
+
     @Test @MainActor func lineNumberRulerKeepsReviewSelectionForNonExpandableRows() throws {
         let theme = theme()
         let font = CenterTypography.resolveCodeFont(family: "", size: 13)
@@ -2431,6 +2684,23 @@ let second = true
         #expect(result.newCode.lines.first?.expansionEdge == .bottom)
     }
 
+    @Test func splitDocumentRendersSharedExpandAllContextRow() throws {
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            group: sharedExpandableContextGroup(edge: nil, collapsedLineCount: 4),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.oldCode.attributedString.string.components(separatedBy: "\n") == ["Expand all 4 unchanged lines"])
+        #expect(result.oldCode.lines.first?.expansionKey == .shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1"))
+        #expect(result.oldCode.lines.first?.expansionBoundary == .below)
+        #expect(result.oldCode.lines.first?.expansionEdge == nil)
+        #expect(result.newCode.lines.first?.expansionEdge == nil)
+    }
+
     @Test func stackedDocumentRendersExpandableContextBoundaryRows() throws {
         let result = DiffPaneTextDocumentBuilder.buildStacked(
             group: expandableContextGroup(boundary: .below, collapsedLineCount: 7),
@@ -2461,6 +2731,22 @@ let second = true
         #expect(result.code.lines.first?.expansionKey == .shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1"))
         #expect(result.code.lines.first?.expansionBoundary == .below)
         #expect(result.code.lines.first?.expansionEdge == .top)
+    }
+
+    @Test func stackedDocumentRendersSharedExpandAllContextRow() throws {
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: sharedExpandableContextGroup(edge: nil, collapsedLineCount: 4),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        #expect(result.code.attributedString.string.components(separatedBy: "\n") == ["Expand all 4 unchanged lines"])
+        #expect(result.code.lines.first?.expansionKey == .shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1"))
+        #expect(result.code.lines.first?.expansionBoundary == .below)
+        #expect(result.code.lines.first?.expansionEdge == nil)
     }
 
     @Test func singleDocumentPreservesExpandableContextMetadata() throws {

--- a/docs/superpowers/specs/2026-07-16-shared-diff-context-boundaries-design.md
+++ b/docs/superpowers/specs/2026-07-16-shared-diff-context-boundaries-design.md
@@ -1,0 +1,194 @@
+# Shared Diff Context Boundaries Design
+
+## Overview
+
+Diff review panels currently expose context expansion as hunk-owned edges. The
+first hunk can own an `above` edge, and every hunk can own a `below` edge. That
+avoids duplicate controls, but it makes intermediate hunks appear to be missing
+an "expand above" affordance. It also leaves nearby hunks visually separated
+after expanded context makes their visible ranges contiguous.
+
+The review diff should model hidden context between neighboring hunks as one
+shared boundary. A shared boundary renders one bridge with directional
+expansion controls and a discoverable full-gap action. When no hidden lines
+remain between two hunks, their visual panes should fuse into one contiguous
+container while preserving the original hunk structure for comments, anchors,
+and review actions.
+
+This applies to both split and stacked diff views.
+
+## Goals
+
+- Show an above-direction expansion affordance for every hunk that has hidden
+  context before it.
+- Render one shared inter-hunk bridge for each hidden gap between neighboring
+  hunks.
+- Provide three shared bridge actions: expand toward the upper hunk, expand all
+  hidden lines, and expand toward the lower hunk.
+- Fuse visual panes when two hunks become contiguous through expansion.
+- Keep parsed diff hunks immutable so existing hunk identity, anchors, comments,
+  and actions remain stable.
+- Support the same behavior in split and stacked views.
+
+## Non-Goals
+
+- Do not merge or rewrite the parsed diff hunks themselves.
+- Do not change staging, commenting, or hunk action semantics.
+- Do not add a "nearby hunks only" threshold. Shared bridges appear for every
+  hidden inter-hunk gap.
+- Do not redesign the existing first-hunk top or last-hunk bottom single-edge
+  controls beyond moving them onto the same internal boundary model.
+
+## Current Behavior
+
+`DiffContextExpandedDisplayBuilder` decides ownership with
+`ownsBoundary(groupIndex:boundary:)`. Today, `.above` is only owned by the first
+group, while `.below` is owned by every group. This means the hidden gap between
+two hunks is represented as the previous hunk's `below` boundary. The next hunk
+does not render an `above` control, which is visible in review panels as a
+missing "Expand context above" button.
+
+The display builder already has enough range information to understand previous
+and next hunks, and context expansion state is already separate from the parsed
+diff. The missing concept is an explicit display-layer boundary for the shared
+hidden range between two neighboring hunks.
+
+## Proposed Model
+
+Introduce a display-layer boundary model that projects a file into ordered
+render elements:
+
+```text
+external-top-boundary?
+group
+shared-boundary?
+group
+shared-boundary?
+group
+external-bottom-boundary?
+```
+
+Boundary types:
+
+- `externalTop`: hidden file context before the first hunk.
+- `externalBottom`: hidden file context after the last hunk.
+- `shared`: hidden file context between two neighboring hunks.
+
+External boundaries preserve the existing one-direction behavior:
+
+- `externalTop` renders "expand context above" for the first hunk.
+- `externalBottom` renders "expand context below" for the last hunk.
+
+Shared boundaries are keyed by the gap identity rather than by either hunk's
+individual edge. A shared boundary tracks the source line range hidden between
+two neighboring groups and the amount currently revealed from each side.
+
+The shared boundary state must support:
+
+- chunk expansion from the top side of the gap;
+- chunk expansion from the bottom side of the gap;
+- full expansion of the remaining gap;
+- clamping when top and bottom reveals meet or overlap;
+- reporting that the boundary is fully revealed.
+
+Parsed diff hunks remain unchanged. The display builder composes original
+hunks, expanded context lines, and boundary rows into render output.
+
+## Rendering And Interaction
+
+### Split View
+
+In split view, a shared boundary renders as a full-width bridge row between two
+hunk bodies. The bridge spans both old and new panes and visually belongs to the
+gap rather than to either hunk.
+
+The bridge exposes three actions:
+
+- Up control: reveal the next chunk from the top side of the shared gap.
+- Center action: reveal the entire remaining gap immediately.
+- Down control: reveal the next chunk from the bottom side of the shared gap.
+
+The center label should read `Expand all N lines` when the exact hidden line
+count is known. If the full-file snapshot is not loaded yet, it can fall back to
+`Expand all context` until the provider resolves the source lines.
+
+### Stacked View
+
+In stacked view, the same shared boundary renders as one unified row. The
+directional controls live in the line-number gutter area, and the center action
+lives in the code/content lane. Controls are not duplicated per old/new side.
+
+The visual treatment should make the row read as one bridge in the single
+stacked code stream while preserving the same actions as split view.
+
+### Modifier Behavior
+
+The bridge keeps the existing chunk and modifier interaction model:
+
+- Click `up`: expand one chunk toward the upper hunk.
+- Click `down`: expand one chunk toward the lower hunk.
+- Option-click `up` or `down`: expand all remaining lines from that direction.
+- Click `Expand all N lines`: reveal the entire remaining shared gap.
+
+## Pane Fusion
+
+When a shared boundary is fully revealed, the two neighboring hunks should no
+longer render as separate bordered panes. The display should coalesce their
+visual containers into one outer pane because there is no hidden gap between
+them.
+
+Fusion is a presentation concern. It should not merge parsed hunks or remove
+their original identities. Hunk headers may remain as internal landmarks if they
+are still useful for orientation, but the outer border and spacing should read
+as one contiguous diff block.
+
+The same rule applies when hunks are already contiguous in the original diff:
+there should be no empty bridge, and the panes should render as fused from the
+start.
+
+## Edge Cases
+
+- If a file has only one hunk, it keeps the existing top and bottom expansion
+  behavior through external boundaries.
+- If an inter-hunk gap has zero hidden lines, no shared bridge renders.
+- If expansion from both sides would overlap, reveal counts are clamped so no
+  context line is duplicated.
+- If snapshot loading fails, the diff should remain usable. The boundary should
+  avoid showing an exact line count and should degrade the same way current
+  context expansion does.
+- If a snapshot is not loaded yet, labels and enabled states may be optimistic
+  or generic, but actions must resolve against the loaded source range before
+  inserting context lines.
+
+## Testing Plan
+
+Display-builder tests should cover:
+
+- external top and bottom boundaries;
+- shared boundaries between every neighboring hunk pair;
+- chunk expansion from the top side of a shared gap;
+- chunk expansion from the bottom side of a shared gap;
+- full-gap expansion;
+- overlap clamping when both sides expand into the same gap;
+- no bridge emitted after a boundary is fully revealed;
+- no bridge emitted for initially contiguous hunks.
+
+View-level tests should cover:
+
+- split view renders one shared bridge for an intermediate hidden gap;
+- stacked view renders one shared bridge for the same hidden gap;
+- intermediate hunks have an above-direction affordance through the shared
+  bridge;
+- the full-gap action is present when a shared gap exists;
+- panes fuse after a shared gap is fully revealed.
+
+## Open Decisions
+
+No open product decisions remain from the brainstorming session. The approved
+behavior is:
+
+- shared bridges appear for every hidden inter-hunk gap;
+- split and stacked views both support the feature;
+- directional controls expand one chunk by default;
+- Option-click directional controls expand all remaining lines from that side;
+- the center bridge action expands the whole gap immediately.


### PR DESCRIPTION
## Summary
- model hidden inter-hunk context as shared expansion boundaries
- preserve edge-aware expand controls in split and stacked diff views
- fuse adjacent hunk panes when shared context makes them visually contiguous
- keep review inline feedback from fusing cards that are not physically adjacent

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffContextExpansionTests -only-testing:AlasTests/DiffDisplaySignatureTests -only-testing:AlasTests/DiffPaneViewTests
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test failed locally only in SSHIntegrationTests because this machine lacks key-authenticated ssh localhost; CI does not run that optional integration suite