### PR TITLE
fix(diff): break split-pane row-height sync live-lock (beachball)

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -794,9 +794,10 @@ final class DiffPaneTextScrollView: NSScrollView {
             // otherwise leave a stale per-line height in place and make the
             // row too short to match its counterpart.
             var candidateLineHeight: CGFloat?
+            var lineCount = 1
             if let targetHeight {
                 let lineCountHeight = previousLineHeight ?? lineHeight()
-                let lineCount = max(1, Int(round(currentRows[index].height / max(lineCountHeight, 1))))
+                lineCount = max(1, Int(round(currentRows[index].height / max(lineCountHeight, 1))))
                 let computed = targetHeight / CGFloat(lineCount)
                 if computed > lineHeight() + 0.5 {
                     candidateLineHeight = computed
@@ -808,13 +809,17 @@ final class DiffPaneTextScrollView: NSScrollView {
             // recomputing an identical value every pass is what previously
             // turned a single legitimate height change into an unbounded
             // apply/strip/reapply cycle that re-triggered
-            // `invalidateIntrinsicContentSize()` forever.
+            // `invalidateIntrinsicContentSize()` forever. Compare the TOTAL
+            // row height (per-line delta × line count), not the per-line
+            // delta alone — a row wrapped into many fragments can have a
+            // genuine multi-point total height change that rounds to well
+            // under 0.5pt per line, which would otherwise be skipped.
             let valueUnchanged: Bool
             switch (previousLineHeight, candidateLineHeight) {
             case (nil, nil):
                 valueUnchanged = true
             case let (previous?, candidate?):
-                valueUnchanged = abs(previous - candidate) <= 0.5
+                valueUnchanged = abs(previous - candidate) * CGFloat(lineCount) <= 0.5
             default:
                 valueUnchanged = false
             }
@@ -845,8 +850,16 @@ final class DiffPaneTextScrollView: NSScrollView {
         textStorage.endEditing()
 
         synchronizedRowLineHeights = nextLineHeights
-        textView.lineTones = lineTones
-        textView.theme = theme
+        // `lineTones`'s didSet unconditionally invalidates cached row
+        // geometry, so only forward these when they actually differ —
+        // otherwise a fully-stable call (nothing above changed) would still
+        // force a row-geometry recompute on every parent layout pass.
+        if textView.lineTones != lineTones {
+            textView.lineTones = lineTones
+        }
+        if textView.theme != theme {
+            textView.theme = theme
+        }
         if changedParagraphs {
             needsLayout = true
             invalidateIntrinsicContentSize()

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -787,7 +787,6 @@ final class DiffPaneTextScrollView: NSScrollView {
         let previousRowHeights = synchronizedRowHeights
         var nextLineHeights = Array<CGFloat?>(repeating: nil, count: rowHeights.count)
         var changedParagraphs = false
-        var needsFollowUpSynchronization = false
         let affectedCount = min(max(rowHeights.count, previousRowHeights.count), baseDocument.lines.count, currentRows.count)
 
         textStorage.beginEditing()
@@ -798,7 +797,16 @@ final class DiffPaneTextScrollView: NSScrollView {
             let targetChanged = previousHeight == nil
                 || targetHeight == nil
                 || abs(previousHeight! - targetHeight!) > 0.5
-            guard targetChanged || previousLineHeight != nil
+            // A row whose target height hasn't moved keeps whatever paragraph
+            // style it already has. Re-deriving it here purely because some
+            // OTHER row's target changed would strip a still-needed custom
+            // line height (e.g. a row that permanently needs padding because
+            // its paired old/new row wraps to a different line count), which
+            // then gets re-applied on the very next layout pass once the
+            // strip's own height delta is observed — an unbounded
+            // apply/strip/reapply cycle that re-triggers
+            // `invalidateIntrinsicContentSize()` forever.
+            guard targetChanged
             else {
                 nextLineHeights[index] = previousLineHeight
                 continue
@@ -814,7 +822,7 @@ final class DiffPaneTextScrollView: NSScrollView {
             let paragraph = NSMutableParagraphStyle()
             paragraph.setParagraphStyle(baseParagraph)
 
-            if targetChanged, let targetHeight {
+            if let targetHeight {
                 let lineCountHeight = synchronizedLineHeight(at: index) ?? lineHeight()
                 let lineCount = max(1, Int(round(currentRows[index].height / max(lineCountHeight, 1))))
                 let targetLineHeight = targetHeight / CGFloat(lineCount)
@@ -823,8 +831,6 @@ final class DiffPaneTextScrollView: NSScrollView {
                     paragraph.maximumLineHeight = targetLineHeight
                     nextLineHeights[index] = targetLineHeight
                 }
-            } else if previousLineHeight != nil {
-                needsFollowUpSynchronization = true
             }
 
             textStorage.addAttribute(.paragraphStyle, value: paragraph, range: paragraphRange)
@@ -832,7 +838,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         }
         textStorage.endEditing()
 
-        synchronizedRowHeights = needsFollowUpSynchronization ? [] : rowHeights
+        synchronizedRowHeights = rowHeights
         synchronizedRowLineHeights = nextLineHeights
         textView.lineTones = lineTones
         textView.theme = theme

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -609,7 +609,6 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var lineTones: [DiffPaneLineTone] = []
     private var expansionRequests: [(key: DiffContextExpansionKey, edge: DiffContextExpansionEdge?)?] = []
     private var baseDocument: DiffPaneTextDocumentBuilder.CodeDocument?
-    private var synchronizedRowHeights: [CGFloat] = []
     private var synchronizedRowLineHeights: [CGFloat?] = []
     private var shouldResetHorizontalOrigin = false
     private var wraps = false
@@ -725,7 +724,6 @@ final class DiffPaneTextScrollView: NSScrollView {
             metadata.expansionKey.map { (key: $0, edge: metadata.expansionEdge) }
         }
         self.baseDocument = document
-        self.synchronizedRowHeights = []
         self.synchronizedRowLineHeights = []
         self.shouldResetHorizontalOrigin = true
         self.wraps = wraps
@@ -776,38 +774,51 @@ final class DiffPaneTextScrollView: NSScrollView {
     func synchronizeRowHeights(_ rowHeights: [CGFloat]) {
         guard let baseDocument else { return }
         guard rowHeights.count > 0 else { return }
-        guard rowHeights.count != synchronizedRowHeights.count
-            || zip(rowHeights, synchronizedRowHeights).contains(where: { abs($0.0 - $0.1) > 0.5 })
-        else {
-            return
-        }
 
         let currentRows = textView.diffRowRects()
         guard let textStorage = textView.textStorage else { return }
-        let previousRowHeights = synchronizedRowHeights
         var nextLineHeights = Array<CGFloat?>(repeating: nil, count: rowHeights.count)
         var changedParagraphs = false
-        let affectedCount = min(max(rowHeights.count, previousRowHeights.count), baseDocument.lines.count, currentRows.count)
+        let affectedCount = min(max(rowHeights.count, synchronizedRowLineHeights.count), baseDocument.lines.count, currentRows.count)
 
         textStorage.beginEditing()
         for index in 0..<affectedCount {
-            let previousHeight = index < previousRowHeights.count ? previousRowHeights[index] : nil
             let targetHeight = index < rowHeights.count ? rowHeights[index] : nil
             let previousLineHeight = index < synchronizedRowLineHeights.count ? synchronizedRowLineHeights[index] : nil
-            let targetChanged = previousHeight == nil
-                || targetHeight == nil
-                || abs(previousHeight! - targetHeight!) > 0.5
-            // A row whose target height hasn't moved keeps whatever paragraph
-            // style it already has. Re-deriving it here purely because some
-            // OTHER row's target changed would strip a still-needed custom
-            // line height (e.g. a row that permanently needs padding because
-            // its paired old/new row wraps to a different line count), which
-            // then gets re-applied on the very next layout pass once the
-            // strip's own height delta is observed — an unbounded
-            // apply/strip/reapply cycle that re-triggers
+
+            // Always re-derive the ideal per-line height from the row's
+            // CURRENT geometry (rather than gating on "did the target height
+            // change since last time"): a resize can change how many visual
+            // lines this row's own text wraps to while the target height
+            // (driven by the paired old/new row) stays the same, which would
+            // otherwise leave a stale per-line height in place and make the
+            // row too short to match its counterpart.
+            var candidateLineHeight: CGFloat?
+            if let targetHeight {
+                let lineCountHeight = previousLineHeight ?? lineHeight()
+                let lineCount = max(1, Int(round(currentRows[index].height / max(lineCountHeight, 1))))
+                let computed = targetHeight / CGFloat(lineCount)
+                if computed > lineHeight() + 0.5 {
+                    candidateLineHeight = computed
+                }
+            }
+
+            // Only touch textStorage (and invalidate layout) when the
+            // derived value actually differs from what's already applied —
+            // recomputing an identical value every pass is what previously
+            // turned a single legitimate height change into an unbounded
+            // apply/strip/reapply cycle that re-triggered
             // `invalidateIntrinsicContentSize()` forever.
-            guard targetChanged
-            else {
+            let valueUnchanged: Bool
+            switch (previousLineHeight, candidateLineHeight) {
+            case (nil, nil):
+                valueUnchanged = true
+            case let (previous?, candidate?):
+                valueUnchanged = abs(previous - candidate) <= 0.5
+            default:
+                valueUnchanged = false
+            }
+            guard !valueUnchanged else {
                 nextLineHeights[index] = previousLineHeight
                 continue
             }
@@ -822,15 +833,10 @@ final class DiffPaneTextScrollView: NSScrollView {
             let paragraph = NSMutableParagraphStyle()
             paragraph.setParagraphStyle(baseParagraph)
 
-            if let targetHeight {
-                let lineCountHeight = synchronizedLineHeight(at: index) ?? lineHeight()
-                let lineCount = max(1, Int(round(currentRows[index].height / max(lineCountHeight, 1))))
-                let targetLineHeight = targetHeight / CGFloat(lineCount)
-                if targetLineHeight > lineHeight() + 0.5 {
-                    paragraph.minimumLineHeight = targetLineHeight
-                    paragraph.maximumLineHeight = targetLineHeight
-                    nextLineHeights[index] = targetLineHeight
-                }
+            if let candidateLineHeight {
+                paragraph.minimumLineHeight = candidateLineHeight
+                paragraph.maximumLineHeight = candidateLineHeight
+                nextLineHeights[index] = candidateLineHeight
             }
 
             textStorage.addAttribute(.paragraphStyle, value: paragraph, range: paragraphRange)
@@ -838,7 +844,6 @@ final class DiffPaneTextScrollView: NSScrollView {
         }
         textStorage.endEditing()
 
-        synchronizedRowHeights = rowHeights
         synchronizedRowLineHeights = nextLineHeights
         textView.lineTones = lineTones
         textView.theme = theme
@@ -855,11 +860,6 @@ final class DiffPaneTextScrollView: NSScrollView {
     ) -> NSParagraphStyle {
         document.attributedString.attribute(.paragraphStyle, at: location, effectiveRange: nil) as? NSParagraphStyle
             ?? CenterTypography.paragraphStyle()
-    }
-
-    private func synchronizedLineHeight(at index: Int) -> CGFloat? {
-        guard index < synchronizedRowLineHeights.count else { return nil }
-        return synchronizedRowLineHeights[index]
     }
 
     override func layout() {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -861,6 +861,14 @@ final class DiffPaneTextScrollView: NSScrollView {
             textView.theme = theme
         }
         if changedParagraphs {
+            // Explicit, rather than relying on the paragraph-style edit to
+            // indirectly trigger it (e.g. via a `lineTones` reassignment):
+            // `diffRowRects()` is typically already cached from an earlier
+            // read in this same layout pass (the row heights this method was
+            // just handed were measured from it), so a just-applied padding
+            // change must invalidate it directly or callers later in the same
+            // pass (e.g. `documentHeight`) read pre-padding geometry.
+            textView.invalidateDiffRowGeometry()
             needsLayout = true
             invalidateIntrinsicContentSize()
             (verticalRulerView as? DiffPaneLineNumberRulerView)?.needsDisplay = true

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1278,6 +1278,85 @@ let second = true
         #expect(value == "kept")
     }
 
+    /// Regression test for a review-flagged edge case in the beachball fix: a
+    /// row's OWN local wrap count can change on a resize (e.g. widening the
+    /// pane lets a previously two-line row fit on one line) while its target
+    /// height — driven by the paired old/new row — stays exactly the same.
+    /// The applied per-line height must be re-derived from the row's CURRENT
+    /// geometry in that case, not left at the stale value computed for the
+    /// old wrap count, or the row renders too short and misaligns with its
+    /// counterpart.
+    @Test func synchronizeRowHeightsRecomputesAfterWrapCountChangesWithStableTarget() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let longLine = "let value = \"padding padding padding padding\""
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: 0, length: (longLine as NSString).length)
+            ),
+        ]
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: longLine,
+                attributes: [
+                    .font: font,
+                    .paragraphStyle: CenterTypography.paragraphStyle(),
+                ]
+            ),
+            lines: metadata
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 160, height: 200))
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["1"],
+            wraps: true,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let narrowRows = codeView.diffRowRects()
+        #expect(narrowRows.count == 1)
+
+        let fontLineHeight = ceil(font.ascender + abs(font.descender) + font.leading)
+        let narrowLineCount = max(1, Int(round(narrowRows[0].height / fontLineHeight)))
+        #expect(narrowLineCount > 1)
+
+        // Simulate a counterpart on the other side that's one visual line
+        // taller than this (currently multi-line-wrapped) row.
+        let target = CGFloat(narrowLineCount + 1) * fontLineHeight
+        scrollView.synchronizeRowHeights([target])
+
+        let paddedParagraph = try #require(
+            codeView.textStorage?.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        )
+        #expect(abs(paddedParagraph.minimumLineHeight - target / CGFloat(narrowLineCount)) < 0.5)
+
+        // Widen the pane so the same text now fits on a single visual line.
+        // The row's target height (still `target`, as if the counterpart
+        // hasn't changed) is unchanged, but the per-line height needed to
+        // reach it is no longer `target / 2` — it's `target / 1`.
+        scrollView.setFrameSize(NSSize(width: 600, height: 200))
+        scrollView.layoutSubtreeIfNeeded()
+
+        scrollView.synchronizeRowHeights([target])
+        scrollView.layoutSubtreeIfNeeded()
+
+        let wideRows = codeView.diffRowRects()
+        #expect(wideRows.count == 1)
+        #expect(abs(wideRows[0].height - target) < 0.5)
+
+        let recomputedParagraph = try #require(
+            codeView.textStorage?.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        )
+        #expect(abs(recomputedParagraph.minimumLineHeight - target) < 0.5)
+    }
+
     /// Regression test for a live-lock (beachball): a row whose target height
     /// permanently differs from its natural height (e.g. its paired old/new
     /// row wraps to a different line count) must keep its custom line-height

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1278,7 +1278,16 @@ let second = true
         #expect(value == "kept")
     }
 
-    @Test func synchronizedRowHeightsResetPreviouslyPaddedRowsForRemeasurement() throws {
+    /// Regression test for a live-lock (beachball): a row whose target height
+    /// permanently differs from its natural height (e.g. its paired old/new
+    /// row wraps to a different line count) must keep its custom line-height
+    /// paragraph style untouched while some OTHER row's target changes.
+    /// Previously, any other row's target change unconditionally stripped
+    /// every already-padded row for "remeasurement", which reapplied the same
+    /// padding on the very next layout pass — an unbounded
+    /// apply/strip/reapply cycle that kept calling
+    /// `invalidateIntrinsicContentSize()` forever.
+    @Test func synchronizedRowHeightsKeepsStablePaddingWhileOtherRowsChange() throws {
         let theme = theme()
         let font = CenterTypography.resolveCodeFont(family: "", size: 13)
         let lines = [
@@ -1322,6 +1331,9 @@ let second = true
         let rowRects = codeView.diffRowRects()
         #expect(rowRects.count == 3)
 
+        // Row 0 permanently needs padding (its paired row on the other side
+        // is taller by a whole line) — its target height never changes
+        // across any of the following calls.
         let firstInflatedHeight = rowRects[0].height + 18
         scrollView.synchronizeRowHeights([
             firstInflatedHeight,
@@ -1334,17 +1346,20 @@ let second = true
         )
         #expect(paddedParagraph.minimumLineHeight > rowRects[0].height + 0.5)
 
+        // Row 1's target changes; row 0's does not. Row 0's existing padding
+        // must be left alone, not stripped back to the base paragraph style.
         scrollView.synchronizeRowHeights([
             firstInflatedHeight,
             rowRects[1].height + 18,
             rowRects[2].height,
         ])
 
-        let restoredParagraph = try #require(
+        let unchangedParagraph = try #require(
             codeView.textStorage?.attribute(.paragraphStyle, at: metadata[0].range.location, effectiveRange: nil) as? NSParagraphStyle
         )
-        #expect(restoredParagraph.minimumLineHeight <= rowRects[0].height + 0.5)
+        #expect(unchangedParagraph.minimumLineHeight > rowRects[0].height + 0.5)
 
+        // Settling further with the same heights must not disturb row 0 either.
         scrollView.layoutSubtreeIfNeeded()
         scrollView.synchronizeRowHeights([
             firstInflatedHeight,
@@ -1352,10 +1367,70 @@ let second = true
             rowRects[2].height,
         ])
 
-        let reappliedParagraph = try #require(
+        let stillUnchangedParagraph = try #require(
             codeView.textStorage?.attribute(.paragraphStyle, at: metadata[0].range.location, effectiveRange: nil) as? NSParagraphStyle
         )
-        #expect(reappliedParagraph.minimumLineHeight > rowRects[0].height + 0.5)
+        #expect(stillUnchangedParagraph.minimumLineHeight > rowRects[0].height + 0.5)
+    }
+
+    /// Regression test for the beachball: once row heights settle, calling
+    /// `synchronizeRowHeights` again with the identical target heights must be
+    /// a no-op that doesn't re-trigger a layout pass. If it did, the resulting
+    /// `invalidateIntrinsicContentSize()` would schedule another AppKit
+    /// layout, which re-enters this same synchronization and never converges
+    /// — pegging the main thread at 100% CPU (the live-lock this guards
+    /// against).
+    @Test func synchronizeRowHeightsIsNoOpOnceStable() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let lines = [
+            "let first = true",
+            "let second = false",
+            "let third = true",
+        ]
+        let text = lines.joined(separator: "\n")
+        var location = 0
+        let metadata = lines.map { line in
+            defer { location += (line as NSString).length + 1 }
+            return DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: location, length: (line as NSString).length)
+            )
+        }
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: text,
+                attributes: [
+                    .font: font,
+                    .paragraphStyle: CenterTypography.paragraphStyle(),
+                ]
+            ),
+            lines: metadata
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 140))
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["1", "2", "3"],
+            wraps: true,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let rowRects = codeView.diffRowRects()
+        #expect(rowRects.count == 3)
+
+        let heights = [rowRects[0].height + 18, rowRects[1].height, rowRects[2].height]
+        scrollView.synchronizeRowHeights(heights)
+        scrollView.layoutSubtreeIfNeeded()
+        #expect(scrollView.needsLayout == false)
+
+        scrollView.synchronizeRowHeights(heights)
+        #expect(scrollView.needsLayout == false)
     }
 
     @Test func gutterSelectionOutlineWrapsContiguousRows() {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1357,6 +1357,83 @@ let second = true
         #expect(abs(recomputedParagraph.minimumLineHeight - target) < 0.5)
     }
 
+    /// Regression test for a second review-flagged edge case: a row wrapped
+    /// into many visual fragments can have a genuine target-height change
+    /// that's small per line (well under the 0.5pt tolerance) but adds up to
+    /// several points across the whole row. Comparing only the per-line delta
+    /// would skip the update and leave the row visibly too short; the
+    /// comparison must scale by the row's line count so the TOTAL height
+    /// delta is what's checked against the tolerance.
+    @Test func synchronizeRowHeightsAppliesSmallPerLineDeltasThatAddUpAcrossManyWraps() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let longLine = String(repeating: "padding ", count: 30)
+        let metadata = [
+            DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: 0, length: (longLine as NSString).length)
+            ),
+        ]
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: longLine,
+                attributes: [
+                    .font: font,
+                    .paragraphStyle: CenterTypography.paragraphStyle(),
+                ]
+            ),
+            lines: metadata
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 400))
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["1"],
+            wraps: true,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        let naturalRows = codeView.diffRowRects()
+        #expect(naturalRows.count == 1)
+
+        let fontLineHeight = ceil(font.ascender + abs(font.descender) + font.leading)
+        let naturalLineCount = max(1, Int(round(naturalRows[0].height / fontLineHeight)))
+        #expect(naturalLineCount >= 7)
+
+        let target1 = CGFloat(naturalLineCount + 2) * fontLineHeight
+        scrollView.synchronizeRowHeights([target1])
+        scrollView.layoutSubtreeIfNeeded()
+
+        let firstParagraph = try #require(
+            codeView.textStorage?.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        )
+        let firstLineHeight = firstParagraph.minimumLineHeight
+
+        // A total target increase small enough that spread across every wrap
+        // it's under 0.5pt per line, but it's still several points overall.
+        let totalDelta: CGFloat = 3
+        #expect(totalDelta / CGFloat(naturalLineCount) < 0.5)
+        let target2 = target1 + totalDelta
+        scrollView.synchronizeRowHeights([target2])
+        scrollView.layoutSubtreeIfNeeded()
+
+        // The row must grow to reflect the new (larger) target — a stale
+        // per-line height that only differs by "under 0.5pt" locally would
+        // otherwise leave the row under-height by roughly `totalDelta`.
+        let rows = codeView.diffRowRects()
+        #expect(abs(rows[0].height - target2) < 0.75)
+
+        let secondParagraph = try #require(
+            codeView.textStorage?.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        )
+        #expect(secondParagraph.minimumLineHeight - firstLineHeight > 0.1)
+    }
+
     /// Regression test for a live-lock (beachball): a row whose target height
     /// permanently differs from its natural height (e.g. its paired old/new
     /// row wraps to a different line count) must keep its custom line-height

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -1278,6 +1278,69 @@ let second = true
         #expect(value == "kept")
     }
 
