### PR TITLE
fix(acp): transcript live-lock (beachball) in chat view

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		2ED636DD3A179B95C061A9E6 /* InlineErrorStripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */; };
 		2ED82820F76F5032E4339926 /* ZmxClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */; };
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
+		2F1165AE6FD339D03943C182 /* ACPTranscriptRowContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
 		2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */; };
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
@@ -2431,6 +2432,7 @@
 		E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHost.swift; sourceTree = "<group>"; };
 		E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictMinimap.swift; sourceTree = "<group>"; };
 		E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneViewTests.swift; sourceTree = "<group>"; };
+		E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowContentTests.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPStatusPolicyTests.swift; sourceTree = "<group>"; };
 		E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActionButton.swift; sourceTree = "<group>"; };
@@ -3516,6 +3518,7 @@
 				39B7BC45B64591618784F650 /* ACPSlashPickerTests.swift */,
 				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
+				E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
 				CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
@@ -5862,6 +5865,7 @@
 				A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */,
 				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,
 				6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */,
+				2F1165AE6FD339D03943C182 /* ACPTranscriptRowContentTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
 				441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -629,6 +629,7 @@
 		8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */; };
 		8035C82C1C3F79801A0F2F39 /* ImageDiffPairKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */; };
 		804D11E10C7478C00C0F5C40 /* DraftCommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */; };
+		806A8D3076BDF74084FF05AB /* ACPVisibleRowsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */; };
 		809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */; };
 		8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */; };
 		81214C5FDACA47C2FFC15E9E /* HoverWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */; };
@@ -2279,6 +2280,7 @@
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
 		C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEditView.swift; sourceTree = "<group>"; };
 		C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediatorTests.swift; sourceTree = "<group>"; };
+		CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPVisibleRowsCacheTests.swift; sourceTree = "<group>"; };
 		CA43AA9C8462D579E733B46C /* AppIntents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
 		CA554728676F9D3B5E2C05FA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CAB5BDBCB990CC0452BF9164 /* ReviewRequestDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDraft.swift; sourceTree = "<group>"; };
@@ -3513,6 +3515,7 @@
 				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
+				CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
 			);
 			path = UI;
@@ -5860,6 +5863,7 @@
 				441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */,
 				FD5AC98DEE4448EB95C49485 /* ACPUserInputFormStateTests.swift in Sources */,
 				83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */,
+				806A8D3076BDF74084FF05AB /* ACPVisibleRowsCacheTests.swift in Sources */,
 				E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,
 				FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -505,6 +505,7 @@
 		61FEA0F7DAF21FA0AFE88BAE /* RemoteFileAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */; };
 		62055BD147E504C658B93E20 /* ACPFirstRunConnectingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737A9A3D11EA28582CA5D061 /* ACPFirstRunConnectingView.swift */; };
 		6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1874031C788ADB4398151FF1 /* StageChip.swift */; };
+		625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84BC1A10866A165EA321719 /* ACPTranscriptTests.swift */; };
 		6291072E82FC282625FD1617 /* GitServiceCommitEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */; };
 		6294D44BE2DC7F96933F7C4B /* ACPMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */; };
 		629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */; };
@@ -2517,6 +2518,7 @@
 		F748F06725644571785BF658 /* PendingStashDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingStashDrop.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
 		F83370751580C42D5DE93F80 /* GitInvocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInvocation.swift; sourceTree = "<group>"; };
+		F84BC1A10866A165EA321719 /* ACPTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptTests.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
 		F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerAttachRestoreTests.swift; sourceTree = "<group>"; };
 		F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceDiscardTests.swift; sourceTree = "<group>"; };
@@ -4160,6 +4162,7 @@
 				0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */,
 				3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */,
 				A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */,
+				F84BC1A10866A165EA321719 /* ACPTranscriptTests.swift */,
 				7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */,
 				FE7A4A7B920C0E748973F282 /* BuiltInAlasMCPTests.swift */,
 				336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */,
@@ -5859,6 +5862,7 @@
 				A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */,
 				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,
 				6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */,
