### PR TITLE
fix(diff): shared expand-all before context loads

### DIFF
--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -361,13 +361,27 @@ enum DiffContextExpandedDisplayBuilder {
             ) else {
                 return []
             }
-            return [expandableRow(
+            let expandable = expandableRow(
                 group: attachedGroup,
                 boundary: attachedBoundary,
                 remaining: 0,
                 key: key,
                 edge: edge
-            )]
+            )
+            guard edge == .top else {
+                return [expandable]
+            }
+            return [
+                expandable,
+                expandableRow(
+                    group: attachedGroup,
+                    boundary: attachedBoundary,
+                    remaining: 0,
+                    key: key,
+                    edge: nil,
+                    defaultsEdgeFromBoundary: false
+                ),
+            ]
         }
 
         let range = boundaryRange(

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -131,6 +131,27 @@ struct DiffContextExpansionTests {
         #expect(expanded[1].sharedContextBefore == nil)
     }
 
+    @Test func derivesSharedExpandAllBridgeBeforeSnapshotLoads() throws {
+        let groups = twoSeparatedGroups()
+
+        let expanded = DiffContextExpandedDisplayBuilder.derive(
+            groups: groups,
+            snapshot: nil,
+            providerAvailable: true,
+            expansion: DiffContextExpansionState(),
+            filePath: "a.swift",
+            chunkSize: 2
+        )
+
+        let key = DiffContextExpansionKey.shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id)
+        let upperExpansionRows = expanded[0].rows.compactMap(\.contextExpansion).filter { $0.key == key }
+        let lowerExpansionRows = expanded[1].rows.compactMap(\.contextExpansion).filter { $0.key == key }
+
+        #expect(upperExpansionRows.map(\.edge) == [.top, nil])
+        #expect(upperExpansionRows.map(\.remainingLineCount) == [0, 0])
+        #expect(lowerExpansionRows.map(\.edge) == [.bottom])
+    }
+
     @Test func sharedBridgeAvailableLineCountUsesInterHunkGap() {
         let groups = twoSeparatedGroups()
         let key = DiffContextExpansionKey.shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id)


### PR DESCRIPTION
## Summary
- render the shared full-gap expansion row before context snapshots load
- add a regression test for optimistic shared bridge controls

## Verification
- xcodegen
- swiftformat Alas AlasTests --lint
- git diff --check
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffContextExpansionTests -only-testing:AlasTests/DiffPaneViewTests

Follow-up for Codex feedback on #817.