### PR TITLE
fix(diff): render diff expansion actions inline

### DIFF
--- a/Alas/Sources/Center/Diff/DiffContextExpansion.swift
+++ b/Alas/Sources/Center/Diff/DiffContextExpansion.swift
@@ -368,20 +368,7 @@ enum DiffContextExpandedDisplayBuilder {
                 key: key,
                 edge: edge
             )
-            guard edge == .top else {
-                return [expandable]
-            }
-            return [
-                expandable,
-                expandableRow(
-                    group: attachedGroup,
-                    boundary: attachedBoundary,
-                    remaining: 0,
-                    key: key,
-                    edge: nil,
-                    defaultsEdgeFromBoundary: false
-                ),
-            ]
+            return [expandable]
         }
 
         let range = boundaryRange(
@@ -464,17 +451,6 @@ enum DiffContextExpandedDisplayBuilder {
         switch edge {
         case .top:
             rows.insert(expandable, at: rows.endIndex)
-            rows.insert(
-                expandableRow(
-                    group: attachedGroup,
-                    boundary: attachedBoundary,
-                    remaining: remaining,
-                    key: key,
-                    edge: nil,
-                    defaultsEdgeFromBoundary: false
-                ),
-                at: rows.endIndex
-            )
         case .bottom:
             rows.insert(expandable, at: rows.startIndex)
         }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -2,6 +2,19 @@ import AppKit
 import SwiftUI
 
 struct DiffPaneTextDocumentBuilder {
+    enum ContextExpansionActionMode: Equatable {
+        case chunk
+        case all
+    }
+
+    struct ContextExpansionAction: Equatable {
+        let key: DiffContextExpansionKey
+        let boundary: DiffContextBoundary
+        let edge: DiffContextExpansionEdge?
+        let mode: ContextExpansionActionMode
+        let range: NSRange
+    }
+
     struct LineMetadata: Equatable {
         let kind: DiffDisplayRow.Kind
         let range: NSRange
@@ -12,6 +25,7 @@ struct DiffPaneTextDocumentBuilder {
         var expansionKey: DiffContextExpansionKey? = nil
         var expansionBoundary: DiffContextBoundary? = nil
         var expansionEdge: DiffContextExpansionEdge? = nil
+        var expansionActions: [ContextExpansionAction] = []
     }
 
     struct CodeDocument {
@@ -303,7 +317,8 @@ struct DiffPaneTextDocumentBuilder {
                 range: NSRange(location: start, length: output.length - start),
                 expansionKey: row.contextExpansion?.key,
                 expansionBoundary: row.contextExpansion?.boundary,
-                expansionEdge: row.contextExpansion?.edge
+                expansionEdge: row.contextExpansion?.edge,
+                expansionActions: contextExpansionActions(for: row.contextExpansion, lineStart: start)
             ))
         }
 
@@ -339,7 +354,8 @@ struct DiffPaneTextDocumentBuilder {
                     range: NSRange(location: start, length: output.length - start),
                     expansionKey: row.contextExpansion?.key,
                     expansionBoundary: row.contextExpansion?.boundary,
-                    expansionEdge: row.contextExpansion?.edge
+                    expansionEdge: row.contextExpansion?.edge,
+                    expansionActions: contextExpansionActions(for: row.contextExpansion, lineStart: start)
                 ))
                 index += 1
                 continue
@@ -512,7 +528,7 @@ struct DiffPaneTextDocumentBuilder {
         theme: Theme
     ) -> NSAttributedString {
         NSAttributedString(
-            string: expandableContextLabel(row),
+            string: expandableContextText(row.contextExpansion, fallbackBoundary: row.contextExpansion?.boundary),
             attributes: expandableContextAttributes(font: font, theme: theme)
         )
     }
@@ -523,6 +539,7 @@ struct DiffPaneTextDocumentBuilder {
         let headIndent = expandableContextHeadIndent(font: font)
         paragraph.firstLineHeadIndent = headIndent
         paragraph.headIndent = headIndent
+        paragraph.lineBreakMode = .byClipping
         // Size the row from the font (code font is user-configurable up to 64pt),
         // not a fixed height: natural line height plus symmetric vertical padding,
         // so the row rect grows with the glyphs and the pill keeps its breathing
@@ -551,21 +568,88 @@ struct DiffPaneTextDocumentBuilder {
     }
 
     static func expandableContextLabel(_ row: DiffDisplayRow) -> String {
-        if row.contextExpansion?.key.isShared == true, row.contextExpansion?.edge == nil {
-            guard row.collapsedLineCount > 0 else {
+        expandableContextLabel(
+            expansion: row.contextExpansion,
+            remainingLineCount: row.collapsedLineCount
+        )
+    }
+
+    private static func expandableContextLabel(
+        expansion: DiffContextExpansionRow?,
+        remainingLineCount: Int
+    ) -> String {
+        if expansion?.key.isShared == true, expansion?.edge == nil {
+            guard remainingLineCount > 0 else {
                 return "Expand all context"
             }
-            return "Expand all \(row.collapsedLineCount) unchanged lines"
+            return "Expand all \(remainingLineCount) unchanged lines"
         }
-        let boundaryText = row.contextExpansion?.boundary == .below ? "below" : "above"
-        guard row.collapsedLineCount > 0 else {
+        let boundary = expansion?.boundary
+        let boundaryText = boundary == .below ? "below" : "above"
+        guard remainingLineCount > 0 else {
             return "Expand context \(boundaryText)"
         }
-        return "Expand \(row.collapsedLineCount) unchanged lines \(boundaryText)"
+        return "Expand \(remainingLineCount) unchanged lines \(boundaryText)"
     }
 
     static func expandableContextSymbolName(boundary: DiffContextBoundary?) -> String {
         boundary == .above ? "chevron.up" : "chevron.down"
+    }
+
+    private static let expandableContextActionSeparator = "      "
+
+    private static func expandableContextText(
+        _ expansion: DiffContextExpansionRow?,
+        fallbackBoundary: DiffContextBoundary?
+    ) -> String {
+        guard let expansion else {
+            let boundaryText = fallbackBoundary == .below ? "below" : "above"
+            return "Expand context \(boundaryText)"
+        }
+        return contextExpansionActionLabels(for: expansion).map(\.label).joined(separator: expandableContextActionSeparator)
+    }
+
+    fileprivate static func contextExpansionActions(
+        for expansion: DiffContextExpansionRow?,
+        lineStart: Int
+    ) -> [ContextExpansionAction] {
+        guard let expansion else { return [] }
+        let labels = contextExpansionActionLabels(for: expansion)
+
+        var location = lineStart
+        var actions: [ContextExpansionAction] = []
+        actions.reserveCapacity(labels.count)
+        for (index, item) in labels.enumerated() {
+            let labelLength = (item.label as NSString).length
+            actions.append(ContextExpansionAction(
+                key: expansion.key,
+                boundary: expansion.boundary,
+                edge: expansion.edge,
+                mode: item.mode,
+                range: NSRange(location: location, length: labelLength)
+            ))
+            location += labelLength
+            if index < labels.count - 1 {
+                location += (expandableContextActionSeparator as NSString).length
+            }
+        }
+        return actions
+    }
+
+    private static func contextExpansionActionLabels(
+        for expansion: DiffContextExpansionRow
+    ) -> [(label: String, mode: ContextExpansionActionMode)] {
+        let primaryMode: ContextExpansionActionMode = expansion.key.isShared && expansion.edge == nil ? .all : .chunk
+        var labels: [(label: String, mode: ContextExpansionActionMode)] = [
+            (
+                expandableContextLabel(expansion: expansion, remainingLineCount: expansion.remainingLineCount),
+                primaryMode
+            ),
+        ]
+        if primaryMode != .all {
+            labels.append(("Expand all context", .all))
+        }
+        return labels
     }
 
     private static func collapsedTextAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {
@@ -974,7 +1058,10 @@ private struct ColumnAccumulator {
             syntaxGroup: lineSyntaxGroup,
             expansionKey: expansion?.key,
             expansionBoundary: expansion?.boundary,
-            expansionEdge: expansion?.edge
+            expansionEdge: expansion?.edge,
+            expansionActions: line.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? []
+                : DiffPaneTextDocumentBuilder.contextExpansionActions(for: expansion, lineStart: start)
         ))
     }
 

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -997,6 +997,11 @@ final class DiffPaneCodeTextView: NSTextView {
         let firstLineFragmentRects: [NSRect]
     }
 
+    private struct ExpansionTarget: Equatable {
+        let row: Int
+        let action: DiffPaneTextDocumentBuilder.ContextExpansionAction
+    }
+
     static func placeholderHatchRect(in rowRect: NSRect) -> NSRect {
         rowRect.insetBy(dx: 0, dy: 1)
     }
@@ -1029,13 +1034,13 @@ final class DiffPaneCodeTextView: NSTextView {
     private var lspController: DiffPaneLSPController?
     private var cachedRowGeometry: RowGeometry?
     private var rowGeometryComputationCount = 0
-    private var hoverExpansionRow: Int? {
-        didSet { if hoverExpansionRow != oldValue { needsDisplay = true } }
+    private var hoverExpansionTarget: ExpansionTarget? {
+        didSet { if hoverExpansionTarget != oldValue { needsDisplay = true } }
     }
-    private var pressedExpansionRow: Int? {
-        didSet { if pressedExpansionRow != oldValue { needsDisplay = true } }
+    private var pressedExpansionTarget: ExpansionTarget? {
+        didSet { if pressedExpansionTarget != oldValue { needsDisplay = true } }
     }
-    private var armedExpansionRow: Int?
+    private var armedExpansionTarget: ExpansionTarget?
     private var armedExpansionOptionKey = false
     /// Whether we last forced the pointing-hand cursor, so it can be restored to
     /// the default when the mouse leaves the view.
@@ -1190,7 +1195,7 @@ final class DiffPaneCodeTextView: NSTextView {
         super.mouseMoved(with: event)
         let point = convert(event.locationInWindow, from: nil)
         hoverHandler?(point)
-        hoverExpansionRow = expansionRow(at: point)
+        hoverExpansionTarget = expansionTarget(at: point)
         // `super.mouseMoved` re-asserts the text view's I-beam on every move and
         // wins the ordering against `cursorUpdate`, so re-apply the pointer here
         // (unconditionally, no cached-state guard) after super has run.
@@ -1198,7 +1203,7 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     private func applyPointerCursorIfNeeded(at point: NSPoint) {
-        if let row = reviewLineRow(at: point), rowShouldUsePointingHandCursor(row) {
+        if shouldUsePointingHandCursor(at: point) {
             NSCursor.pointingHand.set()
             didSetPointerCursor = true
         } else {
@@ -1208,10 +1213,10 @@ final class DiffPaneCodeTextView: NSTextView {
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        if let row = expansionRow(at: point) {
-            armedExpansionRow = row
+        if let target = expansionTarget(at: point) {
+            armedExpansionTarget = target
             armedExpansionOptionKey = event.modifierFlags.contains(.option)
-            pressedExpansionRow = row
+            pressedExpansionTarget = target
             return
         }
         if event.modifierFlags.contains(.command), let commandClickHandler {
@@ -1229,26 +1234,26 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard let armed = armedExpansionRow else {
+        guard let armed = armedExpansionTarget else {
             super.mouseDragged(with: event)
             return
         }
         let point = convert(event.locationInWindow, from: nil)
-        pressedExpansionRow = expansionRow(at: point) == armed ? armed : nil
+        pressedExpansionTarget = expansionTarget(at: point) == armed ? armed : nil
     }
 
     override func mouseUp(with event: NSEvent) {
-        guard let armed = armedExpansionRow else {
+        guard let armed = armedExpansionTarget else {
             super.mouseUp(with: event)
             return
         }
         let point = convert(event.locationInWindow, from: nil)
-        let releasedInside = expansionRow(at: point) == armed
+        let releasedInside = expansionTarget(at: point) == armed
         let optionKey = armedExpansionOptionKey
-        pressedExpansionRow = nil
-        armedExpansionRow = nil
-        if releasedInside, let request = expansionRequest(atRow: armed) {
-            invokeExpansion(request: request, optionKey: optionKey)
+        pressedExpansionTarget = nil
+        armedExpansionTarget = nil
+        if releasedInside {
+            invokeExpansion(action: armed.action, optionKey: optionKey)
         }
     }
 
@@ -1259,7 +1264,7 @@ final class DiffPaneCodeTextView: NSTextView {
 
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
-        hoverExpansionRow = nil
+        hoverExpansionTarget = nil
         // Restore the default cursor when leaving the view, otherwise a pointing
         // hand set over an expandable/source row can linger over the surrounding
         // non-interactive chrome until the next cursor update.
@@ -1543,7 +1548,7 @@ final class DiffPaneCodeTextView: NSTextView {
         // `addCursorRect`/`resetCursorRects` mechanism. Override it here so
         // expandable-context and reviewable source rows show the pointer instead.
         let point = convert(event.locationInWindow, from: nil)
-        if let row = reviewLineRow(at: point), rowShouldUsePointingHandCursor(row) {
+        if shouldUsePointingHandCursor(at: point) {
             NSCursor.pointingHand.set()
             didSetPointerCursor = true
         } else {
@@ -1552,46 +1557,64 @@ final class DiffPaneCodeTextView: NSTextView {
         }
     }
 
+    private func shouldUsePointingHandCursor(at point: NSPoint) -> Bool {
+        if expansionTarget(at: point) != nil {
+            return true
+        }
+        guard let row = reviewLineRow(at: point) else { return false }
+        return rowShouldUsePointingHandCursor(row)
+    }
+
     private func rowShouldUsePointingHandCursor(_ row: Int) -> Bool {
         guard lineMetadata.indices.contains(row) else { return false }
         let metadata = lineMetadata[row]
-        return metadata.expansionKey != nil || metadata.sourceLine != nil
+        return metadata.sourceLine != nil
     }
 
     func invokeExpansionForTesting(row: Int, optionKey: Bool) {
-        guard let request = expansionRequest(atRow: row) else { return }
-        invokeExpansion(request: request, optionKey: optionKey)
+        guard let action = expansionActions(atRow: row).first else { return }
+        invokeExpansion(action: action, optionKey: optionKey)
     }
 
-    /// Row index of the expandable-context button under `point`, if any.
-    private func expansionRow(at point: NSPoint) -> Int? {
+    private func expansionTarget(at point: NSPoint) -> ExpansionTarget? {
         let rowRects = diffRowRects()
-        guard let row = rowRects.binarySearchRow(containing: point),
-              expansionRequest(atRow: row) != nil
-        else { return nil }
-        return row
-    }
-
-    private func expansionRequest(atRow row: Int) -> (key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?)? {
-        guard lineMetadata.indices.contains(row),
-              let key = lineMetadata[row].expansionKey
-        else { return nil }
-        return (key, lineMetadata[row].expansionEdge)
-    }
-
-    private func invokeExpansion(request: (key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?), optionKey: Bool) {
-        let mode = expansionMode(for: request, optionKey: optionKey)
-        contextExpansionHandler(request.key, mode, request.edge)
-    }
-
-    private func expansionMode(
-        for request: (key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?),
-        optionKey: Bool
-    ) -> DiffContextExpansionMode {
-        if optionKey || (request.key.isShared && request.edge == nil) {
-            return .all
+        guard let row = rowRects.binarySearchRow(containing: point) else { return nil }
+        let rowRect = rowRects[row]
+        for action in expansionActions(atRow: row) {
+            guard let pillRect = expansionPillRect(action: action, rowRect: rowRect) else { continue }
+            if pillRect.contains(point) {
+                return ExpansionTarget(row: row, action: action)
+            }
         }
-        return .chunk(size: diffContextExpansionChunkSize)
+        return nil
+    }
+
+    private func expansionActions(atRow row: Int) -> [DiffPaneTextDocumentBuilder.ContextExpansionAction] {
+        guard lineMetadata.indices.contains(row) else { return [] }
+        let metadata = lineMetadata[row]
+        if !metadata.expansionActions.isEmpty {
+            return metadata.expansionActions
+        }
+        guard let key = metadata.expansionKey else { return [] }
+        let mode: DiffPaneTextDocumentBuilder.ContextExpansionActionMode = key.isShared && metadata.expansionEdge == nil ? .all : .chunk
+        return [
+            DiffPaneTextDocumentBuilder.ContextExpansionAction(
+                key: key,
+                boundary: metadata.expansionBoundary ?? key.boundary,
+                edge: metadata.expansionEdge,
+                mode: mode,
+                range: metadata.range
+            ),
+        ]
+    }
+
+    private func invokeExpansion(
+        action: DiffPaneTextDocumentBuilder.ContextExpansionAction,
+        optionKey: Bool
+    ) {
+        let actionMode: DiffPaneTextDocumentBuilder.ContextExpansionActionMode = optionKey ? .all : action.mode
+        let mode: DiffContextExpansionMode = actionMode == .all ? .all : .chunk(size: diffContextExpansionChunkSize)
+        contextExpansionHandler(action.key, mode, action.edge)
     }
 
     private func drawLineBackgrounds(in dirtyRect: NSRect) {
@@ -1755,49 +1778,75 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     private func drawExpandableContextPill(row: Int, in rowRect: NSRect, theme: Theme) {
-        guard lineMetadata.indices.contains(row),
-              let layoutManager,
-              let textContainer
-        else {
-            return
-        }
-
-        let range = lineMetadata[row].range
-        guard range.length > 0 else { return }
-
-        // In split mode the opposite column keeps the expandable-context metadata
-        // on a blank " " placeholder. Only the column holding the real label
-        // should render the button, so skip rows whose text is empty.
-        let label = (string as NSString).substring(with: range)
-        guard !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-
-        let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
-        guard glyphRange.length > 0 else { return }
-
-        let textRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
-            .offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
-        guard !textRect.isEmpty else { return }
+        let actions = expansionActions(atRow: row)
+        guard !actions.isEmpty else { return }
 
         // Split panes can synchronize a row to be taller than its first text
         // fragment. Keep the pill attached to the fragment where the label is
         // drawn instead of centering it in the full synchronized row.
         // The chevron is drawn here (not baked into the text) so the backing
         // string stays a plain label for selection/copy.
-        let chevronGap: CGFloat = 5
         let tint = NSColor(theme.color("seg-pill-active-fg"))
-        let chevronImage = Self.expandChevronImage(
-            boundary: lineMetadata[row].expansionBoundary,
-            font: font,
-            color: tint
-        )
-        let chevronSize = chevronImage?.size ?? .zero
-        let chevronLeftX = textRect.minX - chevronGap - chevronSize.width
+        for action in actions {
+            guard let pillRect = expansionPillRect(action: action, rowRect: rowRect) else { continue }
+            let target = ExpansionTarget(row: row, action: action)
+            let alpha = Self.expandPillFillAlpha(
+                hovered: hoverExpansionTarget == target,
+                pressed: pressedExpansionTarget == target
+            )
+            let path = NSBezierPath(roundedRect: pillRect, xRadius: 6, yRadius: 6)
+            NSColor(theme.color("accent")).withAlphaComponent(alpha).setFill()
+            path.fill()
 
-        let firstLineRect = firstLineFragmentRect(
-            for: range,
-            layoutManager: layoutManager,
-            origin: textContainerOrigin
+            guard
+                let chevronImage = Self.expandChevronImage(
+                    boundary: action.boundary,
+                    font: font,
+                    color: tint
+                ),
+                let chevronRect = expansionChevronRect(action: action, rowRect: rowRect)
+            else {
+                continue
+            }
+            chevronImage.draw(in: chevronRect)
+        }
+    }
+
+    private func expansionPillRect(
+        action: DiffPaneTextDocumentBuilder.ContextExpansionAction,
+        rowRect: NSRect
+    ) -> NSRect? {
+        guard let textRect = expansionActionTextRect(action) else { return nil }
+        let chevronGap: CGFloat = 5
+        let chevronSize = Self.expandChevronImage(
+            boundary: action.boundary,
+            font: font,
+            color: .textColor
+        )?.size ?? .zero
+        let firstLineRect = expansionActionFirstLineRect(action)
+        return Self.expandPillRect(
+            textRect: textRect,
+            firstLineRect: firstLineRect,
+            rowRect: rowRect,
+            chevronSize: chevronSize,
+            chevronGap: chevronGap
         )
+    }
+
+    private func expansionChevronRect(
+        action: DiffPaneTextDocumentBuilder.ContextExpansionAction,
+        rowRect: NSRect
+    ) -> NSRect? {
+        guard let textRect = expansionActionTextRect(action) else { return nil }
+        let chevronGap: CGFloat = 5
+        let chevronImage = Self.expandChevronImage(
+            boundary: action.boundary,
+            font: font,
+            color: .textColor
+        )
+        guard let chevronImage else { return nil }
+        let chevronSize = chevronImage.size
+        let firstLineRect = expansionActionFirstLineRect(action)
         let pillRect = Self.expandPillRect(
             textRect: textRect,
             firstLineRect: firstLineRect,
@@ -1805,22 +1854,46 @@ final class DiffPaneCodeTextView: NSTextView {
             chevronSize: chevronSize,
             chevronGap: chevronGap
         )
-        let alpha = Self.expandPillFillAlpha(
-            hovered: hoverExpansionRow == row,
-            pressed: pressedExpansionRow == row
+        return Self.expandChevronRect(
+            chevronLeftX: textRect.minX - chevronGap - chevronSize.width,
+            chevronSize: chevronSize,
+            pillRect: pillRect
         )
-        let path = NSBezierPath(roundedRect: pillRect, xRadius: 6, yRadius: 6)
-        NSColor(theme.color("accent")).withAlphaComponent(alpha).setFill()
-        path.fill()
+    }
 
-        if let chevronImage {
-            let chevronRect = Self.expandChevronRect(
-                chevronLeftX: chevronLeftX,
-                chevronSize: chevronSize,
-                pillRect: pillRect
-            )
-            chevronImage.draw(in: chevronRect)
+    private func expansionActionTextRect(
+        _ action: DiffPaneTextDocumentBuilder.ContextExpansionAction
+    ) -> NSRect? {
+        guard let layoutManager, let textContainer else { return nil }
+        let textLength = (string as NSString).length
+        guard action.range.location >= 0,
+              action.range.length > 0,
+              action.range.location < textLength,
+              action.range.length <= textLength - action.range.location
+        else {
+            return nil
         }
+
+        let label = (string as NSString).substring(with: action.range)
+        guard !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: action.range, actualCharacterRange: nil)
+        guard glyphRange.length > 0 else { return nil }
+
+        let textRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+            .offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
+        return textRect.isEmpty ? nil : textRect
+    }
+
+    private func expansionActionFirstLineRect(
+        _ action: DiffPaneTextDocumentBuilder.ContextExpansionAction
+    ) -> NSRect {
+        guard let layoutManager else { return .zero }
+        return firstLineFragmentRect(
+            for: action.range,
+            layoutManager: layoutManager,
+            origin: textContainerOrigin
+        )
     }
 
     private static func expandChevronImage(

--- a/AlasTests/DiffContextExpansionTests.swift
+++ b/AlasTests/DiffContextExpansionTests.swift
@@ -119,12 +119,10 @@ struct DiffContextExpansionTests {
 
         let key = DiffContextExpansionKey.shared(upperGroupID: groups[0].id, lowerGroupID: groups[1].id)
         let firstBridge = try #require(expanded[0].rows.compactMap(\.contextExpansion).first { $0.key == key && $0.edge == .top })
-        let allBridge = try #require(expanded[0].rows.compactMap(\.contextExpansion).first { $0.key == key && $0.edge == nil })
         let secondBridge = expanded[1].rows.first?.contextExpansion
         #expect(firstBridge.key == key)
         #expect(firstBridge.edge == .top)
-        #expect(allBridge.key == key)
-        #expect(allBridge.edge == nil)
+        #expect(expanded[0].rows.compactMap(\.contextExpansion).filter { $0.key == key }.map(\.edge) == [.top])
         #expect(secondBridge?.key == key)
         #expect(secondBridge?.edge == .bottom)
         #expect(expanded[0].sharedContextAfter == nil)
@@ -147,8 +145,8 @@ struct DiffContextExpansionTests {
         let upperExpansionRows = expanded[0].rows.compactMap(\.contextExpansion).filter { $0.key == key }
         let lowerExpansionRows = expanded[1].rows.compactMap(\.contextExpansion).filter { $0.key == key }
 
-        #expect(upperExpansionRows.map(\.edge) == [.top, nil])
-        #expect(upperExpansionRows.map(\.remainingLineCount) == [0, 0])
+        #expect(upperExpansionRows.map(\.edge) == [.top])
+        #expect(upperExpansionRows.map(\.remainingLineCount) == [0])
         #expect(lowerExpansionRows.map(\.edge) == [.bottom])
     }
 

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -2158,6 +2158,47 @@ let second = true
         #expect(captured?.2 == .bottom)
     }
 
+    @Test @MainActor func lineNumberRulerOptionClickInvokesFullExpansionForSharedEdge() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "2 unchanged lines above",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: key,
+                    expansionBoundary: .above,
+                    expansionEdge: .bottom
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode, DiffContextExpansionEdge?)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode, edge in captured = (key, mode, edge) }
+        )
+
+        let ruler = try #require(scrollView.verticalRulerView as? DiffPaneLineNumberRulerView)
+        ruler.invokeExpansionForTesting(row: 0, optionKey: true)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .all)
+        #expect(captured?.2 == .bottom)
+    }
+
     @Test @MainActor func lineNumberRulerInvokesSharedExpandAllWithoutOption() throws {
         let theme = theme()
         let font = CenterTypography.resolveCodeFont(family: "", size: 13)
@@ -2409,6 +2450,76 @@ let second = true
         #expect(captured?.2 == .bottom)
     }
 
+    @Test @MainActor func codeTextViewOptionClickInvokesFullExpansionForSharedEdge() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let key = DiffContextExpansionKey.shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1")
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: "2 unchanged lines above",
+                attributes: [.font: font]
+            ),
+            lines: [
+                DiffPaneTextDocumentBuilder.LineMetadata(
+                    kind: .expandableContext,
+                    range: NSRange(location: 0, length: 23),
+                    expansionKey: key,
+                    expansionBoundary: .above,
+                    expansionEdge: .bottom
+                ),
+            ]
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        let window = NSWindow(contentRect: scrollView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(scrollView)
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode, DiffContextExpansionEdge?)?
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode, edge in captured = (key, mode, edge) }
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let textView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRect = try #require(textView.diffRowRects().first)
+        let windowPoint = textView.convert(NSPoint(x: rowRect.midX, y: rowRect.midY), to: nil)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: .option,
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let upEvent = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: windowPoint,
+            modifierFlags: .option,
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        textView.mouseDown(with: event)
+        textView.mouseUp(with: upEvent)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .all)
+        #expect(captured?.2 == .bottom)
+    }
+
     @Test @MainActor func codeTextViewInvokesSharedExpandAllWithoutOption() throws {
         let theme = theme()
         let font = CenterTypography.resolveCodeFont(family: "", size: 13)
@@ -2477,6 +2588,70 @@ let second = true
         #expect(captured?.0 == key)
         #expect(captured?.1 == .all)
         #expect(captured?.2 == nil)
+    }
+
+    @Test @MainActor func codeTextViewInvokesFullExpansionFromSecondInlineAction() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let document = DiffPaneTextDocumentBuilder.buildStacked(
+            group: expandableContextGroup(boundary: .below, collapsedLineCount: 0),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: font,
+            showWhitespace: false,
+            theme: theme
+        )
+        let key = DiffContextExpansionKey(groupID: "hunk-0", boundary: .below)
+        let secondAction = try #require(document.code.lines.first?.expansionActions.first { $0.mode == .all })
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 80))
+        let window = NSWindow(contentRect: scrollView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(scrollView)
+        var captured: (DiffContextExpansionKey, DiffContextExpansionMode)?
+
+        scrollView.update(
+            document: document.code,
+            lineLabels: ["+"],
+            wraps: false,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new,
+            onContextExpansion: { key, mode, _ in captured = (key, mode) }
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let textView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRect = try #require(textView.diffRowRects().first)
+        let secondActionRect = try #require(textView.symbolAnchorRect(for: secondAction.range))
+        let windowPoint = textView.convert(NSPoint(x: secondActionRect.midX, y: rowRect.midY), to: nil)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let upEvent = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        textView.mouseDown(with: event)
+        textView.mouseUp(with: upEvent)
+
+        #expect(captured?.0 == key)
+        #expect(captured?.1 == .all)
     }
 
     @Test @MainActor func lineNumberRulerKeepsReviewSelectionForNonExpandableRows() throws {
@@ -2658,7 +2833,7 @@ let second = true
 
         #expect(result.oldGutter.string.components(separatedBy: "\n") == ["+"])
         #expect(result.newGutter.string.components(separatedBy: "\n") == [""])
-        #expect(result.oldCode.attributedString.string.components(separatedBy: "\n") == ["Expand 9 unchanged lines above"])
+        #expect(result.oldCode.attributedString.string.components(separatedBy: "\n") == ["Expand 9 unchanged lines above      Expand all context"])
         #expect(result.newCode.attributedString.string.components(separatedBy: "\n") == [" "])
         #expect(result.oldCode.lines.count == result.oldGutter.string.components(separatedBy: "\n").count)
         #expect(result.newCode.lines.count == result.newGutter.string.components(separatedBy: "\n").count)
@@ -2712,7 +2887,7 @@ let second = true
         )
 
         #expect(result.gutter.string.components(separatedBy: "\n") == ["+"])
-        #expect(result.code.attributedString.string.components(separatedBy: "\n") == ["Expand 7 unchanged lines below"])
+        #expect(result.code.attributedString.string.components(separatedBy: "\n") == ["Expand 7 unchanged lines below      Expand all context"])
         #expect(result.code.lines.count == result.gutter.string.components(separatedBy: "\n").count)
         #expect(result.code.lines.first?.expansionKey == DiffContextExpansionKey(groupID: "hunk-0", boundary: .below))
         #expect(result.code.lines.first?.expansionBoundary == .below)
@@ -2731,6 +2906,8 @@ let second = true
         #expect(result.code.lines.first?.expansionKey == .shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1"))
         #expect(result.code.lines.first?.expansionBoundary == .below)
         #expect(result.code.lines.first?.expansionEdge == .top)
+        #expect(result.code.lines.first?.expansionActions.map(\.mode) == [.chunk, .all])
+        #expect(result.code.lines.first?.expansionActions.map(\.edge) == [.top, .top])
     }
 
     @Test func stackedDocumentRendersSharedExpandAllContextRow() throws {
@@ -2747,6 +2924,31 @@ let second = true
         #expect(result.code.lines.first?.expansionKey == .shared(upperGroupID: "hunk-0", lowerGroupID: "hunk-1"))
         #expect(result.code.lines.first?.expansionBoundary == .below)
         #expect(result.code.lines.first?.expansionEdge == nil)
+        #expect(result.code.lines.first?.expansionActions.map(\.mode) == [.all])
+        #expect(result.code.lines.first?.expansionActions.map(\.edge) == [nil])
+    }
+
+    @Test func stackedDocumentRendersChunkAndFullExpansionActionsSideBySide() throws {
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            group: expandableContextGroup(boundary: .below, collapsedLineCount: 0),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme()
+        )
+
+        let line = try #require(result.code.lines.first)
+        let paragraph = try #require(result.code.attributedString.attribute(
+            .paragraphStyle,
+            at: line.range.location,
+            effectiveRange: nil
+        ) as? NSParagraphStyle)
+        #expect(result.code.attributedString.string.components(separatedBy: "\n") == ["Expand context below      Expand all context"])
+        #expect(result.code.lines.count == 1)
+        #expect(line.expansionActions.map(\.mode) == [.chunk, .all])
+        #expect(line.expansionActions.map(\.edge) == [line.expansionEdge, line.expansionEdge])
+        #expect(paragraph.lineBreakMode == .byClipping)
     }
 
     @Test func singleDocumentPreservesExpandableContextMetadata() throws {


### PR DESCRIPTION
## Summary
Multiple context expansion actions can appear on the same diff row. This PR renders them as separate inline targets so the chunk expansion and full expansion controls sit side by side instead of stacking on consecutive rows.

## Changes
- Tracks each context expansion action with its own text range, boundary, and action mode.
- Draws hover, pressed state, chevron, and pill backgrounds per inline expansion action.
- Dispatches clicks based on the exact inline target, so `Expand all context` invokes full expansion without requiring Option-click.
- Covers the side-by-side builder output and second inline action hit testing in `DiffPaneViewTests`.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -skip-testing:AlasTests/SSHIntegrationTests test`
- `git diff --check`

Note: the unskipped full local suite only failed on `SSHIntegrationTests`, which are explicitly gated by `ALAS_SSH_INTEGRATION=1`.