+				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
 				441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */,
 				FD5AC98DEE4448EB95C49485 /* ACPUserInputFormStateTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -44,6 +44,13 @@ final class ACPTranscript: ObservableObject {
     /// stableId + StreamingText identity equality keep the ForEach row
     /// tree stable across ticks.
     @Published var streamingTick: UInt32 = 0
+    /// Wall-clock time (`ProcessInfo.systemUptime`) of the last `streamingTick`
+    /// publish. Used to throttle publishes to `streamingTickMinInterval`.
+    private var lastStreamingTickPublish: TimeInterval = 0
+    /// Pending trailing-edge publish scheduled when a chunk arrives inside
+    /// the throttle window. Guarantees the last chunk of a fast burst still
+    /// produces a publish even if no further chunk arrives to trigger one.
+    private var streamingTickDrain: Task<Void, Never>?
     /// True while post-hydration tail-first backfill is materialising older
     /// persisted rows. This is separate from `visibleHead`: a non-zero head
     /// means older rows are available behind the render window, not that an
@@ -112,6 +119,8 @@ final class ACPTranscript: ObservableObject {
     /// discarded (e.g. session close).
     func resetMarkdownCaches() {
         markdownCaches.removeAll()
+        streamingTickDrain?.cancel()
+        streamingTickDrain = nil
     }
 
     private func refreshPlanCaches() {
@@ -167,14 +176,73 @@ final class ACPTranscript: ObservableObject {
         }
     }
 
+    /// Decision returned by `streamingTickAction` for a single streaming
+    /// chunk arrival.
+    enum StreamingTickAction: Equatable {
+        /// Publish `streamingTick` immediately.
+        case publishNow
+        /// Coalesce this chunk into a trailing-edge publish fired after
+        /// `after` seconds, unless a further chunk supersedes it first.
+        case scheduleDrain(after: TimeInterval)
+        /// A drain is already pending; nothing to do for this chunk.
+        case drop
+    }
+
+    /// Target throttle interval for `streamingTick` publishes: roughly
+    /// display refresh rate, so a fast agent response cannot force more than
+    /// ~30 full `ACPMessageList` body re-evals per second. `nonisolated`
+    /// alongside `streamingTickAction` so the pure decision function stays
+    /// callable (and testable) without main-actor isolation.
+    nonisolated static let streamingTickMinInterval: TimeInterval = 1.0 / 30.0
+
+    /// Pure decision for how a streaming chunk arrival should affect the
+    /// throttled `streamingTick` publish. Kept side-effect free and
+    /// `nonisolated` so it is trivially unit-testable without a running
+    /// transcript instance.
+    nonisolated static func streamingTickAction(
+        elapsedSincePublish: TimeInterval,
+        hasPendingDrain: Bool,
+        minInterval: TimeInterval = streamingTickMinInterval
+    ) -> StreamingTickAction {
+        if hasPendingDrain { return .drop }
+        if elapsedSincePublish >= minInterval { return .publishNow }
+        return .scheduleDrain(after: minInterval - elapsedSincePublish)
+    }
+
     /// Streaming chunk appends mutate a `StreamingText` buffer in place —
     /// the array element compares equal (identity equality), so
     /// `messages.didSet` cannot see them. Callers pass the mutated index.
     /// Replaces direct `streamingTick &+= 1` writes.
+    ///
+    /// `streamingTick` publishes are throttled to `streamingTickMinInterval`
+    /// with a trailing edge (see `streamingTickAction`): a fast burst of
+    /// chunks coalesces into at most ~30 publishes/sec, but the last chunk
+    /// in a burst is always eventually delivered via the scheduled drain
+    /// task, even if no further chunk arrives. The change log recording
+    /// below is intentionally NOT throttled — every chunk still records a
+    /// per-index dirty entry for remote-web gateway consumers.
     func noteStreamingChange(at index: Int) {
-        streamingTick &+= 1
         if changeLog.isTracking, messages.indices.contains(index) {
             changeLog.record(index: index)
+        }
+        let now = ProcessInfo.processInfo.systemUptime
+        switch Self.streamingTickAction(
+            elapsedSincePublish: now - lastStreamingTickPublish,
+            hasPendingDrain: streamingTickDrain != nil
+        ) {
+        case .publishNow:
+            lastStreamingTickPublish = now
+            streamingTick &+= 1
+        case .scheduleDrain(let delay):
+            streamingTickDrain = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                guard let self, !Task.isCancelled else { return }
+                self.streamingTickDrain = nil
+                self.lastStreamingTickPublish = ProcessInfo.processInfo.systemUptime
+                self.streamingTick &+= 1
+            }
+        case .drop:
+            break
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -10,10 +10,15 @@ import Combine
 final class ACPTranscript: ObservableObject {
     @Published var messages: [ACPMessage] = [] {
         didSet {
+            messagesGeneration &+= 1
             refreshPlanCaches()
             recordMessagesDiff(old: oldValue)
         }
     }
+    /// Bumped on every `messages` array mutation. Non-published: consumed by
+    /// value caches (visible-rows lookup) that must invalidate when the array
+    /// changes, without adding another objectWillChange source.
+    private(set) var messagesGeneration: UInt64 = 0
     /// Mutation log consumed by remote-web gateways for incremental deltas.
     /// Recording is enabled only while at least one gateway is subscribed.
     let changeLog = ACPTranscriptChangeLog()

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -921,14 +921,22 @@ struct ACPMessageList: View {
         proxy: ScrollViewProxy
     ) {
         // Tail-follow pause/resume — reuse the shared classifier so the rules
-        // match the legacy observer exactly.
-        let currentEventType = NSApp.currentEvent?.type
-        let isUserDriven = ACPUserScrollEvent.isUserDriven(currentEventType)
+        // match the legacy observer exactly. `NSApp.currentEvent` reports the
+        // most recently processed event, not necessarily the cause of this
+        // geometry change, so a stale event (from a scroll gesture long over)
+        // must not be classified as driving the current bounds change.
+        let event = NSApp.currentEvent
+        let eventIsFresh = ACPUserScrollEvent.isFresh(
+            eventTimestamp: event?.timestamp,
+            now: ProcessInfo.processInfo.systemUptime
+        )
+        let currentEventType = eventIsFresh ? event?.type : nil
+        let isUserDriven = eventIsFresh && ACPUserScrollEvent.isUserDriven(currentEventType)
         let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
             currentEventType,
             previousMinY: previousMinY,
             newMinY: newMinY,
-            isScrollbarTrackHit: ACPUserScrollEvent.isScrollbarTrackMouseDown(NSApp.currentEvent)
+            isScrollbarTrackHit: ACPUserScrollEvent.isScrollbarTrackMouseDown(eventIsFresh ? event : nil)
         )
         let decision = ACPScrollDirectionClassifier.decide(
             previousOffsetY: previousMinY,
@@ -1360,7 +1368,12 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
         }
 
         private static var isUserDrivenScrollEvent: Bool {
-            ACPUserScrollEvent.isUserDriven(NSApp.currentEvent?.type)
+            let event = NSApp.currentEvent
+            let eventIsFresh = ACPUserScrollEvent.isFresh(
+                eventTimestamp: event?.timestamp,
+                now: ProcessInfo.processInfo.systemUptime
+            )
+            return eventIsFresh && ACPUserScrollEvent.isUserDriven(event?.type)
         }
     }
 
@@ -1406,6 +1419,25 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
 /// The covered cases (trackpad and dragging the scroller knob) only fire while
 /// actually scrolling, so they can't be confused with idle layout reflow.
 enum ACPUserScrollEvent {
+    /// `NSApp.currentEvent` lingers after the gesture ends; only treat it as
+    /// the cause of a bounds change when it happened within this window.
+    /// Trackpad momentum keeps emitting scrollWheel events, so live scrolling
+    /// stays fresh.
+    static let freshnessWindow: TimeInterval = 0.35
+
+    /// `NSEvent.timestamp` is seconds since system startup, the same
+    /// timebase as `ProcessInfo.processInfo.systemUptime` (per Apple's
+    /// documentation for `NSEvent.timestamp`), so the two are directly
+    /// comparable without conversion.
+    static func isFresh(
+        eventTimestamp: TimeInterval?,
+        now: TimeInterval,
+        window: TimeInterval = freshnessWindow
+    ) -> Bool {
+        guard let eventTimestamp else { return false }
+        return now - eventTimestamp <= window
+    }
+
     static func isUserDriven(_ type: NSEvent.EventType?) -> Bool {
         guard let type else { return false }
         switch type {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -488,19 +488,31 @@ struct ACPMessageList: View {
 
     private func handleRowFramePreference(_ frames: [String: CGRect], proxy: ScrollViewProxy) {
         restoreRememberedAnchorIfNeeded(proxy: proxy)
+        guard let anchor = Self.topVisibleAnchorID(in: frames) else { return }
+        // Unlike the modern per-row `onGeometryChange` callback (fired once per
+        // ROW), this legacy path receives the full frame dictionary once per
+        // PreferenceKey change — effectively once per layout pass already — so
+        // keeping `latestTopVisibleAnchor` current here isn't the O(rows) cost
+        // the early-out below guards against on the modern path. This is also
+        // the ONLY place that populates `latestTopVisibleAnchor` on the legacy
+        // path (there is no unconditional frame cache to fall back to here,
+        // unlike `modernRowFrameCache` on the modern path) — gating this write
+        // left `setFollowsTranscriptTail`'s pause-anchor fallback with nothing
+        // correct to use on macOS 14, so it must stay live even while
+        // following the tail.
+        let anchorChanged = latestTopVisibleAnchor.value != anchor
+        if anchorChanged {
+            latestTopVisibleAnchor.value = anchor
+        }
         // Same early-out as `handleModernRowFrame`: while following the tail,
         // restoring, or backfilling older messages, the remainder of this
-        // method is discarded work.
+        // method (the remembered-anchor persistence bookkeeping) is discarded
+        // work.
         guard Self.shouldTrackAnchorFromRowFrames(
             followsTranscriptTail: session.followsTranscriptTail,
             isRestoringTail: scrollBook.isRestoringTail,
             isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
         ) else { return }
-        guard let anchor = Self.topVisibleAnchorID(in: frames) else { return }
-        let anchorChanged = latestTopVisibleAnchor.value != anchor
-        if anchorChanged {
-            latestTopVisibleAnchor.value = anchor
-        }
         let lookup = visibleMessageLookup
         let rememberedAnchor = rememberedScrollAnchor()
         let anchorIndex = lookup.transcriptIndex(for: anchor)

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -445,8 +445,13 @@ struct ACPMessageList: View {
             scrollBook.pendingTailScrollTask?.cancel()
             scrollBook.pendingTailScrollTask = nil
             let lookup = visibleMessageLookup
+            // Tail-follow no longer maintains `latestTopVisibleAnchor` on every
+            // row callback (see `handleModernRowFrame`), so compute it here,
+            // lazily, only now that we actually need a pause anchor.
+            let pauseAnchor = latestTopVisibleAnchor.value
+                ?? Self.topVisibleAnchorID(in: modernRowFrameCache.frames)
             let anchor = Self.rememberedAnchorWhenPausingTailFollow(
-                latestTopVisibleAnchor: latestTopVisibleAnchor.value,
+                latestTopVisibleAnchor: pauseAnchor,
                 lookup: lookup,
                 allowFirstRenderedAnchorFallback: allowFirstRenderedAnchorFallback
             )
@@ -463,14 +468,20 @@ struct ACPMessageList: View {
 
     private func handleRowFramePreference(_ frames: [String: CGRect], proxy: ScrollViewProxy) {
         restoreRememberedAnchorIfNeeded(proxy: proxy)
+        // Same early-out as `handleModernRowFrame`: while following the tail,
+        // restoring, or backfilling older messages, the remainder of this
+        // method is discarded work.
+        guard Self.shouldTrackAnchorFromRowFrames(
+            followsTranscriptTail: session.followsTranscriptTail,
+            isRestoringTail: scrollBook.isRestoringTail,
+            isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
+        ) else { return }
         guard let anchor = Self.topVisibleAnchorID(in: frames) else { return }
         let anchorChanged = latestTopVisibleAnchor.value != anchor
         if anchorChanged {
             latestTopVisibleAnchor.value = anchor
         }
         let lookup = visibleMessageLookup
-        guard !scrollBook.isRestoringTail else { return }
-        guard !session.followsTranscriptTail else { return }
         let rememberedAnchor = rememberedScrollAnchor()
         let anchorIndex = lookup.transcriptIndex(for: anchor)
         let anchorIndexChanged = rememberedAnchor == anchor && scrollBook.latestRememberedScrollAnchorIndex != anchorIndex
@@ -492,14 +503,21 @@ struct ACPMessageList: View {
     private func handleModernRowFrame(id: String, frame: CGRect) {
         let lookup = visibleMessageLookup
         modernRowFrameCache.update(id: id, frame: frame, lookup: lookup)
+        // While following the tail (streaming), restoring, or backfilling
+        // older messages, the anchor bookkeeping below is discarded by the
+        // guards further down anyway — skip it entirely so every streamed
+        // row's geometry callback stays O(1) instead of paying an O(rows)
+        // lookup + min-scan that's thrown away.
+        guard Self.shouldTrackAnchorFromRowFrames(
+            followsTranscriptTail: session.followsTranscriptTail,
+            isRestoringTail: scrollBook.isRestoringTail,
+            isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
+        ) else { return }
         guard let anchor = Self.topVisibleAnchorID(in: modernRowFrameCache.frames) else { return }
         let anchorChanged = latestTopVisibleAnchor.value != anchor
         if anchorChanged {
             latestTopVisibleAnchor.value = anchor
         }
-        guard !scrollBook.isRestoringTail else { return }
-        guard !session.followsTranscriptTail else { return }
-        guard !transcript.isBackfillingOlderMessages else { return }
         let rememberedAnchor = rememberedScrollAnchor()
         let anchorIndex = lookup.transcriptIndex(for: anchor)
         let anchorIndexChanged = rememberedAnchor == anchor && scrollBook.latestRememberedScrollAnchorIndex != anchorIndex
@@ -736,6 +754,19 @@ struct ACPMessageList: View {
     ) -> Bool {
         guard followsTranscriptTail else { return false }
         return abs(newWidth - previousWidth) > 0.5
+    }
+
+    /// Whether a row-frame callback should bother finding/remembering the
+    /// top-visible anchor at all. While following the tail (streaming),
+    /// restoring a programmatic scroll, or backfilling older messages, the
+    /// result is discarded by later guards anyway — skipping the lookup here
+    /// keeps every row's geometry callback O(1) instead of O(rows) per row.
+    nonisolated static func shouldTrackAnchorFromRowFrames(
+        followsTranscriptTail: Bool,
+        isRestoringTail: Bool,
+        isBackfillingOlderMessages: Bool
+    ) -> Bool {
+        !followsTranscriptTail && !isRestoringTail && !isBackfillingOlderMessages
     }
 
     nonisolated static func topVisibleAnchorID(in frames: [String: CGRect]) -> String? {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -1056,16 +1056,112 @@ struct ACPMessageList: View {
     private func visibleRow(_ visibleRow: VisibleRow) -> some View {
         if transcript.messages.indices.contains(visibleRow.index) {
             let message = transcript.messages[visibleRow.index]
-            row(for: message, stableId: visibleRow.stableId)
-                .background(rowFrameReporter(id: visibleRow.stableId))
+            ACPTranscriptRowContent(
+                stableId: visibleRow.stableId,
+                message: message,
+                contentMaxWidth: contentMaxWidth,
+                typography: typography,
+                trustedImageRoot: trustedImageRoot,
+                transcript: transcript,
+                session: session,
+                onOpenDiff: onOpenDiff,
+                onLoadFullToolCallContent: onLoadFullToolCallContent
+            )
+            .equatable()
+            .background(rowFrameReporter(id: visibleRow.stableId))
         } else {
             EmptyView()
         }
     }
 
-    @ViewBuilder
-    private func row(for m: ACPMessage, stableId: String) -> some View {
-        switch m {
+    static func markdownCacheMessageId(for message: ACPMessage) -> String {
+        message.stableId
+    }
+}
+
+/// A single transcript row's content, extracted from `ACPMessageList.body` so
+/// it can be gated with `.equatable()`. A full-list body re-eval (from a
+/// scroll/geometry pass) used to re-diff every visible row's deep modifier
+/// tree even when nothing about the row had changed — the dominant cost in
+/// the live-lock sample (`ModifiedViewList.applyNodes`,
+/// `LazySubviewPlacements.placeSubviews`). Gating on the render-relevant
+/// values below lets SwiftUI skip re-diffing a row's subtree entirely when
+/// they're unchanged. See docs/plans/2026-07-17-acp-transcript-livelock-fix.md
+/// (Task 7) for the stale-closure audit backing the excluded fields below.
+struct ACPTranscriptRowContent: View, Equatable {
+    // Compared (render-relevant values):
+    let stableId: String
+    let message: ACPMessage
+    let contentMaxWidth: CGFloat
+    let typography: ACPChatTypography
+    let trustedImageRoot: URL?
+    // Excluded from equality — reference-stable for the session's lifetime
+    // (`transcript`/`session` are `let` properties on `ACPSession`, never
+    // reassigned), or closures whose behavior only depends on already-compared
+    // data:
+    // - `onOpenDiff` / queue callbacks capture stable host references
+    //   (`state`, `worktree`, `manager`, `sessionId`) wired once by
+    //   `ACPTabView`, not per-render-varying state.
+    // - `onLoadFullToolCallContent` is only ever invoked when
+    //   `tc.isContentTruncated` is true; that flag is intentionally excluded
+    //   from `ACPMessage.ToolCall`'s own `==`/`hash` (a row must stay equal
+    //   across the in-memory truncation boundary), but `truncateForOffWindow`
+    //   only fires on messages that are, at that same moment, leaving the
+    //   render window (`ACPTranscript.trimHiddenMessage`) — so the flag never
+    //   flips on a message that remains part of an already-rendered,
+    //   gate-compared row. When a row re-enters the window later it is
+    //   constructed fresh (no prior instance to gate against), so the current
+    //   `isContentTruncated` value is always picked up correctly.
+    // - `session.terminalHost` is itself a `let` (stable reference) on
+    //   `ACPSession`; the terminal card's own live output flows through a
+    //   nested `@ObservedObject var terminal: ACPTerminal` inside
+    //   `ACPTerminalTailView`, which keeps reacting independently of this
+    //   gate — the same pattern already relied on for streaming `StreamingText`
+    //   buffers inside `AgentMessageRow`. New terminal-id associations arrive
+    //   via `tc.terminalIds`, which IS part of `message` and thus compared.
+    let transcript: ACPTranscript
+    let session: ACPSession
+    let onOpenDiff: (String) -> Void
+    let onLoadFullToolCallContent: (String) async -> String?
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        equalityKey(
+            stableId: lhs.stableId, message: lhs.message,
+            contentMaxWidth: lhs.contentMaxWidth, typography: lhs.typography,
+            trustedImageRoot: lhs.trustedImageRoot
+        )
+        == equalityKey(
+            stableId: rhs.stableId, message: rhs.message,
+            contentMaxWidth: rhs.contentMaxWidth, typography: rhs.typography,
+            trustedImageRoot: rhs.trustedImageRoot
+        )
+    }
+
+    /// Exposed so equality can be exercised in tests without constructing
+    /// (and rendering) a `View`.
+    static func equalityKey(
+        stableId: String,
+        message: ACPMessage,
+        contentMaxWidth: CGFloat,
+        typography: ACPChatTypography,
+        trustedImageRoot: URL?
+    ) -> EqualityKey {
+        EqualityKey(
+            stableId: stableId, message: message, contentMaxWidth: contentMaxWidth,
+            typography: typography, trustedImageRoot: trustedImageRoot
+        )
+    }
+
+    struct EqualityKey: Equatable {
+        let stableId: String
+        let message: ACPMessage
+        let contentMaxWidth: CGFloat
+        let typography: ACPChatTypography
+        let trustedImageRoot: URL?
+    }
+
+    var body: some View {
+        switch message {
         case .user(_, _, let text, let attachments, let delegatedSource):
             ACPMessageGutter(copySource: .text(text)) {
                 UserMessageRow(
@@ -1100,10 +1196,6 @@ struct ACPMessageList: View {
         case .systemNotice(_, let text):
             ACPSystemNoticeView(text: text)
         }
-    }
-
-    static func markdownCacheMessageId(for message: ACPMessage) -> String {
-        message.stableId
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -450,6 +450,16 @@ struct ACPMessageList: View {
             transcript.resetWindowToTail()
             onRememberScrollAnchor(nil, nil, true)
             scrollBook.latestRememberedScrollAnchorIndex = nil
+            // `latestTopVisibleAnchor` is only maintained while NOT following
+            // the tail (see `shouldTrackAnchorFromRowFrames`), so a value left
+            // over from a previous pause must not survive a resume: without
+            // this reset, the NEXT pause would reuse that stale anchor instead
+            // of falling through to a fresh computation from
+            // `modernRowFrameCache.frames`.
+            latestTopVisibleAnchor.value = Self.trackedAnchorAfterFollowsChange(
+                follows: true,
+                previousTrackedAnchor: latestTopVisibleAnchor.value
+            )
         } else {
             session.followsTranscriptTail = false
             scrollBook.pendingTailScrollTask?.cancel()
@@ -866,6 +876,19 @@ struct ACPMessageList: View {
             indexByStableId: indexByStableId,
             firstStableId: rows.first?.stableId
         )
+    }
+
+    /// The value `latestTopVisibleAnchor.value` should hold after a
+    /// tail-follow transition. Resuming (`follows == true`) always clears it:
+    /// the anchor-tracking row callbacks are skipped while following the
+    /// tail, so a value left over from before the resume is stale by
+    /// construction and must not be reused by a later pause. Pausing leaves
+    /// it untouched — the pause path computes its own anchor separately.
+    nonisolated static func trackedAnchorAfterFollowsChange(
+        follows: Bool,
+        previousTrackedAnchor: String?
+    ) -> String? {
+        follows ? nil : previousTrackedAnchor
     }
 
     nonisolated static func rememberedAnchorWhenPausingTailFollow(

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -522,7 +522,20 @@ struct ACPMessageList: View {
 
     private func handleModernRowFrame(id: String, frame: CGRect) {
         let lookup = visibleMessageLookup
-        modernRowFrameCache.update(id: id, frame: frame, lookup: lookup)
+        // `windowKey` gates `ACPRowFrameCache`'s stale-entry scan to only run
+        // when the render window has actually moved since the last cleanup
+        // (see `ACPRowFrameCache.update`), so this call is O(1) per row on
+        // every callback except the first one after the window shifts.
+        modernRowFrameCache.update(
+            id: id,
+            frame: frame,
+            lookup: lookup,
+            windowKey: ACPRowFrameCache.WindowKey(
+                generation: transcript.messagesGeneration,
+                head: transcript.visibleHead,
+                tail: transcript.visibleTailBound
+            )
+        )
         // While following the tail (streaming), restoring, or backfilling
         // older messages, the anchor bookkeeping below is discarded by the
         // guards further down anyway — skip it entirely so every streamed
@@ -1261,21 +1274,46 @@ private final class ACPTranscriptScrollBookkeeping {
 /// open `NSMenu`), so assigning a dictionary held in `@State` here would
 /// invalidate the full list for every callback.
 final class ACPRowFrameCache {
+    /// Same shape/idiom as `ACPVisibleRowsCache.Key`: identifies the render
+    /// window a row-frame report belongs to. Kept as its own type (rather
+    /// than sharing that private type) since the two caches are otherwise
+    /// independent.
+    struct WindowKey: Equatable {
+        let generation: UInt64
+        let head: Int
+        let tail: Int
+    }
+
     private(set) var frames: [String: CGRect] = [:]
+    /// The window key the stale-entry scan below last ran against. `nil`
+    /// until the first `update` call, guaranteeing that call always cleans.
+    private var lastCleanedWindowKey: WindowKey?
 
     /// Returns whether the cached frame set changed. Keeping stable reports as
     /// no-ops prevents needless work even outside nested menu tracking loops.
+    ///
+    /// The stale-key scan below is O(rows) — it used to run unconditionally
+    /// on every call, which made a full layout pass (up to
+    /// `ACPTranscript.maxVisibleRows` per-row callbacks) O(rows²). It only
+    /// needs to run once per render window: `lookup` (and therefore which
+    /// keys are stale) only changes when the window moves, so `windowKey`
+    /// lets every row after the first in a pass skip straight to the O(1)
+    /// single-entry update below.
     @discardableResult
     func update(
         id: String,
         frame: CGRect,
-        lookup: ACPMessageList.VisibleMessageLookup
+        lookup: ACPMessageList.VisibleMessageLookup,
+        windowKey: WindowKey
     ) -> Bool {
         var changed = false
-        let staleIDs = frames.keys.filter { !lookup.contains($0) }
-        for staleID in staleIDs {
-            frames.removeValue(forKey: staleID)
-            changed = true
+        if lastCleanedWindowKey != windowKey {
+            let staleIDs = frames.keys.filter { !lookup.contains($0) }
+            for staleID in staleIDs {
+                frames.removeValue(forKey: staleID)
+                changed = true
+            }
+            lastCleanedWindowKey = windowKey
         }
 
         if lookup.contains(id), frame.height > 0, frame.maxY > 0 {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -60,7 +60,12 @@ struct ACPMessageList: View {
     /// Minimum gap between automatic head-back steps so a single scroll
     /// doesn't decrement multiple times before layout settles.
     private let headStepDebounceInterval: TimeInterval = 0.3
-    private var scrollSpaceName: String { "acp-message-list-\(session.id)" }
+    /// A named coordinate space only needs to be unambiguous relative to its
+    /// nearest `.coordinateSpace(.named(...))` ancestor, and each
+    /// `ACPMessageList` instance declares its own locally, so a shared
+    /// constant here is safe even with multiple transcript lists mounted at
+    /// once (e.g. across windows).
+    private static let scrollSpaceName = "acp-message-list"
 
     /// Window-sliced, plan-filtered list of rows to render. The slice
     /// bounds first-paint cost on long transcripts (`visibleHead` is
@@ -228,7 +233,7 @@ struct ACPMessageList: View {
                     .frame(maxWidth: .infinity, alignment: .center)
                     .environment(\.openURL, openTranscriptURLAction)
                 }
-                .coordinateSpace(.named(scrollSpaceName))
+                .coordinateSpace(.named(Self.scrollSpaceName))
                 .modifier(ACPTranscriptScrollTracking(
                     isRestoring: { scrollBook.isRestoringTail },
                     onResolveScrollView: { scrollViewRef.scrollView = $0 },
@@ -611,7 +616,7 @@ struct ACPMessageList: View {
         GeometryReader { rowGeometry in
             Color.clear.preference(
                 key: ACPRowFramesPreferenceKey.self,
-                value: [id: rowGeometry.frame(in: .named(scrollSpaceName))]
+                value: [id: rowGeometry.frame(in: .named(Self.scrollSpaceName))]
             )
         }
     }
@@ -619,7 +624,7 @@ struct ACPMessageList: View {
     @available(macOS 15, *)
     private func modernRowFrameReporter(id: String) -> some View {
         Color.clear.onGeometryChange(for: CGRect.self) { rowGeometry in
-            rowGeometry.frame(in: .named(scrollSpaceName))
+            rowGeometry.frame(in: .named(Self.scrollSpaceName))
         } action: { frame in
             handleModernRowFrame(id: id, frame: frame)
         }
@@ -638,7 +643,7 @@ struct ACPMessageList: View {
         GeometryReader { headGeom in
             Color.clear.preference(
                 key: ACPHeadFramePreferenceKey.self,
-                value: headGeom.frame(in: .named(scrollSpaceName))
+                value: headGeom.frame(in: .named(Self.scrollSpaceName))
             )
         }
         .frame(height: 1)

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -38,6 +38,11 @@ struct ACPMessageList: View {
     // their per-row bookkeeping out of SwiftUI-observed value state: changing
     // a cached frame must not invalidate the entire lazy transcript list.
     @State private var modernRowFrameCache = ACPRowFrameCache()
+    // Rebuilding the window-sliced row list + stable-id lookup is O(rows); it
+    // used to happen from scratch inside every per-row geometry callback,
+    // making a full layout pass O(rows²). Memoized per (messages generation,
+    // window bounds) so a pass rebuilds it once instead of once per row.
+    @State private var visibleRowsCache = ACPVisibleRowsCache()
 
     /// Height of an invisible spacer at the tail of the transcript stack. The
     /// composer pill plus its outer padding occupies roughly this much
@@ -63,6 +68,15 @@ struct ACPMessageList: View {
     /// filter drops `.plan` entries because the toolbar pill renders
     /// the current turn's plan instead of an inline card.
     private var visibleRows: [VisibleRow] {
+        visibleRowsCache.rows(
+            generation: transcript.messagesGeneration,
+            head: transcript.visibleHead,
+            tail: transcript.visibleTailBound,
+            build: buildVisibleRows
+        )
+    }
+
+    private func buildVisibleRows() -> [VisibleRow] {
         Self.visibleRows(
             messages: transcript.messages,
             visibleHead: transcript.visibleHead,
@@ -522,15 +536,11 @@ struct ACPMessageList: View {
         let anchorIndex = lookup.transcriptIndex(for: anchorId)
         scrollBook.isRestoringTail = true
         transcript.stepTailForward(preserving: anchorIndex)
-        let updatedRows = Self.visibleRows(
-            messages: transcript.messages,
-            visibleHead: transcript.visibleHead,
-            visibleTail: transcript.visibleTailBound,
-            stableId: { transcript.stableId(for: $0) }
-        )
-        let updatedLookup = Self.visibleMessageLookup(rows: updatedRows.map { row in
-            (index: row.index, stableId: row.stableId)
-        })
+        // `visibleTailBound` has already advanced (stepTailForward guarantees
+        // newTail > currentTail), so the cache key differs from the
+        // pre-mutation lookup above and this recomputes rather than reusing
+        // the stale entry.
+        let updatedLookup = visibleMessageLookup
         let scrollTargetId = updatedLookup.contains(anchorId) ? anchorId : updatedLookup.firstStableId
         DispatchQueue.main.async {
             if let scrollTargetId {
@@ -593,9 +603,12 @@ struct ACPMessageList: View {
     }
 
     private var visibleMessageLookup: VisibleMessageLookup {
-        Self.visibleMessageLookup(rows: visibleRows.map { row in
-            (index: row.index, stableId: row.stableId)
-        })
+        visibleRowsCache.lookup(
+            generation: transcript.messagesGeneration,
+            head: transcript.visibleHead,
+            tail: transcript.visibleTailBound,
+            build: buildVisibleRows
+        )
     }
 
     private var topPaginationSentinel: some View {
@@ -1086,6 +1099,46 @@ final class ACPRowFrameCache {
             changed = true
         }
         return changed
+    }
+}
+
+/// Non-observed memo for the window-sliced row list + id lookup. Keyed on
+/// (messages generation, window bounds); geometry callbacks hit this once
+/// per layout pass instead of rebuilding an O(rows) dictionary per row.
+/// See docs/plans/2026-07-17-acp-transcript-livelock-fix.md (Task 2).
+@MainActor
+final class ACPVisibleRowsCache {
+    private struct Key: Equatable {
+        let generation: UInt64
+        let head: Int
+        let tail: Int
+    }
+    private var key: Key?
+    private var rows: [ACPMessageList.VisibleRow] = []
+    private var lookup: ACPMessageList.VisibleMessageLookup?
+
+    func rows(
+        generation: UInt64, head: Int, tail: Int,
+        build: () -> [ACPMessageList.VisibleRow]
+    ) -> [ACPMessageList.VisibleRow] {
+        let k = Key(generation: generation, head: head, tail: tail)
+        if key != k {
+            rows = build()
+            lookup = nil
+            key = k
+        }
+        return rows
+    }
+
+    func lookup(
+        generation: UInt64, head: Int, tail: Int,
+        build: () -> [ACPMessageList.VisibleRow]
+    ) -> ACPMessageList.VisibleMessageLookup {
+        let r = rows(generation: generation, head: head, tail: tail, build: build)
+        if let lookup { return lookup }
+        let l = ACPMessageList.visibleMessageLookup(rows: r.map { ($0.index, $0.stableId) })
+        lookup = l
+        return l
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -316,6 +316,7 @@ struct ACPMessageList: View {
     }
 
     private func restoreRememberedAnchorIfNeeded(proxy: ScrollViewProxy) {
+        guard !scrollBook.isRestoringTail else { return }
         guard !session.followsTranscriptTail else {
             scrollBook.restoredRememberedAnchor = nil
             return
@@ -333,6 +334,10 @@ struct ACPMessageList: View {
     private func scrollToTail(proxy: ScrollViewProxy, animated: Bool) {
         scrollBook.pendingTailScrollTask?.cancel()
         scrollBook.pendingTailScrollTask = nil
+        let distance = scrollBook.lastScrollProbe.map {
+            max(0, $0.contentHeight - $0.viewportHeight - $0.minY)
+        }
+        guard Self.shouldPerformTailScroll(distanceFromBottom: distance) else { return }
         scrollBook.isRestoringTail = true
         let scroll = {
             proxy.scrollTo("__composer_spacer__", anchor: .bottom)
@@ -711,13 +716,27 @@ struct ACPMessageList: View {
         newContentHeight: CGFloat,
         viewportHeight: CGFloat,
         newMinY: CGFloat,
-        followsTranscriptTail: Bool
+        followsTranscriptTail: Bool,
+        isRestoring: Bool
     ) -> Bool {
+        guard !isRestoring else { return false }
         guard followsTranscriptTail else { return false }
         guard newContentHeight > previousContentHeight + ACPScrollDirectionClassifier.upwardEpsilon else {
             return false
         }
         let distanceFromBottom = max(0, newContentHeight - viewportHeight - newMinY)
+        return distanceFromBottom > ACPScrollDirectionClassifier.bottomTolerance
+    }
+
+    /// Whether `scrollToTail` should actually issue `proxy.scrollTo`. A
+    /// programmatic scroll that lands where the viewport already sits is
+    /// itself a geometry change that can retrigger the very callback that
+    /// scheduled it — so skip it once the last known probe says we're
+    /// already within tolerance of the bottom. Unknown geometry (no probe
+    /// yet, or the legacy pre-macOS 15 path, which never populates the
+    /// probe) always scrolls, preserving prior behavior there.
+    nonisolated static func shouldPerformTailScroll(distanceFromBottom: CGFloat?) -> Bool {
+        guard let distanceFromBottom else { return true }
         return distanceFromBottom > ACPScrollDirectionClassifier.bottomTolerance
     }
 
@@ -920,6 +939,10 @@ struct ACPMessageList: View {
         contentHeight: CGFloat,
         proxy: ScrollViewProxy
     ) {
+        // Always current for `scrollToTail`'s idempotency check below, even
+        // when none of the branches in this function fire.
+        scrollBook.lastScrollProbe = ACPScrollProbe(
+            minY: newMinY, viewportHeight: viewportHeight, contentHeight: contentHeight)
         // Tail-follow pause/resume — reuse the shared classifier so the rules
         // match the legacy observer exactly. `NSApp.currentEvent` reports the
         // most recently processed event, not necessarily the cause of this
@@ -968,7 +991,8 @@ struct ACPMessageList: View {
             newContentHeight: contentHeight,
             viewportHeight: viewportHeight,
             newMinY: newMinY,
-            followsTranscriptTail: session.followsTranscriptTail
+            followsTranscriptTail: session.followsTranscriptTail,
+            isRestoring: scrollBook.isRestoringTail
         ) {
             scheduleTailScroll(
                 proxy: proxy,
@@ -1104,6 +1128,12 @@ private final class ACPTranscriptScrollBookkeeping {
     var lastHeadStepAt: Date = .distantPast
     var lastTailStepAt: Date = .distantPast
     var pendingTailScrollTask: Task<Void, Never>?
+    /// Most recent modern-path scroll geometry, refreshed on every
+    /// `handleScrollGeometry` call. Lets programmatic scrolls (`scrollToTail`)
+    /// check whether the viewport is already at rest before issuing another
+    /// `proxy.scrollTo`, so a redundant scroll doesn't retrigger the geometry
+    /// callback that scheduled it.
+    var lastScrollProbe: ACPScrollProbe?
 }
 
 /// Non-observed cache for the modern per-row geometry callbacks. SwiftUI's

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -31,15 +31,9 @@ struct ACPMessageList: View {
     /// the row is gone or the payload is undecodable.
     let onLoadFullToolCallContent: (String) async -> String?
     @Environment(\.theme) private var theme
-    @State private var isRestoringTail = false
-    @State private var headFrame: CGRect = .zero
-    @State private var lastHeadStepAt: Date = .distantPast
-    @State private var lastTailStepAt: Date = .distantPast
     @State private var scrollViewRef = ACPWeakScrollViewRef()
     @State private var latestTopVisibleAnchor = ACPMutableScrollAnchor()
-    @State private var latestRememberedScrollAnchorIndex: Int?
-    @State private var restoredRememberedAnchor: String?
-    @State private var pendingTailScrollTask: Task<Void, Never>?
+    @State private var scrollBook = ACPTranscriptScrollBookkeeping()
     // Geometry callbacks can run while AppKit is tracking a native menu. Keep
     // their per-row bookkeeping out of SwiftUI-observed value state: changing
     // a cached frame must not invalidate the entire lazy transcript list.
@@ -222,7 +216,7 @@ struct ACPMessageList: View {
                 }
                 .coordinateSpace(.named(scrollSpaceName))
                 .modifier(ACPTranscriptScrollTracking(
-                    isRestoring: { isRestoringTail },
+                    isRestoring: { scrollBook.isRestoringTail },
                     onResolveScrollView: { scrollViewRef.scrollView = $0 },
                     onHeadFrame: { handleHeadFramePreference($0, proxy: proxy) },
                     onPaused: { setFollowsTranscriptTail(false) },
@@ -244,8 +238,8 @@ struct ACPMessageList: View {
                     restoreRememberedAnchorIfNeeded(proxy: proxy)
                 }
                 .onDisappear {
-                    pendingTailScrollTask?.cancel()
-                    pendingTailScrollTask = nil
+                    scrollBook.pendingTailScrollTask?.cancel()
+                    scrollBook.pendingTailScrollTask = nil
                 }
                 .onChange(of: viewport.size.height) { _, _ in
                     restoreTailIfNeeded(proxy: proxy, animated: false)
@@ -309,23 +303,23 @@ struct ACPMessageList: View {
 
     private func restoreRememberedAnchorIfNeeded(proxy: ScrollViewProxy) {
         guard !session.followsTranscriptTail else {
-            restoredRememberedAnchor = nil
+            scrollBook.restoredRememberedAnchor = nil
             return
         }
-        guard let anchor = rememberedScrollAnchor(), restoredRememberedAnchor != anchor else { return }
+        guard let anchor = rememberedScrollAnchor(), scrollBook.restoredRememberedAnchor != anchor else { return }
         guard visibleMessageLookup.contains(anchor) else { return }
-        isRestoringTail = true
+        scrollBook.isRestoringTail = true
         proxy.scrollTo(anchor, anchor: .top)
-        restoredRememberedAnchor = anchor
+        scrollBook.restoredRememberedAnchor = anchor
         DispatchQueue.main.async {
-            isRestoringTail = false
+            scrollBook.isRestoringTail = false
         }
     }
 
     private func scrollToTail(proxy: ScrollViewProxy, animated: Bool) {
-        pendingTailScrollTask?.cancel()
-        pendingTailScrollTask = nil
-        isRestoringTail = true
+        scrollBook.pendingTailScrollTask?.cancel()
+        scrollBook.pendingTailScrollTask = nil
+        scrollBook.isRestoringTail = true
         let scroll = {
             proxy.scrollTo("__composer_spacer__", anchor: .bottom)
         }
@@ -337,7 +331,7 @@ struct ACPMessageList: View {
             scroll()
         }
         let releaseRestoring = {
-            isRestoringTail = false
+            scrollBook.isRestoringTail = false
         }
         if animated {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
@@ -351,18 +345,18 @@ struct ACPMessageList: View {
     }
 
     private func scheduleTailScroll(proxy: ScrollViewProxy, animated: Bool) {
-        guard Self.shouldScheduleTailScroll(hasPendingTailScroll: pendingTailScrollTask != nil) else {
+        guard Self.shouldScheduleTailScroll(hasPendingTailScroll: scrollBook.pendingTailScrollTask != nil) else {
             return
         }
-        pendingTailScrollTask?.cancel()
-        pendingTailScrollTask = Task { @MainActor in
+        scrollBook.pendingTailScrollTask?.cancel()
+        scrollBook.pendingTailScrollTask = Task { @MainActor in
             await Task.yield()
             guard !Task.isCancelled,
                   ACPMessageList.shouldRunScheduledTailScroll(
                     followsTranscriptTail: session.followsTranscriptTail
                   )
             else {
-                pendingTailScrollTask = nil
+                scrollBook.pendingTailScrollTask = nil
                 return
             }
             scrollToTail(proxy: proxy, animated: animated)
@@ -431,11 +425,11 @@ struct ACPMessageList: View {
             session.followsTranscriptTail = true
             transcript.resetWindowToTail()
             onRememberScrollAnchor(nil, nil, true)
-            latestRememberedScrollAnchorIndex = nil
+            scrollBook.latestRememberedScrollAnchorIndex = nil
         } else {
             session.followsTranscriptTail = false
-            pendingTailScrollTask?.cancel()
-            pendingTailScrollTask = nil
+            scrollBook.pendingTailScrollTask?.cancel()
+            scrollBook.pendingTailScrollTask = nil
             let lookup = visibleMessageLookup
             let anchor = Self.rememberedAnchorWhenPausingTailFollow(
                 latestTopVisibleAnchor: latestTopVisibleAnchor.value,
@@ -448,8 +442,8 @@ struct ACPMessageList: View {
                 anchorIndex,
                 false
             )
-            latestRememberedScrollAnchorIndex = anchorIndex
-            restoredRememberedAnchor = anchor
+            scrollBook.latestRememberedScrollAnchorIndex = anchorIndex
+            scrollBook.restoredRememberedAnchor = anchor
         }
     }
 
@@ -461,24 +455,24 @@ struct ACPMessageList: View {
             latestTopVisibleAnchor.value = anchor
         }
         let lookup = visibleMessageLookup
-        guard !isRestoringTail else { return }
+        guard !scrollBook.isRestoringTail else { return }
         guard !session.followsTranscriptTail else { return }
         let rememberedAnchor = rememberedScrollAnchor()
         let anchorIndex = lookup.transcriptIndex(for: anchor)
-        let anchorIndexChanged = rememberedAnchor == anchor && latestRememberedScrollAnchorIndex != anchorIndex
+        let anchorIndexChanged = rememberedAnchor == anchor && scrollBook.latestRememberedScrollAnchorIndex != anchorIndex
         guard anchorChanged || rememberedAnchor != anchor || anchorIndexChanged else { return }
         if !Self.shouldRememberVisibleAnchor(
             anchor,
             rememberedAnchor: rememberedAnchor,
-            restoredRememberedAnchor: restoredRememberedAnchor,
+            restoredRememberedAnchor: scrollBook.restoredRememberedAnchor,
             visibleMessageIds: lookup.ids,
             isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
         ) {
             return
         }
         onRememberScrollAnchor(anchor, anchorIndex, false)
-        latestRememberedScrollAnchorIndex = anchorIndex
-        restoredRememberedAnchor = anchor
+        scrollBook.latestRememberedScrollAnchorIndex = anchorIndex
+        scrollBook.restoredRememberedAnchor = anchor
     }
 
     private func handleModernRowFrame(id: String, frame: CGRect) {
@@ -489,16 +483,16 @@ struct ACPMessageList: View {
         if anchorChanged {
             latestTopVisibleAnchor.value = anchor
         }
-        guard !isRestoringTail else { return }
+        guard !scrollBook.isRestoringTail else { return }
         guard !session.followsTranscriptTail else { return }
         guard !transcript.isBackfillingOlderMessages else { return }
         let rememberedAnchor = rememberedScrollAnchor()
         let anchorIndex = lookup.transcriptIndex(for: anchor)
-        let anchorIndexChanged = rememberedAnchor == anchor && latestRememberedScrollAnchorIndex != anchorIndex
+        let anchorIndexChanged = rememberedAnchor == anchor && scrollBook.latestRememberedScrollAnchorIndex != anchorIndex
         guard anchorChanged || rememberedAnchor != anchor || anchorIndexChanged else { return }
         onRememberScrollAnchor(anchor, anchorIndex, false)
-        latestRememberedScrollAnchorIndex = anchorIndex
-        restoredRememberedAnchor = anchor
+        scrollBook.latestRememberedScrollAnchorIndex = anchorIndex
+        scrollBook.restoredRememberedAnchor = anchor
     }
 
     private func pauseTailFollowFromGeometry(newMinY: CGFloat) {
@@ -516,17 +510,17 @@ struct ACPMessageList: View {
         proxy: ScrollViewProxy,
         lookup: VisibleMessageLookup
     ) {
-        guard !isRestoringTail else { return }
+        guard !scrollBook.isRestoringTail else { return }
         guard transcript.visibleTailBound < transcript.messages.count else { return }
         let now = Date()
-        guard now.timeIntervalSince(lastTailStepAt) > headStepDebounceInterval else { return }
-        lastTailStepAt = now
+        guard now.timeIntervalSince(scrollBook.lastTailStepAt) > headStepDebounceInterval else { return }
+        scrollBook.lastTailStepAt = now
         let anchorId = Self.anchorForTailForwardPreservation(
             latestTopVisibleAnchor: latestTopVisibleAnchor.value,
             lookup: lookup
         )
         let anchorIndex = lookup.transcriptIndex(for: anchorId)
-        isRestoringTail = true
+        scrollBook.isRestoringTail = true
         transcript.stepTailForward(preserving: anchorIndex)
         let updatedRows = Self.visibleRows(
             messages: transcript.messages,
@@ -543,7 +537,7 @@ struct ACPMessageList: View {
                 proxy.scrollTo(scrollTargetId, anchor: .top)
             }
             DispatchQueue.main.async {
-                isRestoringTail = false
+                scrollBook.isRestoringTail = false
             }
         }
     }
@@ -859,12 +853,11 @@ struct ACPMessageList: View {
     /// would still satisfy `minY < threshold`, defeating the window before the
     /// user scrolled.
     private func handleHeadFramePreference(_ frame: CGRect, proxy: ScrollViewProxy) {
-        headFrame = frame
         guard transcript.visibleHead > 0 else { return }
         guard frame.minY < headStepScrollThreshold, frame.maxY > 0 else { return }
         let now = Date()
-        guard now.timeIntervalSince(lastHeadStepAt) > headStepDebounceInterval else { return }
-        lastHeadStepAt = now
+        guard now.timeIntervalSince(scrollBook.lastHeadStepAt) > headStepDebounceInterval else { return }
+        scrollBook.lastHeadStepAt = now
         stepHeadBackPreservingScroll(proxy: proxy)
     }
 
@@ -898,7 +891,7 @@ struct ACPMessageList: View {
             newOffsetY: newMinY,
             viewportHeight: viewportHeight,
             contentHeight: contentHeight,
-            isRestoring: isRestoringTail,
+            isRestoring: scrollBook.isRestoringTail,
             isUserDriven: isUserDriven
         )
         switch decision {
@@ -909,7 +902,7 @@ struct ACPMessageList: View {
                 proxy: proxy,
                 shouldPageHiddenTail: Self.shouldStepTailForwardFromBottomGeometry(
                     isUserDriven: isUserDriven,
-                    isRestoring: isRestoringTail,
+                    isRestoring: scrollBook.isRestoringTail,
                     previousMinY: previousMinY,
                     newMinY: newMinY,
                     visibleTail: transcript.visibleTailBound,
@@ -940,14 +933,14 @@ struct ACPMessageList: View {
         // settles; geometry alone must not page the transcript upward.
         guard Self.shouldStepHeadBackFromGeometry(
             visibleHead: transcript.visibleHead,
-            isRestoring: isRestoringTail,
+            isRestoring: scrollBook.isRestoringTail,
             isHeadPaginationDriven: isHeadPaginationDriven,
             newMinY: newMinY,
             threshold: headStepScrollThreshold
         ) else { return }
         let now = Date()
-        guard now.timeIntervalSince(lastHeadStepAt) > headStepDebounceInterval else { return }
-        lastHeadStepAt = now
+        guard now.timeIntervalSince(scrollBook.lastHeadStepAt) > headStepDebounceInterval else { return }
+        scrollBook.lastHeadStepAt = now
         stepHeadBackPreservingScroll(proxy: proxy)
     }
 
@@ -973,13 +966,13 @@ struct ACPMessageList: View {
         // does not depend on net content-height changes when the bounded window
         // also trims newer rows from the bottom.
         let anchorId = visibleMessageLookup.firstStableId
-        isRestoringTail = true
+        scrollBook.isRestoringTail = true
         transcript.stepHeadBack()
         DispatchQueue.main.async {
             if let anchorId {
                 proxy.scrollTo(anchorId, anchor: .top)
             }
-            DispatchQueue.main.async { isRestoringTail = false }
+            DispatchQueue.main.async { scrollBook.isRestoringTail = false }
         }
     }
 
@@ -1044,6 +1037,21 @@ private final class ACPWeakScrollViewRef {
 
 private final class ACPMutableScrollAnchor {
     var value: String?
+}
+
+/// Non-observed bookkeeping for scroll/restore callbacks. These values are
+/// only read from callbacks (never from `body`), so keeping them in plain
+/// `@State` value storage would buy nothing except a full-list invalidation
+/// on every write — which is exactly the transaction-feedback edge behind
+/// the transcript live-lock. See docs/plans/2026-07-17-acp-transcript-livelock-fix.md.
+@MainActor
+private final class ACPTranscriptScrollBookkeeping {
+    var isRestoringTail = false
+    var restoredRememberedAnchor: String?
+    var latestRememberedScrollAnchorIndex: Int?
+    var lastHeadStepAt: Date = .distantPast
+    var lastTailStepAt: Date = .distantPast
+    var pendingTailScrollTask: Task<Void, Never>?
 }
 
 /// Non-observed cache for the modern per-row geometry callbacks. SwiftUI's

--- a/AlasTests/ACP/Session/ACPTranscriptTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscript streaming tick throttle")
+struct ACPTranscriptTests {
+    @Test("streamingTickAction throttle decisions")
+    func streamingTickThrottleDecisions() {
+        typealias T = ACPTranscript
+        #expect(T.streamingTickAction(elapsedSincePublish: 1.0, hasPendingDrain: false) == .publishNow)
+        #expect(T.streamingTickAction(elapsedSincePublish: 0.01, hasPendingDrain: false)
+            == .scheduleDrain(after: T.streamingTickMinInterval - 0.01))
+        #expect(T.streamingTickAction(elapsedSincePublish: 0.01, hasPendingDrain: true) == .drop)
+    }
+
+    @Test("streamingTickAction publishes exactly at the min interval boundary")
+    func streamingTickAtBoundary() {
+        typealias T = ACPTranscript
+        #expect(T.streamingTickAction(elapsedSincePublish: T.streamingTickMinInterval, hasPendingDrain: false)
+            == .publishNow)
+    }
+
+    @Test("streamingTickAction with pending drain always drops regardless of elapsed time")
+    func streamingTickPendingDrainAlwaysDrops() {
+        typealias T = ACPTranscript
+        #expect(T.streamingTickAction(elapsedSincePublish: 5.0, hasPendingDrain: true) == .drop)
+    }
+
+    @Test("noteStreamingChange publishes immediately for the first chunk")
+    func firstChunkPublishesImmediately() {
+        let t = ACPTranscript()
+        t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        let before = t.streamingTick
+        t.noteStreamingChange(at: 0)
+        #expect(t.streamingTick == before &+ 1)
+    }
+
+    @Test("noteStreamingChange coalesces a fast burst and still delivers a trailing tick")
+    func burstCoalescesWithTrailingDelivery() async throws {
+        let t = ACPTranscript()
+        t.messages.append(.systemNotice(id: UUID(), text: "x"))
+
+        // First call publishes immediately.
+        t.noteStreamingChange(at: 0)
+        let afterFirst = t.streamingTick
+
+        // Rapid-fire subsequent calls within the same throttle window must not
+        // publish synchronously — they should coalesce into a pending drain.
+        for _ in 0..<20 {
+            t.noteStreamingChange(at: 0)
+        }
+        #expect(t.streamingTick == afterFirst)
+
+        // The trailing drain must eventually fire even though no further chunk
+        // arrives after the burst ends.
+        let deadline = Date().addingTimeInterval(1.0)
+        while t.streamingTick == afterFirst, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(t.streamingTick == afterFirst &+ 1)
+    }
+
+    @Test("noteStreamingChange records the change log entry on every call, unthrottled")
+    func changeLogRecordingStaysUnthrottled() {
+        let t = ACPTranscript()
+        t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        t.changeLog.retainTracking()
+        defer { t.changeLog.releaseTracking() }
+
+        let startVersion = t.changeLog.latestVersion
+        for _ in 0..<5 {
+            t.noteStreamingChange(at: 0)
+        }
+
+        // Every call recorded a changeLog entry even though streamingTick
+        // publishes were throttled — five calls means five version bumps
+        // (coalesced into one dirty index since they share index 0).
+        #expect(t.changeLog.latestVersion == startVersion &+ 5)
+        if case .dirty(let indices) = t.changeLog.changes(since: startVersion) {
+            #expect(indices == [0])
+        } else {
+            Issue.record("expected dirty changes at index 0")
+        }
+    }
+}

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -228,6 +228,27 @@ struct ACPMessageListPaginationTests {
         #expect(lookup.firstStableId == "message-40")
     }
 
+    @Test("tracked anchor is cleared when tail-follow resumes so a later pause can't reuse a stale value")
+    func trackedAnchorResetsWhenTailFollowResumes() {
+        // Resuming clears whatever anchor a previous pause left behind, so
+        // the next pause is forced to recompute from the live frame cache
+        // instead of reusing a value that predates the resume.
+        #expect(ACPMessageList.trackedAnchorAfterFollowsChange(
+            follows: true,
+            previousTrackedAnchor: "message-40"
+        ) == nil)
+        #expect(ACPMessageList.trackedAnchorAfterFollowsChange(
+            follows: true,
+            previousTrackedAnchor: nil
+        ) == nil)
+        // Pausing doesn't touch the tracked anchor; the pause path computes
+        // its own anchor separately.
+        #expect(ACPMessageList.trackedAnchorAfterFollowsChange(
+            follows: false,
+            previousTrackedAnchor: "message-40"
+        ) == "message-40")
+    }
+
     @Test("tail pause anchor selection prefers sampled anchors before fallback")
     func tailPauseAnchorSelectionUsesSampledAnchorBeforeFallback() {
         let lookup = ACPMessageList.visibleMessageLookup(rows: [

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -67,7 +67,8 @@ struct ACPMessageListPaginationTests {
             newContentHeight: newContentHeight,
             viewportHeight: viewportHeight,
             newMinY: oldTailOffset,
-            followsTranscriptTail: true
+            followsTranscriptTail: true,
+            isRestoring: false
         ))
     }
 
@@ -78,7 +79,8 @@ struct ACPMessageListPaginationTests {
             newContentHeight: 5_220,
             viewportHeight: 600,
             newMinY: 4_400,
-            followsTranscriptTail: false
+            followsTranscriptTail: false,
+            isRestoring: false
         ))
     }
 
@@ -93,7 +95,8 @@ struct ACPMessageListPaginationTests {
             newContentHeight: newContentHeight,
             viewportHeight: viewportHeight,
             newMinY: newTailOffset,
-            followsTranscriptTail: true
+            followsTranscriptTail: true,
+            isRestoring: false
         ))
     }
 
@@ -447,5 +450,21 @@ struct ACPMessageListPaginationTests {
             followsTranscriptTail: false, isRestoringTail: false, isBackfillingOlderMessages: true))
         #expect(ACPMessageList.shouldTrackAnchorFromRowFrames(
             followsTranscriptTail: false, isRestoringTail: false, isBackfillingOlderMessages: false))
+    }
+
+    @Test func tailScrollSkippedWhenAlreadyAtBottom() {
+        #expect(!ACPMessageList.shouldPerformTailScroll(distanceFromBottom: 0))
+        #expect(!ACPMessageList.shouldPerformTailScroll(
+            distanceFromBottom: ACPScrollDirectionClassifier.bottomTolerance))
+        #expect(ACPMessageList.shouldPerformTailScroll(
+            distanceFromBottom: ACPScrollDirectionClassifier.bottomTolerance + 1))
+        // Unknown geometry (no probe yet) must scroll.
+        #expect(ACPMessageList.shouldPerformTailScroll(distanceFromBottom: nil))
+    }
+
+    @Test func contentGrowthRestoreSuppressedWhileRestoring() {
+        #expect(!ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: 100, newContentHeight: 200, viewportHeight: 50,
+            newMinY: 0, followsTranscriptTail: true, isRestoring: true))
     }
 }

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -194,9 +194,10 @@ struct ACPMessageListPaginationTests {
         ])
         let cache = ACPRowFrameCache()
         let frame = CGRect(x: 0, y: 16, width: 100, height: 80)
+        let windowKey = ACPRowFrameCache.WindowKey(generation: 1, head: 0, tail: 90)
 
-        #expect(cache.update(id: "message-40", frame: frame, lookup: lookup))
-        #expect(!cache.update(id: "message-40", frame: frame, lookup: lookup))
+        #expect(cache.update(id: "message-40", frame: frame, lookup: lookup, windowKey: windowKey))
+        #expect(!cache.update(id: "message-40", frame: frame, lookup: lookup, windowKey: windowKey))
         #expect(cache.frames == ["message-40": frame])
     }
 
@@ -208,11 +209,57 @@ struct ACPMessageListPaginationTests {
             (index: 40, stableId: "message-40")
         ])
         let emptyLookup = ACPMessageList.visibleMessageLookup(rows: [])
+        let originalWindow = ACPRowFrameCache.WindowKey(generation: 1, head: 0, tail: 90)
+        let movedWindow = ACPRowFrameCache.WindowKey(generation: 1, head: 0, tail: 0)
 
-        #expect(cache.update(id: "message-40", frame: frame, lookup: originalLookup))
-        #expect(cache.update(id: "message-40", frame: frame, lookup: emptyLookup))
-        #expect(!cache.update(id: "message-40", frame: frame, lookup: emptyLookup))
+        #expect(cache.update(id: "message-40", frame: frame, lookup: originalLookup, windowKey: originalWindow))
+        // Window moved (tail bound changed): the stale scan should run once
+        // here and evict "message-40", which the new lookup no longer contains.
+        #expect(cache.update(id: "message-40", frame: frame, lookup: emptyLookup, windowKey: movedWindow))
+        #expect(!cache.update(id: "message-40", frame: frame, lookup: emptyLookup, windowKey: movedWindow))
         #expect(cache.frames.isEmpty)
+    }
+
+    @Test("modern row-frame cache skips the stale-entry scan while the window key is unchanged")
+    func modernRowFrameCacheSkipsStaleScanForUnchangedWindow() {
+        let cache = ACPRowFrameCache()
+        let frame = CGRect(x: 0, y: 16, width: 100, height: 80)
+        let windowKey = ACPRowFrameCache.WindowKey(generation: 1, head: 0, tail: 90)
+        // The lookup no longer contains "message-40", but the window key is
+        // identical to the one already recorded by the cache's first update
+        // below, so the stale scan must not run again and evict it.
+        let lookup = ACPMessageList.visibleMessageLookup(rows: [
+            (index: 41, stableId: "message-41")
+        ])
+
+        #expect(cache.update(id: "message-40", frame: frame, lookup: ACPMessageList.visibleMessageLookup(rows: [
+            (index: 40, stableId: "message-40")
+        ]), windowKey: windowKey))
+        // Same window key as above: even though "message-40" is stale
+        // relative to `lookup`, the cleanup scan already ran for this window
+        // and must not run again, so "message-40" survives this call.
+        #expect(cache.update(id: "message-41", frame: frame, lookup: lookup, windowKey: windowKey))
+        #expect(cache.frames["message-40"] == frame)
+        #expect(cache.frames["message-41"] == frame)
+    }
+
+    @Test("modern row-frame cache runs the stale-entry scan again once the window key changes")
+    func modernRowFrameCacheRerunsStaleScanWhenWindowChanges() {
+        let cache = ACPRowFrameCache()
+        let frame = CGRect(x: 0, y: 16, width: 100, height: 80)
+        let firstWindow = ACPRowFrameCache.WindowKey(generation: 1, head: 0, tail: 90)
+        let secondWindow = ACPRowFrameCache.WindowKey(generation: 1, head: 1, tail: 91)
+        let lookup = ACPMessageList.visibleMessageLookup(rows: [
+            (index: 41, stableId: "message-41")
+        ])
+
+        #expect(cache.update(id: "message-40", frame: frame, lookup: ACPMessageList.visibleMessageLookup(rows: [
+            (index: 40, stableId: "message-40")
+        ]), windowKey: firstWindow))
+        // Different window key: the scan must run and evict "message-40",
+        // which `lookup` no longer contains.
+        #expect(cache.update(id: "message-41", frame: frame, lookup: lookup, windowKey: secondWindow))
+        #expect(cache.frames == ["message-41": frame])
     }
 
     @Test("visible message lookup records ids and transcript indices")

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -437,4 +437,15 @@ struct ACPMessageListPaginationTests {
             isBackfillingOlderMessages: true
         ))
     }
+
+    @Test func rowFrameAnchorTrackingSkippedWhileFollowingTailOrRestoring() {
+        #expect(!ACPMessageList.shouldTrackAnchorFromRowFrames(
+            followsTranscriptTail: true, isRestoringTail: false, isBackfillingOlderMessages: false))
+        #expect(!ACPMessageList.shouldTrackAnchorFromRowFrames(
+            followsTranscriptTail: false, isRestoringTail: true, isBackfillingOlderMessages: false))
+        #expect(!ACPMessageList.shouldTrackAnchorFromRowFrames(
+            followsTranscriptTail: false, isRestoringTail: false, isBackfillingOlderMessages: true))
+        #expect(ACPMessageList.shouldTrackAnchorFromRowFrames(
+            followsTranscriptTail: false, isRestoringTail: false, isBackfillingOlderMessages: false))
+    }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+import CoreGraphics
+@testable import Alas
+
+@Suite("ACPTranscriptRowContent equality")
+struct ACPTranscriptRowContentTests {
+    @Test("equality ignores closure identity")
+    @MainActor
+    func rowContentEqualityIgnoresClosureIdentity() {
+        let msg = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        #expect(a == b)
+    }
+
+    @Test("equality detects a message change")
+    @MainActor
+    func rowContentEqualityDetectsMessageChange() {
+        let msgA = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let msgB = ACPMessage.systemNotice(id: UUID(), text: "goodbye")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msgA, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msgB, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        #expect(a != b)
+    }
+
+    @Test("equality detects a content-width change")
+    @MainActor
+    func rowContentEqualityDetectsWidthChange() {
+        let msg = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 640,
+            typography: .default, trustedImageRoot: nil)
+        #expect(a != b)
+    }
+
+    @Test("equality detects a typography change")
+    @MainActor
+    func rowContentEqualityDetectsTypographyChange() {
+        let msg = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: ACPChatTypography(fontFamily: "Menlo", fontSize: 15),
+            trustedImageRoot: nil)
+        #expect(a != b)
+    }
+
+    @Test("equality detects a stable-id change")
+    @MainActor
+    func rowContentEqualityDetectsStableIdChange() {
+        let msg = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s2", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        #expect(a != b)
+    }
+
+    @Test("equality detects a trusted-image-root change")
+    @MainActor
+    func rowContentEqualityDetectsTrustedImageRootChange() {
+        let msg = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil)
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: URL(fileURLWithPath: "/tmp"))
+        #expect(a != b)
+    }
+}

--- a/AlasTests/ACP/UI/ACPVisibleRowsCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPVisibleRowsCacheTests.swift
@@ -1,0 +1,107 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPVisibleRowsCache")
+@MainActor
+struct ACPVisibleRowsCacheTests {
+    @Test("same key returns the cached rows without rebuilding")
+    func sameKeyReturnsCachedRowsWithoutRebuilding() {
+        let cache = ACPVisibleRowsCache()
+        var buildCount = 0
+        func build() -> [ACPMessageList.VisibleRow] {
+            buildCount += 1
+            return [ACPMessageList.VisibleRow(index: 0, stableId: "a")]
+        }
+
+        let first = cache.rows(generation: 1, head: 0, tail: 1, build: build)
+        let second = cache.rows(generation: 1, head: 0, tail: 1, build: build)
+
+        #expect(buildCount == 1)
+        #expect(first == second)
+    }
+
+    @Test("bumping the generation rebuilds")
+    func bumpingGenerationRebuilds() {
+        let cache = ACPVisibleRowsCache()
+        var buildCount = 0
+        func build() -> [ACPMessageList.VisibleRow] {
+            buildCount += 1
+            return [ACPMessageList.VisibleRow(index: 0, stableId: "a")]
+        }
+
+        _ = cache.rows(generation: 1, head: 0, tail: 1, build: build)
+        _ = cache.rows(generation: 2, head: 0, tail: 1, build: build)
+
+        #expect(buildCount == 2)
+    }
+
+    @Test("changing the head rebuilds")
+    func changingHeadRebuilds() {
+        let cache = ACPVisibleRowsCache()
+        var buildCount = 0
+        func build() -> [ACPMessageList.VisibleRow] {
+            buildCount += 1
+            return [ACPMessageList.VisibleRow(index: 0, stableId: "a")]
+        }
+
+        _ = cache.rows(generation: 1, head: 0, tail: 1, build: build)
+        _ = cache.rows(generation: 1, head: 1, tail: 1, build: build)
+
+        #expect(buildCount == 2)
+    }
+
+    @Test("changing the tail rebuilds")
+    func changingTailRebuilds() {
+        let cache = ACPVisibleRowsCache()
+        var buildCount = 0
+        func build() -> [ACPMessageList.VisibleRow] {
+            buildCount += 1
+            return [ACPMessageList.VisibleRow(index: 0, stableId: "a")]
+        }
+
+        _ = cache.rows(generation: 1, head: 0, tail: 1, build: build)
+        _ = cache.rows(generation: 1, head: 0, tail: 2, build: build)
+
+        #expect(buildCount == 2)
+    }
+
+    @Test("lookup is memoized alongside rows for the same key")
+    func lookupMemoizedForSameKey() {
+        let cache = ACPVisibleRowsCache()
+        var buildCount = 0
+        func build() -> [ACPMessageList.VisibleRow] {
+            buildCount += 1
+            return [
+                ACPMessageList.VisibleRow(index: 0, stableId: "a"),
+                ACPMessageList.VisibleRow(index: 1, stableId: "b")
+            ]
+        }
+
+        let first = cache.lookup(generation: 1, head: 0, tail: 2, build: build)
+        let second = cache.lookup(generation: 1, head: 0, tail: 2, build: build)
+
+        #expect(buildCount == 1)
+        #expect(first.ids == second.ids)
+        #expect(first.contains("a"))
+        #expect(first.contains("b"))
+        #expect(first.transcriptIndex(for: "b") == 1)
+    }
+
+    @Test("lookup rebuilds when the key changes")
+    func lookupRebuildsWhenKeyChanges() {
+        let cache = ACPVisibleRowsCache()
+        var buildCount = 0
+        func build() -> [ACPMessageList.VisibleRow] {
+            buildCount += 1
+            return [ACPMessageList.VisibleRow(index: buildCount - 1, stableId: "row-\(buildCount)")]
+        }
+
+        let first = cache.lookup(generation: 1, head: 0, tail: 1, build: build)
+        let second = cache.lookup(generation: 2, head: 0, tail: 1, build: build)
+
+        #expect(buildCount == 2)
+        #expect(first.contains("row-1"))
+        #expect(!second.contains("row-1"))
+        #expect(second.contains("row-2"))
+    }
+}

--- a/AlasTests/ACPUserScrollEventTests.swift
+++ b/AlasTests/ACPUserScrollEventTests.swift
@@ -74,4 +74,10 @@ struct ACPUserScrollEventTests {
         #expect(!ACPUserScrollEvent.isHeadPaginationDriven(.leftMouseUp))
         #expect(!ACPUserScrollEvent.isHeadPaginationDriven(nil))
     }
+
+    @Test func staleEventIsNotUserDriven() {
+        #expect(ACPUserScrollEvent.isFresh(eventTimestamp: 10.0, now: 10.2))
+        #expect(!ACPUserScrollEvent.isFresh(eventTimestamp: 10.0, now: 10.6))
+        #expect(ACPUserScrollEvent.isFresh(eventTimestamp: nil, now: 10.0) == false)
+    }
 }


### PR DESCRIPTION
## Summary

Diagnosed and fixed a main-thread live-lock (sustained 100% CPU, beachball) in `ACPMessageList`, the ACP chat transcript view. Captured live via `sample` on a hung instance: the main thread was stuck entirely inside `GraphHost.flushTransactions()`, which never drains because scroll/geometry callbacks write `@State`, and any `@State` write invalidates the view even when body never reads it — each transaction's side effects were enqueuing the next transaction. The driving agent process was idle throughout, confirming this was self-sustaining rather than load-driven.

- Moved callback-only bookkeeping (restore/anchor state) out of observed `@State` into non-observed reference boxes, breaking the core feedback loop
- Memoized the visible-row lookup per render-window generation (was O(rows) per row callback, O(rows²) per layout pass)
- Skipped anchor-tracking work entirely while following the tail (streaming), where it was always discarded
- Stopped misclassifying stale `NSApp.currentEvent` as live user scroll gestures
- Made programmatic tail-scrolls and remembered-anchor restores idempotent/non-re-entrant
- Throttled `streamingTick` publishes to ~30Hz with a trailing-edge guarantee
- Added an `Equatable` gate on transcript rows so unchanged rows skip SwiftUI's subtree re-diff (the dominant cost in the live sample), with a stale-closure audit to confirm no excluded dependency can go stale
- Removed a per-row O(rows) stale-key scan in the row-frame cache that was still running unconditionally on every callback

## Test plan

- [x] Full test suite passes locally (5693 tests; only the 8 pre-existing `ALAS_SSH_INTEGRATION`-gated SSH integration tests fail, unrelated to this change)
- [x] Each commit built and tested independently before merge
- [ ] Manual: long transcript + active streaming — tail-follow stays pinned, pause/resume on scroll works, head/bottom pagination work, remembered anchor survives tab switch
- [ ] Manual: idle CPU stays low after streaming ends (previously pegged at 100% indefinitely)