### PR TITLE
feat(acp): Restart local ACP sessions through broker

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
 		67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */; };
 		6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4A215AF2876091E31F6F8A /* LineEnding.swift */; };
+		68D58F9361C2C31EE200479A /* ACPBrokerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A27D9BBDE49BF3A41FAFB7 /* ACPBrokerClient.swift */; };
 		6A10E9DF8A052DBDFF477863 /* OpenCodeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */; };
 		6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */; };
 		6A5B87FF631136E5246D0F38 /* AgentLauncherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */; };
@@ -1164,6 +1165,7 @@
 		E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */; };
 		E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */; };
 		E3217588485CC96AB05AA5B9 /* DialogChromeLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40497B428C9395535DF6C146 /* DialogChromeLayoutTests.swift */; };
+		E362C49BC42468E5CD9321C5 /* ACPBrokerClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E01A18A7215E3FEEB71B07 /* ACPBrokerClientTests.swift */; };
 		E395C1299D215BA0EC4760E8 /* SpaceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7963D4DD10B67EB683510FF6 /* SpaceConfig.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
 		E3C34254BA474878AEC6683D /* PendingReviewTray.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFF1C68250433F4B9891F1A /* PendingReviewTray.swift */; };
@@ -1683,6 +1685,7 @@
 		48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProviderVerdictTests.swift; sourceTree = "<group>"; };
 		4865995B2D4B92166321201F /* CommitContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilder.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
+		48A27D9BBDE49BF3A41FAFB7 /* ACPBrokerClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBrokerClient.swift; sourceTree = "<group>"; };
 		48AFF324FEE695AE18065D5A /* ClaudeCodeACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeACPInstaller.swift; sourceTree = "<group>"; };
 		490AFAD12616D61858A19A31 /* ACPSetupCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupCheckerTests.swift; sourceTree = "<group>"; };
 		4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCard.swift; sourceTree = "<group>"; };
@@ -1891,6 +1894,7 @@
 		71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionStateResolverTests.swift; sourceTree = "<group>"; };
 		71A90560CED6562BBC313F3C /* ProjectConfigHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigHostTests.swift; sourceTree = "<group>"; };
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
+		71E01A18A7215E3FEEB71B07 /* ACPBrokerClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBrokerClientTests.swift; sourceTree = "<group>"; };
 		71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefill.swift; sourceTree = "<group>"; };
 		728F8E1DBF9DA86092C10AD0 /* ACPSessionOrchestrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinator.swift; sourceTree = "<group>"; };
 		7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateView.swift; sourceTree = "<group>"; };
@@ -2751,6 +2755,7 @@
 		0F049E087B583485A8588D8A /* Broker */ = {
 			isa = PBXGroup;
 			children = (
+				48A27D9BBDE49BF3A41FAFB7 /* ACPBrokerClient.swift */,
 				F6F598D32E08FFED3E45351D /* ACPBrokerProtocol.swift */,
 				FAB1A1E525DA701563EF56D5 /* LocalACPBrokerService.swift */,
 			);
@@ -4659,6 +4664,7 @@
 		E983FBC642810DD8F47702D8 /* Broker */ = {
 			isa = PBXGroup;
 			children = (
+				71E01A18A7215E3FEEB71B07 /* ACPBrokerClientTests.swift */,
 				928B582B3F81A605236CBBED /* ACPBrokerProtocolTests.swift */,
 			);
 			path = Broker;
@@ -5126,6 +5132,7 @@
 				6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */,
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
 				0722316C2ADB93575221246D /* ACPBareURLLinkifier.swift in Sources */,
+				68D58F9361C2C31EE200479A /* ACPBrokerClient.swift in Sources */,
 				ED629C6FCCAE2D79FBB3014C /* ACPBrokerProtocol.swift in Sources */,
 				88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */,
 				25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */,
@@ -5813,6 +5820,7 @@
 				D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */,
 				4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */,
 				E71191CF46FA3E7BC2C4A91E /* ACPBareURLLinkifierTests.swift in Sources */,
+				E362C49BC42468E5CD9321C5 /* ACPBrokerClientTests.swift in Sources */,
 				C38EA8BB207FB273032CE292 /* ACPBrokerProtocolTests.swift in Sources */,
 				AC2EA26D999115E66DF40142 /* ACPChangeNotifierTests.swift in Sources */,
 				AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 		72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */; };
+		7339339EEA3D52B6F5BDE5F0 /* LocalACPBrokerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB1A1E525DA701563EF56D5 /* LocalACPBrokerService.swift */; };
 		73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */; };
 		735B86E1E8F8F593049937BB /* ReviewSessionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */; };
 		7374C72F780CEE12E81997B9 /* StashDiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E373805AEFD068B97BC33A82 /* StashDiffTabView.swift */; };
@@ -989,6 +990,7 @@
 		C3292966568305E004CF6604 /* ACPMCPPromptPreambleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1508D249784E402C9167186 /* ACPMCPPromptPreambleTests.swift */; };
 		C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */; };
 		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
+		C38EA8BB207FB273032CE292 /* ACPBrokerProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928B582B3F81A605236CBBED /* ACPBrokerProtocolTests.swift */; };
 		C3B1121E68B4F36F1540C2E1 /* CommitReviewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A5CD97B6A04929595B0A9D /* CommitReviewLoaderTests.swift */; };
 		C3E59948BD9108C1BD3243AD /* RemoteServerPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9126D442E8CDB093FA36BA5 /* RemoteServerPane.swift */; };
 		C4466064F783E6667C5FD25D /* UpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2763F93ADFDCDF6B31D16475 /* UpdateController.swift */; };
@@ -1213,6 +1215,7 @@
 		EC9A9B3211CFE0B652F5CA83 /* MemoryDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */; };
 		ECEE8511CA84DF4A15F01DC1 /* AppConfigTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
+		ED629C6FCCAE2D79FBB3014C /* ACPBrokerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F598D32E08FFED3E45351D /* ACPBrokerProtocol.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE02460865C6A4ED1046B13F /* AgentLifecycleEventMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */; };
 		EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE09B83A747269494B206F23 /* UpdateThrottle.swift */; };
@@ -2031,6 +2034,7 @@
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
 		9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageListPaginationTests.swift; sourceTree = "<group>"; };
 		9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputerTests.swift; sourceTree = "<group>"; };
+		928B582B3F81A605236CBBED /* ACPBrokerProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBrokerProtocolTests.swift; sourceTree = "<group>"; };
 		92F1C71C2574B1077964E5E1 /* ACPPermissionDecisionLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionDecisionLogTests.swift; sourceTree = "<group>"; };
 		93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteZmxInstallerTests.swift; sourceTree = "<group>"; };
 		932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstaller.swift; sourceTree = "<group>"; };
@@ -2534,6 +2538,7 @@
 		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
 		F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBannerTests.swift; sourceTree = "<group>"; };
 		F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPolicyTests.swift; sourceTree = "<group>"; };
+		F6F598D32E08FFED3E45351D /* ACPBrokerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBrokerProtocol.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F748F06725644571785BF658 /* PendingStashDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingStashDrop.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
@@ -2549,6 +2554,7 @@
 		FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilderTests.swift; sourceTree = "<group>"; };
 		FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequestTests.swift; sourceTree = "<group>"; };
+		FAB1A1E525DA701563EF56D5 /* LocalACPBrokerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalACPBrokerService.swift; sourceTree = "<group>"; };
 		FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinitionTests.swift; sourceTree = "<group>"; };
 		FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreDedupTests.swift; sourceTree = "<group>"; };
 		FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefillTests.swift; sourceTree = "<group>"; };
@@ -2740,6 +2746,15 @@
 				AD63F297F7735AD9E1841ACF /* ACPSessionOrchestrationPolicy.swift */,
 			);
 			path = Orchestration;
+			sourceTree = "<group>";
+		};
+		0F049E087B583485A8588D8A /* Broker */ = {
+			isa = PBXGroup;
+			children = (
+				F6F598D32E08FFED3E45351D /* ACPBrokerProtocol.swift */,
+				FAB1A1E525DA701563EF56D5 /* LocalACPBrokerService.swift */,
+			);
+			path = Broker;
 			sourceTree = "<group>";
 		};
 		0F8A8BCD5083CA261EBDEC8C /* Gateway */ = {
@@ -3367,6 +3382,7 @@
 				B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */,
 				45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */,
 				0A9B6A8C7372DB9E6C627A0E /* Adapter */,
+				0F049E087B583485A8588D8A /* Broker */,
 				22693797F2929554193802B2 /* FileWriter */,
 				0C652107D8258A12E8774EF5 /* Orchestration */,
 				3265338C21E4088B279578DE /* Permissions */,
@@ -3794,6 +3810,7 @@
 				FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */,
 				5027B783605BE1C0189308CC /* ACPTranscriptChangeLogTests.swift */,
 				C1CE17139DAF0E60FE9D92C2 /* Adapter */,
+				E983FBC642810DD8F47702D8 /* Broker */,
 				E6055B84E3F6E5717B873689 /* E2E */,
 				075A0E441C47ACE7EEA52334 /* FileWriter */,
 				895189284B82DBD794D9F2F0 /* Fixtures */,
@@ -4639,6 +4656,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		E983FBC642810DD8F47702D8 /* Broker */ = {
+			isa = PBXGroup;
+			children = (
+				928B582B3F81A605236CBBED /* ACPBrokerProtocolTests.swift */,
+			);
+			path = Broker;
+			sourceTree = "<group>";
+		};
 		EA78AC4E93C2130046C92571 /* Commit */ = {
 			isa = PBXGroup;
 			children = (
@@ -5101,6 +5126,7 @@
 				6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */,
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
 				0722316C2ADB93575221246D /* ACPBareURLLinkifier.swift in Sources */,
+				ED629C6FCCAE2D79FBB3014C /* ACPBrokerProtocol.swift in Sources */,
 				88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */,
 				25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */,
 				FE5F2F9B468D045194B9443B /* ACPChatTypography.swift in Sources */,
@@ -5499,6 +5525,7 @@
 				E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */,
 				DE431266B60826A2EA3736DF /* LineBuffer.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
+				7339339EEA3D52B6F5BDE5F0 /* LocalACPBrokerService.swift in Sources */,
 				AC915AF49731E075051CA4FC /* MCPAttachmentPlanner.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */,
@@ -5786,6 +5813,7 @@
 				D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */,
 				4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */,
 				E71191CF46FA3E7BC2C4A91E /* ACPBareURLLinkifierTests.swift in Sources */,
+				C38EA8BB207FB273032CE292 /* ACPBrokerProtocolTests.swift in Sources */,
 				AC2EA26D999115E66DF40142 /* ACPChangeNotifierTests.swift in Sources */,
 				AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */,
 				E2B39318C3417839BAE511A7 /* ACPChatTypographyTests.swift in Sources */,

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -223,6 +223,10 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         if let generation = try? currentGeneration() {
             _ = try? await service.detach(ACPBrokerDetachParams(brokerId: brokerId, generation: generation))
         }
+        finishStreams()
+    }
+
+    private func finishStreams() {
         updatesCont.finish()
         permsCont.finish()
         questionsCont.finish()
@@ -290,6 +294,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             if let decoded = try? JSONDecoder().decode(ACPElicitationCompleteParams.self, from: params.data) {
                 elicitationCompletionsCont.yield(decoded)
             }
+        case "adapter/exit":
+            finishStreams()
         default:
             break
         }

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -182,6 +182,9 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             }
             clearPendingOutboundRequest(id: result.requestId.jsonRPCID)
             let cursor = currentOperationCompletionCursor(for: operationKey)
+            if let cursor {
+                trackDeferredResponse(cursor: cursor)
+            }
             return ACPResponse(
                 body: try (result.result ?? .null).data,
                 durableConsumptionAcknowledgement: { [weak self] in
@@ -561,11 +564,20 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         stateLock.lock()
         unacknowledgedDurableEventCursors.remove(cursor)
         stateLock.unlock()
-        ack(cursor: cursor)
+        ackAfterEarlierDurableEvents(cursor: cursor)
     }
 
     private func ackResponse(cursor: ACPBrokerEventCursor) {
+        stateLock.lock()
+        unacknowledgedDurableEventCursors.remove(cursor)
+        stateLock.unlock()
         ackAfterEarlierDurableEvents(cursor: cursor)
+    }
+
+    private func trackDeferredResponse(cursor: ACPBrokerEventCursor) {
+        stateLock.lock()
+        unacknowledgedDurableEventCursors.insert(cursor)
+        stateLock.unlock()
     }
 
     private func ackAfterEarlierDurableEvents(cursor: ACPBrokerEventCursor) {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -28,6 +28,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private let cwd: String
     private let env: [String: String]
     private let operationKeyPrefix: String
+    private let initialBrokerGeneration: ACPBrokerGeneration?
     private let onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)?
 
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
@@ -73,6 +74,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         cwd: String,
         env: [String: String],
         operationKeyPrefix: String,
+        initialBrokerGeneration: ACPBrokerGeneration? = nil,
         initialAcknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
         onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
     ) {
@@ -84,6 +86,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         self.cwd = cwd
         self.env = env
         self.operationKeyPrefix = operationKeyPrefix
+        self.initialBrokerGeneration = initialBrokerGeneration
         self.acknowledgedCursor = initialAcknowledgedCursor
         self.onDurableStateChanged = onDurableStateChanged
 
@@ -126,6 +129,10 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             cwd: cwd,
             env: env
         ))
+        if let initialBrokerGeneration,
+           initialBrokerGeneration != opened.snapshot.metadata.generation {
+            resetAcknowledgedCursor()
+        }
         setSnapshot(opened.snapshot)
         try await attachAndReplay()
         return opened
@@ -286,6 +293,10 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private func dispatchPendingRequest(_ request: ACPBrokerPendingRequest, cursor: ACPBrokerEventCursor) {
         guard let id = request.adapterRequestId.jsonRPCID else { return }
         stateLock.lock()
+        if pendingInboundCursors[id] != nil {
+            stateLock.unlock()
+            return
+        }
         pendingInboundCursors[id] = cursor
         stateLock.unlock()
 
@@ -506,6 +517,12 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         stateLock.lock()
         defer { stateLock.unlock() }
         return acknowledgedCursor
+    }
+
+    private func resetAcknowledgedCursor() {
+        stateLock.lock()
+        acknowledgedCursor = ACPBrokerEventCursor(rawValue: 0)
+        stateLock.unlock()
     }
 
     private func currentOperationCompletionCursor(for operationKey: ACPBrokerOperationKey) -> ACPBrokerEventCursor? {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -134,21 +134,32 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             return ACPResponse(body: try replayed.data)
         }
         let generation = try currentGeneration()
-        let result = try await service.send(ACPBrokerSendParams(
-            brokerId: brokerId,
-            generation: generation,
-            operationKey: nextOperationKey(method: request.method),
-            method: request.method,
-            params: try ACPBrokerJSONValue(encodable: request.params)
-        ))
-        try await attachAndReplay()
-        let cursor = currentLatestCursor()
-        return ACPResponse(
-            body: try (result.result ?? .null).data,
-            durableConsumptionAcknowledgement: { [weak self] in
-                self?.ack(cursor: cursor)
+        let operationKey = nextOperationKey(method: request.method)
+        let params = try ACPBrokerJSONValue(encodable: request.params)
+        while true {
+            let result = try await service.send(ACPBrokerSendParams(
+                brokerId: brokerId,
+                generation: generation,
+                operationKey: operationKey,
+                method: request.method,
+                params: params
+            ))
+            try await attachAndReplay()
+            if let error = result.error {
+                throw ACPClientError.jsonrpc(error)
             }
-        )
+            if result.pending == true && result.result == nil {
+                try await Task.sleep(for: .milliseconds(50))
+                continue
+            }
+            let cursor = currentLatestCursor()
+            return ACPResponse(
+                body: try (result.result ?? .null).data,
+                durableConsumptionAcknowledgement: { [weak self] in
+                    self?.ack(cursor: cursor)
+                }
+            )
+        }
     }
 
     func notify(_ request: ACPRequest) async throws {
@@ -178,7 +189,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         case .success(let response):
             respond(id: id, value: response)
         case .failure(let error):
-            respond(id: id, value: JSONRPCFailureResult(error: error))
+            respond(id: id, error: error)
         }
     }
 
@@ -349,7 +360,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         Task { [weak self] in
             guard let self else { return }
             do {
-                try await self.respond(id: id, result: ACPBrokerJSONValue(encodable: value))
+                try await self.respond(id: id, result: ACPBrokerJSONValue(encodable: value), error: nil)
             } catch {}
         }
     }
@@ -360,23 +371,32 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             do {
                 switch result {
                 case .success(let data):
-                    try await self.respond(id: id, result: ACPBrokerJSONValue(data: data))
+                    try await self.respond(id: id, result: ACPBrokerJSONValue(data: data), error: nil)
                 case .failure(let error):
-                    try await self.respond(id: id, result: ACPBrokerJSONValue(encodable: JSONRPCFailureResult(error: error)))
+                    try await self.respond(id: id, result: nil, error: error)
                 }
             } catch {}
         }
     }
 
-    private func respond(id: JSONRPCID, result: ACPBrokerJSONValue) async throws {
+    private func respond(id: JSONRPCID, error: JSONRPCError) {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.respond(id: id, result: nil, error: error)
+            } catch {}
+        }
+    }
+
+    private func respond(id: JSONRPCID, result: ACPBrokerJSONValue?, error: JSONRPCError?) async throws {
         let generation = try currentGeneration()
-        guard let requestId = ACPBrokerAdapterRequestID(jsonRPCID: id) else { return }
         _ = try await service.respond(ACPBrokerRespondParams(
             brokerId: brokerId,
             generation: generation,
-            requestId: requestId,
+            requestId: ACPBrokerJSONValue(jsonRPCID: id),
             operationKey: nextOperationKey(method: "respond"),
-            result: result
+            result: result,
+            error: error
         ))
         stateLock.lock()
         let cursor = pendingInboundCursors.removeValue(forKey: id)
@@ -471,10 +491,6 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 }
 
-private struct JSONRPCFailureResult: Encodable {
-    let error: JSONRPCError
-}
-
 private struct AnyEncodableBrokerBox: Encodable {
     let value: Encodable
 
@@ -535,17 +551,13 @@ private extension ACPBrokerJSONValue {
             return nil
         }
     }
-}
 
-private extension ACPBrokerAdapterRequestID {
-    init?(jsonRPCID: JSONRPCID) {
+    init(jsonRPCID: JSONRPCID) {
         switch jsonRPCID {
         case .number(let value):
-            guard value >= 0 else { return nil }
-            self.init(rawValue: UInt64(value))
+            self = .number(Double(value))
         case .string(let value):
-            guard let parsed = UInt64(value) else { return nil }
-            self.init(rawValue: parsed)
+            self = .string(value)
         }
     }
 }

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -143,7 +143,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             return ACPResponse(body: try replayed.data)
         }
         let generation = try currentGeneration()
-        let operationKey = nextOperationKey(method: request.method)
+        let operationKey = request.brokerOperationKey.map(ACPBrokerOperationKey.init(rawValue:))
+            ?? nextOperationKey(method: request.method)
         let params = try ACPBrokerJSONValue(encodable: request.params)
         while true {
             let result = try await service.send(ACPBrokerSendParams(
@@ -240,16 +241,20 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             acknowledgedCursor: cursor
         ))
         setSnapshot(attached.snapshot)
+        let pendingRequestIds = Set(attached.snapshot.pendingRequests.map(\.requestId))
         for event in attached.events {
-            dispatch(event)
+            dispatch(event, pendingRequestIds: pendingRequestIds)
         }
     }
 
-    private func dispatch(_ event: ACPBrokerEvent) {
+    private func dispatch(_ event: ACPBrokerEvent, pendingRequestIds: Set<String>? = nil) {
         switch event.kind {
         case .adapterNotification(let method, let params):
             dispatchAdapterNotification(method: method, params: params, cursor: event.cursor)
         case .pendingRequest(let request):
+            if let pendingRequestIds, !pendingRequestIds.contains(request.requestId) {
+                return
+            }
             dispatchPendingRequest(request, cursor: event.cursor)
         case .operationCompleted(let operationKey, _):
             stateLock.lock()

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -50,6 +50,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var generation: ACPBrokerGeneration?
     private var acknowledgedCursor = ACPBrokerEventCursor(rawValue: 0)
     private var latestCursor = ACPBrokerEventCursor(rawValue: 0)
+    private var initializeResult: ACPBrokerJSONValue?
+    private var remoteSessionResult: ACPBrokerJSONValue?
     private var nextOperationIndex = 0
     private var _yieldedUpdateCount = 0
     private var pendingInboundCursors: [JSONRPCID: ACPBrokerEventCursor] = [:]
@@ -69,6 +71,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         cwd: String,
         env: [String: String],
         operationKeyPrefix: String,
+        initialAcknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
         onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
     ) {
         self.service = service
@@ -79,6 +82,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         self.cwd = cwd
         self.env = env
         self.operationKeyPrefix = operationKeyPrefix
+        self.acknowledgedCursor = initialAcknowledgedCursor
         self.onDurableStateChanged = onDurableStateChanged
 
         var u: AsyncStream<ACPSessionUpdateParams>.Continuation!
@@ -126,6 +130,9 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func send(_ request: ACPRequest) async throws -> ACPResponse {
+        if let replayed = cachedResponse(for: request.method) {
+            return ACPResponse(body: try replayed.data)
+        }
         let generation = try currentGeneration()
         let result = try await service.send(ACPBrokerSendParams(
             brokerId: brokerId,
@@ -406,6 +413,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         generation = snapshot.metadata.generation
         acknowledgedCursor = max(acknowledgedCursor, snapshot.acknowledgedCursor)
         latestCursor = max(latestCursor, snapshot.journalTail)
+        initializeResult = snapshot.initializeResult ?? initializeResult
+        remoteSessionResult = snapshot.remoteSessionResult ?? remoteSessionResult
         let state = durableStateLocked()
         stateLock.unlock()
         if let state {
@@ -437,6 +446,19 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         defer { stateLock.unlock() }
         nextOperationIndex += 1
         return ACPBrokerOperationKey(rawValue: "\(operationKeyPrefix):\(nextOperationIndex):\(method)")
+    }
+
+    private func cachedResponse(for method: String) -> ACPBrokerJSONValue? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        switch method {
+        case "initialize":
+            return initializeResult
+        case "session/new", "session/load", "session/resume":
+            return remoteSessionResult
+        default:
+            return nil
+        }
     }
 
     private func durableStateLocked() -> ACPBrokerDurableState? {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -30,6 +30,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private let operationKeyPrefix: String
     private let initialBrokerGeneration: ACPBrokerGeneration?
     private let onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)?
+    private let onTurnStateChanged: (@Sendable (ACPBrokerTurnState) -> Void)?
 
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
@@ -60,12 +61,19 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var unacknowledgedDurableEventCursors: Set<ACPBrokerEventCursor> = []
     private var deferredOrderedAckCursors: Set<ACPBrokerEventCursor> = []
     private var dispatchedEventCursors: Set<ACPBrokerEventCursor> = []
+    private var turnState: ACPBrokerTurnState = .idle
     private var activeTurnPollingTask: Task<Void, Never>?
 
     var yieldedUpdateCount: Int {
         stateLock.lock()
         defer { stateLock.unlock() }
         return _yieldedUpdateCount
+    }
+
+    var currentTurnState: ACPBrokerTurnState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return turnState
     }
 
     init(
@@ -79,7 +87,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         operationKeyPrefix: String,
         initialBrokerGeneration: ACPBrokerGeneration? = nil,
         initialAcknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
-        onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
+        onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil,
+        onTurnStateChanged: (@Sendable (ACPBrokerTurnState) -> Void)? = nil
     ) {
         self.service = service
         self.brokerId = brokerId
@@ -92,6 +101,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         self.initialBrokerGeneration = initialBrokerGeneration
         self.acknowledgedCursor = initialAcknowledgedCursor
         self.onDurableStateChanged = onDurableStateChanged
+        self.onTurnStateChanged = onTurnStateChanged
 
         var u: AsyncStream<ACPSessionUpdateParams>.Continuation!
         incomingUpdates = AsyncStream { u = $0 }
@@ -338,6 +348,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             stateLock.lock()
             operationCompletionCursors[operationKey] = event.cursor
             stateLock.unlock()
+        case .turnStateChanged(let state):
+            setTurnState(state)
         default:
             break
         }
@@ -584,6 +596,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     private func setSnapshot(_ snapshot: ACPBrokerSnapshot) {
+        let changedTurnState: ACPBrokerTurnState?
         stateLock.lock()
         generation = snapshot.metadata.generation
         acknowledgedCursor = max(acknowledgedCursor, snapshot.acknowledgedCursor)
@@ -597,11 +610,31 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 pendingOutboundRequestIds.remove(id)
             }
         }
+        if turnState != snapshot.turnState {
+            turnState = snapshot.turnState
+            changedTurnState = snapshot.turnState
+        } else {
+            changedTurnState = nil
+        }
         let state = durableStateLocked()
         stateLock.unlock()
         if let state {
             onDurableStateChanged?(state)
         }
+        if let changedTurnState {
+            onTurnStateChanged?(changedTurnState)
+        }
+    }
+
+    private func setTurnState(_ state: ACPBrokerTurnState) {
+        stateLock.lock()
+        guard turnState != state else {
+            stateLock.unlock()
+            return
+        }
+        turnState = state
+        stateLock.unlock()
+        onTurnStateChanged?(state)
     }
 
     private func currentGeneration() throws -> ACPBrokerGeneration {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -236,6 +236,14 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         finishStreams()
     }
 
+    func detach() async {
+        cancelActiveTurnPolling()
+        if let generation = try? currentGeneration() {
+            _ = try? await service.detach(ACPBrokerDetachParams(brokerId: brokerId, generation: generation))
+        }
+        finishStreams()
+    }
+
     private func finishStreams() {
         updatesCont.finish()
         permsCont.finish()

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -20,8 +20,6 @@ struct ACPBrokerDurableState: Equatable, Sendable {
 }
 
 final class ACPBrokerClient: ACPClient, @unchecked Sendable {
-    let advertisesTerminalCapability = false
-
     private let service: ACPBrokerServicing
     private let brokerId: ACPBrokerID
     private let sessionId: String

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -4,6 +4,7 @@ protocol ACPBrokerServicing: Sendable {
     func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult
     func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult
     func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult
+    func notify(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK
     func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK
     func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK
     func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK
@@ -144,7 +145,14 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func notify(_ request: ACPRequest) async throws {
-        throw ACPClientError.decoding("Broker-backed ACP notifications are not supported yet: \(request.method)")
+        let generation = try currentGeneration()
+        _ = try await service.notify(ACPBrokerNotifyParams(
+            brokerId: brokerId,
+            generation: generation,
+            method: request.method,
+            params: try ACPBrokerJSONValue(encodable: request.params)
+        ))
+        try await attachAndReplay()
     }
 
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse) {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -57,7 +57,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var pendingInboundCursors: [JSONRPCID: ACPBrokerEventCursor] = [:]
     private var operationCompletionCursors: [ACPBrokerOperationKey: ACPBrokerEventCursor] = [:]
     private var unacknowledgedDurableEventCursors: Set<ACPBrokerEventCursor> = []
-    private var deferredResponseAckCursors: Set<ACPBrokerEventCursor> = []
+    private var deferredOrderedAckCursors: Set<ACPBrokerEventCursor> = []
 
     var yieldedUpdateCount: Int {
         stateLock.lock()
@@ -437,7 +437,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         let cursor = pendingInboundCursors.removeValue(forKey: id)
         stateLock.unlock()
         if let cursor {
-            ack(cursor: cursor)
+            ackAfterEarlierDurableEvents(cursor: cursor)
         }
     }
 
@@ -460,7 +460,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             if let state {
                 self.onDurableStateChanged?(state)
             }
-            self.flushDeferredResponseAcks()
+            self.flushDeferredOrderedAcks()
         }
     }
 
@@ -472,10 +472,14 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     private func ackResponse(cursor: ACPBrokerEventCursor) {
+        ackAfterEarlierDurableEvents(cursor: cursor)
+    }
+
+    private func ackAfterEarlierDurableEvents(cursor: ACPBrokerEventCursor) {
         stateLock.lock()
         let shouldDefer = unacknowledgedDurableEventCursors.contains(where: { $0 < cursor })
         if shouldDefer {
-            deferredResponseAckCursors.insert(cursor)
+            deferredOrderedAckCursors.insert(cursor)
             stateLock.unlock()
             return
         }
@@ -483,14 +487,14 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         ack(cursor: cursor)
     }
 
-    private func flushDeferredResponseAcks() {
+    private func flushDeferredOrderedAcks() {
         let ready: [ACPBrokerEventCursor]
         stateLock.lock()
-        ready = deferredResponseAckCursors
+        ready = deferredOrderedAckCursors
             .filter { cursor in !unacknowledgedDurableEventCursors.contains(where: { $0 < cursor }) }
             .sorted()
         for cursor in ready {
-            deferredResponseAckCursors.remove(cursor)
+            deferredOrderedAckCursors.remove(cursor)
         }
         stateLock.unlock()
         for cursor in ready {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -20,6 +20,8 @@ struct ACPBrokerDurableState: Equatable, Sendable {
 }
 
 final class ACPBrokerClient: ACPClient, @unchecked Sendable {
+    let advertisesTerminalCapability = false
+
     private let service: ACPBrokerServicing
     private let brokerId: ACPBrokerID
     private let sessionId: String

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -227,7 +227,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     func shutdown() async {
         cancelActiveTurnPolling()
         if let generation = try? currentGeneration() {
-            _ = try? await service.detach(ACPBrokerDetachParams(brokerId: brokerId, generation: generation))
+            _ = try? await service.close(ACPBrokerCloseParams(brokerId: brokerId, generation: generation))
         }
         finishStreams()
     }

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -58,6 +58,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var operationCompletionCursors: [ACPBrokerOperationKey: ACPBrokerEventCursor] = [:]
     private var unacknowledgedDurableEventCursors: Set<ACPBrokerEventCursor> = []
     private var deferredOrderedAckCursors: Set<ACPBrokerEventCursor> = []
+    private var dispatchedEventCursors: Set<ACPBrokerEventCursor> = []
+    private var activeTurnPollingTask: Task<Void, Never>?
 
     var yieldedUpdateCount: Int {
         stateLock.lock()
@@ -134,7 +136,10 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             resetAcknowledgedCursor()
         }
         setSnapshot(opened.snapshot)
-        try await attachAndReplay()
+        let snapshot = try await attachAndReplay()
+        if opened.adopted {
+            startActiveTurnPollingIfNeeded(snapshot: snapshot)
+        }
         return opened
     }
 
@@ -220,6 +225,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func shutdown() async {
+        cancelActiveTurnPolling()
         if let generation = try? currentGeneration() {
             _ = try? await service.detach(ACPBrokerDetachParams(brokerId: brokerId, generation: generation))
         }
@@ -236,7 +242,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         terminalsCont.finish()
     }
 
-    private func attachAndReplay() async throws {
+    @discardableResult
+    private func attachAndReplay() async throws -> ACPBrokerSnapshot {
         let generation = try currentGeneration()
         let cursor = currentAcknowledgedCursor()
         let attached = try await service.attach(ACPBrokerAttachParams(
@@ -249,9 +256,64 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         for event in attached.events {
             dispatch(event, pendingRequestIds: pendingRequestIds)
         }
+        for request in attached.snapshot.pendingRequests {
+            dispatchPendingRequest(request, cursor: attached.snapshot.acknowledgedCursor)
+        }
+        return attached.snapshot
+    }
+
+    private func startActiveTurnPollingIfNeeded(snapshot: ACPBrokerSnapshot) {
+        guard snapshot.turnState.needsActiveTurnPolling else { return }
+        stateLock.lock()
+        if activeTurnPollingTask != nil {
+            stateLock.unlock()
+            return
+        }
+        activeTurnPollingTask = Task { [weak self] in
+            await self?.pollActiveTurn()
+        }
+        stateLock.unlock()
+    }
+
+    private func pollActiveTurn() async {
+        defer { clearActiveTurnPollingTask() }
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(for: .milliseconds(50))
+                let snapshot = try await attachAndReplay()
+                if !snapshot.turnState.needsActiveTurnPolling {
+                    return
+                }
+            } catch {
+                finishStreams()
+                return
+            }
+        }
+    }
+
+    private func cancelActiveTurnPolling() {
+        stateLock.lock()
+        let task = activeTurnPollingTask
+        activeTurnPollingTask = nil
+        stateLock.unlock()
+        task?.cancel()
+    }
+
+    private func clearActiveTurnPollingTask() {
+        stateLock.lock()
+        activeTurnPollingTask = nil
+        stateLock.unlock()
     }
 
     private func dispatch(_ event: ACPBrokerEvent, pendingRequestIds: Set<String>? = nil) {
+        stateLock.lock()
+        if dispatchedEventCursors.contains(event.cursor) {
+            stateLock.unlock()
+            return
+        }
+        dispatchedEventCursors.insert(event.cursor)
+        stateLock.unlock()
+
         switch event.kind {
         case .adapterNotification(let method, let params):
             dispatchAdapterNotification(method: method, params: params, cursor: event.cursor)
@@ -295,6 +357,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 elicitationCompletionsCont.yield(decoded)
             }
         case "adapter/exit":
+            cancelActiveTurnPolling()
             finishStreams()
         default:
             break
@@ -585,6 +648,17 @@ private struct AnyEncodableBrokerBox: Encodable {
 
     func encode(to encoder: Encoder) throws {
         try value.encode(to: encoder)
+    }
+}
+
+private extension ACPBrokerTurnState {
+    var needsActiveTurnPolling: Bool {
+        switch self {
+        case .sending, .streaming, .awaitingInput, .cancelling:
+            return true
+        case .idle, .completed, .ambiguous, .unknown:
+            return false
+        }
     }
 }
 

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -12,6 +12,12 @@ protocol ACPBrokerServicing: Sendable {
 
 extension LocalACPBrokerService: ACPBrokerServicing {}
 
+struct ACPBrokerDurableState: Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+    let acknowledgedCursor: ACPBrokerEventCursor
+}
+
 final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private let service: ACPBrokerServicing
     private let brokerId: ACPBrokerID
@@ -21,6 +27,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private let cwd: String
     private let env: [String: String]
     private let operationKeyPrefix: String
+    private let onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)?
 
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
@@ -60,7 +67,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         args: [String],
         cwd: String,
         env: [String: String],
-        operationKeyPrefix: String
+        operationKeyPrefix: String,
+        onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
     ) {
         self.service = service
         self.brokerId = brokerId
@@ -70,6 +78,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         self.cwd = cwd
         self.env = env
         self.operationKeyPrefix = operationKeyPrefix
+        self.onDurableStateChanged = onDurableStateChanged
 
         var u: AsyncStream<ACPSessionUpdateParams>.Continuation!
         incomingUpdates = AsyncStream { u = $0 }
@@ -365,14 +374,22 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private func ack(cursor: ACPBrokerEventCursor) {
         Task { [weak self] in
             guard let self, let generation = try? self.currentGeneration() else { return }
-            _ = try? await self.service.ack(ACPBrokerAckParams(
-                brokerId: self.brokerId,
-                generation: generation,
-                cursor: cursor
-            ))
+            do {
+                _ = try await self.service.ack(ACPBrokerAckParams(
+                    brokerId: self.brokerId,
+                    generation: generation,
+                    cursor: cursor
+                ))
+            } catch {
+                return
+            }
             self.stateLock.lock()
             self.acknowledgedCursor = max(self.acknowledgedCursor, cursor)
+            let state = self.durableStateLocked()
             self.stateLock.unlock()
+            if let state {
+                self.onDurableStateChanged?(state)
+            }
         }
     }
 
@@ -381,7 +398,11 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         generation = snapshot.metadata.generation
         acknowledgedCursor = max(acknowledgedCursor, snapshot.acknowledgedCursor)
         latestCursor = max(latestCursor, snapshot.journalTail)
+        let state = durableStateLocked()
         stateLock.unlock()
+        if let state {
+            onDurableStateChanged?(state)
+        }
     }
 
     private func currentGeneration() throws -> ACPBrokerGeneration {
@@ -408,6 +429,15 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         defer { stateLock.unlock() }
         nextOperationIndex += 1
         return ACPBrokerOperationKey(rawValue: "\(operationKeyPrefix):\(nextOperationIndex):\(method)")
+    }
+
+    private func durableStateLocked() -> ACPBrokerDurableState? {
+        guard let generation else { return nil }
+        return ACPBrokerDurableState(
+            brokerId: brokerId,
+            generation: generation,
+            acknowledgedCursor: acknowledgedCursor
+        )
     }
 }
 

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -49,12 +49,14 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private let stateLock = NSLock()
     private var generation: ACPBrokerGeneration?
     private var acknowledgedCursor = ACPBrokerEventCursor(rawValue: 0)
-    private var latestCursor = ACPBrokerEventCursor(rawValue: 0)
     private var initializeResult: ACPBrokerJSONValue?
     private var remoteSessionResult: ACPBrokerJSONValue?
     private var nextOperationIndex = 0
     private var _yieldedUpdateCount = 0
     private var pendingInboundCursors: [JSONRPCID: ACPBrokerEventCursor] = [:]
+    private var operationCompletionCursors: [ACPBrokerOperationKey: ACPBrokerEventCursor] = [:]
+    private var unacknowledgedDurableEventCursors: Set<ACPBrokerEventCursor> = []
+    private var deferredResponseAckCursors: Set<ACPBrokerEventCursor> = []
 
     var yieldedUpdateCount: Int {
         stateLock.lock()
@@ -152,11 +154,13 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 try await Task.sleep(for: .milliseconds(50))
                 continue
             }
-            let cursor = currentLatestCursor()
+            let cursor = currentOperationCompletionCursor(for: operationKey)
             return ACPResponse(
                 body: try (result.result ?? .null).data,
                 durableConsumptionAcknowledgement: { [weak self] in
-                    self?.ack(cursor: cursor)
+                    if let cursor {
+                        self?.ackResponse(cursor: cursor)
+                    }
                 }
             )
         }
@@ -235,15 +239,15 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     private func dispatch(_ event: ACPBrokerEvent) {
-        stateLock.lock()
-        latestCursor = max(latestCursor, event.cursor)
-        stateLock.unlock()
-
         switch event.kind {
         case .adapterNotification(let method, let params):
             dispatchAdapterNotification(method: method, params: params, cursor: event.cursor)
         case .pendingRequest(let request):
             dispatchPendingRequest(request, cursor: event.cursor)
+        case .operationCompleted(let operationKey, _):
+            stateLock.lock()
+            operationCompletionCursors[operationKey] = event.cursor
+            stateLock.unlock()
         default:
             break
         }
@@ -261,12 +265,13 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             }
             stateLock.lock()
             _yieldedUpdateCount += 1
+            unacknowledgedDurableEventCursors.insert(cursor)
             stateLock.unlock()
             updatesCont.yield(.init(
                 sessionId: decoded.sessionId,
                 update: decoded.update,
                 durableConsumptionAcknowledgement: { [weak self] in
-                    self?.ack(cursor: cursor)
+                    self?.ackDurableEvent(cursor: cursor)
                 }
             ))
         case "elicitation/complete":
@@ -286,15 +291,18 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
 
         switch request.kind {
         case .permission:
-            if let params = try? JSONDecoder().decode(ACPPermissionRequestParams.self, from: request.payload.data) {
+            let payload = pendingRequestParamsPayload(request.payload)
+            if let params = try? JSONDecoder().decode(ACPPermissionRequestParams.self, from: payload.data) {
                 permsCont.yield((id, params))
             }
         case .question:
-            if let params = try? JSONDecoder().decode(ACPQuestionRequestParams.self, from: request.payload.data) {
+            let payload = pendingRequestParamsPayload(request.payload)
+            if let params = try? JSONDecoder().decode(ACPQuestionRequestParams.self, from: payload.data) {
                 questionsCont.yield(.init(id: id, params: params))
             }
         case .elicitation:
-            if let params = try? JSONDecoder().decode(ACPElicitationRequestParams.self, from: request.payload.data) {
+            let payload = pendingRequestParamsPayload(request.payload)
+            if let params = try? JSONDecoder().decode(ACPElicitationRequestParams.self, from: payload.data) {
                 elicitationsCont.yield(.init(id: id, params: params))
             }
         case .file:
@@ -302,6 +310,17 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         case .terminal:
             dispatchTerminalRequest(id: id, payload: request.payload)
         }
+    }
+
+    private func pendingRequestParamsPayload(_ payload: ACPBrokerJSONValue) -> ACPBrokerJSONValue {
+        guard
+            case .object(let object) = payload,
+            object["method"] != nil,
+            let params = object["params"]
+        else {
+            return payload
+        }
+        return params
     }
 
     private func dispatchFileRequest(id: JSONRPCID, payload: ACPBrokerJSONValue) {
@@ -425,6 +444,41 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             if let state {
                 self.onDurableStateChanged?(state)
             }
+            self.flushDeferredResponseAcks()
+        }
+    }
+
+    private func ackDurableEvent(cursor: ACPBrokerEventCursor) {
+        stateLock.lock()
+        unacknowledgedDurableEventCursors.remove(cursor)
+        stateLock.unlock()
+        ack(cursor: cursor)
+    }
+
+    private func ackResponse(cursor: ACPBrokerEventCursor) {
+        stateLock.lock()
+        let shouldDefer = unacknowledgedDurableEventCursors.contains(where: { $0 < cursor })
+        if shouldDefer {
+            deferredResponseAckCursors.insert(cursor)
+            stateLock.unlock()
+            return
+        }
+        stateLock.unlock()
+        ack(cursor: cursor)
+    }
+
+    private func flushDeferredResponseAcks() {
+        let ready: [ACPBrokerEventCursor]
+        stateLock.lock()
+        ready = deferredResponseAckCursors
+            .filter { cursor in !unacknowledgedDurableEventCursors.contains(where: { $0 < cursor }) }
+            .sorted()
+        for cursor in ready {
+            deferredResponseAckCursors.remove(cursor)
+        }
+        stateLock.unlock()
+        for cursor in ready {
+            ack(cursor: cursor)
         }
     }
 
@@ -432,7 +486,6 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         stateLock.lock()
         generation = snapshot.metadata.generation
         acknowledgedCursor = max(acknowledgedCursor, snapshot.acknowledgedCursor)
-        latestCursor = max(latestCursor, snapshot.journalTail)
         initializeResult = snapshot.initializeResult ?? initializeResult
         remoteSessionResult = snapshot.remoteSessionResult ?? remoteSessionResult
         let state = durableStateLocked()
@@ -455,10 +508,10 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         return acknowledgedCursor
     }
 
-    private func currentLatestCursor() -> ACPBrokerEventCursor {
+    private func currentOperationCompletionCursor(for operationKey: ACPBrokerOperationKey) -> ACPBrokerEventCursor? {
         stateLock.lock()
         defer { stateLock.unlock() }
-        return latestCursor
+        return operationCompletionCursors[operationKey]
     }
 
     private func nextOperationKey(method: String) -> ACPBrokerOperationKey {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -55,6 +55,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var nextOperationIndex = 0
     private var _yieldedUpdateCount = 0
     private var pendingInboundCursors: [JSONRPCID: ACPBrokerEventCursor] = [:]
+    private var pendingOutboundRequestIds: Set<JSONRPCID> = []
     private var operationCompletionCursors: [ACPBrokerOperationKey: ACPBrokerEventCursor] = [:]
     private var unacknowledgedDurableEventCursors: Set<ACPBrokerEventCursor> = []
     private var deferredOrderedAckCursors: Set<ACPBrokerEventCursor> = []
@@ -159,14 +160,17 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 method: request.method,
                 params: params
             ))
+            markPendingOutboundRequest(id: result.requestId.jsonRPCID)
             try await attachAndReplay()
             if let error = result.error {
+                clearPendingOutboundRequest(id: result.requestId.jsonRPCID)
                 throw ACPClientError.jsonrpc(error)
             }
             if result.pending == true && result.result == nil {
                 try await Task.sleep(for: .milliseconds(50))
                 continue
             }
+            clearPendingOutboundRequest(id: result.requestId.jsonRPCID)
             let cursor = currentOperationCompletionCursor(for: operationKey)
             return ACPResponse(
                 body: try (result.result ?? .null).data,
@@ -221,7 +225,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     func hasPendingOutboundRequest(id: JSONRPCID) -> Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
-        return pendingInboundCursors[id] != nil
+        return pendingOutboundRequestIds.contains(id)
     }
 
     func shutdown() async {
@@ -577,6 +581,14 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         acknowledgedCursor = max(acknowledgedCursor, snapshot.acknowledgedCursor)
         initializeResult = snapshot.initializeResult ?? initializeResult
         remoteSessionResult = snapshot.remoteSessionResult ?? remoteSessionResult
+        for operation in snapshot.operations {
+            let id = operation.adapterRequestId.jsonRPCID
+            if operation.terminalOutcome == nil {
+                pendingOutboundRequestIds.insert(id)
+            } else {
+                pendingOutboundRequestIds.remove(id)
+            }
+        }
         let state = durableStateLocked()
         stateLock.unlock()
         if let state {
@@ -607,6 +619,18 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         stateLock.lock()
         defer { stateLock.unlock() }
         return operationCompletionCursors[operationKey]
+    }
+
+    private func markPendingOutboundRequest(id: JSONRPCID) {
+        stateLock.lock()
+        pendingOutboundRequestIds.insert(id)
+        stateLock.unlock()
+    }
+
+    private func clearPendingOutboundRequest(id: JSONRPCID) {
+        stateLock.lock()
+        pendingOutboundRequestIds.remove(id)
+        stateLock.unlock()
     }
 
     private func nextOperationKey(method: String) -> ACPBrokerOperationKey {
@@ -659,6 +683,12 @@ private extension ACPBrokerTurnState {
         case .idle, .completed, .ambiguous, .unknown:
             return false
         }
+    }
+}
+
+private extension ACPBrokerAdapterRequestID {
+    var jsonRPCID: JSONRPCID {
+        .number(Int(rawValue))
     }
 }
 

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -1,0 +1,491 @@
+import Foundation
+
+protocol ACPBrokerServicing: Sendable {
+    func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult
+    func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult
+    func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult
+    func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK
+    func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK
+    func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK
+    func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK
+}
+
+extension LocalACPBrokerService: ACPBrokerServicing {}
+
+final class ACPBrokerClient: ACPClient, @unchecked Sendable {
+    private let service: ACPBrokerServicing
+    private let brokerId: ACPBrokerID
+    private let sessionId: String
+    private let command: String
+    private let args: [String]
+    private let cwd: String
+    private let env: [String: String]
+    private let operationKeyPrefix: String
+
+    private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
+    private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
+    private let questionsCont: AsyncStream<ACPQuestionRequest>.Continuation
+    private let elicitationsCont: AsyncStream<ACPElicitationRequest>.Continuation
+    private let elicitationCompletionsCont: AsyncStream<ACPElicitationCompleteParams>.Continuation
+    private let filesCont: AsyncStream<ACPFileRequest>.Continuation
+    private let terminalsCont: AsyncStream<ACPTerminalRequest>.Continuation
+
+    let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
+    let permissionRequests: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>
+    let questionRequests: AsyncStream<ACPQuestionRequest>
+    let elicitationRequests: AsyncStream<ACPElicitationRequest>
+    let elicitationCompletions: AsyncStream<ACPElicitationCompleteParams>
+    let fileRequests: AsyncStream<ACPFileRequest>
+    let terminalRequests: AsyncStream<ACPTerminalRequest>
+
+    private let stateLock = NSLock()
+    private var generation: ACPBrokerGeneration?
+    private var acknowledgedCursor = ACPBrokerEventCursor(rawValue: 0)
+    private var latestCursor = ACPBrokerEventCursor(rawValue: 0)
+    private var nextOperationIndex = 0
+    private var _yieldedUpdateCount = 0
+    private var pendingInboundCursors: [JSONRPCID: ACPBrokerEventCursor] = [:]
+
+    var yieldedUpdateCount: Int {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _yieldedUpdateCount
+    }
+
+    init(
+        service: ACPBrokerServicing,
+        brokerId: ACPBrokerID,
+        sessionId: String,
+        command: String,
+        args: [String],
+        cwd: String,
+        env: [String: String],
+        operationKeyPrefix: String
+    ) {
+        self.service = service
+        self.brokerId = brokerId
+        self.sessionId = sessionId
+        self.command = command
+        self.args = args
+        self.cwd = cwd
+        self.env = env
+        self.operationKeyPrefix = operationKeyPrefix
+
+        var u: AsyncStream<ACPSessionUpdateParams>.Continuation!
+        incomingUpdates = AsyncStream { u = $0 }
+        updatesCont = u
+
+        var p: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation!
+        permissionRequests = AsyncStream { p = $0 }
+        permsCont = p
+
+        var q: AsyncStream<ACPQuestionRequest>.Continuation!
+        questionRequests = AsyncStream { q = $0 }
+        questionsCont = q
+
+        var e: AsyncStream<ACPElicitationRequest>.Continuation!
+        elicitationRequests = AsyncStream { e = $0 }
+        elicitationsCont = e
+
+        var ec: AsyncStream<ACPElicitationCompleteParams>.Continuation!
+        elicitationCompletions = AsyncStream { ec = $0 }
+        elicitationCompletionsCont = ec
+
+        var f: AsyncStream<ACPFileRequest>.Continuation!
+        fileRequests = AsyncStream { f = $0 }
+        filesCont = f
+
+        var t: AsyncStream<ACPTerminalRequest>.Continuation!
+        terminalRequests = AsyncStream { t = $0 }
+        terminalsCont = t
+    }
+
+    @discardableResult
+    func start() async throws -> ACPBrokerOpenResult {
+        let opened = try await service.open(ACPBrokerOpenParams(
+            brokerId: brokerId,
+            sessionId: sessionId,
+            command: command,
+            args: args,
+            cwd: cwd,
+            env: env
+        ))
+        setSnapshot(opened.snapshot)
+        try await attachAndReplay()
+        return opened
+    }
+
+    func send(_ request: ACPRequest) async throws -> ACPResponse {
+        let generation = try currentGeneration()
+        let result = try await service.send(ACPBrokerSendParams(
+            brokerId: brokerId,
+            generation: generation,
+            operationKey: nextOperationKey(method: request.method),
+            method: request.method,
+            params: try ACPBrokerJSONValue(encodable: request.params)
+        ))
+        try await attachAndReplay()
+        let cursor = currentLatestCursor()
+        return ACPResponse(
+            body: try (result.result ?? .null).data,
+            durableConsumptionAcknowledgement: { [weak self] in
+                self?.ack(cursor: cursor)
+            }
+        )
+    }
+
+    func notify(_ request: ACPRequest) async throws {
+        throw ACPClientError.decoding("Broker-backed ACP notifications are not supported yet: \(request.method)")
+    }
+
+    func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse) {
+        respond(id: id, value: response)
+    }
+
+    func respondToQuestion(id: JSONRPCID, response: ACPQuestionResponse) {
+        respond(id: id, value: response)
+    }
+
+    func respondToElicitation(
+        id: JSONRPCID,
+        result: Result<ACPElicitationResponse, JSONRPCError>
+    ) {
+        switch result {
+        case .success(let response):
+            respond(id: id, value: response)
+        case .failure(let error):
+            respond(id: id, value: JSONRPCFailureResult(error: error))
+        }
+    }
+
+    func respondToFileRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
+        respondToRawResult(id: id, result: result)
+    }
+
+    func respondToTerminalRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
+        respondToRawResult(id: id, result: result)
+    }
+
+    func hasPendingOutboundRequest(id: JSONRPCID) -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return pendingInboundCursors[id] != nil
+    }
+
+    func shutdown() async {
+        if let generation = try? currentGeneration() {
+            _ = try? await service.detach(ACPBrokerDetachParams(brokerId: brokerId, generation: generation))
+        }
+        updatesCont.finish()
+        permsCont.finish()
+        questionsCont.finish()
+        elicitationsCont.finish()
+        elicitationCompletionsCont.finish()
+        filesCont.finish()
+        terminalsCont.finish()
+    }
+
+    private func attachAndReplay() async throws {
+        let generation = try currentGeneration()
+        let cursor = currentAcknowledgedCursor()
+        let attached = try await service.attach(ACPBrokerAttachParams(
+            brokerId: brokerId,
+            generation: generation,
+            acknowledgedCursor: cursor
+        ))
+        setSnapshot(attached.snapshot)
+        for event in attached.events {
+            dispatch(event)
+        }
+    }
+
+    private func dispatch(_ event: ACPBrokerEvent) {
+        stateLock.lock()
+        latestCursor = max(latestCursor, event.cursor)
+        stateLock.unlock()
+
+        switch event.kind {
+        case .adapterNotification(let method, let params):
+            dispatchAdapterNotification(method: method, params: params, cursor: event.cursor)
+        case .pendingRequest(let request):
+            dispatchPendingRequest(request, cursor: event.cursor)
+        default:
+            break
+        }
+    }
+
+    private func dispatchAdapterNotification(
+        method: String,
+        params: ACPBrokerJSONValue,
+        cursor: ACPBrokerEventCursor
+    ) {
+        switch method {
+        case "session/update":
+            guard let decoded = try? JSONDecoder().decode(ACPSessionUpdateParams.self, from: params.data) else {
+                return
+            }
+            stateLock.lock()
+            _yieldedUpdateCount += 1
+            stateLock.unlock()
+            updatesCont.yield(.init(
+                sessionId: decoded.sessionId,
+                update: decoded.update,
+                durableConsumptionAcknowledgement: { [weak self] in
+                    self?.ack(cursor: cursor)
+                }
+            ))
+        case "elicitation/complete":
+            if let decoded = try? JSONDecoder().decode(ACPElicitationCompleteParams.self, from: params.data) {
+                elicitationCompletionsCont.yield(decoded)
+            }
+        default:
+            break
+        }
+    }
+
+    private func dispatchPendingRequest(_ request: ACPBrokerPendingRequest, cursor: ACPBrokerEventCursor) {
+        guard let id = request.adapterRequestId.jsonRPCID else { return }
+        stateLock.lock()
+        pendingInboundCursors[id] = cursor
+        stateLock.unlock()
+
+        switch request.kind {
+        case .permission:
+            if let params = try? JSONDecoder().decode(ACPPermissionRequestParams.self, from: request.payload.data) {
+                permsCont.yield((id, params))
+            }
+        case .question:
+            if let params = try? JSONDecoder().decode(ACPQuestionRequestParams.self, from: request.payload.data) {
+                questionsCont.yield(.init(id: id, params: params))
+            }
+        case .elicitation:
+            if let params = try? JSONDecoder().decode(ACPElicitationRequestParams.self, from: request.payload.data) {
+                elicitationsCont.yield(.init(id: id, params: params))
+            }
+        case .file:
+            dispatchFileRequest(id: id, payload: request.payload)
+        case .terminal:
+            dispatchTerminalRequest(id: id, payload: request.payload)
+        }
+    }
+
+    private func dispatchFileRequest(id: JSONRPCID, payload: ACPBrokerJSONValue) {
+        guard
+            case .object(let object) = payload,
+            case .string(let method)? = object["method"],
+            let params = object["params"]
+        else { return }
+        switch method {
+        case "fs/read_text_file":
+            if let decoded = try? JSONDecoder().decode(ACPFsReadParams.self, from: params.data) {
+                filesCont.yield(.read(id: id, params: decoded))
+            }
+        case "fs/write_text_file":
+            if let decoded = try? JSONDecoder().decode(ACPFsWriteParams.self, from: params.data) {
+                filesCont.yield(.write(id: id, params: decoded))
+            }
+        default:
+            break
+        }
+    }
+
+    private func dispatchTerminalRequest(id: JSONRPCID, payload: ACPBrokerJSONValue) {
+        guard
+            case .object(let object) = payload,
+            case .string(let method)? = object["method"],
+            let params = object["params"]
+        else { return }
+        switch method {
+        case "terminal/create":
+            if let decoded = try? JSONDecoder().decode(ACPTerminalCreateParams.self, from: params.data) {
+                terminalsCont.yield(.create(id: id, params: decoded))
+            }
+        case "terminal/output":
+            if let decoded = try? JSONDecoder().decode(ACPTerminalOutputParams.self, from: params.data) {
+                terminalsCont.yield(.output(id: id, params: decoded))
+            }
+        case "terminal/wait_for_exit":
+            if let decoded = try? JSONDecoder().decode(ACPTerminalIdParams.self, from: params.data) {
+                terminalsCont.yield(.waitForExit(id: id, params: decoded))
+            }
+        case "terminal/kill":
+            if let decoded = try? JSONDecoder().decode(ACPTerminalIdParams.self, from: params.data) {
+                terminalsCont.yield(.kill(id: id, params: decoded))
+            }
+        case "terminal/release":
+            if let decoded = try? JSONDecoder().decode(ACPTerminalIdParams.self, from: params.data) {
+                terminalsCont.yield(.release(id: id, params: decoded))
+            }
+        default:
+            break
+        }
+    }
+
+    private func respond<T: Encodable>(id: JSONRPCID, value: T) {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.respond(id: id, result: ACPBrokerJSONValue(encodable: value))
+            } catch {}
+        }
+    }
+
+    private func respondToRawResult(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                switch result {
+                case .success(let data):
+                    try await self.respond(id: id, result: ACPBrokerJSONValue(data: data))
+                case .failure(let error):
+                    try await self.respond(id: id, result: ACPBrokerJSONValue(encodable: JSONRPCFailureResult(error: error)))
+                }
+            } catch {}
+        }
+    }
+
+    private func respond(id: JSONRPCID, result: ACPBrokerJSONValue) async throws {
+        let generation = try currentGeneration()
+        guard let requestId = ACPBrokerAdapterRequestID(jsonRPCID: id) else { return }
+        _ = try await service.respond(ACPBrokerRespondParams(
+            brokerId: brokerId,
+            generation: generation,
+            requestId: requestId,
+            operationKey: nextOperationKey(method: "respond"),
+            result: result
+        ))
+        stateLock.lock()
+        let cursor = pendingInboundCursors.removeValue(forKey: id)
+        stateLock.unlock()
+        if let cursor {
+            ack(cursor: cursor)
+        }
+    }
+
+    private func ack(cursor: ACPBrokerEventCursor) {
+        Task { [weak self] in
+            guard let self, let generation = try? self.currentGeneration() else { return }
+            _ = try? await self.service.ack(ACPBrokerAckParams(
+                brokerId: self.brokerId,
+                generation: generation,
+                cursor: cursor
+            ))
+            self.stateLock.lock()
+            self.acknowledgedCursor = max(self.acknowledgedCursor, cursor)
+            self.stateLock.unlock()
+        }
+    }
+
+    private func setSnapshot(_ snapshot: ACPBrokerSnapshot) {
+        stateLock.lock()
+        generation = snapshot.metadata.generation
+        acknowledgedCursor = max(acknowledgedCursor, snapshot.acknowledgedCursor)
+        latestCursor = max(latestCursor, snapshot.journalTail)
+        stateLock.unlock()
+    }
+
+    private func currentGeneration() throws -> ACPBrokerGeneration {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard let generation else { throw ACPClientError.notRunning }
+        return generation
+    }
+
+    private func currentAcknowledgedCursor() -> ACPBrokerEventCursor {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return acknowledgedCursor
+    }
+
+    private func currentLatestCursor() -> ACPBrokerEventCursor {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return latestCursor
+    }
+
+    private func nextOperationKey(method: String) -> ACPBrokerOperationKey {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        nextOperationIndex += 1
+        return ACPBrokerOperationKey(rawValue: "\(operationKeyPrefix):\(nextOperationIndex):\(method)")
+    }
+}
+
+private struct JSONRPCFailureResult: Encodable {
+    let error: JSONRPCError
+}
+
+private struct AnyEncodableBrokerBox: Encodable {
+    let value: Encodable
+
+    init(_ value: Encodable) {
+        self.value = value
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
+private extension ACPBrokerJSONValue {
+    init(encodable value: Encodable?) throws {
+        guard let value else {
+            self = .null
+            return
+        }
+        let data = try JSONEncoder().encode(AnyEncodableBrokerBox(value))
+        try self.init(data: data)
+    }
+
+    init(data: Data) throws {
+        let object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        try self.init(jsonObject: object)
+    }
+
+    init(jsonObject: Any) throws {
+        switch jsonObject {
+        case is NSNull:
+            self = .null
+        case let value as Bool:
+            self = .bool(value)
+        case let value as Int:
+            self = .number(Double(value))
+        case let value as UInt:
+            self = .number(Double(value))
+        case let value as Double:
+            self = .number(value)
+        case let value as String:
+            self = .string(value)
+        case let value as [Any]:
+            self = .array(try value.map { try ACPBrokerJSONValue(jsonObject: $0) })
+        case let value as [String: Any]:
+            self = .object(try value.mapValues { try ACPBrokerJSONValue(jsonObject: $0) })
+        default:
+            throw ACPClientError.decoding("Unsupported broker JSON value: \(type(of: jsonObject))")
+        }
+    }
+
+    var jsonRPCID: JSONRPCID? {
+        switch self {
+        case .number(let value):
+            return .number(Int(value))
+        case .string(let value):
+            return .string(value)
+        default:
+            return nil
+        }
+    }
+}
+
+private extension ACPBrokerAdapterRequestID {
+    init?(jsonRPCID: JSONRPCID) {
+        switch jsonRPCID {
+        case .number(let value):
+            guard value >= 0 else { return nil }
+            self.init(rawValue: UInt64(value))
+        case .string(let value):
+            guard let parsed = UInt64(value) else { return nil }
+            self.init(rawValue: parsed)
+        }
+    }
+}

--- a/Alas/Sources/ACP/Broker/ACPBrokerProtocol.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerProtocol.swift
@@ -1,0 +1,438 @@
+import Foundation
+
+struct ACPBrokerID: RawRepresentable, Codable, Hashable, Sendable {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+struct ACPBrokerGeneration: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    let rawValue: UInt64
+
+    init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(UInt64.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    static func < (lhs: ACPBrokerGeneration, rhs: ACPBrokerGeneration) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+struct ACPBrokerEventCursor: RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    let rawValue: UInt64
+
+    init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(UInt64.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    static func < (lhs: ACPBrokerEventCursor, rhs: ACPBrokerEventCursor) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+struct ACPBrokerOperationKey: RawRepresentable, Codable, Hashable, Sendable {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+struct ACPBrokerAdapterRequestID: RawRepresentable, Codable, Hashable, Sendable {
+    let rawValue: UInt64
+
+    init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(UInt64.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+enum ACPBrokerTurnState: Equatable, Sendable {
+    case idle
+    case sending
+    case streaming
+    case awaitingInput
+    case cancelling
+    case completed
+    case ambiguous
+    case unknown(String)
+}
+
+extension ACPBrokerTurnState: Codable {
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        switch raw {
+        case "idle": self = .idle
+        case "sending": self = .sending
+        case "streaming": self = .streaming
+        case "awaitingInput": self = .awaitingInput
+        case "cancelling": self = .cancelling
+        case "completed": self = .completed
+        case "ambiguous": self = .ambiguous
+        default: self = .unknown(raw)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .idle: try container.encode("idle")
+        case .sending: try container.encode("sending")
+        case .streaming: try container.encode("streaming")
+        case .awaitingInput: try container.encode("awaitingInput")
+        case .cancelling: try container.encode("cancelling")
+        case .completed: try container.encode("completed")
+        case .ambiguous: try container.encode("ambiguous")
+        case .unknown(let raw): try container.encode(raw)
+        }
+    }
+}
+
+enum ACPBrokerPendingRequestKind: String, Codable, Equatable, Sendable {
+    case permission
+    case question
+    case elicitation
+    case file
+    case terminal
+}
+
+struct ACPBrokerMetadata: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+    let alasSessionId: String
+    let adapterProgram: String
+    let adapterArgs: [String]
+    let cwd: String
+    let envKeys: [String]
+    let createdAtMillis: UInt64
+}
+
+struct ACPBrokerPendingRequest: Codable, Equatable, Sendable {
+    let requestId: String
+    let adapterRequestId: ACPBrokerJSONValue
+    let kind: ACPBrokerPendingRequestKind
+    let payload: ACPBrokerJSONValue
+}
+
+struct ACPBrokerOperationSnapshot: Codable, Equatable, Sendable {
+    let operationKey: ACPBrokerOperationKey
+    let adapterRequestId: ACPBrokerAdapterRequestID
+    let method: String
+    let params: ACPBrokerJSONValue
+    let terminalResult: ACPBrokerJSONValue?
+}
+
+struct ACPBrokerSnapshot: Codable, Equatable, Sendable {
+    let metadata: ACPBrokerMetadata
+    let initializeResult: ACPBrokerJSONValue?
+    let remoteSessionResult: ACPBrokerJSONValue?
+    let turnState: ACPBrokerTurnState
+    let acknowledgedCursor: ACPBrokerEventCursor
+    let journalTail: ACPBrokerEventCursor
+    let pendingRequests: [ACPBrokerPendingRequest]
+    let operations: [ACPBrokerOperationSnapshot]
+}
+
+struct ACPBrokerEvent: Codable, Equatable, Sendable {
+    let cursor: ACPBrokerEventCursor
+    let kind: ACPBrokerEventKind
+}
+
+enum ACPBrokerEventKind: Equatable, Sendable {
+    case initialized(result: ACPBrokerJSONValue)
+    case remoteSessionReady(result: ACPBrokerJSONValue)
+    case turnStateChanged(state: ACPBrokerTurnState)
+    case pendingRequest(ACPBrokerPendingRequest)
+    case pendingRequestResolved(requestId: String, response: ACPBrokerJSONValue)
+    case operationStarted(
+        operationKey: ACPBrokerOperationKey,
+        adapterRequestId: ACPBrokerAdapterRequestID,
+        method: String,
+        params: ACPBrokerJSONValue
+    )
+    case operationCompleted(operationKey: ACPBrokerOperationKey, result: ACPBrokerJSONValue)
+    case adapterNotification(method: String, params: ACPBrokerJSONValue)
+    case unknown(type: String, payload: [String: ACPBrokerJSONValue])
+}
+
+extension ACPBrokerEventKind: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case result
+        case state
+        case request
+        case requestId
+        case response
+        case operationKey
+        case adapterRequestId
+        case method
+        case params
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "initialized":
+            self = .initialized(result: try container.decode(ACPBrokerJSONValue.self, forKey: .result))
+        case "remoteSessionReady":
+            self = .remoteSessionReady(result: try container.decode(ACPBrokerJSONValue.self, forKey: .result))
+        case "turnStateChanged":
+            self = .turnStateChanged(state: try container.decode(ACPBrokerTurnState.self, forKey: .state))
+        case "pendingRequest":
+            self = .pendingRequest(try container.decode(ACPBrokerPendingRequest.self, forKey: .request))
+        case "pendingRequestResolved":
+            self = .pendingRequestResolved(
+                requestId: try container.decode(String.self, forKey: .requestId),
+                response: try container.decode(ACPBrokerJSONValue.self, forKey: .response)
+            )
+        case "operationStarted":
+            self = .operationStarted(
+                operationKey: try container.decode(ACPBrokerOperationKey.self, forKey: .operationKey),
+                adapterRequestId: try container.decode(ACPBrokerAdapterRequestID.self, forKey: .adapterRequestId),
+                method: try container.decode(String.self, forKey: .method),
+                params: try container.decode(ACPBrokerJSONValue.self, forKey: .params)
+            )
+        case "operationCompleted":
+            self = .operationCompleted(
+                operationKey: try container.decode(ACPBrokerOperationKey.self, forKey: .operationKey),
+                result: try container.decode(ACPBrokerJSONValue.self, forKey: .result)
+            )
+        case "adapterNotification":
+            self = .adapterNotification(
+                method: try container.decode(String.self, forKey: .method),
+                params: try container.decode(ACPBrokerJSONValue.self, forKey: .params)
+            )
+        default:
+            let payload = try ACPBrokerJSONValue.object(from: decoder)
+            self = .unknown(type: type, payload: payload)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .initialized(let result):
+            try container.encode("initialized", forKey: .type)
+            try container.encode(result, forKey: .result)
+        case .remoteSessionReady(let result):
+            try container.encode("remoteSessionReady", forKey: .type)
+            try container.encode(result, forKey: .result)
+        case .turnStateChanged(let state):
+            try container.encode("turnStateChanged", forKey: .type)
+            try container.encode(state, forKey: .state)
+        case .pendingRequest(let request):
+            try container.encode("pendingRequest", forKey: .type)
+            try container.encode(request, forKey: .request)
+        case .pendingRequestResolved(let requestId, let response):
+            try container.encode("pendingRequestResolved", forKey: .type)
+            try container.encode(requestId, forKey: .requestId)
+            try container.encode(response, forKey: .response)
+        case .operationStarted(let operationKey, let adapterRequestId, let method, let params):
+            try container.encode("operationStarted", forKey: .type)
+            try container.encode(operationKey, forKey: .operationKey)
+            try container.encode(adapterRequestId, forKey: .adapterRequestId)
+            try container.encode(method, forKey: .method)
+            try container.encode(params, forKey: .params)
+        case .operationCompleted(let operationKey, let result):
+            try container.encode("operationCompleted", forKey: .type)
+            try container.encode(operationKey, forKey: .operationKey)
+            try container.encode(result, forKey: .result)
+        case .adapterNotification(let method, let params):
+            try container.encode("adapterNotification", forKey: .type)
+            try container.encode(method, forKey: .method)
+            try container.encode(params, forKey: .params)
+        case .unknown(let type, let payload):
+            try container.encode(type, forKey: .type)
+            var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+            for (key, value) in payload where key != "type" {
+                try dynamicContainer.encode(value, forKey: DynamicCodingKey(stringValue: key))
+            }
+        }
+    }
+}
+
+private struct DynamicCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+        return nil
+    }
+}
+
+struct ACPBrokerOpenParams: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let sessionId: String
+    let command: String
+    let args: [String]
+    let cwd: String
+    let env: [String: String]
+}
+
+struct ACPBrokerOpenResult: Codable, Equatable, Sendable {
+    let snapshot: ACPBrokerSnapshot
+    let adopted: Bool
+}
+
+struct ACPBrokerAttachParams: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+    let acknowledgedCursor: ACPBrokerEventCursor
+}
+
+struct ACPBrokerAttachResult: Codable, Equatable, Sendable {
+    let snapshot: ACPBrokerSnapshot
+    let events: [ACPBrokerEvent]
+}
+
+struct ACPBrokerSendParams: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+    let operationKey: ACPBrokerOperationKey
+    let method: String
+    let params: ACPBrokerJSONValue
+}
+
+struct ACPBrokerSendResult: Codable, Equatable, Sendable {
+    let requestId: ACPBrokerAdapterRequestID
+    let replayed: Bool
+    let result: ACPBrokerJSONValue?
+    let pending: Bool?
+}
+
+struct ACPBrokerRespondParams: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+    let requestId: ACPBrokerAdapterRequestID
+    let operationKey: ACPBrokerOperationKey
+    let result: ACPBrokerJSONValue
+}
+
+struct ACPBrokerSimpleOK: Codable, Equatable, Sendable {
+    let ok: Bool
+}
+
+struct ACPBrokerAckParams: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+    let cursor: ACPBrokerEventCursor
+}
+
+struct ACPBrokerDetachParams: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+}
+
+struct ACPBrokerCloseParams: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+}
+
+struct ACPBrokerListResult: Codable, Equatable, Sendable {
+    let brokers: [ACPBrokerSnapshot]
+}
+
+enum ACPBrokerJSONValue: Codable, Equatable, Sendable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([ACPBrokerJSONValue])
+    case object([String: ACPBrokerJSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let number = try? container.decode(Double.self) {
+            self = .number(number)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([ACPBrokerJSONValue].self) {
+            self = .array(array)
+        } else {
+            self = .object(try container.decode([String: ACPBrokerJSONValue].self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .bool(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        }
+    }
+
+    static func object(from decoder: Decoder) throws -> [String: ACPBrokerJSONValue] {
+        try [String: ACPBrokerJSONValue](from: decoder)
+    }
+
+    var data: Data {
+        get throws {
+            try JSONEncoder().encode(self)
+        }
+    }
+}

--- a/Alas/Sources/ACP/Broker/ACPBrokerProtocol.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerProtocol.swift
@@ -344,6 +344,13 @@ struct ACPBrokerSendParams: Codable, Equatable, Sendable {
     let params: ACPBrokerJSONValue
 }
 
+struct ACPBrokerNotifyParams: Codable, Equatable, Sendable {
+    let brokerId: ACPBrokerID
+    let generation: ACPBrokerGeneration
+    let method: String
+    let params: ACPBrokerJSONValue
+}
+
 struct ACPBrokerSendResult: Codable, Equatable, Sendable {
     let requestId: ACPBrokerAdapterRequestID
     let replayed: Bool

--- a/Alas/Sources/ACP/Broker/ACPBrokerProtocol.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerProtocol.swift
@@ -160,12 +160,17 @@ struct ACPBrokerPendingRequest: Codable, Equatable, Sendable {
     let payload: ACPBrokerJSONValue
 }
 
+struct ACPBrokerRPCOutcome: Codable, Equatable, Sendable {
+    let result: ACPBrokerJSONValue?
+    let error: JSONRPCError?
+}
+
 struct ACPBrokerOperationSnapshot: Codable, Equatable, Sendable {
     let operationKey: ACPBrokerOperationKey
     let adapterRequestId: ACPBrokerAdapterRequestID
     let method: String
     let params: ACPBrokerJSONValue
-    let terminalResult: ACPBrokerJSONValue?
+    let terminalOutcome: ACPBrokerRPCOutcome?
 }
 
 struct ACPBrokerSnapshot: Codable, Equatable, Sendable {
@@ -189,14 +194,14 @@ enum ACPBrokerEventKind: Equatable, Sendable {
     case remoteSessionReady(result: ACPBrokerJSONValue)
     case turnStateChanged(state: ACPBrokerTurnState)
     case pendingRequest(ACPBrokerPendingRequest)
-    case pendingRequestResolved(requestId: String, response: ACPBrokerJSONValue)
+    case pendingRequestResolved(requestId: String, response: ACPBrokerRPCOutcome)
     case operationStarted(
         operationKey: ACPBrokerOperationKey,
         adapterRequestId: ACPBrokerAdapterRequestID,
         method: String,
         params: ACPBrokerJSONValue
     )
-    case operationCompleted(operationKey: ACPBrokerOperationKey, result: ACPBrokerJSONValue)
+    case operationCompleted(operationKey: ACPBrokerOperationKey, outcome: ACPBrokerRPCOutcome)
     case adapterNotification(method: String, params: ACPBrokerJSONValue)
     case unknown(type: String, payload: [String: ACPBrokerJSONValue])
 }
@@ -213,6 +218,8 @@ extension ACPBrokerEventKind: Codable {
         case adapterRequestId
         case method
         case params
+        case outcome
+        case error
     }
 
     init(from decoder: Decoder) throws {
@@ -230,7 +237,7 @@ extension ACPBrokerEventKind: Codable {
         case "pendingRequestResolved":
             self = .pendingRequestResolved(
                 requestId: try container.decode(String.self, forKey: .requestId),
-                response: try container.decode(ACPBrokerJSONValue.self, forKey: .response)
+                response: try container.decode(ACPBrokerRPCOutcome.self, forKey: .response)
             )
         case "operationStarted":
             self = .operationStarted(
@@ -240,9 +247,14 @@ extension ACPBrokerEventKind: Codable {
                 params: try container.decode(ACPBrokerJSONValue.self, forKey: .params)
             )
         case "operationCompleted":
+            let outcome = try container.decodeIfPresent(ACPBrokerRPCOutcome.self, forKey: .outcome)
+                ?? ACPBrokerRPCOutcome(
+                    result: try container.decodeIfPresent(ACPBrokerJSONValue.self, forKey: .result),
+                    error: try container.decodeIfPresent(JSONRPCError.self, forKey: .error)
+                )
             self = .operationCompleted(
                 operationKey: try container.decode(ACPBrokerOperationKey.self, forKey: .operationKey),
-                result: try container.decode(ACPBrokerJSONValue.self, forKey: .result)
+                outcome: outcome
             )
         case "adapterNotification":
             self = .adapterNotification(
@@ -280,10 +292,10 @@ extension ACPBrokerEventKind: Codable {
             try container.encode(adapterRequestId, forKey: .adapterRequestId)
             try container.encode(method, forKey: .method)
             try container.encode(params, forKey: .params)
-        case .operationCompleted(let operationKey, let result):
+        case .operationCompleted(let operationKey, let outcome):
             try container.encode("operationCompleted", forKey: .type)
             try container.encode(operationKey, forKey: .operationKey)
-            try container.encode(result, forKey: .result)
+            try container.encode(outcome, forKey: .outcome)
         case .adapterNotification(let method, let params):
             try container.encode("adapterNotification", forKey: .type)
             try container.encode(method, forKey: .method)
@@ -355,15 +367,47 @@ struct ACPBrokerSendResult: Codable, Equatable, Sendable {
     let requestId: ACPBrokerAdapterRequestID
     let replayed: Bool
     let result: ACPBrokerJSONValue?
+    let error: JSONRPCError?
     let pending: Bool?
+
+    init(
+        requestId: ACPBrokerAdapterRequestID,
+        replayed: Bool,
+        result: ACPBrokerJSONValue? = nil,
+        error: JSONRPCError? = nil,
+        pending: Bool? = nil
+    ) {
+        self.requestId = requestId
+        self.replayed = replayed
+        self.result = result
+        self.error = error
+        self.pending = pending
+    }
 }
 
 struct ACPBrokerRespondParams: Codable, Equatable, Sendable {
     let brokerId: ACPBrokerID
     let generation: ACPBrokerGeneration
-    let requestId: ACPBrokerAdapterRequestID
+    let requestId: ACPBrokerJSONValue
     let operationKey: ACPBrokerOperationKey
-    let result: ACPBrokerJSONValue
+    let result: ACPBrokerJSONValue?
+    let error: JSONRPCError?
+
+    init(
+        brokerId: ACPBrokerID,
+        generation: ACPBrokerGeneration,
+        requestId: ACPBrokerJSONValue,
+        operationKey: ACPBrokerOperationKey,
+        result: ACPBrokerJSONValue? = nil,
+        error: JSONRPCError? = nil
+    ) {
+        self.brokerId = brokerId
+        self.generation = generation
+        self.requestId = requestId
+        self.operationKey = operationKey
+        self.result = result
+        self.error = error
+    }
 }
 
 struct ACPBrokerSimpleOK: Codable, Equatable, Sendable {

--- a/Alas/Sources/ACP/Broker/LocalACPBrokerService.swift
+++ b/Alas/Sources/ACP/Broker/LocalACPBrokerService.swift
@@ -75,6 +75,11 @@ actor LocalACPBrokerService {
         return try await client.sendACPBroker(params)
     }
 
+    func notify(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK {
+        try await verifyACPIfNeeded()
+        return try await client.notifyACPBroker(params)
+    }
+
     func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
         try await verifyACPIfNeeded()
         return try await client.respondACPBroker(params)

--- a/Alas/Sources/ACP/Broker/LocalACPBrokerService.swift
+++ b/Alas/Sources/ACP/Broker/LocalACPBrokerService.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+enum LocalACPBrokerServiceError: LocalizedError, Equatable {
+    case helperUnavailable(String)
+    case helperMissing(URL)
+    case helperNotExecutable(URL)
+    case helperDoesNotSupportACP
+
+    var errorDescription: String? {
+        switch self {
+        case .helperUnavailable(let message):
+            return message
+        case .helperMissing(let url):
+            return "Bundled Alas helper is missing at \(url.path)."
+        case .helperNotExecutable(let url):
+            return "Bundled Alas helper is not executable at \(url.path)."
+        case .helperDoesNotSupportACP:
+            return "Bundled Alas helper does not support ACP brokers."
+        }
+    }
+}
+
+actor LocalACPBrokerService {
+    private let client: RemoteHelperClient
+    private var verifiedACP = false
+
+    init(client: RemoteHelperClient) {
+        self.client = client
+    }
+
+    init(resourceURL: URL) throws {
+        let binary = try Self.resolveBundledHelper(resourceURL: resourceURL)
+        client = RemoteHelperClient(
+            host: "local",
+            transportFactory: {
+                JSONRPCStdioTransport(
+                    executable: binary,
+                    arguments: ["serve"],
+                    environment: nil,
+                    framing: .newline
+                )
+            }
+        )
+    }
+
+    static func resolveBundledHelper(resourceURL: URL) throws -> URL {
+        guard let binary = RemoteHelperInstaller.bundledBinaryPath(
+            os: .macos,
+            arch: RemoteHelperInstaller.localArch,
+            resourceURL: resourceURL
+        ) else {
+            throw LocalACPBrokerServiceError.helperUnavailable("No bundled helper exists for this Mac architecture.")
+        }
+        guard FileManager.default.fileExists(atPath: binary.path) else {
+            throw LocalACPBrokerServiceError.helperMissing(binary)
+        }
+        guard FileManager.default.isExecutableFile(atPath: binary.path) else {
+            throw LocalACPBrokerServiceError.helperNotExecutable(binary)
+        }
+        return binary
+    }
+
+    func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
+        try await verifyACPIfNeeded()
+        return try await client.openACPBroker(params)
+    }
+
+    func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
+        try await verifyACPIfNeeded()
+        return try await client.attachACPBroker(params)
+    }
+
+    func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        try await verifyACPIfNeeded()
+        return try await client.sendACPBroker(params)
+    }
+
+    func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
+        try await verifyACPIfNeeded()
+        return try await client.respondACPBroker(params)
+    }
+
+    func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK {
+        try await verifyACPIfNeeded()
+        return try await client.ackACPBroker(params)
+    }
+
+    func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
+        try await verifyACPIfNeeded()
+        return try await client.detachACPBroker(params)
+    }
+
+    func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
+        try await verifyACPIfNeeded()
+        return try await client.closeACPBroker(params)
+    }
+
+    func list() async throws -> ACPBrokerListResult {
+        try await verifyACPIfNeeded()
+        return try await client.listACPBroker()
+    }
+
+    nonisolated func shutdown() {
+        Task {
+            await client.shutdown()
+        }
+    }
+
+    private func verifyACPIfNeeded() async throws {
+        guard !verifiedACP else { return }
+        let hello = try await client.hello()
+        guard hello.capabilities.acp == true else {
+            throw LocalACPBrokerServiceError.helperDoesNotSupportACP
+        }
+        verifiedACP = true
+    }
+}
+
+actor LocalACPBrokerServicePool {
+    static let shared = LocalACPBrokerServicePool()
+
+    private var service: LocalACPBrokerService?
+
+    func service(resourceURL: URL) throws -> LocalACPBrokerService {
+        if let service {
+            return service
+        }
+        let next = try LocalACPBrokerService(resourceURL: resourceURL)
+        service = next
+        return next
+    }
+
+    func shutdown() {
+        service?.shutdown()
+        service = nil
+    }
+}

--- a/Alas/Sources/ACP/Protocol/ACPClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPClient.swift
@@ -82,6 +82,7 @@ protocol ACPClient: AnyObject {
     /// Terminal requests (`terminal/create`, `terminal/output`,
     /// `terminal/wait_for_exit`, `terminal/kill`, `terminal/release`).
     var terminalRequests: AsyncStream<ACPTerminalRequest> { get }
+    var advertisesTerminalCapability: Bool { get }
 
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse)
     func respondToQuestion(id: JSONRPCID, response: ACPQuestionResponse)
@@ -98,6 +99,8 @@ protocol ACPClient: AnyObject {
 }
 
 extension ACPClient {
+    var advertisesTerminalCapability: Bool { true }
+
     var elicitationRequests: AsyncStream<ACPElicitationRequest> {
         AsyncStream { $0.finish() }
     }

--- a/Alas/Sources/ACP/Protocol/ACPClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPClient.swift
@@ -5,8 +5,13 @@ typealias ACPDurableConsumptionAcknowledgement = @Sendable () -> Void
 struct ACPRequest {
     let method: String
     let params: Encodable?
-    init(method: String, params: Encodable? = nil) { self.method = method
-    self.params = params }
+    let brokerOperationKey: String?
+
+    init(method: String, params: Encodable? = nil, brokerOperationKey: String? = nil) {
+        self.method = method
+        self.params = params
+        self.brokerOperationKey = brokerOperationKey
+    }
 }
 
 struct ACPResponse {

--- a/Alas/Sources/ACP/Protocol/ACPClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPClient.swift
@@ -93,6 +93,7 @@ protocol ACPClient: AnyObject {
     func respondToTerminalRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>)
     func hasPendingOutboundRequest(id: JSONRPCID) -> Bool
 
+    func detach() async
     func shutdown() async
 }
 
@@ -111,6 +112,10 @@ extension ACPClient {
     ) {}
 
     func hasPendingOutboundRequest(id: JSONRPCID) -> Bool { true }
+
+    func detach() async {
+        await shutdown()
+    }
 }
 
 enum ACPFileRequest {

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -20,13 +20,14 @@ final class ACPConnection: @unchecked Sendable {
     /// Returns the initialize outcome advertised by the agent, defaulting
     /// missing prompt capability fields to false and missing auth methods to empty.
     @discardableResult
-    func initialize() async throws -> ACPInitializeOutcome {
+    func initialize(brokerOperationKey: String? = nil) async throws -> ACPInitializeOutcome {
         let req = ACPRequest(method: "initialize",
                              params: ACPInitializeParams(
                                 protocolVersion: ACPProtocolVersion.current,
                                 clientCapabilities: .init(
                                     fs: .init(readTextFile: true, writeTextFile: true),
-                                    terminal: client.advertisesTerminalCapability)))
+                                    terminal: client.advertisesTerminalCapability)),
+                             brokerOperationKey: brokerOperationKey)
         let resp = try await client.send(req)
         defer { resp.acknowledgeDurableConsumption() }
         let result = try JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
@@ -39,9 +40,14 @@ final class ACPConnection: @unchecked Sendable {
         )
     }
 
-    func newSession(cwd: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
+    func newSession(
+        cwd: String,
+        mcpServers: [ACPMCPServer],
+        brokerOperationKey: String? = nil
+    ) async throws -> ACPSessionNewResult {
         let req = ACPRequest(method: "session/new",
-                             params: ACPSessionNewParams(cwd: cwd, mcpServers: mcpServers))
+                             params: ACPSessionNewParams(cwd: cwd, mcpServers: mcpServers),
+                             brokerOperationKey: brokerOperationKey)
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
         guard !result.sessionId.isEmpty else {
@@ -62,19 +68,31 @@ final class ACPConnection: @unchecked Sendable {
         resp.acknowledgeDurableConsumption()
     }
 
-    func loadSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
+    func loadSession(
+        cwd: String,
+        sessionId: String,
+        mcpServers: [ACPMCPServer],
+        brokerOperationKey: String? = nil
+    ) async throws -> ACPSessionNewResult {
         let req = ACPRequest(method: "session/load",
-                             params: ACPSessionLoadParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers))
+                             params: ACPSessionLoadParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers),
+                             brokerOperationKey: brokerOperationKey)
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
         deferDurableSessionResponse(resp)
         return result.sessionId.isEmpty ? result.withSessionId(sessionId) : result
     }
 
-    func resumeSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
+    func resumeSession(
+        cwd: String,
+        sessionId: String,
+        mcpServers: [ACPMCPServer],
+        brokerOperationKey: String? = nil
+    ) async throws -> ACPSessionNewResult {
         let req = ACPRequest(
             method: "session/resume",
-            params: ACPSessionResumeParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers)
+            params: ACPSessionResumeParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers),
+            brokerOperationKey: brokerOperationKey
         )
         let resp = try await client.send(req)
         let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -26,7 +26,7 @@ final class ACPConnection: @unchecked Sendable {
                                 protocolVersion: ACPProtocolVersion.current,
                                 clientCapabilities: .init(
                                     fs: .init(readTextFile: true, writeTextFile: true),
-                                    terminal: true)))
+                                    terminal: client.advertisesTerminalCapability)))
         let resp = try await client.send(req)
         defer { resp.acknowledgeDurableConsumption() }
         let result = try JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -145,9 +145,10 @@ final class ACPConnection: @unchecked Sendable {
         return result?.configOptions ?? []
     }
 
-    func prompt(sessionId: String, blocks: [ACPContentBlock]) async throws {
+    func prompt(sessionId: String, blocks: [ACPContentBlock], brokerOperationKey: String? = nil) async throws {
         let resp = try await client.send(ACPRequest(method: "session/prompt",
-                                                    params: ACPSessionPromptParams(sessionId: sessionId, prompt: blocks)))
+                                                    params: ACPSessionPromptParams(sessionId: sessionId, prompt: blocks),
+                                                    brokerOperationKey: brokerOperationKey))
         resp.acknowledgeDurableConsumption()
     }
 

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -170,4 +170,6 @@ final class ACPConnection: @unchecked Sendable {
     }
 
     func shutdown() async { await client.shutdown() }
+
+    func detach() async { await client.detach() }
 }

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -163,11 +163,21 @@ final class ACPConnection: @unchecked Sendable {
         return result?.configOptions ?? []
     }
 
-    func prompt(sessionId: String, blocks: [ACPContentBlock], brokerOperationKey: String? = nil) async throws {
+    @discardableResult
+    func prompt(
+        sessionId: String,
+        blocks: [ACPContentBlock],
+        brokerOperationKey: String? = nil,
+        acknowledgeDurableConsumption: Bool = true
+    ) async throws -> ACPDurableConsumptionAcknowledgement? {
         let resp = try await client.send(ACPRequest(method: "session/prompt",
                                                     params: ACPSessionPromptParams(sessionId: sessionId, prompt: blocks),
                                                     brokerOperationKey: brokerOperationKey))
-        resp.acknowledgeDurableConsumption()
+        if acknowledgeDurableConsumption {
+            resp.acknowledgeDurableConsumption()
+            return nil
+        }
+        return resp.durableConsumptionAcknowledgement
     }
 
     func acknowledgeDurableSessionResponses() {

--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 final class ACPMockClient: ACPClient, @unchecked Sendable {
+    var advertisesTerminalCapability = true
+
     private(set) var sent: [ACPRequest] = []
     private var scripts: [String: (ACPRequest) throws -> Data] = [:]
     private var asyncScripts: [String: (ACPRequest) async throws -> Data] = [:]

--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -6,6 +6,7 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     private(set) var sent: [ACPRequest] = []
     private var scripts: [String: (ACPRequest) throws -> Data] = [:]
     private var asyncScripts: [String: (ACPRequest) async throws -> Data] = [:]
+    private var responseScripts: [String: (ACPRequest) async throws -> ACPResponse] = [:]
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
     private let questionsCont: AsyncStream<ACPQuestionRequest>.Continuation
@@ -58,6 +59,9 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
 
     func send(_ request: ACPRequest) async throws -> ACPResponse {
         sent.append(request)
+        if let script = responseScripts[request.method] {
+            return try await script(request)
+        }
         if let script = asyncScripts[request.method] {
             return ACPResponse(body: try await script(request))
         }
@@ -118,6 +122,10 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
 
     func script(method: String, _ handler: @escaping (ACPRequest) throws -> Data) {
         scripts[method] = handler
+    }
+
+    func scriptResponse(method: String, _ handler: @escaping (ACPRequest) async throws -> ACPResponse) {
+        responseScripts[method] = handler
     }
 
     func scriptAsync(method: String, _ handler: @escaping (ACPRequest) async throws -> Data) {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -855,9 +855,6 @@ final class ACPSession: ObservableObject, Identifiable {
 
         var item = queue.remove(at: idx)
         item.status = .pending
-        if item.lastError != nil {
-            item.advanceBrokerOperationAttempt()
-        }
         item.lastError = nil
 
         let insertAt = protectedPrefixCount
@@ -937,10 +934,13 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Roll the `.sending` head back to `.pending` with an error message.
     /// Used by the flusher's failure path. Keeps the item at the head so
     /// the user sees "Retry" on the bubble.
-    func setQueueHeadError(_ message: String) {
+    func setQueueHeadError(_ message: String, advancesBrokerOperationAttempt: Bool = false) {
         guard !queue.isEmpty else { return }
         var item = queue.removeFirst()
         item.status = .pending
+        if advancesBrokerOperationAttempt {
+            item.advanceBrokerOperationAttempt()
+        }
         item.lastError = message
 
         if let forcedId = forceSendAfterSendingHeadId,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -855,6 +855,9 @@ final class ACPSession: ObservableObject, Identifiable {
 
         var item = queue.remove(at: idx)
         item.status = .pending
+        if item.lastError != nil {
+            item.advanceBrokerOperationAttempt()
+        }
         item.lastError = nil
 
         let insertAt = protectedPrefixCount
@@ -876,6 +879,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if queue[idx].status == .sending { return }
         queue[idx].blocks = blocks
         queue[idx].draft = nil
+        queue[idx].advanceBrokerOperationAttempt()
     }
 
     /// Remove all `.pending` items; return the snapshot in original order so
@@ -910,10 +914,12 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Mark the head item `.sending`. Called by the flusher right before
     /// it spawns the prompt RPC. Clears any previous `lastError` so a
     /// retried item displays cleanly while in-flight.
-    func markQueueHeadSending() {
-        guard !queue.isEmpty, queue[0].status == .pending else { return }
+    @discardableResult
+    func markQueueHeadSending() -> String? {
+        guard !queue.isEmpty, queue[0].status == .pending else { return nil }
         queue[0].status = .sending
         queue[0].lastError = nil
+        return queue[0].brokerOperationKey
     }
 
     /// Pop the head only if it's currently `.sending`. Returns it. Used by

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1590,6 +1590,17 @@ final class ACPSessionManager: ObservableObject {
         return String(("local-" + String(sanitized)).prefix(160))
     }
 
+    private static func brokerStartupOperationKey(
+        sessionId: ACPSession.ID,
+        method: String,
+        remoteSessionId: String? = nil
+    ) -> String {
+        if let remoteSessionId, !remoteSessionId.isEmpty {
+            return "startup:\(sessionId):\(method):\(remoteSessionId)"
+        }
+        return "startup:\(sessionId):\(method)"
+    }
+
     private static func brokerCursor(from row: ACPSessionRow?) -> ACPBrokerEventCursor {
         let raw = row?.acpBrokerAcknowledgedCursor ?? 0
         guard raw > 0 else { return ACPBrokerEventCursor(rawValue: 0) }
@@ -2440,7 +2451,12 @@ extension ACPSessionManager {
             if firstRunAttach {
                 session.firstRunConnectingPhase = .initializing
             }
-            let initialized = try await connection.initialize()
+            let initialized = try await connection.initialize(
+                brokerOperationKey: Self.brokerStartupOperationKey(
+                    sessionId: sessionId,
+                    method: "initialize"
+                )
+            )
             session.promptCapabilities = initialized.promptCapabilities
             session.authMethods = initialized.authMethods
             let projectContext = mcpProjectContextProvider?()
@@ -2607,7 +2623,14 @@ extension ACPSessionManager {
                 session.firstRunConnectingPhase = .creatingSession
             }
             if freshlyCreated {
-                result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
+                result = try await connection.newSession(
+                    cwd: worktreePath,
+                    mcpServers: wireMCPServers,
+                    brokerOperationKey: Self.brokerStartupOperationKey(
+                        sessionId: sessionId,
+                        method: "session/new"
+                    )
+                )
                 createdFreshRemoteSession = true
             } else if let remoteId = session.remoteSessionId, !remoteId.isEmpty {
                 if session.hasConversationTranscript {
@@ -2617,7 +2640,15 @@ extension ACPSessionManager {
                 case .resume:
                     do {
                         result = try await connection.resumeSession(
-                            cwd: worktreePath, sessionId: remoteId, mcpServers: wireMCPServers)
+                            cwd: worktreePath,
+                            sessionId: remoteId,
+                            mcpServers: wireMCPServers,
+                            brokerOperationKey: Self.brokerStartupOperationKey(
+                                sessionId: sessionId,
+                                method: "session/resume",
+                                remoteSessionId: remoteId
+                            )
+                        )
                         runner.finishSuppressingLoadReplay(
                             throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                         )
@@ -2637,7 +2668,14 @@ extension ACPSessionManager {
                         guard session.origin == .alasCreated,
                               ACPAuthFailure.message(from: error) == nil
                         else { throw error }
-                        result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
+                        result = try await connection.newSession(
+                            cwd: worktreePath,
+                            mcpServers: wireMCPServers,
+                            brokerOperationKey: Self.brokerStartupOperationKey(
+                                sessionId: sessionId,
+                                method: "session/new"
+                            )
+                        )
                         createdFreshRemoteSession = true
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
@@ -2658,7 +2696,15 @@ extension ACPSessionManager {
                 case .loadStrict:
                     do {
                         result = try await connection.loadSession(
-                            cwd: worktreePath, sessionId: remoteId, mcpServers: wireMCPServers)
+                            cwd: worktreePath,
+                            sessionId: remoteId,
+                            mcpServers: wireMCPServers,
+                            brokerOperationKey: Self.brokerStartupOperationKey(
+                                sessionId: sessionId,
+                                method: "session/load",
+                                remoteSessionId: remoteId
+                            )
+                        )
                         runner.finishSuppressingLoadReplay(
                             throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                         )
@@ -2674,7 +2720,15 @@ extension ACPSessionManager {
                 case .loadWithRecovery:
                     do {
                         result = try await connection.loadSession(
-                            cwd: worktreePath, sessionId: remoteId, mcpServers: wireMCPServers)
+                            cwd: worktreePath,
+                            sessionId: remoteId,
+                            mcpServers: wireMCPServers,
+                            brokerOperationKey: Self.brokerStartupOperationKey(
+                                sessionId: sessionId,
+                                method: "session/load",
+                                remoteSessionId: remoteId
+                            )
+                        )
                         runner.finishSuppressingLoadReplay(
                             throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                         )
@@ -2688,7 +2742,14 @@ extension ACPSessionManager {
                         if ACPAuthFailure.message(from: error) != nil {
                             throw error
                         }
-                        result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
+                        result = try await connection.newSession(
+                            cwd: worktreePath,
+                            mcpServers: wireMCPServers,
+                            brokerOperationKey: Self.brokerStartupOperationKey(
+                                sessionId: sessionId,
+                                method: "session/new"
+                            )
+                        )
                         createdFreshRemoteSession = true
                         if session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
@@ -2713,7 +2774,14 @@ extension ACPSessionManager {
                     throw ACPSessionAttachError.remoteSessionUnsupported
                 }
             } else {
-                result = try await connection.newSession(cwd: worktreePath, mcpServers: wireMCPServers)
+                result = try await connection.newSession(
+                    cwd: worktreePath,
+                    mcpServers: wireMCPServers,
+                    brokerOperationKey: Self.brokerStartupOperationKey(
+                        sessionId: sessionId,
+                        method: "session/new"
+                    )
+                )
                 createdFreshRemoteSession = true
                 if session.hasConversationTranscript {
                     shouldHoldQueueForRecovery = true

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2900,7 +2900,11 @@ extension ACPSessionManager {
             session.contextRestoreWarning = restoreWarning
             guard await persistSessionRemoteId(session) else {
                 session.remoteSessionId = persistedRows[sessionId]?.remoteSessionId
-                await connection.shutdown()
+                if isDisposed {
+                    await connection.shutdown()
+                } else {
+                    await connection.detach()
+                }
                 startedRunner?.stop()
                 await startedRunner?.flushPersistence()
                 session.agentState = .idle

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2000,7 +2000,7 @@ extension ACPSessionManager {
             runner.invalidateActivePrompt()
             runner.stop()
             await runner.flushPersistence()
-            await runner.connection.shutdown()
+            await runner.connection.detach()
         }
         autoReconnectTasks.removeValue(forKey: sessionId)?.cancel()
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1558,6 +1558,7 @@ final class ACPSessionManager: ObservableObject {
         service: ACPBrokerServicing,
         launchSpec: ACPLaunchSpec,
         sessionId: ACPSession.ID,
+        session: ACPSession,
         environment: [String: String]
     ) async throws -> ACPConnection {
         let brokerId = ACPBrokerID(rawValue: persistedRows[sessionId]?.acpBrokerId ?? Self.defaultBrokerId(
@@ -1578,9 +1579,16 @@ final class ACPSessionManager: ObservableObject {
                 Task { @MainActor [weak self] in
                     self?.persistACPBrokerState(sessionId: sessionId, state: state)
                 }
+            },
+            onTurnStateChanged: { [weak self] turnState in
+                Task { @MainActor [weak self] in
+                    guard let session = self?.sessions[sessionId] else { return }
+                    Self.applyBrokerTurnState(turnState, to: session)
+                }
             }
         )
         try await client.start()
+        Self.applyBrokerTurnState(client.currentTurnState, to: session)
         return ACPConnection(client: client)
     }
 
@@ -1599,6 +1607,19 @@ final class ACPSessionManager: ObservableObject {
             return "startup:\(sessionId):\(method):\(remoteSessionId)"
         }
         return "startup:\(sessionId):\(method)"
+    }
+
+    private static func applyBrokerTurnState(_ turnState: ACPBrokerTurnState, to session: ACPSession) {
+        switch turnState {
+        case .sending, .cancelling:
+            session.transcript.streamingState = .sending
+        case .streaming:
+            session.transcript.streamingState = .streaming
+        case .awaitingInput:
+            session.transcript.streamingState = .awaitingInput
+        case .idle, .completed, .ambiguous, .unknown:
+            session.transcript.streamingState = .idle
+        }
     }
 
     private static func brokerCursor(from row: ACPSessionRow?) -> ACPBrokerEventCursor {
@@ -2383,6 +2404,7 @@ extension ACPSessionManager {
                     service: try await brokerServiceFactory(),
                     launchSpec: launchSpec,
                     sessionId: sessionId,
+                    session: session,
                     environment: agentEnvironment
                 )
             } else {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1157,7 +1157,9 @@ final class ACPSessionManager: ObservableObject {
                 && row.acpBrokerGeneration == generation
             row.acpBrokerId = state.brokerId.rawValue
             row.acpBrokerGeneration = generation
-            row.acpBrokerAcknowledgedCursor = max(row.acpBrokerAcknowledgedCursor, acknowledgedCursor)
+            row.acpBrokerAcknowledgedCursor = matchesCurrentGeneration
+                ? max(row.acpBrokerAcknowledgedCursor, acknowledgedCursor)
+                : acknowledgedCursor
             persistedRows[sessionId] = row
             replaceRecentRow(row)
         } else {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2397,7 +2397,6 @@ extension ACPSessionManager {
         // a delegated session (`launchSpec` itself is scoped to this
         // `do` block, so its `extraEnv` is captured here for later use).
         var cliParentSessionId: String?
-        var effectiveLaunchSpec = spec
         let agentEnvironment: [String: String]
         do {
             let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
@@ -2407,7 +2406,6 @@ extension ACPSessionManager {
                 cliEnvActive = true
                 cliParentSessionId = launchSpec.extraEnv["ALAS_PARENT_SESSION_ID"]
             }
-            effectiveLaunchSpec = launchSpec
             agentEnvironment = ACPProcessEnvironment.sanitizedForACP(extra: launchSpec.extraEnv)
             if let injectedConnectionFactory {
                 connection = try injectedConnectionFactory(launchSpec, host, worktreePath)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1570,6 +1570,7 @@ final class ACPSessionManager: ObservableObject {
             cwd: worktreePath,
             env: environment,
             operationKeyPrefix: "\(instanceId):\(sessionId):\(UUID().uuidString)",
+            initialBrokerGeneration: Self.brokerGeneration(from: persistedRows[sessionId]),
             initialAcknowledgedCursor: Self.brokerCursor(from: persistedRows[sessionId]),
             onDurableStateChanged: { [weak self] state in
                 Task { @MainActor [weak self] in
@@ -1591,6 +1592,11 @@ final class ACPSessionManager: ObservableObject {
         let raw = row?.acpBrokerAcknowledgedCursor ?? 0
         guard raw > 0 else { return ACPBrokerEventCursor(rawValue: 0) }
         return ACPBrokerEventCursor(rawValue: UInt64(raw))
+    }
+
+    private static func brokerGeneration(from row: ACPSessionRow?) -> ACPBrokerGeneration? {
+        guard let raw = row?.acpBrokerGeneration, raw > 0 else { return nil }
+        return ACPBrokerGeneration(rawValue: UInt64(raw))
     }
 
     private static func makeDefaultConnection(

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -27,6 +27,7 @@ final class ACPSessionManager: ObservableObject {
         _ host: String?,
         _ worktreePath: String
     ) throws -> ACPConnection
+    typealias ACPBrokerServiceFactory = @MainActor () async throws -> ACPBrokerServicing
     typealias MCPProjectContextProvider = @MainActor () -> MCPProjectContext?
     typealias BuiltInMCPProvider = @MainActor (
         _ worktreePath: String,
@@ -276,6 +277,7 @@ final class ACPSessionManager: ObservableObject {
     private let remoteAdapterResolver: ACPRemoteAdapterResolver
     private let connectionFactory: ACPConnectionFactory
     private let injectedConnectionFactory: ACPConnectionFactory?
+    private let brokerServiceFactory: ACPBrokerServiceFactory?
     private var resolvedRemoteAdapters: [String: ACPResolvedRemoteAdapter] = [:]
     private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
     /// Per-session task that prepends pre-tail messages after the initial
@@ -340,6 +342,7 @@ final class ACPSessionManager: ObservableObject {
          setupEvaluator: ACPSetupEvaluator? = nil,
          remoteAdapterResolver: ACPRemoteAdapterResolver? = nil,
          connectionFactory: ACPConnectionFactory? = nil,
+         brokerServiceFactory: ACPBrokerServiceFactory? = nil,
          mcpProjectContextProvider: MCPProjectContextProvider? = nil,
          builtInMCPProvider: BuiltInMCPProvider? = nil)
     {
@@ -374,6 +377,7 @@ final class ACPSessionManager: ObservableObject {
         }
         self.injectedConnectionFactory = connectionFactory
         self.connectionFactory = connectionFactory ?? Self.makeStdioConnection
+        self.brokerServiceFactory = brokerServiceFactory
         let initialRecent = store.flatMap { try? $0.recentSessions() } ?? []
         self.recent = initialRecent
         self.persistedRows = Dictionary(uniqueKeysWithValues: initialRecent.map { ($0.id, $0) })
@@ -1117,6 +1121,11 @@ final class ACPSessionManager: ObservableObject {
         }
     }
 
+    private static func sqliteBrokerInt64(_ value: UInt64) -> Int64? {
+        guard value <= UInt64(Int64.max) else { return nil }
+        return Int64(value)
+    }
+
     private func resetHelperProcOffsets(sessionId: ACPSession.ID) async {
         guard !isMirror(sessionId: sessionId) else { return }
         if var row = persistedRows[sessionId] {
@@ -1132,6 +1141,44 @@ final class ACPSessionManager: ObservableObject {
             )
         }
         await task.value
+    }
+
+    private func persistACPBrokerState(sessionId: ACPSession.ID, state: ACPBrokerDurableState) {
+        guard !isMirror(sessionId: sessionId) else { return }
+        guard let generation = Self.sqliteBrokerInt64(state.generation.rawValue),
+              let acknowledgedCursor = Self.sqliteBrokerInt64(state.acknowledgedCursor.rawValue)
+        else {
+            persistenceError = "ACP broker cursor state is out of SQLite Int64 range."
+            return
+        }
+        let matchesCurrentGeneration: Bool
+        if var row = persistedRows[sessionId] {
+            matchesCurrentGeneration = row.acpBrokerId == state.brokerId.rawValue
+                && row.acpBrokerGeneration == generation
+            row.acpBrokerId = state.brokerId.rawValue
+            row.acpBrokerGeneration = generation
+            row.acpBrokerAcknowledgedCursor = max(row.acpBrokerAcknowledgedCursor, acknowledgedCursor)
+            persistedRows[sessionId] = row
+            replaceRecentRow(row)
+        } else {
+            matchesCurrentGeneration = false
+        }
+        let fence = leaseFence(sessionId: sessionId)
+        enqueuePersistence { persistence in
+            if matchesCurrentGeneration {
+                _ = try await persistence.updateACPBrokerAcknowledgedCursor(
+                    sessionId: sessionId,
+                    state: state,
+                    fence: fence
+                )
+            } else {
+                _ = try await persistence.updateACPBrokerState(
+                    sessionId: sessionId,
+                    state: state,
+                    fence: fence
+                )
+            }
+        }
     }
 
     /// Rename a session with the given title and source. Updates both
@@ -1503,6 +1550,47 @@ final class ACPSessionManager: ObservableObject {
             sessionId: nil,
             useHelperProc: false
         )
+    }
+
+    private func makeBrokerConnection(
+        service: ACPBrokerServicing,
+        launchSpec: ACPLaunchSpec,
+        sessionId: ACPSession.ID,
+        environment: [String: String]
+    ) async throws -> ACPConnection {
+        let brokerId = ACPBrokerID(rawValue: persistedRows[sessionId]?.acpBrokerId ?? Self.defaultBrokerId(
+            for: sessionId
+        ))
+        let client = ACPBrokerClient(
+            service: service,
+            brokerId: brokerId,
+            sessionId: sessionId,
+            command: launchSpec.command,
+            args: launchSpec.arguments,
+            cwd: worktreePath,
+            env: environment,
+            operationKeyPrefix: "\(instanceId):\(sessionId):\(UUID().uuidString)",
+            initialAcknowledgedCursor: Self.brokerCursor(from: persistedRows[sessionId]),
+            onDurableStateChanged: { [weak self] state in
+                Task { @MainActor [weak self] in
+                    self?.persistACPBrokerState(sessionId: sessionId, state: state)
+                }
+            }
+        )
+        try await client.start()
+        return ACPConnection(client: client)
+    }
+
+    private static func defaultBrokerId(for sessionId: ACPSession.ID) -> String {
+        let allowed = Set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+        let sanitized = sessionId.map { allowed.contains($0) ? $0 : "_" }
+        return String(("local-" + String(sanitized)).prefix(160))
+    }
+
+    private static func brokerCursor(from row: ACPSessionRow?) -> ACPBrokerEventCursor {
+        let raw = row?.acpBrokerAcknowledgedCursor ?? 0
+        guard raw > 0 else { return ACPBrokerEventCursor(rawValue: 0) }
+        return ACPBrokerEventCursor(rawValue: UInt64(raw))
     }
 
     private static func makeDefaultConnection(
@@ -2258,6 +2346,7 @@ extension ACPSessionManager {
         // `do` block, so its `extraEnv` is captured here for later use).
         var cliParentSessionId: String?
         var effectiveLaunchSpec = spec
+        let agentEnvironment: [String: String]
         do {
             let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
             var launchSpec = await resolvedLaunchSpec(for: spec, host: host)
@@ -2267,8 +2356,16 @@ extension ACPSessionManager {
                 cliParentSessionId = launchSpec.extraEnv["ALAS_PARENT_SESSION_ID"]
             }
             effectiveLaunchSpec = launchSpec
+            agentEnvironment = ACPProcessEnvironment.sanitizedForACP(extra: launchSpec.extraEnv)
             if let injectedConnectionFactory {
                 connection = try injectedConnectionFactory(launchSpec, host, worktreePath)
+            } else if host == nil, let brokerServiceFactory {
+                connection = try await makeBrokerConnection(
+                    service: try await brokerServiceFactory(),
+                    launchSpec: launchSpec,
+                    sessionId: sessionId,
+                    environment: agentEnvironment
+                )
             } else {
                 let useHelperProc = if let host {
                     await remoteHelperSupportsProc(host: host)
@@ -2338,7 +2435,6 @@ extension ACPSessionManager {
             let initialized = try await connection.initialize()
             session.promptCapabilities = initialized.promptCapabilities
             session.authMethods = initialized.authMethods
-            let agentEnvironment = ACPProcessEnvironment.sanitizedForACP(extra: effectiveLaunchSpec.extraEnv)
             let projectContext = mcpProjectContextProvider?()
                 ?? MCPProjectContext(projectDirectory: worktreePath, configuredServers: [])
             let mcpPlan = MCPAttachmentPlanner.plan(.init(

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1582,8 +1582,11 @@ final class ACPSessionManager: ObservableObject {
             },
             onTurnStateChanged: { [weak self] turnState in
                 Task { @MainActor [weak self] in
-                    guard let session = self?.sessions[sessionId] else { return }
+                    guard let self, let session = self.sessions[sessionId] else { return }
                     Self.applyBrokerTurnState(turnState, to: session)
+                    if Self.brokerTurnStateAllowsQueueFlush(turnState) {
+                        self.runners[sessionId]?.flushQueueIfIdle()
+                    }
                 }
             }
         )
@@ -1619,6 +1622,15 @@ final class ACPSessionManager: ObservableObject {
             session.transcript.streamingState = .awaitingInput
         case .idle, .completed, .ambiguous, .unknown:
             session.transcript.streamingState = .idle
+        }
+    }
+
+    private static func brokerTurnStateAllowsQueueFlush(_ turnState: ACPBrokerTurnState) -> Bool {
+        switch turnState {
+        case .idle, .completed, .ambiguous, .unknown:
+            return true
+        case .sending, .streaming, .awaitingInput, .cancelling:
+            return false
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2788,7 +2788,11 @@ extension ACPSessionManager {
                 shouldAbortAttach = !(await confirmedWriterLease(for: sessionId))
             }
             if shouldAbortAttach {
-                await connection.shutdown()
+                if isDisposed {
+                    await connection.shutdown()
+                } else {
+                    await connection.detach()
+                }
                 startedRunner?.stop()
                 await startedRunner?.flushPersistence()
                 session.agentState = .idle

--- a/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
@@ -1,6 +1,17 @@
 import Foundation
 import SQLite3
 
+private enum ACPSessionPersistenceError: Error, LocalizedError {
+    case brokerValueOutOfRange(field: String, value: UInt64)
+
+    var errorDescription: String? {
+        switch self {
+        case .brokerValueOutOfRange(let field, let value):
+            return "ACP broker \(field) is out of SQLite Int64 range: \(value)"
+        }
+    }
+}
+
 /// Serial, off-main owner of a worktree's writable ACP session store.
 ///
 /// The initializer only records a path. Opening SQLite and running migrations
@@ -147,6 +158,72 @@ actor ACPSessionPersistence {
         let operation = { try store.resetHelperProcOffsets(sessionId: sessionId) }
         if let fence { return try store.withLeaseFence(fence, operation) ?? false }
         return try operation()
+    }
+
+    @discardableResult
+    func updateACPBrokerState(
+        sessionId: String,
+        state: ACPBrokerDurableState,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let generation = try sqliteBrokerInt64(state.generation.rawValue, field: "generation")
+        let acknowledgedCursor = try sqliteBrokerInt64(
+            state.acknowledgedCursor.rawValue,
+            field: "acknowledged cursor"
+        )
+        let operation = {
+            try store.updateACPBrokerState(
+                sessionId: sessionId,
+                brokerId: state.brokerId.rawValue,
+                generation: generation,
+                acknowledgedCursor: acknowledgedCursor
+            )
+        }
+        if let fence { return try store.withLeaseFence(fence, operation) ?? false }
+        return try operation()
+    }
+
+    @discardableResult
+    func updateACPBrokerAcknowledgedCursor(
+        sessionId: String,
+        state: ACPBrokerDurableState,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let generation = try sqliteBrokerInt64(state.generation.rawValue, field: "generation")
+        let acknowledgedCursor = try sqliteBrokerInt64(
+            state.acknowledgedCursor.rawValue,
+            field: "acknowledged cursor"
+        )
+        let operation = {
+            try store.updateACPBrokerAcknowledgedCursor(
+                sessionId: sessionId,
+                brokerId: state.brokerId.rawValue,
+                generation: generation,
+                cursor: acknowledgedCursor
+            )
+        }
+        if let fence { return try store.withLeaseFence(fence, operation) ?? false }
+        return try operation()
+    }
+
+    @discardableResult
+    func clearACPBrokerState(
+        sessionId: String,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = { try store.clearACPBrokerState(sessionId: sessionId) }
+        if let fence { return try store.withLeaseFence(fence, operation) ?? false }
+        return try operation()
+    }
+
+    private func sqliteBrokerInt64(_ value: UInt64, field: String) throws -> Int64 {
+        guard value <= UInt64(Int64.max) else {
+            throw ACPSessionPersistenceError.brokerValueOutOfRange(field: field, value: value)
+        }
+        return Int64(value)
     }
 
     @discardableResult

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1325,9 +1325,14 @@ extension ACPSessionRunner {
               head.lastError == nil
         else { return }
         if case .needsAuth = session.setupState { return }
-        session.markQueueHeadSending()
+        let brokerOperationKey = session.markQueueHeadSending()
         persistQueue()
-        sendNow(blocks: head.blocks, queuedItemId: head.id, delegatedSource: head.delegatedSource)
+        sendNow(
+            blocks: head.blocks,
+            queuedItemId: head.id,
+            delegatedSource: head.delegatedSource,
+            brokerOperationKey: brokerOperationKey
+        )
     }
 
     /// User clicked the row-local "send now" affordance for a queued item.
@@ -1473,6 +1478,7 @@ extension ACPSessionRunner {
         blocks: [ACPContentBlock],
         queuedItemId: UUID?,
         delegatedSource: ACPDelegatedPromptSource? = nil,
+        brokerOperationKey: String? = nil,
         recordUserPrompt: Bool = true,
         draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
@@ -1582,7 +1588,11 @@ extension ACPSessionRunner {
                 guard await self.hasConfirmedLeaseForSideEffect() else {
                     throw CancellationError()
                 }
-                try await self.connection.prompt(sessionId: remoteId, blocks: wireBlocks)
+                try await self.connection.prompt(
+                    sessionId: remoteId,
+                    blocks: wireBlocks,
+                    brokerOperationKey: brokerOperationKey
+                )
                 await MainActor.run {
                     let isActivePrompt = self.activePromptID == promptID
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1635,7 +1635,17 @@ extension ACPSessionRunner {
                             // at the head with lastError so the bubble shows
                             // Retry. Cancelled queued sends had the item
                             // discarded elsewhere (steer) and don't surface.
-                            self.session.setQueueHeadError(errorMessage)
+                            let terminalBrokerFailure: Bool = {
+                                guard brokerOperationKey != nil else { return false }
+                                if case ACPClientError.jsonrpc = error {
+                                    return true
+                                }
+                                return false
+                            }()
+                            self.session.setQueueHeadError(
+                                errorMessage,
+                                advancesBrokerOperationAttempt: terminalBrokerFailure
+                            )
                             self.persistQueue()
                         } else if queuedItemId != nil, authReason != nil {
                             self.session.restoreQueue(self.session.queue)

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1271,17 +1271,31 @@ extension ACPSessionRunner {
     /// swallowed — the same pattern as transcript persistence; surfacing
     /// would block the UI for a transient SQLite error and we'd rather
     /// lose a queue snapshot than the user's draft.
-    func persistQueue() {
+    func persistQueue(acknowledging acknowledgement: ACPDurableConsumptionAcknowledgement? = nil) {
         guard holdsLeaseForWrite() else { return }
         let items = session.queue
         let fence = leaseFenceProvider()
         let sessionId = sessionId
-        enqueuePersistence { persistence in
-            _ = try await persistence.upsertQueue(
-                sessionId: sessionId,
-                items: items,
-                fence: fence
-            )
+        if let acknowledgement {
+            enqueuePersistence({ persistence in
+                try await persistence.upsertQueue(
+                    sessionId: sessionId,
+                    items: items,
+                    fence: fence
+                )
+            }, completion: { persisted in
+                if persisted == true {
+                    acknowledgement()
+                }
+            })
+        } else {
+            enqueuePersistence { persistence in
+                _ = try await persistence.upsertQueue(
+                    sessionId: sessionId,
+                    items: items,
+                    fence: fence
+                )
+            }
         }
     }
 
@@ -1588,10 +1602,11 @@ extension ACPSessionRunner {
                 guard await self.hasConfirmedLeaseForSideEffect() else {
                     throw CancellationError()
                 }
-                try await self.connection.prompt(
+                let promptAcknowledgement = try await self.connection.prompt(
                     sessionId: remoteId,
                     blocks: wireBlocks,
-                    brokerOperationKey: brokerOperationKey
+                    brokerOperationKey: brokerOperationKey,
+                    acknowledgeDurableConsumption: queuedItemId == nil
                 )
                 await MainActor.run {
                     let isActivePrompt = self.activePromptID == promptID
@@ -1609,7 +1624,7 @@ extension ACPSessionRunner {
                     if isActivePrompt {
                         if queuedItemId != nil {
                             _ = self.session.popQueueHead()
-                            self.persistQueue()
+                            self.persistQueue(acknowledging: promptAcknowledgement)
                         }
                         self.activePromptID = nil
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -357,10 +357,12 @@ extension ACPSessionStore {
             helper_proc_stderr_offset = COALESCE(excluded.helper_proc_stderr_offset, sessions.helper_proc_stderr_offset),
             acp_broker_id = COALESCE(excluded.acp_broker_id, sessions.acp_broker_id),
             acp_broker_generation = COALESCE(excluded.acp_broker_generation, sessions.acp_broker_generation),
-            acp_broker_acknowledged_cursor = MAX(
-                sessions.acp_broker_acknowledged_cursor,
-                excluded.acp_broker_acknowledged_cursor
-            ),
+            acp_broker_acknowledged_cursor = CASE
+                WHEN COALESCE(excluded.acp_broker_id, sessions.acp_broker_id) IS sessions.acp_broker_id
+                 AND COALESCE(excluded.acp_broker_generation, sessions.acp_broker_generation) IS sessions.acp_broker_generation
+                THEN MAX(sessions.acp_broker_acknowledged_cursor, excluded.acp_broker_acknowledged_cursor)
+                ELSE excluded.acp_broker_acknowledged_cursor
+            END,
             updated_at = excluded.updated_at,
             last_opened_at = excluded.last_opened_at,
             archived = excluded.archived

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 13
+    static let targetSchemaVersion = 14
     let path: String
     let db: SQLiteDatabase
 
@@ -40,6 +40,7 @@ final class ACPSessionStore {
         if current < 11 { try migrate_to_v11() }
         if current < 12 { try migrate_to_v12() }
         if current < 13 { try migrate_to_v13() }
+        if current < 14 { try migrate_to_v14() }
         try recoverFromConcurrentWriters()
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
@@ -216,6 +217,25 @@ final class ACPSessionStore {
             try db.exec("ALTER TABLE sessions ADD COLUMN mcp_preamble_sent INTEGER NOT NULL DEFAULT 0")
         }
     }
+
+    private func migrate_to_v14() throws {
+        let columns = try db.query("PRAGMA table_info(sessions)")
+        let names = Set(columns.compactMap { $0["name"] as? String })
+        if !names.contains("acp_broker_id") {
+            try db.exec("ALTER TABLE sessions ADD COLUMN acp_broker_id TEXT")
+        }
+        if !names.contains("acp_broker_generation") {
+            try db.exec("ALTER TABLE sessions ADD COLUMN acp_broker_generation INTEGER")
+        }
+        if !names.contains("acp_broker_acknowledged_cursor") {
+            try db.exec("ALTER TABLE sessions ADD COLUMN acp_broker_acknowledged_cursor INTEGER NOT NULL DEFAULT 0")
+        }
+        try db.exec("""
+        CREATE INDEX IF NOT EXISTS sessions_acp_broker_idx
+        ON sessions(acp_broker_id)
+        WHERE acp_broker_id IS NOT NULL
+        """)
+    }
 }
 
 struct ACPSessionLease: Equatable, Sendable {
@@ -254,6 +274,9 @@ struct ACPSessionRow: Equatable, Sendable {
     var autoRun: Bool
     var helperProcStdoutOffset: Int64? = nil
     var helperProcStderrOffset: Int64? = nil
+    var acpBrokerId: String? = nil
+    var acpBrokerGeneration: Int64? = nil
+    var acpBrokerAcknowledgedCursor: Int64 = 0
     let createdAt: Int64
     var updatedAt: Int64
     var lastOpenedAt: Int64
@@ -316,8 +339,9 @@ extension ACPSessionStore {
         INSERT INTO sessions (id, agent_id, title, title_source, remote_session_id, origin, context_recovery_pending,
                               mcp_preamble_pending, mcp_preamble_sent,
                               current_model, current_mode, auto_run, helper_proc_stdout_offset,
-                              helper_proc_stderr_offset, created_at, updated_at, last_opened_at, archived)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                              helper_proc_stderr_offset, acp_broker_id, acp_broker_generation,
+                              acp_broker_acknowledged_cursor, created_at, updated_at, last_opened_at, archived)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         ON CONFLICT(id) DO UPDATE SET
             title = CASE WHEN ? THEN sessions.title ELSE excluded.title END,
             title_source = CASE WHEN ? THEN sessions.title_source ELSE excluded.title_source END,
@@ -331,6 +355,12 @@ extension ACPSessionStore {
             auto_run = excluded.auto_run,
             helper_proc_stdout_offset = COALESCE(excluded.helper_proc_stdout_offset, sessions.helper_proc_stdout_offset),
             helper_proc_stderr_offset = COALESCE(excluded.helper_proc_stderr_offset, sessions.helper_proc_stderr_offset),
+            acp_broker_id = COALESCE(excluded.acp_broker_id, sessions.acp_broker_id),
+            acp_broker_generation = COALESCE(excluded.acp_broker_generation, sessions.acp_broker_generation),
+            acp_broker_acknowledged_cursor = MAX(
+                sessions.acp_broker_acknowledged_cursor,
+                excluded.acp_broker_acknowledged_cursor
+            ),
             updated_at = excluded.updated_at,
             last_opened_at = excluded.last_opened_at,
             archived = excluded.archived
@@ -340,6 +370,7 @@ extension ACPSessionStore {
             s.mcpPreamblePending, s.mcpPreambleSent ? 1 : 0,
             s.currentModel, s.currentMode, s.autoRun ? 1 : 0,
             s.helperProcStdoutOffset, s.helperProcStderrOffset,
+            s.acpBrokerId, s.acpBrokerGeneration, s.acpBrokerAcknowledgedCursor,
             s.createdAt, s.updatedAt, s.lastOpenedAt, s.archived ? 1 : 0,
             preserveTitle ? 1 : 0,
             preserveTitle ? 1 : 0
@@ -348,6 +379,16 @@ extension ACPSessionStore {
 
     func loadSession(id: String) throws -> ACPSessionRow? {
         let rows = try db.query("SELECT * FROM sessions WHERE id = ?", bindings: [id])
+        return rows.first.map(Self.rowToSession)
+    }
+
+    func loadSession(acpBrokerId: String) throws -> ACPSessionRow? {
+        let rows = try db.query("""
+        SELECT * FROM sessions
+        WHERE acp_broker_id = ? AND archived = 0
+        ORDER BY last_opened_at DESC
+        LIMIT 1
+        """, bindings: [acpBrokerId])
         return rows.first.map(Self.rowToSession)
     }
 
@@ -412,6 +453,49 @@ extension ACPSessionStore {
         UPDATE sessions
         SET helper_proc_stdout_offset = 0,
             helper_proc_stderr_offset = 0
+        WHERE id = ?
+        """, bindings: [sessionId]) > 0
+    }
+
+    func updateACPBrokerState(
+        sessionId: String,
+        brokerId: String,
+        generation: Int64,
+        acknowledgedCursor: Int64
+    ) throws -> Bool {
+        try db.execChanges("""
+        UPDATE sessions
+        SET acp_broker_id = ?,
+            acp_broker_generation = ?,
+            acp_broker_acknowledged_cursor = ?
+        WHERE id = ?
+        """, bindings: [brokerId, generation, acknowledgedCursor, sessionId]) > 0
+    }
+
+    func updateACPBrokerAcknowledgedCursor(
+        sessionId: String,
+        brokerId: String,
+        generation: Int64,
+        cursor: Int64
+    ) throws -> Bool {
+        try db.execChanges("""
+        UPDATE sessions
+        SET acp_broker_acknowledged_cursor = CASE
+                WHEN acp_broker_acknowledged_cursor < ? THEN ?
+                ELSE acp_broker_acknowledged_cursor
+            END
+        WHERE id = ?
+          AND acp_broker_id = ?
+          AND acp_broker_generation = ?
+        """, bindings: [cursor, cursor, sessionId, brokerId, generation]) > 0
+    }
+
+    func clearACPBrokerState(sessionId: String) throws -> Bool {
+        try db.execChanges("""
+        UPDATE sessions
+        SET acp_broker_id = NULL,
+            acp_broker_generation = NULL,
+            acp_broker_acknowledged_cursor = 0
         WHERE id = ?
         """, bindings: [sessionId]) > 0
     }
@@ -694,6 +778,9 @@ extension ACPSessionStore {
             autoRun: ((r["auto_run"] as? Int64) ?? 0) != 0,
             helperProcStdoutOffset: r["helper_proc_stdout_offset"] as? Int64,
             helperProcStderrOffset: r["helper_proc_stderr_offset"] as? Int64,
+            acpBrokerId: r["acp_broker_id"] as? String,
+            acpBrokerGeneration: r["acp_broker_generation"] as? Int64,
+            acpBrokerAcknowledgedCursor: (r["acp_broker_acknowledged_cursor"] as? Int64) ?? 0,
             createdAt: (r["created_at"] as? Int64) ?? 0,
             updatedAt: (r["updated_at"] as? Int64) ?? 0,
             lastOpenedAt: (r["last_opened_at"] as? Int64) ?? 0,

--- a/Alas/Sources/ACP/Session/QueuedPrompt.swift
+++ b/Alas/Sources/ACP/Session/QueuedPrompt.swift
@@ -24,6 +24,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
     /// Present only for prompts delivered by a direct delegated-session edge.
     /// It is intentionally omitted from ordinary prompt JSON for compatibility.
     let delegatedSource: ACPDelegatedPromptSource?
+    var brokerOperationAttempt: Int
 
     init(id: UUID = UUID(),
          blocks: [ACPContentBlock],
@@ -32,7 +33,8 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
          lastError: String? = nil,
          draft: ACPComposerDraft? = nil,
          delegatedSource: ACPDelegatedPromptSource? = nil,
-         transcriptRecorded: Bool = false)
+         transcriptRecorded: Bool = false,
+         brokerOperationAttempt: Int = 0)
     {
         self.id = id
         self.blocks = blocks
@@ -42,10 +44,11 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
         self.draft = draft
         self.delegatedSource = delegatedSource
         self.transcriptRecorded = transcriptRecorded
+        self.brokerOperationAttempt = brokerOperationAttempt
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, blocks, enqueuedAt, status, lastError, draft, delegatedSource, transcriptRecorded
+        case id, blocks, enqueuedAt, status, lastError, draft, delegatedSource, transcriptRecorded, brokerOperationAttempt
     }
 
     init(from decoder: Decoder) throws {
@@ -58,6 +61,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
         draft = try? c.decode(ACPComposerDraft.self, forKey: .draft)
         delegatedSource = try? c.decode(ACPDelegatedPromptSource.self, forKey: .delegatedSource)
         transcriptRecorded = (try? c.decode(Bool.self, forKey: .transcriptRecorded)) ?? false
+        brokerOperationAttempt = (try? c.decode(Int.self, forKey: .brokerOperationAttempt)) ?? 0
     }
 
     /// Used by the persistence decoder: any item that was mid-send when
@@ -76,5 +80,13 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
     /// of `blocks`. See the `draft` field for why the fallback is lossy.
     var restorableDraft: ACPComposerDraft {
         draft ?? ACPComposerDraft(blocks: blocks)
+    }
+
+    var brokerOperationKey: String {
+        "queued-prompt:\(id.uuidString):\(brokerOperationAttempt):session/prompt"
+    }
+
+    mutating func advanceBrokerOperationAttempt() {
+        brokerOperationAttempt += 1
     }
 }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -426,6 +426,7 @@ private struct ACPSessionView: View {
             onQueueRetry: isMirror ? { _ in } : { id in
                 guard let idx = session.queue.firstIndex(where: { $0.id == id }) else { return }
                 session.queue[idx].lastError = nil
+                session.queue[idx].advanceBrokerOperationAttempt()
                 manager.persistQueue(for: session)
                 manager.runners[sessionId]?.flushQueueIfIdle()
             },

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -426,7 +426,6 @@ private struct ACPSessionView: View {
             onQueueRetry: isMirror ? { _ in } : { id in
                 guard let idx = session.queue.firstIndex(where: { $0.id == id }) else { return }
                 session.queue[idx].lastError = nil
-                session.queue[idx].advanceBrokerOperationAttempt()
                 manager.persistQueue(for: session)
                 manager.runners[sessionId]?.flushQueueIfIdle()
             },

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4738,6 +4738,10 @@ final class AppState {
                     await self.deliverPendingDelegatedMessages(to: sessionId, manager: manager)
                 }
             },
+            brokerServiceFactory: {
+                let resourceURL = Bundle.main.resourceURL ?? Bundle.main.bundleURL
+                return try await LocalACPBrokerServicePool.shared.service(resourceURL: resourceURL)
+            },
             mcpProjectContextProvider: { [weak self] in
                 guard let project = self?.projects.first(where: { $0.id == worktree.projectId }) else {
                     return nil

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -434,6 +434,38 @@ actor RemoteHelperClient {
         try await request(method: "proc/list", params: RemoteHelperNoParams())
     }
 
+    func openACPBroker(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
+        try await request(method: "acp/open", params: params)
+    }
+
+    func attachACPBroker(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
+        try await request(method: "acp/attach", params: params)
+    }
+
+    func sendACPBroker(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        try await request(method: "acp/send", params: params, replaySubscriptionsOnStart: false)
+    }
+
+    func respondACPBroker(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
+        try await request(method: "acp/respond", params: params, replaySubscriptionsOnStart: false)
+    }
+
+    func ackACPBroker(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK {
+        try await request(method: "acp/ack", params: params, replaySubscriptionsOnStart: false)
+    }
+
+    func detachACPBroker(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
+        try await request(method: "acp/detach", params: params, replaySubscriptionsOnStart: false)
+    }
+
+    func closeACPBroker(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
+        try await request(method: "acp/close", params: params, replaySubscriptionsOnStart: false)
+    }
+
+    func listACPBroker() async throws -> ACPBrokerListResult {
+        try await request(method: "acp/list", params: RemoteHelperNoParams(), replaySubscriptionsOnStart: false)
+    }
+
     func shutdown() {
         idleShutdownTask?.cancel()
         idleShutdownTask = nil

--- a/Alas/Sources/SSH/RemoteHelperClient.swift
+++ b/Alas/Sources/SSH/RemoteHelperClient.swift
@@ -446,6 +446,10 @@ actor RemoteHelperClient {
         try await request(method: "acp/send", params: params, replaySubscriptionsOnStart: false)
     }
 
+    func notifyACPBroker(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK {
+        try await request(method: "acp/notify", params: params, replaySubscriptionsOnStart: false)
+    }
+
     func respondACPBroker(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
         try await request(method: "acp/respond", params: params, replaySubscriptionsOnStart: false)
     }

--- a/Alas/Sources/SSH/RemoteHelperInstaller.swift
+++ b/Alas/Sources/SSH/RemoteHelperInstaller.swift
@@ -3,6 +3,12 @@ import Foundation
 /// Installs and verifies the bundled Alas helper in the app's private remote
 /// directory. Consent is owned by AppState so upgrades can reuse it.
 enum RemoteHelperInstaller {
+    #if arch(arm64)
+    static let localArch = "aarch64"
+    #else
+    static let localArch = "x86_64"
+    #endif
+
     static func bundledBinaryPath(
         os: RemoteHostCapabilities.OS,
         arch: String?,

--- a/Alas/Sources/SSH/RemoteHelperProtocol.swift
+++ b/Alas/Sources/SSH/RemoteHelperProtocol.swift
@@ -26,6 +26,7 @@ struct RemoteHelperCapabilities: Codable, Equatable, Sendable {
     let fs: RemoteHelperFSCapabilities
     let search: Bool?
     let proc: Bool?
+    let acp: Bool?
     let ping: Bool
 }
 

--- a/AlasHelper/src/acp_broker.rs
+++ b/AlasHelper/src/acp_broker.rs
@@ -467,12 +467,7 @@ impl ACPBrokerState {
                 "pending request already exists",
             ));
         }
-        if self.resolved_requests.contains(&request_id) {
-            return Err(BrokerError::new(
-                BrokerErrorKind::PendingRequestAlreadyResolved,
-                "pending request was already resolved",
-            ));
-        }
+        self.resolved_requests.remove(&request_id);
 
         let request = PendingClientRequest {
             request_id: request_id.clone(),

--- a/AlasHelper/src/acp_broker.rs
+++ b/AlasHelper/src/acp_broker.rs
@@ -72,6 +72,40 @@ impl AdapterRequestId {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JSONRPCErrorObject {
+    pub code: i64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdapterRPCOutcome {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JSONRPCErrorObject>,
+}
+
+impl AdapterRPCOutcome {
+    pub fn result(result: Value) -> Self {
+        Self {
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(error: JSONRPCErrorObject) -> Self {
+        Self {
+            result: None,
+            error: Some(error),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum BrokerTurnState {
@@ -113,7 +147,7 @@ pub struct OperationStart {
     pub operation_key: OperationKey,
     pub adapter_request_id: AdapterRequestId,
     pub replayed: bool,
-    pub terminal_result: Option<Value>,
+    pub terminal_outcome: Option<AdapterRPCOutcome>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -153,7 +187,7 @@ pub enum BrokerEventKind {
     },
     PendingRequestResolved {
         request_id: String,
-        response: Value,
+        response: AdapterRPCOutcome,
     },
     OperationStarted {
         operation_key: OperationKey,
@@ -163,7 +197,7 @@ pub enum BrokerEventKind {
     },
     OperationCompleted {
         operation_key: OperationKey,
-        result: Value,
+        outcome: AdapterRPCOutcome,
     },
     AdapterNotification {
         method: String,
@@ -191,7 +225,7 @@ pub struct OperationSnapshot {
     pub adapter_request_id: AdapterRequestId,
     pub method: String,
     pub params: Value,
-    pub terminal_result: Option<Value>,
+    pub terminal_outcome: Option<AdapterRPCOutcome>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -248,7 +282,7 @@ struct OperationRecord {
     key: OperationKey,
     fingerprint: OperationFingerprint,
     adapter_request_id: AdapterRequestId,
-    terminal_result: Option<Value>,
+    terminal_outcome: Option<AdapterRPCOutcome>,
 }
 
 #[derive(Clone, Debug)]
@@ -345,7 +379,7 @@ impl ACPBrokerState {
                 operation_key,
                 adapter_request_id: record.adapter_request_id,
                 replayed: true,
-                terminal_result: record.terminal_result.clone(),
+                terminal_outcome: record.terminal_outcome.clone(),
             });
         }
 
@@ -355,7 +389,7 @@ impl ACPBrokerState {
             key: operation_key.clone(),
             fingerprint,
             adapter_request_id,
-            terminal_result: None,
+            terminal_outcome: None,
         };
         self.push_event(BrokerEventKind::OperationStarted {
             operation_key: operation_key.clone(),
@@ -369,15 +403,15 @@ impl ACPBrokerState {
             operation_key,
             adapter_request_id,
             replayed: false,
-            terminal_result: None,
+            terminal_outcome: None,
         })
     }
 
     pub fn complete_operation(
         &mut self,
         operation_key: &OperationKey,
-        result: Value,
-    ) -> Result<Value, BrokerError> {
+        outcome: AdapterRPCOutcome,
+    ) -> Result<AdapterRPCOutcome, BrokerError> {
         let record = self.operations.get_mut(operation_key).ok_or_else(|| {
             BrokerError::new(
                 BrokerErrorKind::OperationNotFound,
@@ -385,9 +419,9 @@ impl ACPBrokerState {
             )
         })?;
 
-        if let Some(existing_result) = &record.terminal_result {
-            if existing_result == &result {
-                return Ok(existing_result.clone());
+        if let Some(existing_outcome) = &record.terminal_outcome {
+            if existing_outcome == &outcome {
+                return Ok(existing_outcome.clone());
             }
             return Err(BrokerError::new(
                 BrokerErrorKind::OperationAlreadyCompletedWithDifferentResult,
@@ -395,12 +429,12 @@ impl ACPBrokerState {
             ));
         }
 
-        record.terminal_result = Some(result.clone());
+        record.terminal_outcome = Some(outcome.clone());
         self.push_event(BrokerEventKind::OperationCompleted {
             operation_key: operation_key.clone(),
-            result: result.clone(),
+            outcome: outcome.clone(),
         });
-        Ok(result)
+        Ok(outcome)
     }
 
     pub fn set_turn_state(&mut self, state: BrokerTurnState) -> Result<EventCursor, BrokerError> {
@@ -453,7 +487,7 @@ impl ACPBrokerState {
     pub fn respond_to_pending_request(
         &mut self,
         request_id: &str,
-        response: Value,
+        response: AdapterRPCOutcome,
     ) -> Result<EventCursor, BrokerError> {
         if self.resolved_requests.contains(request_id) {
             return Err(BrokerError::new(
@@ -524,7 +558,7 @@ impl ACPBrokerState {
                 adapter_request_id: record.adapter_request_id,
                 method: record.fingerprint.method.clone(),
                 params: record.fingerprint.params.clone(),
-                terminal_result: record.terminal_result.clone(),
+                terminal_outcome: record.terminal_outcome.clone(),
             })
             .collect();
         operations.sort_by(|lhs, rhs| lhs.operation_key.as_str().cmp(rhs.operation_key.as_str()));

--- a/AlasHelper/src/acp_broker.rs
+++ b/AlasHelper/src/acp_broker.rs
@@ -283,6 +283,7 @@ struct OperationRecord {
     fingerprint: OperationFingerprint,
     adapter_request_id: AdapterRequestId,
     terminal_outcome: Option<AdapterRPCOutcome>,
+    completed_cursor: Option<EventCursor>,
 }
 
 #[derive(Clone, Debug)]
@@ -387,6 +388,7 @@ impl ACPBrokerState {
             fingerprint,
             adapter_request_id,
             terminal_outcome: None,
+            completed_cursor: None,
         };
         self.push_event(BrokerEventKind::OperationStarted {
             operation_key: operation_key.clone(),
@@ -427,10 +429,13 @@ impl ACPBrokerState {
         }
 
         record.terminal_outcome = Some(outcome.clone());
-        self.push_event(BrokerEventKind::OperationCompleted {
+        let cursor = self.push_event(BrokerEventKind::OperationCompleted {
             operation_key: operation_key.clone(),
             outcome: outcome.clone(),
         });
+        if let Some(record) = self.operations.get_mut(operation_key) {
+            record.completed_cursor = Some(cursor);
+        }
         Ok(outcome)
     }
 
@@ -516,6 +521,12 @@ impl ACPBrokerState {
         }
         self.acknowledged_cursor = cursor;
         self.journal.retain(|event| event.cursor > cursor);
+        self.operations.retain(|_, record| {
+            record
+                .completed_cursor
+                .map(|completed_cursor| completed_cursor > cursor)
+                .unwrap_or(true)
+        });
         Ok(())
     }
 

--- a/AlasHelper/src/acp_broker.rs
+++ b/AlasHelper/src/acp_broker.rs
@@ -326,10 +326,7 @@ impl ACPBrokerState {
     }
 
     pub fn journal_tail(&self) -> EventCursor {
-        self.journal
-            .last()
-            .map(|event| event.cursor)
-            .unwrap_or(EventCursor(0))
+        EventCursor(self.next_event_cursor.0.saturating_sub(1))
     }
 
     pub fn record_initialize_result(&mut self, result: Value) -> Result<EventCursor, BrokerError> {
@@ -518,6 +515,7 @@ impl ACPBrokerState {
             ));
         }
         self.acknowledged_cursor = cursor;
+        self.journal.retain(|event| event.cursor > cursor);
         Ok(())
     }
 

--- a/AlasHelper/src/acp_broker.rs
+++ b/AlasHelper/src/acp_broker.rs
@@ -133,7 +133,11 @@ pub struct BrokerEvent {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", tag = "type")]
+#[serde(
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    tag = "type"
+)]
 pub enum BrokerEventKind {
     Initialized {
         result: Value,

--- a/AlasHelper/src/acp_broker.rs
+++ b/AlasHelper/src/acp_broker.rs
@@ -1,0 +1,546 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BrokerId(pub String);
+
+impl BrokerId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct BrokerGeneration(pub u64);
+
+impl BrokerGeneration {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct EventCursor(pub u64);
+
+impl EventCursor {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn value(self) -> u64 {
+        self.0
+    }
+
+    fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct OperationKey(pub String);
+
+impl OperationKey {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct AdapterRequestId(pub u64);
+
+impl AdapterRequestId {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum BrokerTurnState {
+    Idle,
+    Sending,
+    Streaming,
+    AwaitingInput,
+    Cancelling,
+    Completed,
+    Ambiguous,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PendingClientRequestKind {
+    Permission,
+    Question,
+    Elicitation,
+    File,
+    Terminal,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ACPBrokerMetadata {
+    pub broker_id: BrokerId,
+    pub generation: BrokerGeneration,
+    pub alas_session_id: String,
+    pub adapter_program: String,
+    pub adapter_args: Vec<String>,
+    pub cwd: String,
+    pub env_keys: Vec<String>,
+    pub created_at_millis: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationStart {
+    pub operation_key: OperationKey,
+    pub adapter_request_id: AdapterRequestId,
+    pub replayed: bool,
+    pub terminal_result: Option<Value>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingClientRequest {
+    pub request_id: String,
+    pub adapter_request_id: Value,
+    pub kind: PendingClientRequestKind,
+    pub payload: Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrokerEvent {
+    pub cursor: EventCursor,
+    pub kind: BrokerEventKind,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum BrokerEventKind {
+    Initialized {
+        result: Value,
+    },
+    RemoteSessionReady {
+        result: Value,
+    },
+    TurnStateChanged {
+        state: BrokerTurnState,
+    },
+    PendingRequest {
+        request: PendingClientRequest,
+    },
+    PendingRequestResolved {
+        request_id: String,
+        response: Value,
+    },
+    OperationStarted {
+        operation_key: OperationKey,
+        adapter_request_id: AdapterRequestId,
+        method: String,
+        params: Value,
+    },
+    OperationCompleted {
+        operation_key: OperationKey,
+        result: Value,
+    },
+    AdapterNotification {
+        method: String,
+        params: Value,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ACPBrokerSnapshot {
+    pub metadata: ACPBrokerMetadata,
+    pub initialize_result: Option<Value>,
+    pub remote_session_result: Option<Value>,
+    pub turn_state: BrokerTurnState,
+    pub acknowledged_cursor: EventCursor,
+    pub journal_tail: EventCursor,
+    pub pending_requests: Vec<PendingClientRequest>,
+    pub operations: Vec<OperationSnapshot>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSnapshot {
+    pub operation_key: OperationKey,
+    pub adapter_request_id: AdapterRequestId,
+    pub method: String,
+    pub params: Value,
+    pub terminal_result: Option<Value>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BrokerErrorKind {
+    AlreadyInitialized,
+    AlreadyHasRemoteSession,
+    CursorBeyondJournalTail,
+    CursorBehindAcknowledged,
+    OperationKeyPayloadMismatch,
+    OperationNotFound,
+    OperationAlreadyCompletedWithDifferentResult,
+    PendingRequestAlreadyExists,
+    PendingRequestAlreadyResolved,
+    PendingRequestNotFound,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BrokerError {
+    kind: BrokerErrorKind,
+    message: String,
+}
+
+impl BrokerError {
+    pub fn kind(&self) -> BrokerErrorKind {
+        self.kind
+    }
+
+    fn new(kind: BrokerErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BrokerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for BrokerError {}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OperationFingerprint {
+    method: String,
+    params: Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OperationRecord {
+    key: OperationKey,
+    fingerprint: OperationFingerprint,
+    adapter_request_id: AdapterRequestId,
+    terminal_result: Option<Value>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ACPBrokerState {
+    metadata: ACPBrokerMetadata,
+    initialize_result: Option<Value>,
+    remote_session_result: Option<Value>,
+    next_event_cursor: EventCursor,
+    acknowledged_cursor: EventCursor,
+    next_adapter_request_id: u64,
+    turn_state: BrokerTurnState,
+    journal: Vec<BrokerEvent>,
+    operations: HashMap<OperationKey, OperationRecord>,
+    pending_requests: HashMap<String, PendingClientRequest>,
+    resolved_requests: HashSet<String>,
+}
+
+impl ACPBrokerState {
+    pub fn new(metadata: ACPBrokerMetadata) -> Self {
+        Self {
+            metadata,
+            initialize_result: None,
+            remote_session_result: None,
+            next_event_cursor: EventCursor(1),
+            acknowledged_cursor: EventCursor(0),
+            next_adapter_request_id: 1,
+            turn_state: BrokerTurnState::Idle,
+            journal: Vec::new(),
+            operations: HashMap::new(),
+            pending_requests: HashMap::new(),
+            resolved_requests: HashSet::new(),
+        }
+    }
+
+    pub fn metadata(&self) -> &ACPBrokerMetadata {
+        &self.metadata
+    }
+
+    pub fn acknowledged_cursor(&self) -> EventCursor {
+        self.acknowledged_cursor
+    }
+
+    pub fn journal_tail(&self) -> EventCursor {
+        self.journal
+            .last()
+            .map(|event| event.cursor)
+            .unwrap_or(EventCursor(0))
+    }
+
+    pub fn record_initialize_result(&mut self, result: Value) -> Result<EventCursor, BrokerError> {
+        if self.initialize_result.is_some() {
+            return Err(BrokerError::new(
+                BrokerErrorKind::AlreadyInitialized,
+                "broker generation already recorded initialize result",
+            ));
+        }
+        self.initialize_result = Some(result.clone());
+        Ok(self.push_event(BrokerEventKind::Initialized { result }))
+    }
+
+    pub fn record_remote_session_result(
+        &mut self,
+        result: Value,
+    ) -> Result<EventCursor, BrokerError> {
+        if self.remote_session_result.is_some() {
+            return Err(BrokerError::new(
+                BrokerErrorKind::AlreadyHasRemoteSession,
+                "broker generation already recorded remote session result",
+            ));
+        }
+        self.remote_session_result = Some(result.clone());
+        Ok(self.push_event(BrokerEventKind::RemoteSessionReady { result }))
+    }
+
+    pub fn begin_operation(
+        &mut self,
+        operation_key: OperationKey,
+        method: impl Into<String>,
+        params: Value,
+    ) -> Result<OperationStart, BrokerError> {
+        let fingerprint = OperationFingerprint {
+            method: method.into(),
+            params,
+        };
+
+        if let Some(record) = self.operations.get(&operation_key) {
+            if record.fingerprint != fingerprint {
+                return Err(BrokerError::new(
+                    BrokerErrorKind::OperationKeyPayloadMismatch,
+                    "operation key was reused with a different payload",
+                ));
+            }
+            return Ok(OperationStart {
+                operation_key,
+                adapter_request_id: record.adapter_request_id,
+                replayed: true,
+                terminal_result: record.terminal_result.clone(),
+            });
+        }
+
+        let adapter_request_id = AdapterRequestId(self.next_adapter_request_id);
+        self.next_adapter_request_id += 1;
+        let record = OperationRecord {
+            key: operation_key.clone(),
+            fingerprint,
+            adapter_request_id,
+            terminal_result: None,
+        };
+        self.push_event(BrokerEventKind::OperationStarted {
+            operation_key: operation_key.clone(),
+            adapter_request_id,
+            method: record.fingerprint.method.clone(),
+            params: record.fingerprint.params.clone(),
+        });
+        self.operations.insert(operation_key.clone(), record);
+
+        Ok(OperationStart {
+            operation_key,
+            adapter_request_id,
+            replayed: false,
+            terminal_result: None,
+        })
+    }
+
+    pub fn complete_operation(
+        &mut self,
+        operation_key: &OperationKey,
+        result: Value,
+    ) -> Result<Value, BrokerError> {
+        let record = self.operations.get_mut(operation_key).ok_or_else(|| {
+            BrokerError::new(
+                BrokerErrorKind::OperationNotFound,
+                "operation key was not registered",
+            )
+        })?;
+
+        if let Some(existing_result) = &record.terminal_result {
+            if existing_result == &result {
+                return Ok(existing_result.clone());
+            }
+            return Err(BrokerError::new(
+                BrokerErrorKind::OperationAlreadyCompletedWithDifferentResult,
+                "operation was already completed with a different result",
+            ));
+        }
+
+        record.terminal_result = Some(result.clone());
+        self.push_event(BrokerEventKind::OperationCompleted {
+            operation_key: operation_key.clone(),
+            result: result.clone(),
+        });
+        Ok(result)
+    }
+
+    pub fn set_turn_state(&mut self, state: BrokerTurnState) -> Result<EventCursor, BrokerError> {
+        self.turn_state = state;
+        Ok(self.push_event(BrokerEventKind::TurnStateChanged { state }))
+    }
+
+    pub fn add_adapter_notification(
+        &mut self,
+        method: impl Into<String>,
+        params: Value,
+    ) -> EventCursor {
+        self.push_event(BrokerEventKind::AdapterNotification {
+            method: method.into(),
+            params,
+        })
+    }
+
+    pub fn add_pending_request(
+        &mut self,
+        request_id: impl Into<String>,
+        adapter_request_id: Value,
+        kind: PendingClientRequestKind,
+        payload: Value,
+    ) -> Result<EventCursor, BrokerError> {
+        let request_id = request_id.into();
+        if self.pending_requests.contains_key(&request_id) {
+            return Err(BrokerError::new(
+                BrokerErrorKind::PendingRequestAlreadyExists,
+                "pending request already exists",
+            ));
+        }
+        if self.resolved_requests.contains(&request_id) {
+            return Err(BrokerError::new(
+                BrokerErrorKind::PendingRequestAlreadyResolved,
+                "pending request was already resolved",
+            ));
+        }
+
+        let request = PendingClientRequest {
+            request_id: request_id.clone(),
+            adapter_request_id,
+            kind,
+            payload,
+        };
+        self.pending_requests.insert(request_id, request.clone());
+        Ok(self.push_event(BrokerEventKind::PendingRequest { request }))
+    }
+
+    pub fn respond_to_pending_request(
+        &mut self,
+        request_id: &str,
+        response: Value,
+    ) -> Result<EventCursor, BrokerError> {
+        if self.resolved_requests.contains(request_id) {
+            return Err(BrokerError::new(
+                BrokerErrorKind::PendingRequestAlreadyResolved,
+                "pending request was already resolved",
+            ));
+        }
+        if self.pending_requests.remove(request_id).is_none() {
+            return Err(BrokerError::new(
+                BrokerErrorKind::PendingRequestNotFound,
+                "pending request was not found",
+            ));
+        }
+
+        self.resolved_requests.insert(request_id.to_string());
+        Ok(self.push_event(BrokerEventKind::PendingRequestResolved {
+            request_id: request_id.to_string(),
+            response,
+        }))
+    }
+
+    pub fn ack(&mut self, cursor: EventCursor) -> Result<(), BrokerError> {
+        if cursor > self.journal_tail() {
+            return Err(BrokerError::new(
+                BrokerErrorKind::CursorBeyondJournalTail,
+                "acknowledged cursor is beyond the journal tail",
+            ));
+        }
+        if cursor < self.acknowledged_cursor {
+            return Err(BrokerError::new(
+                BrokerErrorKind::CursorBehindAcknowledged,
+                "acknowledged cursor moved backwards",
+            ));
+        }
+        self.acknowledged_cursor = cursor;
+        Ok(())
+    }
+
+    pub fn replay_after_ack(&self) -> Vec<BrokerEvent> {
+        self.replay_after(self.acknowledged_cursor)
+            .expect("acknowledged cursor is always within the journal")
+    }
+
+    pub fn replay_after(&self, cursor: EventCursor) -> Result<Vec<BrokerEvent>, BrokerError> {
+        if cursor > self.journal_tail() {
+            return Err(BrokerError::new(
+                BrokerErrorKind::CursorBeyondJournalTail,
+                "replay cursor is beyond the journal tail",
+            ));
+        }
+        Ok(self
+            .journal
+            .iter()
+            .filter(|event| event.cursor > cursor)
+            .cloned()
+            .collect())
+    }
+
+    pub fn snapshot(&self) -> ACPBrokerSnapshot {
+        let mut pending_requests: Vec<_> = self.pending_requests.values().cloned().collect();
+        pending_requests.sort_by(|lhs, rhs| lhs.request_id.cmp(&rhs.request_id));
+
+        let mut operations: Vec<_> = self
+            .operations
+            .values()
+            .map(|record| OperationSnapshot {
+                operation_key: record.key.clone(),
+                adapter_request_id: record.adapter_request_id,
+                method: record.fingerprint.method.clone(),
+                params: record.fingerprint.params.clone(),
+                terminal_result: record.terminal_result.clone(),
+            })
+            .collect();
+        operations.sort_by(|lhs, rhs| lhs.operation_key.as_str().cmp(rhs.operation_key.as_str()));
+
+        ACPBrokerSnapshot {
+            metadata: self.metadata.clone(),
+            initialize_result: self.initialize_result.clone(),
+            remote_session_result: self.remote_session_result.clone(),
+            turn_state: self.turn_state,
+            acknowledged_cursor: self.acknowledged_cursor,
+            journal_tail: self.journal_tail(),
+            pending_requests,
+            operations,
+        }
+    }
+
+    fn push_event(&mut self, kind: BrokerEventKind) -> EventCursor {
+        let cursor = self.next_event_cursor;
+        self.next_event_cursor = self.next_event_cursor.next();
+        self.journal.push(BrokerEvent { cursor, kind });
+        cursor
+    }
+}

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -75,6 +75,8 @@ struct Runtime {
 struct RuntimeState {
     broker: ACPBrokerState,
     pending_methods: HashMap<u64, PendingOperation>,
+    adapter_process_group_id: Option<u32>,
+    adapter_exited: bool,
     closing: bool,
 }
 
@@ -164,12 +166,15 @@ fn run_broker_supervisor_inner(dir: PathBuf) -> Result<(), AcpBrokerProcessError
         .stderr
         .take()
         .ok_or_else(|| broker_error(-32071, "adapter stderr unavailable"))?;
+    let adapter_process_group_id = adapter_process_group_id(&child);
 
     let runtime = Runtime {
         state: Arc::new((
             Mutex::new(RuntimeState {
                 broker: ACPBrokerState::new(metadata),
                 pending_methods: HashMap::new(),
+                adapter_process_group_id,
+                adapter_exited: false,
                 closing: false,
             }),
             Condvar::new(),
@@ -522,9 +527,17 @@ fn broker_ack(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrok
 
 fn broker_close(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     let params: AcpCloseParams = decode(params)?;
-    let mut state = lock_runtime(runtime);
-    ensure_generation(&state, params.generation)?;
-    state.closing = true;
+    let adapter_process_group_id = {
+        let mut state = lock_runtime(runtime);
+        ensure_generation(&state, params.generation)?;
+        state.closing = true;
+        if state.adapter_exited {
+            None
+        } else {
+            state.adapter_process_group_id
+        }
+    };
+    terminate_adapter_process_group(runtime, adapter_process_group_id);
     Ok(json!({ "ok": true }))
 }
 
@@ -552,6 +565,7 @@ fn spawn_waiter(runtime: Runtime, mut child: std::process::Child) {
         let _ = child.wait();
         let (lock, condvar) = &*runtime.state;
         let mut state = lock.lock().expect("broker state poisoned");
+        state.adapter_exited = true;
         if !state.closing {
             let _ = state.broker.set_turn_state(BrokerTurnState::Ambiguous);
             complete_pending_operations_after_adapter_exit(&mut state);
@@ -1052,6 +1066,56 @@ fn current_process_group_id(pid: u32) -> Option<u32> {
 fn current_process_group_id(_pid: u32) -> Option<u32> {
     None
 }
+
+#[cfg(unix)]
+fn adapter_process_group_id(child: &std::process::Child) -> Option<u32> {
+    Some(child.id())
+}
+
+#[cfg(not(unix))]
+fn adapter_process_group_id(_child: &std::process::Child) -> Option<u32> {
+    None
+}
+
+fn terminate_adapter_process_group(runtime: &Runtime, process_group_id: Option<u32>) {
+    let Some(process_group_id) = process_group_id else {
+        return;
+    };
+    signal_process_group(process_group_id, 15);
+    if wait_for_adapter_exit(runtime, Duration::from_millis(500)) {
+        return;
+    }
+    signal_process_group(process_group_id, 9);
+    let _ = wait_for_adapter_exit(runtime, Duration::from_secs(2));
+}
+
+fn wait_for_adapter_exit(runtime: &Runtime, timeout: Duration) -> bool {
+    let (lock, condvar) = &*runtime.state;
+    let mut state = lock.lock().expect("broker state poisoned");
+    let deadline = std::time::Instant::now() + timeout;
+    while !state.adapter_exited {
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            break;
+        }
+        let (next_state, _) = condvar
+            .wait_timeout(state, deadline.saturating_duration_since(now))
+            .expect("broker state poisoned");
+        state = next_state;
+    }
+    state.adapter_exited
+}
+
+#[cfg(unix)]
+fn signal_process_group(process_group_id: u32, signal: i32) {
+    unsafe {
+        let _ = libc_kill(-(process_group_id as i32), signal);
+        let _ = libc_kill(process_group_id as i32, signal);
+    }
+}
+
+#[cfg(not(unix))]
+fn signal_process_group(_process_group_id: u32, _signal: i32) {}
 
 #[cfg(unix)]
 unsafe extern "C" {

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -437,8 +437,6 @@ fn broker_attach(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpB
 
 fn broker_send(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     let params: AcpSendParams = decode(params)?;
-    let method = params.method.clone();
-    let operation_key = params.operation_key.clone();
     let operation = {
         let mut state = lock_runtime(runtime);
         ensure_generation(&state, params.generation)?;
@@ -482,14 +480,11 @@ fn broker_send(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBro
             params.params,
         )?;
     }
-    if method == "session/prompt" {
-        return Ok(json!({
-            "requestId": operation.adapter_request_id,
-            "replayed": operation.replayed,
-            "pending": true
-        }));
-    }
-    wait_for_operation_or_pending_input(runtime, &operation_key, Duration::from_secs(24 * 60 * 60))
+    Ok(json!({
+        "requestId": operation.adapter_request_id,
+        "replayed": operation.replayed,
+        "pending": true
+    }))
 }
 
 fn broker_notify(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
@@ -756,74 +751,6 @@ fn apply_outcome_fields(response: &mut Value, outcome: AdapterRPCOutcome) {
             }
         }
     }
-}
-
-fn wait_for_operation_or_pending_input(
-    runtime: &Runtime,
-    operation_key: &OperationKey,
-    timeout: Duration,
-) -> Result<Value, AcpBrokerProcessError> {
-    let (lock, condvar) = &*runtime.state;
-    let mut state = lock.lock().expect("broker state poisoned");
-    let deadline = std::time::Instant::now() + timeout;
-    loop {
-        let snapshot = state.broker.snapshot();
-        if let Some(operation) = snapshot
-            .operations
-            .iter()
-            .find(|operation| operation.operation_key == *operation_key)
-        {
-            if let Some(outcome) = &operation.terminal_outcome {
-                let mut response = json!({
-                    "requestId": operation.adapter_request_id,
-                    "replayed": false,
-                });
-                apply_outcome_fields(&mut response, outcome.clone());
-                return Ok(response);
-            }
-            if !snapshot.pending_requests.is_empty() {
-                return Ok(json!({
-                    "requestId": operation.adapter_request_id,
-                    "replayed": false,
-                    "pending": true
-                }));
-            }
-            if has_replayable_progress(&state) {
-                return Ok(json!({
-                    "requestId": operation.adapter_request_id,
-                    "replayed": false,
-                    "pending": true
-                }));
-            }
-        }
-        let now = std::time::Instant::now();
-        if now >= deadline {
-            return Err(broker_error(-32073, "operation timed out"));
-        }
-        let wait_for = deadline
-            .saturating_duration_since(now)
-            .min(Duration::from_secs(1));
-        let (next_state, _) = condvar
-            .wait_timeout(state, wait_for)
-            .expect("broker state poisoned");
-        state = next_state;
-    }
-}
-
-fn has_replayable_progress(state: &RuntimeState) -> bool {
-    let snapshot = state.broker.snapshot();
-    state
-        .broker
-        .replay_after_ack()
-        .into_iter()
-        .any(|event| match event.kind {
-            crate::acp_broker::BrokerEventKind::AdapterNotification { .. } => true,
-            crate::acp_broker::BrokerEventKind::PendingRequest { request } => snapshot
-                .pending_requests
-                .iter()
-                .any(|pending| pending.request_id == request.request_id),
-            _ => false,
-        })
 }
 
 fn write_adapter_request(

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -126,7 +126,7 @@ fn run_broker_supervisor_inner(dir: PathBuf) -> Result<(), AcpBrokerProcessError
 
     let metadata = ACPBrokerMetadata {
         broker_id: launch.broker_id.clone(),
-        generation: BrokerGeneration::new(current_millis()),
+        generation: BrokerGeneration::new(current_nanos()),
         alas_session_id: launch.session_id.clone(),
         adapter_program: launch.command.clone(),
         adapter_args: launch.args.clone(),
@@ -1210,6 +1210,13 @@ fn current_millis() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+fn current_nanos() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos() as u64)
         .unwrap_or_default()
 }
 

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -553,11 +553,13 @@ fn handle_adapter_stdout_line(runtime: &Runtime, line: &str) {
         handle_adapter_client_request(runtime, value);
     } else if let Some(method) = value.get("method").and_then(Value::as_str) {
         let params = value.get("params").cloned().unwrap_or(Value::Null);
-        let mut state = lock_runtime(runtime);
+        let (lock, condvar) = &*runtime.state;
+        let mut state = lock.lock().expect("broker state poisoned");
         if method == "session/update" {
             let _ = state.broker.set_turn_state(BrokerTurnState::Streaming);
         }
         state.broker.add_adapter_notification(method, params);
+        condvar.notify_all();
     }
 }
 
@@ -715,6 +717,13 @@ fn wait_for_operation_or_pending_input(
                     "pending": true
                 }));
             }
+            if has_replayable_progress(&state) {
+                return Ok(json!({
+                    "requestId": operation.adapter_request_id,
+                    "replayed": false,
+                    "pending": true
+                }));
+            }
         }
         let now = std::time::Instant::now();
         if now >= deadline {
@@ -728,6 +737,22 @@ fn wait_for_operation_or_pending_input(
             .expect("broker state poisoned");
         state = next_state;
     }
+}
+
+fn has_replayable_progress(state: &RuntimeState) -> bool {
+    let snapshot = state.broker.snapshot();
+    state
+        .broker
+        .replay_after_ack()
+        .into_iter()
+        .any(|event| match event.kind {
+            crate::acp_broker::BrokerEventKind::AdapterNotification { .. } => true,
+            crate::acp_broker::BrokerEventKind::PendingRequest { request } => snapshot
+                .pending_requests
+                .iter()
+                .any(|pending| pending.request_id == request.request_id),
+            _ => false,
+        })
 }
 
 fn write_adapter_request(

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -721,8 +721,19 @@ fn handle_adapter_client_request(runtime: &Runtime, value: Value) {
         kind,
         json!({ "method": method, "params": params }),
     );
-    let _ = state.broker.set_turn_state(BrokerTurnState::AwaitingInput);
+    if pending_kind_awaits_user(kind) {
+        let _ = state.broker.set_turn_state(BrokerTurnState::AwaitingInput);
+    }
     condvar.notify_all();
+}
+
+fn pending_kind_awaits_user(kind: PendingClientRequestKind) -> bool {
+    matches!(
+        kind,
+        PendingClientRequestKind::Permission
+            | PendingClientRequestKind::Question
+            | PendingClientRequestKind::Elicitation
+    )
 }
 
 fn pending_kind(method: &str) -> PendingClientRequestKind {
@@ -1211,4 +1222,24 @@ fn domain_error(error: crate::acp_broker::BrokerError) -> AcpBrokerProcessError 
 
 fn broker_error(code: i64, message: impl Into<String>) -> AcpBrokerProcessError {
     AcpBrokerProcessError::new(code, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_user_facing_pending_requests_move_turn_to_awaiting_input() {
+        assert!(pending_kind_awaits_user(
+            PendingClientRequestKind::Permission
+        ));
+        assert!(pending_kind_awaits_user(PendingClientRequestKind::Question));
+        assert!(pending_kind_awaits_user(
+            PendingClientRequestKind::Elicitation
+        ));
+        assert!(!pending_kind_awaits_user(PendingClientRequestKind::File));
+        assert!(!pending_kind_awaits_user(
+            PendingClientRequestKind::Terminal
+        ));
+    }
 }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -283,7 +283,11 @@ fn acp_close(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     let params: AcpCloseParams = decode(params)?;
     let dir = broker_dir(params.broker_id.as_str())?;
     if broker_is_running(&dir) {
-        let _ = send_ipc(&dir, "close", json!({}));
+        send_ipc(
+            &dir,
+            "close",
+            serde_json::to_value(&params).expect("close params serialize"),
+        )?;
     }
     remove_broker_dir(&dir)?;
     Ok(json!({ "ok": true }))
@@ -395,10 +399,7 @@ fn handle_ipc_request(
         "notify" => broker_notify(runtime, request.params),
         "respond" => broker_respond(runtime, request.params),
         "ack" => broker_ack(runtime, request.params),
-        "close" => {
-            lock_runtime(runtime).closing = true;
-            Ok(json!({ "ok": true }))
-        }
+        "close" => broker_close(runtime, request.params),
         _ => Err(broker_error(
             -32601,
             format!("broker method not found: {}", request.method),
@@ -520,6 +521,14 @@ fn broker_ack(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrok
     let mut state = lock_runtime(runtime);
     ensure_generation(&state, params.generation)?;
     state.broker.ack(params.cursor).map_err(domain_error)?;
+    Ok(json!({ "ok": true }))
+}
+
+fn broker_close(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpCloseParams = decode(params)?;
+    let mut state = lock_runtime(runtime);
+    ensure_generation(&state, params.generation)?;
+    state.closing = true;
     Ok(json!({ "ok": true }))
 }
 

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1028,9 +1028,12 @@ fn spawn_broker_supervisor(dir: &Path) -> Result<(), AcpBrokerProcessError> {
         use std::os::unix::process::CommandExt;
         command.process_group(0);
     }
-    command
+    let mut child = command
         .spawn()
         .map_err(|error| broker_error(-32070, format!("broker spawn failed: {error}")))?;
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
     Ok(())
 }
 

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1,6 +1,6 @@
 use crate::acp_broker::{
-    ACPBrokerMetadata, ACPBrokerState, AdapterRPCOutcome, BrokerGeneration, BrokerId,
-    BrokerTurnState, JSONRPCErrorObject, OperationKey, PendingClientRequestKind,
+    ACPBrokerMetadata, ACPBrokerSnapshot, ACPBrokerState, AdapterRPCOutcome, BrokerGeneration,
+    BrokerId, BrokerTurnState, JSONRPCErrorObject, OperationKey, PendingClientRequestKind,
 };
 use crate::acp_broker_protocol::{
     AcpAckParams, AcpAttachParams, AcpCloseParams, AcpDetachParams, AcpNotifyParams, AcpOpenParams,
@@ -199,13 +199,31 @@ fn acp_open(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     if broker_is_running(&dir) {
         match send_ipc_with_retry(&dir, "snapshot", json!({}), Duration::from_secs(2)) {
             Ok(result) => {
-                return Ok(json!(AcpOpenResult {
-                    snapshot: serde_json::from_value(result).map_err(|error| broker_error(
-                        -32072,
-                        format!("snapshot decode failed: {error}")
-                    ))?,
-                    adopted: true,
-                }));
+                let snapshot: ACPBrokerSnapshot =
+                    serde_json::from_value(result.clone()).map_err(|error| {
+                        broker_error(-32072, format!("snapshot decode failed: {error}"))
+                    })?;
+                if result
+                    .get("adapterExited")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    let _ = send_ipc(
+                        &dir,
+                        "close",
+                        json!({
+                            "brokerId": params.broker_id.clone(),
+                            "generation": snapshot.metadata.generation
+                        }),
+                    );
+                    // The supervisor is alive but its adapter is gone. Close
+                    // that generation and fall through to spawn a replacement.
+                } else {
+                    return Ok(json!(AcpOpenResult {
+                        snapshot,
+                        adopted: true,
+                    }));
+                }
             }
             Err(error) if broker_is_running(&dir) => {
                 return Err(error);
@@ -319,6 +337,13 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
             continue;
         }
         if let Ok(snapshot) = send_ipc(&dir, "snapshot", json!({})) {
+            if snapshot
+                .get("adapterExited")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                continue;
+            }
             brokers.push(snapshot);
         }
     }
@@ -407,7 +432,7 @@ fn handle_ipc_request(
     request: BrokerIpcRequest,
 ) -> Result<Value, AcpBrokerProcessError> {
     match request.method.as_str() {
-        "snapshot" => Ok(json!(lock_runtime(runtime).broker.snapshot())),
+        "snapshot" => Ok(broker_snapshot(runtime)),
         "attach" => broker_attach(runtime, request.params),
         "send" => broker_send(runtime, request.params),
         "notify" => broker_notify(runtime, request.params),
@@ -419,6 +444,15 @@ fn handle_ipc_request(
             format!("broker method not found: {}", request.method),
         )),
     }
+}
+
+fn broker_snapshot(runtime: &Runtime) -> Value {
+    let state = lock_runtime(runtime);
+    let mut snapshot = json!(state.broker.snapshot());
+    if let Some(object) = snapshot.as_object_mut() {
+        object.insert("adapterExited".to_string(), json!(state.adapter_exited));
+    }
+    snapshot
 }
 
 fn broker_attach(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -412,6 +412,8 @@ fn broker_attach(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpB
 
 fn broker_send(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     let params: AcpSendParams = decode(params)?;
+    let method = params.method.clone();
+    let operation_key = params.operation_key.clone();
     let operation = {
         let mut state = lock_runtime(runtime);
         ensure_generation(&state, params.generation)?;
@@ -455,11 +457,14 @@ fn broker_send(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBro
             params.params,
         )?;
     }
-    wait_for_operation_or_pending_input(
-        runtime,
-        &params.operation_key,
-        Duration::from_secs(24 * 60 * 60),
-    )
+    if method == "session/prompt" {
+        return Ok(json!({
+            "requestId": operation.adapter_request_id,
+            "replayed": operation.replayed,
+            "pending": true
+        }));
+    }
+    wait_for_operation_or_pending_input(runtime, &operation_key, Duration::from_secs(24 * 60 * 60))
 }
 
 fn broker_notify(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -106,6 +106,14 @@ pub fn handle_control_request(
 }
 
 pub fn run_broker_supervisor(dir: PathBuf) -> Result<(), AcpBrokerProcessError> {
+    let result = run_broker_supervisor_inner(dir.clone());
+    if let Err(error) = &result {
+        let _ = write_restrictive_bytes(&dir.join("startup-error"), error.message.as_bytes());
+    }
+    result
+}
+
+fn run_broker_supervisor_inner(dir: PathBuf) -> Result<(), AcpBrokerProcessError> {
     let launch_path = dir.join("launch.json");
     let launch: BrokerLaunch = serde_json::from_slice(
         &std::fs::read(&launch_path)
@@ -203,6 +211,7 @@ fn acp_open(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
         cwd: params.cwd,
         env,
     };
+    remove_transient_startup_files(&dir);
     write_restrictive_json(&dir.join("launch.json"), &launch)?;
     spawn_broker_supervisor(&dir)?;
     let snapshot = send_ipc_with_retry(&dir, "snapshot", json!({}), Duration::from_secs(2))?;
@@ -787,6 +796,9 @@ fn send_ipc_with_retry(
 ) -> Result<Value, AcpBrokerProcessError> {
     let deadline = std::time::Instant::now() + timeout;
     loop {
+        if let Some(message) = read_startup_error(dir) {
+            return Err(broker_error(-32072, message));
+        }
         match send_ipc(dir, method, params.clone()) {
             Ok(value) => return Ok(value),
             Err(error) if std::time::Instant::now() < deadline => {
@@ -795,6 +807,22 @@ fn send_ipc_with_retry(
             }
             Err(error) => return Err(error),
         }
+    }
+}
+
+fn read_startup_error(dir: &Path) -> Option<String> {
+    let message = std::fs::read_to_string(dir.join("startup-error")).ok()?;
+    let trimmed = message.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn remove_transient_startup_files(dir: &Path) {
+    for name in ["broker.sock", "ready", "startup-error", "pid.json"] {
+        let _ = std::fs::remove_file(dir.join(name));
     }
 }
 

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -192,14 +192,15 @@ fn acp_open(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     set_restrictive_dir_permissions(&dir)?;
 
     if broker_is_running(&dir) {
-        let result = send_ipc(&dir, "snapshot", json!({}))?;
-        return Ok(json!(AcpOpenResult {
-            snapshot: serde_json::from_value(result).map_err(|error| broker_error(
-                -32072,
-                format!("snapshot decode failed: {error}")
-            ))?,
-            adopted: true,
-        }));
+        if let Ok(result) = send_ipc(&dir, "snapshot", json!({})) {
+            return Ok(json!(AcpOpenResult {
+                snapshot: serde_json::from_value(result).map_err(|error| broker_error(
+                    -32072,
+                    format!("snapshot decode failed: {error}")
+                ))?,
+                adopted: true,
+            }));
+        }
     }
 
     let env = decode_env(params.env)?;
@@ -319,7 +320,21 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
                 Ok(stream) => stream,
                 Err(_) => continue,
             };
-            let _ = handle_ipc_stream(runtime.clone(), stream);
+            let mut line = String::new();
+            {
+                let mut reader = BufReader::new(&stream);
+                if reader.read_line(&mut line).is_err() {
+                    continue;
+                }
+            }
+            if ipc_line_is_close(&line) {
+                let _ = handle_ipc_line(runtime.clone(), stream, line);
+            } else {
+                let request_runtime = runtime.clone();
+                std::thread::spawn(move || {
+                    let _ = handle_ipc_line(request_runtime, stream, line);
+                });
+            }
             if runtime_is_closing(&runtime) {
                 break;
             }
@@ -335,12 +350,7 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
 }
 
 #[cfg(unix)]
-fn handle_ipc_stream(runtime: Runtime, mut stream: UnixStream) -> io::Result<()> {
-    let mut line = String::new();
-    {
-        let mut reader = BufReader::new(&stream);
-        reader.read_line(&mut line)?;
-    }
+fn handle_ipc_line(runtime: Runtime, mut stream: UnixStream, line: String) -> io::Result<()> {
     let response = match serde_json::from_str::<BrokerIpcRequest>(&line) {
         Ok(request) => match handle_ipc_request(&runtime, request) {
             Ok(result) => BrokerIpcResponse {
@@ -366,6 +376,12 @@ fn handle_ipc_stream(runtime: Runtime, mut stream: UnixStream) -> io::Result<()>
         serde_json::to_string(&response).expect("IPC response serialization")
     )?;
     stream.flush()
+}
+
+fn ipc_line_is_close(line: &str) -> bool {
+    serde_json::from_str::<BrokerIpcRequest>(line)
+        .map(|request| request.method == "close")
+        .unwrap_or(false)
 }
 
 fn handle_ipc_request(

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -409,12 +409,8 @@ fn handle_ipc_request(
 
 fn broker_attach(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     let params: AcpAttachParams = decode(params)?;
-    let mut state = lock_runtime(runtime);
+    let state = lock_runtime(runtime);
     ensure_generation(&state, params.generation)?;
-    state
-        .broker
-        .ack(params.acknowledged_cursor)
-        .map_err(domain_error)?;
     let events = state
         .broker
         .replay_after(params.acknowledged_cursor)
@@ -602,7 +598,12 @@ fn handle_adapter_stdout_line(runtime: &Runtime, line: &str) {
         let params = value.get("params").cloned().unwrap_or(Value::Null);
         let (lock, condvar) = &*runtime.state;
         let mut state = lock.lock().expect("broker state poisoned");
-        if method == "session/update" {
+        if method == "session/update"
+            && state
+                .pending_methods
+                .values()
+                .any(|pending| pending.method == "session/prompt")
+        {
             let _ = state.broker.set_turn_state(BrokerTurnState::Streaming);
         }
         state.broker.add_adapter_notification(method, params);

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -139,6 +139,7 @@ fn run_broker_supervisor_inner(dir: PathBuf) -> Result<(), AcpBrokerProcessError
     command
         .args(&launch.args)
         .current_dir(&launch.cwd)
+        .env_clear()
         .envs(&launch.env)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -318,10 +319,7 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
                 Ok(stream) => stream,
                 Err(_) => continue,
             };
-            let request_runtime = runtime.clone();
-            std::thread::spawn(move || {
-                let _ = handle_ipc_stream(request_runtime, stream);
-            });
+            let _ = handle_ipc_stream(runtime.clone(), stream);
             if runtime_is_closing(&runtime) {
                 break;
             }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -965,16 +965,28 @@ fn spawn_broker_supervisor(dir: &Path) -> Result<(), AcpBrokerProcessError> {
 }
 
 fn broker_is_running(dir: &Path) -> bool {
-    let Some(pid) = read_broker_pid(dir) else {
+    let Some(metadata) = read_broker_pid_metadata(dir) else {
         return false;
     };
-    pid_is_alive(pid)
+    if !pid_is_alive(metadata.pid) {
+        mark_stale_broker_pid(dir);
+        return false;
+    }
+    if let Some(expected_pgid) = metadata.process_group_id {
+        if current_process_group_id(metadata.pid) != Some(expected_pgid) {
+            mark_stale_broker_pid(dir);
+            return false;
+        }
+    }
+    true
 }
 
-fn read_broker_pid(dir: &Path) -> Option<u32> {
-    serde_json::from_slice::<BrokerPidMetadata>(&std::fs::read(dir.join("pid.json")).ok()?)
-        .ok()
-        .map(|metadata| metadata.pid)
+fn read_broker_pid_metadata(dir: &Path) -> Option<BrokerPidMetadata> {
+    serde_json::from_slice::<BrokerPidMetadata>(&std::fs::read(dir.join("pid.json")).ok()?).ok()
+}
+
+fn mark_stale_broker_pid(dir: &Path) {
+    let _ = std::fs::remove_file(dir.join("pid.json"));
 }
 
 fn write_broker_pid(dir: &Path) -> Result<(), AcpBrokerProcessError> {

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1,6 +1,6 @@
 use crate::acp_broker::{
-    ACPBrokerMetadata, ACPBrokerState, BrokerGeneration, BrokerId, BrokerTurnState, OperationKey,
-    PendingClientRequestKind,
+    ACPBrokerMetadata, ACPBrokerState, AdapterRPCOutcome, BrokerGeneration, BrokerId,
+    BrokerTurnState, JSONRPCErrorObject, OperationKey, PendingClientRequestKind,
 };
 use crate::acp_broker_protocol::{
     AcpAckParams, AcpAttachParams, AcpCloseParams, AcpDetachParams, AcpNotifyParams, AcpOpenParams,
@@ -70,7 +70,6 @@ struct BrokerIpcResponse {
 struct Runtime {
     state: Arc<(Mutex<RuntimeState>, Condvar)>,
     adapter_stdin: Arc<Mutex<std::process::ChildStdin>>,
-    broker_dir: PathBuf,
 }
 
 struct RuntimeState {
@@ -175,7 +174,6 @@ fn run_broker_supervisor_inner(dir: PathBuf) -> Result<(), AcpBrokerProcessError
             Condvar::new(),
         )),
         adapter_stdin: Arc::new(Mutex::new(adapter_stdin)),
-        broker_dir: dir.clone(),
     };
 
     spawn_stdout_reader(runtime.clone(), adapter_stdout);
@@ -426,39 +424,38 @@ fn broker_send(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBro
             )
             .map_err(domain_error)?;
         if operation.replayed {
-            if let Some(result) = operation.terminal_result {
-                return Ok(json!({
+            if let Some(outcome) = operation.terminal_outcome {
+                let mut response = json!({
                     "requestId": operation.adapter_request_id,
                     "replayed": true,
-                    "result": result
-                }));
+                });
+                apply_outcome_fields(&mut response, outcome);
+                return Ok(response);
             }
-            return Ok(json!({
-                "requestId": operation.adapter_request_id,
-                "replayed": true,
-                "pending": true
-            }));
-        }
-        state.pending_methods.insert(
-            operation.adapter_request_id.value(),
-            PendingOperation {
-                operation_key: params.operation_key.clone(),
-                method: params.method.clone(),
-            },
-        );
-        if params.method == "session/prompt" {
-            let _ = state.broker.set_turn_state(BrokerTurnState::Sending);
+        } else {
+            state.pending_methods.insert(
+                operation.adapter_request_id.value(),
+                PendingOperation {
+                    operation_key: params.operation_key.clone(),
+                    method: params.method.clone(),
+                },
+            );
+            if params.method == "session/prompt" {
+                let _ = state.broker.set_turn_state(BrokerTurnState::Sending);
+            }
         }
         operation
     };
 
-    write_adapter_request(
-        runtime,
-        operation.adapter_request_id.value(),
-        &params.method,
-        params.params,
-    )?;
-    wait_for_operation(
+    if !operation.replayed {
+        write_adapter_request(
+            runtime,
+            operation.adapter_request_id.value(),
+            &params.method,
+            params.params,
+        )?;
+    }
+    wait_for_operation_or_pending_input(
         runtime,
         &params.operation_key,
         Duration::from_secs(24 * 60 * 60),
@@ -483,18 +480,19 @@ fn broker_respond(
     params: Option<Value>,
 ) -> Result<Value, AcpBrokerProcessError> {
     let params: AcpRespondParams = decode(params)?;
+    let request_key = request_id_key(&params.request_id);
+    let outcome = params
+        .outcome()
+        .ok_or_else(|| broker_error(-32602, "respond requires exactly one of result or error"))?;
     {
         let mut state = lock_runtime(runtime);
         ensure_generation(&state, params.generation)?;
         state
             .broker
-            .respond_to_pending_request(
-                &params.request_id.value().to_string(),
-                params.result.clone(),
-            )
+            .respond_to_pending_request(&request_key, outcome.clone())
             .map_err(domain_error)?;
     }
-    write_adapter_response(runtime, params.request_id.value(), params.result)?;
+    write_adapter_response(runtime, params.request_id, outcome)?;
     Ok(json!({ "ok": true }))
 }
 
@@ -567,10 +565,9 @@ fn handle_adapter_response(runtime: &Runtime, value: Value) {
     let Some(id) = value.get("id").and_then(Value::as_u64) else {
         return;
     };
-    let result = value
-        .get("result")
-        .cloned()
-        .unwrap_or_else(|| json!({ "error": value.get("error").cloned().unwrap_or(Value::Null) }));
+    let Some(outcome) = adapter_response_outcome(&value) else {
+        return;
+    };
     let (lock, condvar) = &*runtime.state;
     let mut state = lock.lock().expect("broker state poisoned");
     let Some(pending) = state.pending_methods.remove(&id) else {
@@ -579,19 +576,22 @@ fn handle_adapter_response(runtime: &Runtime, value: Value) {
             .add_adapter_notification("adapter/orphanResponse", value);
         return;
     };
-    if pending.method == "initialize" {
-        let _ = state.broker.record_initialize_result(result.clone());
-    } else if matches!(
-        pending.method.as_str(),
-        "session/new" | "session/load" | "session/resume"
-    ) {
-        let _ = state.broker.record_remote_session_result(result.clone());
-    } else if pending.method == "session/prompt" {
+    if let Some(result) = &outcome.result {
+        if pending.method == "initialize" {
+            let _ = state.broker.record_initialize_result(result.clone());
+        } else if matches!(
+            pending.method.as_str(),
+            "session/new" | "session/load" | "session/resume"
+        ) {
+            let _ = state.broker.record_remote_session_result(result.clone());
+        }
+    }
+    if pending.method == "session/prompt" {
         let _ = state.broker.set_turn_state(BrokerTurnState::Completed);
     }
     let _ = state
         .broker
-        .complete_operation(&pending.operation_key, result);
+        .complete_operation(&pending.operation_key, outcome);
     condvar.notify_all();
 }
 
@@ -611,7 +611,8 @@ fn handle_adapter_client_request(runtime: &Runtime, value: Value) {
         .to_string();
     let params = value.get("params").cloned().unwrap_or(Value::Null);
     let kind = pending_kind(&method);
-    let mut state = lock_runtime(runtime);
+    let (lock, condvar) = &*runtime.state;
+    let mut state = lock.lock().expect("broker state poisoned");
     let _ = state.broker.add_pending_request(
         request_id,
         id,
@@ -619,6 +620,7 @@ fn handle_adapter_client_request(runtime: &Runtime, value: Value) {
         json!({ "method": method, "params": params }),
     );
     let _ = state.broker.set_turn_state(BrokerTurnState::AwaitingInput);
+    condvar.notify_all();
 }
 
 fn pending_kind(method: &str) -> PendingClientRequestKind {
@@ -635,7 +637,55 @@ fn pending_kind(method: &str) -> PendingClientRequestKind {
     }
 }
 
-fn wait_for_operation(
+fn adapter_response_outcome(value: &Value) -> Option<AdapterRPCOutcome> {
+    if let Some(result) = value.get("result") {
+        return Some(AdapterRPCOutcome::result(result.clone()));
+    }
+    if let Some(error) = value.get("error") {
+        return Some(AdapterRPCOutcome::error(jsonrpc_error_object(error)));
+    }
+    None
+}
+
+fn jsonrpc_error_object(value: &Value) -> JSONRPCErrorObject {
+    JSONRPCErrorObject {
+        code: value.get("code").and_then(Value::as_i64).unwrap_or(-32000),
+        message: value
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("adapter JSON-RPC error")
+            .to_string(),
+        data: value.get("data").cloned(),
+    }
+}
+
+fn request_id_key(id: &Value) -> String {
+    id.as_u64()
+        .map(|number| number.to_string())
+        .or_else(|| id.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| id.to_string())
+}
+
+fn apply_outcome_fields(response: &mut Value, outcome: AdapterRPCOutcome) {
+    if let Some(object) = response.as_object_mut() {
+        match (outcome.result, outcome.error) {
+            (Some(result), None) => {
+                object.insert("result".to_string(), result);
+            }
+            (None, Some(error)) => {
+                object.insert("error".to_string(), json!(error));
+            }
+            _ => {
+                object.insert(
+                    "error".to_string(),
+                    json!({ "code": -32603, "message": "invalid broker outcome" }),
+                );
+            }
+        }
+    }
+}
+
+fn wait_for_operation_or_pending_input(
     runtime: &Runtime,
     operation_key: &OperationKey,
     timeout: Duration,
@@ -650,11 +700,19 @@ fn wait_for_operation(
             .iter()
             .find(|operation| operation.operation_key == *operation_key)
         {
-            if let Some(result) = &operation.terminal_result {
+            if let Some(outcome) = &operation.terminal_outcome {
+                let mut response = json!({
+                    "requestId": operation.adapter_request_id,
+                    "replayed": false,
+                });
+                apply_outcome_fields(&mut response, outcome.clone());
+                return Ok(response);
+            }
+            if !snapshot.pending_requests.is_empty() {
                 return Ok(json!({
                     "requestId": operation.adapter_request_id,
                     "replayed": false,
-                    "result": result
+                    "pending": true
                 }));
             }
         }
@@ -702,14 +760,14 @@ fn write_adapter_notification(
 
 fn write_adapter_response(
     runtime: &Runtime,
-    id: u64,
-    result: Value,
+    id: Value,
+    outcome: AdapterRPCOutcome,
 ) -> Result<(), AcpBrokerProcessError> {
-    let response = json!({
+    let mut response = json!({
         "jsonrpc": "2.0",
         "id": id,
-        "result": result
     });
+    apply_outcome_fields(&mut response, outcome);
     write_adapter_line(runtime, &response)
 }
 

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -765,12 +765,7 @@ fn decode_env(value: Value) -> Result<HashMap<String, String>, AcpBrokerProcessE
 }
 
 fn validate_env_key(key: &str) -> Result<(), AcpBrokerProcessError> {
-    if !key.is_empty()
-        && !key.as_bytes()[0].is_ascii_digit()
-        && key
-            .bytes()
-            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
-    {
+    if !key.is_empty() && !key.bytes().any(|byte| byte == b'=' || byte == b'\0') {
         return Ok(());
     }
     Err(broker_error(-32602, format!("invalid env key: {key}")))

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -197,14 +197,23 @@ fn acp_open(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     set_restrictive_dir_permissions(&dir)?;
 
     if broker_is_running(&dir) {
-        if let Ok(result) = send_ipc(&dir, "snapshot", json!({})) {
-            return Ok(json!(AcpOpenResult {
-                snapshot: serde_json::from_value(result).map_err(|error| broker_error(
-                    -32072,
-                    format!("snapshot decode failed: {error}")
-                ))?,
-                adopted: true,
-            }));
+        match send_ipc_with_retry(&dir, "snapshot", json!({}), Duration::from_secs(2)) {
+            Ok(result) => {
+                return Ok(json!(AcpOpenResult {
+                    snapshot: serde_json::from_value(result).map_err(|error| broker_error(
+                        -32072,
+                        format!("snapshot decode failed: {error}")
+                    ))?,
+                    adopted: true,
+                }));
+            }
+            Err(error) if broker_is_running(&dir) => {
+                return Err(error);
+            }
+            Err(_) => {
+                // The pid disappeared while we were waiting for its socket.
+                // It is now safe to remove stale startup files and spawn a replacement.
+            }
         }
     }
 

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -549,12 +549,31 @@ fn spawn_waiter(runtime: Runtime, mut child: std::process::Child) {
         let mut state = lock.lock().expect("broker state poisoned");
         if !state.closing {
             let _ = state.broker.set_turn_state(BrokerTurnState::Ambiguous);
+            complete_pending_operations_after_adapter_exit(&mut state);
             state
                 .broker
                 .add_adapter_notification("adapter/exit", json!({ "unexpected": true }));
         }
         condvar.notify_all();
     });
+}
+
+fn complete_pending_operations_after_adapter_exit(state: &mut RuntimeState) {
+    let outcome = AdapterRPCOutcome::error(JSONRPCErrorObject {
+        code: -32074,
+        message: "adapter exited before completing request".to_string(),
+        data: None,
+    });
+    let pending: Vec<_> = state
+        .pending_methods
+        .drain()
+        .map(|(_, pending)| pending)
+        .collect();
+    for pending in pending {
+        let _ = state
+            .broker
+            .complete_operation(&pending.operation_key, outcome.clone());
+    }
 }
 
 fn handle_adapter_stdout_line(runtime: &Runtime, line: &str) {

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1,0 +1,966 @@
+use crate::acp_broker::{
+    ACPBrokerMetadata, ACPBrokerState, BrokerGeneration, BrokerId, BrokerTurnState, OperationKey,
+    PendingClientRequestKind,
+};
+use crate::acp_broker_protocol::{
+    AcpAckParams, AcpAttachParams, AcpCloseParams, AcpDetachParams, AcpOpenParams, AcpOpenResult,
+    AcpRespondParams, AcpSendParams,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::os::unix::net::{UnixListener, UnixStream};
+
+#[derive(Debug)]
+pub struct AcpBrokerProcessError {
+    pub code: i64,
+    pub message: String,
+}
+
+impl AcpBrokerProcessError {
+    fn new(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BrokerLaunch {
+    broker_id: BrokerId,
+    session_id: String,
+    command: String,
+    args: Vec<String>,
+    cwd: String,
+    env: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BrokerPidMetadata {
+    pid: u32,
+    process_group_id: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BrokerIpcRequest {
+    method: String,
+    params: Option<Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BrokerIpcResponse {
+    ok: bool,
+    result: Option<Value>,
+    error: Option<String>,
+}
+
+#[derive(Clone)]
+struct Runtime {
+    state: Arc<(Mutex<RuntimeState>, Condvar)>,
+    adapter_stdin: Arc<Mutex<std::process::ChildStdin>>,
+    broker_dir: PathBuf,
+}
+
+struct RuntimeState {
+    broker: ACPBrokerState,
+    pending_methods: HashMap<u64, PendingOperation>,
+    closing: bool,
+}
+
+#[derive(Clone, Debug)]
+struct PendingOperation {
+    operation_key: OperationKey,
+    method: String,
+}
+
+pub fn handle_control_request(
+    method: &str,
+    params: Option<Value>,
+) -> Result<Value, AcpBrokerProcessError> {
+    match method {
+        "acp/open" => acp_open(params),
+        "acp/attach" => acp_attach(params),
+        "acp/send" => acp_send(params),
+        "acp/respond" => acp_respond(params),
+        "acp/ack" => acp_ack(params),
+        "acp/detach" => acp_detach(params),
+        "acp/close" => acp_close(params),
+        "acp/list" => acp_list(),
+        _ => Err(AcpBrokerProcessError::new(
+            -32601,
+            format!("method not found: {method}"),
+        )),
+    }
+}
+
+pub fn run_broker_supervisor(dir: PathBuf) -> Result<(), AcpBrokerProcessError> {
+    let launch_path = dir.join("launch.json");
+    let launch: BrokerLaunch = serde_json::from_slice(
+        &std::fs::read(&launch_path)
+            .map_err(|error| broker_error(-32070, format!("launch read failed: {error}")))?,
+    )
+    .map_err(|error| broker_error(-32070, format!("launch decode failed: {error}")))?;
+    let _ = std::fs::remove_file(&launch_path);
+
+    let metadata = ACPBrokerMetadata {
+        broker_id: launch.broker_id.clone(),
+        generation: BrokerGeneration::new(current_millis()),
+        alas_session_id: launch.session_id.clone(),
+        adapter_program: launch.command.clone(),
+        adapter_args: launch.args.clone(),
+        cwd: launch.cwd.clone(),
+        env_keys: sorted_env_keys(&launch.env),
+        created_at_millis: current_millis(),
+    };
+    write_restrictive_json(&dir.join("metadata.json"), &metadata)?;
+    write_broker_pid(&dir)?;
+
+    let mut command = Command::new(&launch.command);
+    command
+        .args(&launch.args)
+        .current_dir(&launch.cwd)
+        .envs(&launch.env)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|error| broker_error(-32071, format!("adapter spawn failed: {error}")))?;
+    let adapter_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| broker_error(-32071, "adapter stdin unavailable"))?;
+    let adapter_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| broker_error(-32071, "adapter stdout unavailable"))?;
+    let adapter_stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| broker_error(-32071, "adapter stderr unavailable"))?;
+
+    let runtime = Runtime {
+        state: Arc::new((
+            Mutex::new(RuntimeState {
+                broker: ACPBrokerState::new(metadata),
+                pending_methods: HashMap::new(),
+                closing: false,
+            }),
+            Condvar::new(),
+        )),
+        adapter_stdin: Arc::new(Mutex::new(adapter_stdin)),
+        broker_dir: dir.clone(),
+    };
+
+    spawn_stdout_reader(runtime.clone(), adapter_stdout);
+    spawn_stderr_reader(runtime.clone(), adapter_stderr);
+    spawn_waiter(runtime.clone(), child);
+    serve_broker_ipc(runtime, dir)
+}
+
+fn acp_open(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpOpenParams = decode(params)?;
+    validate_broker_id(params.broker_id.as_str())?;
+    let dir = broker_dir(params.broker_id.as_str())?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|error| broker_error(-32070, format!("broker dir failed: {error}")))?;
+    set_restrictive_dir_permissions(&dir)?;
+
+    if broker_is_running(&dir) {
+        let result = send_ipc(&dir, "snapshot", json!({}))?;
+        return Ok(json!(AcpOpenResult {
+            snapshot: serde_json::from_value(result).map_err(|error| broker_error(
+                -32072,
+                format!("snapshot decode failed: {error}")
+            ))?,
+            adopted: true,
+        }));
+    }
+
+    let env = decode_env(params.env)?;
+    let launch = BrokerLaunch {
+        broker_id: params.broker_id,
+        session_id: params.session_id,
+        command: params.command,
+        args: params.args,
+        cwd: params.cwd,
+        env,
+    };
+    write_restrictive_json(&dir.join("launch.json"), &launch)?;
+    spawn_broker_supervisor(&dir)?;
+    let snapshot = send_ipc_with_retry(&dir, "snapshot", json!({}), Duration::from_secs(2))?;
+    Ok(json!(AcpOpenResult {
+        snapshot: serde_json::from_value(snapshot)
+            .map_err(|error| broker_error(-32072, format!("snapshot decode failed: {error}")))?,
+        adopted: false,
+    }))
+}
+
+fn acp_attach(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpAttachParams = decode(params)?;
+    let result = send_ipc(
+        &broker_dir(params.broker_id.as_str())?,
+        "attach",
+        serde_json::to_value(params).expect("attach params serialize"),
+    )?;
+    Ok(result)
+}
+
+fn acp_send(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpSendParams = decode(params)?;
+    let result = send_ipc(
+        &broker_dir(params.broker_id.as_str())?,
+        "send",
+        serde_json::to_value(params).expect("send params serialize"),
+    )?;
+    Ok(result)
+}
+
+fn acp_respond(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpRespondParams = decode(params)?;
+    let result = send_ipc(
+        &broker_dir(params.broker_id.as_str())?,
+        "respond",
+        serde_json::to_value(params).expect("respond params serialize"),
+    )?;
+    Ok(result)
+}
+
+fn acp_ack(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpAckParams = decode(params)?;
+    let result = send_ipc(
+        &broker_dir(params.broker_id.as_str())?,
+        "ack",
+        serde_json::to_value(params).expect("ack params serialize"),
+    )?;
+    Ok(result)
+}
+
+fn acp_detach(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpDetachParams = decode(params)?;
+    let _ = broker_dir(params.broker_id.as_str())?;
+    Ok(json!({ "ok": true }))
+}
+
+fn acp_close(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpCloseParams = decode(params)?;
+    let dir = broker_dir(params.broker_id.as_str())?;
+    if broker_is_running(&dir) {
+        let _ = send_ipc(&dir, "close", json!({}));
+    }
+    remove_broker_dir(&dir)?;
+    Ok(json!({ "ok": true }))
+}
+
+fn acp_list() -> Result<Value, AcpBrokerProcessError> {
+    let root = broker_root()?;
+    let mut brokers = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Ok(json!({ "brokers": brokers }));
+    };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() || !broker_is_running(&dir) {
+            continue;
+        }
+        if let Ok(snapshot) = send_ipc(&dir, "snapshot", json!({})) {
+            brokers.push(snapshot);
+        }
+    }
+    Ok(json!({ "brokers": brokers }))
+}
+
+fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProcessError> {
+    #[cfg(unix)]
+    {
+        let socket_path = dir.join("broker.sock");
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path)
+            .map_err(|error| broker_error(-32072, format!("socket bind failed: {error}")))?;
+        write_restrictive_bytes(&dir.join("ready"), b"1\n")?;
+        for stream in listener.incoming() {
+            let stream = match stream {
+                Ok(stream) => stream,
+                Err(_) => continue,
+            };
+            let request_runtime = runtime.clone();
+            std::thread::spawn(move || {
+                let _ = handle_ipc_stream(request_runtime, stream);
+            });
+            if runtime_is_closing(&runtime) {
+                break;
+            }
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = runtime;
+        let _ = dir;
+        Err(broker_error(-32072, "ACP broker IPC requires Unix sockets"))
+    }
+}
+
+#[cfg(unix)]
+fn handle_ipc_stream(runtime: Runtime, mut stream: UnixStream) -> io::Result<()> {
+    let mut line = String::new();
+    {
+        let mut reader = BufReader::new(&stream);
+        reader.read_line(&mut line)?;
+    }
+    let response = match serde_json::from_str::<BrokerIpcRequest>(&line) {
+        Ok(request) => match handle_ipc_request(&runtime, request) {
+            Ok(result) => BrokerIpcResponse {
+                ok: true,
+                result: Some(result),
+                error: None,
+            },
+            Err(error) => BrokerIpcResponse {
+                ok: false,
+                result: None,
+                error: Some(error.message),
+            },
+        },
+        Err(error) => BrokerIpcResponse {
+            ok: false,
+            result: None,
+            error: Some(format!("invalid IPC request: {error}")),
+        },
+    };
+    writeln!(
+        stream,
+        "{}",
+        serde_json::to_string(&response).expect("IPC response serialization")
+    )?;
+    stream.flush()
+}
+
+fn handle_ipc_request(
+    runtime: &Runtime,
+    request: BrokerIpcRequest,
+) -> Result<Value, AcpBrokerProcessError> {
+    match request.method.as_str() {
+        "snapshot" => Ok(json!(lock_runtime(runtime).broker.snapshot())),
+        "attach" => broker_attach(runtime, request.params),
+        "send" => broker_send(runtime, request.params),
+        "respond" => broker_respond(runtime, request.params),
+        "ack" => broker_ack(runtime, request.params),
+        "close" => {
+            lock_runtime(runtime).closing = true;
+            Ok(json!({ "ok": true }))
+        }
+        _ => Err(broker_error(
+            -32601,
+            format!("broker method not found: {}", request.method),
+        )),
+    }
+}
+
+fn broker_attach(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpAttachParams = decode(params)?;
+    let mut state = lock_runtime(runtime);
+    ensure_generation(&state, params.generation)?;
+    state
+        .broker
+        .ack(params.acknowledged_cursor)
+        .map_err(domain_error)?;
+    let events = state
+        .broker
+        .replay_after(params.acknowledged_cursor)
+        .map_err(domain_error)?;
+    Ok(json!({
+        "snapshot": state.broker.snapshot(),
+        "events": events
+    }))
+}
+
+fn broker_send(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpSendParams = decode(params)?;
+    let operation = {
+        let mut state = lock_runtime(runtime);
+        ensure_generation(&state, params.generation)?;
+        let operation = state
+            .broker
+            .begin_operation(
+                params.operation_key.clone(),
+                params.method.clone(),
+                params.params.clone(),
+            )
+            .map_err(domain_error)?;
+        if operation.replayed {
+            if let Some(result) = operation.terminal_result {
+                return Ok(json!({
+                    "requestId": operation.adapter_request_id,
+                    "replayed": true,
+                    "result": result
+                }));
+            }
+            return Ok(json!({
+                "requestId": operation.adapter_request_id,
+                "replayed": true,
+                "pending": true
+            }));
+        }
+        state.pending_methods.insert(
+            operation.adapter_request_id.value(),
+            PendingOperation {
+                operation_key: params.operation_key.clone(),
+                method: params.method.clone(),
+            },
+        );
+        if params.method == "session/prompt" {
+            let _ = state.broker.set_turn_state(BrokerTurnState::Sending);
+        }
+        operation
+    };
+
+    write_adapter_request(
+        runtime,
+        operation.adapter_request_id.value(),
+        &params.method,
+        params.params,
+    )?;
+    wait_for_operation(
+        runtime,
+        &params.operation_key,
+        Duration::from_secs(24 * 60 * 60),
+    )
+}
+
+fn broker_respond(
+    runtime: &Runtime,
+    params: Option<Value>,
+) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpRespondParams = decode(params)?;
+    {
+        let mut state = lock_runtime(runtime);
+        ensure_generation(&state, params.generation)?;
+        state
+            .broker
+            .respond_to_pending_request(
+                &params.request_id.value().to_string(),
+                params.result.clone(),
+            )
+            .map_err(domain_error)?;
+    }
+    write_adapter_response(runtime, params.request_id.value(), params.result)?;
+    Ok(json!({ "ok": true }))
+}
+
+fn broker_ack(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpAckParams = decode(params)?;
+    let mut state = lock_runtime(runtime);
+    ensure_generation(&state, params.generation)?;
+    state.broker.ack(params.cursor).map_err(domain_error)?;
+    Ok(json!({ "ok": true }))
+}
+
+fn spawn_stdout_reader(runtime: Runtime, stdout: std::process::ChildStdout) {
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            handle_adapter_stdout_line(&runtime, &line);
+        }
+    });
+}
+
+fn spawn_stderr_reader(runtime: Runtime, stderr: std::process::ChildStderr) {
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            let mut state = lock_runtime(&runtime);
+            state
+                .broker
+                .add_adapter_notification("adapter/stderr", json!({ "text": line }));
+        }
+    });
+}
+
+fn spawn_waiter(runtime: Runtime, mut child: std::process::Child) {
+    std::thread::spawn(move || {
+        let _ = child.wait();
+        let (lock, condvar) = &*runtime.state;
+        let mut state = lock.lock().expect("broker state poisoned");
+        if !state.closing {
+            let _ = state.broker.set_turn_state(BrokerTurnState::Ambiguous);
+            state
+                .broker
+                .add_adapter_notification("adapter/exit", json!({ "unexpected": true }));
+        }
+        condvar.notify_all();
+    });
+}
+
+fn handle_adapter_stdout_line(runtime: &Runtime, line: &str) {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        let mut state = lock_runtime(runtime);
+        state
+            .broker
+            .add_adapter_notification("adapter/stdout", json!({ "line": line }));
+        return;
+    };
+    if value.get("id").is_some() && (value.get("result").is_some() || value.get("error").is_some())
+    {
+        handle_adapter_response(runtime, value);
+    } else if value.get("id").is_some() && value.get("method").is_some() {
+        handle_adapter_client_request(runtime, value);
+    } else if let Some(method) = value.get("method").and_then(Value::as_str) {
+        let params = value.get("params").cloned().unwrap_or(Value::Null);
+        let mut state = lock_runtime(runtime);
+        if method == "session/update" {
+            let _ = state.broker.set_turn_state(BrokerTurnState::Streaming);
+        }
+        state.broker.add_adapter_notification(method, params);
+    }
+}
+
+fn handle_adapter_response(runtime: &Runtime, value: Value) {
+    let Some(id) = value.get("id").and_then(Value::as_u64) else {
+        return;
+    };
+    let result = value
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| json!({ "error": value.get("error").cloned().unwrap_or(Value::Null) }));
+    let (lock, condvar) = &*runtime.state;
+    let mut state = lock.lock().expect("broker state poisoned");
+    let Some(pending) = state.pending_methods.remove(&id) else {
+        state
+            .broker
+            .add_adapter_notification("adapter/orphanResponse", value);
+        return;
+    };
+    if pending.method == "initialize" {
+        let _ = state.broker.record_initialize_result(result.clone());
+    } else if matches!(
+        pending.method.as_str(),
+        "session/new" | "session/load" | "session/resume"
+    ) {
+        let _ = state.broker.record_remote_session_result(result.clone());
+    } else if pending.method == "session/prompt" {
+        let _ = state.broker.set_turn_state(BrokerTurnState::Completed);
+    }
+    let _ = state
+        .broker
+        .complete_operation(&pending.operation_key, result);
+    condvar.notify_all();
+}
+
+fn handle_adapter_client_request(runtime: &Runtime, value: Value) {
+    let Some(id) = value.get("id").cloned() else {
+        return;
+    };
+    let request_id = id
+        .as_u64()
+        .map(|number| number.to_string())
+        .or_else(|| id.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| id.to_string());
+    let method = value
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("adapter/request")
+        .to_string();
+    let params = value.get("params").cloned().unwrap_or(Value::Null);
+    let kind = pending_kind(&method);
+    let mut state = lock_runtime(runtime);
+    let _ = state.broker.add_pending_request(
+        request_id,
+        id,
+        kind,
+        json!({ "method": method, "params": params }),
+    );
+    let _ = state.broker.set_turn_state(BrokerTurnState::AwaitingInput);
+}
+
+fn pending_kind(method: &str) -> PendingClientRequestKind {
+    if method.contains("permission") {
+        PendingClientRequestKind::Permission
+    } else if method.contains("question") {
+        PendingClientRequestKind::Question
+    } else if method.contains("elicitation") {
+        PendingClientRequestKind::Elicitation
+    } else if method.contains("file") {
+        PendingClientRequestKind::File
+    } else {
+        PendingClientRequestKind::Terminal
+    }
+}
+
+fn wait_for_operation(
+    runtime: &Runtime,
+    operation_key: &OperationKey,
+    timeout: Duration,
+) -> Result<Value, AcpBrokerProcessError> {
+    let (lock, condvar) = &*runtime.state;
+    let mut state = lock.lock().expect("broker state poisoned");
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let snapshot = state.broker.snapshot();
+        if let Some(operation) = snapshot
+            .operations
+            .iter()
+            .find(|operation| operation.operation_key == *operation_key)
+        {
+            if let Some(result) = &operation.terminal_result {
+                return Ok(json!({
+                    "requestId": operation.adapter_request_id,
+                    "replayed": false,
+                    "result": result
+                }));
+            }
+        }
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            return Err(broker_error(-32073, "operation timed out"));
+        }
+        let wait_for = deadline
+            .saturating_duration_since(now)
+            .min(Duration::from_secs(1));
+        let (next_state, _) = condvar
+            .wait_timeout(state, wait_for)
+            .expect("broker state poisoned");
+        state = next_state;
+    }
+}
+
+fn write_adapter_request(
+    runtime: &Runtime,
+    id: u64,
+    method: &str,
+    params: Value,
+) -> Result<(), AcpBrokerProcessError> {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params
+    });
+    write_adapter_line(runtime, &request)
+}
+
+fn write_adapter_response(
+    runtime: &Runtime,
+    id: u64,
+    result: Value,
+) -> Result<(), AcpBrokerProcessError> {
+    let response = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    });
+    write_adapter_line(runtime, &response)
+}
+
+fn write_adapter_line(runtime: &Runtime, value: &Value) -> Result<(), AcpBrokerProcessError> {
+    let mut stdin = runtime
+        .adapter_stdin
+        .lock()
+        .map_err(|_| broker_error(-32074, "adapter stdin lock poisoned"))?;
+    writeln!(stdin, "{value}")
+        .map_err(|error| broker_error(-32074, format!("adapter write failed: {error}")))?;
+    stdin
+        .flush()
+        .map_err(|error| broker_error(-32074, format!("adapter flush failed: {error}")))
+}
+
+fn ensure_generation(
+    state: &RuntimeState,
+    generation: BrokerGeneration,
+) -> Result<(), AcpBrokerProcessError> {
+    if state.broker.metadata().generation != generation {
+        return Err(broker_error(-32075, "broker generation mismatch"));
+    }
+    Ok(())
+}
+
+fn lock_runtime(runtime: &Runtime) -> std::sync::MutexGuard<'_, RuntimeState> {
+    runtime.state.0.lock().expect("broker state poisoned")
+}
+
+fn runtime_is_closing(runtime: &Runtime) -> bool {
+    lock_runtime(runtime).closing
+}
+
+fn decode<T: for<'de> Deserialize<'de>>(params: Option<Value>) -> Result<T, AcpBrokerProcessError> {
+    let params = params.ok_or_else(|| broker_error(-32602, "missing params"))?;
+    serde_json::from_value(params)
+        .map_err(|error| broker_error(-32602, format!("invalid params: {error}")))
+}
+
+fn decode_env(value: Value) -> Result<HashMap<String, String>, AcpBrokerProcessError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| broker_error(-32602, "env must be an object"))?;
+    let mut env = HashMap::new();
+    for (key, value) in object {
+        validate_env_key(key)?;
+        let string = value
+            .as_str()
+            .ok_or_else(|| broker_error(-32602, format!("env value for {key} must be a string")))?;
+        env.insert(key.clone(), string.to_string());
+    }
+    Ok(env)
+}
+
+fn validate_env_key(key: &str) -> Result<(), AcpBrokerProcessError> {
+    if !key.is_empty()
+        && !key.as_bytes()[0].is_ascii_digit()
+        && key
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+    {
+        return Ok(());
+    }
+    Err(broker_error(-32602, format!("invalid env key: {key}")))
+}
+
+fn sorted_env_keys(env: &HashMap<String, String>) -> Vec<String> {
+    let mut keys: Vec<_> = env.keys().cloned().collect();
+    keys.sort();
+    keys
+}
+
+fn send_ipc(dir: &Path, method: &str, params: Value) -> Result<Value, AcpBrokerProcessError> {
+    #[cfg(unix)]
+    {
+        let mut stream = UnixStream::connect(dir.join("broker.sock"))
+            .map_err(|error| broker_error(-32072, format!("broker connect failed: {error}")))?;
+        let request = BrokerIpcRequest {
+            method: method.to_string(),
+            params: Some(params),
+        };
+        writeln!(
+            stream,
+            "{}",
+            serde_json::to_string(&request).expect("IPC request serialization")
+        )
+        .map_err(|error| broker_error(-32072, format!("broker write failed: {error}")))?;
+        stream
+            .flush()
+            .map_err(|error| broker_error(-32072, format!("broker flush failed: {error}")))?;
+        let mut line = String::new();
+        BufReader::new(stream)
+            .read_line(&mut line)
+            .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?;
+        let response: BrokerIpcResponse = serde_json::from_str(&line)
+            .map_err(|error| broker_error(-32072, format!("broker response failed: {error}")))?;
+        if response.ok {
+            Ok(response.result.unwrap_or(Value::Null))
+        } else {
+            Err(broker_error(
+                -32072,
+                response
+                    .error
+                    .unwrap_or_else(|| "broker request failed".to_string()),
+            ))
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = dir;
+        let _ = method;
+        let _ = params;
+        Err(broker_error(-32072, "ACP broker IPC requires Unix sockets"))
+    }
+}
+
+fn send_ipc_with_retry(
+    dir: &Path,
+    method: &str,
+    params: Value,
+    timeout: Duration,
+) -> Result<Value, AcpBrokerProcessError> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match send_ipc(dir, method, params.clone()) {
+            Ok(value) => return Ok(value),
+            Err(error) if std::time::Instant::now() < deadline => {
+                let _ = error;
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn spawn_broker_supervisor(dir: &Path) -> Result<(), AcpBrokerProcessError> {
+    let exe = std::env::current_exe()
+        .map_err(|error| broker_error(-32070, format!("helper path failed: {error}")))?;
+    let mut command = Command::new(exe);
+    command
+        .arg("acp-broker-supervise")
+        .arg(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    command
+        .spawn()
+        .map_err(|error| broker_error(-32070, format!("broker spawn failed: {error}")))?;
+    Ok(())
+}
+
+fn broker_is_running(dir: &Path) -> bool {
+    let Some(pid) = read_broker_pid(dir) else {
+        return false;
+    };
+    pid_is_alive(pid)
+}
+
+fn read_broker_pid(dir: &Path) -> Option<u32> {
+    serde_json::from_slice::<BrokerPidMetadata>(&std::fs::read(dir.join("pid.json")).ok()?)
+        .ok()
+        .map(|metadata| metadata.pid)
+}
+
+fn write_broker_pid(dir: &Path) -> Result<(), AcpBrokerProcessError> {
+    let metadata = BrokerPidMetadata {
+        pid: std::process::id(),
+        process_group_id: current_process_group_id(std::process::id()),
+    };
+    write_restrictive_json(&dir.join("pid.json"), &metadata)
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    unsafe { libc_kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn pid_is_alive(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn current_process_group_id(pid: u32) -> Option<u32> {
+    let pgid = unsafe { libc_getpgid(pid as i32) };
+    if pgid >= 0 { Some(pgid as u32) } else { None }
+}
+
+#[cfg(not(unix))]
+fn current_process_group_id(_pid: u32) -> Option<u32> {
+    None
+}
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+    fn getpgid(pid: i32) -> i32;
+}
+
+#[cfg(unix)]
+unsafe fn libc_kill(pid: i32, sig: i32) -> i32 {
+    unsafe { kill(pid, sig) }
+}
+
+#[cfg(unix)]
+unsafe fn libc_getpgid(pid: i32) -> i32 {
+    unsafe { getpgid(pid) }
+}
+
+fn validate_broker_id(broker_id: &str) -> Result<(), AcpBrokerProcessError> {
+    if broker_id.is_empty()
+        || broker_id.len() > 160
+        || !broker_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+    {
+        return Err(broker_error(-32602, "invalid brokerId"));
+    }
+    Ok(())
+}
+
+fn broker_root() -> Result<PathBuf, AcpBrokerProcessError> {
+    let home = std::env::var("HOME").map_err(|_| broker_error(-32070, "HOME is not set"))?;
+    Ok(PathBuf::from(home).join(".alas").join("acp-brokers"))
+}
+
+fn broker_dir(broker_id: &str) -> Result<PathBuf, AcpBrokerProcessError> {
+    validate_broker_id(broker_id)?;
+    Ok(broker_root()?.join(broker_id))
+}
+
+fn remove_broker_dir(dir: &Path) -> Result<(), AcpBrokerProcessError> {
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(broker_error(
+            -32070,
+            format!("broker cleanup failed: {error}"),
+        )),
+    }
+}
+
+fn write_restrictive_json<T: Serialize>(
+    path: &Path,
+    value: &T,
+) -> Result<(), AcpBrokerProcessError> {
+    write_restrictive_bytes(
+        path,
+        &serde_json::to_vec(value).expect("broker JSON serialization"),
+    )
+}
+
+fn write_restrictive_bytes(path: &Path, bytes: &[u8]) -> Result<(), AcpBrokerProcessError> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| broker_error(-32070, format!("file create failed: {error}")))?;
+    file.write_all(bytes)
+        .map_err(|error| broker_error(-32070, format!("file write failed: {error}")))?;
+    file.flush()
+        .map_err(|error| broker_error(-32070, format!("file flush failed: {error}")))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_restrictive_dir_permissions(dir: &Path) -> Result<(), AcpBrokerProcessError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+        .map_err(|error| broker_error(-32070, format!("broker chmod failed: {error}")))
+}
+
+#[cfg(not(unix))]
+fn set_restrictive_dir_permissions(_dir: &Path) -> Result<(), AcpBrokerProcessError> {
+    Ok(())
+}
+
+fn current_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+fn domain_error(error: crate::acp_broker::BrokerError) -> AcpBrokerProcessError {
+    broker_error(-32076, format!("broker state error: {:?}", error.kind()))
+}
+
+fn broker_error(code: i64, message: impl Into<String>) -> AcpBrokerProcessError {
+    AcpBrokerProcessError::new(code, message)
+}

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -3,8 +3,8 @@ use crate::acp_broker::{
     PendingClientRequestKind,
 };
 use crate::acp_broker_protocol::{
-    AcpAckParams, AcpAttachParams, AcpCloseParams, AcpDetachParams, AcpOpenParams, AcpOpenResult,
-    AcpRespondParams, AcpSendParams,
+    AcpAckParams, AcpAttachParams, AcpCloseParams, AcpDetachParams, AcpNotifyParams, AcpOpenParams,
+    AcpOpenResult, AcpRespondParams, AcpSendParams,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -93,6 +93,7 @@ pub fn handle_control_request(
         "acp/open" => acp_open(params),
         "acp/attach" => acp_attach(params),
         "acp/send" => acp_send(params),
+        "acp/notify" => acp_notify(params),
         "acp/respond" => acp_respond(params),
         "acp/ack" => acp_ack(params),
         "acp/detach" => acp_detach(params),
@@ -242,6 +243,16 @@ fn acp_send(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     Ok(result)
 }
 
+fn acp_notify(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpNotifyParams = decode(params)?;
+    let result = send_ipc(
+        &broker_dir(params.broker_id.as_str())?,
+        "notify",
+        serde_json::to_value(params).expect("notify params serialize"),
+    )?;
+    Ok(result)
+}
+
 fn acp_respond(params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
     let params: AcpRespondParams = decode(params)?;
     let result = send_ipc(
@@ -369,6 +380,7 @@ fn handle_ipc_request(
         "snapshot" => Ok(json!(lock_runtime(runtime).broker.snapshot())),
         "attach" => broker_attach(runtime, request.params),
         "send" => broker_send(runtime, request.params),
+        "notify" => broker_notify(runtime, request.params),
         "respond" => broker_respond(runtime, request.params),
         "ack" => broker_ack(runtime, request.params),
         "close" => {
@@ -451,6 +463,19 @@ fn broker_send(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBro
         &params.operation_key,
         Duration::from_secs(24 * 60 * 60),
     )
+}
+
+fn broker_notify(runtime: &Runtime, params: Option<Value>) -> Result<Value, AcpBrokerProcessError> {
+    let params: AcpNotifyParams = decode(params)?;
+    {
+        let mut state = lock_runtime(runtime);
+        ensure_generation(&state, params.generation)?;
+        if params.method == "session/cancel" {
+            let _ = state.broker.set_turn_state(BrokerTurnState::Cancelling);
+        }
+    }
+    write_adapter_notification(runtime, &params.method, params.params)?;
+    Ok(json!({ "ok": true }))
 }
 
 fn broker_respond(
@@ -660,6 +685,19 @@ fn write_adapter_request(
         "params": params
     });
     write_adapter_line(runtime, &request)
+}
+
+fn write_adapter_notification(
+    runtime: &Runtime,
+    method: &str,
+    params: Value,
+) -> Result<(), AcpBrokerProcessError> {
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params
+    });
+    write_adapter_line(runtime, &notification)
 }
 
 fn write_adapter_response(

--- a/AlasHelper/src/acp_broker_protocol.rs
+++ b/AlasHelper/src/acp_broker_protocol.rs
@@ -2,7 +2,7 @@ use crate::acp_broker::{
     ACPBrokerSnapshot, AdapterRPCOutcome, BrokerGeneration, BrokerId, EventCursor,
     JSONRPCErrorObject, OperationKey,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -50,15 +50,63 @@ pub struct AcpNotifyParams {
     pub params: Value,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AcpRespondParams {
     pub broker_id: BrokerId,
     pub generation: BrokerGeneration,
     pub request_id: Value,
     pub operation_key: OperationKey,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<JSONRPCErrorObject>,
+}
+
+impl<'de> Deserialize<'de> for AcpRespondParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut object = Value::deserialize(deserializer)?
+            .as_object()
+            .cloned()
+            .ok_or_else(|| serde::de::Error::custom("AcpRespondParams must be an object"))?;
+        let result = if object.contains_key("result") {
+            Some(object.remove("result").unwrap_or(Value::Null))
+        } else {
+            None
+        };
+        let error = match object.remove("error") {
+            Some(Value::Null) | None => None,
+            Some(value) => Some(serde_json::from_value(value).map_err(serde::de::Error::custom)?),
+        };
+        Ok(Self {
+            broker_id: serde_json::from_value(
+                object
+                    .remove("brokerId")
+                    .ok_or_else(|| serde::de::Error::missing_field("brokerId"))?,
+            )
+            .map_err(serde::de::Error::custom)?,
+            generation: serde_json::from_value(
+                object
+                    .remove("generation")
+                    .ok_or_else(|| serde::de::Error::missing_field("generation"))?,
+            )
+            .map_err(serde::de::Error::custom)?,
+            request_id: object
+                .remove("requestId")
+                .ok_or_else(|| serde::de::Error::missing_field("requestId"))?,
+            operation_key: serde_json::from_value(
+                object
+                    .remove("operationKey")
+                    .ok_or_else(|| serde::de::Error::missing_field("operationKey"))?,
+            )
+            .map_err(serde::de::Error::custom)?,
+            result,
+            error,
+        })
+    }
 }
 
 impl AcpRespondParams {

--- a/AlasHelper/src/acp_broker_protocol.rs
+++ b/AlasHelper/src/acp_broker_protocol.rs
@@ -1,0 +1,106 @@
+use crate::acp_broker::{
+    ACPBrokerSnapshot, AdapterRequestId, BrokerGeneration, BrokerId, EventCursor, OperationKey,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpOpenParams {
+    pub broker_id: BrokerId,
+    pub session_id: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub cwd: String,
+    pub env: Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpOpenResult {
+    pub snapshot: ACPBrokerSnapshot,
+    pub adopted: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpAttachParams {
+    pub broker_id: BrokerId,
+    pub generation: BrokerGeneration,
+    pub acknowledged_cursor: EventCursor,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpSendParams {
+    pub broker_id: BrokerId,
+    pub generation: BrokerGeneration,
+    pub operation_key: OperationKey,
+    pub method: String,
+    pub params: Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpRespondParams {
+    pub broker_id: BrokerId,
+    pub generation: BrokerGeneration,
+    pub request_id: AdapterRequestId,
+    pub operation_key: OperationKey,
+    pub result: Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpAckParams {
+    pub broker_id: BrokerId,
+    pub generation: BrokerGeneration,
+    pub cursor: EventCursor,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpDetachParams {
+    pub broker_id: BrokerId,
+    pub generation: BrokerGeneration,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpCloseParams {
+    pub broker_id: BrokerId,
+    pub generation: BrokerGeneration,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpListResult {
+    pub brokers: Vec<ACPBrokerSnapshot>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AcpBrokerMethod {
+    Open,
+    Attach,
+    Send,
+    Respond,
+    Ack,
+    Detach,
+    Close,
+    List,
+}
+
+impl AcpBrokerMethod {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "acp/open",
+            Self::Attach => "acp/attach",
+            Self::Send => "acp/send",
+            Self::Respond => "acp/respond",
+            Self::Ack => "acp/ack",
+            Self::Detach => "acp/detach",
+            Self::Close => "acp/close",
+            Self::List => "acp/list",
+        }
+    }
+}

--- a/AlasHelper/src/acp_broker_protocol.rs
+++ b/AlasHelper/src/acp_broker_protocol.rs
@@ -1,5 +1,6 @@
 use crate::acp_broker::{
-    ACPBrokerSnapshot, AdapterRequestId, BrokerGeneration, BrokerId, EventCursor, OperationKey,
+    ACPBrokerSnapshot, AdapterRPCOutcome, BrokerGeneration, BrokerId, EventCursor,
+    JSONRPCErrorObject, OperationKey,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -54,9 +55,20 @@ pub struct AcpNotifyParams {
 pub struct AcpRespondParams {
     pub broker_id: BrokerId,
     pub generation: BrokerGeneration,
-    pub request_id: AdapterRequestId,
+    pub request_id: Value,
     pub operation_key: OperationKey,
-    pub result: Value,
+    pub result: Option<Value>,
+    pub error: Option<JSONRPCErrorObject>,
+}
+
+impl AcpRespondParams {
+    pub fn outcome(&self) -> Option<AdapterRPCOutcome> {
+        match (&self.result, &self.error) {
+            (Some(result), None) => Some(AdapterRPCOutcome::result(result.clone())),
+            (None, Some(error)) => Some(AdapterRPCOutcome::error(error.clone())),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/AlasHelper/src/acp_broker_protocol.rs
+++ b/AlasHelper/src/acp_broker_protocol.rs
@@ -42,6 +42,15 @@ pub struct AcpSendParams {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AcpNotifyParams {
+    pub broker_id: BrokerId,
+    pub generation: BrokerGeneration,
+    pub method: String,
+    pub params: Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AcpRespondParams {
     pub broker_id: BrokerId,
     pub generation: BrokerGeneration,
@@ -83,6 +92,7 @@ pub enum AcpBrokerMethod {
     Open,
     Attach,
     Send,
+    Notify,
     Respond,
     Ack,
     Detach,
@@ -96,6 +106,7 @@ impl AcpBrokerMethod {
             Self::Open => "acp/open",
             Self::Attach => "acp/attach",
             Self::Send => "acp/send",
+            Self::Notify => "acp/notify",
             Self::Respond => "acp/respond",
             Self::Ack => "acp/ack",
             Self::Detach => "acp/detach",

--- a/AlasHelper/src/lib.rs
+++ b/AlasHelper/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod acp_broker;
+pub mod acp_broker_process;
 pub mod acp_broker_protocol;

--- a/AlasHelper/src/lib.rs
+++ b/AlasHelper/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod acp_broker;
+pub mod acp_broker_protocol;

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -1,5 +1,6 @@
 mod watch;
 
+use alas_helper::acp_broker_process;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -236,6 +237,8 @@ fn capabilities() -> Value {
         "search": true,
         "ping": true,
         "proc": true
+        ,
+        "acp": true
     })
 }
 
@@ -263,6 +266,16 @@ fn main() {
             };
             if let Err(error) = proc_supervise(PathBuf::from(dir)) {
                 eprintln!("alas-helper proc-supervise: {}", error.message);
+                std::process::exit(1);
+            }
+        }
+        Some("acp-broker-supervise") => {
+            let Some(dir) = args.next() else {
+                eprintln!("usage: alas-helper acp-broker-supervise <broker-dir>");
+                std::process::exit(2);
+            };
+            if let Err(error) = acp_broker_process::run_broker_supervisor(PathBuf::from(dir)) {
+                eprintln!("alas-helper acp-broker-supervise: {}", error.message);
                 std::process::exit(1);
             }
         }
@@ -530,6 +543,14 @@ fn handle_request(
         "proc/write" => proc_write(params),
         "proc/kill" => proc_kill(params),
         "proc/list" => proc_list(),
+        method if method.starts_with("acp/") => {
+            acp_broker_process::handle_control_request(method, params).map_err(|error| {
+                HelperError {
+                    code: error.code,
+                    message: error.message,
+                }
+            })
+        }
         _ => Err(jsonrpc_error(-32601, format!("method not found: {method}"))),
     }
 }

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -240,6 +240,73 @@ fn prompt_streaming_update_returns_progress_before_turn_completion() {
 }
 
 #[test]
+fn adapter_exit_completes_inflight_prompt_with_error() {
+    let fixture = Fixture::new("prompt-exit");
+    let mut helper = Helper::start(&fixture.home);
+    let mut open_params = fixture.open_params("broker-prompt-exit", 0);
+    open_params["env"]["FAKE_ACP_EXIT_DURING_PROMPT"] = json!("1");
+    let open = helper.request("acp/open", open_params);
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-prompt-exit",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+    send(
+        &mut helper,
+        "broker-prompt-exit",
+        generation.clone(),
+        "session/new",
+        "session-new",
+        json!({}),
+    );
+
+    let completed = drive_until_prompt_completed(
+        &mut helper,
+        "broker-prompt-exit",
+        generation.clone(),
+        "prompt-exit",
+        json!({ "prompt": "adapter exits" }),
+    );
+
+    assert_eq!(completed["replayed"], true, "{completed}");
+    assert_eq!(completed["error"]["code"], -32074, "{completed}");
+    assert_eq!(
+        completed["error"]["message"],
+        "adapter exited before completing request"
+    );
+
+    let attached = helper.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-prompt-exit",
+            "generation": generation,
+            "acknowledgedCursor": 0
+        }),
+    );
+    let events = attached["events"].as_array().expect("events");
+    assert!(
+        events.iter().any(|event| {
+            event["kind"]["type"] == "operationCompleted"
+                && event["kind"]["operationKey"] == "prompt-exit"
+                && event["kind"]["outcome"]["error"]["code"] == -32074
+        }),
+        "attached payload: {attached}"
+    );
+    assert!(
+        events.iter().any(|event| {
+            event["kind"]["type"] == "adapterNotification"
+                && event["kind"]["method"] == "adapter/exit"
+        }),
+        "attached payload: {attached}"
+    );
+}
+
+#[test]
 fn pending_permission_survives_helper_crash_and_can_be_answered_after_attach() {
     let fixture = Fixture::new("permission-crash");
     let mut helper = Helper::start(&fixture.home);
@@ -503,6 +570,71 @@ fn adapter_jsonrpc_errors_are_returned_as_send_errors() {
     assert!(failed.get("result").is_none());
 }
 
+#[test]
+fn adapter_exit_completes_pending_operation_and_replays_error() {
+    let fixture = Fixture::new("adapter-exit");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-adapter-exit", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-adapter-exit",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+
+    helper.write_request_without_reading(
+        "acp/send",
+        json!({
+            "brokerId": "broker-adapter-exit",
+            "generation": generation,
+            "operationKey": "session-load-exit",
+            "method": "session/load",
+            "params": { "sessionId": "exit-load" }
+        }),
+    );
+    fixture.wait_for_log("session/load\n");
+    std::thread::sleep(Duration::from_millis(250));
+
+    let mut inspector = Helper::start(&fixture.home);
+    let attached = inspector.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-adapter-exit",
+            "generation": open["snapshot"]["metadata"]["generation"],
+            "acknowledgedCursor": 0
+        }),
+    );
+    assert!(
+        attached["events"].as_array().unwrap().iter().any(|event| {
+            event["kind"]["type"] == "operationCompleted"
+                && event["kind"]["operationKey"] == "session-load-exit"
+                && event["kind"]["outcome"]["error"]["code"] == -32074
+        }),
+        "attached payload: {attached}"
+    );
+
+    let retried = inspector.request(
+        "acp/send",
+        json!({
+            "brokerId": "broker-adapter-exit",
+            "generation": open["snapshot"]["metadata"]["generation"],
+            "operationKey": "session-load-exit",
+            "method": "session/load",
+            "params": { "sessionId": "exit-load" }
+        }),
+    );
+    assert_eq!(retried["replayed"], true);
+    assert_eq!(retried["error"]["code"], -32074);
+    assert_eq!(
+        retried["error"]["message"],
+        "adapter exited before completing request"
+    );
+}
+
 fn send(
     helper: &mut Helper,
     broker_id: &str,
@@ -690,11 +822,17 @@ while IFS= read -r line; do
       ;;
     *'"method":"session/load"'*)
       printf 'session/load\n' >> "$FAKE_ACP_LOG"
+      if printf '%s\n' "$line" | grep -q exit-load; then
+        exit 42
+      fi
       printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32042,"message":"load failed"}}\n' "$id"
       ;;
     *'"method":"session/prompt"'*)
       printf 'session/prompt\n' >> "$FAKE_ACP_LOG"
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"remote-1","update":{"kind":"text","text":"started"}}}\n'
+      if [ "${FAKE_ACP_EXIT_DURING_PROMPT:-0}" = "1" ]; then
+        exit 42
+      fi
       if printf '%s\n' "$line" | grep -q permission; then
         if printf '%s\n' "$line" | grep -q string-permission; then
           request_id='"req-alpha"'

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -283,6 +283,211 @@ fn pending_permission_survives_helper_crash_and_can_be_answered_after_attach() {
     assert_eq!(retried["result"]["stopReason"], "end_turn");
 }
 
+#[test]
+fn pending_permission_returns_before_prompt_completion_and_can_resume() {
+    let fixture = Fixture::new("permission-pending");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-pending", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-pending",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+    send(
+        &mut helper,
+        "broker-pending",
+        generation.clone(),
+        "session/new",
+        "session-new",
+        json!({}),
+    );
+
+    let pending = send(
+        &mut helper,
+        "broker-pending",
+        generation.clone(),
+        "session/prompt",
+        "prompt-permission",
+        json!({ "prompt": "needs permission" }),
+    );
+    assert_eq!(pending["pending"], true);
+
+    let attached = helper.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-pending",
+            "generation": generation,
+            "acknowledgedCursor": 0
+        }),
+    );
+    assert!(
+        attached["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|event| event["kind"]["type"] == "pendingRequest")
+    );
+
+    let response = helper.request(
+        "acp/respond",
+        json!({
+            "brokerId": "broker-pending",
+            "generation": open["snapshot"]["metadata"]["generation"],
+            "requestId": 900,
+            "operationKey": "permission-answer",
+            "result": { "outcome": "approved" }
+        }),
+    );
+    assert_eq!(response["ok"], true);
+
+    let completed = send(
+        &mut helper,
+        "broker-pending",
+        open["snapshot"]["metadata"]["generation"].clone(),
+        "session/prompt",
+        "prompt-permission",
+        json!({ "prompt": "needs permission" }),
+    );
+    assert_eq!(completed["replayed"], false);
+    assert_eq!(completed["result"]["stopReason"], "end_turn");
+}
+
+#[test]
+fn string_permission_request_id_is_preserved_when_responding() {
+    let fixture = Fixture::new("permission-string-id");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-string-id", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-string-id",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+    send(
+        &mut helper,
+        "broker-string-id",
+        generation.clone(),
+        "session/new",
+        "session-new",
+        json!({}),
+    );
+
+    let pending = send(
+        &mut helper,
+        "broker-string-id",
+        generation.clone(),
+        "session/prompt",
+        "prompt-string-permission",
+        json!({ "prompt": "needs string-permission" }),
+    );
+    assert_eq!(pending["pending"], true);
+
+    helper.request(
+        "acp/respond",
+        json!({
+            "brokerId": "broker-string-id",
+            "generation": generation,
+            "requestId": "req-alpha",
+            "operationKey": "permission-answer",
+            "result": { "outcome": "approved" }
+        }),
+    );
+    fixture.wait_for_log("\"id\":\"req-alpha\"");
+    let log = std::fs::read_to_string(&fixture.log).expect("adapter log");
+    assert!(
+        log.contains("\"result\":{\"outcome\":\"approved\"}"),
+        "{log}"
+    );
+}
+
+#[test]
+fn failed_permission_response_is_sent_to_adapter_as_jsonrpc_error() {
+    let fixture = Fixture::new("permission-error");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request(
+        "acp/open",
+        fixture.open_params("broker-permission-error", 0),
+    );
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-permission-error",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+    send(
+        &mut helper,
+        "broker-permission-error",
+        generation.clone(),
+        "session/new",
+        "session-new",
+        json!({}),
+    );
+
+    let pending = send(
+        &mut helper,
+        "broker-permission-error",
+        generation.clone(),
+        "session/prompt",
+        "prompt-string-permission",
+        json!({ "prompt": "needs string-permission" }),
+    );
+    assert_eq!(pending["pending"], true);
+
+    helper.request(
+        "acp/respond",
+        json!({
+            "brokerId": "broker-permission-error",
+            "generation": generation,
+            "requestId": "req-alpha",
+            "operationKey": "permission-answer",
+            "error": { "code": -32001, "message": "denied" }
+        }),
+    );
+    fixture.wait_for_log("\"error\":{\"code\":-32001");
+}
+
+#[test]
+fn adapter_jsonrpc_errors_are_returned_as_send_errors() {
+    let fixture = Fixture::new("adapter-error");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-adapter-error", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-adapter-error",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+
+    let failed = send(
+        &mut helper,
+        "broker-adapter-error",
+        generation.clone(),
+        "session/load",
+        "session-load-error",
+        json!({ "sessionId": "fail-load" }),
+    );
+    assert_eq!(failed["error"]["code"], -32042);
+    assert_eq!(failed["error"]["message"], "load failed");
+    assert!(failed.get("result").is_none());
+}
+
 fn send(
     helper: &mut Helper,
     broker_id: &str,
@@ -382,11 +587,20 @@ while IFS= read -r line; do
       printf 'session/new\n' >> "$FAKE_ACP_LOG"
       printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"remote-1"}}\n' "$id"
       ;;
+    *'"method":"session/load"'*)
+      printf 'session/load\n' >> "$FAKE_ACP_LOG"
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32042,"message":"load failed"}}\n' "$id"
+      ;;
     *'"method":"session/prompt"'*)
       printf 'session/prompt\n' >> "$FAKE_ACP_LOG"
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"remote-1","update":{"kind":"text","text":"started"}}}\n'
       if printf '%s\n' "$line" | grep -q permission; then
-        printf '{"jsonrpc":"2.0","id":900,"method":"session/request_permission","params":{"toolCallId":"tool-1"}}\n'
+        if printf '%s\n' "$line" | grep -q string-permission; then
+          request_id='"req-alpha"'
+        else
+          request_id='900'
+        fi
+        printf '{"jsonrpc":"2.0","id":%s,"method":"session/request_permission","params":{"toolCallId":"tool-1"}}\n' "$request_id"
         IFS= read -r answer
         printf 'permission-answer:%s\n' "$answer" >> "$FAKE_ACP_LOG"
       fi

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -680,7 +680,7 @@ fn adapter_jsonrpc_errors_are_returned_as_send_errors() {
     let open = helper.request("acp/open", fixture.open_params("broker-adapter-error", 0));
     let generation = open["snapshot"]["metadata"]["generation"].clone();
 
-    send(
+    drive_until_operation_completed(
         &mut helper,
         "broker-adapter-error",
         generation.clone(),
@@ -689,7 +689,7 @@ fn adapter_jsonrpc_errors_are_returned_as_send_errors() {
         json!({}),
     );
 
-    let failed = send(
+    let failed = drive_until_operation_completed(
         &mut helper,
         "broker-adapter-error",
         generation.clone(),
@@ -785,6 +785,32 @@ fn send(
             "params": params
         }),
     )
+}
+
+fn drive_until_operation_completed(
+    helper: &mut Helper,
+    broker_id: &str,
+    generation: Value,
+    method: &str,
+    operation_key: &str,
+    params: Value,
+) -> Value {
+    for _ in 0..20 {
+        let result = send(
+            helper,
+            broker_id,
+            generation.clone(),
+            method,
+            operation_key,
+            params.clone(),
+        );
+        if result.get("result").is_some() || result.get("error").is_some() {
+            return result;
+        }
+        assert_eq!(result["pending"], true, "{result}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for operation completion");
 }
 
 fn drive_until_pending_request(

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -1,0 +1,405 @@
+use serde_json::{Value, json};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+struct Helper {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+    next_id: u64,
+}
+
+impl Helper {
+    fn start(home: &Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_alas-helper"))
+            .arg("serve")
+            .env("HOME", home)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("helper serve starts");
+        let stdin = child.stdin.take().expect("helper stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("helper stdout"));
+        Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        }
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        writeln!(
+            self.stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": params
+            })
+        )
+        .expect("write helper request");
+        self.stdin.flush().expect("flush helper request");
+        let mut line = String::new();
+        self.stdout
+            .read_line(&mut line)
+            .expect("read helper response");
+        let response: Value = serde_json::from_str(&line).expect("helper response JSON");
+        if response.get("error").is_some() {
+            panic!("helper error for {method}: {response}");
+        }
+        response["result"].clone()
+    }
+
+    fn write_request_without_reading(&mut self, method: &str, params: Value) {
+        let id = self.next_id;
+        self.next_id += 1;
+        writeln!(
+            self.stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": params
+            })
+        )
+        .expect("write helper request");
+        self.stdin.flush().expect("flush helper request");
+    }
+
+    fn kill(mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for Helper {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn open_list_and_close_broker_without_persisting_env_values() {
+    let fixture = Fixture::new("open-list-close");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-open", 0));
+
+    assert_eq!(open["adopted"], false);
+    assert_eq!(open["snapshot"]["metadata"]["brokerId"], "broker-open");
+    assert_eq!(
+        open["snapshot"]["metadata"]["envKeys"],
+        json!(["FAKE_ACP_LOG", "FAKE_ACP_PROMPT_DELAY"])
+    );
+
+    let metadata = std::fs::read_to_string(
+        fixture
+            .home
+            .join(".alas/acp-brokers/broker-open/metadata.json"),
+    )
+    .expect("metadata exists");
+    assert!(metadata.contains("FAKE_ACP_LOG"));
+    assert!(!metadata.contains(fixture.log.to_string_lossy().as_ref()));
+
+    let adopted = helper.request("acp/open", fixture.open_params("broker-open", 0));
+    assert_eq!(adopted["adopted"], true);
+
+    let mut helper2 = Helper::start(&fixture.home);
+    let list = helper2.request("acp/list", json!({}));
+    assert_eq!(list["brokers"].as_array().unwrap().len(), 1);
+
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+    let close = helper2.request(
+        "acp/close",
+        json!({ "brokerId": "broker-open", "generation": generation }),
+    );
+    assert_eq!(close["ok"], true);
+}
+
+#[test]
+fn helper_crash_during_prompt_preserves_completion_and_replays_events() {
+    let fixture = Fixture::new("prompt-crash");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-prompt", 1));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-prompt",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+    send(
+        &mut helper,
+        "broker-prompt",
+        generation.clone(),
+        "session/new",
+        "session-new",
+        json!({}),
+    );
+
+    helper.write_request_without_reading(
+        "acp/send",
+        json!({
+            "brokerId": "broker-prompt",
+            "generation": generation,
+            "operationKey": "prompt-1",
+            "method": "session/prompt",
+            "params": { "prompt": "finish after crash" }
+        }),
+    );
+    fixture.wait_for_log("session/prompt\n");
+    helper.kill();
+    std::thread::sleep(Duration::from_millis(1200));
+
+    let mut recovered = Helper::start(&fixture.home);
+    let attached = recovered.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-prompt",
+            "generation": open["snapshot"]["metadata"]["generation"],
+            "acknowledgedCursor": 0
+        }),
+    );
+    let events = attached["events"].as_array().expect("events");
+    assert!(
+        events.iter().any(|event| {
+            event["kind"]["type"] == "operationCompleted"
+                && event["kind"]["operationKey"] == "prompt-1"
+        }),
+        "attached payload: {attached}"
+    );
+
+    let retried = recovered.request(
+        "acp/send",
+        json!({
+            "brokerId": "broker-prompt",
+            "generation": open["snapshot"]["metadata"]["generation"],
+            "operationKey": "prompt-1",
+            "method": "session/prompt",
+            "params": { "prompt": "finish after crash" }
+        }),
+    );
+    assert_eq!(retried["replayed"], true);
+    assert_eq!(retried["result"]["stopReason"], "end_turn");
+
+    let log = std::fs::read_to_string(&fixture.log).expect("adapter log");
+    assert_eq!(log.matches("initialize\n").count(), 1);
+    assert_eq!(log.matches("session/prompt\n").count(), 1);
+}
+
+#[test]
+fn pending_permission_survives_helper_crash_and_can_be_answered_after_attach() {
+    let fixture = Fixture::new("permission-crash");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-permission", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-permission",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+    send(
+        &mut helper,
+        "broker-permission",
+        generation.clone(),
+        "session/new",
+        "session-new",
+        json!({}),
+    );
+
+    helper.write_request_without_reading(
+        "acp/send",
+        json!({
+            "brokerId": "broker-permission",
+            "generation": generation,
+            "operationKey": "prompt-permission",
+            "method": "session/prompt",
+            "params": { "prompt": "needs permission" }
+        }),
+    );
+    fixture.wait_for_log("session/prompt\n");
+    helper.kill();
+
+    let mut recovered = Helper::start(&fixture.home);
+    let attached = recovered.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-permission",
+            "generation": open["snapshot"]["metadata"]["generation"],
+            "acknowledgedCursor": 0
+        }),
+    );
+    assert!(
+        attached["snapshot"]["pendingRequests"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|request| request["requestId"] == "900")
+    );
+
+    let response = recovered.request(
+        "acp/respond",
+        json!({
+            "brokerId": "broker-permission",
+            "generation": open["snapshot"]["metadata"]["generation"],
+            "requestId": 900,
+            "operationKey": "permission-answer",
+            "result": { "outcome": "approved" }
+        }),
+    );
+    assert_eq!(response["ok"], true);
+    std::thread::sleep(Duration::from_millis(250));
+
+    let retried = recovered.request(
+        "acp/send",
+        json!({
+            "brokerId": "broker-permission",
+            "generation": open["snapshot"]["metadata"]["generation"],
+            "operationKey": "prompt-permission",
+            "method": "session/prompt",
+            "params": { "prompt": "needs permission" }
+        }),
+    );
+    assert_eq!(retried["replayed"], true);
+    assert_eq!(retried["result"]["stopReason"], "end_turn");
+}
+
+fn send(
+    helper: &mut Helper,
+    broker_id: &str,
+    generation: Value,
+    method: &str,
+    operation_key: &str,
+    params: Value,
+) -> Value {
+    helper.request(
+        "acp/send",
+        json!({
+            "brokerId": broker_id,
+            "generation": generation,
+            "operationKey": operation_key,
+            "method": method,
+            "params": params
+        }),
+    )
+}
+
+struct Fixture {
+    root: PathBuf,
+    home: PathBuf,
+    adapter: PathBuf,
+    log: PathBuf,
+}
+
+impl Fixture {
+    fn new(_name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = PathBuf::from(format!("/tmp/aab-{}-{nonce}", std::process::id()));
+        std::fs::create_dir_all(&root).expect("fixture root");
+        let home = root.join("home");
+        std::fs::create_dir_all(&home).expect("fixture home");
+        let adapter = root.join("fake-acp.sh");
+        let log = root.join("adapter.log");
+        write_fake_adapter(&adapter);
+        Self {
+            root,
+            home,
+            adapter,
+            log,
+        }
+    }
+
+    fn open_params(&self, broker_id: &str, delay_seconds: u64) -> Value {
+        json!({
+            "brokerId": broker_id,
+            "sessionId": format!("{broker_id}-session"),
+            "command": self.adapter,
+            "args": [],
+            "cwd": self.root,
+            "env": {
+                "FAKE_ACP_LOG": self.log,
+                "FAKE_ACP_PROMPT_DELAY": delay_seconds.to_string()
+            }
+        })
+    }
+
+    fn wait_for_log(&self, needle: &str) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if std::fs::read_to_string(&self.log)
+                .map(|log| log.contains(needle))
+                .unwrap_or(false)
+            {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        panic!("timed out waiting for adapter log entry {needle:?}");
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn write_fake_adapter(path: &Path) {
+    std::fs::write(
+        path,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf 'initialize\n' >> "$FAKE_ACP_LOG"
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"capabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf 'session/new\n' >> "$FAKE_ACP_LOG"
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"remote-1"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf 'session/prompt\n' >> "$FAKE_ACP_LOG"
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"remote-1","update":{"kind":"text","text":"started"}}}\n'
+      if printf '%s\n' "$line" | grep -q permission; then
+        printf '{"jsonrpc":"2.0","id":900,"method":"session/request_permission","params":{"toolCallId":"tool-1"}}\n'
+        IFS= read -r answer
+        printf 'permission-answer:%s\n' "$answer" >> "$FAKE_ACP_LOG"
+      fi
+      sleep "${FAKE_ACP_PROMPT_DELAY:-0}"
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      ;;
+    *)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      ;;
+  esac
+done
+"#,
+    )
+    .expect("write fake adapter");
+    let status = Command::new("chmod")
+        .arg("+x")
+        .arg(path)
+        .status()
+        .expect("chmod fake adapter");
+    assert!(status.success());
+}

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -203,6 +203,43 @@ fn helper_crash_during_prompt_preserves_completion_and_replays_events() {
 }
 
 #[test]
+fn prompt_streaming_update_returns_progress_before_turn_completion() {
+    let fixture = Fixture::new("prompt-progress");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-progress", 1));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-progress",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+    send(
+        &mut helper,
+        "broker-progress",
+        generation.clone(),
+        "session/new",
+        "session-new",
+        json!({}),
+    );
+
+    let progress = send(
+        &mut helper,
+        "broker-progress",
+        generation,
+        "session/prompt",
+        "prompt-progress",
+        json!({ "prompt": "stream before completion" }),
+    );
+
+    assert_eq!(progress["pending"], true);
+    assert!(progress.get("result").is_none(), "{progress}");
+}
+
+#[test]
 fn pending_permission_survives_helper_crash_and_can_be_answered_after_attach() {
     let fixture = Fixture::new("permission-crash");
     let mut helper = Helper::start(&fixture.home);
@@ -307,31 +344,14 @@ fn pending_permission_returns_before_prompt_completion_and_can_resume() {
         json!({}),
     );
 
-    let pending = send(
+    let attached = drive_until_pending_request(
         &mut helper,
         "broker-pending",
         generation.clone(),
-        "session/prompt",
         "prompt-permission",
         json!({ "prompt": "needs permission" }),
     );
-    assert_eq!(pending["pending"], true);
-
-    let attached = helper.request(
-        "acp/attach",
-        json!({
-            "brokerId": "broker-pending",
-            "generation": generation,
-            "acknowledgedCursor": 0
-        }),
-    );
-    assert!(
-        attached["events"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|event| event["kind"]["type"] == "pendingRequest")
-    );
+    assert!(attached_has_pending_request(&attached), "{attached}");
 
     let response = helper.request(
         "acp/respond",
@@ -381,15 +401,13 @@ fn string_permission_request_id_is_preserved_when_responding() {
         json!({}),
     );
 
-    let pending = send(
+    drive_until_pending_request(
         &mut helper,
         "broker-string-id",
         generation.clone(),
-        "session/prompt",
         "prompt-string-permission",
         json!({ "prompt": "needs string-permission" }),
     );
-    assert_eq!(pending["pending"], true);
 
     helper.request(
         "acp/respond",
@@ -436,15 +454,13 @@ fn failed_permission_response_is_sent_to_adapter_as_jsonrpc_error() {
         json!({}),
     );
 
-    let pending = send(
+    drive_until_pending_request(
         &mut helper,
         "broker-permission-error",
         generation.clone(),
-        "session/prompt",
         "prompt-string-permission",
         json!({ "prompt": "needs string-permission" }),
     );
-    assert_eq!(pending["pending"], true);
 
     helper.request(
         "acp/respond",
@@ -506,6 +522,66 @@ fn send(
             "params": params
         }),
     )
+}
+
+fn drive_until_pending_request(
+    helper: &mut Helper,
+    broker_id: &str,
+    generation: Value,
+    operation_key: &str,
+    params: Value,
+) -> Value {
+    let mut acknowledged_cursor = 0;
+    let mut last_attached = Value::Null;
+    for _ in 0..5 {
+        let progress = send(
+            helper,
+            broker_id,
+            generation.clone(),
+            "session/prompt",
+            operation_key,
+            params.clone(),
+        );
+        assert_eq!(progress["pending"], true, "{progress}");
+
+        last_attached = helper.request(
+            "acp/attach",
+            json!({
+                "brokerId": broker_id,
+                "generation": generation.clone(),
+                "acknowledgedCursor": acknowledged_cursor
+            }),
+        );
+        if attached_has_pending_request(&last_attached) {
+            return last_attached;
+        }
+
+        let journal_tail = last_attached["snapshot"]["journalTail"]
+            .as_u64()
+            .unwrap_or(acknowledged_cursor);
+        if journal_tail > acknowledged_cursor {
+            helper.request(
+                "acp/ack",
+                json!({
+                    "brokerId": broker_id,
+                    "generation": generation.clone(),
+                    "cursor": journal_tail
+                }),
+            );
+            acknowledged_cursor = journal_tail;
+        }
+    }
+    panic!("timed out waiting for pending request: {last_attached}");
+}
+
+fn attached_has_pending_request(attached: &Value) -> bool {
+    attached["events"].as_array().is_some_and(|events| {
+        events
+            .iter()
+            .any(|event| event["kind"]["type"] == "pendingRequest")
+    }) || attached["snapshot"]["pendingRequests"]
+        .as_array()
+        .is_some_and(|requests| !requests.is_empty())
 }
 
 struct Fixture {

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -97,7 +97,11 @@ fn open_list_and_close_broker_without_persisting_env_values() {
     assert_eq!(open["snapshot"]["metadata"]["brokerId"], "broker-open");
     assert_eq!(
         open["snapshot"]["metadata"]["envKeys"],
-        json!(["FAKE_ACP_LOG", "FAKE_ACP_PROMPT_DELAY"])
+        json!([
+            "FAKE_ACP_LOG",
+            "FAKE_ACP_PROMPT_DELAY",
+            "__CFBundleIdentifier"
+        ])
     );
 
     let metadata = std::fs::read_to_string(
@@ -336,7 +340,8 @@ impl Fixture {
             "cwd": self.root,
             "env": {
                 "FAKE_ACP_LOG": self.log,
-                "FAKE_ACP_PROMPT_DELAY": delay_seconds.to_string()
+                "FAKE_ACP_PROMPT_DELAY": delay_seconds.to_string(),
+                "__CFBundleIdentifier": "io.nlopez.alas"
             }
         })
     }

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -135,6 +135,37 @@ fn open_list_and_close_broker_without_persisting_env_values() {
     assert_eq!(close["ok"], true);
 }
 
+#[cfg(unix)]
+#[test]
+fn open_reclaims_stale_broker_pid_when_process_group_mismatches() {
+    let fixture = Fixture::new("stale-broker-pid");
+    let broker_dir = fixture
+        .home
+        .join(".alas/acp-brokers/broker-stale-reused-pid");
+    std::fs::create_dir_all(&broker_dir).expect("broker dir");
+    std::fs::write(
+        broker_dir.join("pid.json"),
+        serde_json::to_vec(&json!({
+            "pid": std::process::id(),
+            "processGroupId": 0
+        }))
+        .expect("pid metadata"),
+    )
+    .expect("stale pid metadata");
+
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request(
+        "acp/open",
+        fixture.open_params("broker-stale-reused-pid", 0),
+    );
+
+    assert_eq!(open["adopted"], false);
+    assert_eq!(
+        open["snapshot"]["metadata"]["brokerId"],
+        "broker-stale-reused-pid"
+    );
+}
+
 #[test]
 fn close_rejects_stale_generation_without_removing_broker() {
     let fixture = Fixture::new("close-stale-generation");
@@ -473,17 +504,16 @@ fn pending_permission_survives_helper_crash_and_can_be_answered_after_attach() {
         }),
     );
     fixture.wait_for_log("session/prompt\n");
-    helper.kill();
 
     let mut recovered = Helper::start(&fixture.home);
-    let attached = recovered.request(
-        "acp/attach",
-        json!({
-            "brokerId": "broker-permission",
-            "generation": open["snapshot"]["metadata"]["generation"],
-            "acknowledgedCursor": 0
-        }),
+    let attached = wait_for_pending_request_visible(
+        &mut recovered,
+        "broker-permission",
+        open["snapshot"]["metadata"]["generation"].clone(),
+        json!("900"),
     );
+    helper.kill();
+
     assert!(
         attached["snapshot"]["pendingRequests"]
             .as_array()
@@ -822,7 +852,7 @@ fn drive_until_pending_request(
 ) -> Value {
     let mut acknowledged_cursor = 0;
     let mut last_attached = Value::Null;
-    for _ in 0..20 {
+    for _ in 0..60 {
         let progress = send(
             helper,
             broker_id,
@@ -862,6 +892,37 @@ fn drive_until_pending_request(
         std::thread::sleep(Duration::from_millis(50));
     }
     panic!("timed out waiting for pending request: {last_attached}");
+}
+
+fn wait_for_pending_request_visible(
+    helper: &mut Helper,
+    broker_id: &str,
+    generation: Value,
+    request_id: Value,
+) -> Value {
+    let mut last_attached = Value::Null;
+    for _ in 0..60 {
+        last_attached = helper.request(
+            "acp/attach",
+            json!({
+                "brokerId": broker_id,
+                "generation": generation.clone(),
+                "acknowledgedCursor": 0
+            }),
+        );
+        if last_attached["snapshot"]["pendingRequests"]
+            .as_array()
+            .is_some_and(|requests| {
+                requests
+                    .iter()
+                    .any(|request| request["requestId"] == request_id)
+            })
+        {
+            return last_attached;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for pending request visibility: {last_attached}");
 }
 
 fn drive_until_prompt_completed(

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -2,7 +2,10 @@ use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+static NEXT_FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
 
 struct Helper {
     child: Child,
@@ -750,11 +753,12 @@ struct Fixture {
 
 impl Fixture {
     fn new(_name: &str) -> Self {
+        let id = NEXT_FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let root = PathBuf::from(format!("/tmp/aab-{}-{nonce}", std::process::id()));
+        let root = PathBuf::from(format!("/tmp/aab-{}-{id}-{nonce}", std::process::id()));
         std::fs::create_dir_all(&root).expect("fixture root");
         let home = root.join("home");
         std::fs::create_dir_all(&home).expect("fixture home");

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -797,6 +797,50 @@ fn adapter_exit_completes_pending_operation_and_replays_error() {
     );
 }
 
+#[test]
+fn open_replaces_broker_after_adapter_exit() {
+    let fixture = Fixture::new("adapter-exit-reopen");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-exit-reopen", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-exit-reopen",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+
+    let failed = drive_until_operation_completed(
+        &mut helper,
+        "broker-exit-reopen",
+        generation,
+        "session/load",
+        "session-load-exit",
+        json!({ "sessionId": "exit-load" }),
+    );
+    assert_eq!(failed["error"]["code"], -32074);
+
+    let reopened = helper.request("acp/open", fixture.open_params("broker-exit-reopen", 0));
+    assert_eq!(reopened["adopted"], false);
+    assert_ne!(
+        reopened["snapshot"]["metadata"]["generation"],
+        open["snapshot"]["metadata"]["generation"]
+    );
+
+    let initialized = send(
+        &mut helper,
+        "broker-exit-reopen",
+        reopened["snapshot"]["metadata"]["generation"].clone(),
+        "initialize",
+        "init-reopened",
+        json!({}),
+    );
+    assert!(initialized.get("error").is_none(), "{initialized}");
+}
+
 fn send(
     helper: &mut Helper,
     broker_id: &str,
@@ -825,7 +869,7 @@ fn drive_until_operation_completed(
     operation_key: &str,
     params: Value,
 ) -> Value {
-    for _ in 0..20 {
+    for _ in 0..60 {
         let result = send(
             helper,
             broker_id,

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -365,15 +365,14 @@ fn pending_permission_returns_before_prompt_completion_and_can_resume() {
     );
     assert_eq!(response["ok"], true);
 
-    let completed = send(
+    let completed = drive_until_prompt_completed(
         &mut helper,
         "broker-pending",
         open["snapshot"]["metadata"]["generation"].clone(),
-        "session/prompt",
         "prompt-permission",
         json!({ "prompt": "needs permission" }),
     );
-    assert_eq!(completed["replayed"], false);
+    assert_eq!(completed["replayed"], true);
     assert_eq!(completed["result"]["stopReason"], "end_turn");
 }
 
@@ -533,7 +532,7 @@ fn drive_until_pending_request(
 ) -> Value {
     let mut acknowledged_cursor = 0;
     let mut last_attached = Value::Null;
-    for _ in 0..5 {
+    for _ in 0..20 {
         let progress = send(
             helper,
             broker_id,
@@ -570,8 +569,34 @@ fn drive_until_pending_request(
             );
             acknowledged_cursor = journal_tail;
         }
+        std::thread::sleep(Duration::from_millis(50));
     }
     panic!("timed out waiting for pending request: {last_attached}");
+}
+
+fn drive_until_prompt_completed(
+    helper: &mut Helper,
+    broker_id: &str,
+    generation: Value,
+    operation_key: &str,
+    params: Value,
+) -> Value {
+    for _ in 0..20 {
+        let result = send(
+            helper,
+            broker_id,
+            generation.clone(),
+            "session/prompt",
+            operation_key,
+            params.clone(),
+        );
+        if result.get("result").is_some() || result.get("error").is_some() {
+            return result;
+        }
+        assert_eq!(result["pending"], true, "{result}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for prompt completion");
 }
 
 fn attached_has_pending_request(attached: &Value) -> bool {

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -277,6 +277,101 @@ fn prompt_streaming_update_returns_progress_before_turn_completion() {
 }
 
 #[test]
+fn attach_replays_from_stale_persisted_cursor_without_moving_ack_back() {
+    let fixture = Fixture::new("stale-attach-cursor");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-stale-attach", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    send(
+        &mut helper,
+        "broker-stale-attach",
+        generation.clone(),
+        "initialize",
+        "init",
+        json!({}),
+    );
+
+    let attached = helper.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-stale-attach",
+            "generation": generation.clone(),
+            "acknowledgedCursor": 0
+        }),
+    );
+    let journal_tail = attached["snapshot"]["journalTail"]
+        .as_u64()
+        .expect("journal tail");
+    assert!(journal_tail > 0, "{attached}");
+
+    helper.request(
+        "acp/ack",
+        json!({
+            "brokerId": "broker-stale-attach",
+            "generation": generation.clone(),
+            "cursor": journal_tail
+        }),
+    );
+
+    let stale_attach = helper.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-stale-attach",
+            "generation": generation,
+            "acknowledgedCursor": 0
+        }),
+    );
+    assert_eq!(
+        stale_attach["snapshot"]["acknowledgedCursor"],
+        json!(journal_tail)
+    );
+    assert!(
+        stale_attach["events"]
+            .as_array()
+            .is_some_and(|events| !events.is_empty()),
+        "{stale_attach}"
+    );
+}
+
+#[test]
+fn load_updates_do_not_mark_turn_as_streaming() {
+    let fixture = Fixture::new("load-update-state");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-load-update", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    let mut loaded = Value::Null;
+    for _ in 0..20 {
+        let result = send(
+            &mut helper,
+            "broker-load-update",
+            generation.clone(),
+            "session/load",
+            "load-with-update",
+            json!({ "mode": "stream-load" }),
+        );
+        if result["result"]["sessionId"] == "remote-loaded" {
+            loaded = result;
+            break;
+        }
+        assert_eq!(result["pending"], true, "{result}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(loaded["result"]["sessionId"], "remote-loaded");
+
+    let attached = helper.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-load-update",
+            "generation": generation,
+            "acknowledgedCursor": 0
+        }),
+    );
+    assert_ne!(attached["snapshot"]["turnState"], "streaming", "{attached}");
+}
+
+#[test]
 fn adapter_exit_completes_inflight_prompt_with_error() {
     let fixture = Fixture::new("prompt-exit");
     let mut helper = Helper::start(&fixture.home);
@@ -862,6 +957,11 @@ while IFS= read -r line; do
       printf 'session/load\n' >> "$FAKE_ACP_LOG"
       if printf '%s\n' "$line" | grep -q exit-load; then
         exit 42
+      fi
+      if printf '%s\n' "$line" | grep -q stream-load; then
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"remote-loaded","update":{"kind":"text","text":"restored"}}}\n'
+        printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"remote-loaded"}}\n' "$id"
+        continue
       fi
       printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32042,"message":"load failed"}}\n' "$id"
       ;;

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -308,7 +308,7 @@ fn prompt_streaming_update_returns_progress_before_turn_completion() {
 }
 
 #[test]
-fn attach_replays_from_stale_persisted_cursor_without_moving_ack_back() {
+fn attach_with_stale_persisted_cursor_does_not_move_ack_back() {
     let fixture = Fixture::new("stale-attach-cursor");
     let mut helper = Helper::start(&fixture.home);
     let open = helper.request("acp/open", fixture.open_params("broker-stale-attach", 0));
@@ -357,12 +357,7 @@ fn attach_replays_from_stale_persisted_cursor_without_moving_ack_back() {
         stale_attach["snapshot"]["acknowledgedCursor"],
         json!(journal_tail)
     );
-    assert!(
-        stale_attach["events"]
-            .as_array()
-            .is_some_and(|events| !events.is_empty()),
-        "{stale_attach}"
-    );
+    assert_eq!(stale_attach["events"], json!([]), "{stale_attach}");
 }
 
 #[test]

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -35,6 +35,14 @@ impl Helper {
     }
 
     fn request(&mut self, method: &str, params: Value) -> Value {
+        let response = self.raw_request(method, params);
+        if response.get("error").is_some() {
+            panic!("helper error for {method}: {response}");
+        }
+        response["result"].clone()
+    }
+
+    fn raw_request(&mut self, method: &str, params: Value) -> Value {
         let id = self.next_id;
         self.next_id += 1;
         writeln!(
@@ -53,11 +61,7 @@ impl Helper {
         self.stdout
             .read_line(&mut line)
             .expect("read helper response");
-        let response: Value = serde_json::from_str(&line).expect("helper response JSON");
-        if response.get("error").is_some() {
-            panic!("helper error for {method}: {response}");
-        }
-        response["result"].clone()
+        serde_json::from_str(&line).expect("helper response JSON")
     }
 
     fn write_request_without_reading(&mut self, method: &str, params: Value) {
@@ -127,6 +131,36 @@ fn open_list_and_close_broker_without_persisting_env_values() {
     let close = helper2.request(
         "acp/close",
         json!({ "brokerId": "broker-open", "generation": generation }),
+    );
+    assert_eq!(close["ok"], true);
+}
+
+#[test]
+fn close_rejects_stale_generation_without_removing_broker() {
+    let fixture = Fixture::new("close-stale-generation");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-close-stale", 0));
+    let generation = open["snapshot"]["metadata"]["generation"]
+        .as_u64()
+        .expect("generation");
+
+    let stale = helper.raw_request(
+        "acp/close",
+        json!({ "brokerId": "broker-close-stale", "generation": generation + 1 }),
+    );
+    assert!(
+        stale["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("broker generation mismatch")),
+        "stale close response: {stale}"
+    );
+
+    let list = helper.request("acp/list", json!({}));
+    assert_eq!(list["brokers"].as_array().unwrap().len(), 1);
+
+    let close = helper.request(
+        "acp/close",
+        json!({ "brokerId": "broker-close-stale", "generation": generation }),
     );
     assert_eq!(close["ok"], true);
 }

--- a/AlasHelper/tests/acp_broker_protocol.rs
+++ b/AlasHelper/tests/acp_broker_protocol.rs
@@ -308,6 +308,28 @@ fn acknowledgement_prunes_events_without_reusing_cursors() {
 }
 
 #[test]
+fn acknowledgement_prunes_completed_operation_records() {
+    let mut broker = broker();
+    let key = OperationKey::new("prompt-1");
+    broker
+        .begin_operation(key.clone(), "session/prompt", json!({"prompt": "large"}))
+        .unwrap();
+    broker
+        .complete_operation(
+            &key,
+            AdapterRPCOutcome::result(json!({"stopReason": "end_turn"})),
+        )
+        .unwrap();
+
+    let completed_tail = broker.journal_tail();
+    assert_eq!(broker.snapshot().operations.len(), 1);
+
+    broker.ack(completed_tail).unwrap();
+    assert!(broker.snapshot().operations.is_empty());
+    assert_eq!(broker.journal_tail(), completed_tail);
+}
+
+#[test]
 fn pending_request_variants_are_snapshotted_and_answered_once() {
     let mut broker = broker();
     let variants = [

--- a/AlasHelper/tests/acp_broker_protocol.rs
+++ b/AlasHelper/tests/acp_broker_protocol.rs
@@ -329,6 +329,20 @@ fn pending_request_variants_are_snapshotted_and_answered_once() {
             .kind(),
         BrokerErrorKind::PendingRequestAlreadyResolved
     );
+    broker
+        .add_pending_request(
+            "permission",
+            json!("permission"),
+            PendingClientRequestKind::Permission,
+            json!({"requestId": "permission", "attempt": 2}),
+        )
+        .unwrap();
+    broker
+        .respond_to_pending_request(
+            "permission",
+            AdapterRPCOutcome::result(json!({"outcome": "approved-again"})),
+        )
+        .unwrap();
 
     let snapshot = broker.snapshot();
     assert_eq!(snapshot.pending_requests.len(), 4);

--- a/AlasHelper/tests/acp_broker_protocol.rs
+++ b/AlasHelper/tests/acp_broker_protocol.rs
@@ -275,6 +275,7 @@ fn acknowledgement_is_monotonic_and_bounded_by_journal_tail() {
 
     broker.ack(EventCursor::new(1)).unwrap();
     assert_eq!(broker.acknowledged_cursor(), EventCursor::new(1));
+    assert_eq!(broker.replay_after(EventCursor::new(0)).unwrap().len(), 1);
     assert_eq!(
         broker.ack(EventCursor::new(0)).unwrap_err().kind(),
         BrokerErrorKind::CursorBehindAcknowledged
@@ -287,6 +288,23 @@ fn acknowledgement_is_monotonic_and_bounded_by_journal_tail() {
         broker.replay_after(EventCursor::new(3)).unwrap_err().kind(),
         BrokerErrorKind::CursorBeyondJournalTail
     );
+}
+
+#[test]
+fn acknowledgement_prunes_events_without_reusing_cursors() {
+    let mut broker = broker();
+    broker.add_adapter_notification("session/update", json!({"kind": "one"}));
+    broker.add_adapter_notification("session/update", json!({"kind": "two"}));
+
+    broker.ack(EventCursor::new(2)).unwrap();
+    assert!(broker.replay_after(EventCursor::new(0)).unwrap().is_empty());
+    assert_eq!(broker.snapshot().journal_tail, EventCursor::new(2));
+
+    let third = broker.add_adapter_notification("session/update", json!({"kind": "three"}));
+    assert_eq!(third, EventCursor::new(3));
+    let replay = broker.replay_after(EventCursor::new(2)).unwrap();
+    assert_eq!(replay.len(), 1);
+    assert_eq!(replay[0].cursor, third);
 }
 
 #[test]

--- a/AlasHelper/tests/acp_broker_protocol.rs
+++ b/AlasHelper/tests/acp_broker_protocol.rs
@@ -1,0 +1,474 @@
+use alas_helper::acp_broker::{
+    ACPBrokerMetadata, ACPBrokerState, AdapterRequestId, BrokerErrorKind, BrokerEventKind,
+    BrokerGeneration, BrokerId, BrokerTurnState, EventCursor, OperationKey,
+    PendingClientRequestKind,
+};
+use alas_helper::acp_broker_protocol::{
+    AcpAckParams, AcpAttachParams, AcpBrokerMethod, AcpCloseParams, AcpDetachParams, AcpListResult,
+    AcpOpenParams, AcpOpenResult, AcpRespondParams, AcpSendParams,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::{Value, json};
+
+fn metadata() -> ACPBrokerMetadata {
+    ACPBrokerMetadata {
+        broker_id: BrokerId::new("session-local-1"),
+        generation: BrokerGeneration::new(7),
+        alas_session_id: "alas-session-1".to_string(),
+        adapter_program: "codex-acp".to_string(),
+        adapter_args: vec!["--stdio".to_string()],
+        cwd: "/tmp/project".to_string(),
+        env_keys: vec!["OPENAI_API_KEY".to_string(), "SECRET_TOKEN".to_string()],
+        created_at_millis: 123,
+    }
+}
+
+fn broker() -> ACPBrokerState {
+    ACPBrokerState::new(metadata())
+}
+
+fn round_trip<T>(value: &T) -> T
+where
+    T: Serialize + DeserializeOwned,
+{
+    serde_json::from_value(serde_json::to_value(value).unwrap()).unwrap()
+}
+
+#[test]
+fn records_initialize_and_session_once_per_generation() {
+    let mut broker = broker();
+
+    broker
+        .record_initialize_result(json!({"protocolVersion": 1}))
+        .unwrap();
+    broker
+        .record_remote_session_result(json!({"sessionId": "remote-1"}))
+        .unwrap();
+
+    assert_eq!(
+        broker
+            .record_initialize_result(json!({"protocolVersion": 1}))
+            .unwrap_err()
+            .kind(),
+        BrokerErrorKind::AlreadyInitialized
+    );
+    assert_eq!(
+        broker
+            .record_remote_session_result(json!({"sessionId": "remote-1"}))
+            .unwrap_err()
+            .kind(),
+        BrokerErrorKind::AlreadyHasRemoteSession
+    );
+
+    let snapshot = broker.snapshot();
+    assert_eq!(
+        snapshot.initialize_result,
+        Some(json!({"protocolVersion": 1}))
+    );
+    assert_eq!(
+        snapshot.remote_session_result,
+        Some(json!({"sessionId": "remote-1"}))
+    );
+}
+
+#[test]
+fn stable_request_ids_are_owned_by_operations_not_attachments() {
+    let mut broker = broker();
+
+    let first = broker
+        .begin_operation(
+            OperationKey::new("queue-item-1"),
+            "session/prompt",
+            json!({"prompt": "a"}),
+        )
+        .unwrap();
+    let retried = broker
+        .begin_operation(
+            OperationKey::new("queue-item-1"),
+            "session/prompt",
+            json!({"prompt": "a"}),
+        )
+        .unwrap();
+    let second = broker
+        .begin_operation(
+            OperationKey::new("queue-item-2"),
+            "session/prompt",
+            json!({"prompt": "b"}),
+        )
+        .unwrap();
+
+    assert_eq!(first.adapter_request_id, retried.adapter_request_id);
+    assert!(retried.replayed);
+    assert_eq!(first.adapter_request_id.value(), 1);
+    assert_eq!(second.adapter_request_id.value(), 2);
+}
+
+#[test]
+fn operation_key_reuse_with_different_payload_is_rejected() {
+    let mut broker = broker();
+    broker
+        .begin_operation(
+            OperationKey::new("stable-key"),
+            "session/prompt",
+            json!({"prompt": "a"}),
+        )
+        .unwrap();
+
+    assert_eq!(
+        broker
+            .begin_operation(
+                OperationKey::new("stable-key"),
+                "session/prompt",
+                json!({"prompt": "b"}),
+            )
+            .unwrap_err()
+            .kind(),
+        BrokerErrorKind::OperationKeyPayloadMismatch
+    );
+}
+
+#[test]
+fn completed_operations_return_the_original_terminal_result_on_retry() {
+    let mut broker = broker();
+    broker
+        .begin_operation(
+            OperationKey::new("stable-key"),
+            "session/prompt",
+            json!({"prompt": "a"}),
+        )
+        .unwrap();
+    broker
+        .complete_operation(&OperationKey::new("stable-key"), json!({"ok": true}))
+        .unwrap();
+
+    let retried = broker
+        .begin_operation(
+            OperationKey::new("stable-key"),
+            "session/prompt",
+            json!({"prompt": "a"}),
+        )
+        .unwrap();
+
+    assert!(retried.replayed);
+    assert_eq!(retried.terminal_result, Some(json!({"ok": true})));
+}
+
+#[test]
+fn completing_operation_twice_with_different_result_is_rejected() {
+    let mut broker = broker();
+    broker
+        .begin_operation(
+            OperationKey::new("stable-key"),
+            "session/prompt",
+            json!({"prompt": "a"}),
+        )
+        .unwrap();
+    broker
+        .complete_operation(&OperationKey::new("stable-key"), json!({"ok": true}))
+        .unwrap();
+
+    assert_eq!(
+        broker
+            .complete_operation(&OperationKey::new("stable-key"), json!({"ok": false}))
+            .unwrap_err()
+            .kind(),
+        BrokerErrorKind::OperationAlreadyCompletedWithDifferentResult
+    );
+}
+
+#[test]
+fn turn_state_covers_recovery_states() {
+    let mut broker = broker();
+    let states = [
+        BrokerTurnState::Idle,
+        BrokerTurnState::Sending,
+        BrokerTurnState::Streaming,
+        BrokerTurnState::AwaitingInput,
+        BrokerTurnState::Cancelling,
+        BrokerTurnState::Completed,
+        BrokerTurnState::Ambiguous,
+    ];
+
+    for state in states {
+        broker.set_turn_state(state).unwrap();
+        assert_eq!(broker.snapshot().turn_state, state);
+    }
+}
+
+#[test]
+fn event_journal_replays_strictly_after_acknowledged_cursor() {
+    let mut broker = broker();
+    let first = broker.add_adapter_notification(
+        "session/update",
+        json!({"sessionId": "remote-1", "update": {"kind": "one"}}),
+    );
+    let second = broker.add_adapter_notification("session/update", json!({"kind": "two"}));
+    let third = broker.set_turn_state(BrokerTurnState::Completed).unwrap();
+
+    assert_eq!(first.value(), 1);
+    assert_eq!(second.value(), 2);
+    assert_eq!(third.value(), 3);
+
+    let replay = broker.replay_after(EventCursor::new(1)).unwrap();
+    assert_eq!(replay.len(), 2);
+    assert_eq!(replay[0].cursor, second);
+    assert_eq!(replay[1].cursor, third);
+}
+
+#[test]
+fn acknowledgement_is_monotonic_and_bounded_by_journal_tail() {
+    let mut broker = broker();
+    broker.add_adapter_notification("session/update", json!({"kind": "one"}));
+    broker.add_adapter_notification("session/update", json!({"kind": "two"}));
+
+    broker.ack(EventCursor::new(1)).unwrap();
+    assert_eq!(broker.acknowledged_cursor(), EventCursor::new(1));
+    assert_eq!(
+        broker.ack(EventCursor::new(0)).unwrap_err().kind(),
+        BrokerErrorKind::CursorBehindAcknowledged
+    );
+    assert_eq!(
+        broker.ack(EventCursor::new(3)).unwrap_err().kind(),
+        BrokerErrorKind::CursorBeyondJournalTail
+    );
+    assert_eq!(
+        broker.replay_after(EventCursor::new(3)).unwrap_err().kind(),
+        BrokerErrorKind::CursorBeyondJournalTail
+    );
+}
+
+#[test]
+fn pending_request_variants_are_snapshotted_and_answered_once() {
+    let mut broker = broker();
+    let variants = [
+        ("permission", PendingClientRequestKind::Permission),
+        ("question", PendingClientRequestKind::Question),
+        ("elicitation", PendingClientRequestKind::Elicitation),
+        ("file", PendingClientRequestKind::File),
+        ("terminal", PendingClientRequestKind::Terminal),
+    ];
+
+    for (request_id, kind) in variants {
+        broker
+            .add_pending_request(
+                request_id,
+                json!(request_id),
+                kind,
+                json!({"requestId": request_id}),
+            )
+            .unwrap();
+    }
+
+    assert_eq!(broker.snapshot().pending_requests.len(), 5);
+
+    broker
+        .respond_to_pending_request("permission", json!({"outcome": "approved"}))
+        .unwrap();
+    assert_eq!(
+        broker
+            .respond_to_pending_request("permission", json!({"outcome": "approved"}))
+            .unwrap_err()
+            .kind(),
+        BrokerErrorKind::PendingRequestAlreadyResolved
+    );
+
+    let snapshot = broker.snapshot();
+    assert_eq!(snapshot.pending_requests.len(), 4);
+    assert_eq!(
+        snapshot
+            .pending_requests
+            .iter()
+            .map(|request| request.kind)
+            .collect::<Vec<_>>(),
+        vec![
+            PendingClientRequestKind::Elicitation,
+            PendingClientRequestKind::File,
+            PendingClientRequestKind::Question,
+            PendingClientRequestKind::Terminal
+        ]
+    );
+}
+
+#[test]
+fn missing_pending_request_response_fails_closed() {
+    let mut broker = broker();
+
+    assert_eq!(
+        broker
+            .respond_to_pending_request("missing", json!({"ok": true}))
+            .unwrap_err()
+            .kind(),
+        BrokerErrorKind::PendingRequestNotFound
+    );
+}
+
+#[test]
+fn duplicate_pending_request_ids_are_rejected() {
+    let mut broker = broker();
+    broker
+        .add_pending_request(
+            "permission",
+            json!(1),
+            PendingClientRequestKind::Permission,
+            json!({}),
+        )
+        .unwrap();
+
+    assert_eq!(
+        broker
+            .add_pending_request(
+                "permission",
+                json!(2),
+                PendingClientRequestKind::Permission,
+                json!({}),
+            )
+            .unwrap_err()
+            .kind(),
+        BrokerErrorKind::PendingRequestAlreadyExists
+    );
+}
+
+#[test]
+fn snapshot_round_trip_excludes_secret_environment_values() {
+    let mut broker = broker();
+    broker
+        .record_initialize_result(json!({"capabilities": {"tools": true}}))
+        .unwrap();
+    broker
+        .begin_operation(
+            OperationKey::new("secret-bearing-prompt"),
+            "session/prompt",
+            json!({"promptFingerprint": "canonical"}),
+        )
+        .unwrap();
+
+    let snapshot = broker.snapshot();
+    let encoded = serde_json::to_string(&snapshot).unwrap();
+    let decoded = round_trip(&snapshot);
+
+    assert_eq!(decoded, snapshot);
+    assert!(encoded.contains("codex-acp"));
+    assert!(encoded.contains("OPENAI_API_KEY"));
+    assert!(!encoded.contains("sk-test"));
+    assert!(encoded.contains("SECRET_TOKEN"));
+    assert!(!encoded.contains("secret-value"));
+}
+
+#[test]
+fn protocol_dtos_use_stable_wire_field_names() {
+    let snapshot = broker().snapshot();
+    let open = AcpOpenParams {
+        broker_id: BrokerId::new("local-session"),
+        session_id: "alas-session".to_string(),
+        command: "codex-acp".to_string(),
+        args: vec!["--stdio".to_string()],
+        cwd: "/tmp/project".to_string(),
+        env: json!({"OPENAI_API_KEY": "sk-test"}),
+    };
+    let send = AcpSendParams {
+        broker_id: BrokerId::new("local-session"),
+        generation: BrokerGeneration::new(1),
+        operation_key: OperationKey::new("queue-item"),
+        method: "session/prompt".to_string(),
+        params: json!({"prompt": "hi"}),
+    };
+
+    assert_eq!(AcpBrokerMethod::Open.as_str(), "acp/open");
+    assert_eq!(AcpBrokerMethod::Attach.as_str(), "acp/attach");
+    assert_eq!(AcpBrokerMethod::Send.as_str(), "acp/send");
+    assert_eq!(AcpBrokerMethod::Respond.as_str(), "acp/respond");
+    assert_eq!(AcpBrokerMethod::Ack.as_str(), "acp/ack");
+    assert_eq!(AcpBrokerMethod::Detach.as_str(), "acp/detach");
+    assert_eq!(AcpBrokerMethod::Close.as_str(), "acp/close");
+    assert_eq!(AcpBrokerMethod::List.as_str(), "acp/list");
+
+    assert_eq!(
+        serde_json::to_value(&open).unwrap(),
+        json!({
+            "brokerId": "local-session",
+            "sessionId": "alas-session",
+            "command": "codex-acp",
+            "args": ["--stdio"],
+            "cwd": "/tmp/project",
+            "env": {"OPENAI_API_KEY": "sk-test"}
+        })
+    );
+    assert_eq!(
+        serde_json::to_value(&send).unwrap(),
+        json!({
+            "brokerId": "local-session",
+            "generation": 1,
+            "operationKey": "queue-item",
+            "method": "session/prompt",
+            "params": {"prompt": "hi"}
+        })
+    );
+
+    let _: AcpOpenResult = round_trip(&AcpOpenResult {
+        snapshot: snapshot.clone(),
+        adopted: false,
+    });
+    let _: AcpAttachParams = round_trip(&AcpAttachParams {
+        broker_id: BrokerId::new("local-session"),
+        generation: BrokerGeneration::new(1),
+        acknowledged_cursor: EventCursor::new(0),
+    });
+    let _: AcpRespondParams = round_trip(&AcpRespondParams {
+        broker_id: BrokerId::new("local-session"),
+        generation: BrokerGeneration::new(1),
+        request_id: AdapterRequestId::new(1),
+        operation_key: OperationKey::new("answer"),
+        result: Value::Null,
+    });
+    let _: AcpAckParams = round_trip(&AcpAckParams {
+        broker_id: BrokerId::new("local-session"),
+        generation: BrokerGeneration::new(1),
+        cursor: EventCursor::new(0),
+    });
+    let _: AcpDetachParams = round_trip(&AcpDetachParams {
+        broker_id: BrokerId::new("local-session"),
+        generation: BrokerGeneration::new(1),
+    });
+    let _: AcpCloseParams = round_trip(&AcpCloseParams {
+        broker_id: BrokerId::new("local-session"),
+        generation: BrokerGeneration::new(1),
+    });
+    let _: AcpListResult = round_trip(&AcpListResult {
+        brokers: vec![snapshot],
+    });
+}
+
+#[test]
+fn journal_contains_semantic_events_for_protocol_replay() {
+    let mut broker = broker();
+    broker
+        .record_initialize_result(json!({"protocolVersion": 1}))
+        .unwrap();
+    broker
+        .begin_operation(
+            OperationKey::new("queue-item"),
+            "session/prompt",
+            json!({"prompt": "hi"}),
+        )
+        .unwrap();
+    broker
+        .complete_operation(
+            &OperationKey::new("queue-item"),
+            json!({"stopReason": "end_turn"}),
+        )
+        .unwrap();
+
+    let replay = broker.replay_after(EventCursor::new(0)).unwrap();
+    assert!(matches!(
+        replay[0].kind,
+        BrokerEventKind::Initialized { .. }
+    ));
+    assert!(matches!(
+        replay[1].kind,
+        BrokerEventKind::OperationStarted { .. }
+    ));
+    assert!(matches!(
+        replay[2].kind,
+        BrokerEventKind::OperationCompleted { .. }
+    ));
+}

--- a/AlasHelper/tests/acp_broker_protocol.rs
+++ b/AlasHelper/tests/acp_broker_protocol.rs
@@ -376,6 +376,7 @@ fn protocol_dtos_use_stable_wire_field_names() {
     assert_eq!(AcpBrokerMethod::Open.as_str(), "acp/open");
     assert_eq!(AcpBrokerMethod::Attach.as_str(), "acp/attach");
     assert_eq!(AcpBrokerMethod::Send.as_str(), "acp/send");
+    assert_eq!(AcpBrokerMethod::Notify.as_str(), "acp/notify");
     assert_eq!(AcpBrokerMethod::Respond.as_str(), "acp/respond");
     assert_eq!(AcpBrokerMethod::Ack.as_str(), "acp/ack");
     assert_eq!(AcpBrokerMethod::Detach.as_str(), "acp/detach");

--- a/AlasHelper/tests/acp_broker_protocol.rs
+++ b/AlasHelper/tests/acp_broker_protocol.rs
@@ -1,7 +1,7 @@
 use alas_helper::acp_broker::{
-    ACPBrokerMetadata, ACPBrokerState, AdapterRequestId, BrokerErrorKind, BrokerEventKind,
-    BrokerGeneration, BrokerId, BrokerTurnState, EventCursor, OperationKey,
-    PendingClientRequestKind,
+    ACPBrokerMetadata, ACPBrokerState, AdapterRPCOutcome, AdapterRequestId, BrokerErrorKind,
+    BrokerEventKind, BrokerGeneration, BrokerId, BrokerTurnState, EventCursor, JSONRPCErrorObject,
+    OperationKey, PendingClientRequestKind,
 };
 use alas_helper::acp_broker_protocol::{
     AcpAckParams, AcpAttachParams, AcpBrokerMethod, AcpCloseParams, AcpDetachParams, AcpListResult,
@@ -138,7 +138,10 @@ fn completed_operations_return_the_original_terminal_result_on_retry() {
         )
         .unwrap();
     broker
-        .complete_operation(&OperationKey::new("stable-key"), json!({"ok": true}))
+        .complete_operation(
+            &OperationKey::new("stable-key"),
+            AdapterRPCOutcome::result(json!({"ok": true})),
+        )
         .unwrap();
 
     let retried = broker
@@ -150,7 +153,50 @@ fn completed_operations_return_the_original_terminal_result_on_retry() {
         .unwrap();
 
     assert!(retried.replayed);
-    assert_eq!(retried.terminal_result, Some(json!({"ok": true})));
+    assert_eq!(
+        retried.terminal_outcome,
+        Some(AdapterRPCOutcome::result(json!({"ok": true})))
+    );
+}
+
+#[test]
+fn completed_operations_replay_jsonrpc_errors() {
+    let mut broker = broker();
+    broker
+        .begin_operation(
+            OperationKey::new("stable-key"),
+            "session/prompt",
+            json!({"prompt": "a"}),
+        )
+        .unwrap();
+    broker
+        .complete_operation(
+            &OperationKey::new("stable-key"),
+            AdapterRPCOutcome::error(JSONRPCErrorObject {
+                code: -32001,
+                message: "denied".to_string(),
+                data: None,
+            }),
+        )
+        .unwrap();
+
+    let retried = broker
+        .begin_operation(
+            OperationKey::new("stable-key"),
+            "session/prompt",
+            json!({"prompt": "a"}),
+        )
+        .unwrap();
+
+    assert!(retried.replayed);
+    assert_eq!(
+        retried.terminal_outcome,
+        Some(AdapterRPCOutcome::error(JSONRPCErrorObject {
+            code: -32001,
+            message: "denied".to_string(),
+            data: None,
+        }))
+    );
 }
 
 #[test]
@@ -164,12 +210,18 @@ fn completing_operation_twice_with_different_result_is_rejected() {
         )
         .unwrap();
     broker
-        .complete_operation(&OperationKey::new("stable-key"), json!({"ok": true}))
+        .complete_operation(
+            &OperationKey::new("stable-key"),
+            AdapterRPCOutcome::result(json!({"ok": true})),
+        )
         .unwrap();
 
     assert_eq!(
         broker
-            .complete_operation(&OperationKey::new("stable-key"), json!({"ok": false}))
+            .complete_operation(
+                &OperationKey::new("stable-key"),
+                AdapterRPCOutcome::result(json!({"ok": false})),
+            )
             .unwrap_err()
             .kind(),
         BrokerErrorKind::OperationAlreadyCompletedWithDifferentResult
@@ -262,11 +314,17 @@ fn pending_request_variants_are_snapshotted_and_answered_once() {
     assert_eq!(broker.snapshot().pending_requests.len(), 5);
 
     broker
-        .respond_to_pending_request("permission", json!({"outcome": "approved"}))
+        .respond_to_pending_request(
+            "permission",
+            AdapterRPCOutcome::result(json!({"outcome": "approved"})),
+        )
         .unwrap();
     assert_eq!(
         broker
-            .respond_to_pending_request("permission", json!({"outcome": "approved"}))
+            .respond_to_pending_request(
+                "permission",
+                AdapterRPCOutcome::result(json!({"outcome": "approved"})),
+            )
             .unwrap_err()
             .kind(),
         BrokerErrorKind::PendingRequestAlreadyResolved
@@ -295,7 +353,7 @@ fn missing_pending_request_response_fails_closed() {
 
     assert_eq!(
         broker
-            .respond_to_pending_request("missing", json!({"ok": true}))
+            .respond_to_pending_request("missing", AdapterRPCOutcome::result(json!({"ok": true})))
             .unwrap_err()
             .kind(),
         BrokerErrorKind::PendingRequestNotFound
@@ -417,9 +475,10 @@ fn protocol_dtos_use_stable_wire_field_names() {
     let _: AcpRespondParams = round_trip(&AcpRespondParams {
         broker_id: BrokerId::new("local-session"),
         generation: BrokerGeneration::new(1),
-        request_id: AdapterRequestId::new(1),
+        request_id: json!(1),
         operation_key: OperationKey::new("answer"),
-        result: Value::Null,
+        result: Some(Value::Null),
+        error: None,
     });
     let _: AcpAckParams = round_trip(&AcpAckParams {
         broker_id: BrokerId::new("local-session"),
@@ -455,7 +514,7 @@ fn journal_contains_semantic_events_for_protocol_replay() {
     broker
         .complete_operation(
             &OperationKey::new("queue-item"),
-            json!({"stopReason": "end_turn"}),
+            AdapterRPCOutcome::result(json!({"stopReason": "end_turn"})),
         )
         .unwrap();
 

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -330,6 +330,45 @@ struct ACPBrokerClientTests {
         #expect(await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)])
     }
 
+    @Test func snapshotPendingRequestIsYieldedWhenEventIsAlreadyAcknowledged() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(
+            events: [],
+            snapshotPendingRequests: [
+                ACPBrokerPendingRequest(
+                    requestId: "99",
+                    adapterRequestId: .number(99),
+                    kind: .permission,
+                    payload: .object([
+                        "method": .string("session/request_permission"),
+                        "params": .object([
+                            "sessionId": .string("remote-1"),
+                            "toolCall": .object(["toolCallId": .string("tool-1")]),
+                            "options": .array([])
+                        ])
+                    ])
+                )
+            ],
+            snapshotJournalTail: ACPBrokerEventCursor(rawValue: 8)
+        )
+        let client = makeClient(
+            service: service,
+            initialAcknowledgedCursor: ACPBrokerEventCursor(rawValue: 5)
+        )
+        let permissionTask = Task { try await nextPermission(from: client.permissionRequests) }
+
+        try await client.start()
+
+        let permission = try await permissionTask.value
+        #expect(permission.id == .number(99))
+        client.respondToPermission(id: permission.id, response: .init(outcome: .selected(optionId: "allow")))
+
+        try await waitUntil { await service.responded.count == 1 }
+        let response = try await #require(service.responded.first)
+        #expect(response.requestId == .number(99))
+        #expect(await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 5)])
+    }
+
     @Test func pendingRequestAckWaitsForEarlierStreamedUpdateAck() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [
@@ -486,6 +525,56 @@ struct ACPBrokerClientTests {
         #expect(await service.attached.count == 3)
     }
 
+    @Test func adoptedActiveTurnPollsForLaterEventsAfterStart() async throws {
+        let service = MockBrokerService()
+        await service.setOpenAdopted(true)
+        await service.enqueueAttach(events: [], turnState: .streaming)
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("hello")
+                            ])
+                        ])
+                    ])
+                )
+            )
+        ], turnState: .streaming)
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .operationCompleted(
+                    operationKey: ACPBrokerOperationKey(rawValue: "queued-prompt:item:0:session/prompt"),
+                    outcome: ACPBrokerRPCOutcome(
+                        result: .object(["stopReason": .string("end_turn")]),
+                        error: nil
+                    )
+                )
+            )
+        ], turnState: .completed)
+        let client = makeClient(service: service)
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+
+        try await client.start()
+
+        let update = try await updateTask.value
+        if case .agentMessageChunk(let chunk) = update.update {
+            #expect(chunk.content == .text("hello"))
+        } else {
+            Issue.record("expected agent message chunk")
+        }
+        try await waitUntil { await service.attached.count == 3 }
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(await service.attached.count == 3)
+    }
+
     @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [
@@ -613,17 +702,32 @@ private actor MockBrokerService: ACPBrokerServicing {
     var acks: [ACPBrokerAckParams] = []
     var detached: [ACPBrokerDetachParams] = []
     var closed: [ACPBrokerCloseParams] = []
-    var attachEvents: [[ACPBrokerEvent]] = []
+    private var attachReplies: [AttachReply] = []
     var sendResults: [ACPBrokerSendResult] = []
     var snapshotInitializeResult: ACPBrokerJSONValue?
     var snapshotRemoteSessionResult: ACPBrokerJSONValue?
+    var openAdopted = false
 
-    func enqueueAttach(events: [ACPBrokerEvent]) {
-        attachEvents.append(events)
+    func enqueueAttach(
+        events: [ACPBrokerEvent],
+        snapshotPendingRequests: [ACPBrokerPendingRequest]? = nil,
+        snapshotJournalTail: ACPBrokerEventCursor? = nil,
+        turnState: ACPBrokerTurnState = .idle
+    ) {
+        attachReplies.append(AttachReply(
+            events: events,
+            snapshotPendingRequests: snapshotPendingRequests,
+            snapshotJournalTail: snapshotJournalTail,
+            turnState: turnState
+        ))
     }
 
     func enqueueSendResult(_ result: ACPBrokerSendResult) {
         sendResults.append(result)
+    }
+
+    func setOpenAdopted(_ adopted: Bool) {
+        openAdopted = adopted
     }
 
     func setSnapshotResults(
@@ -636,17 +740,20 @@ private actor MockBrokerService: ACPBrokerServicing {
 
     func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
         opened.append(params)
-        return ACPBrokerOpenResult(snapshot: snapshot(journalTail: 0), adopted: false)
+        return ACPBrokerOpenResult(snapshot: snapshot(journalTail: 0), adopted: openAdopted)
     }
 
     func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
         attached.append(params)
-        let events = attachEvents.isEmpty ? [] : attachEvents.removeFirst()
-        let tail = events.map(\.cursor).max() ?? params.acknowledgedCursor
+        let reply = attachReplies.isEmpty ? AttachReply(events: []) : attachReplies.removeFirst()
+        let events = reply.events
+        let tail = reply.snapshotJournalTail ?? events.map(\.cursor).max() ?? params.acknowledgedCursor
         return ACPBrokerAttachResult(
             snapshot: snapshot(
                 journalTail: tail.rawValue,
-                pendingRequests: pendingRequests(from: events)
+                acknowledgedCursor: params.acknowledgedCursor,
+                pendingRequests: reply.snapshotPendingRequests ?? pendingRequests(from: events),
+                turnState: reply.turnState
             ),
             events: events
         )
@@ -691,7 +798,9 @@ private actor MockBrokerService: ACPBrokerServicing {
 
     private func snapshot(
         journalTail: UInt64,
-        pendingRequests: [ACPBrokerPendingRequest] = []
+        acknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
+        pendingRequests: [ACPBrokerPendingRequest] = [],
+        turnState: ACPBrokerTurnState = .idle
     ) -> ACPBrokerSnapshot {
         ACPBrokerSnapshot(
             metadata: ACPBrokerMetadata(
@@ -706,8 +815,8 @@ private actor MockBrokerService: ACPBrokerServicing {
             ),
             initializeResult: snapshotInitializeResult,
             remoteSessionResult: snapshotRemoteSessionResult,
-            turnState: .idle,
-            acknowledgedCursor: ACPBrokerEventCursor(rawValue: 0),
+            turnState: turnState,
+            acknowledgedCursor: acknowledgedCursor,
             journalTail: ACPBrokerEventCursor(rawValue: journalTail),
             pendingRequests: pendingRequests,
             operations: []
@@ -727,5 +836,24 @@ private actor MockBrokerService: ACPBrokerServicing {
             }
         }
         return Array(pending.values)
+    }
+
+    private struct AttachReply {
+        let events: [ACPBrokerEvent]
+        let snapshotPendingRequests: [ACPBrokerPendingRequest]?
+        let snapshotJournalTail: ACPBrokerEventCursor?
+        let turnState: ACPBrokerTurnState
+
+        init(
+            events: [ACPBrokerEvent],
+            snapshotPendingRequests: [ACPBrokerPendingRequest]? = nil,
+            snapshotJournalTail: ACPBrokerEventCursor? = nil,
+            turnState: ACPBrokerTurnState = .idle
+        ) {
+            self.events = events
+            self.snapshotPendingRequests = snapshotPendingRequests
+            self.snapshotJournalTail = snapshotJournalTail
+            self.turnState = turnState
+        }
     }
 }

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -197,15 +197,22 @@ struct ACPBrokerClientTests {
         #expect(await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)])
     }
 
-    @Test func notifyFailsClosedUntilBrokerSupportsNotifications() async throws {
+    @Test func notifyUsesBrokerNotificationPath() async throws {
         let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
         await service.enqueueAttach(events: [])
         let client = makeClient(service: service)
         try await client.start()
 
-        await #expect(throws: ACPClientError.self) {
-            try await client.notify(ACPRequest(method: "session/cancel"))
-        }
+        try await client.notify(ACPRequest(
+            method: "session/cancel",
+            params: ACPSessionCancelParams(sessionId: "remote-1")
+        ))
+
+        let notified = try await #require(service.notified.first)
+        #expect(notified.method == "session/cancel")
+        #expect(notified.params == .object(["sessionId": .string("remote-1")]))
+        #expect(await service.attached.count == 2)
     }
 
     private func makeClient(
@@ -277,6 +284,7 @@ private actor MockBrokerService: ACPBrokerServicing {
     var opened: [ACPBrokerOpenParams] = []
     var attached: [ACPBrokerAttachParams] = []
     var sent: [ACPBrokerSendParams] = []
+    var notified: [ACPBrokerNotifyParams] = []
     var responded: [ACPBrokerRespondParams] = []
     var acks: [ACPBrokerAckParams] = []
     var detached: [ACPBrokerDetachParams] = []
@@ -314,6 +322,11 @@ private actor MockBrokerService: ACPBrokerServicing {
                 pending: nil
             )
             : sendResults.removeFirst()
+    }
+
+    func notify(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK {
+        notified.append(params)
+        return ACPBrokerSimpleOK(ok: true)
     }
 
     func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -240,13 +240,16 @@ struct ACPBrokerClientTests {
                     adapterRequestId: .string("req-alpha"),
                     kind: .permission,
                     payload: .object([
-                        "sessionId": .string("remote-1"),
-                        "toolCall": .object(["toolCallId": .string("tool-1")]),
-                        "options": .array([
-                            .object([
-                                "optionId": .string("allow"),
-                                "name": .string("Allow"),
-                                "kind": .string("allow_once")
+                        "method": .string("session/request_permission"),
+                        "params": .object([
+                            "sessionId": .string("remote-1"),
+                            "toolCall": .object(["toolCallId": .string("tool-1")]),
+                            "options": .array([
+                                .object([
+                                    "optionId": .string("allow"),
+                                    "name": .string("Allow"),
+                                    "kind": .string("allow_once")
+                                ])
                             ])
                         ])
                     ])
@@ -265,6 +268,65 @@ struct ACPBrokerClientTests {
         let response = try await #require(service.responded.first)
         #expect(response.requestId == .string("req-alpha"))
         #expect(await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)])
+    }
+
+    @Test func promptResponseAckWaitsForEarlierStreamedUpdateAck() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("hello")
+                            ])
+                        ])
+                    ])
+                )
+            ),
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .operationCompleted(
+                    operationKey: ACPBrokerOperationKey(rawValue: "op-prefix:1:session/prompt"),
+                    outcome: ACPBrokerRPCOutcome(
+                        result: .object(["stopReason": .string("end_turn")]),
+                        error: nil
+                    )
+                )
+            )
+        ])
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: false,
+            result: .object(["stopReason": .string("end_turn")])
+        ))
+        let client = makeClient(service: service)
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+        try await client.start()
+
+        let response = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")])
+        ))
+        let update = try await updateTask.value
+
+        response.acknowledgeDurableConsumption()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await service.acks.isEmpty)
+
+        update.durableConsumptionAcknowledgement?()
+        try await waitUntil {
+            await service.acks.map(\.cursor) == [
+                ACPBrokerEventCursor(rawValue: 2),
+                ACPBrokerEventCursor(rawValue: 3)
+            ]
+        }
     }
 
     @Test func sendWaitsAcrossPendingResultAndReplaysPendingRequest() async throws {

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -308,6 +308,61 @@ struct ACPBrokerClientTests {
         #expect(await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)])
     }
 
+    @Test func pendingRequestAckWaitsForEarlierStreamedUpdateAck() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("hello")
+                            ])
+                        ])
+                    ])
+                )
+            ),
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .pendingRequest(ACPBrokerPendingRequest(
+                    requestId: "99",
+                    adapterRequestId: .number(99),
+                    kind: .permission,
+                    payload: .object([
+                        "sessionId": .string("remote-1"),
+                        "toolCall": .object(["toolCallId": .string("tool-1")]),
+                        "options": .array([])
+                    ])
+                ))
+            )
+        ])
+        let client = makeClient(service: service)
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+        let permissionTask = Task { try await nextPermission(from: client.permissionRequests) }
+        try await client.start()
+
+        let update = try await updateTask.value
+        let permission = try await permissionTask.value
+        client.respondToPermission(id: permission.id, response: .init(outcome: .selected(optionId: "allow")))
+
+        try await waitUntil { await service.responded.count == 1 }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await service.acks.isEmpty)
+
+        update.durableConsumptionAcknowledgement?()
+        try await waitUntil {
+            await service.acks.map(\.cursor) == [
+                ACPBrokerEventCursor(rawValue: 2),
+                ACPBrokerEventCursor(rawValue: 3)
+            ]
+        }
+    }
+
     @Test func promptResponseAckWaitsForEarlierStreamedUpdateAck() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [])

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -511,6 +511,65 @@ struct ACPBrokerClientTests {
         }
     }
 
+    @Test func laterStreamedUpdateAckWaitsForDeferredPromptResponseAck() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .operationCompleted(
+                    operationKey: ACPBrokerOperationKey(rawValue: "op-prefix:1:session/prompt"),
+                    outcome: ACPBrokerRPCOutcome(
+                        result: .object(["stopReason": .string("end_turn")]),
+                        error: nil
+                    )
+                )
+            ),
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("after-completion")
+                            ])
+                        ])
+                    ])
+                )
+            )
+        ])
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: false,
+            result: .object(["stopReason": .string("end_turn")])
+        ))
+        let client = makeClient(service: service)
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+        try await client.start()
+
+        let response = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")])
+        ))
+        let update = try await updateTask.value
+
+        update.durableConsumptionAcknowledgement?()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await service.acks.isEmpty)
+
+        response.acknowledgeDurableConsumption()
+        try await waitUntil {
+            await service.acks.map(\.cursor) == [
+                ACPBrokerEventCursor(rawValue: 2),
+                ACPBrokerEventCursor(rawValue: 3)
+            ]
+        }
+    }
+
     @Test func sendWaitsAcrossPendingResultAndReplaysPendingRequest() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [])

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -229,6 +229,28 @@ struct ACPBrokerClientTests {
         }
     }
 
+    @Test func adapterExitNotificationFinishesUpdateStream() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .adapterNotification(
+                    method: "adapter/exit",
+                    params: .object(["unexpected": .bool(true)])
+                )
+            )
+        ])
+        let client = makeClient(service: service)
+        let finishedTask = Task {
+            var iterator = client.incomingUpdates.makeAsyncIterator()
+            return await iterator.next() == nil
+        }
+
+        try await client.start()
+
+        #expect(await finishedTask.value == true)
+    }
+
     @Test func pendingPermissionResponseUsesBrokerRespondAndAcksRequestCursor() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -1,0 +1,278 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct ACPBrokerClientTests {
+    @Test func startOpensAndAttachesBroker() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        let client = makeClient(service: service)
+
+        let opened = try await client.start()
+
+        #expect(opened.adopted == false)
+        let openParams = try await #require(service.opened.first)
+        #expect(openParams.brokerId == ACPBrokerID(rawValue: "broker-1"))
+        #expect(openParams.sessionId == "local-session-1")
+        #expect(openParams.command == "codex-acp")
+        let attachParams = try await #require(service.attached.first)
+        #expect(attachParams.acknowledgedCursor == ACPBrokerEventCursor(rawValue: 0))
+    }
+
+    @Test func sendUsesBrokerOperationAndReturnsResult() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        await service.enqueueAttach(events: [])
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: false,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: nil
+        ))
+        let client = makeClient(service: service)
+        try await client.start()
+
+        let response = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")])
+        ))
+
+        let body = try #require(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+        #expect(body["stopReason"] as? String == "end_turn")
+        let sent = try await #require(service.sent.first)
+        #expect(sent.operationKey == ACPBrokerOperationKey(rawValue: "op-prefix:1:session/prompt"))
+        #expect(sent.method == "session/prompt")
+        #expect(sent.params == .object([
+            "sessionId": .string("remote-1"),
+            "prompt": .array([.object([
+                "type": .string("text"),
+                "text": .string("hi")
+            ])])
+        ]))
+    }
+
+    @Test func replayedSessionUpdateIsYieldedAndAckedAfterDurableConsumption() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("hello")
+                            ])
+                        ])
+                    ])
+                )
+            )
+        ])
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: false,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: nil
+        ))
+        let client = makeClient(service: service)
+        try await client.start()
+
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+        _ = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")])
+        ))
+
+        let update = try await updateTask.value
+        #expect(client.yieldedUpdateCount == 1)
+        if case .agentMessageChunk(let chunk) = update.update {
+            #expect(chunk.content == .text("hello"))
+        } else {
+            Issue.record("expected agent message chunk")
+        }
+        #expect(await service.acks.isEmpty)
+        update.durableConsumptionAcknowledgement?()
+        try await waitUntil { await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 3)] }
+    }
+
+    @Test func pendingPermissionResponseUsesBrokerRespondAndAcksRequestCursor() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .pendingRequest(ACPBrokerPendingRequest(
+                    requestId: "99",
+                    adapterRequestId: .number(99),
+                    kind: .permission,
+                    payload: .object([
+                        "sessionId": .string("remote-1"),
+                        "toolCall": .object(["toolCallId": .string("tool-1")]),
+                        "options": .array([
+                            .object([
+                                "optionId": .string("allow"),
+                                "name": .string("Allow"),
+                                "kind": .string("allow_once")
+                            ])
+                        ])
+                    ])
+                ))
+            )
+        ])
+        let client = makeClient(service: service)
+        let permissionTask = Task { try await nextPermission(from: client.permissionRequests) }
+        try await client.start()
+
+        let permission = try await permissionTask.value
+        #expect(permission.id == .number(99))
+        #expect(permission.params.toolCall.toolCallId == "tool-1")
+        client.respondToPermission(id: permission.id, response: .init(outcome: .selected(optionId: "allow")))
+
+        try await waitUntil { await service.responded.count == 1 }
+        let response = try await #require(service.responded.first)
+        #expect(response.requestId == ACPBrokerAdapterRequestID(rawValue: 99))
+        #expect(response.operationKey == ACPBrokerOperationKey(rawValue: "op-prefix:1:respond"))
+        #expect(await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)])
+    }
+
+    @Test func notifyFailsClosedUntilBrokerSupportsNotifications() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        let client = makeClient(service: service)
+        try await client.start()
+
+        await #expect(throws: ACPClientError.self) {
+            try await client.notify(ACPRequest(method: "session/cancel"))
+        }
+    }
+
+    private func makeClient(service: MockBrokerService) -> ACPBrokerClient {
+        ACPBrokerClient(
+            service: service,
+            brokerId: ACPBrokerID(rawValue: "broker-1"),
+            sessionId: "local-session-1",
+            command: "codex-acp",
+            args: ["--stdio"],
+            cwd: "/repo",
+            env: ["PATH": "/bin"],
+            operationKeyPrefix: "op-prefix"
+        )
+    }
+
+    private func nextUpdate(from stream: AsyncStream<ACPSessionUpdateParams>) async throws -> ACPSessionUpdateParams {
+        var iterator = stream.makeAsyncIterator()
+        return try #require(await iterator.next())
+    }
+
+    private func nextPermission(
+        from stream: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>
+    ) async throws -> (id: JSONRPCID, params: ACPPermissionRequestParams) {
+        var iterator = stream.makeAsyncIterator()
+        return try #require(await iterator.next())
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping @MainActor () async -> Bool
+    ) async throws {
+        let start = ContinuousClock.now
+        while !(await predicate()) {
+            if ContinuousClock.now - start > timeout {
+                throw ACPBrokerClientTestTimeout()
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+private struct ACPBrokerClientTestTimeout: Error {}
+
+private actor MockBrokerService: ACPBrokerServicing {
+    var opened: [ACPBrokerOpenParams] = []
+    var attached: [ACPBrokerAttachParams] = []
+    var sent: [ACPBrokerSendParams] = []
+    var responded: [ACPBrokerRespondParams] = []
+    var acks: [ACPBrokerAckParams] = []
+    var detached: [ACPBrokerDetachParams] = []
+    var closed: [ACPBrokerCloseParams] = []
+    var attachEvents: [[ACPBrokerEvent]] = []
+    var sendResults: [ACPBrokerSendResult] = []
+
+    func enqueueAttach(events: [ACPBrokerEvent]) {
+        attachEvents.append(events)
+    }
+
+    func enqueueSendResult(_ result: ACPBrokerSendResult) {
+        sendResults.append(result)
+    }
+
+    func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
+        opened.append(params)
+        return ACPBrokerOpenResult(snapshot: snapshot(journalTail: 0), adopted: false)
+    }
+
+    func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
+        attached.append(params)
+        let events = attachEvents.isEmpty ? [] : attachEvents.removeFirst()
+        let tail = events.map(\.cursor).max() ?? params.acknowledgedCursor
+        return ACPBrokerAttachResult(snapshot: snapshot(journalTail: tail.rawValue), events: events)
+    }
+
+    func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        sent.append(params)
+        return sendResults.isEmpty
+            ? ACPBrokerSendResult(
+                requestId: ACPBrokerAdapterRequestID(rawValue: 1),
+                replayed: false,
+                result: .object([:]),
+                pending: nil
+            )
+            : sendResults.removeFirst()
+    }
+
+    func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
+        responded.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK {
+        acks.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
+        detached.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
+        closed.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    private func snapshot(journalTail: UInt64) -> ACPBrokerSnapshot {
+        ACPBrokerSnapshot(
+            metadata: ACPBrokerMetadata(
+                brokerId: ACPBrokerID(rawValue: "broker-1"),
+                generation: ACPBrokerGeneration(rawValue: 7),
+                alasSessionId: "local-session-1",
+                adapterProgram: "codex-acp",
+                adapterArgs: ["--stdio"],
+                cwd: "/repo",
+                envKeys: ["PATH"],
+                createdAtMillis: 10
+            ),
+            initializeResult: nil,
+            remoteSessionResult: nil,
+            turnState: .idle,
+            acknowledgedCursor: ACPBrokerEventCursor(rawValue: 0),
+            journalTail: ACPBrokerEventCursor(rawValue: journalTail),
+            pendingRequests: [],
+            operations: []
+        )
+    }
+}

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -20,6 +20,23 @@ struct ACPBrokerClientTests {
         #expect(attachParams.acknowledgedCursor == ACPBrokerEventCursor(rawValue: 0))
     }
 
+    @Test func startPublishesDurableStateFromBrokerSnapshots() async throws {
+        let service = MockBrokerService()
+        let stateSink = DurableStateSink()
+        await service.enqueueAttach(events: [])
+        let client = makeClient(service: service) { state in
+            Task { await stateSink.append(state) }
+        }
+
+        try await client.start()
+
+        try await waitUntil { await stateSink.recordCount() >= 2 }
+        let last = try await #require(stateSink.lastRecord())
+        #expect(last.brokerId == ACPBrokerID(rawValue: "broker-1"))
+        #expect(last.generation == ACPBrokerGeneration(rawValue: 7))
+        #expect(last.acknowledgedCursor == ACPBrokerEventCursor(rawValue: 0))
+    }
+
     @Test func sendUsesBrokerOperationAndReturnsResult() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [])
@@ -100,6 +117,47 @@ struct ACPBrokerClientTests {
         try await waitUntil { await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 3)] }
     }
 
+    @Test func durableConsumptionReportsAdvancedCursorAfterBrokerAck() async throws {
+        let service = MockBrokerService()
+        let stateSink = DurableStateSink()
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 5),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("hello")
+                            ])
+                        ])
+                    ])
+                )
+            )
+        ])
+        let client = makeClient(service: service) { state in
+            Task { await stateSink.append(state) }
+        }
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+        try await client.start()
+
+        let update = try await updateTask.value
+        let snapshotStateCount = await stateSink.recordCount()
+        update.durableConsumptionAcknowledgement?()
+
+        let expectedState = ACPBrokerDurableState(
+            brokerId: ACPBrokerID(rawValue: "broker-1"),
+            generation: ACPBrokerGeneration(rawValue: 7),
+            acknowledgedCursor: ACPBrokerEventCursor(rawValue: 5)
+        )
+        try await waitUntil {
+            await stateSink.hasLastRecord(after: snapshotStateCount, matching: expectedState)
+        }
+    }
+
     @Test func pendingPermissionResponseUsesBrokerRespondAndAcksRequestCursor() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [
@@ -150,7 +208,10 @@ struct ACPBrokerClientTests {
         }
     }
 
-    private func makeClient(service: MockBrokerService) -> ACPBrokerClient {
+    private func makeClient(
+        service: MockBrokerService,
+        onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
+    ) -> ACPBrokerClient {
         ACPBrokerClient(
             service: service,
             brokerId: ACPBrokerID(rawValue: "broker-1"),
@@ -159,7 +220,8 @@ struct ACPBrokerClientTests {
             args: ["--stdio"],
             cwd: "/repo",
             env: ["PATH": "/bin"],
-            operationKeyPrefix: "op-prefix"
+            operationKeyPrefix: "op-prefix",
+            onDurableStateChanged: onDurableStateChanged
         )
     }
 
@@ -190,6 +252,26 @@ struct ACPBrokerClientTests {
 }
 
 private struct ACPBrokerClientTestTimeout: Error {}
+
+private actor DurableStateSink {
+    private var records: [ACPBrokerDurableState] = []
+
+    func append(_ state: ACPBrokerDurableState) {
+        records.append(state)
+    }
+
+    func recordCount() -> Int {
+        records.count
+    }
+
+    func lastRecord() -> ACPBrokerDurableState? {
+        records.last
+    }
+
+    func hasLastRecord(after count: Int, matching expected: ACPBrokerDurableState) -> Bool {
+        records.count == count + 1 && records.last == expected
+    }
+}
 
 private actor MockBrokerService: ACPBrokerServicing {
     var opened: [ACPBrokerOpenParams] = []

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -40,6 +40,21 @@ struct ACPBrokerClientTests {
         #expect(last.acknowledgedCursor == ACPBrokerEventCursor(rawValue: 0))
     }
 
+    @Test func startResetsInitialCursorWhenBrokerGenerationChanges() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        let client = makeClient(
+            service: service,
+            initialBrokerGeneration: ACPBrokerGeneration(rawValue: 6),
+            initialAcknowledgedCursor: ACPBrokerEventCursor(rawValue: 4)
+        )
+
+        try await client.start()
+
+        let attachParams = try await #require(service.attached.first)
+        #expect(attachParams.acknowledgedCursor == ACPBrokerEventCursor(rawValue: 0))
+    }
+
     @Test func sendUsesBrokerOperationAndReturnsResult() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [])
@@ -391,6 +406,7 @@ struct ACPBrokerClientTests {
 
     private func makeClient(
         service: MockBrokerService,
+        initialBrokerGeneration: ACPBrokerGeneration? = nil,
         initialAcknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
         onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
     ) -> ACPBrokerClient {
@@ -403,6 +419,7 @@ struct ACPBrokerClientTests {
             cwd: "/repo",
             env: ["PATH": "/bin"],
             operationKeyPrefix: "op-prefix",
+            initialBrokerGeneration: initialBrokerGeneration,
             initialAcknowledgedCursor: initialAcknowledgedCursor,
             onDurableStateChanged: onDurableStateChanged
         )

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -251,6 +251,20 @@ struct ACPBrokerClientTests {
         #expect(await finishedTask.value == true)
     }
 
+    @Test func shutdownClosesBrokerGeneration() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        let client = makeClient(service: service)
+        try await client.start()
+
+        await client.shutdown()
+
+        let close = try await #require(service.closed.first)
+        #expect(close.brokerId == ACPBrokerID(rawValue: "broker-1"))
+        #expect(close.generation == ACPBrokerGeneration(rawValue: 7))
+        #expect(await service.detached.isEmpty)
+    }
+
     @Test func pendingPermissionResponseUsesBrokerRespondAndAcksRequestCursor() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -87,6 +87,29 @@ struct ACPBrokerClientTests {
         ]))
     }
 
+    @Test func sendUsesExplicitBrokerOperationKeyWhenProvided() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        await service.enqueueAttach(events: [])
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: false,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: nil
+        ))
+        let client = makeClient(service: service)
+        try await client.start()
+
+        _ = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("queued")]),
+            brokerOperationKey: "queued-prompt:item-1:0:session/prompt"
+        ))
+
+        let sent = try await #require(service.sent.first)
+        #expect(sent.operationKey == ACPBrokerOperationKey(rawValue: "queued-prompt:item-1:0:session/prompt"))
+    }
+
     @Test func adoptedHandshakeAndRemoteSessionResultsAreReplayedFromSnapshot() async throws {
         let service = MockBrokerService()
         await service.setSnapshotResults(
@@ -386,6 +409,37 @@ struct ACPBrokerClientTests {
         #expect(await service.attached.count == 3)
     }
 
+    @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .pendingRequest(ACPBrokerPendingRequest(
+                    requestId: "99",
+                    adapterRequestId: .number(99),
+                    kind: .permission,
+                    payload: .object([
+                        "sessionId": .string("remote-1"),
+                        "toolCall": .object(["toolCallId": .string("tool-1")]),
+                        "options": .array([])
+                    ])
+                ))
+            ),
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .pendingRequestResolved(
+                    requestId: "99",
+                    response: ACPBrokerRPCOutcome(result: .object(["outcome": .string("approved")]), error: nil)
+                )
+            )
+        ])
+        let client = makeClient(service: service)
+
+        try await client.start()
+
+        #expect(client.hasPendingOutboundRequest(id: .number(99)) == false)
+    }
+
     @Test func notifyUsesBrokerNotificationPath() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [])
@@ -512,7 +566,13 @@ private actor MockBrokerService: ACPBrokerServicing {
         attached.append(params)
         let events = attachEvents.isEmpty ? [] : attachEvents.removeFirst()
         let tail = events.map(\.cursor).max() ?? params.acknowledgedCursor
-        return ACPBrokerAttachResult(snapshot: snapshot(journalTail: tail.rawValue), events: events)
+        return ACPBrokerAttachResult(
+            snapshot: snapshot(
+                journalTail: tail.rawValue,
+                pendingRequests: pendingRequests(from: events)
+            ),
+            events: events
+        )
     }
 
     func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
@@ -552,7 +612,10 @@ private actor MockBrokerService: ACPBrokerServicing {
         return ACPBrokerSimpleOK(ok: true)
     }
 
-    private func snapshot(journalTail: UInt64) -> ACPBrokerSnapshot {
+    private func snapshot(
+        journalTail: UInt64,
+        pendingRequests: [ACPBrokerPendingRequest] = []
+    ) -> ACPBrokerSnapshot {
         ACPBrokerSnapshot(
             metadata: ACPBrokerMetadata(
                 brokerId: ACPBrokerID(rawValue: "broker-1"),
@@ -569,8 +632,23 @@ private actor MockBrokerService: ACPBrokerServicing {
             turnState: .idle,
             acknowledgedCursor: ACPBrokerEventCursor(rawValue: 0),
             journalTail: ACPBrokerEventCursor(rawValue: journalTail),
-            pendingRequests: [],
+            pendingRequests: pendingRequests,
             operations: []
         )
+    }
+
+    private func pendingRequests(from events: [ACPBrokerEvent]) -> [ACPBrokerPendingRequest] {
+        var pending: [String: ACPBrokerPendingRequest] = [:]
+        for event in events {
+            switch event.kind {
+            case .pendingRequest(let request):
+                pending[request.requestId] = request
+            case .pendingRequestResolved(let requestId, _):
+                pending.removeValue(forKey: requestId)
+            default:
+                break
+            }
+        }
+        return Array(pending.values)
     }
 }

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -7,7 +7,10 @@ struct ACPBrokerClientTests {
     @Test func startOpensAndAttachesBroker() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [])
-        let client = makeClient(service: service)
+        let client = makeClient(
+            service: service,
+            initialAcknowledgedCursor: ACPBrokerEventCursor(rawValue: 4)
+        )
 
         let opened = try await client.start()
 
@@ -17,7 +20,7 @@ struct ACPBrokerClientTests {
         #expect(openParams.sessionId == "local-session-1")
         #expect(openParams.command == "codex-acp")
         let attachParams = try await #require(service.attached.first)
-        #expect(attachParams.acknowledgedCursor == ACPBrokerEventCursor(rawValue: 0))
+        #expect(attachParams.acknowledgedCursor == ACPBrokerEventCursor(rawValue: 4))
     }
 
     @Test func startPublishesDurableStateFromBrokerSnapshots() async throws {
@@ -67,6 +70,36 @@ struct ACPBrokerClientTests {
                 "text": .string("hi")
             ])])
         ]))
+    }
+
+    @Test func adoptedHandshakeAndRemoteSessionResultsAreReplayedFromSnapshot() async throws {
+        let service = MockBrokerService()
+        await service.setSnapshotResults(
+            initializeResult: .object([
+                "protocolVersion": .number(1),
+                "agentCapabilities": .object([
+                    "loadSession": .bool(true),
+                    "sessionCapabilities": .object(["load": .object([:])])
+                ]),
+                "authMethods": .array([])
+            ]),
+            remoteSessionResult: .object(["sessionId": .string("remote-restored")])
+        )
+        await service.enqueueAttach(events: [])
+        let client = makeClient(service: service)
+        try await client.start()
+
+        let initialize = try await client.send(ACPRequest(method: "initialize"))
+        let initialized = try JSONDecoder().decode(ACPInitializeResult.self, from: initialize.body)
+        #expect(initialized.protocolVersion == 1)
+
+        let session = try await client.send(ACPRequest(
+            method: "session/load",
+            params: ACPSessionLoadParams(cwd: "/repo", sessionId: "remote-old", mcpServers: [])
+        ))
+        let loaded = try JSONDecoder().decode(ACPSessionNewResult.self, from: session.body)
+        #expect(loaded.sessionId == "remote-restored")
+        #expect(await service.sent.isEmpty)
     }
 
     @Test func replayedSessionUpdateIsYieldedAndAckedAfterDurableConsumption() async throws {
@@ -217,6 +250,7 @@ struct ACPBrokerClientTests {
 
     private func makeClient(
         service: MockBrokerService,
+        initialAcknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
         onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
     ) -> ACPBrokerClient {
         ACPBrokerClient(
@@ -228,6 +262,7 @@ struct ACPBrokerClientTests {
             cwd: "/repo",
             env: ["PATH": "/bin"],
             operationKeyPrefix: "op-prefix",
+            initialAcknowledgedCursor: initialAcknowledgedCursor,
             onDurableStateChanged: onDurableStateChanged
         )
     }
@@ -291,6 +326,8 @@ private actor MockBrokerService: ACPBrokerServicing {
     var closed: [ACPBrokerCloseParams] = []
     var attachEvents: [[ACPBrokerEvent]] = []
     var sendResults: [ACPBrokerSendResult] = []
+    var snapshotInitializeResult: ACPBrokerJSONValue?
+    var snapshotRemoteSessionResult: ACPBrokerJSONValue?
 
     func enqueueAttach(events: [ACPBrokerEvent]) {
         attachEvents.append(events)
@@ -298,6 +335,14 @@ private actor MockBrokerService: ACPBrokerServicing {
 
     func enqueueSendResult(_ result: ACPBrokerSendResult) {
         sendResults.append(result)
+    }
+
+    func setSnapshotResults(
+        initializeResult: ACPBrokerJSONValue?,
+        remoteSessionResult: ACPBrokerJSONValue?
+    ) {
+        snapshotInitializeResult = initializeResult
+        snapshotRemoteSessionResult = remoteSessionResult
     }
 
     func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
@@ -361,8 +406,8 @@ private actor MockBrokerService: ACPBrokerServicing {
                 envKeys: ["PATH"],
                 createdAtMillis: 10
             ),
-            initializeResult: nil,
-            remoteSessionResult: nil,
+            initializeResult: snapshotInitializeResult,
+            remoteSessionResult: snapshotRemoteSessionResult,
             turnState: .idle,
             acknowledgedCursor: ACPBrokerEventCursor(rawValue: 0),
             journalTail: ACPBrokerEventCursor(rawValue: journalTail),

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -265,6 +265,20 @@ struct ACPBrokerClientTests {
         #expect(await service.detached.isEmpty)
     }
 
+    @Test func detachDoesNotCloseBrokerGeneration() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        let client = makeClient(service: service)
+        try await client.start()
+
+        await client.detach()
+
+        let detach = try await #require(service.detached.first)
+        #expect(detach.brokerId == ACPBrokerID(rawValue: "broker-1"))
+        #expect(detach.generation == ACPBrokerGeneration(rawValue: 7))
+        #expect(await service.closed.isEmpty)
+    }
+
     @Test func pendingPermissionResponseUsesBrokerRespondAndAcksRequestCursor() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -539,6 +539,57 @@ struct ACPBrokerClientTests {
         #expect(await service.attached.count == 3)
     }
 
+    @Test func pendingBrokerSendTracksOutboundRequestIdForScopedElicitations() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        await service.enqueueAttach(events: [])
+        await service.enqueueAttach(events: [])
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: false,
+            pending: true
+        ))
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: true,
+            result: .object(["stopReason": .string("end_turn")])
+        ))
+        let client = makeClient(service: service)
+        try await client.start()
+
+        let sendTask = Task {
+            try await client.send(ACPRequest(
+                method: "session/prompt",
+                params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")])
+            ))
+        }
+
+        try await waitUntil { client.hasPendingOutboundRequest(id: .number(4)) }
+        _ = try await sendTask.value
+        #expect(client.hasPendingOutboundRequest(id: .number(4)) == false)
+    }
+
+    @Test func restoredActiveOperationTracksOutboundRequestId() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(
+            events: [],
+            snapshotOperations: [
+                ACPBrokerOperationSnapshot(
+                    operationKey: ACPBrokerOperationKey(rawValue: "queued-prompt:item:0:session/prompt"),
+                    adapterRequestId: ACPBrokerAdapterRequestID(rawValue: 7),
+                    method: "session/prompt",
+                    params: .object(["prompt": .string("hi")]),
+                    terminalOutcome: nil
+                )
+            ]
+        )
+        let client = makeClient(service: service)
+
+        try await client.start()
+
+        #expect(client.hasPendingOutboundRequest(id: .number(7)) == true)
+    }
+
     @Test func adoptedActiveTurnPollsForLaterEventsAfterStart() async throws {
         let service = MockBrokerService()
         await service.setOpenAdopted(true)
@@ -726,12 +777,14 @@ private actor MockBrokerService: ACPBrokerServicing {
         events: [ACPBrokerEvent],
         snapshotPendingRequests: [ACPBrokerPendingRequest]? = nil,
         snapshotJournalTail: ACPBrokerEventCursor? = nil,
+        snapshotOperations: [ACPBrokerOperationSnapshot] = [],
         turnState: ACPBrokerTurnState = .idle
     ) {
         attachReplies.append(AttachReply(
             events: events,
             snapshotPendingRequests: snapshotPendingRequests,
             snapshotJournalTail: snapshotJournalTail,
+            snapshotOperations: snapshotOperations,
             turnState: turnState
         ))
     }
@@ -767,6 +820,7 @@ private actor MockBrokerService: ACPBrokerServicing {
                 journalTail: tail.rawValue,
                 acknowledgedCursor: params.acknowledgedCursor,
                 pendingRequests: reply.snapshotPendingRequests ?? pendingRequests(from: events),
+                operations: reply.snapshotOperations,
                 turnState: reply.turnState
             ),
             events: events
@@ -814,6 +868,7 @@ private actor MockBrokerService: ACPBrokerServicing {
         journalTail: UInt64,
         acknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
         pendingRequests: [ACPBrokerPendingRequest] = [],
+        operations: [ACPBrokerOperationSnapshot] = [],
         turnState: ACPBrokerTurnState = .idle
     ) -> ACPBrokerSnapshot {
         ACPBrokerSnapshot(
@@ -833,7 +888,7 @@ private actor MockBrokerService: ACPBrokerServicing {
             acknowledgedCursor: acknowledgedCursor,
             journalTail: ACPBrokerEventCursor(rawValue: journalTail),
             pendingRequests: pendingRequests,
-            operations: []
+            operations: operations
         )
     }
 
@@ -856,17 +911,20 @@ private actor MockBrokerService: ACPBrokerServicing {
         let events: [ACPBrokerEvent]
         let snapshotPendingRequests: [ACPBrokerPendingRequest]?
         let snapshotJournalTail: ACPBrokerEventCursor?
+        let snapshotOperations: [ACPBrokerOperationSnapshot]
         let turnState: ACPBrokerTurnState
 
         init(
             events: [ACPBrokerEvent],
             snapshotPendingRequests: [ACPBrokerPendingRequest]? = nil,
             snapshotJournalTail: ACPBrokerEventCursor? = nil,
+            snapshotOperations: [ACPBrokerOperationSnapshot] = [],
             turnState: ACPBrokerTurnState = .idle
         ) {
             self.events = events
             self.snapshotPendingRequests = snapshotPendingRequests
             self.snapshotJournalTail = snapshotJournalTail
+            self.snapshotOperations = snapshotOperations
             self.turnState = turnState
         }
     }

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -225,9 +225,88 @@ struct ACPBrokerClientTests {
 
         try await waitUntil { await service.responded.count == 1 }
         let response = try await #require(service.responded.first)
-        #expect(response.requestId == ACPBrokerAdapterRequestID(rawValue: 99))
+        #expect(response.requestId == .number(99))
         #expect(response.operationKey == ACPBrokerOperationKey(rawValue: "op-prefix:1:respond"))
         #expect(await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)])
+    }
+
+    @Test func pendingPermissionResponsePreservesStringRequestId() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .pendingRequest(ACPBrokerPendingRequest(
+                    requestId: "req-alpha",
+                    adapterRequestId: .string("req-alpha"),
+                    kind: .permission,
+                    payload: .object([
+                        "sessionId": .string("remote-1"),
+                        "toolCall": .object(["toolCallId": .string("tool-1")]),
+                        "options": .array([
+                            .object([
+                                "optionId": .string("allow"),
+                                "name": .string("Allow"),
+                                "kind": .string("allow_once")
+                            ])
+                        ])
+                    ])
+                ))
+            )
+        ])
+        let client = makeClient(service: service)
+        let permissionTask = Task { try await nextPermission(from: client.permissionRequests) }
+        try await client.start()
+
+        let permission = try await permissionTask.value
+        #expect(permission.id == .string("req-alpha"))
+        client.respondToPermission(id: permission.id, response: .init(outcome: .selected(optionId: "allow")))
+
+        try await waitUntil { await service.responded.count == 1 }
+        let response = try await #require(service.responded.first)
+        #expect(response.requestId == .string("req-alpha"))
+        #expect(await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)])
+    }
+
+    @Test func sendWaitsAcrossPendingResultAndReplaysPendingRequest() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [])
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .pendingRequest(ACPBrokerPendingRequest(
+                    requestId: "99",
+                    adapterRequestId: .number(99),
+                    kind: .permission,
+                    payload: .object([
+                        "sessionId": .string("remote-1"),
+                        "toolCall": .object(["toolCallId": .string("tool-1")]),
+                        "options": .array([])
+                    ])
+                ))
+            )
+        ])
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: false,
+            pending: true
+        ))
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: true,
+            result: .object(["stopReason": .string("end_turn")])
+        ))
+        let client = makeClient(service: service)
+        try await client.start()
+
+        let response = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")])
+        ))
+
+        let body = try #require(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+        #expect(body["stopReason"] as? String == "end_turn")
+        #expect(await service.sent.count == 2)
+        #expect(await service.attached.count == 3)
     }
 
     @Test func notifyUsesBrokerNotificationPath() async throws {

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -27,9 +27,9 @@ struct ACPBrokerClientTests {
         let service = MockBrokerService()
         let stateSink = DurableStateSink()
         await service.enqueueAttach(events: [])
-        let client = makeClient(service: service) { state in
+        let client = makeClient(service: service, onDurableStateChanged: { state in
             Task { await stateSink.append(state) }
-        }
+        })
 
         try await client.start()
 
@@ -209,9 +209,9 @@ struct ACPBrokerClientTests {
                 )
             )
         ])
-        let client = makeClient(service: service) { state in
+        let client = makeClient(service: service, onDurableStateChanged: { state in
             Task { await stateSink.append(state) }
-        }
+        })
         let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
         try await client.start()
 
@@ -638,7 +638,13 @@ struct ACPBrokerClientTests {
                 )
             )
         ], turnState: .completed)
-        let client = makeClient(service: service)
+        let turnStateSink = TurnStateSink()
+        let client = makeClient(
+            service: service,
+            onTurnStateChanged: { state in
+                Task { await turnStateSink.append(state) }
+            }
+        )
         let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
 
         try await client.start()
@@ -650,6 +656,7 @@ struct ACPBrokerClientTests {
             Issue.record("expected agent message chunk")
         }
         try await waitUntil { await service.attached.count == 3 }
+        try await waitUntil { await turnStateSink.records() == [.streaming, .completed] }
         try await Task.sleep(for: .milliseconds(120))
         #expect(await service.attached.count == 3)
     }
@@ -707,6 +714,7 @@ struct ACPBrokerClientTests {
         service: MockBrokerService,
         initialBrokerGeneration: ACPBrokerGeneration? = nil,
         initialAcknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
+        onTurnStateChanged: (@Sendable (ACPBrokerTurnState) -> Void)? = nil,
         onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
     ) -> ACPBrokerClient {
         ACPBrokerClient(
@@ -720,7 +728,8 @@ struct ACPBrokerClientTests {
             operationKeyPrefix: "op-prefix",
             initialBrokerGeneration: initialBrokerGeneration,
             initialAcknowledgedCursor: initialAcknowledgedCursor,
-            onDurableStateChanged: onDurableStateChanged
+            onDurableStateChanged: onDurableStateChanged,
+            onTurnStateChanged: onTurnStateChanged
         )
     }
 
@@ -769,6 +778,18 @@ private actor DurableStateSink {
 
     func hasLastRecord(after count: Int, matching expected: ACPBrokerDurableState) -> Bool {
         records.count == count + 1 && records.last == expected
+    }
+}
+
+private actor TurnStateSink {
+    private var recordedStates: [ACPBrokerTurnState] = []
+
+    func append(_ state: ACPBrokerTurnState) {
+        recordedStates.append(state)
+    }
+
+    func records() -> [ACPBrokerTurnState] {
+        recordedStates
     }
 }
 

--- a/AlasTests/ACP/Broker/ACPBrokerProtocolTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerProtocolTests.swift
@@ -55,7 +55,7 @@ struct ACPBrokerProtocolTests {
           "kind": {
             "type": "operationCompleted",
             "operationKey": "prompt-1",
-            "result": { "stopReason": "end_turn" }
+            "outcome": { "result": { "stopReason": "end_turn" } }
           }
         }
         """#.utf8)
@@ -64,8 +64,28 @@ struct ACPBrokerProtocolTests {
         #expect(event.cursor == ACPBrokerEventCursor(rawValue: 12))
         #expect(event.kind == .operationCompleted(
             operationKey: ACPBrokerOperationKey(rawValue: "prompt-1"),
-            result: .object(["stopReason": .string("end_turn")])
+            outcome: ACPBrokerRPCOutcome(
+                result: .object(["stopReason": .string("end_turn")]),
+                error: nil
+            )
         ))
+    }
+
+    @Test func respondParamsPreserveStringRequestIdsAndErrorShape() throws {
+        let params = ACPBrokerRespondParams(
+            brokerId: ACPBrokerID(rawValue: "broker-1"),
+            generation: ACPBrokerGeneration(rawValue: 1),
+            requestId: .string("req-alpha"),
+            operationKey: ACPBrokerOperationKey(rawValue: "respond-1"),
+            error: JSONRPCError(code: -32001, message: "denied", data: nil)
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(params)) as? [String: Any])
+        #expect(object["requestId"] as? String == "req-alpha")
+        #expect(object["result"] == nil)
+        let error = try #require(object["error"] as? [String: Any])
+        #expect(error["code"] as? Int == -32001)
+        #expect(error["message"] as? String == "denied")
     }
 
     @Test func unknownEventKindPreservesPayloadWhenReencoded() throws {

--- a/AlasTests/ACP/Broker/ACPBrokerProtocolTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerProtocolTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct ACPBrokerProtocolTests {
+    @Test func brokerIdentifiersEncodeAsWireScalars() throws {
+        let params = ACPBrokerSendParams(
+            brokerId: ACPBrokerID(rawValue: "broker-1"),
+            generation: ACPBrokerGeneration(rawValue: 9),
+            operationKey: ACPBrokerOperationKey(rawValue: "queue-1"),
+            method: "session/prompt",
+            params: .object(["prompt": .string("hi")])
+        )
+
+        let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(params)) as? [String: Any])
+        #expect(object["brokerId"] as? String == "broker-1")
+        #expect(object["generation"] as? Int == 9)
+        #expect(object["operationKey"] as? String == "queue-1")
+        #expect(object["method"] as? String == "session/prompt")
+        #expect((object["params"] as? [String: Any])?["prompt"] as? String == "hi")
+    }
+
+    @Test func unknownTurnStateDecodesForwardCompatibly() throws {
+        let data = Data(#"""
+        {
+          "metadata": {
+            "brokerId": "broker-1",
+            "generation": 1,
+            "alasSessionId": "session-1",
+            "adapterProgram": "codex-acp",
+            "adapterArgs": [],
+            "cwd": "/repo",
+            "envKeys": [],
+            "createdAtMillis": 10
+          },
+          "initializeResult": null,
+          "remoteSessionResult": null,
+          "turnState": "waitingForSomethingNew",
+          "acknowledgedCursor": 0,
+          "journalTail": 0,
+          "pendingRequests": [],
+          "operations": []
+        }
+        """#.utf8)
+
+        let snapshot = try JSONDecoder().decode(ACPBrokerSnapshot.self, from: data)
+        #expect(snapshot.turnState == .unknown("waitingForSomethingNew"))
+    }
+
+    @Test func eventKindDecodesOperationCompletedWireShape() throws {
+        let data = Data(#"""
+        {
+          "cursor": 12,
+          "kind": {
+            "type": "operationCompleted",
+            "operationKey": "prompt-1",
+            "result": { "stopReason": "end_turn" }
+          }
+        }
+        """#.utf8)
+
+        let event = try JSONDecoder().decode(ACPBrokerEvent.self, from: data)
+        #expect(event.cursor == ACPBrokerEventCursor(rawValue: 12))
+        #expect(event.kind == .operationCompleted(
+            operationKey: ACPBrokerOperationKey(rawValue: "prompt-1"),
+            result: .object(["stopReason": .string("end_turn")])
+        ))
+    }
+
+    @Test func unknownEventKindPreservesPayloadWhenReencoded() throws {
+        let data = Data(#"""
+        {
+          "cursor": 13,
+          "kind": {
+            "type": "futureEvent",
+            "extra": { "value": 2 }
+          }
+        }
+        """#.utf8)
+
+        let event = try JSONDecoder().decode(ACPBrokerEvent.self, from: data)
+        #expect(event.kind == .unknown(
+            type: "futureEvent",
+            payload: [
+                "type": .string("futureEvent"),
+                "extra": .object(["value": .number(2)])
+            ]
+        ))
+
+        let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(event)) as? [String: Any])
+        let kind = try #require(object["kind"] as? [String: Any])
+        #expect(kind["type"] as? String == "futureEvent")
+        #expect((kind["extra"] as? [String: Any])?["value"] as? Int == 2)
+    }
+
+    @Test func remoteHelperEncodesBrokerOpenAndSendMethods() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "local",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+
+        let open = Task {
+            try await client.openACPBroker(ACPBrokerOpenParams(
+                brokerId: ACPBrokerID(rawValue: "broker-1"),
+                sessionId: "session-1",
+                command: "codex-acp",
+                args: ["--stdio"],
+                cwd: "/repo",
+                env: ["PATH": "/bin"]
+            ))
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        var request = try #require(JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any])
+        #expect(request["method"] as? String == "acp/open")
+        var params = try #require(request["params"] as? [String: Any])
+        #expect(params["brokerId"] as? String == "broker-1")
+        #expect(params["sessionId"] as? String == "session-1")
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "adopted": false,
+          "snapshot": {
+            "metadata": {
+              "brokerId": "broker-1",
+              "generation": 1,
+              "alasSessionId": "session-1",
+              "adapterProgram": "codex-acp",
+              "adapterArgs": ["--stdio"],
+              "cwd": "/repo",
+              "envKeys": ["PATH"],
+              "createdAtMillis": 10
+            },
+            "initializeResult": null,
+            "remoteSessionResult": null,
+            "turnState": "idle",
+            "acknowledgedCursor": 0,
+            "journalTail": 0,
+            "pendingRequests": [],
+            "operations": []
+          }
+        }}
+        """#.utf8))
+        #expect(try await open.value.adopted == false)
+
+        let send = Task {
+            try await client.sendACPBroker(ACPBrokerSendParams(
+                brokerId: ACPBrokerID(rawValue: "broker-1"),
+                generation: ACPBrokerGeneration(rawValue: 1),
+                operationKey: ACPBrokerOperationKey(rawValue: "prompt-1"),
+                method: "session/prompt",
+                params: .object(["prompt": .string("hi")])
+            ))
+        }
+        try await waitUntil { transport.sentFrames.count == 2 }
+        request = try #require(JSONSerialization.jsonObject(with: transport.sentFrames[1]) as? [String: Any])
+        #expect(request["method"] as? String == "acp/send")
+        params = try #require(request["params"] as? [String: Any])
+        #expect(params["operationKey"] as? String == "prompt-1")
+        #expect(params["generation"] as? Int == 1)
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":2,"result":{
+          "requestId": 3,
+          "replayed": true,
+          "result": { "stopReason": "end_turn" },
+          "pending": null
+        }}
+        """#.utf8))
+        #expect(try await send.value.result == .object(["stopReason": .string("end_turn")]))
+    }
+
+    @Test func localBrokerServiceRejectsHelperWithoutACPCapability() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = RemoteHelperClient(
+            host: "local",
+            idleShutdownNanoseconds: 0,
+            transportFactory: { transport }
+        )
+        let service = LocalACPBrokerService(client: client)
+
+        let list = Task {
+            try await service.list()
+        }
+        try await waitUntil { transport.sentFrames.count == 1 }
+        transport.send(frame: Data(#"""
+        {"jsonrpc":"2.0","id":1,"result":{
+          "name":"alas-helper",
+          "protocolVersion":1,
+          "binaryVersion":"0.5.0",
+          "capabilities":{
+            "watchKinds":[],
+            "fs":{"read":true,"write":true,"stat":true},
+            "ping":true,
+            "proc":true
+          }
+        }}
+        """#.utf8))
+
+        await #expect(throws: LocalACPBrokerServiceError.helperDoesNotSupportACP) {
+            try await list.value
+        }
+    }
+
+    @Test func localHelperResolutionUsesBundledMacArchitecture() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("alas-helper-test-\(UUID().uuidString)")
+        let helper = root
+            .appendingPathComponent("alas-helper")
+            .appendingPathComponent("macos-\(RemoteHelperInstaller.localArch)")
+            .appendingPathComponent("alas-helper")
+        try FileManager.default.createDirectory(
+            at: helper.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: helper.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        #expect(try LocalACPBrokerService.resolveBundledHelper(resourceURL: root) == helper)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping @MainActor () -> Bool
+    ) async throws {
+        let start = ContinuousClock.now
+        while !predicate() {
+            if ContinuousClock.now - start > timeout {
+                throw ACPBrokerProtocolTestTimeout()
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+private struct ACPBrokerProtocolTestTimeout: Error {}

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -85,6 +85,71 @@ struct ACPConnectionTests {
         #expect(params.clientCapabilities.terminal == false)
     }
 
+    @Test("startup methods carry broker operation keys")
+    func startupMethodsCarryBrokerOperationKeys() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: nil,
+                authMethods: []
+            ))
+        }
+        mock.script(method: "session/new") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-new",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        mock.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-loaded",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        mock.script(method: "session/resume") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-resumed",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+
+        let conn = ACPConnection(client: mock)
+        try await conn.initialize(brokerOperationKey: "startup:init")
+        _ = try await conn.newSession(cwd: "/tmp", mcpServers: [], brokerOperationKey: "startup:new")
+        _ = try await conn.loadSession(
+            cwd: "/tmp",
+            sessionId: "remote-1",
+            mcpServers: [],
+            brokerOperationKey: "startup:load"
+        )
+        _ = try await conn.resumeSession(
+            cwd: "/tmp",
+            sessionId: "remote-1",
+            mcpServers: [],
+            brokerOperationKey: "startup:resume"
+        )
+
+        #expect(mock.sent.map(\.brokerOperationKey) == [
+            "startup:init",
+            "startup:new",
+            "startup:load",
+            "startup:resume"
+        ])
+    }
+
     @Test("loadSession sends session/load with cwd and remote session id")
     func loadSessionRPC() async throws {
         let mock = ACPMockClient()

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -66,6 +66,25 @@ struct ACPConnectionTests {
         #expect(initialized.mcpCapabilities == .init(http: true, sse: true))
     }
 
+    @Test("initialize can suppress terminal capability")
+    func initializeSuppressesTerminalCapability() async throws {
+        let mock = ACPMockClient()
+        mock.advertisesTerminalCapability = false
+        mock.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: nil,
+                authMethods: []
+            ))
+        }
+
+        let conn = ACPConnection(client: mock)
+        try await conn.initialize()
+
+        let params = try #require(mock.sent.first?.params as? ACPInitializeParams)
+        #expect(params.clientCapabilities.terminal == false)
+    }
+
     @Test("loadSession sends session/load with cwd and remote session id")
     func loadSessionRPC() async throws {
         let mock = ACPMockClient()

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -26,6 +26,104 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(summary.configurationFingerprint == MCPAttachmentPlanner.configurationFingerprint(for: configuredServers))
     }
 
+    @Test("local attach uses broker client and persists durable broker state")
+    func localAttachUsesBrokerClientAndPersistsDurableState() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let broker = ManagerBrokerService()
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+        let session = manager.createSession(id: "local-session-1", agentId: "claude")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+        await manager.flushAllPersistence()
+
+        let openParams = try await #require(broker.opened.first)
+        #expect(openParams.brokerId == ACPBrokerID(rawValue: "local-local-session-1"))
+        #expect(openParams.sessionId == "local-session-1")
+        #expect(openParams.command.isEmpty == false)
+        #expect(openParams.cwd == "/tmp/wt")
+        #expect(openParams.env["PATH"] != nil)
+        #expect(await broker.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(session.remoteSessionId == "remote-broker")
+        #expect(session.agentState == .ready)
+
+        let row = try #require(try store.loadSession(id: "local-session-1"))
+        #expect(row.remoteSessionId == "remote-broker")
+        #expect(row.acpBrokerId == "local-local-session-1")
+        #expect(row.acpBrokerGeneration == 7)
+        #expect(row.acpBrokerAcknowledgedCursor == 0)
+    }
+
+    @Test("reopened local broker session attaches from persisted cursor")
+    func reopenedLocalBrokerSessionAttachesFromPersistedCursor() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(.init(
+            id: "local-session-1",
+            agentId: "claude",
+            title: "Stored session",
+            titleSource: .placeholder,
+            remoteSessionId: "remote-old",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            acpBrokerId: "broker-existing",
+            acpBrokerGeneration: 7,
+            acpBrokerAcknowledgedCursor: 4,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        ))
+        let broker = ManagerBrokerService()
+        await broker.setSnapshotResults(
+            initializeResult: .object([
+                "protocolVersion": .number(1),
+                "agentCapabilities": .object([
+                    "loadSession": .bool(true),
+                    "sessionCapabilities": .object(["resume": .object([:])])
+                ]),
+                "authMethods": .array([])
+            ]),
+            remoteSessionResult: .object([
+                "sessionId": .string("remote-restored"),
+                "availableModels": .array([]),
+                "availableModes": .array([]),
+                "promptSuggestions": .array([]),
+                "configOptions": .array([])
+            ])
+        )
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+
+        let session = try #require(manager.placeholderSession(id: "local-session-1"))
+        await manager.hydrateIfNeeded(id: session.id)
+        await manager.attach(to: session.id, freshlyCreated: false)
+        await manager.flushAllPersistence()
+
+        let openParams = try await #require(broker.opened.first)
+        #expect(openParams.brokerId == ACPBrokerID(rawValue: "broker-existing"))
+        let attachParams = try await #require(broker.attached.first)
+        #expect(attachParams.acknowledgedCursor == ACPBrokerEventCursor(rawValue: 4))
+        #expect(await broker.sent.isEmpty)
+        #expect(session.remoteSessionId == "remote-restored")
+        #expect(session.agentState == .ready)
+
+        let row = try #require(try store.loadSession(id: "local-session-1"))
+        #expect(row.acpBrokerId == "broker-existing")
+        #expect(row.acpBrokerGeneration == 7)
+        #expect(row.acpBrokerAcknowledgedCursor == 4)
+    }
+
     @Test("reopened session uses session/load")
     func reopenedSessionUsesLoad() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
@@ -1837,5 +1935,139 @@ struct ACPSessionManagerAttachRestoreTests {
             continuation?.resume()
             continuation = nil
         }
+    }
+}
+
+private actor ManagerBrokerService: ACPBrokerServicing {
+    var opened: [ACPBrokerOpenParams] = []
+    var attached: [ACPBrokerAttachParams] = []
+    var sent: [ACPBrokerSendParams] = []
+    var notified: [ACPBrokerNotifyParams] = []
+    var responded: [ACPBrokerRespondParams] = []
+    var acks: [ACPBrokerAckParams] = []
+    var detached: [ACPBrokerDetachParams] = []
+    var closed: [ACPBrokerCloseParams] = []
+    var snapshotInitializeResult: ACPBrokerJSONValue?
+    var snapshotRemoteSessionResult: ACPBrokerJSONValue?
+
+    func setSnapshotResults(
+        initializeResult: ACPBrokerJSONValue?,
+        remoteSessionResult: ACPBrokerJSONValue?
+    ) {
+        snapshotInitializeResult = initializeResult
+        snapshotRemoteSessionResult = remoteSessionResult
+    }
+
+    func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
+        opened.append(params)
+        return ACPBrokerOpenResult(snapshot: snapshot(params: params), adopted: false)
+    }
+
+    func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
+        attached.append(params)
+        return ACPBrokerAttachResult(
+            snapshot: snapshot(brokerId: params.brokerId, acknowledgedCursor: params.acknowledgedCursor),
+            events: []
+        )
+    }
+
+    func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        sent.append(params)
+        let result: ACPBrokerJSONValue
+        switch params.method {
+        case "initialize":
+            result = .object([
+                "protocolVersion": .number(1),
+                "authMethods": .array([])
+            ])
+        case "session/new":
+            result = .object([
+                "sessionId": .string("remote-broker"),
+                "availableModels": .array([]),
+                "availableModes": .array([]),
+                "promptSuggestions": .array([]),
+                "configOptions": .array([])
+            ])
+        default:
+            throw ACPClientError.noScript(method: params.method)
+        }
+        return ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: UInt64(sent.count)),
+            replayed: false,
+            result: result,
+            pending: nil
+        )
+    }
+
+    func notify(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK {
+        notified.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
+        responded.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK {
+        acks.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
+        detached.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
+        closed.append(params)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    private func snapshot(params: ACPBrokerOpenParams) -> ACPBrokerSnapshot {
+        ACPBrokerSnapshot(
+            metadata: ACPBrokerMetadata(
+                brokerId: params.brokerId,
+                generation: ACPBrokerGeneration(rawValue: 7),
+                alasSessionId: params.sessionId,
+                adapterProgram: params.command,
+                adapterArgs: params.args,
+                cwd: params.cwd,
+                envKeys: params.env.keys.sorted(),
+                createdAtMillis: 10
+            ),
+            initializeResult: snapshotInitializeResult,
+            remoteSessionResult: snapshotRemoteSessionResult,
+            turnState: .idle,
+            acknowledgedCursor: ACPBrokerEventCursor(rawValue: 0),
+            journalTail: ACPBrokerEventCursor(rawValue: 0),
+            pendingRequests: [],
+            operations: []
+        )
+    }
+
+    private func snapshot(
+        brokerId: ACPBrokerID,
+        acknowledgedCursor: ACPBrokerEventCursor
+    ) -> ACPBrokerSnapshot {
+        ACPBrokerSnapshot(
+            metadata: ACPBrokerMetadata(
+                brokerId: brokerId,
+                generation: ACPBrokerGeneration(rawValue: 7),
+                alasSessionId: "local-session-1",
+                adapterProgram: "mock",
+                adapterArgs: [],
+                cwd: "/tmp/wt",
+                envKeys: [],
+                createdAtMillis: 10
+            ),
+            initializeResult: snapshotInitializeResult,
+            remoteSessionResult: snapshotRemoteSessionResult,
+            turnState: .idle,
+            acknowledgedCursor: acknowledgedCursor,
+            journalTail: ACPBrokerEventCursor(rawValue: 0),
+            pendingRequests: [],
+            operations: []
+        )
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -73,11 +73,28 @@ struct ACPSessionQueueAPITests {
         s.enqueue(blocks: [.text("a")])
         s.queue[0].lastError = "network"
         let id = s.queue[0].id
+        let operationKey = s.queue[0].brokerOperationKey
 
         #expect(s.forceQueueItem(id: id))
         #expect(s.queue[0].id == id)
         #expect(s.queue[0].lastError == nil)
         #expect(s.queue[0].status == .pending)
+        #expect(s.queue[0].brokerOperationKey == operationKey)
+    }
+
+    @Test("terminal queue errors advance the retry broker operation key")
+    func terminalQueueErrorAdvancesBrokerOperationKey() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.markQueueHeadSending()
+        let operationKey = s.queue[0].brokerOperationKey
+
+        s.setQueueHeadError("terminal", advancesBrokerOperationAttempt: true)
+        #expect(s.queue[0].brokerOperationKey != operationKey)
+
+        let retryKey = s.queue[0].brokerOperationKey
+        #expect(s.forceQueueItem(id: s.queue[0].id))
+        #expect(s.queue[0].brokerOperationKey == retryKey)
     }
 
     @Test("forceQueueItem refuses a .sending item")

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -195,6 +195,29 @@ struct ACPSessionRunnerQueueTests {
         #expect(session.queue[0].brokerOperationKey != operationKey)
     }
 
+    @Test("queued prompt response ack waits for durable queue pop")
+    func queuedPromptResponseAckWaitsForDurableQueuePop() async throws {
+        let (runner, mock, session, store) = try mkRunner()
+        let acknowledgement = DurableAcknowledgementRecorder()
+        mock.scriptResponse(method: "session/prompt") { _ in
+            ACPResponse(
+                body: Data("null".utf8),
+                durableConsumptionAcknowledgement: { acknowledgement.record() }
+            )
+        }
+        session.enqueue(blocks: [.text("ack-after-pop")])
+        runner.persistQueue()
+        await runner.flushPersistence()
+
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await runner.flushPersistence()
+
+        #expect(session.queue.isEmpty)
+        #expect(try store.loadQueue(sessionId: "s").isEmpty)
+        #expect(acknowledgement.recordedCount == 1)
+    }
+
     @Test(".steer while streaming with queue → cancel sent, queue cleared, new prompt sent, snapshot captured")
     func steerClearsAndSends() async throws {
         let (runner, mock, session, store) = try mkRunner()
@@ -638,5 +661,22 @@ struct ACPSessionRunnerQueueTests {
         #expect(session2.queue.isEmpty)
         let prompts = mock2.sent.filter { $0.method == "session/prompt" }
         #expect(prompts.count == 2)
+    }
+}
+
+private final class DurableAcknowledgementRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var recordedCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func record() {
+        lock.lock()
+        count += 1
+        lock.unlock()
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -164,14 +164,35 @@ struct ACPSessionRunnerQueueTests {
             throw ACPClientError.noScript(method: "session/prompt")  // any throw
         }
         session.enqueue(blocks: [.text("will-fail")])
+        let operationKey = session.queue[0].brokerOperationKey
         runner.persistQueue()
         runner.flushQueueIfIdle()
         try await Task.sleep(nanoseconds: 200_000_000)
         #expect(session.queue.count == 1)
         #expect(session.queue[0].status == .pending)
         #expect(session.queue[0].lastError != nil)
+        #expect(session.queue[0].brokerOperationKey == operationKey)
         let persisted = try store.loadQueue(sessionId: "s")
         #expect(persisted == session.queue)
+    }
+
+    @Test("terminal queued failure advances broker operation key before retry")
+    func terminalQueuedFailureAdvancesBrokerOperationKey() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in
+            throw ACPClientError.jsonrpc(.init(code: -32042, message: "terminal", data: nil))
+        }
+        session.enqueue(blocks: [.text("will-fail-terminally")])
+        let operationKey = session.queue[0].brokerOperationKey
+
+        runner.persistQueue()
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].status == .pending)
+        #expect(session.queue[0].lastError != nil)
+        #expect(session.queue[0].brokerOperationKey != operationKey)
     }
 
     @Test(".steer while streaming with queue → cancel sent, queue cleared, new prompt sent, snapshot captured")

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -234,6 +234,49 @@ struct ACPSessionStoreCRUDTests {
         #expect(row.acpBrokerAcknowledgedCursor == 7)
     }
 
+    @Test("session upsert resets broker cursor when generation changes")
+    func sessionUpsertResetsBrokerCursorWhenGenerationChanges() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Recovered",
+            titleSource: .manual,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: true,
+            acpBrokerId: "broker-1",
+            acpBrokerGeneration: 10,
+            acpBrokerAcknowledgedCursor: 12,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Recovered",
+            titleSource: .manual,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: true,
+            acpBrokerId: "broker-1",
+            acpBrokerGeneration: 11,
+            acpBrokerAcknowledgedCursor: 2,
+            createdAt: 1,
+            updatedAt: 4,
+            lastOpenedAt: 5,
+            archived: false
+        ))
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.acpBrokerId == "broker-1")
+        #expect(row.acpBrokerGeneration == 11)
+        #expect(row.acpBrokerAcknowledgedCursor == 2)
+    }
+
     @Test("broker state clears explicitly")
     func brokerStateClearsExplicitly() throws {
         let store = try tmp()

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -133,6 +133,139 @@ struct ACPSessionStoreCRUDTests {
         #expect(respawnedRow.helperProcStderrOffset == 1)
     }
 
+    @Test("broker state round-trips and survives metadata-only upserts")
+    func brokerStateSurvivesMetadataUpserts() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Recovered",
+            titleSource: .manual,
+            currentModel: "sonnet",
+            currentMode: nil,
+            autoRun: true,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        #expect(try store.updateACPBrokerState(
+            sessionId: "local-1",
+            brokerId: "broker-1",
+            generation: 10,
+            acknowledgedCursor: 4
+        ))
+
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Recovered",
+            titleSource: .manual,
+            currentModel: "opus",
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 4,
+            lastOpenedAt: 5,
+            archived: false
+        ))
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.acpBrokerId == "broker-1")
+        #expect(row.acpBrokerGeneration == 10)
+        #expect(row.acpBrokerAcknowledgedCursor == 4)
+        #expect(row.currentModel == "opus")
+        #expect(row.autoRun == false)
+
+        let byBroker = try #require(try store.loadSession(acpBrokerId: "broker-1"))
+        #expect(byBroker.id == "local-1")
+    }
+
+    @Test("broker cursor updates are monotonic and fenced by broker generation")
+    func brokerCursorUpdatesAreMonotonicAndFenced() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Recovered",
+            titleSource: .manual,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: true,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+        #expect(try store.updateACPBrokerState(
+            sessionId: "local-1",
+            brokerId: "broker-1",
+            generation: 10,
+            acknowledgedCursor: 4
+        ))
+
+        #expect(try store.updateACPBrokerAcknowledgedCursor(
+            sessionId: "local-1",
+            brokerId: "broker-1",
+            generation: 10,
+            cursor: 7
+        ))
+        #expect(try store.updateACPBrokerAcknowledgedCursor(
+            sessionId: "local-1",
+            brokerId: "broker-1",
+            generation: 10,
+            cursor: 5
+        ))
+        #expect(!(try store.updateACPBrokerAcknowledgedCursor(
+            sessionId: "local-1",
+            brokerId: "broker-1",
+            generation: 11,
+            cursor: 9
+        )))
+        #expect(!(try store.updateACPBrokerAcknowledgedCursor(
+            sessionId: "local-1",
+            brokerId: "broker-2",
+            generation: 10,
+            cursor: 9
+        )))
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.acpBrokerAcknowledgedCursor == 7)
+    }
+
+    @Test("broker state clears explicitly")
+    func brokerStateClearsExplicitly() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Recovered",
+            titleSource: .manual,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: true,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+        #expect(try store.updateACPBrokerState(
+            sessionId: "local-1",
+            brokerId: "broker-1",
+            generation: 10,
+            acknowledgedCursor: 4
+        ))
+
+        #expect(try store.clearACPBrokerState(sessionId: "local-1"))
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.acpBrokerId == nil)
+        #expect(row.acpBrokerGeneration == nil)
+        #expect(row.acpBrokerAcknowledgedCursor == 0)
+        #expect(try store.loadSession(acpBrokerId: "broker-1") == nil)
+    }
+
     @Test("metadata-only upsert can preserve stored title")
     func sessionMetadataUpsertPreservesStoredTitleWhenRequested() throws {
         let store = try tmp()

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -37,9 +37,34 @@ struct ACPSessionStoreSchemaTests {
         let sessionColumns = try store.db.query("PRAGMA table_info(sessions)")
         #expect(sessionColumns.contains { ($0["name"] as? String) == "helper_proc_stdout_offset" })
         #expect(sessionColumns.contains { ($0["name"] as? String) == "helper_proc_stderr_offset" })
+        #expect(sessionColumns.contains { ($0["name"] as? String) == "acp_broker_id" })
+        #expect(sessionColumns.contains { ($0["name"] as? String) == "acp_broker_generation" })
+        #expect(sessionColumns.contains { ($0["name"] as? String) == "acp_broker_acknowledged_cursor" })
         #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
 
         _ = try ACPSessionStore(path: url.path)
+    }
+
+    @Test("migrates schema version 13 with broker state columns and index")
+    func migratesV13BrokerState() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-store-\(UUID()).sqlite")
+        do {
+            let store = try ACPSessionStore(path: url.path)
+            try store.db.exec("DROP INDEX IF EXISTS sessions_acp_broker_idx")
+            try store.db.exec("ALTER TABLE sessions DROP COLUMN acp_broker_id")
+            try store.db.exec("ALTER TABLE sessions DROP COLUMN acp_broker_generation")
+            try store.db.exec("ALTER TABLE sessions DROP COLUMN acp_broker_acknowledged_cursor")
+            try store.db.exec("UPDATE schema_version SET version = 13")
+        }
+
+        let store = try ACPSessionStore(path: url.path)
+        let columns = try store.db.query("PRAGMA table_info(sessions)")
+        #expect(columns.contains { ($0["name"] as? String) == "acp_broker_id" })
+        #expect(columns.contains { ($0["name"] as? String) == "acp_broker_generation" })
+        #expect(columns.contains { ($0["name"] as? String) == "acp_broker_acknowledged_cursor" })
+        let indexes = try store.db.query("PRAGMA index_list(sessions)")
+        #expect(indexes.contains { ($0["name"] as? String) == "sessions_acp_broker_idx" })
+        #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
     }
 
     @Test("migrates schema version 1 to current target")


### PR DESCRIPTION
## Summary
- add helper-backed ACP broker state and process supervision for recoverable local sessions
- route local ACPSessionManager attaches through ACPBrokerClient and persist broker cursors
- replay adopted broker initialize/session snapshots after relaunch and harden helper environment handling

## Testing
- rtk git diff --check
- rtk cargo test --manifest-path AlasHelper/Cargo.toml
- rtk xcodegen
- rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionStoreSchemaTests -only-testing:AlasTests/ACPSessionStoreCRUDTests -only-testing:AlasTests/ACPBrokerClientTests -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests -quiet test
- rtk env ALAS_FFF_TARGET_ARCH=arm64 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- Full xcodebuild test before rebase ran 5689 tests; only SSHIntegrationTests failed because ALAS_SSH_INTEGRATION=1 is required.