### PR TITLE
feat(acp): pi parity for Alas tools via CLI env and pi-mcp-adapter

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */; };
 		25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
+		255B96A469DFFEA473CF1A42 /* AlasCLIEnvInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107D334C822CF40697E7F15B /* AlasCLIEnvInjection.swift */; };
 		255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */; };
 		257D3CF69FE6A97D058FF959 /* RemoteRepoValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */; };
 		2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2F213480B30034B25B2B8 /* AgentRunError.swift */; };
@@ -908,6 +909,7 @@
 		B58BF89C3A788A31CBED2067 /* TreeSitterJavaScript in Frameworks */ = {isa = PBXBuildFile; productRef = B3568F495249430FBBE2FCCF /* TreeSitterJavaScript */; };
 		B5E38A6134CDE9F8D5EA76D1 /* CompletionWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */; };
 		B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */; };
+		B647C09E6FFD4F2136E2E64F /* AlasCLIEnvInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA9CC6DA19BF2D0FD8FBDF3 /* AlasCLIEnvInjectionTests.swift */; };
 		B6580745C7EDF5AA65DB0A86 /* QueuedPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */; };
 		B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */; };
 		B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */; };
@@ -1387,6 +1389,7 @@
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
 		10602801D3FA990E60CB072D /* ACPQueueHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueueHeader.swift; sourceTree = "<group>"; };
+		107D334C822CF40697E7F15B /* AlasCLIEnvInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIEnvInjection.swift; sourceTree = "<group>"; };
 		10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostCapabilities.swift; sourceTree = "<group>"; };
 		10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalMessages.swift; sourceTree = "<group>"; };
 		11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClientTests.swift; sourceTree = "<group>"; };
@@ -2000,6 +2003,7 @@
 		8DF79BBCD948528D655A9A81 /* RemoteHostRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostRegistry.swift; sourceTree = "<group>"; };
 		8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcherTests.swift; sourceTree = "<group>"; };
 		8E8EB674A5221235F1C7594E /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
+		8EA9CC6DA19BF2D0FD8FBDF3 /* AlasCLIEnvInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIEnvInjectionTests.swift; sourceTree = "<group>"; };
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidatorTests.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
@@ -3588,6 +3592,7 @@
 				38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */,
 				04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */,
 				955B9084309744F3B9A44CBC /* ACPUserInput.swift */,
+				107D334C822CF40697E7F15B /* AlasCLIEnvInjection.swift */,
 				6B7BEEA16E15CB254BD84F5F /* BuiltInAlasMCP.swift */,
 				87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */,
 				AA6486CAD3FE633F9B6F4ABF /* MCPAttachmentPlanner.swift */,
@@ -4173,6 +4178,7 @@
 				A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */,
 				F84BC1A10866A165EA321719 /* ACPTranscriptTests.swift */,
 				7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */,
+				8EA9CC6DA19BF2D0FD8FBDF3 /* AlasCLIEnvInjectionTests.swift */,
 				FE7A4A7B920C0E748973F282 /* BuiltInAlasMCPTests.swift */,
 				336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */,
 				532AA1B8AD5E8139D2EEE948 /* MCPAttachmentPlannerTests.swift */,
@@ -5227,6 +5233,7 @@
 				8CAD455D39C888978F7E66EF /* AlasApplicationDelegate.swift in Sources */,
 				5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */,
 				6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */,
+				255B96A469DFFEA473CF1A42 /* AlasCLIEnvInjection.swift in Sources */,
 				29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */,
 				DC8458FA4C5FCC854BB46B96 /* AlasCLIReviewTargetResolver.swift in Sources */,
 				00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */,
@@ -5898,6 +5905,7 @@
 				13E762EA8D84EFE6F0228806 /* AgentTerminalLaunchTests.swift in Sources */,
 				C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */,
 				026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */,
+				B647C09E6FFD4F2136E2E64F /* AlasCLIEnvInjectionTests.swift in Sources */,
 				8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */,
 				CEEDAC1603DF2F3BD9223238 /* AlasCLIReviewTargetResolverTests.swift in Sources */,
 				4780D23AF088EC5923A17102 /* AlasCLIWorktreeResolverTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		00ED86F7E72AFBF6C8DD69C7 /* GitInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
 		018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */; };
+		019CF838931D47EB13E8C107 /* PiMCPConfigWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B36F1F6A541E5ADB96FCA6 /* PiMCPConfigWriterTests.swift */; };
 		019D3627B3CEB44C34CC34F9 /* RemoteHelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B0D8590E0335CD31B758E0 /* RemoteHelperProtocol.swift */; };
 		019EE52A9C64CF5D15AD9AF2 /* RightPaneStateContentFingerprintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */; };
 		01C919A6F3868980D51539DD /* ACPInitializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */; };
@@ -100,6 +101,7 @@
 		12EB0B042A0225258B8A6C99 /* ACPOrchestrationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */; };
 		133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */; };
 		1339BE8F736D53991DDD19CD /* FileSearchBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */; };
+		137BF3AED8FFF6D42228EFC0 /* PiMCPAdapterInspectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */; };
 		13928612F39D3D86ED3313AC /* ReviewChangesModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */; };
 		139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */; };
 		13E762EA8D84EFE6F0228806 /* AgentTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */; };
@@ -517,6 +519,7 @@
 		647E2B3A14A7722D514B113E /* TreeSitterC in Frameworks */ = {isa = PBXBuildFile; productRef = FF43B3EA560936C516C215A1 /* TreeSitterC */; };
 		64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F721FB733081A583D4053DDA /* FileTypeIconView.swift */; };
 		64DD701281B8BF9468C50C58 /* ACPUserInputFormState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC35CACDC7D469C7D0382F31 /* ACPUserInputFormState.swift */; };
+		64FC756BD56C4997B7B3ADB2 /* PiMCPAdapterInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D8F686002C542458620289 /* PiMCPAdapterInspector.swift */; };
 		65095BDBA1E160D7DF4F2A65 /* AgentLauncherDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFB85AF60C0E4520ED0DA8E /* AgentLauncherDialog.swift */; };
 		659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */; };
 		65E2D21A8616B9E86E684136 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */; };
@@ -1043,6 +1046,7 @@
 		CDE156FA8E19E85437E79908 /* CompletionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
+		CE3F1650AEEC80D937F8E0E9 /* PiMCPConfigWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387BB7FB76FEF0181EF3BBE5 /* PiMCPConfigWriter.swift */; };
 		CE41DBC2472CA576CA52062C /* RemoteExec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF3C93B3FB8B2FDDD8E859D /* RemoteExec.swift */; };
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
 		CEEDAC1603DF2F3BD9223238 /* AlasCLIReviewTargetResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0482EAA16C6A9987C16EE8 /* AlasCLIReviewTargetResolverTests.swift */; };
@@ -1280,6 +1284,7 @@
 		FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
+		FDE59101CBC2CA8CD6FFF91B /* ACPMCPExternalStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01291607F0A46E4A50104BB /* ACPMCPExternalStatus.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
 		FE5846F4401C702264817399 /* SpaceEmojiPickerSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */; };
 		FE5F2F9B468D045194B9443B /* ACPChatTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */; };
@@ -1593,6 +1598,7 @@
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
 		38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptChangeLog.swift; sourceTree = "<group>"; };
+		387BB7FB76FEF0181EF3BBE5 /* PiMCPConfigWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPConfigWriter.swift; sourceTree = "<group>"; };
 		389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderEligibility.swift; sourceTree = "<group>"; };
 		38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairKind.swift; sourceTree = "<group>"; };
 		38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceHeadMessageTests.swift; sourceTree = "<group>"; };
@@ -1833,6 +1839,7 @@
 		695C887147631ACF1FA73C3F /* MergeView3Way.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeView3Way.swift; sourceTree = "<group>"; };
 		699EA14937A07B8DDD57F401 /* OutdatedThreadsDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutdatedThreadsDrawer.swift; sourceTree = "<group>"; };
 		69B2FEBEDD6FD3B2B37F4895 /* RemoteLastActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLastActivityTests.swift; sourceTree = "<group>"; };
+		69B36F1F6A541E5ADB96FCA6 /* PiMCPConfigWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPConfigWriterTests.swift; sourceTree = "<group>"; };
 		69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
 		69CF2E2BF116094A9FEE3F8D /* SelfUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfUpdater.swift; sourceTree = "<group>"; };
@@ -2345,6 +2352,7 @@
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
 		D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentStoreTests.swift; sourceTree = "<group>"; };
+		D3D8F686002C542458620289 /* PiMCPAdapterInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspector.swift; sourceTree = "<group>"; };
 		D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilterTests.swift; sourceTree = "<group>"; };
 		D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAutoRunToggle.swift; sourceTree = "<group>"; };
 		D43B2247BD2DC3FE9E1EA2CC /* RangeReviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReviewLoader.swift; sourceTree = "<group>"; };
@@ -2406,6 +2414,7 @@
 		DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoader.swift; sourceTree = "<group>"; };
 		DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolver.swift; sourceTree = "<group>"; };
 		E00A5AB85B99550DFDB99F46 /* JSONRPCFramer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCFramer.swift; sourceTree = "<group>"; };
+		E01291607F0A46E4A50104BB /* ACPMCPExternalStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPExternalStatus.swift; sourceTree = "<group>"; };
 		E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubprocessRunner.swift; sourceTree = "<group>"; };
 		E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTabView.swift; sourceTree = "<group>"; };
 		E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngineTests.swift; sourceTree = "<group>"; };
@@ -2513,6 +2522,7 @@
 		F332906E17C5865856DBB90B /* ACPSessionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunner.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceCommitEditingTests.swift; sourceTree = "<group>"; };
+		F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspectorTests.swift; sourceTree = "<group>"; };
 		F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabViewTests.swift; sourceTree = "<group>"; };
 		F4526714086C04ED5B472C90 /* DiffInlineCommentCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentCard.swift; sourceTree = "<group>"; };
 		F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifierTests.swift; sourceTree = "<group>"; };
@@ -3075,6 +3085,7 @@
 				E53B7655C8A8FB0CEC069C7B /* Center */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 				EAD92DAB367A7F31FF1223D1 /* Diagnostics */,
+				C71D037587A1C3F230C2D36F /* Harness */,
 				CD11051897966EA15D00BC48 /* Integrations */,
 				08BD96F4379A0D250DE4303C /* JSONRPC */,
 				D7416CBAB1B316023E546714 /* Persistence */,
@@ -3574,6 +3585,7 @@
 				A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */,
 				E3C49F11F34AA97B21936FC1 /* ACPElicitationCoordinator.swift */,
 				73539FDFE4BDBD4D3B4DE546 /* ACPFirstRunConnectingPhase.swift */,
+				E01291607F0A46E4A50104BB /* ACPMCPExternalStatus.swift */,
 				E48A1E612514DDA810791ED5 /* ACPMCPPromptPreamble.swift */,
 				321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */,
 				D21F30DB5A812E396262A926 /* ACPMessageWire.swift */,
@@ -4248,6 +4260,8 @@
 				2975A1465CA308E9766521F2 /* NotificationService.swift */,
 				CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */,
 				932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */,
+				D3D8F686002C542458620289 /* PiMCPAdapterInspector.swift */,
+				387BB7FB76FEF0181EF3BBE5 /* PiMCPConfigWriter.swift */,
 			);
 			path = Harness;
 			sourceTree = "<group>";
@@ -4409,6 +4423,15 @@
 				F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */,
 			);
 			path = RepoSelector;
