### PR TITLE
feat(acp): make injected MCP tools discoverable via a first-prompt preamble

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -978,6 +978,7 @@
 		C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2942AD875C0E7AB71E8E3CAD /* VerdictSheet.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
 		C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */; };
+		C3292966568305E004CF6604 /* ACPMCPPromptPreambleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1508D249784E402C9167186 /* ACPMCPPromptPreambleTests.swift */; };
 		C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */; };
 		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
 		C3B1121E68B4F36F1540C2E1 /* CommitReviewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A5CD97B6A04929595B0A9D /* CommitReviewLoaderTests.swift */; };
@@ -1134,6 +1135,7 @@
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
 		E0F4EFE612252BDD7F999A70 /* ReviewFeedbackAgentSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
+		E19AEA6E45D16B5EEC1CE411 /* ACPMCPPromptPreamble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A1E612514DDA810791ED5 /* ACPMCPPromptPreamble.swift */; };
 		E1D9EF82D0A80D3E2036CAD6 /* FileHistoryTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A526016296D5A07C2422BC19 /* FileHistoryTabView.swift */; };
 		E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */; };
 		E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */; };
@@ -2149,6 +2151,7 @@
 		B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopDrawerTests.swift; sourceTree = "<group>"; };
 		B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentStore.swift; sourceTree = "<group>"; };
 		B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagerAccessorsTests.swift; sourceTree = "<group>"; };
+		B1508D249784E402C9167186 /* ACPMCPPromptPreambleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPPromptPreambleTests.swift; sourceTree = "<group>"; };
 		B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneSelectionState.swift; sourceTree = "<group>"; };
 		B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncoding.swift; sourceTree = "<group>"; };
 		B16BDCBFE4C1EB1C8EA6D4D5 /* RemoteDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDevice.swift; sourceTree = "<group>"; };
@@ -2421,6 +2424,7 @@
 		E4128039056F417E483AB4DC /* DiffFeedbackLaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffFeedbackLaneTests.swift; sourceTree = "<group>"; };
 		E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderViewTests.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
+		E48A1E612514DDA810791ED5 /* ACPMCPPromptPreamble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPPromptPreamble.swift; sourceTree = "<group>"; };
 		E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPicker.swift; sourceTree = "<group>"; };
 		E4A54DD8080E3395C8E7049E /* RemoteProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProtocol.swift; sourceTree = "<group>"; };
 		E4C4BEC7F392AF938F468B1F /* ACPConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnection.swift; sourceTree = "<group>"; };
@@ -3558,6 +3562,7 @@
 				A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */,
 				E3C49F11F34AA97B21936FC1 /* ACPElicitationCoordinator.swift */,
 				73539FDFE4BDBD4D3B4DE546 /* ACPFirstRunConnectingPhase.swift */,
+				E48A1E612514DDA810791ED5 /* ACPMCPPromptPreamble.swift */,
 				321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */,
 				D21F30DB5A812E396262A926 /* ACPMessageWire.swift */,
 				4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */,
@@ -4123,6 +4128,7 @@
 				D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */,
 				D906A11E19D165C7F5447E67 /* ACPElicitationCoordinatorTests.swift */,
 				BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */,
+				B1508D249784E402C9167186 /* ACPMCPPromptPreambleTests.swift */,
 				6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */,
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
 				2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */,
@@ -5095,6 +5101,7 @@
 				433EC05E13C676C1C2EB6888 /* ACPLaunchCatalog.swift in Sources */,
 				5789FC76BEC6965E56C2DF3C /* ACPLaunchPathResolver.swift in Sources */,
 				542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */,
+				E19AEA6E45D16B5EEC1CE411 /* ACPMCPPromptPreamble.swift in Sources */,
 				6294D44BE2DC7F96933F7C4B /* ACPMCPServer.swift in Sources */,
 				BBACA7DCC1EFA6D55AEB38CE /* ACPMCPStatusControl.swift in Sources */,
 				D0F370E528AA4D07814AEB15 /* ACPMCPStatusPolicy.swift in Sources */,