+    /// Regression test for a review-flagged edge case: skipping the
+    /// unconditional `lineTones` reassignment when it hasn't changed must not
+    /// skip invalidating the row-geometry cache when a paragraph style
+    /// actually changed. `diffRowRects()` is asserted immediately after
+    /// `synchronizeRowHeights` returns, with no intervening AppKit layout
+    /// pass, to catch the exact staleness window a caller reading
+    /// `documentHeight` later in the same `layout()` pass would hit.
+    @Test func synchronizeRowHeightsInvalidatesRowGeometryImmediatelyAfterPadding() throws {
+        let theme = theme()
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let lines = [
+            "let first = true",
+            "let second = false",
+        ]
+        let text = lines.joined(separator: "\n")
+        var location = 0
+        let metadata = lines.map { line in
+            defer { location += (line as NSString).length + 1 }
+            return DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: location, length: (line as NSString).length)
+            )
+        }
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(
+                string: text,
+                attributes: [
+                    .font: font,
+                    .paragraphStyle: CenterTypography.paragraphStyle(),
+                ]
+            ),
+            lines: metadata
+        )
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 140))
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["1", "2"],
+            wraps: true,
+            font: font,
+            theme: theme,
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
+        scrollView.layoutSubtreeIfNeeded()
+
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        // Populate the row-geometry cache with pre-padding measurements,
+        // mirroring `synchronizeSplitRowHeights` reading `diffRowRects()`
+        // right before calling `synchronizeRowHeights`.
+        let rowRects = codeView.diffRowRects()
+        #expect(rowRects.count == 2)
+
+        let target = rowRects[0].height + 18
+        scrollView.synchronizeRowHeights([target, rowRects[1].height])
+
+        // No `layoutSubtreeIfNeeded()` here: read geometry exactly as a
+        // caller later in the same layout pass would, before any further
+        // AppKit layout tick could paper over stale cached geometry.
+        let paddedRows = codeView.diffRowRects()
+        #expect(abs(paddedRows[0].height - target) < 0.5)
+    }
+
     /// Regression test for a review-flagged edge case in the beachball fix: a
     /// row's OWN local wrap count can change on a resize (e.g. widening the
     /// pane lets a previously two-line row fit on one line) while its target