+			sourceTree = "<group>";
+		};
+		C71D037587A1C3F230C2D36F /* Harness */ = {
+			isa = PBXGroup;
+			children = (
+				F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */,
+				69B36F1F6A541E5ADB96FCA6 /* PiMCPConfigWriterTests.swift */,
+			);
+			path = Harness;
 			sourceTree = "<group>";
 		};
 		C86FE0D59F990939C552C7E2 /* Products */ = {
@@ -5116,6 +5139,7 @@
 				433EC05E13C676C1C2EB6888 /* ACPLaunchCatalog.swift in Sources */,
 				5789FC76BEC6965E56C2DF3C /* ACPLaunchPathResolver.swift in Sources */,
 				542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */,
+				FDE59101CBC2CA8CD6FFF91B /* ACPMCPExternalStatus.swift in Sources */,
 				E19AEA6E45D16B5EEC1CE411 /* ACPMCPPromptPreamble.swift in Sources */,
 				6294D44BE2DC7F96933F7C4B /* ACPMCPServer.swift in Sources */,
 				BBACA7DCC1EFA6D55AEB38CE /* ACPMCPStatusControl.swift in Sources */,
@@ -5533,6 +5557,8 @@
 				671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */,
 				E99E4DB46496707E7A3F044A /* PiACPInstaller.swift in Sources */,
 				5E687CE659E83EF3B71CA86F /* PiInstaller.swift in Sources */,
+				64FC756BD56C4997B7B3ADB2 /* PiMCPAdapterInspector.swift in Sources */,
+				CE3F1650AEEC80D937F8E0E9 /* PiMCPConfigWriter.swift in Sources */,
 				1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */,
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
 				106120CBE8107E0AC4EA353A /* ProcessKiller.swift in Sources */,
@@ -6133,6 +6159,8 @@
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				ADF6D3B634D9CCA17D7884EC /* PiACPInstallerTests.swift in Sources */,
 				04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */,
+				137BF3AED8FFF6D42228EFC0 /* PiMCPAdapterInspectorTests.swift in Sources */,
+				019CF838931D47EB13E8C107 /* PiMCPConfigWriterTests.swift in Sources */,
 				D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				82544FFCF9960E0BA0FD2C7F /* ProcessMemoryProbeTests.swift in Sources */,

--- a/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
@@ -98,7 +98,8 @@ enum ACPLaunchCatalog {
                 binary: ACPManagedAdapterDescriptor.pi.binaryName,
                 npmPackage: ACPManagedAdapterDescriptor.pi.packageName),
             supportsModelSelection: false,
-            supportsModeSelection: false),
+            supportsModeSelection: false,
+            mcpInjection: .external(hint: "Pi ignores ACP MCP config. Alas tools work via the alas CLI; other MCP servers need the pi-mcp-adapter extension.")),
     ]
 
     static func spec(for agentID: String) -> ACPLaunchSpec? {

--- a/Alas/Sources/ACP/Adapter/ACPLaunchSpec.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchSpec.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// How an adapter receives MCP servers. Most honor the `mcpServers`
+/// payload in ACP `session/new`; `.external` adapters ignore it and need
+/// agent-side setup (config files, plugins) instead.
+enum ACPMCPInjectionSupport: Equatable {
+    case sessionNew
+    case external(hint: String)
+}
+
 struct ACPLaunchSpec: Equatable {
     let agentID: String
     let command: String
@@ -8,6 +16,7 @@ struct ACPLaunchSpec: Equatable {
     let setupCheck: ACPSetupCheck
     let supportsModelSelection: Bool
     let supportsModeSelection: Bool
+    let mcpInjection: ACPMCPInjectionSupport
     let remoteNodeBinDirectory: String?
 
     init(
@@ -18,6 +27,7 @@ struct ACPLaunchSpec: Equatable {
         setupCheck: ACPSetupCheck,
         supportsModelSelection: Bool,
         supportsModeSelection: Bool,
+        mcpInjection: ACPMCPInjectionSupport = .sessionNew,
         remoteNodeBinDirectory: String? = nil
     ) {
         self.agentID = agentID
@@ -27,6 +37,7 @@ struct ACPLaunchSpec: Equatable {
         self.setupCheck = setupCheck
         self.supportsModelSelection = supportsModelSelection
         self.supportsModeSelection = supportsModeSelection
+        self.mcpInjection = mcpInjection
         self.remoteNodeBinDirectory = remoteNodeBinDirectory
     }
 
@@ -56,6 +67,19 @@ struct ACPLaunchSpec: Equatable {
             setupCheck: setupCheck,
             supportsModelSelection: supportsModelSelection,
             supportsModeSelection: supportsModeSelection,
+            mcpInjection: mcpInjection,
+            remoteNodeBinDirectory: remoteNodeBinDirectory)
+    }
+
+    /// A copy of this spec with `env` overlaid onto `extraEnv` (new keys win).
+    func mergingExtraEnv(_ env: [String: String]) -> ACPLaunchSpec {
+        ACPLaunchSpec(
+            agentID: agentID, command: command, arguments: arguments,
+            extraEnv: extraEnv.merging(env) { _, new in new },
+            setupCheck: setupCheck,
+            supportsModelSelection: supportsModelSelection,
+            supportsModeSelection: supportsModeSelection,
+            mcpInjection: mcpInjection,
             remoteNodeBinDirectory: remoteNodeBinDirectory)
     }
 }

--- a/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Snapshot of how MCP reaches an `.external` adapter (one that ignores ACP
+/// `session/new` MCP config) for the most recent attach. Runtime-only —
+/// recomputed every attach, never persisted.
+struct ACPMCPExternalStatus: Equatable {
+    let cliActive: Bool
+    let adapterState: PiMCPAdapterInspector.State
+    let configOutcome: PiMCPConfigWriter.Outcome?
+    let hint: String
+
+    var adapterInstalled: Bool { adapterState == .installed }
+}

--- a/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
@@ -28,6 +28,8 @@ struct ACPMCPExternalStatus: Equatable {
     /// resolved regardless of adapter/config state so the preamble can name
     /// them even when they are not (yet) reachable.
     let userServerNames: [String]
+    /// Project MCP servers skipped by the external adapter's own planning pass.
+    let skippedServerStatuses: [MCPAttachmentServerStatus]
     /// True when the current host can run the local remediation action for a
     /// missing adapter. Remote worktrees must not offer the local install button.
     let canInstallAdapterLocally: Bool
@@ -38,6 +40,7 @@ struct ACPMCPExternalStatus: Equatable {
         configOutcome: PiMCPConfigWriter.Outcome?,
         hint: String,
         userServerNames: [String],
+        skippedServerStatuses: [MCPAttachmentServerStatus] = [],
         canInstallAdapterLocally: Bool = true
     ) {
         self.cliActive = cliActive
@@ -45,6 +48,7 @@ struct ACPMCPExternalStatus: Equatable {
         self.configOutcome = configOutcome
         self.hint = hint
         self.userServerNames = userServerNames
+        self.skippedServerStatuses = skippedServerStatuses
         self.canInstallAdapterLocally = canInstallAdapterLocally
     }
 

--- a/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
@@ -10,4 +10,10 @@ struct ACPMCPExternalStatus: Equatable {
     let hint: String
 
     var adapterInstalled: Bool { adapterState == .installed }
+
+    /// True when the adapter is installed AND the last `.pi/mcp.json` sync
+    /// actually succeeded — a failed write means user MCP servers are not
+    /// reachable through pi-mcp-adapter even though the extension itself is
+    /// present.
+    var adapterServersAvailable: Bool { adapterState == .installed && configOutcome != .failed }
 }

--- a/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
@@ -28,6 +28,25 @@ struct ACPMCPExternalStatus: Equatable {
     /// resolved regardless of adapter/config state so the preamble can name
     /// them even when they are not (yet) reachable.
     let userServerNames: [String]
+    /// True when the current host can run the local remediation action for a
+    /// missing adapter. Remote worktrees must not offer the local install button.
+    let canInstallAdapterLocally: Bool
+
+    init(
+        cliActive: Bool,
+        adapterState: PiMCPAdapterInspector.State,
+        configOutcome: PiMCPConfigWriter.Outcome?,
+        hint: String,
+        userServerNames: [String],
+        canInstallAdapterLocally: Bool = true
+    ) {
+        self.cliActive = cliActive
+        self.adapterState = adapterState
+        self.configOutcome = configOutcome
+        self.hint = hint
+        self.userServerNames = userServerNames
+        self.canInstallAdapterLocally = canInstallAdapterLocally
+    }
 
     var adapterInstalled: Bool { adapterState == .installed }
 

--- a/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
@@ -4,16 +4,47 @@ import Foundation
 /// `session/new` MCP config) for the most recent attach. Runtime-only —
 /// recomputed every attach, never persisted.
 struct ACPMCPExternalStatus: Equatable {
+    /// Availability of the project's MCP servers through the external
+    /// adapter, distinguishing *why* they may not be reachable.
+    enum AdapterServerAvailability: Equatable {
+        /// Alas wrote/maintains a managed `.pi/mcp.json` with the servers.
+        case available
+        /// pi-mcp-adapter extension absent.
+        case notInstalled
+        /// Installed, but Alas could not write `.pi/mcp.json`.
+        case syncFailed
+        /// Installed, but an unmanaged `.pi/mcp.json` exists — Alas did not
+        /// write the project's servers into it.
+        case userManaged
+        /// Installed, but there is nothing to provide.
+        case noServers
+    }
+
     let cliActive: Bool
     let adapterState: PiMCPAdapterInspector.State
     let configOutcome: PiMCPConfigWriter.Outcome?
     let hint: String
+    /// The project's `.external`-plan (all-transports) MCP server names,
+    /// resolved regardless of adapter/config state so the preamble can name
+    /// them even when they are not (yet) reachable.
+    let userServerNames: [String]
 
     var adapterInstalled: Bool { adapterState == .installed }
 
-    /// True when the adapter is installed AND the last `.pi/mcp.json` sync
-    /// actually succeeded — a failed write means user MCP servers are not
-    /// reachable through pi-mcp-adapter even though the extension itself is
-    /// present.
-    var adapterServersAvailable: Bool { adapterState == .installed && configOutcome != .failed }
+    /// Precise reason the project's MCP servers are (or are not) reachable
+    /// through the external adapter.
+    var adapterServerAvailability: AdapterServerAvailability {
+        guard adapterState == .installed else { return .notInstalled }
+        switch configOutcome {
+        case .wrote?, .unchanged?: return .available
+        case .failed?: return .syncFailed
+        case .refusedUnmanaged?: return .userManaged
+        case .removedManaged?, .noServers?, nil: return .noServers
+        }
+    }
+
+    /// True only when the adapter is installed AND Alas actually wrote (or
+    /// confirmed unchanged) the managed `.pi/mcp.json` — i.e. the project's
+    /// servers are genuinely reachable through pi-mcp-adapter.
+    var adapterServersAvailable: Bool { adapterServerAvailability == .available }
 }

--- a/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPExternalStatus.swift
@@ -34,6 +34,9 @@ struct ACPMCPExternalStatus: Equatable {
     /// Precise reason the project's MCP servers are (or are not) reachable
     /// through the external adapter.
     var adapterServerAvailability: AdapterServerAvailability {
+        if userServerNames.isEmpty || configOutcome == .noServers || configOutcome == .removedManaged {
+            return .noServers
+        }
         guard adapterState == .installed else { return .notInstalled }
         switch configOutcome {
         case .wrote?, .unchanged?: return .available

--- a/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
@@ -10,7 +10,7 @@ import Foundation
 /// names.
 enum ACPMCPPreambleMode: Equatable {
     case mcp
-    case cli(adapterInstalled: Bool)
+    case cli(serverAvailability: ACPMCPExternalStatus.AdapterServerAvailability)
 }
 
 /// Builds the one-time, wire-only context preamble injected into the first
@@ -44,12 +44,12 @@ enum ACPMCPPromptPreamble {
                 builtInInjected: builtInInjected,
                 isDelegated: isDelegated,
                 userServerNames: userServerNames)
-        case .cli(let adapterInstalled):
+        case .cli(let serverAvailability):
             return cliText(
                 builtInInjected: builtInInjected,
                 isDelegated: isDelegated,
                 userServerNames: userServerNames,
-                adapterInstalled: adapterInstalled)
+                serverAvailability: serverAvailability)
         }
     }
 
@@ -96,12 +96,12 @@ enum ACPMCPPromptPreamble {
         builtInInjected: Bool,
         isDelegated: Bool,
         userServerNames: [String],
-        adapterInstalled: Bool
+        serverAvailability: ACPMCPExternalStatus.AdapterServerAvailability
     ) -> String {
         var lines: [String] = []
         lines.append("<alas-workspace-context>")
         var intro = "This session runs inside Alas, the user's macOS workspace app."
-        if adapterInstalled, !userServerNames.isEmpty {
+        if serverAvailability == .available, !userServerNames.isEmpty {
             intro += " MCP tools may be deferred behind tool search — they ARE "
                 + "available; use your tool discovery/search mechanism to load them."
         }
@@ -126,15 +126,25 @@ enum ACPMCPPromptPreamble {
             lines.append(line)
         }
         if !userServerNames.isEmpty {
-            if adapterInstalled {
+            let names = userServerNames.joined(separator: ", ")
+            switch serverAvailability {
+            case .available:
                 lines.append("Additional MCP servers are available through the "
-                    + "`mcp()` tool (pi-mcp-adapter): "
-                    + userServerNames.joined(separator: ", ") + ".")
-            } else {
-                lines.append("This project configures MCP servers ("
-                    + userServerNames.joined(separator: ", ")
-                    + ") that cannot be reached until the pi-mcp-adapter extension "
+                    + "`mcp()` tool (pi-mcp-adapter): \(names).")
+            case .notInstalled:
+                lines.append("This project configures MCP servers (\(names)) "
+                    + "that cannot be reached until the pi-mcp-adapter extension "
                     + "is installed.")
+            case .syncFailed:
+                lines.append("This project configures MCP servers (\(names)), "
+                    + "but Alas could not write .pi/mcp.json, so they may not "
+                    + "be reachable.")
+            case .userManaged:
+                lines.append("This project configures MCP servers (\(names)), "
+                    + "but an existing .pi/mcp.json governs pi's MCP config, so "
+                    + "Alas did not add them — they may not be present.")
+            case .noServers:
+                break
             }
         }
         lines.append("</alas-workspace-context>")

--- a/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// How the preamble should describe Alas tool access for this agent.
+///
+/// Most adapters honor the ACP `session/new` `mcpServers` payload, so the
+/// preamble describes the attached MCP tools (`.mcp`). Adapters that ignore
+/// MCP config entirely (`ACPMCPInjectionSupport.external`) get the `alas`
+/// CLI env injected into their process instead (see `AlasCLIEnvInjection`),
+/// so the preamble must point the agent at CLI commands rather than tool
+/// names.
+enum ACPMCPPreambleMode: Equatable {
+    case mcp
+    case cli(adapterInstalled: Bool)
+}
+
 /// Builds the one-time, wire-only context preamble injected into the first
 /// prompt of a freshly created ACP session. Modern agent harnesses defer MCP
 /// tools behind tool search, so the model never sees the attached tools
@@ -21,9 +34,30 @@ enum ACPMCPPromptPreamble {
     static func text(
         builtInInjected: Bool,
         isDelegated: Bool,
-        userServerNames: [String]
+        userServerNames: [String],
+        mode: ACPMCPPreambleMode = .mcp
     ) -> String? {
         guard builtInInjected || !userServerNames.isEmpty else { return nil }
+        switch mode {
+        case .mcp:
+            return mcpText(
+                builtInInjected: builtInInjected,
+                isDelegated: isDelegated,
+                userServerNames: userServerNames)
+        case .cli(let adapterInstalled):
+            return cliText(
+                builtInInjected: builtInInjected,
+                isDelegated: isDelegated,
+                userServerNames: userServerNames,
+                adapterInstalled: adapterInstalled)
+        }
+    }
+
+    private static func mcpText(
+        builtInInjected: Bool,
+        isDelegated: Bool,
+        userServerNames: [String]
+    ) -> String {
         var lines: [String] = []
         lines.append("<alas-workspace-context>")
         lines.append(
@@ -53,6 +87,55 @@ enum ACPMCPPromptPreamble {
         if !userServerNames.isEmpty {
             lines.append("Additional MCP servers attached: "
                 + userServerNames.joined(separator: ", ") + ".")
+        }
+        lines.append("</alas-workspace-context>")
+        return lines.joined(separator: "\n")
+    }
+
+    private static func cliText(
+        builtInInjected: Bool,
+        isDelegated: Bool,
+        userServerNames: [String],
+        adapterInstalled: Bool
+    ) -> String {
+        var lines: [String] = []
+        lines.append("<alas-workspace-context>")
+        var intro = "This session runs inside Alas, the user's macOS workspace app."
+        if adapterInstalled, !userServerNames.isEmpty {
+            intro += " MCP tools may be deferred behind tool search — they ARE "
+                + "available; use your tool discovery/search mechanism to load them."
+        }
+        lines.append(intro)
+        if builtInInjected {
+            let sessionCLI = isDelegated
+                ? "alas session send <session-id> <prompt>"
+                : "alas session list | alas session new --prompt <text> | alas session send <session-id> <prompt>"
+            var line = "Use the `alas` CLI via your shell tool to drive the Alas UI: "
+                + "`alas open <path>` reveals a file to the user, "
+                + "`alas notify <body>` posts a macOS notification, "
+                + "`alas wt list|switch|new|delete` manages worktrees, "
+                + "`alas review …` drives the review pane (comments/reply/resolve/finish), "
+                + "and `\(sessionCLI)` manages delegated sessions."
+            if isDelegated {
+                line += " This session was delegated by a parent session: it cannot "
+                    + "create descendants; return results or questions through "
+                    + "`alas session send`."
+            }
+            line += " Prefer these commands when the user asks to open/show files, "
+                + "manage worktrees, run or respond to reviews, or be notified."
+            lines.append(line)
+        }
+        if !userServerNames.isEmpty {
+            if adapterInstalled {
+                lines.append("Additional MCP servers are available through the "
+                    + "`mcp()` tool (pi-mcp-adapter): "
+                    + userServerNames.joined(separator: ", ") + ".")
+            } else {
+                lines.append("This project configures MCP servers ("
+                    + userServerNames.joined(separator: ", ")
+                    + ") that cannot be reached until the pi-mcp-adapter extension "
+                    + "is installed.")
+            }
         }
         lines.append("</alas-workspace-context>")
         return lines.joined(separator: "\n")

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -93,6 +93,10 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var pendingMCPPreamble: String?
     /// Whether this session's MCP preamble was delivered in a prompt.
     @Published var mcpPreambleSent: Bool = false
+    /// Runtime-only status for adapters that ignore ACP MCP config
+    /// (`ACPMCPInjectionSupport.external`): how Alas tools and user MCP
+    /// servers actually reach this agent. Recomputed on every attach.
+    @Published var mcpExternalStatus: ACPMCPExternalStatus?
     /// Runtime-only auth method selected by the user in the sign-in banner.
     /// The next attach consumes it by calling ACP `authenticate` after
     /// initialize and before session creation/loading.

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2256,6 +2256,7 @@ extension ACPSessionManager {
         // a delegated session (`launchSpec` itself is scoped to this
         // `do` block, so its `extraEnv` is captured here for later use).
         var cliParentSessionId: String?
+        var effectiveLaunchSpec = spec
         do {
             let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
             var launchSpec = await resolvedLaunchSpec(for: spec, host: host)
@@ -2264,6 +2265,7 @@ extension ACPSessionManager {
                 cliEnvActive = true
                 cliParentSessionId = launchSpec.extraEnv["ALAS_PARENT_SESSION_ID"]
             }
+            effectiveLaunchSpec = launchSpec
             if let injectedConnectionFactory {
                 connection = try injectedConnectionFactory(launchSpec, host, worktreePath)
             } else {
@@ -2335,7 +2337,7 @@ extension ACPSessionManager {
             let initialized = try await connection.initialize()
             session.promptCapabilities = initialized.promptCapabilities
             session.authMethods = initialized.authMethods
-            let agentEnvironment = ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv)
+            let agentEnvironment = ACPProcessEnvironment.sanitizedForACP(extra: effectiveLaunchSpec.extraEnv)
             let projectContext = mcpProjectContextProvider?()
                 ?? MCPProjectContext(projectDirectory: worktreePath, configuredServers: [])
             let mcpPlan = MCPAttachmentPlanner.plan(.init(

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2363,13 +2363,26 @@ extension ACPSessionManager {
             // every attach so a freshly installed adapter or an edited
             // server list is picked up on the next reconnect.
             if case let .external(hint) = spec.mcpInjection {
-                let external = await externalMCPStatusProvider?(worktreePath)
-                session.mcpExternalStatus = ACPMCPExternalStatus(
-                    cliActive: cliEnvActive,
-                    adapterState: external?.adapterState ?? .unknown,
-                    configOutcome: external?.configOutcome,
-                    hint: hint
-                )
+                if remoteHost == nil {
+                    let external = await externalMCPStatusProvider?(worktreePath)
+                    session.mcpExternalStatus = ACPMCPExternalStatus(
+                        cliActive: cliEnvActive,
+                        adapterState: external?.adapterState ?? .unknown,
+                        configOutcome: external?.configOutcome,
+                        hint: hint
+                    )
+                } else {
+                    // Remote pi session: the worktree lives on the remote host, so
+                    // there is no local `.pi/agent` to inspect and no local
+                    // `.pi/mcp.json` to write. Report an honest "unavailable"
+                    // status instead of calling the (local-only) status provider.
+                    session.mcpExternalStatus = ACPMCPExternalStatus(
+                        cliActive: false,
+                        adapterState: .unknown,
+                        configOutcome: nil,
+                        hint: hint
+                    )
+                }
             } else {
                 session.mcpExternalStatus = nil
             }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -38,6 +38,12 @@ final class ACPSessionManager: ObservableObject {
         _ worktreePath: String,
         _ sessionId: ACPSession.ID
     ) async -> [String: String]?
+    /// For `.external` adapters (which ignore ACP MCP config), inspects the
+    /// agent-side adapter and syncs its managed config file. Called once per
+    /// attach, after the built-in MCP composition, so `attach` can populate
+    /// `session.mcpExternalStatus` before the first-prompt preamble is built.
+    typealias ExternalMCPStatusProvider = @MainActor (_ worktreePath: String) async
+        -> (adapterState: PiMCPAdapterInspector.State, configOutcome: PiMCPConfigWriter.Outcome?)
 
     let instanceId: String
     let pid: Int64
@@ -69,6 +75,11 @@ final class ACPSessionManager: ObservableObject {
     /// through every manager construction call site. Local sessions only;
     /// remote hosts skip it in `attach`.
     var alasCLIEnvProvider: AlasCLIEnvProvider?
+    /// Builds the `.external` adapter status (adapter inspection + managed
+    /// config sync) for a worktree path. Set post-init, mirroring
+    /// `alasCLIEnvProvider`, so AppState can wire it without threading it
+    /// through every manager construction call site.
+    var externalMCPStatusProvider: ExternalMCPStatusProvider?
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     @Published private(set) var persistenceError: String?
@@ -2347,6 +2358,21 @@ extension ACPSessionManager {
                 statuses: plannedStatuses,
                 configurationFingerprint: mcpPlan.configurationFingerprint
             )
+            // `.external` adapters ignore the ACP MCP config above and need
+            // agent-side setup instead (config files, plugins). Recomputed on
+            // every attach so a freshly installed adapter or an edited
+            // server list is picked up on the next reconnect.
+            if case let .external(hint) = spec.mcpInjection {
+                let external = await externalMCPStatusProvider?(worktreePath)
+                session.mcpExternalStatus = ACPMCPExternalStatus(
+                    cliActive: cliEnvActive,
+                    adapterState: external?.adapterState ?? .unknown,
+                    configOutcome: external?.configOutcome,
+                    hint: hint
+                )
+            } else {
+                session.mcpExternalStatus = nil
+            }
             let mcpSplit = remoteHost.map { _ in
                 ACPRemoteMCPFilter.split(plannedWireServers)
             }
@@ -2590,10 +2616,7 @@ extension ACPSessionManager {
                     .filter { !(builtInMCP != nil && $0 == BuiltInAlasMCP.serverName) }
                 let preambleMode: ACPMCPPreambleMode
                 if case .external = spec.mcpInjection {
-                    // Task 5 wires the pi-mcp-adapter inspector into
-                    // `session.mcpExternalStatus`; until then, assume the
-                    // adapter is not installed.
-                    let adapterInstalled = false
+                    let adapterInstalled = session.mcpExternalStatus?.adapterInstalled == true
                     preambleMode = .cli(adapterInstalled: adapterInstalled)
                 } else {
                     preambleMode = .mcp

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2235,12 +2235,19 @@ extension ACPSessionManager {
         // to decide whether the first-prompt preamble should mention the
         // CLI alongside any injected MCP servers.
         var cliEnvActive = false
+        // Set alongside `cliEnvActive`, from the merged launch spec's
+        // `ALAS_PARENT_SESSION_ID` (see `AlasCLIEnvInjection.environment`).
+        // Consumed by the CLI-mode preamble below to decide whether this is
+        // a delegated session (`launchSpec` itself is scoped to this
+        // `do` block, so its `extraEnv` is captured here for later use).
+        var cliParentSessionId: String?
         do {
             let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
             var launchSpec = await resolvedLaunchSpec(for: spec, host: host)
             if host == nil, let cliEnv = await alasCLIEnvProvider?(worktreePath, sessionId) {
                 launchSpec = launchSpec.mergingExtraEnv(cliEnv)
                 cliEnvActive = true
+                cliParentSessionId = launchSpec.extraEnv["ALAS_PARENT_SESSION_ID"]
             }
             if let injectedConnectionFactory {
                 connection = try injectedConnectionFactory(launchSpec, host, worktreePath)
@@ -2272,9 +2279,9 @@ extension ACPSessionManager {
             await releaseWriterLease(sessionId: sessionId)
             return
         }
-        // TODO(pi-MCP-parity task 4): fold into the first-prompt preamble
-        // alongside injected MCP servers.
-        _ = cliEnvActive
+        // `cliEnvActive` / `cliParentSessionId` are consumed below, once we
+        // know whether this attach created a fresh remote session (the
+        // preamble is only sent once, on first prompt).
         // Collect a short tail of stderr so we can surface it when the
         // agent rejects initialize / new for protocol or auth reasons.
         let stderrBuffer = StderrBuffer()
@@ -2581,10 +2588,23 @@ extension ACPSessionManager {
             if createdFreshRemoteSession {
                 let userServerNames = wireMCPServers.map(\.name)
                     .filter { !(builtInMCP != nil && $0 == BuiltInAlasMCP.serverName) }
+                let preambleMode: ACPMCPPreambleMode
+                if case .external = spec.mcpInjection {
+                    // Task 5 wires the pi-mcp-adapter inspector into
+                    // `session.mcpExternalStatus`; until then, assume the
+                    // adapter is not installed.
+                    let adapterInstalled = false
+                    preambleMode = .cli(adapterInstalled: adapterInstalled)
+                } else {
+                    preambleMode = .mcp
+                }
                 let preamble = ACPMCPPromptPreamble.text(
-                    builtInInjected: builtInMCP != nil,
-                    isDelegated: builtInMCP?.isDelegated == true,
-                    userServerNames: userServerNames
+                    builtInInjected: preambleMode == .mcp ? (builtInMCP != nil) : cliEnvActive,
+                    isDelegated: preambleMode == .mcp
+                        ? (builtInMCP?.isDelegated == true)
+                        : (cliParentSessionId != nil),
+                    userServerNames: userServerNames,
+                    mode: preambleMode
                 )
                 if isWriter(for: sessionId) {
                     session.pendingMCPPreamble = preamble

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2388,7 +2388,7 @@ extension ACPSessionManager {
                         adapterState: .unknown,
                         configOutcome: nil,
                         hint: hint,
-                        userServerNames: []
+                        userServerNames: mcpPlan.statuses.map(\.name)
                     )
                 }
             } else {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2629,7 +2629,7 @@ extension ACPSessionManager {
                     .filter { !(builtInMCP != nil && $0 == BuiltInAlasMCP.serverName) }
                 let preambleMode: ACPMCPPreambleMode
                 if case .external = spec.mcpInjection {
-                    let adapterInstalled = session.mcpExternalStatus?.adapterInstalled == true
+                    let adapterInstalled = session.mcpExternalStatus?.adapterServersAvailable == true
                     preambleMode = .cli(adapterInstalled: adapterInstalled)
                 } else {
                     preambleMode = .mcp

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2388,7 +2388,8 @@ extension ACPSessionManager {
                         adapterState: .unknown,
                         configOutcome: nil,
                         hint: hint,
-                        userServerNames: mcpPlan.statuses.map(\.name)
+                        userServerNames: mcpPlan.statuses.map(\.name),
+                        canInstallAdapterLocally: false
                     )
                 }
             } else {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -46,7 +46,8 @@ final class ACPSessionManager: ObservableObject {
         -> (
             adapterState: PiMCPAdapterInspector.State,
             configOutcome: PiMCPConfigWriter.Outcome?,
-            userServerNames: [String]
+            userServerNames: [String],
+            skippedServerStatuses: [MCPAttachmentServerStatus]
         )
 
     let instanceId: String
@@ -2376,7 +2377,8 @@ extension ACPSessionManager {
                         adapterState: external?.adapterState ?? .unknown,
                         configOutcome: external?.configOutcome,
                         hint: hint,
-                        userServerNames: external?.userServerNames ?? []
+                        userServerNames: external?.userServerNames ?? [],
+                        skippedServerStatuses: external?.skippedServerStatuses ?? []
                     )
                 } else {
                     // Remote pi session: the worktree lives on the remote host, so
@@ -2389,6 +2391,10 @@ extension ACPSessionManager {
                         configOutcome: nil,
                         hint: hint,
                         userServerNames: mcpPlan.statuses.map(\.name),
+                        skippedServerStatuses: mcpPlan.statuses.filter {
+                            if case .skipped = $0.disposition { return true }
+                            return false
+                        },
                         canInstallAdapterLocally: false
                     )
                 }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -43,7 +43,11 @@ final class ACPSessionManager: ObservableObject {
     /// attach, after the built-in MCP composition, so `attach` can populate
     /// `session.mcpExternalStatus` before the first-prompt preamble is built.
     typealias ExternalMCPStatusProvider = @MainActor (_ worktreePath: String) async
-        -> (adapterState: PiMCPAdapterInspector.State, configOutcome: PiMCPConfigWriter.Outcome?)
+        -> (
+            adapterState: PiMCPAdapterInspector.State,
+            configOutcome: PiMCPConfigWriter.Outcome?,
+            userServerNames: [String]
+        )
 
     let instanceId: String
     let pid: Int64
@@ -2369,7 +2373,8 @@ extension ACPSessionManager {
                         cliActive: cliEnvActive,
                         adapterState: external?.adapterState ?? .unknown,
                         configOutcome: external?.configOutcome,
-                        hint: hint
+                        hint: hint,
+                        userServerNames: external?.userServerNames ?? []
                     )
                 } else {
                     // Remote pi session: the worktree lives on the remote host, so
@@ -2380,7 +2385,8 @@ extension ACPSessionManager {
                         cliActive: false,
                         adapterState: .unknown,
                         configOutcome: nil,
-                        hint: hint
+                        hint: hint,
+                        userServerNames: []
                     )
                 }
             } else {
@@ -2625,13 +2631,22 @@ extension ACPSessionManager {
                 }
             }
             if createdFreshRemoteSession {
-                let userServerNames = wireMCPServers.map(\.name)
-                    .filter { !(builtInMCP != nil && $0 == BuiltInAlasMCP.serverName) }
                 let preambleMode: ACPMCPPreambleMode
+                let userServerNames: [String]
                 if case .external = spec.mcpInjection {
-                    let adapterInstalled = session.mcpExternalStatus?.adapterServersAvailable == true
-                    preambleMode = .cli(adapterInstalled: adapterInstalled)
+                    // The `.external` (pi) status provider resolves an
+                    // all-transports plan (http/sse force-enabled) because
+                    // pi-mcp-adapter — unlike pi-acp's own ACP MCP support —
+                    // can reach those transports. `wireMCPServers` here was
+                    // planned against pi's real (http/sse-less)
+                    // capabilities and would drop them, so the preamble must
+                    // use the external status's resolved names instead.
+                    userServerNames = session.mcpExternalStatus?.userServerNames ?? []
+                    let serverAvailability = session.mcpExternalStatus?.adapterServerAvailability ?? .notInstalled
+                    preambleMode = .cli(serverAvailability: serverAvailability)
                 } else {
+                    userServerNames = wireMCPServers.map(\.name)
+                        .filter { !(builtInMCP != nil && $0 == BuiltInAlasMCP.serverName) }
                     preambleMode = .mcp
                 }
                 let preamble = ACPMCPPromptPreamble.text(

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -32,6 +32,12 @@ final class ACPSessionManager: ObservableObject {
         _ worktreePath: String,
         _ sessionId: ACPSession.ID
     ) async -> BuiltInAlasMCP.Injection?
+    /// Extra process env for locally spawned adapters so any agent's shell
+    /// can drive the `alas` CLI. Nil (or a nil return) skips injection.
+    typealias AlasCLIEnvProvider = @MainActor (
+        _ worktreePath: String,
+        _ sessionId: ACPSession.ID
+    ) async -> [String: String]?
 
     let instanceId: String
     let pid: Int64
@@ -57,6 +63,12 @@ final class ACPSessionManager: ObservableObject {
     /// or nil when injection is disabled/unavailable. Fetched per attach so
     /// the settings toggle applies to the next (re)connect.
     private let builtInMCPProvider: BuiltInMCPProvider?
+    /// Builds extra env for locally spawned adapter processes so the agent's
+    /// shell can drive the `alas` CLI. Set post-init (unlike
+    /// `builtInMCPProvider`) so AppState can wire it without threading it
+    /// through every manager construction call site. Local sessions only;
+    /// remote hosts skip it in `attach`.
+    var alasCLIEnvProvider: AlasCLIEnvProvider?
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     @Published private(set) var persistenceError: String?
@@ -2218,9 +2230,18 @@ extension ACPSessionManager {
         }
 
         let connection: ACPConnection
+        // Set inside the do-block below when the alas CLI env was merged
+        // into the launch spec (local sessions only). Consumed further down
+        // to decide whether the first-prompt preamble should mention the
+        // CLI alongside any injected MCP servers.
+        var cliEnvActive = false
         do {
             let host = RemoteHostRegistry.shared.host(forPath: worktreePath)
-            let launchSpec = await resolvedLaunchSpec(for: spec, host: host)
+            var launchSpec = await resolvedLaunchSpec(for: spec, host: host)
+            if host == nil, let cliEnv = await alasCLIEnvProvider?(worktreePath, sessionId) {
+                launchSpec = launchSpec.mergingExtraEnv(cliEnv)
+                cliEnvActive = true
+            }
             if let injectedConnectionFactory {
                 connection = try injectedConnectionFactory(launchSpec, host, worktreePath)
             } else {
@@ -2251,6 +2272,9 @@ extension ACPSessionManager {
             await releaseWriterLease(sessionId: sessionId)
             return
         }
+        // TODO(pi-MCP-parity task 4): fold into the first-prompt preamble
+        // alongside injected MCP servers.
+        _ = cliEnvActive
         // Collect a short tail of stderr so we can surface it when the
         // agent rejects initialize / new for protocol or auth reasons.
         let stderrBuffer = StderrBuffer()

--- a/Alas/Sources/ACP/Session/AlasCLIEnvInjection.swift
+++ b/Alas/Sources/ACP/Session/AlasCLIEnvInjection.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Environment injected into locally spawned ACP adapter processes so any
+/// agent's shell can drive the `alas` CLI (open files, worktrees, reviews,
+/// notify) against the running app. The same tool surface the built-in MCP
+/// server shims; for adapters that ignore ACP MCP config (see
+/// `ACPMCPInjectionSupport.external`) this is the only path to Alas tools.
+enum AlasCLIEnvInjection {
+    /// The extra process env, or nil when the CLI is unavailable
+    /// (feature disabled, managed binary or app socket missing).
+    static func environment(
+        enabled: Bool,
+        binDirPath: String?,
+        socketPath: String?,
+        worktreePath: String,
+        sessionId: String,
+        parentSessionId: String?,
+        basePATH: String?
+    ) -> [String: String]? {
+        guard enabled, let binDirPath, let socketPath else { return nil }
+        var env: [String: String] = [
+            "ALAS_SOCKET_PATH": socketPath,
+            "ALAS_WORKTREE_DIR": worktreePath,
+            "ALAS_SESSION_ID": sessionId,
+            "PATH": TerminalCLIInjection.pathValue(prepending: binDirPath, to: basePATH),
+        ]
+        if let parentSessionId {
+            env["ALAS_PARENT_SESSION_ID"] = parentSessionId
+        }
+        return env
+    }
+}

--- a/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
+++ b/Alas/Sources/ACP/Session/MCPAttachmentPlanner.swift
@@ -135,6 +135,13 @@ enum MCPAttachmentPlanner {
         return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
+    static func resolvedConfigurationFingerprint(for servers: [ACPMCPServer]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let data = (try? encoder.encode(servers)) ?? Data()
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
     private static func resolvedEnvironment(for input: MCPAttachmentPlannerInput) -> [String: String] {
         var environment = input.environment
         environment["PROJECT_DIR"] = input.projectDirectory

--- a/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct ACPMCPStatusControl: View {
     @ObservedObject var session: ACPSession
     let currentServers: [ProjectMCPServer]
+    var onInstallPiMCPAdapter: (() async -> Bool)? = nil
     @Environment(\.theme) private var theme
     @State private var popoverOpen = false
 
@@ -14,7 +15,8 @@ struct ACPMCPStatusControl: View {
             summary: session.mcpAttachmentSummary,
             currentServers: currentServers,
             preamblePending: session.pendingMCPPreamble != nil,
-            preambleSent: session.mcpPreambleSent
+            preambleSent: session.mcpPreambleSent,
+            externalStatus: session.mcpExternalStatus
         )
     }
 
@@ -51,7 +53,7 @@ struct ACPMCPStatusControl: View {
             .help(status.accessibilitySummary)
             .accessibilityLabel(status.accessibilitySummary)
             .popover(isPresented: $popoverOpen, arrowEdge: .top) {
-                ACPMCPStatusPopover(status: status)
+                ACPMCPStatusPopover(status: status, onInstallPiMCPAdapter: onInstallPiMCPAdapter)
             }
         }
     }
@@ -69,8 +71,12 @@ struct ACPMCPStatusControl: View {
 }
 
 private struct ACPMCPStatusPopover: View {
+    enum InstallState { case idle, running, done, failed }
+
     let status: ACPMCPStatusState
+    var onInstallPiMCPAdapter: (() async -> Bool)? = nil
     @Environment(\.theme) private var theme
+    @State private var installState: InstallState = .idle
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -103,7 +109,7 @@ private struct ACPMCPStatusPopover: View {
             Divider().background(theme.color("line"))
 
             VStack(spacing: 0) {
-                ForEach(status.rows) { row in
+                ForEach(status.externalRows ?? status.rows) { row in
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Image(systemName: row.isRequested ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                             .font(.system(size: 11))
@@ -125,6 +131,10 @@ private struct ACPMCPStatusPopover: View {
                 }
             }
 
+            if status.showsAdapterInstallAction {
+                installActionRow
+            }
+
             if let detail = status.preambleDetail {
                 Divider().background(theme.color("line"))
                 HStack(spacing: 7) {
@@ -141,5 +151,39 @@ private struct ACPMCPStatusPopover: View {
         }
         .frame(width: 300)
         .background(theme.color("bg-1"))
+    }
+
+    @ViewBuilder
+    private var installActionRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            switch installState {
+            case .idle:
+                AlasButton(title: "Install pi-mcp-adapter", style: .subtle) {
+                    guard let onInstallPiMCPAdapter else { return }
+                    installState = .running
+                    Task {
+                        let success = await onInstallPiMCPAdapter()
+                        installState = success ? .done : .failed
+                    }
+                }
+            case .running:
+                HStack(spacing: 7) {
+                    ProgressView().controlSize(.small)
+                    Text("Installing pi-mcp-adapter…")
+                        .font(.system(size: 11))
+                }
+                .foregroundStyle(theme.color("fg-muted"))
+            case .done:
+                Text("Installed ✓ — reconnect to apply")
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("add"))
+            case .failed:
+                Text("Install failed — see pi output")
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("warn"))
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -54,20 +54,33 @@ struct ACPMCPStatusState: Equatable {
                     ? "via alas CLI (environment injected)"
                     : "unavailable (Alas CLI not injected)",
                 isRequested: externalStatus.cliActive)
+            let availability = externalStatus.adapterServerAvailability
             let adapterDetail: String
-            switch (externalStatus.adapterState, externalStatus.configOutcome) {
-            case (.installed, .refusedUnmanaged?): adapterDetail = "using your existing .pi/mcp.json"
-            case (.installed, .failed?): adapterDetail = "config sync failed — see logs"
-            case (.installed, _): adapterDetail = "via pi-mcp-adapter"
-            case (.missing, _), (.unknown, _): adapterDetail = "requires the pi-mcp-adapter extension"
+            let adapterIsRequested: Bool
+            switch availability {
+            case .available:
+                adapterDetail = "via pi-mcp-adapter"
+                adapterIsRequested = true
+            case .userManaged:
+                adapterDetail = "using your existing .pi/mcp.json"
+                adapterIsRequested = false
+            case .syncFailed:
+                adapterDetail = "config sync failed — see logs"
+                adapterIsRequested = false
+            case .notInstalled:
+                adapterDetail = "requires the pi-mcp-adapter extension"
+                adapterIsRequested = false
+            case .noServers:
+                adapterDetail = "via pi-mcp-adapter"
+                adapterIsRequested = false
             }
             let adapterRow = Row(
                 id: "external-adapter", name: "user MCP servers",
                 transport: "pi-mcp-adapter",
                 detail: adapterDetail,
-                isRequested: externalStatus.adapterServersAvailable)
+                isRequested: adapterIsRequested)
             externalRows = [cliRow, adapterRow]
-            showsAdapterInstallAction = externalStatus.adapterState != .installed
+            showsAdapterInstallAction = availability == .notInstalled
         } else {
             externalRows = nil
             showsAdapterInstallAction = false

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -89,6 +89,7 @@ struct ACPMCPStatusState: Equatable {
             skippedCount = (cliRow.isRequested ? 0 : 1)
                 + (adapterCountsAsSkipped ? 1 : 0)
             showsAdapterInstallAction = availability == .notInstalled
+                && externalStatus.canInstallAdapterLocally
         } else {
             externalRows = nil
             requestedCount = summary.statuses.count { $0.disposition == .requested }

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -32,8 +32,6 @@ struct ACPMCPStatusState: Equatable {
             return nil
         }
 
-        requestedCount = summary.statuses.count { $0.disposition == .requested }
-        skippedCount = summary.statuses.count - requestedCount
         isStale = summary.configurationFingerprint
             != MCPAttachmentPlanner.configurationFingerprint(for: currentServers)
         rows = summary.statuses.map(Self.row)
@@ -79,10 +77,15 @@ struct ACPMCPStatusState: Equatable {
                 transport: "pi-mcp-adapter",
                 detail: adapterDetail,
                 isRequested: adapterIsRequested)
-            externalRows = [cliRow, adapterRow]
+            let rows = [cliRow, adapterRow]
+            externalRows = rows
+            requestedCount = rows.count(where: \.isRequested)
+            skippedCount = rows.count - requestedCount
             showsAdapterInstallAction = availability == .notInstalled
         } else {
             externalRows = nil
+            requestedCount = summary.statuses.count { $0.disposition == .requested }
+            skippedCount = summary.statuses.count - requestedCount
             showsAdapterInstallAction = false
         }
     }

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -34,7 +34,7 @@ struct ACPMCPStatusState: Equatable {
 
         isStale = summary.configurationFingerprint
             != MCPAttachmentPlanner.configurationFingerprint(for: currentServers)
-        rows = summary.statuses.map(Self.row)
+        rows = summary.statuses.map { Self.row($0) }
 
         if preamblePending {
             preambleDetail = "Context preamble pending — sent with the next prompt"
@@ -83,11 +83,15 @@ struct ACPMCPStatusState: Equatable {
                 transport: "pi-mcp-adapter",
                 detail: adapterDetail,
                 isRequested: adapterIsRequested)
-            let rows = [cliRow, adapterRow]
+            let skippedRows = externalStatus.skippedServerStatuses.map {
+                Self.row($0, idPrefix: "external-skipped-")
+            }
+            let rows = [cliRow, adapterRow] + skippedRows
             externalRows = rows
             requestedCount = rows.count(where: \.isRequested)
             skippedCount = (cliRow.isRequested ? 0 : 1)
                 + (adapterCountsAsSkipped ? 1 : 0)
+                + skippedRows.count
             showsAdapterInstallAction = availability == .notInstalled
                 && externalStatus.canInstallAdapterLocally
         } else {
@@ -113,7 +117,7 @@ struct ACPMCPStatusState: Equatable {
         return parts.joined(separator: ", ")
     }
 
-    private static func row(_ status: MCPAttachmentServerStatus) -> Row {
+    private static func row(_ status: MCPAttachmentServerStatus, idPrefix: String = "") -> Row {
         let transport: String
         switch status.transport {
         case .stdio: transport = "stdio"
@@ -124,7 +128,7 @@ struct ACPMCPStatusState: Equatable {
         switch status.disposition {
         case .requested:
             return .init(
-                id: status.id,
+                id: idPrefix + status.id,
                 name: status.name,
                 transport: transport,
                 detail: "Requested",
@@ -132,7 +136,7 @@ struct ACPMCPStatusState: Equatable {
             )
         case let .skipped(reason):
             return .init(
-                id: status.id,
+                id: idPrefix + status.id,
                 name: status.name,
                 transport: transport,
                 detail: skipDetail(reason),

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -57,6 +57,7 @@ struct ACPMCPStatusState: Equatable {
             let adapterDetail: String
             switch (externalStatus.adapterState, externalStatus.configOutcome) {
             case (.installed, .refusedUnmanaged?): adapterDetail = "using your existing .pi/mcp.json"
+            case (.installed, .failed?): adapterDetail = "config sync failed — see logs"
             case (.installed, _): adapterDetail = "via pi-mcp-adapter"
             case (.missing, _), (.unknown, _): adapterDetail = "requires the pi-mcp-adapter extension"
             }
@@ -64,7 +65,7 @@ struct ACPMCPStatusState: Equatable {
                 id: "external-adapter", name: "user MCP servers",
                 transport: "pi-mcp-adapter",
                 detail: adapterDetail,
-                isRequested: externalStatus.adapterState == .installed)
+                isRequested: externalStatus.adapterServersAvailable)
             externalRows = [cliRow, adapterRow]
             showsAdapterInstallAction = externalStatus.adapterState != .installed
         } else {

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -55,22 +55,28 @@ struct ACPMCPStatusState: Equatable {
             let availability = externalStatus.adapterServerAvailability
             let adapterDetail: String
             let adapterIsRequested: Bool
+            let adapterCountsAsSkipped: Bool
             switch availability {
             case .available:
                 adapterDetail = "via pi-mcp-adapter"
                 adapterIsRequested = true
+                adapterCountsAsSkipped = false
             case .userManaged:
                 adapterDetail = "using your existing .pi/mcp.json"
                 adapterIsRequested = false
+                adapterCountsAsSkipped = true
             case .syncFailed:
                 adapterDetail = "config sync failed — see logs"
                 adapterIsRequested = false
+                adapterCountsAsSkipped = true
             case .notInstalled:
                 adapterDetail = "requires the pi-mcp-adapter extension"
                 adapterIsRequested = false
+                adapterCountsAsSkipped = true
             case .noServers:
                 adapterDetail = "via pi-mcp-adapter"
                 adapterIsRequested = false
+                adapterCountsAsSkipped = false
             }
             let adapterRow = Row(
                 id: "external-adapter", name: "user MCP servers",
@@ -80,7 +86,8 @@ struct ACPMCPStatusState: Equatable {
             let rows = [cliRow, adapterRow]
             externalRows = rows
             requestedCount = rows.count(where: \.isRequested)
-            skippedCount = rows.count - requestedCount
+            skippedCount = (cliRow.isRequested ? 0 : 1)
+                + (adapterCountsAsSkipped ? 1 : 0)
             showsAdapterInstallAction = availability == .notInstalled
         } else {
             externalRows = nil

--- a/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusPolicy.swift
@@ -17,12 +17,15 @@ struct ACPMCPStatusState: Equatable {
     let isStale: Bool
     let rows: [Row]
     let preambleDetail: String?
+    let externalRows: [Row]?
+    let showsAdapterInstallAction: Bool
 
     init?(
         summary: MCPAttachmentSummary?,
         currentServers: [ProjectMCPServer],
         preamblePending: Bool = false,
-        preambleSent: Bool = false
+        preambleSent: Bool = false,
+        externalStatus: ACPMCPExternalStatus? = nil
     ) {
         guard let summary,
               !summary.statuses.isEmpty || !currentServers.isEmpty else {
@@ -41,6 +44,32 @@ struct ACPMCPStatusState: Equatable {
             preambleDetail = "Context preamble sent"
         } else {
             preambleDetail = nil
+        }
+
+        if let externalStatus {
+            let cliRow = Row(
+                id: "external-cli", name: "alas tools",
+                transport: "CLI",
+                detail: externalStatus.cliActive
+                    ? "via alas CLI (environment injected)"
+                    : "unavailable (Alas CLI not injected)",
+                isRequested: externalStatus.cliActive)
+            let adapterDetail: String
+            switch (externalStatus.adapterState, externalStatus.configOutcome) {
+            case (.installed, .refusedUnmanaged?): adapterDetail = "using your existing .pi/mcp.json"
+            case (.installed, _): adapterDetail = "via pi-mcp-adapter"
+            case (.missing, _), (.unknown, _): adapterDetail = "requires the pi-mcp-adapter extension"
+            }
+            let adapterRow = Row(
+                id: "external-adapter", name: "user MCP servers",
+                transport: "pi-mcp-adapter",
+                detail: adapterDetail,
+                isRequested: externalStatus.adapterState == .installed)
+            externalRows = [cliRow, adapterRow]
+            showsAdapterInstallAction = externalStatus.adapterState != .installed
+        } else {
+            externalRows = nil
+            showsAdapterInstallAction = false
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPToolbar.swift
+++ b/Alas/Sources/ACP/UI/ACPToolbar.swift
@@ -21,7 +21,8 @@ struct ACPToolbar: View {
             )
             ACPMCPStatusControl(
                 session: session,
-                currentServers: state.projects.first(where: { $0.id == worktree.projectId })?.mcpServers ?? []
+                currentServers: state.projects.first(where: { $0.id == worktree.projectId })?.mcpServers ?? [],
+                onInstallPiMCPAdapter: { await state.installPiMCPAdapter() }
             )
             ACPRecoveryPill(session: session)
             if let currentGoal = session.currentGoal {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4793,14 +4793,34 @@ final class AppState {
             guard let self else { return (.unknown, nil) }
             let adapterState = PiMCPAdapterInspector.state()
             guard adapterState == .installed else { return (adapterState, nil) }
-            let servers = self.projects.first(where: { $0.id == worktree.projectId })?.mcpServers ?? []
+            let project = self.projects.first(where: { $0.id == worktree.projectId })
+            let servers = project?.mcpServers ?? []
             let fingerprint = MCPAttachmentPlanner.configurationFingerprint(for: servers)
             let worktreeURL = URL(fileURLWithPath: worktreePath)
-            let configOutcome = try? PiMCPConfigWriter.sync(
-                worktreeURL: worktreeURL,
-                servers: servers,
-                fingerprint: fingerprint
-            )
+            // pi-mcp-adapter reads the resolved wire config, not the raw
+            // project definitions, so ${WORKTREE_DIR}/${PROJECT_DIR}
+            // templates are interpolated exactly as the normal ACP
+            // session/new attach path does. Unlike that path, http/sse are
+            // force-enabled here: pi-mcp-adapter supports them even though
+            // pi-acp's own ACP layer reports them unsupported, so this must
+            // not drop those servers.
+            let plan = MCPAttachmentPlanner.plan(.init(
+                configuredServers: servers,
+                projectDirectory: project?.path ?? worktreePath,
+                worktreeDirectory: worktreePath,
+                environment: ACPProcessEnvironment.sanitizedForACP(extra: [:]),
+                capabilities: ACPMCPServerCapabilities(http: true, sse: true)
+            ))
+            let configOutcome: PiMCPConfigWriter.Outcome
+            do {
+                configOutcome = try PiMCPConfigWriter.sync(
+                    worktreeURL: worktreeURL,
+                    servers: plan.wireServers,
+                    fingerprint: fingerprint
+                )
+            } catch {
+                configOutcome = .failed
+            }
             if configOutcome == .wrote {
                 await self.excludePiDirectoryFromGit(worktreeURL: worktreeURL)
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4789,12 +4789,63 @@ final class AppState {
                 basePATH: ACPProcessEnvironment.augmented()["PATH"]
             )
         }
+        mgr.externalMCPStatusProvider = { [weak self] worktreePath in
+            guard let self else { return (.unknown, nil) }
+            let adapterState = PiMCPAdapterInspector.state()
+            guard adapterState == .installed else { return (adapterState, nil) }
+            let servers = self.projects.first(where: { $0.id == worktree.projectId })?.mcpServers ?? []
+            let fingerprint = MCPAttachmentPlanner.configurationFingerprint(for: servers)
+            let worktreeURL = URL(fileURLWithPath: worktreePath)
+            let configOutcome = try? PiMCPConfigWriter.sync(
+                worktreeURL: worktreeURL,
+                servers: servers,
+                fingerprint: fingerprint
+            )
+            if configOutcome == .wrote {
+                await self.excludePiDirectoryFromGit(worktreeURL: worktreeURL)
+            }
+            return (adapterState, configOutcome)
+        }
         acpManagers[worktree.id] = mgr
         acpHarnessBridge.attach(manager: mgr)
         #if DEBUG
         memoryDiagnostics.attach(manager: mgr)
         #endif
         return mgr
+    }
+
+    /// Adds `.pi/` to this worktree's `.git/info/exclude` after a managed
+    /// `.pi/mcp.json` is first written, so the generated file never shows up
+    /// as untracked/dirty in the changes list. `GitIgnoreService.appendIgnore`
+    /// is idempotent (skips if the pattern already exists), so calling this
+    /// on every write is safe. Linked worktrees keep `info/exclude` outside
+    /// the working tree, so the path is resolved via
+    /// `git rev-parse --git-path` — same approach as
+    /// `RightPaneState.ignore(path:isDirectory:destination:)`. Best-effort:
+    /// failures are silently ignored (worst case `.pi/` shows as untracked).
+    private func excludePiDirectoryFromGit(worktreeURL: URL) async {
+        do {
+            let infoExcludeURL = try await resolveGitInfoExcludeURL(worktreeURL: worktreeURL)
+            _ = try GitIgnoreService.appendIgnore(
+                entryPath: ".pi",
+                isDirectory: true,
+                destination: .infoExclude,
+                repoURL: worktreeURL,
+                infoExcludeURL: infoExcludeURL
+            )
+        } catch {
+            // Non-fatal: the managed mcp.json still works, it just may show
+            // as untracked until the next successful attach retries this.
+        }
+    }
+
+    private func resolveGitInfoExcludeURL(worktreeURL: URL) async throws -> URL {
+        let result = try await Process.git(["rev-parse", "--git-path", "info/exclude"], cwd: worktreeURL)
+        let raw = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        if raw.hasPrefix("/") {
+            return URL(fileURLWithPath: raw)
+        }
+        return URL(fileURLWithPath: raw, relativeTo: worktreeURL).standardizedFileURL
     }
 
     /// Release the ACP session manager for the given worktree id.

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4790,20 +4790,22 @@ final class AppState {
             )
         }
         mgr.externalMCPStatusProvider = { [weak self] worktreePath in
-            guard let self else { return (.unknown, nil) }
+            guard let self else { return (.unknown, nil, []) }
             let adapterState = PiMCPAdapterInspector.state()
-            guard adapterState == .installed else { return (adapterState, nil) }
             let project = self.projects.first(where: { $0.id == worktree.projectId })
             let servers = project?.mcpServers ?? []
-            let fingerprint = MCPAttachmentPlanner.configurationFingerprint(for: servers)
             let worktreeURL = URL(fileURLWithPath: worktreePath)
-            // pi-mcp-adapter reads the resolved wire config, not the raw
-            // project definitions, so ${WORKTREE_DIR}/${PROJECT_DIR}
-            // templates are interpolated exactly as the normal ACP
-            // session/new attach path does. Unlike that path, http/sse are
-            // force-enabled here: pi-mcp-adapter supports them even though
-            // pi-acp's own ACP layer reports them unsupported, so this must
-            // not drop those servers.
+            // Resolved unconditionally — even when the adapter is not
+            // (yet) installed — so the preamble can name the project's
+            // servers regardless of adapter state ("not installed" wording
+            // still lists them). pi-mcp-adapter reads the resolved wire
+            // config, not the raw project definitions, so
+            // ${WORKTREE_DIR}/${PROJECT_DIR} templates are interpolated
+            // exactly as the normal ACP session/new attach path does.
+            // Unlike that path, http/sse are force-enabled here:
+            // pi-mcp-adapter supports them even though pi-acp's own ACP
+            // layer reports them unsupported, so this must not drop those
+            // servers.
             let plan = MCPAttachmentPlanner.plan(.init(
                 configuredServers: servers,
                 projectDirectory: project?.path ?? worktreePath,
@@ -4811,6 +4813,9 @@ final class AppState {
                 environment: ACPProcessEnvironment.sanitizedForACP(extra: [:]),
                 capabilities: ACPMCPServerCapabilities(http: true, sse: true)
             ))
+            let userServerNames = plan.wireServers.map(\.name)
+            guard adapterState == .installed else { return (adapterState, nil, userServerNames) }
+            let fingerprint = MCPAttachmentPlanner.configurationFingerprint(for: servers)
             let configOutcome: PiMCPConfigWriter.Outcome
             do {
                 configOutcome = try PiMCPConfigWriter.sync(
@@ -4824,7 +4829,7 @@ final class AppState {
             if configOutcome == .wrote {
                 await self.excludePiDirectoryFromGit(worktreeURL: worktreeURL)
             }
-            return (adapterState, configOutcome)
+            return (adapterState, configOutcome, userServerNames)
         }
         acpManagers[worktree.id] = mgr
         acpHarnessBridge.attach(manager: mgr)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4771,6 +4771,24 @@ final class AppState {
                 )
             }
         )
+        mgr.alasCLIEnvProvider = { [weak self] worktreePath, sessionId in
+            guard let self else { return nil }
+            let binDirPath = (try? TerminalCLIInjection.installExecutables())?.path
+            let persistedParent = try? await self.acpOrchestrationPersistence.parent(
+                childSessionId: sessionId
+            )
+            let parentSessionId = self.delegatedSessionParents[sessionId]
+                ?? persistedParent?.parentSessionId
+            return AlasCLIEnvInjection.environment(
+                enabled: self.config.harness.exposeAlasMCP,
+                binDirPath: binDirPath,
+                socketPath: self.harness.socketServer.socketPath,
+                worktreePath: worktreePath,
+                sessionId: sessionId,
+                parentSessionId: parentSessionId,
+                basePATH: ACPProcessEnvironment.augmented()["PATH"]
+            )
+        }
         acpManagers[worktree.id] = mgr
         acpHarnessBridge.attach(manager: mgr)
         #if DEBUG

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4826,7 +4826,7 @@ final class AppState {
             } catch {
                 configOutcome = .failed
             }
-            if configOutcome == .wrote {
+            if Self.shouldExcludePiDirectory(after: configOutcome) {
                 await self.excludePiDirectoryFromGit(worktreeURL: worktreeURL)
             }
             return (adapterState, configOutcome, userServerNames)
@@ -4840,11 +4840,11 @@ final class AppState {
     }
 
     /// Adds `.pi/` to this worktree's `.git/info/exclude` after a managed
-    /// `.pi/mcp.json` is first written, so the generated file never shows up
-    /// as untracked/dirty in the changes list. `GitIgnoreService.appendIgnore`
-    /// is idempotent (skips if the pattern already exists), so calling this
-    /// on every write is safe. Linked worktrees keep `info/exclude` outside
-    /// the working tree, so the path is resolved via
+    /// `.pi/mcp.json` is written or confirmed unchanged, so the generated file
+    /// never shows up as untracked/dirty in the changes list. `GitIgnoreService.appendIgnore`
+    /// is idempotent (skips if the pattern already exists), so retrying this
+    /// for managed configs is safe. Linked worktrees keep `info/exclude`
+    /// outside the working tree, so the path is resolved via
     /// `git rev-parse --git-path` — same approach as
     /// `RightPaneState.ignore(path:isDirectory:destination:)`. Best-effort:
     /// failures are silently ignored (worst case `.pi/` shows as untracked).
@@ -4862,6 +4862,10 @@ final class AppState {
             // Non-fatal: the managed mcp.json still works, it just may show
             // as untracked until the next successful attach retries this.
         }
+    }
+
+    static func shouldExcludePiDirectory(after outcome: PiMCPConfigWriter.Outcome) -> Bool {
+        outcome == .wrote || outcome == .unchanged
     }
 
     private func resolveGitInfoExcludeURL(worktreeURL: URL) async throws -> URL {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6,6 +6,8 @@ import os
 @Observable
 @MainActor
 final class AppState {
+    static let piMCPGeneratedConfigExcludePath = ".pi/mcp.json"
+
     /// Stable for this process; identifies this app instance to the ACP
     /// session-lease layer so two running Alas builds don't fight over a
     /// shared per-worktree database.
@@ -4852,8 +4854,8 @@ final class AppState {
         do {
             let infoExcludeURL = try await resolveGitInfoExcludeURL(worktreeURL: worktreeURL)
             _ = try GitIgnoreService.appendIgnore(
-                entryPath: ".pi",
-                isDirectory: true,
+                entryPath: Self.piMCPGeneratedConfigExcludePath,
+                isDirectory: false,
                 destination: .infoExclude,
                 repoURL: worktreeURL,
                 infoExcludeURL: infoExcludeURL

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4791,10 +4791,10 @@ final class AppState {
         }
         mgr.externalMCPStatusProvider = { [weak self] worktreePath in
             guard let self else { return (.unknown, nil, []) }
-            let adapterState = PiMCPAdapterInspector.state()
+            let worktreeURL = URL(fileURLWithPath: worktreePath)
+            let adapterState = PiMCPAdapterInspector.state(worktreeURL: worktreeURL)
             let project = self.projects.first(where: { $0.id == worktree.projectId })
             let servers = project?.mcpServers ?? []
-            let worktreeURL = URL(fileURLWithPath: worktreePath)
             // Resolved unconditionally — even when the adapter is not
             // (yet) installed — so the preamble can name the project's
             // servers regardless of adapter state ("not installed" wording

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4815,7 +4815,7 @@ final class AppState {
             ))
             let userServerNames = plan.wireServers.map(\.name)
             guard adapterState == .installed else { return (adapterState, nil, userServerNames) }
-            let fingerprint = MCPAttachmentPlanner.configurationFingerprint(for: servers)
+            let fingerprint = MCPAttachmentPlanner.resolvedConfigurationFingerprint(for: plan.wireServers)
             let configOutcome: PiMCPConfigWriter.Outcome
             do {
                 configOutcome = try PiMCPConfigWriter.sync(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4792,7 +4792,7 @@ final class AppState {
             )
         }
         mgr.externalMCPStatusProvider = { [weak self] worktreePath in
-            guard let self else { return (.unknown, nil, []) }
+            guard let self else { return (.unknown, nil, [], []) }
             let worktreeURL = URL(fileURLWithPath: worktreePath)
             let adapterState = PiMCPAdapterInspector.state(worktreeURL: worktreeURL)
             let project = self.projects.first(where: { $0.id == worktree.projectId })
@@ -4816,7 +4816,13 @@ final class AppState {
                 capabilities: ACPMCPServerCapabilities(http: true, sse: true)
             ))
             let userServerNames = plan.wireServers.map(\.name)
-            guard adapterState == .installed else { return (adapterState, nil, userServerNames) }
+            let skippedServerStatuses = plan.statuses.filter {
+                if case .skipped = $0.disposition { return true }
+                return false
+            }
+            guard adapterState == .installed else {
+                return (adapterState, nil, userServerNames, skippedServerStatuses)
+            }
             let fingerprint = MCPAttachmentPlanner.resolvedConfigurationFingerprint(for: plan.wireServers)
             let configOutcome: PiMCPConfigWriter.Outcome
             do {
@@ -4831,7 +4837,7 @@ final class AppState {
             if Self.shouldExcludePiDirectory(after: configOutcome) {
                 await self.excludePiDirectoryFromGit(worktreeURL: worktreeURL)
             }
-            return (adapterState, configOutcome, userServerNames)
+            return (adapterState, configOutcome, userServerNames, skippedServerStatuses)
         }
         acpManagers[worktree.id] = mgr
         acpHarnessBridge.attach(manager: mgr)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4848,6 +4848,26 @@ final class AppState {
         return URL(fileURLWithPath: raw, relativeTo: worktreeURL).standardizedFileURL
     }
 
+    /// Runs `pi install npm:pi-mcp-adapter` (pi resolves its own package
+    /// management). Returns true when pi exits 0.
+    func installPiMCPAdapter() async -> Bool {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+                process.arguments = ["pi", "install", "npm:pi-mcp-adapter"]
+                process.environment = ACPProcessEnvironment.augmented()
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    continuation.resume(returning: process.terminationStatus == 0)
+                } catch {
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+
     /// Release the ACP session manager for the given worktree id.
     /// Called from `cleanupWorktreeState` when a worktree is
     /// removed/archived. Stops every attached runner (which cancels

--- a/Alas/Sources/Harness/PiMCPAdapterInspector.swift
+++ b/Alas/Sources/Harness/PiMCPAdapterInspector.swift
@@ -10,10 +10,10 @@ enum PiMCPAdapterInspector {
     static let packageName = "pi-mcp-adapter"
 
     static func state(
-        agentDir: URL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".pi/agent", isDirectory: true),
+        agentDir: URL? = nil,
         worktreeURL: URL? = nil
     ) -> State {
+        let agentDir = agentDir ?? defaultAgentDir()
         var states: [State] = []
         if let worktreeURL {
             states.append(manifestState(worktreeURL.appendingPathComponent(".pi/npm/package.json")))
@@ -22,6 +22,17 @@ enum PiMCPAdapterInspector {
         if states.contains(.installed) { return .installed }
         if states.contains(.missing) { return .missing }
         return .unknown
+    }
+
+    static func defaultAgentDir(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let custom = environment["PI_CODING_AGENT_DIR"],
+           !custom.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return URL(fileURLWithPath: custom, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".pi/agent", isDirectory: true)
     }
 
     private static func manifestState(_ manifest: URL) -> State {

--- a/Alas/Sources/Harness/PiMCPAdapterInspector.swift
+++ b/Alas/Sources/Harness/PiMCPAdapterInspector.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Detects whether pi has the `pi-mcp-adapter` extension installed.
+/// `pi install npm:<pkg>` records packages as dependencies in
+/// `<agent dir>/npm/package.json` (verified against a live install).
+enum PiMCPAdapterInspector {
+    enum State: Equatable { case installed, missing, unknown }
+
+    static let packageName = "pi-mcp-adapter"
+
+    static func state(
+        agentDir: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".pi/agent", isDirectory: true)
+    ) -> State {
+        let manifest = agentDir.appendingPathComponent("npm/package.json")
+        guard let data = try? Data(contentsOf: manifest),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return .unknown }
+        let dependencies = json["dependencies"] as? [String: Any] ?? [:]
+        return dependencies[packageName] != nil ? .installed : .missing
+    }
+}

--- a/Alas/Sources/Harness/PiMCPAdapterInspector.swift
+++ b/Alas/Sources/Harness/PiMCPAdapterInspector.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// Detects whether pi has the `pi-mcp-adapter` extension installed.
 /// `pi install npm:<pkg>` records packages as dependencies in
-/// `<agent dir>/npm/package.json` (verified against a live install).
+/// `<agent dir>/npm/package.json` (verified against a live install). Project
+/// local installs live under the worktree's `.pi/npm/package.json`.
 enum PiMCPAdapterInspector {
     enum State: Equatable { case installed, missing, unknown }
 
@@ -10,9 +11,20 @@ enum PiMCPAdapterInspector {
 
     static func state(
         agentDir: URL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".pi/agent", isDirectory: true)
+            .appendingPathComponent(".pi/agent", isDirectory: true),
+        worktreeURL: URL? = nil
     ) -> State {
-        let manifest = agentDir.appendingPathComponent("npm/package.json")
+        var states: [State] = []
+        if let worktreeURL {
+            states.append(manifestState(worktreeURL.appendingPathComponent(".pi/npm/package.json")))
+        }
+        states.append(manifestState(agentDir.appendingPathComponent("npm/package.json")))
+        if states.contains(.installed) { return .installed }
+        if states.contains(.missing) { return .missing }
+        return .unknown
+    }
+
+    private static func manifestState(_ manifest: URL) -> State {
         guard let data = try? Data(contentsOf: manifest),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return .unknown }

--- a/Alas/Sources/Harness/PiMCPConfigWriter.swift
+++ b/Alas/Sources/Harness/PiMCPConfigWriter.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Generates the pi-mcp-adapter project override (`.pi/mcp.json`) from the
+/// project's configured MCP servers. Managed files carry a `"$alas"` marker;
+/// unmanaged files are never touched. The built-in alas server is never
+/// written here — its env is per-session, and the CLI covers it.
+enum PiMCPConfigWriter {
+    enum Outcome: Equatable { case wrote, unchanged, refusedUnmanaged, removedManaged, noServers }
+
+    static let markerKey = "$alas"
+
+    static func sync(
+        worktreeURL: URL,
+        servers: [ProjectMCPServer],
+        fingerprint: String
+    ) throws -> Outcome {
+        let dir = worktreeURL.appendingPathComponent(".pi", isDirectory: true)
+        let fileURL = dir.appendingPathComponent("mcp.json")
+        let existing = readExisting(fileURL)
+
+        switch existing {
+        case .unmanaged:
+            return .refusedUnmanaged
+        case .managed(let existingFingerprint):
+            if servers.isEmpty {
+                try FileManager.default.removeItem(at: fileURL)
+                return .removedManaged
+            }
+            if existingFingerprint == fingerprint { return .unchanged }
+        case .absent:
+            if servers.isEmpty { return .noServers }
+        }
+
+        var mcpServers: [String: Any] = [:]
+        for server in servers {
+            switch server.transport {
+            case let .stdio(command, args, environment):
+                var entry: [String: Any] = ["command": command, "args": args]
+                if !environment.isEmpty {
+                    entry["env"] = Dictionary(environment.map { ($0.name, $0.value) }) { _, last in last }
+                }
+                mcpServers[server.name] = entry
+            case let .http(url, headers), let .sse(url, headers):
+                var entry: [String: Any] = ["url": url]
+                if !headers.isEmpty {
+                    entry["headers"] = Dictionary(headers.map { ($0.name, $0.value) }) { _, last in last }
+                }
+                mcpServers[server.name] = entry
+            }
+        }
+        let payload: [String: Any] = [
+            markerKey: ["managed": true, "fingerprint": fingerprint],
+            "mcpServers": mcpServers,
+        ]
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys, .prettyPrinted])
+        try data.write(to: fileURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+        return .wrote
+    }
+
+    private enum Existing { case absent, unmanaged, managed(fingerprint: String?) }
+
+    private static func readExisting(_ url: URL) -> Existing {
+        guard let data = try? Data(contentsOf: url) else { return .absent }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let marker = json[markerKey] as? [String: Any],
+              marker["managed"] as? Bool == true
+        else { return .unmanaged }
+        return .managed(fingerprint: marker["fingerprint"] as? String)
+    }
+}

--- a/Alas/Sources/Harness/PiMCPConfigWriter.swift
+++ b/Alas/Sources/Harness/PiMCPConfigWriter.swift
@@ -5,13 +5,16 @@ import Foundation
 /// unmanaged files are never touched. The built-in alas server is never
 /// written here — its env is per-session, and the CLI covers it.
 enum PiMCPConfigWriter {
-    enum Outcome: Equatable { case wrote, unchanged, refusedUnmanaged, removedManaged, noServers }
+    enum Outcome: Equatable { case wrote, unchanged, refusedUnmanaged, removedManaged, noServers, failed }
 
     static let markerKey = "$alas"
 
+    /// `servers` must already be fully resolved (e.g. via
+    /// `MCPAttachmentPlanner.plan(...).wireServers`) — `${WORKTREE_DIR}` /
+    /// `${PROJECT_DIR}` templates are not interpolated here.
     static func sync(
         worktreeURL: URL,
-        servers: [ProjectMCPServer],
+        servers: [ACPMCPServer],
         fingerprint: String
     ) throws -> Outcome {
         let dir = worktreeURL.appendingPathComponent(".pi", isDirectory: true)
@@ -33,19 +36,19 @@ enum PiMCPConfigWriter {
 
         var mcpServers: [String: Any] = [:]
         for server in servers {
-            switch server.transport {
-            case let .stdio(command, args, environment):
+            switch server {
+            case let .stdio(name, command, args, env):
                 var entry: [String: Any] = ["command": command, "args": args]
-                if !environment.isEmpty {
-                    entry["env"] = Dictionary(environment.map { ($0.name, $0.value) }) { _, last in last }
+                if !env.isEmpty {
+                    entry["env"] = Dictionary(env.map { ($0.name, $0.value) }) { _, last in last }
                 }
-                mcpServers[server.name] = entry
-            case let .http(url, headers), let .sse(url, headers):
+                mcpServers[name] = entry
+            case let .http(name, url, headers), let .sse(name, url, headers):
                 var entry: [String: Any] = ["url": url]
                 if !headers.isEmpty {
                     entry["headers"] = Dictionary(headers.map { ($0.name, $0.value) }) { _, last in last }
                 }
-                mcpServers[server.name] = entry
+                mcpServers[name] = entry
             }
         }
         let payload: [String: Any] = [

--- a/Alas/Sources/Harness/PiMCPConfigWriter.swift
+++ b/Alas/Sources/Harness/PiMCPConfigWriter.swift
@@ -57,16 +57,18 @@ enum PiMCPConfigWriter {
         ]
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys, .prettyPrinted])
-        // Create the file with 0600 *before* any token-bearing content is
-        // written, so there is never a window where a world/group-readable
-        // file holds MCP server tokens. A non-atomic write into an
-        // already-created file truncates in place and does not reset the
-        // mode bits picked at creation; the trailing `setAttributes` call
-        // re-asserts 0600 defensively in case that assumption ever changes.
-        guard FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: [.posixPermissions: 0o600]) else {
+        let tempURL = dir.appendingPathComponent(".mcp.json.\(UUID().uuidString).tmp")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        guard FileManager.default.createFile(atPath: tempURL.path, contents: nil, attributes: [.posixPermissions: 0o600]) else {
             throw CocoaError(.fileWriteUnknown)
         }
-        try data.write(to: fileURL)
+        try data.write(to: tempURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempURL.path)
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+        } else {
+            try FileManager.default.moveItem(at: tempURL, to: fileURL)
+        }
         try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
         return .wrote
     }

--- a/Alas/Sources/Harness/PiMCPConfigWriter.swift
+++ b/Alas/Sources/Harness/PiMCPConfigWriter.swift
@@ -54,7 +54,16 @@ enum PiMCPConfigWriter {
         ]
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys, .prettyPrinted])
-        try data.write(to: fileURL, options: .atomic)
+        // Create the file with 0600 *before* any token-bearing content is
+        // written, so there is never a window where a world/group-readable
+        // file holds MCP server tokens. A non-atomic write into an
+        // already-created file truncates in place and does not reset the
+        // mode bits picked at creation; the trailing `setAttributes` call
+        // re-asserts 0600 defensively in case that assumption ever changes.
+        guard FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: [.posixPermissions: 0o600]) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        try data.write(to: fileURL)
         try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
         return .wrote
     }

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -6,6 +6,7 @@ struct AgentsPane: View {
     var onNavigate: (SettingsSection) -> Void = { _ in }
 
     @State private var editing: EditTarget?
+    @State private var piAdapterState: PiMCPAdapterInspector.State = .unknown
 
     /// The sheet's content depends on what was clicked: existing agent (by
     /// id) or a brand-new custom (`.new`).
@@ -72,10 +73,22 @@ struct AgentsPane: View {
                             onNavigate(.terminal)
                         }
                     }
+                    if piAdapterState != .installed {
+                        SettingsRow(name: "Pi MCP adapter",
+                                    desc: "Pi reaches MCP servers through the pi-mcp-adapter extension.") {
+                            AlasButton(title: "Install pi-mcp-adapter", style: .subtle) {
+                                Task {
+                                    _ = await state.installPiMCPAdapter()
+                                    piAdapterState = PiMCPAdapterInspector.state()
+                                }
+                            }
+                        }
+                    }
                 }
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
         }
+        .onAppear { piAdapterState = PiMCPAdapterInspector.state() }
         .sheet(item: $editing) { target in
             AgentEditView(
                 state: state,

--- a/AlasTests/ACP/Adapter/ACPLaunchCatalogTests.swift
+++ b/AlasTests/ACP/Adapter/ACPLaunchCatalogTests.swift
@@ -23,4 +23,29 @@ struct ACPLaunchCatalogTests {
         #expect(ids.contains("copilot"))
         #expect(ids.contains("pi"))
     }
+
+    @Test("pi is the only external MCP-injection adapter")
+    func piIsExternal() throws {
+        let pi = try #require(ACPLaunchCatalog.spec(for: "pi"))
+        guard case let .external(hint) = pi.mcpInjection else {
+            Issue.record("expected .external for pi")
+            return
+        }
+        #expect(hint.contains("alas CLI"))
+        #expect(hint.contains("pi-mcp-adapter"))
+        for spec in ACPLaunchCatalog.specs where spec.agentID != "pi" {
+            #expect(spec.mcpInjection == .sessionNew, "\(spec.agentID) should default to sessionNew")
+        }
+    }
+
+    @Test("mergingExtraEnv overlays and preserves everything else")
+    func mergingExtraEnv() throws {
+        let base = try #require(ACPLaunchCatalog.spec(for: "pi"))
+        let merged = base.mergingExtraEnv(["ALAS_SESSION_ID": "s1", "PATH": "/x"])
+        #expect(merged.extraEnv["ALAS_SESSION_ID"] == "s1")
+        #expect(merged.extraEnv["PATH"] == "/x")
+        #expect(merged.agentID == base.agentID)
+        #expect(merged.command == base.command)
+        #expect(merged.mcpInjection == base.mcpInjection)
+    }
 }

--- a/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
+++ b/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
@@ -68,7 +68,7 @@ struct ACPMCPPromptPreambleTests {
     func cliMode() throws {
         let text = try #require(ACPMCPPromptPreamble.text(
             builtInInjected: true, isDelegated: false, userServerNames: [],
-            mode: .cli(adapterInstalled: false)))
+            mode: .cli(serverAvailability: .notInstalled)))
         #expect(text.contains("alas open"))
         #expect(text.contains("alas wt list"))
         #expect(text.contains("alas review"))
@@ -82,26 +82,45 @@ struct ACPMCPPromptPreambleTests {
     func cliModeDelegated() throws {
         let text = try #require(ACPMCPPromptPreamble.text(
             builtInInjected: true, isDelegated: true, userServerNames: [],
-            mode: .cli(adapterInstalled: false)))
+            mode: .cli(serverAvailability: .notInstalled)))
         #expect(text.contains("alas session send"))
         #expect(!text.contains("alas session new"))
         #expect(text.contains("delegated by a parent session"))
     }
 
-    @Test("cli mode user servers depend on adapter state")
+    @Test("cli mode user servers depend on adapter server availability")
     func cliModeUserServers() throws {
-        let installed = try #require(ACPMCPPromptPreamble.text(
+        let available = try #require(ACPMCPPromptPreamble.text(
             builtInInjected: false, isDelegated: false, userServerNames: ["linear"],
-            mode: .cli(adapterInstalled: true)))
-        #expect(installed.contains("mcp()"))
-        #expect(installed.contains("pi-mcp-adapter"))
-        #expect(installed.contains("linear"))
+            mode: .cli(serverAvailability: .available)))
+        #expect(available.contains("mcp()"))
+        #expect(available.contains("pi-mcp-adapter"))
+        #expect(available.contains("linear"))
 
-        let missing = try #require(ACPMCPPromptPreamble.text(
+        let notInstalled = try #require(ACPMCPPromptPreamble.text(
             builtInInjected: false, isDelegated: false, userServerNames: ["linear"],
-            mode: .cli(adapterInstalled: false)))
-        #expect(missing.contains("cannot be reached"))
-        #expect(missing.contains("pi-mcp-adapter"))
+            mode: .cli(serverAvailability: .notInstalled)))
+        #expect(notInstalled.contains("cannot be reached"))
+        #expect(notInstalled.contains("pi-mcp-adapter"))
+
+        let syncFailed = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: false, isDelegated: false, userServerNames: ["linear"],
+            mode: .cli(serverAvailability: .syncFailed)))
+        #expect(syncFailed.contains("linear"))
+        #expect(syncFailed.contains("could not write .pi/mcp.json"))
+
+        let userManaged = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: false, isDelegated: false, userServerNames: ["linear"],
+            mode: .cli(serverAvailability: .userManaged)))
+        #expect(userManaged.contains("linear"))
+        #expect(userManaged.contains("existing .pi/mcp.json"))
+        #expect(userManaged.contains("Alas did not add them"))
+
+        let noServers = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: false, userServerNames: [],
+            mode: .cli(serverAvailability: .noServers)))
+        #expect(!noServers.contains("Additional MCP servers"))
+        #expect(!noServers.contains("This project configures"))
     }
 
     @Test("default mode is unchanged mcp wording")

--- a/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
+++ b/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
@@ -63,4 +63,51 @@ struct ACPMCPPromptPreambleTests {
             "review_comment_add", "review_finish",
         ])
     }
+
+    @Test("cli mode swaps MCP wording for alas CLI commands")
+    func cliMode() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: false, userServerNames: [],
+            mode: .cli(adapterInstalled: false)))
+        #expect(text.contains("alas open"))
+        #expect(text.contains("alas wt list"))
+        #expect(text.contains("alas review"))
+        #expect(text.contains("alas session"))
+        #expect(!text.contains("MCP server \"alas\""))
+        // no adapter → no tool-search hint
+        #expect(!text.contains("tool search"))
+    }
+
+    @Test("cli mode delegated variant restricts session commands")
+    func cliModeDelegated() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: true, userServerNames: [],
+            mode: .cli(adapterInstalled: false)))
+        #expect(text.contains("alas session send"))
+        #expect(!text.contains("alas session new"))
+        #expect(text.contains("delegated by a parent session"))
+    }
+
+    @Test("cli mode user servers depend on adapter state")
+    func cliModeUserServers() throws {
+        let installed = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: false, isDelegated: false, userServerNames: ["linear"],
+            mode: .cli(adapterInstalled: true)))
+        #expect(installed.contains("mcp()"))
+        #expect(installed.contains("pi-mcp-adapter"))
+        #expect(installed.contains("linear"))
+
+        let missing = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: false, isDelegated: false, userServerNames: ["linear"],
+            mode: .cli(adapterInstalled: false)))
+        #expect(missing.contains("cannot be reached"))
+        #expect(missing.contains("pi-mcp-adapter"))
+    }
+
+    @Test("default mode is unchanged mcp wording")
+    func defaultModeUnchanged() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: false, userServerNames: []))
+        #expect(text.contains("MCP server \"alas\""))
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -128,6 +128,69 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.mcpPreambleSent == false)
     }
 
+    @Test("local attach merges alas CLI env into the launch spec")
+    func localAttachMergesCLIEnv() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        var capturedSpec: ACPLaunchSpec?
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { spec, _, _ in
+                capturedSpec = spec
+                return ACPConnection(client: client)
+            }
+        )
+        let session = manager.createSession(agentId: "claude")
+        manager.alasCLIEnvProvider = { _, sessionId in
+            ["ALAS_SESSION_ID": sessionId, "PATH": "/managed/bin:/usr/bin"]
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        let spec = try #require(capturedSpec)
+        #expect(spec.extraEnv["ALAS_SESSION_ID"] == session.id)
+        #expect(spec.extraEnv["PATH"] == "/managed/bin:/usr/bin")
+    }
+
+    @Test("remote attach skips alas CLI env")
+    func remoteAttachSkipsCLIEnv() async throws {
+        let root = "/srv/task3-remote-cli-env-\(UUID().uuidString)"
+        RemoteHostRegistry.shared.register(root: root, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root) }
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        var capturedSpec: ACPLaunchSpec?
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: root,
+            store: store,
+            remoteAdapterResolver: { _, _, _ in
+                .ready(.init(adapterPath: "/home/dev/.alas/acp/codex/bin/codex-acp", nodeBinDirectory: ""))
+            },
+            connectionFactory: { spec, _, _ in
+                capturedSpec = spec
+                return ACPConnection(client: client)
+            }
+        )
+        let session = manager.createSession(agentId: "codex")
+        manager.alasCLIEnvProvider = { _, sessionId in
+            ["ALAS_SESSION_ID": sessionId, "PATH": "/managed/bin:/usr/bin"]
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        let spec = try #require(capturedSpec)
+        #expect(spec.extraEnv["ALAS_SESSION_ID"] == nil)
+        #expect(spec.extraEnv["PATH"] != "/managed/bin:/usr/bin")
+    }
+
     @Test("Codex-style load response without session id restores normally")
     func codexStyleLoadResponseWithoutSessionIdRestoresNormally() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -343,6 +343,7 @@ struct ACPSessionManagerAttachRestoreTests {
 
         #expect(session.mcpExternalStatus?.userServerNames == ["linear"])
         #expect(session.mcpExternalStatus?.adapterServerAvailability == .notInstalled)
+        #expect(session.mcpExternalStatus?.canInstallAdapterLocally == false)
         let preamble = try #require(session.pendingMCPPreamble)
         #expect(preamble.contains("linear"))
         #expect(preamble.contains("cannot be reached"))

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -216,6 +216,66 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(!preamble.contains("MCP server \"alas\""))
     }
 
+    @Test("local pi attach invokes the external MCP status provider")
+    func localPiAttachInvokesExternalMCPStatusProvider() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = manager.createSession(agentId: ACPLaunchCatalog.spec(for: "pi")!.agentID)
+        var providerCalled = false
+        manager.externalMCPStatusProvider = { _ in
+            providerCalled = true
+            return (adapterState: .installed, configOutcome: .wrote)
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        #expect(providerCalled)
+        #expect(session.mcpExternalStatus?.adapterState == .installed)
+        #expect(session.mcpExternalStatus?.configOutcome == .wrote)
+    }
+
+    @Test("remote pi attach skips the external MCP status provider")
+    func remotePiAttachSkipsExternalMCPStatusProvider() async throws {
+        let root = "/srv/task5-remote-external-mcp-\(UUID().uuidString)"
+        RemoteHostRegistry.shared.register(root: root, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root) }
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: root,
+            store: store,
+            remoteAdapterResolver: { _, _, _ in
+                .ready(.init(adapterPath: "/home/dev/.alas/acp/pi/bin/pi-acp", nodeBinDirectory: ""))
+            },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = manager.createSession(agentId: ACPLaunchCatalog.spec(for: "pi")!.agentID)
+        var providerCalled = false
+        manager.externalMCPStatusProvider = { _ in
+            providerCalled = true
+            return (adapterState: .installed, configOutcome: .wrote)
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        #expect(!providerCalled)
+        #expect(session.mcpExternalStatus?.adapterState == .unknown)
+        #expect(session.mcpExternalStatus?.cliActive == false)
+        #expect(session.mcpExternalStatus?.configOutcome == nil)
+    }
+
     @Test("Codex-style load response without session id restores normally")
     func codexStyleLoadResponseWithoutSessionIdRestoresNormally() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -235,7 +235,7 @@ struct ACPSessionManagerAttachRestoreTests {
         var providerCalled = false
         manager.externalMCPStatusProvider = { _ in
             providerCalled = true
-            return (adapterState: .installed, configOutcome: .wrote, userServerNames: [])
+            return (adapterState: .installed, configOutcome: .wrote, userServerNames: [], skippedServerStatuses: [])
         }
 
         await manager.attach(to: session.id, freshlyCreated: true)
@@ -270,7 +270,7 @@ struct ACPSessionManagerAttachRestoreTests {
             ["ALAS_SESSION_ID": sessionId, "PATH": "/managed/bin:/usr/bin"]
         }
         manager.externalMCPStatusProvider = { _ in
-            (adapterState: .installed, configOutcome: .wrote, userServerNames: ["docs-http"])
+            (adapterState: .installed, configOutcome: .wrote, userServerNames: ["docs-http"], skippedServerStatuses: [])
         }
 
         await manager.attach(to: session.id, freshlyCreated: true)
@@ -302,7 +302,7 @@ struct ACPSessionManagerAttachRestoreTests {
         var providerCalled = false
         manager.externalMCPStatusProvider = { _ in
             providerCalled = true
-            return (adapterState: .installed, configOutcome: .wrote, userServerNames: [])
+            return (adapterState: .installed, configOutcome: .wrote, userServerNames: [], skippedServerStatuses: [])
         }
 
         await manager.attach(to: session.id, freshlyCreated: true)

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -313,6 +313,41 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.mcpExternalStatus?.configOutcome == nil)
     }
 
+    @Test("remote pi attach preserves configured MCP server names as unavailable")
+    func remotePiAttachPreservesConfiguredMCPServerNames() async throws {
+        let root = "/srv/task5-remote-external-mcp-names-\(UUID().uuidString)"
+        RemoteHostRegistry.shared.register(root: root, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root) }
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let configuredServers = [
+            ProjectMCPServer.stdio(name: "linear", command: "linear-mcp")
+        ]
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: root,
+            store: store,
+            remoteAdapterResolver: { _, _, _ in
+                .ready(.init(adapterPath: "/home/dev/.alas/acp/pi/bin/pi-acp", nodeBinDirectory: ""))
+            },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) },
+            mcpProjectContextProvider: {
+                MCPProjectContext(projectDirectory: root, configuredServers: configuredServers)
+            }
+        )
+        let session = manager.createSession(agentId: ACPLaunchCatalog.spec(for: "pi")!.agentID)
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        #expect(session.mcpExternalStatus?.userServerNames == ["linear"])
+        #expect(session.mcpExternalStatus?.adapterServerAvailability == .notInstalled)
+        let preamble = try #require(session.pendingMCPPreamble)
+        #expect(preamble.contains("linear"))
+        #expect(preamble.contains("cannot be reached"))
+    }
+
     @Test("Codex-style load response without session id restores normally")
     func codexStyleLoadResponseWithoutSessionIdRestoresNormally() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -155,6 +155,8 @@ struct ACPSessionManagerAttachRestoreTests {
         let spec = try #require(capturedSpec)
         #expect(spec.extraEnv["ALAS_SESSION_ID"] == session.id)
         #expect(spec.extraEnv["PATH"] == "/managed/bin:/usr/bin")
+        #expect(session.terminalHost.sessionEnv["ALAS_SESSION_ID"] == session.id)
+        #expect(session.terminalHost.sessionEnv["PATH"] == "/managed/bin:/usr/bin")
     }
 
     @Test("remote attach skips alas CLI env")

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -191,6 +191,31 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(spec.extraEnv["PATH"] != "/managed/bin:/usr/bin")
     }
 
+    @Test("fresh pi attach with CLI env active produces a CLI-mode preamble")
+    func freshPiAttachProducesCLIModePreamble() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = manager.createSession(agentId: ACPLaunchCatalog.spec(for: "pi")!.agentID)
+        manager.alasCLIEnvProvider = { _, sessionId in
+            ["ALAS_SESSION_ID": sessionId, "PATH": "/managed/bin:/usr/bin"]
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        let preamble = try #require(session.pendingMCPPreamble)
+        #expect(preamble.contains("alas open"))
+        #expect(!preamble.contains("MCP server \"alas\""))
+    }
+
     @Test("Codex-style load response without session id restores normally")
     func codexStyleLoadResponseWithoutSessionIdRestoresNormally() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -233,7 +233,7 @@ struct ACPSessionManagerAttachRestoreTests {
         var providerCalled = false
         manager.externalMCPStatusProvider = { _ in
             providerCalled = true
-            return (adapterState: .installed, configOutcome: .wrote)
+            return (adapterState: .installed, configOutcome: .wrote, userServerNames: [])
         }
 
         await manager.attach(to: session.id, freshlyCreated: true)
@@ -241,6 +241,41 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(providerCalled)
         #expect(session.mcpExternalStatus?.adapterState == .installed)
         #expect(session.mcpExternalStatus?.configOutcome == .wrote)
+    }
+
+    @Test("pi attach preamble names http/sse-only servers from the external plan")
+    func piAttachPreambleNamesExternalPlanServers() async throws {
+        // Regression guard: `wireMCPServers` is planned against pi's real
+        // (http/sse-less) ACP capabilities and would drop an http/sse-only
+        // server, but `.pi/mcp.json` is written from the external plan's
+        // all-transports resolution and DOES include it. The preamble must
+        // use the external status's resolved names, not `wireMCPServers`,
+        // or it silently omits the `mcp()` hint for exactly the servers
+        // this feature exists to surface.
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = manager.createSession(agentId: ACPLaunchCatalog.spec(for: "pi")!.agentID)
+        manager.alasCLIEnvProvider = { _, sessionId in
+            ["ALAS_SESSION_ID": sessionId, "PATH": "/managed/bin:/usr/bin"]
+        }
+        manager.externalMCPStatusProvider = { _ in
+            (adapterState: .installed, configOutcome: .wrote, userServerNames: ["docs-http"])
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        let preamble = try #require(session.pendingMCPPreamble)
+        #expect(preamble.contains("docs-http"))
+        #expect(preamble.contains("mcp()"))
     }
 
     @Test("remote pi attach skips the external MCP status provider")
@@ -265,7 +300,7 @@ struct ACPSessionManagerAttachRestoreTests {
         var providerCalled = false
         manager.externalMCPStatusProvider = { _ in
             providerCalled = true
-            return (adapterState: .installed, configOutcome: .wrote)
+            return (adapterState: .installed, configOutcome: .wrote, userServerNames: [])
         }
 
         await manager.attach(to: session.id, freshlyCreated: true)

--- a/AlasTests/ACP/Session/AlasCLIEnvInjectionTests.swift
+++ b/AlasTests/ACP/Session/AlasCLIEnvInjectionTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import Alas
+
+@Suite("AlasCLIEnvInjection")
+struct AlasCLIEnvInjectionTests {
+    @Test("builds the full env with PATH prepend")
+    func buildsEnv() throws {
+        let env = try #require(AlasCLIEnvInjection.environment(
+            enabled: true, binDirPath: "/managed/bin", socketPath: "/tmp/a.sock",
+            worktreePath: "/repos/p/wt", sessionId: "s1",
+            parentSessionId: nil, basePATH: "/usr/bin"))
+        #expect(env["ALAS_SOCKET_PATH"] == "/tmp/a.sock")
+        #expect(env["ALAS_WORKTREE_DIR"] == "/repos/p/wt")
+        #expect(env["ALAS_SESSION_ID"] == "s1")
+        #expect(env["ALAS_PARENT_SESSION_ID"] == nil)
+        #expect(env["PATH"] == "/managed/bin:/usr/bin")
+    }
+
+    @Test("delegated sessions carry the parent id")
+    func delegated() throws {
+        let env = try #require(AlasCLIEnvInjection.environment(
+            enabled: true, binDirPath: "/b", socketPath: "/s",
+            worktreePath: "/w", sessionId: "child",
+            parentSessionId: "parent", basePATH: nil))
+        #expect(env["ALAS_PARENT_SESSION_ID"] == "parent")
+        // basePATH: nil falls back to TerminalCLIInjection's system PATH
+        // (see TerminalCLIInjectionTests.pathValueUsesSystemFallbackWhenCurrentPathIsEmpty),
+        // not an empty base — the prepended dir is still first.
+        #expect(env["PATH"]?.hasPrefix("/b:") == true)
+        #expect(env["PATH"]?.contains("/usr/bin") == true)
+    }
+
+    @Test("unavailable inputs produce nil")
+    func unavailable() {
+        #expect(AlasCLIEnvInjection.environment(
+            enabled: false, binDirPath: "/b", socketPath: "/s",
+            worktreePath: "/w", sessionId: "s", parentSessionId: nil, basePATH: nil) == nil)
+        #expect(AlasCLIEnvInjection.environment(
+            enabled: true, binDirPath: nil, socketPath: "/s",
+            worktreePath: "/w", sessionId: "s", parentSessionId: nil, basePATH: nil) == nil)
+        #expect(AlasCLIEnvInjection.environment(
+            enabled: true, binDirPath: "/b", socketPath: nil,
+            worktreePath: "/w", sessionId: "s", parentSessionId: nil, basePATH: nil) == nil)
+    }
+}

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -79,4 +79,40 @@ struct ACPMCPStatusPolicyTests {
             summary: summary, currentServers: []))
         #expect(none.preambleDetail == nil)
     }
+
+    @Test("external status replaces rows and drives the install action")
+    func externalStatusRows() throws {
+        let summary = MCPAttachmentSummary(
+            statuses: [.init(id: "a", name: "alas", transport: .stdio, disposition: .requested)],
+            configurationFingerprint: "fp")
+
+        let installed = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [],
+            externalStatus: .init(cliActive: true, adapterState: .installed,
+                                  configOutcome: .wrote, hint: "h")))
+        let rows = try #require(installed.externalRows)
+        #expect(rows.count == 2)
+        #expect(rows[0].detail == "via alas CLI (environment injected)")
+        #expect(rows[1].detail == "via pi-mcp-adapter")
+        #expect(installed.showsAdapterInstallAction == false)
+
+        let missing = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [],
+            externalStatus: .init(cliActive: false, adapterState: .missing,
+                                  configOutcome: nil, hint: "h")))
+        let mrows = try #require(missing.externalRows)
+        #expect(mrows[0].detail == "unavailable (Alas CLI not injected)")
+        #expect(mrows[1].detail == "requires the pi-mcp-adapter extension")
+        #expect(missing.showsAdapterInstallAction == true)
+
+        let unmanaged = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [],
+            externalStatus: .init(cliActive: true, adapterState: .installed,
+                                  configOutcome: .refusedUnmanaged, hint: "h")))
+        #expect(try #require(unmanaged.externalRows)[1].detail == "using your existing .pi/mcp.json")
+
+        // no external status → unchanged classic behavior
+        let classic = try #require(ACPMCPStatusState(summary: summary, currentServers: []))
+        #expect(classic.externalRows == nil)
+    }
 }

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -111,6 +111,14 @@ struct ACPMCPStatusPolicyTests {
         #expect(notInstalled.skippedCount == 2)
         #expect(notInstalled.showsAdapterInstallAction == true)
 
+        let noServers = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [],
+            externalStatus: .init(cliActive: true, adapterState: .missing,
+                                  configOutcome: nil, hint: "h", userServerNames: [])))
+        #expect(noServers.requestedCount == 1)
+        #expect(noServers.skippedCount == 0)
+        #expect(noServers.showsAdapterInstallAction == false)
+
         let userManaged = try #require(ACPMCPStatusState(
             summary: summary, currentServers: [],
             externalStatus: .init(cliActive: true, adapterState: .installed,

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -111,6 +111,16 @@ struct ACPMCPStatusPolicyTests {
                                   configOutcome: .refusedUnmanaged, hint: "h")))
         #expect(try #require(unmanaged.externalRows)[1].detail == "using your existing .pi/mcp.json")
 
+        let failedSync = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [],
+            externalStatus: .init(cliActive: true, adapterState: .installed,
+                                  configOutcome: .failed, hint: "h")))
+        let failedRows = try #require(failedSync.externalRows)
+        #expect(failedRows[1].detail == "config sync failed — see logs")
+        #expect(failedRows[1].isRequested == false)
+        // the adapter extension itself is installed, so no install action
+        #expect(failedSync.showsAdapterInstallAction == false)
+
         // no external status → unchanged classic behavior
         let classic = try #require(ACPMCPStatusState(summary: summary, currentServers: []))
         #expect(classic.externalRows == nil)

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -95,6 +95,8 @@ struct ACPMCPStatusPolicyTests {
         #expect(rows[0].detail == "via alas CLI (environment injected)")
         #expect(rows[1].detail == "via pi-mcp-adapter")
         #expect(rows[1].isRequested == true)
+        #expect(available.requestedCount == 2)
+        #expect(available.skippedCount == 0)
         #expect(available.showsAdapterInstallAction == false)
 
         let notInstalled = try #require(ACPMCPStatusState(
@@ -105,6 +107,8 @@ struct ACPMCPStatusPolicyTests {
         #expect(mrows[0].detail == "unavailable (Alas CLI not injected)")
         #expect(mrows[1].detail == "requires the pi-mcp-adapter extension")
         #expect(mrows[1].isRequested == false)
+        #expect(notInstalled.requestedCount == 0)
+        #expect(notInstalled.skippedCount == 2)
         #expect(notInstalled.showsAdapterInstallAction == true)
 
         let userManaged = try #require(ACPMCPStatusState(

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -86,40 +86,46 @@ struct ACPMCPStatusPolicyTests {
             statuses: [.init(id: "a", name: "alas", transport: .stdio, disposition: .requested)],
             configurationFingerprint: "fp")
 
-        let installed = try #require(ACPMCPStatusState(
+        let available = try #require(ACPMCPStatusState(
             summary: summary, currentServers: [],
             externalStatus: .init(cliActive: true, adapterState: .installed,
-                                  configOutcome: .wrote, hint: "h")))
-        let rows = try #require(installed.externalRows)
+                                  configOutcome: .wrote, hint: "h", userServerNames: ["linear"])))
+        let rows = try #require(available.externalRows)
         #expect(rows.count == 2)
         #expect(rows[0].detail == "via alas CLI (environment injected)")
         #expect(rows[1].detail == "via pi-mcp-adapter")
