### PR TITLE
feat(review): support keyboard range selection

### DIFF
--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
@@ -409,9 +409,17 @@ struct ReviewTargetDialog: View {
             }
             return .handled
         case .upArrow:
+            if press.modifiers.contains(.shift),
+               model.extendCommitRangeSelection(step: -1) {
+                return .handled
+            }
             model.moveSelection(step: -1, selectable: selectable)
             return .handled
         case .downArrow:
+            if press.modifiers.contains(.shift),
+               model.extendCommitRangeSelection(step: 1) {
+                return .handled
+            }
             model.moveSelection(step: 1, selectable: selectable)
             return .handled
         case .return:

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -186,6 +186,36 @@ final class ReviewTargetPaletteModel {
         }
     }
 
+    /// Extends a commit-range selection from the current commit to the next
+    /// visible commit. Returns true when the key press was consumed, including
+    /// the edge where there is no further commit in that direction.
+    @discardableResult
+    func extendCommitRangeSelection(step: Int) -> Bool {
+        guard step != 0, case .targets = level else { return false }
+        let rows = targetRows()
+        guard rows.indices.contains(selectedIndex),
+              case .commit(let currentCommit) = rows[selectedIndex]
+        else { return false }
+
+        var nextIndex = selectedIndex + step
+        while rows.indices.contains(nextIndex) {
+            switch rows[nextIndex] {
+            case .commit:
+                if rangeAnchor == nil {
+                    rangeAnchor = currentCommit
+                }
+                selectedIndex = nextIndex
+                scrollToSelectionTick &+= 1
+                return true
+            case .header, .message:
+                nextIndex += step
+            case .branch:
+                return true
+            }
+        }
+        return true
+    }
+
     /// Set selection directly, snapping forward (then backward) to the
     /// nearest selectable row if the target is not selectable. Used on hover
     /// and by the level-2 default selection.
@@ -277,7 +307,6 @@ final class ReviewTargetPaletteModel {
         guard case .targets(let worktree) = level else { return }
         isLoadingTargets = true
         targetsError = nil
-        defer { isLoadingTargets = false }
         do {
             async let ahead = env.loadCommitsAhead(worktree)
             async let branchList = env.loadBranches(worktree)
@@ -289,11 +318,13 @@ final class ReviewTargetPaletteModel {
             if let ref = result.comparisonRef {
                 comparisonRefs[worktree.id] = ref
             }
+            isLoadingTargets = false
             let rows = targetRows()
             setSelectedIndex(0, selectable: rows.map(\.isSelectable))
         } catch {
             guard case .targets(let current) = level, current.id == worktree.id else { return }
             targetsError = "Could not load commits: \(error.localizedDescription)"
+            isLoadingTargets = false
         }
     }
 

--- a/AlasTests/ReviewTargetPaletteModelTests.swift
+++ b/AlasTests/ReviewTargetPaletteModelTests.swift
@@ -181,6 +181,64 @@ struct ReviewTargetPaletteModelTests {
         #expect(opened?.payload == .commitRange(base: "aaa1^", head: "ccc3"))
     }
 
+    @Test func shiftDownAnchorsCurrentCommitAndLaunchesOrderedRange() async {
+        let model = ReviewTargetPaletteModel()
+        let w = worktree("feature")
+        model.open(prefill: w)
+        // Newest first, git log order.
+        let newest = commit("ccc3", "third")
+        let middle = commit("bbb2", "second")
+        let oldest = commit("aaa1", "first")
+        var opened: ReviewSessionTarget?
+        let env = environment(commits: [newest, middle, oldest], onOpen: { t, _ in opened = t })
+        await model.loadTargets(environment: env)
+
+        #expect(model.selectedIndex == 1)
+        #expect(model.extendCommitRangeSelection(step: 1))
+        #expect(model.rangeAnchor == newest)
+        #expect(model.selectedIndex == 2)
+
+        await model.activateSelection(environment: env)
+        #expect(opened?.kind == .commitRange)
+        #expect(opened?.payload == .commitRange(base: "bbb2^", head: "ccc3"))
+    }
+
+    @Test func repeatedShiftDownKeepsOriginalAnchorAndExtendsRange() async {
+        let model = ReviewTargetPaletteModel()
+        let w = worktree("feature")
+        model.open(prefill: w)
+        // Newest first, git log order.
+        let newest = commit("ccc3", "third")
+        let middle = commit("bbb2", "second")
+        let oldest = commit("aaa1", "first")
+        var opened: ReviewSessionTarget?
+        let env = environment(commits: [newest, middle, oldest], onOpen: { t, _ in opened = t })
+        await model.loadTargets(environment: env)
+
+        #expect(model.extendCommitRangeSelection(step: 1))
+        #expect(model.extendCommitRangeSelection(step: 1))
+        #expect(model.rangeAnchor == newest)
+        #expect(model.selectedIndex == 3)
+
+        await model.activateSelection(environment: env)
+        #expect(opened?.kind == .commitRange)
+        #expect(opened?.payload == .commitRange(base: "aaa1^", head: "ccc3"))
+    }
+
+    @Test func shiftDownFromLastCommitDoesNotMoveIntoBranchRows() async {
+        let model = ReviewTargetPaletteModel()
+        let w = worktree("feature")
+        model.open(prefill: w)
+        let only = commit("aaa1", "first")
+        let env = environment(commits: [only], branches: ["main"])
+        await model.loadTargets(environment: env)
+
+        #expect(model.selectedIndex == 1)
+        #expect(model.extendCommitRangeSelection(step: 1))
+        #expect(model.selectedIndex == 1)
+        #expect(model.rangeAnchor == nil)
+    }
+
     @Test func enterOnBranchLaunchesPinnedBranchReview() async {
         let model = ReviewTargetPaletteModel()
         model.open(prefill: worktree("feature"))


### PR DESCRIPTION
## Summary
- add Shift+Up/Shift+Down range extension in the review target palette commit list
- reuse the existing commit range target flow when activating the selected range
- fix target-list loading selection so loaded commits snap to the first selectable row

## Verification
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/ReviewTargetPaletteModelTests test`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build`