### PR DESCRIPTION
## Summary
- Fixes a live-lock (beachball) in split-layout diff review: `synchronizeRowHeights` stripped a row's custom line-height padding whenever any *other* row's target height changed, even when that row's own padding was still needed.
- Removing the padding shrank the row, which the next layout pass detected as a change, reapplying the padding and invalidating layout again — an unbounded apply/strip/reapply cycle that pegged the main thread at 100% CPU for any split diff with a line-wrap mismatch between old/new sides (a very common case, not an edge case).
- Root-caused from a live `sample` trace of the actually-hung process (main thread stuck continuously in `GraphHost.flushTransactions()` across multiple samples over 30 minutes with no user input).

## Test plan
- [x] Updated `synchronizedRowHeightsResetPreviouslyPaddedRowsForRemeasurement` (renamed `synchronizedRowHeightsKeepsStablePaddingWhileOtherRowsChange`) to assert the correct, stable behavior instead of the oscillation it previously encoded as intended.
- [x] Added `synchronizeRowHeightsIsNoOpOnceStable`, a direct regression guard asserting a repeat call with unchanged heights does not re-trigger `needsLayout`.
- [x] `xcodebuild test` — full suite passes (only pre-existing, opt-in `SSHIntegrationTests` gated behind `ALAS_SSH_INTEGRATION=1` fail, unrelated).