-        #expect(installed.showsAdapterInstallAction == false)
+        #expect(rows[1].isRequested == true)
+        #expect(available.showsAdapterInstallAction == false)
 
-        let missing = try #require(ACPMCPStatusState(
+        let notInstalled = try #require(ACPMCPStatusState(
             summary: summary, currentServers: [],
             externalStatus: .init(cliActive: false, adapterState: .missing,
-                                  configOutcome: nil, hint: "h")))
-        let mrows = try #require(missing.externalRows)
+                                  configOutcome: nil, hint: "h", userServerNames: ["linear"])))
+        let mrows = try #require(notInstalled.externalRows)
         #expect(mrows[0].detail == "unavailable (Alas CLI not injected)")
         #expect(mrows[1].detail == "requires the pi-mcp-adapter extension")
-        #expect(missing.showsAdapterInstallAction == true)
+        #expect(mrows[1].isRequested == false)
+        #expect(notInstalled.showsAdapterInstallAction == true)
 
-        let unmanaged = try #require(ACPMCPStatusState(
+        let userManaged = try #require(ACPMCPStatusState(
             summary: summary, currentServers: [],
             externalStatus: .init(cliActive: true, adapterState: .installed,
-                                  configOutcome: .refusedUnmanaged, hint: "h")))
-        #expect(try #require(unmanaged.externalRows)[1].detail == "using your existing .pi/mcp.json")
+                                  configOutcome: .refusedUnmanaged, hint: "h", userServerNames: ["linear"])))
+        let userManagedRows = try #require(userManaged.externalRows)
+        #expect(userManagedRows[1].detail == "using your existing .pi/mcp.json")
+        #expect(userManagedRows[1].isRequested == false)
+        // an unmanaged file means the extension IS installed — no install action
+        #expect(userManaged.showsAdapterInstallAction == false)
 
