### PR TITLE
fix(commit): auto-expand commit description in commit details tab

### DIFF
--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -184,6 +184,7 @@ struct CommitTabView: View {
         activeReviewKey = nil
         activeReviewID = UUID()
         loadingReviewSession = false
+        headerExpanded = true
         defer {
             if activeDetailsKey == requestedKey { loadingDetails = false }
         }


### PR DESCRIPTION
## Summary

- Expands the commit description/header block automatically when opening the commit details tab (distinct from the commit review tab).
- Keeps the header expanded when navigating between commits in the same tab by resetting the state at the start of each details load.

## What changed

- `Alas/Sources/Center/Commit/CommitTabView.swift`: set `headerExpanded = true` inside `loadDetails()` alongside the existing per-load state resets.

## Test Plan

- [x] `CommitHeaderViewTests` passes (expanded/collapsed rendering smoke tests).
- [x] `CommitTabViewTests` passes.
- [x] App builds successfully for macOS.