@@ -5769,6 +5776,7 @@
 				DD2553E3635BFE3B15355E08 /* ACPLaunchPathResolverTests.swift in Sources */,
 				864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */,
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
+				C3292966568305E004CF6604 /* ACPMCPPromptPreambleTests.swift in Sources */,
 				BD0DE08853936F416EFD377C /* ACPMCPServerTests.swift in Sources */,
 				847356E199302CCFDA9172DA /* ACPMCPStatusPolicyTests.swift in Sources */,
 				3DBBAB113CDB6FEEB01C588E /* ACPManagedAdapterDescriptorTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPMCPServer.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMCPServer.swift
@@ -10,6 +10,13 @@ enum ACPMCPServer: Codable, Equatable {
     case http(name: String, url: String, headers: [ACPMCPKeyValue])
     case sse(name: String, url: String, headers: [ACPMCPKeyValue])
 
+    var name: String {
+        switch self {
+        case let .stdio(name, _, _, _), let .http(name, _, _), let .sse(name, _, _):
+            return name
+        }
+    }
+
     private enum CodingKeys: String, CodingKey {
         case type
         case name

--- a/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Builds the one-time, wire-only context preamble injected into the first
+/// prompt of a freshly created ACP session. Modern agent harnesses defer MCP
+/// tools behind tool search, so the model never sees the attached tools
+/// unless something in the prompt tells it they exist. See
+/// docs/superpowers/specs/2026-07-17-mcp-discoverability-design.md.
+enum ACPMCPPromptPreamble {
+    /// Built-in server tool names, mirroring `tool_definitions` in
+    /// AlasCLI/crates/alas/src/mcp.rs (its unit test asserts this order).
+    /// Update both sides together.
+    static let builtInToolNames: [String] = [
+        "open", "notify",
+        "session_list", "session_new", "session_send",
+        "worktree_list", "worktree_switch", "worktree_new", "worktree_delete",
+        "review", "review_comments", "review_reply", "review_resolve",
+        "review_comment_add", "review_finish",
+    ]
+
+    /// The preamble text, or nil when no MCP server was attached.
+    static func text(
+        builtInInjected: Bool,
+        isDelegated: Bool,
+        userServerNames: [String]
+    ) -> String? {
+        guard builtInInjected || !userServerNames.isEmpty else { return nil }
+        var lines: [String] = []
+        lines.append("<alas-workspace-context>")
+        lines.append(
+            "This session runs inside Alas, the user's macOS workspace app. "
+            + "MCP servers are attached to this session. Some agent harnesses "
+            + "defer MCP tools behind tool search, so they may not appear in "
+            + "your direct tool inventory — they ARE available; use your tool "
+            + "discovery/search mechanism to load them.")
+        if builtInInjected {
+            let sessionTools = isDelegated
+                ? "session_list/session_send"
+                : "session_list/session_new/session_send (delegate direct child agent sessions)"
+            var line = "The MCP server \"alas\" (built-in) drives the Alas UI: "
+                + "open (reveal files to the user), notify (macOS notification), "
+                + "worktree_list/worktree_switch/worktree_new/worktree_delete, "
+                + "review, review_comments/review_reply/review_resolve/"
+                + "review_comment_add/review_finish, \(sessionTools)."
+            if isDelegated {
+                line += " This session was delegated by a parent session: it "
+                    + "cannot create descendants; return results or questions "
+                    + "through session_send."
+            }
+            line += " Prefer these tools when the user asks to open/show files, "
+                + "manage worktrees, run or respond to reviews, or be notified."
+            lines.append(line)
+        }
+        if !userServerNames.isEmpty {
+            lines.append("Additional MCP servers attached: "
+                + userServerNames.joined(separator: ", ") + ".")
+        }
+        lines.append("</alas-workspace-context>")
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -85,6 +85,14 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Runtime-only MCP attachment result for the most recent attach. It
     /// contains no resolved commands, environment values, or headers.
     @Published var mcpAttachmentSummary: MCPAttachmentSummary?
+    /// MCP context preamble queued for the next prompt of a freshly created
+    /// remote session. Wire-only: prepended to the outgoing blocks by the
+    /// runner, never recorded in the transcript. Cleared after the first
+    /// successful `session/prompt`. Persisted so an app restart before the
+    /// first prompt does not lose it.
+    @Published var pendingMCPPreamble: String?
+    /// Whether this session's MCP preamble was delivered in a prompt.
+    @Published var mcpPreambleSent: Bool = false
     /// Runtime-only auth method selected by the user in the sign-in banner.
     /// The next attach consumes it by calling ACP `authenticate` after
     /// initialize and before session creation/loading.

--- a/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
@@ -116,6 +116,8 @@ struct HydrationResult: Sendable {
                 remoteSessionId: row.remoteSessionId,
                 origin: row.origin,
                 contextRecoveryPending: row.contextRecoveryPending,
+                mcpPreamblePending: row.mcpPreamblePending,
+                mcpPreambleSent: row.mcpPreambleSent,
                 currentModel: row.currentModel, currentMode: row.currentMode,
                 autoRun: row.autoRun,
                 createdAt: row.createdAt, updatedAt: row.updatedAt,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -622,6 +622,8 @@ final class ACPSessionManager: ObservableObject {
                 session.contextRecoveryStatus = .sendingTranscript
             }
         }
+        session.pendingMCPPreamble = result.row.mcpPreamblePending
+        session.mcpPreambleSent = result.row.mcpPreambleSent
         session.autoRunEnabled = result.row.autoRun
         // Title intentionally NOT overwritten: `placeholderSession` already
         // seeded it from the same row, and a rename made through the
@@ -1035,6 +1037,23 @@ final class ACPSessionManager: ObservableObject {
             _ = try await persistence.setContextRecoveryPending(
                 sessionId: sessionId,
                 pending: pending,
+                fence: fence
+            )
+        }
+    }
+
+    private func persistMCPPreamble(sessionId: ACPSession.ID, pendingText: String?, sent: Bool) {
+        if var row = persistedRows[sessionId] {
+            row.mcpPreamblePending = pendingText
+            row.mcpPreambleSent = sent
+            persistedRows[sessionId] = row
+        }
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            _ = try await persistence.setMCPPreamble(
+                sessionId: sessionId,
+                pendingText: pendingText,
+                sent: sent,
                 fence: fence
             )
         }
@@ -2390,6 +2409,7 @@ extension ACPSessionManager {
                 startRunnerIfNeeded()
             }
             let pendingRecovery = persistedRows[sessionId]?.contextRecoveryPending == true
+            var createdFreshRemoteSession = false
             let result: ACPSessionNewResult
             var restoreWarning: ACPSession.ContextRestoreWarning?
             let hasRestorableContext = pendingRecovery || session.hasConversationTranscript
@@ -2399,6 +2419,7 @@ extension ACPSessionManager {
             }
             if freshlyCreated {
                 result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
+                createdFreshRemoteSession = true
             } else if let remoteId = session.remoteSessionId, !remoteId.isEmpty {
                 if session.hasConversationTranscript {
                     session.contextRecoveryStatus = .restoring
@@ -2428,6 +2449,7 @@ extension ACPSessionManager {
                               ACPAuthFailure.message(from: error) == nil
                         else { throw error }
                         result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
+                        createdFreshRemoteSession = true
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
                             if isWriter(for: sessionId) {
@@ -2478,6 +2500,7 @@ extension ACPSessionManager {
                             throw error
                         }
                         result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
+                        createdFreshRemoteSession = true
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
                             // Guard the store write: if another instance took over
@@ -2502,6 +2525,7 @@ extension ACPSessionManager {
                 }
             } else {
                 result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
+                createdFreshRemoteSession = true
                 if session.hasConversationTranscript {
                     shouldHoldQueueForRecovery = true
                     // Guard the store write: if another instance took over
@@ -2528,6 +2552,20 @@ extension ACPSessionManager {
                 )
                 if session.hasConversationTranscript {
                     session.contextRecoveryStatus = .sendingTranscript
+                }
+            }
+            if createdFreshRemoteSession {
+                let userServerNames = wireMCPServers.map(\.name)
+                    .filter { !(builtInMCP != nil && $0 == BuiltInAlasMCP.serverName) }
+                let preamble = ACPMCPPromptPreamble.text(
+                    builtInInjected: builtInMCP != nil,
+                    isDelegated: builtInMCP?.isDelegated == true,
+                    userServerNames: userServerNames
+                )
+                session.pendingMCPPreamble = preamble
+                session.mcpPreambleSent = false
+                if isWriter(for: sessionId) {
+                    persistMCPPreamble(sessionId: sessionId, pendingText: preamble, sent: false)
                 }
             }
             // Abort the commit if we were taken over OR the manager was disposed

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2562,9 +2562,9 @@ extension ACPSessionManager {
                     isDelegated: builtInMCP?.isDelegated == true,
                     userServerNames: userServerNames
                 )
-                session.pendingMCPPreamble = preamble
-                session.mcpPreambleSent = false
                 if isWriter(for: sessionId) {
+                    session.pendingMCPPreamble = preamble
+                    session.mcpPreambleSent = false
                     persistMCPPreamble(sessionId: sessionId, pendingText: preamble, sent: false)
                 }
             }

--- a/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
@@ -115,6 +115,10 @@ actor ACPSessionPersistence {
         try openedStore().setContextRecoveryPending(sessionId: sessionId, pending: pending)
     }
 
+    func setMCPPreamble(sessionId: String, pendingText: String?, sent: Bool) throws {
+        try openedStore().setMCPPreamble(sessionId: sessionId, pendingText: pendingText, sent: sent)
+    }
+
     @discardableResult
     func updateHelperProcOffsets(
         sessionId: String,
@@ -153,6 +157,20 @@ actor ACPSessionPersistence {
     ) throws -> Bool {
         let store = try openedStore()
         let operation = { try store.setContextRecoveryPending(sessionId: sessionId, pending: pending) }
+        if let fence { return try store.withLeaseFence(fence, operation) != nil }
+        try operation()
+        return true
+    }
+
+    @discardableResult
+    func setMCPPreamble(
+        sessionId: String,
+        pendingText: String?,
+        sent: Bool,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = { try store.setMCPPreamble(sessionId: sessionId, pendingText: pendingText, sent: sent) }
         if let fence { return try store.withLeaseFence(fence, operation) != nil }
         try operation()
         return true

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1290,6 +1290,10 @@ extension ACPSessionRunner {
     /// `sendNow` right after the wire prompt that carried the preamble
     /// succeeds — mirrors `persistQueue()`'s fire-and-forget pattern since
     /// losing this write just means the preamble is (harmlessly) resent.
+    /// When `holdsLeaseForWrite()` is false this returns early and leaves
+    /// the row `pending`: a later hydrate on the writing instance will see
+    /// the still-pending row and re-inject the preamble, which is a benign
+    /// duplicate delivery — the agent just sees the context text twice.
     private func persistMCPPreambleSent() {
         guard holdsLeaseForWrite() else { return }
         let fence = leaseFenceProvider()

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1285,6 +1285,21 @@ extension ACPSessionRunner {
         }
     }
 
+    /// Persist that the one-time MCP context preamble has been delivered:
+    /// clears the pending text and flips `mcpPreambleSent`. Called from
+    /// `sendNow` right after the wire prompt that carried the preamble
+    /// succeeds — mirrors `persistQueue()`'s fire-and-forget pattern since
+    /// losing this write just means the preamble is (harmlessly) resent.
+    private func persistMCPPreambleSent() {
+        guard holdsLeaseForWrite() else { return }
+        let fence = leaseFenceProvider()
+        let sessionId = sessionId
+        enqueuePersistence { persistence in
+            _ = try await persistence.setMCPPreamble(
+                sessionId: sessionId, pendingText: nil, sent: true, fence: fence)
+        }
+    }
+
     /// Drain the queue head if the runner is still live, setup is not
     /// blocked on auth, no prompt owns the transport, transcript state is
     /// `.idle`, the head is `.pending`, and the head has no `lastError`.
@@ -1548,11 +1563,18 @@ extension ACPSessionRunner {
                 // Read the capability flags on the main actor (cheap), then
                 // hydrate off-main so file reads + encoding don't block UI.
                 let promptCapabilities = self.session.promptCapabilities
-                let wireBlocks = await Self.hydrate(
+                let pendingPreamble = self.session.pendingMCPPreamble
+                var wireBlocks = await Self.hydrate(
                     blocks,
                     promptCapabilities: promptCapabilities,
                     worktreePath: self.worktreePath
                 )
+                // Wire-only MCP context preamble: prepended for the agent,
+                // never part of the recorded transcript — `recordUserPrompt`
+                // above already ran on the original `blocks`.
+                if let pendingPreamble {
+                    wireBlocks.insert(.text(pendingPreamble), at: 0)
+                }
                 guard await self.hasConfirmedLeaseForSideEffect() else {
                     throw CancellationError()
                 }
@@ -1560,6 +1582,16 @@ extension ACPSessionRunner {
                 await MainActor.run {
                     let isActivePrompt = self.activePromptID == promptID
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
+                    // The agent received the preamble whenever the RPC above
+                    // succeeded, regardless of whether this prompt is still
+                    // "active" by the time we get back on the main actor —
+                    // guard against a racing change (e.g. a new preamble
+                    // queued mid-flight) before clearing.
+                    if let pendingPreamble, self.session.pendingMCPPreamble == pendingPreamble {
+                        self.session.pendingMCPPreamble = nil
+                        self.session.mcpPreambleSent = true
+                        self.persistMCPPreambleSent()
+                    }
                     if isActivePrompt {
                         if queuedItemId != nil {
                             _ = self.session.popQueueHead()

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 12
+    static let targetSchemaVersion = 13
     let path: String
     let db: SQLiteDatabase
 
@@ -39,6 +39,7 @@ final class ACPSessionStore {
         if current < 10 { try migrate_to_v10() }
         if current < 11 { try migrate_to_v11() }
         if current < 12 { try migrate_to_v12() }
+        if current < 13 { try migrate_to_v13() }
         try recoverFromConcurrentWriters()
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
@@ -204,6 +205,17 @@ final class ACPSessionStore {
             try db.exec("ALTER TABLE sessions ADD COLUMN helper_proc_stderr_offset INTEGER")
         }
     }
+
+    private func migrate_to_v13() throws {
+        let columns = try db.query("PRAGMA table_info(sessions)")
+        let names = Set(columns.compactMap { $0["name"] as? String })
+        if !names.contains("mcp_preamble_pending") {
+            try db.exec("ALTER TABLE sessions ADD COLUMN mcp_preamble_pending TEXT")
+        }
+        if !names.contains("mcp_preamble_sent") {
+            try db.exec("ALTER TABLE sessions ADD COLUMN mcp_preamble_sent INTEGER NOT NULL DEFAULT 0")
+        }
+    }
 }
 
 struct ACPSessionLease: Equatable, Sendable {
@@ -235,6 +247,8 @@ struct ACPSessionRow: Equatable, Sendable {
     var remoteSessionId: String? = nil
     var origin: ACPSessionOrigin = .alasCreated
     var contextRecoveryPending: Bool = false
+    var mcpPreamblePending: String? = nil
+    var mcpPreambleSent: Bool = false
     var currentModel: String?
     var currentMode: String?
     var autoRun: Bool
@@ -300,15 +314,18 @@ extension ACPSessionStore {
     func upsertSession(_ s: ACPSessionRow, preserveTitle: Bool = false) throws {
         try db.exec("""
         INSERT INTO sessions (id, agent_id, title, title_source, remote_session_id, origin, context_recovery_pending,
+                              mcp_preamble_pending, mcp_preamble_sent,
                               current_model, current_mode, auto_run, helper_proc_stdout_offset,
                               helper_proc_stderr_offset, created_at, updated_at, last_opened_at, archived)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         ON CONFLICT(id) DO UPDATE SET
             title = CASE WHEN ? THEN sessions.title ELSE excluded.title END,
             title_source = CASE WHEN ? THEN sessions.title_source ELSE excluded.title_source END,
             remote_session_id = COALESCE(excluded.remote_session_id, sessions.remote_session_id),
             origin = excluded.origin,
             context_recovery_pending = sessions.context_recovery_pending,
+            mcp_preamble_pending = sessions.mcp_preamble_pending,
+            mcp_preamble_sent = sessions.mcp_preamble_sent,
             current_model = excluded.current_model,
             current_mode = excluded.current_mode,
             auto_run = excluded.auto_run,
@@ -320,6 +337,7 @@ extension ACPSessionStore {
         """, bindings: [
             s.id, s.agentId, s.title, s.titleSource.rawValue, s.remoteSessionId, s.origin.rawValue,
             s.contextRecoveryPending ? 1 : 0,
+            s.mcpPreamblePending, s.mcpPreambleSent ? 1 : 0,
             s.currentModel, s.currentMode, s.autoRun ? 1 : 0,
             s.helperProcStdoutOffset, s.helperProcStderrOffset,
             s.createdAt, s.updatedAt, s.lastOpenedAt, s.archived ? 1 : 0,
@@ -358,6 +376,13 @@ extension ACPSessionStore {
         try db.exec(
             "UPDATE sessions SET context_recovery_pending = ? WHERE id = ?",
             bindings: [pending ? 1 : 0, sessionId]
+        )
+    }
+
+    func setMCPPreamble(sessionId: String, pendingText: String?, sent: Bool) throws {
+        try db.exec(
+            "UPDATE sessions SET mcp_preamble_pending = ?, mcp_preamble_sent = ? WHERE id = ?",
+            bindings: [pendingText, sent ? 1 : 0, sessionId]
         )
     }
 
@@ -662,6 +687,8 @@ extension ACPSessionStore {
             remoteSessionId: r["remote_session_id"] as? String,
             origin: ACPSessionOrigin(rawValue: r["origin"] as? String ?? "") ?? .alasCreated,
             contextRecoveryPending: ((r["context_recovery_pending"] as? Int64) ?? 0) != 0,
+            mcpPreamblePending: r["mcp_preamble_pending"] as? String,
+            mcpPreambleSent: ((r["mcp_preamble_sent"] as? Int64) ?? 0) != 0,
             currentModel: r["current_model"] as? String,
             currentMode: r["current_mode"] as? String,
             autoRun: ((r["auto_run"] as? Int64) ?? 0) != 0,

--- a/Alas/Sources/ACP/Session/BuiltInAlasMCP.swift
+++ b/Alas/Sources/ACP/Session/BuiltInAlasMCP.swift
@@ -12,6 +12,7 @@ enum BuiltInAlasMCP {
     struct Injection: Equatable {
         let server: ACPMCPServer
         let status: MCPAttachmentServerStatus
+        let isDelegated: Bool
     }
 
     /// The wire entry + status row for the built-in server, or nil when it
@@ -48,7 +49,8 @@ enum BuiltInAlasMCP {
                 name: serverName,
                 transport: .stdio,
                 disposition: .requested
-            )
+            ),
+            isDelegated: parentSessionId != nil
         )
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
@@ -12,7 +12,9 @@ struct ACPMCPStatusControl: View {
     private var status: ACPMCPStatusState? {
         ACPMCPStatusState(
             summary: session.mcpAttachmentSummary,
-            currentServers: currentServers
+            currentServers: currentServers,
+            preamblePending: session.pendingMCPPreamble != nil,
+            preambleSent: session.mcpPreambleSent
         )
     }
 
@@ -121,6 +123,20 @@ private struct ACPMCPStatusPopover: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
                 }
+            }
+
+            if let detail = status.preambleDetail {
+                Divider().background(theme.color("line"))
+                HStack(spacing: 7) {
+                    Image(systemName: "text.bubble")
+                        .font(.system(size: 10))
+                    Text(detail)
+                        .font(.system(size: 10.5))
+                }
+                .foregroundStyle(theme.color("fg-muted"))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .frame(width: 300)

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -16,8 +16,14 @@ struct ACPMCPStatusState: Equatable {
     let skippedCount: Int
     let isStale: Bool
     let rows: [Row]
+    let preambleDetail: String?
 
-    init?(summary: MCPAttachmentSummary?, currentServers: [ProjectMCPServer]) {
+    init?(
+        summary: MCPAttachmentSummary?,
+        currentServers: [ProjectMCPServer],
+        preamblePending: Bool = false,
+        preambleSent: Bool = false
+    ) {
         guard let summary,
               !summary.statuses.isEmpty || !currentServers.isEmpty else {
             return nil
@@ -28,6 +34,14 @@ struct ACPMCPStatusState: Equatable {
         isStale = summary.configurationFingerprint
             != MCPAttachmentPlanner.configurationFingerprint(for: currentServers)
         rows = summary.statuses.map(Self.row)
+
+        if preamblePending {
+            preambleDetail = "Context preamble pending — sent with the next prompt"
+        } else if preambleSent {
+            preambleDetail = "Context preamble sent"
+        } else {
+            preambleDetail = nil
+        }
     }
 
     var summaryText: String {

--- a/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
+++ b/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPMCPPromptPreamble")
+struct ACPMCPPromptPreambleTests {
+    @Test("nothing attached produces no preamble")
+    func nothingAttached() {
+        #expect(ACPMCPPromptPreamble.text(
+            builtInInjected: false, isDelegated: false, userServerNames: []) == nil)
+    }
+
+    @Test("root built-in preamble names every tool and the search hint")
+    func rootBuiltIn() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: false, userServerNames: []))
+        #expect(text.hasPrefix("<alas-workspace-context>"))
+        #expect(text.hasSuffix("</alas-workspace-context>"))
+        for tool in ACPMCPPromptPreamble.builtInToolNames {
+            #expect(text.contains(tool), "missing tool \(tool)")
+        }
+        #expect(text.contains("tool search"))
+        #expect(text.contains("\"alas\""))
+        #expect(!text.contains("Additional MCP servers"))
+    }
+
+    @Test("delegated preamble omits session_new and explains delegation")
+    func delegated() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: true, userServerNames: []))
+        #expect(!text.contains("session_new"))
+        #expect(text.contains("delegated by a parent session"))
+        #expect(text.contains("session_send"))
+    }
+
+    @Test("user servers are listed by name")
+    func userServers() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: false, isDelegated: false,
+            userServerNames: ["linear", "sentry"]))
+        #expect(text.contains("Additional MCP servers attached: linear, sentry."))
+        #expect(!text.contains("\"alas\""))
+    }
+
+    @Test("built-in plus user servers renders both sections")
+    func builtInPlusUserServers() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: false,
+            userServerNames: ["linear"]))
+        #expect(text.contains("\"alas\""))
+        #expect(text.contains("Additional MCP servers attached: linear."))
+    }
+
+    @Test("tool name list matches the Rust server inventory")
+    func toolNameInventory() {
+        // Mirrors `tool_definitions` in AlasCLI/crates/alas/src/mcp.rs.
+        // The Rust unit test asserting name order is the authority; update
+        // BOTH when tools change.
+        #expect(ACPMCPPromptPreamble.builtInToolNames == [
+            "open", "notify",
+            "session_list", "session_new", "session_send",
+            "worktree_list", "worktree_switch", "worktree_new", "worktree_delete",
+            "review", "review_comments", "review_reply", "review_resolve",
+            "review_comment_add", "review_finish",
+        ])
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -84,6 +84,50 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.pendingMCPPreamble == nil)
     }
 
+    @Test("fresh remote session preamble omits built-in but names a surviving user server")
+    func freshRemoteSessionPreambleOmitsBuiltInButNamesUserServer() async throws {
+        let root = "/srv/task4-remote-preamble-\(UUID().uuidString)"
+        RemoteHostRegistry.shared.register(root: root, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root) }
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(mcpCapabilities: .init(http: true)),
+                authMethods: []
+            ))
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let configuredServers = [
+            ProjectMCPServer(
+                id: UUID().uuidString,
+                name: "docs",
+                transport: .http(url: "https://mcp.example.com/docs", headers: [])
+            )
+        ]
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: root,
+            store: store,
+            remoteAdapterResolver: { _, _, _ in
+                .ready(.init(adapterPath: "/home/dev/.alas/acp/codex/bin/codex-acp", nodeBinDirectory: ""))
+            },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) },
+            mcpProjectContextProvider: {
+                MCPProjectContext(projectDirectory: root, configuredServers: configuredServers)
+            }
+        )
+        let session = manager.createSession(agentId: "codex")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        let preamble = try #require(session.pendingMCPPreamble)
+        #expect(preamble.contains("(built-in)") == false)
+        #expect(preamble.contains("docs") == true)
+        #expect(session.mcpPreambleSent == false)
+    }
+
     @Test("Codex-style load response without session id restores normally")
     func codexStyleLoadResponseWithoutSessionIdRestoresNormally() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -46,6 +46,44 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadSession(id: "local")?.remoteSessionId == "remote-restored")
     }
 
+    @Test("fresh session/new sets a pending MCP preamble when servers attach")
+    func freshSessionSetsPendingPreamble() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let configuredServers = [ProjectMCPServer.stdio(name: "filesystem", command: "mcp-files")]
+        let manager = manager(store: store, client: client, mcpProjectContextProvider: {
+            MCPProjectContext(projectDirectory: "/tmp/project", configuredServers: configuredServers)
+        })
+        let session = manager.createSession(agentId: "claude")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        #expect(session.pendingMCPPreamble?.contains("filesystem") == true)
+        #expect(session.mcpPreambleSent == false)
+    }
+
+    @Test("loaded session does not reset the MCP preamble")
+    func loadedSessionDoesNotResetPreamble() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-restored")
+        let configuredServers = [ProjectMCPServer.stdio(name: "filesystem", command: "mcp-files")]
+        let manager = manager(store: store, client: client, mcpProjectContextProvider: {
+            MCPProjectContext(projectDirectory: "/tmp/project", configuredServers: configuredServers)
+        })
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load"])
+        #expect(session.pendingMCPPreamble == nil)
+    }
+
     @Test("Codex-style load response without session id restores normally")
     func codexStyleLoadResponseWithoutSessionIdRestoresNormally() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -3029,11 +3029,13 @@ struct ACPSessionRunnerTests {
             mock.sent.first { $0.method == "session/prompt" }?.params as? ACPSessionPromptParams)
         #expect(params.prompt.count == 2)
         guard case let .text(first) = params.prompt[0] else {
-            Issue.record("expected leading text block"); return
+            Issue.record("expected leading text block")
+            return
         }
         #expect(first == "<alas-workspace-context>ctx</alas-workspace-context>")
         guard case let .text(second) = params.prompt[1] else {
-            Issue.record("expected user text block"); return
+            Issue.record("expected user text block")
+            return
         }
         #expect(second == "hello")
 

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -3014,6 +3014,71 @@ struct ACPSessionRunnerTests {
         #expect(session.titleSource == .manual)
     }
 
+    @Test("first prompt prepends pending MCP preamble wire-only and clears it")
+    func firstPromptPrependsPreamble() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.session.pendingMCPPreamble = "<alas-workspace-context>ctx</alas-workspace-context>"
+        mock.script(method: "session/prompt") { _ in Data("{}".utf8) }
+
+        let ok = await withCheckedContinuation { c in
+            runner.send(text: "hello", attachments: []) { c.resume(returning: $0) }
+        }
+        #expect(ok == true)
+
+        let params = try #require(
+            mock.sent.first { $0.method == "session/prompt" }?.params as? ACPSessionPromptParams)
+        #expect(params.prompt.count == 2)
+        guard case let .text(first) = params.prompt[0] else {
+            Issue.record("expected leading text block"); return
+        }
+        #expect(first == "<alas-workspace-context>ctx</alas-workspace-context>")
+        guard case let .text(second) = params.prompt[1] else {
+            Issue.record("expected user text block"); return
+        }
+        #expect(second == "hello")
+
+        // Cleared + marked sent; transcript shows only the typed text.
+        #expect(runner.session.pendingMCPPreamble == nil)
+        #expect(runner.session.mcpPreambleSent == true)
+        #expect(runner.session.transcript.messages.contains {
+            if case .user(_, _, let text, _, _) = $0 {
+                return text.contains("alas-workspace-context")
+            }
+            return false
+        } == false)
+    }
+
+    @Test("second prompt does not re-send the MCP preamble")
+    func secondPromptOmitsPreamble() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.session.pendingMCPPreamble = "<ctx>"
+        mock.script(method: "session/prompt") { _ in Data("{}".utf8) }
+
+        for text in ["one", "two"] {
+            _ = await withCheckedContinuation { c in
+                runner.send(text: text, attachments: []) { c.resume(returning: $0) }
+            }
+        }
+        let prompts = mock.sent.filter { $0.method == "session/prompt" }
+            .compactMap { $0.params as? ACPSessionPromptParams }
+        #expect(prompts.count == 2)
+        #expect(prompts[0].prompt.count == 2)
+        #expect(prompts[1].prompt.count == 1)
+    }
+
+    @Test("failed prompt keeps the MCP preamble pending")
+    func failedPromptKeepsPreamblePending() async throws {
+        let (runner, _) = try makeRunner() // no session/prompt script → send fails
+        runner.session.pendingMCPPreamble = "<ctx>"
+
+        let ok = await withCheckedContinuation { c in
+            runner.send(text: "hello", attachments: []) { c.resume(returning: $0) }
+        }
+        #expect(ok == false)
+        #expect(runner.session.pendingMCPPreamble == "<ctx>")
+        #expect(runner.session.mcpPreambleSent == false)
+    }
+
     private func waitUntil(
         timeoutNanoseconds: UInt64 = 1_000_000_000,
         _ condition: @escaping @MainActor () -> Bool

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -131,4 +131,37 @@ struct ACPSessionStoreSchemaTests {
         }
         #expect(text.value == "new owner")
     }
+
+    @Test("mcp preamble round-trips and survives upsert")
+    func mcpPreambleRoundTrip() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("store-preamble-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        // Defaults: nothing pending, not sent.
+        var row = try #require(try store.loadSession(id: "s"))
+        #expect(row.mcpPreamblePending == nil)
+        #expect(row.mcpPreambleSent == false)
+
+        try store.setMCPPreamble(sessionId: "s", pendingText: "<ctx>", sent: false)
+        row = try #require(try store.loadSession(id: "s"))
+        #expect(row.mcpPreamblePending == "<ctx>")
+        #expect(row.mcpPreambleSent == false)
+
+        // A runtime upsert must not clobber preamble state (mirrors
+        // context_recovery_pending semantics).
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t2",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 1, lastOpenedAt: 1, archived: false))
+        row = try #require(try store.loadSession(id: "s"))
+        #expect(row.mcpPreamblePending == "<ctx>")
+
+        try store.setMCPPreamble(sessionId: "s", pendingText: nil, sent: true)
+        row = try #require(try store.loadSession(id: "s"))
+        #expect(row.mcpPreamblePending == nil)
+        #expect(row.mcpPreambleSent == true)
+    }
 }

--- a/AlasTests/ACP/Session/BuiltInAlasMCPTests.swift
+++ b/AlasTests/ACP/Session/BuiltInAlasMCPTests.swift
@@ -60,4 +60,20 @@ struct BuiltInAlasMCPTests {
         #expect(split.kept.isEmpty)
         #expect(split.droppedStdio == ["alas"])
     }
+
+    @Test("injection marks delegated sessions")
+    func injectionMarksDelegated() throws {
+        let root = try #require(BuiltInAlasMCP.injection(
+            enabled: true, configuredServers: [],
+            binaryPath: "/bin/alas", socketPath: "/tmp/s.sock",
+            worktreePath: "/repos/proj/wt", sessionId: "s1"))
+        #expect(root.isDelegated == false)
+
+        let child = try #require(BuiltInAlasMCP.injection(
+            enabled: true, configuredServers: [],
+            binaryPath: "/bin/alas", socketPath: "/tmp/s.sock",
+            worktreePath: "/repos/proj/wt", sessionId: "s2",
+            parentSessionId: "s1"))
+        #expect(child.isDelegated == true)
+    }
 }

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -60,4 +60,23 @@ struct ACPMCPStatusPolicyTests {
         #expect(state?.requestedCount == 0)
         #expect(state?.isStale == true)
     }
+
+    @Test("preamble detail reflects pending, sent, and none")
+    func preambleDetailStates() throws {
+        let summary = MCPAttachmentSummary(
+            statuses: [.init(id: "a", name: "alas", transport: .stdio, disposition: .requested)],
+            configurationFingerprint: "fp")
+
+        let pending = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [], preamblePending: true, preambleSent: false))
+        #expect(pending.preambleDetail == "Context preamble pending — sent with the next prompt")
+
+        let sent = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [], preamblePending: false, preambleSent: true))
+        #expect(sent.preambleDetail == "Context preamble sent")
+
+        let none = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: []))
+        #expect(none.preambleDetail == nil)
+    }
 }


### PR DESCRIPTION
## Problem

Agents run inside Alas (Claude, Codex, Cursor) reported having no `alas` MCP tools and rarely used them, even though the MCP badge showed the server attached.

Root cause (verified with a minimal ACP client + a logging shim around `alas mcp`): the plumbing works end-to-end — every agent receives the `mcpServers` payload, spawns `alas mcp`, completes the handshake, and fetches all 15 tools via `tools/list`; explicit tool calls succeed. But **modern harnesses defer MCP tools behind tool search** (Codex core 0.144.x exposes only `tool_search`; Claude Code defers when many tools are attached), so the model never sees the tools and doesn't reach for them. The server-level `instructions` string isn't surfaced to the model by Codex at all. Any user-configured MCP server injected by Alas suffers identically.

## Fix

Inject a short, one-time, **wire-only** context preamble into the first prompt of each freshly created ACP session, naming the attached MCP servers and telling the agent to use its tool-search mechanism to load them. It never enters the recorded transcript; the MCP badge popover gains an informational "preamble pending/sent" line.

- **`ACPMCPPromptPreamble`** — pure builder; tool-name list mirrors `mcp.rs` `tool_definitions` (drift-guarded by test). Root vs delegated variants; names user-configured servers too.
- **Schema v13** — persisted `mcp_preamble_pending` / `mcp_preamble_sent` (additive, idempotent, preserved across upserts) so the preamble survives an app restart before the first prompt.
- **Attach** — computed and stored only on the fresh `session/new` path (never on load/resume/fork), writer-lease-guarded; restored on hydrate.
- **Runner** — prepends the preamble to the first wire prompt, clears + persists on success, keeps it pending on failure.
- **Badge popover** — shows preamble pending/sent.

Local-only by construction: for remote SSH sessions the built-in stdio server is skipped, so the preamble omits the built-in line but still names surviving http/sse user servers.

## Verification

- Build clean; 207/207 across the 10 touched focused suites, plus the added remote-composition test.
- **End-to-end A/B against `codex-acp`**, identical bare prompt ("What git worktrees exist in this project?"):
  - **With** the preamble → codex plans a tool search, finds `mcp.alas.worktree_list`, and **invokes it**.
  - **Without** → codex uses only shell tools; the `alas` MCP server is never touched.

## Notes

- No changes to the Rust `alas mcp` server or its tool descriptions.
- The MCP badge still reflects the attach plan (not observed connections) by design; a popover line now surfaces preamble delivery state.