-        let failedSync = try #require(ACPMCPStatusState(
+        let syncFailed = try #require(ACPMCPStatusState(
             summary: summary, currentServers: [],
             externalStatus: .init(cliActive: true, adapterState: .installed,
-                                  configOutcome: .failed, hint: "h")))
-        let failedRows = try #require(failedSync.externalRows)
+                                  configOutcome: .failed, hint: "h", userServerNames: ["linear"])))
+        let failedRows = try #require(syncFailed.externalRows)
         #expect(failedRows[1].detail == "config sync failed — see logs")
         #expect(failedRows[1].isRequested == false)
         // the adapter extension itself is installed, so no install action
-        #expect(failedSync.showsAdapterInstallAction == false)
+        #expect(syncFailed.showsAdapterInstallAction == false)
 
         // no external status → unchanged classic behavior
         let classic = try #require(ACPMCPStatusState(summary: summary, currentServers: []))

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -111,6 +111,15 @@ struct ACPMCPStatusPolicyTests {
         #expect(notInstalled.skippedCount == 2)
         #expect(notInstalled.showsAdapterInstallAction == true)
 
+        let remoteNotInstalled = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [],
+            externalStatus: .init(cliActive: false, adapterState: .unknown,
+                                  configOutcome: nil, hint: "h", userServerNames: ["linear"],
+                                  canInstallAdapterLocally: false)))
+        let remoteRows = try #require(remoteNotInstalled.externalRows)
+        #expect(remoteRows[1].detail == "requires the pi-mcp-adapter extension")
+        #expect(remoteNotInstalled.showsAdapterInstallAction == false)
+
         let noServers = try #require(ACPMCPStatusState(
             summary: summary, currentServers: [],
             externalStatus: .init(cliActive: true, adapterState: .missing,

--- a/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPMCPStatusPolicyTests.swift
@@ -120,6 +120,22 @@ struct ACPMCPStatusPolicyTests {
         #expect(remoteRows[1].detail == "requires the pi-mcp-adapter extension")
         #expect(remoteNotInstalled.showsAdapterInstallAction == false)
 
+        let skippedExternal = try #require(ACPMCPStatusState(
+            summary: summary, currentServers: [],
+            externalStatus: .init(
+                cliActive: true, adapterState: .installed, configOutcome: .noServers,
+                hint: "h", userServerNames: [],
+                skippedServerStatuses: [
+                    .init(
+                        id: "bad-token", name: "linear", transport: .stdio,
+                        disposition: .skipped(.missingVariable("LINEAR_TOKEN")))
+                ])))
+        let skippedRows = try #require(skippedExternal.externalRows)
+        #expect(skippedRows.map(\.id).contains("external-skipped-bad-token"))
+        #expect(skippedRows.map(\.detail).contains("Skipped: missing LINEAR_TOKEN"))
+        #expect(skippedExternal.requestedCount == 1)
+        #expect(skippedExternal.skippedCount == 1)
+
         let noServers = try #require(ACPMCPStatusState(
             summary: summary, currentServers: [],
             externalStatus: .init(cliActive: true, adapterState: .missing,

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -32,6 +32,7 @@ struct AppStateCleanupTests {
     }
 
     @Test func piMCPExcludeRetriesForUnchangedManagedConfig() {
+        #expect(AppState.piMCPGeneratedConfigExcludePath == ".pi/mcp.json")
         #expect(AppState.shouldExcludePiDirectory(after: .wrote))
         #expect(AppState.shouldExcludePiDirectory(after: .unchanged))
         #expect(!AppState.shouldExcludePiDirectory(after: .failed))

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -31,6 +31,15 @@ struct AppStateCleanupTests {
         return dir
     }
 
+    @Test func piMCPExcludeRetriesForUnchangedManagedConfig() {
+        #expect(AppState.shouldExcludePiDirectory(after: .wrote))
+        #expect(AppState.shouldExcludePiDirectory(after: .unchanged))
+        #expect(!AppState.shouldExcludePiDirectory(after: .failed))
+        #expect(!AppState.shouldExcludePiDirectory(after: .refusedUnmanaged))
+        #expect(!AppState.shouldExcludePiDirectory(after: .removedManaged))
+        #expect(!AppState.shouldExcludePiDirectory(after: .noServers))
+    }
+
     @Test func allWorktreeIdsReturnsIdsAfterRefresh() async throws {
         let repo = try await makeRepo(name: "all-ids")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/Harness/PiMCPAdapterInspectorTests.swift
+++ b/AlasTests/Harness/PiMCPAdapterInspectorTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("PiMCPAdapterInspector")
+struct PiMCPAdapterInspectorTests {
+    private func makeAgentDir(packageJSON: String?) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pi-agent-\(UUID().uuidString)/npm", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if let packageJSON {
+            try packageJSON.write(to: dir.appendingPathComponent("package.json"),
+                                  atomically: true, encoding: .utf8)
+        }
+        return dir.deletingLastPathComponent()
+    }
+
+    @Test("installed when dependencies contain pi-mcp-adapter")
+    func installed() throws {
+        let dir = try makeAgentDir(packageJSON:
+            #"{"dependencies": {"pi-mcp-adapter": "^2.11.0", "other": "1.0.0"}}"#)
+        #expect(PiMCPAdapterInspector.state(agentDir: dir) == .installed)
+    }
+
+    @Test("missing when the manifest parses without it")
+    func missing() throws {
+        let dir = try makeAgentDir(packageJSON: #"{"dependencies": {"other": "1.0.0"}}"#)
+        #expect(PiMCPAdapterInspector.state(agentDir: dir) == .missing)
+    }
+
+    @Test("unknown when manifest is absent or unreadable")
+    func unknown() throws {
+        let absent = try makeAgentDir(packageJSON: nil)
+        #expect(PiMCPAdapterInspector.state(agentDir: absent) == .unknown)
+        let garbled = try makeAgentDir(packageJSON: "not json")
+        #expect(PiMCPAdapterInspector.state(agentDir: garbled) == .unknown)
+    }
+}

--- a/AlasTests/Harness/PiMCPAdapterInspectorTests.swift
+++ b/AlasTests/Harness/PiMCPAdapterInspectorTests.swift
@@ -42,6 +42,15 @@ struct PiMCPAdapterInspectorTests {
         #expect(PiMCPAdapterInspector.state(agentDir: agentDir, worktreeURL: worktree) == .installed)
     }
 
+    @Test("default agent directory honors PI_CODING_AGENT_DIR")
+    func defaultAgentDirHonorsEnvironmentOverride() {
+        let dir = PiMCPAdapterInspector.defaultAgentDir(environment: [
+            "PI_CODING_AGENT_DIR": "/tmp/custom-pi-agent"
+        ])
+
+        #expect(dir.path == "/tmp/custom-pi-agent")
+    }
+
     @Test("missing when the manifest parses without it")
     func missing() throws {
         let dir = try makeAgentDir(packageJSON: #"{"dependencies": {"other": "1.0.0"}}"#)

--- a/AlasTests/Harness/PiMCPAdapterInspectorTests.swift
+++ b/AlasTests/Harness/PiMCPAdapterInspectorTests.swift
@@ -15,11 +15,31 @@ struct PiMCPAdapterInspectorTests {
         return dir.deletingLastPathComponent()
     }
 
+    private func makeWorktree(packageJSON: String?) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pi-worktree-\(UUID().uuidString)/.pi/npm", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if let packageJSON {
+            try packageJSON.write(to: dir.appendingPathComponent("package.json"),
+                                  atomically: true, encoding: .utf8)
+        }
+        return dir.deletingLastPathComponent().deletingLastPathComponent()
+    }
+
     @Test("installed when dependencies contain pi-mcp-adapter")
     func installed() throws {
         let dir = try makeAgentDir(packageJSON:
             #"{"dependencies": {"pi-mcp-adapter": "^2.11.0", "other": "1.0.0"}}"#)
         #expect(PiMCPAdapterInspector.state(agentDir: dir) == .installed)
+    }
+
+    @Test("installed when project-local dependencies contain pi-mcp-adapter")
+    func installedProjectLocal() throws {
+        let agentDir = try makeAgentDir(packageJSON: nil)
+        let worktree = try makeWorktree(packageJSON:
+            #"{"dependencies": {"pi-mcp-adapter": "^2.11.0"}}"#)
+
+        #expect(PiMCPAdapterInspector.state(agentDir: agentDir, worktreeURL: worktree) == .installed)
     }
 
     @Test("missing when the manifest parses without it")

--- a/AlasTests/Harness/PiMCPConfigWriterTests.swift
+++ b/AlasTests/Harness/PiMCPConfigWriterTests.swift
@@ -46,6 +46,18 @@ struct PiMCPConfigWriterTests {
         #expect(try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp2") == .wrote)
     }
 
+    @Test("rewrites managed configs through a private temp file")
+    func rewriteLeavesNoTempFiles() throws {
+        let wt = try makeWorktree()
+        _ = try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp1")
+        #expect(try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp2") == .wrote)
+        let dir = wt.appendingPathComponent(".pi", isDirectory: true)
+        let entries = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+        #expect(entries == ["mcp.json"])
+        let attrs = try FileManager.default.attributesOfItem(atPath: dir.appendingPathComponent("mcp.json").path)
+        #expect((attrs[.posixPermissions] as? NSNumber)?.uint16Value == 0o600)
+    }
+
     @Test("resolved wire fingerprint changes when interpolated values change")
     func resolvedWireFingerprintFreshness() throws {
         let wt = try makeWorktree()

--- a/AlasTests/Harness/PiMCPConfigWriterTests.swift
+++ b/AlasTests/Harness/PiMCPConfigWriterTests.swift
@@ -10,11 +10,10 @@ struct PiMCPConfigWriterTests {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
     }
-    private var servers: [ProjectMCPServer] {
-        [ProjectMCPServer(
-            id: "1", name: "linear",
-            transport: .stdio(command: "/usr/bin/linear-mcp", args: ["--x"],
-                              environment: [MCPKeyValue(id: "k", name: "TOKEN", value: "t0k")]))]
+    private var servers: [ACPMCPServer] {
+        [.stdio(
+            name: "linear", command: "/usr/bin/linear-mcp", args: ["--x"],
+            env: [ACPMCPKeyValue(name: "TOKEN", value: "t0k")])]
     }
 
     @Test("writes a managed config with 0600 and standard mcpServers shape")
@@ -73,14 +72,52 @@ struct PiMCPConfigWriterTests {
     @Test("http and sse servers map to url and headers")
     func httpShape() throws {
         let wt = try makeWorktree()
-        let http = [ProjectMCPServer(id: "2", name: "docs",
-            transport: .http(url: "https://x/mcp",
-                             headers: [MCPKeyValue(id: "h", name: "Authorization", value: "Bearer z")]))]
+        let http: [ACPMCPServer] = [.http(
+            name: "docs", url: "https://x/mcp",
+            headers: [ACPMCPKeyValue(name: "Authorization", value: "Bearer z")])]
         _ = try PiMCPConfigWriter.sync(worktreeURL: wt, servers: http, fingerprint: "fp")
         let json = try #require(try JSONSerialization.jsonObject(
             with: Data(contentsOf: wt.appendingPathComponent(".pi/mcp.json"))) as? [String: Any])
         let docs = try #require((json["mcpServers"] as? [String: Any])?["docs"] as? [String: Any])
         #expect(docs["url"] as? String == "https://x/mcp")
         #expect((docs["headers"] as? [String: String])?["Authorization"] == "Bearer z")
+    }
+
+    @Test("throws when the .pi path is occupied by a regular file")
+    func throwsWhenPiPathIsAFile() throws {
+        let wt = try makeWorktree()
+        try Data("not a directory".utf8).write(to: wt.appendingPathComponent(".pi"))
+        #expect(throws: (any Error).self) {
+            try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp1")
+        }
+    }
+
+    @Test("template variables are resolved before reaching the written file")
+    func writesResolvedTemplates() throws {
+        let wt = try makeWorktree()
+        let raw = [ProjectMCPServer(
+            id: "1", name: "scoped",
+            transport: .stdio(
+                command: "/usr/bin/tool",
+                args: ["--root=${WORKTREE_DIR}"],
+                environment: []))]
+        let plan = MCPAttachmentPlanner.plan(.init(
+            configuredServers: raw,
+            projectDirectory: "/tmp/project",
+            worktreeDirectory: wt.path,
+            environment: [:],
+            capabilities: ACPMCPServerCapabilities(http: true, sse: true)
+        ))
+        #expect(plan.wireServers.count == 1)
+        let fingerprint = MCPAttachmentPlanner.configurationFingerprint(for: raw)
+        let outcome = try PiMCPConfigWriter.sync(
+            worktreeURL: wt, servers: plan.wireServers, fingerprint: fingerprint)
+        #expect(outcome == .wrote)
+        let json = try #require(try JSONSerialization.jsonObject(
+            with: Data(contentsOf: wt.appendingPathComponent(".pi/mcp.json"))) as? [String: Any])
+        let scoped = try #require((json["mcpServers"] as? [String: Any])?["scoped"] as? [String: Any])
+        let args = try #require(scoped["args"] as? [String])
+        #expect(args == ["--root=\(wt.path)"])
+        #expect(!args.contains { $0.contains("${WORKTREE_DIR}") })
     }
 }

--- a/AlasTests/Harness/PiMCPConfigWriterTests.swift
+++ b/AlasTests/Harness/PiMCPConfigWriterTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("PiMCPConfigWriter")
+struct PiMCPConfigWriterTests {
+    private func makeWorktree() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wt-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+    private var servers: [ProjectMCPServer] {
+        [ProjectMCPServer(
+            id: "1", name: "linear",
+            transport: .stdio(command: "/usr/bin/linear-mcp", args: ["--x"],
+                              environment: [MCPKeyValue(id: "k", name: "TOKEN", value: "t0k")]))]
+    }
+
+    @Test("writes a managed config with 0600 and standard mcpServers shape")
+    func writes() throws {
+        let wt = try makeWorktree()
+        let outcome = try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp1")
+        #expect(outcome == .wrote)
+        let url = wt.appendingPathComponent(".pi/mcp.json")
+        let data = try Data(contentsOf: url)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let alas = try #require(json["$alas"] as? [String: Any])
+        #expect(alas["managed"] as? Bool == true)
+        #expect(alas["fingerprint"] as? String == "fp1")
+        let mcp = try #require(json["mcpServers"] as? [String: Any])
+        let linear = try #require(mcp["linear"] as? [String: Any])
+        #expect(linear["command"] as? String == "/usr/bin/linear-mcp")
+        #expect(linear["args"] as? [String] == ["--x"])
+        #expect((linear["env"] as? [String: String])?["TOKEN"] == "t0k")
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attrs[.posixPermissions] as? NSNumber)?.uint16Value == 0o600)
+        // no alas server ever written
+        #expect(mcp["alas"] == nil)
+    }
+
+    @Test("same fingerprint is a no-op; new fingerprint rewrites")
+    func fingerprintFreshness() throws {
+        let wt = try makeWorktree()
+        _ = try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp1")
+        #expect(try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp1") == .unchanged)
+        #expect(try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp2") == .wrote)
+    }
+
+    @Test("refuses to touch an unmanaged file")
+    func refusesUnmanaged() throws {
+        let wt = try makeWorktree()
+        let dir = wt.appendingPathComponent(".pi", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try #"{"mcpServers": {"mine": {"command": "x"}}}"#
+            .write(to: dir.appendingPathComponent("mcp.json"), atomically: true, encoding: .utf8)
+        #expect(try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp") == .refusedUnmanaged)
+        let contents = try String(contentsOf: dir.appendingPathComponent("mcp.json"), encoding: .utf8)
+        #expect(contents.contains("mine"))
+    }
+
+    @Test("removes a managed file when no servers remain")
+    func removesManaged() throws {
+        let wt = try makeWorktree()
+        _ = try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp")
+        #expect(try PiMCPConfigWriter.sync(worktreeURL: wt, servers: [], fingerprint: "fp0") == .removedManaged)
+        #expect(!FileManager.default.fileExists(atPath: wt.appendingPathComponent(".pi/mcp.json").path))
+        // and a fresh worktree with no servers is a clean no-op
+        let wt2 = try makeWorktree()
+        #expect(try PiMCPConfigWriter.sync(worktreeURL: wt2, servers: [], fingerprint: "fp0") == .noServers)
+    }
+
+    @Test("http and sse servers map to url and headers")
+    func httpShape() throws {
+        let wt = try makeWorktree()
+        let http = [ProjectMCPServer(id: "2", name: "docs",
+            transport: .http(url: "https://x/mcp",
+                             headers: [MCPKeyValue(id: "h", name: "Authorization", value: "Bearer z")]))]
+        _ = try PiMCPConfigWriter.sync(worktreeURL: wt, servers: http, fingerprint: "fp")
+        let json = try #require(try JSONSerialization.jsonObject(
+            with: Data(contentsOf: wt.appendingPathComponent(".pi/mcp.json"))) as? [String: Any])
+        let docs = try #require((json["mcpServers"] as? [String: Any])?["docs"] as? [String: Any])
+        #expect(docs["url"] as? String == "https://x/mcp")
+        #expect((docs["headers"] as? [String: String])?["Authorization"] == "Bearer z")
+    }
+}

--- a/AlasTests/Harness/PiMCPConfigWriterTests.swift
+++ b/AlasTests/Harness/PiMCPConfigWriterTests.swift
@@ -46,6 +46,36 @@ struct PiMCPConfigWriterTests {
         #expect(try PiMCPConfigWriter.sync(worktreeURL: wt, servers: servers, fingerprint: "fp2") == .wrote)
     }
 
+    @Test("resolved wire fingerprint changes when interpolated values change")
+    func resolvedWireFingerprintFreshness() throws {
+        let wt = try makeWorktree()
+        let first: [ACPMCPServer] = [.http(
+            name: "docs", url: "https://x/mcp",
+            headers: [ACPMCPKeyValue(name: "Authorization", value: "Bearer one")]
+        )]
+        let second: [ACPMCPServer] = [.http(
+            name: "docs", url: "https://x/mcp",
+            headers: [ACPMCPKeyValue(name: "Authorization", value: "Bearer two")]
+        )]
+
+        _ = try PiMCPConfigWriter.sync(
+            worktreeURL: wt,
+            servers: first,
+            fingerprint: MCPAttachmentPlanner.resolvedConfigurationFingerprint(for: first)
+        )
+        let outcome = try PiMCPConfigWriter.sync(
+            worktreeURL: wt,
+            servers: second,
+            fingerprint: MCPAttachmentPlanner.resolvedConfigurationFingerprint(for: second)
+        )
+
+        #expect(outcome == .wrote)
+        let json = try #require(try JSONSerialization.jsonObject(
+            with: Data(contentsOf: wt.appendingPathComponent(".pi/mcp.json"))) as? [String: Any])
+        let docs = try #require((json["mcpServers"] as? [String: Any])?["docs"] as? [String: Any])
+        #expect((docs["headers"] as? [String: String])?["Authorization"] == "Bearer two")
+    }
+
     @Test("refuses to touch an unmanaged file")
     func refusesUnmanaged() throws {
         let wt = try makeWorktree()


### PR DESCRIPTION
## Problem

`pi-acp` ignores the `mcpServers` payload in ACP `session/new` entirely (verified with a logging shim: the injected `alas mcp` server is never spawned), so the Alas MCP tools — and any user-configured MCP server — never reach pi. Pi's ecosystem answers this two ways, and this PR embraces both: pi's CLI-first philosophy, and the OSS `pi-mcp-adapter` extension.

## Fix

For agents that ignore ACP MCP config (curated `ACPMCPInjectionSupport.external`; today just pi):

- **Built-in Alas tools → the `alas` CLI.** At spawn, Alas injects `ALAS_*` env + prepends the managed `alas` bin dir to `PATH` for local agent processes (matching what terminals already get), and the first-prompt preamble gains a `.cli` mode telling the agent to run `alas open`, `alas wt …`, `alas review …`, etc. — the same surface the MCP server shims.
- **User MCP servers → pi-mcp-adapter.** When the adapter is installed, Alas writes a managed `.pi/mcp.json` (project override) from the project's configured servers, git-excluded via `.git/info/exclude`. The badge popover detects the adapter and offers a one-click "Install pi-mcp-adapter".
- **Honest badge popover.** For `.external` agents the popover shows how tools actually reach the agent (CLI / adapter) instead of the misleading "requested" rows.

`.sessionNew` agents (Claude/Codex/Cursor/…) are provably unchanged: the `.mcp` preamble path is byte-identical to #825, and the injected CLI env is additive and inert when unused.

## Safety

- `.pi/mcp.json` is written 0600 (created 0600 before content — no world-readable window), never contains the built-in `alas` server, and never overwrites a file lacking the `$alas` managed marker.
- Env injection and adapter inspection/writing are **local-only** — remote sessions skip both and the popover reports CLI unavailable on remote hosts.

## Verification

- Build clean; 142/142 across 8 focused suites (+ the remote-gating and 0600 fix tests).
- **E2E CLI path:** with the injected env + `.cli` preamble, pi runs `alas open README.md` (vs. shell-only without it).
- **E2E adapter path:** the real pi-mcp-adapter (v2.11) parses the generated `.pi/mcp.json`, discovers the server, and connects.

## Follow-ups (non-blocking, tracked)

- Agents-settings "Install pi-mcp-adapter" row currently shows when pi is absent/`.unknown`, not only installed-but-missing.
- `installPiMCPAdapter()` doesn't capture pi stdout/stderr, so the "see pi output" failure copy is unbacked; install-button state has no in-popover retry.
- git-exclude of `.pi/` is only retried on a fresh `.wrote`, not `.unchanged`.
- `alasCLIEnvProvider` doesn't cache the resolved parent session id (minor redundant DB read).
- No integration test for the AppState provider wiring (units are covered).

## Notes

- No changes to the Rust `alas` CLI / MCP server.
- Builds on #825 (first-prompt MCP preamble).
