### PR TITLE
fix(acp): preserve integer params through broker JSON round-trip

### DIFF
--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -745,7 +745,7 @@ private extension ACPBrokerAdapterRequestID {
     }
 }
 
-private extension ACPBrokerJSONValue {
+extension ACPBrokerJSONValue {
     init(encodable value: Encodable?) throws {
         guard let value else {
             self = .null
@@ -764,14 +764,18 @@ private extension ACPBrokerJSONValue {
         switch jsonObject {
         case is NSNull:
             self = .null
-        case let value as Bool:
-            self = .bool(value)
-        case let value as Int:
-            self = .number(Double(value))
-        case let value as UInt:
-            self = .number(Double(value))
-        case let value as Double:
-            self = .number(value)
+        case let value as NSNumber:
+            // `JSONSerialization` boxes every JSON number *and* boolean as an
+            // `NSNumber`. Bridging that to `Bool` (`as Bool`) succeeds for any
+            // value equal to 0 or 1, so an integer `1` — e.g. `initialize`'s
+            // `protocolVersion` — would be misread as `true`. JSON booleans are
+            // backed by `CFBoolean`, which has a distinct `CFTypeID`; use it to
+            // tell real booleans apart from numbers before mapping.
+            if CFGetTypeID(value) == CFBooleanGetTypeID() {
+                self = .bool(value.boolValue)
+            } else {
+                self = .number(value.doubleValue)
+            }
         case let value as String:
             self = .string(value)
         case let value as [Any]:

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -4,6 +4,30 @@ import Testing
 
 @MainActor
 struct ACPBrokerClientTests {
+    // Regression: `JSONSerialization` returns every JSON number as an
+    // `NSNumber`, and bridging an `NSNumber` to `Bool` succeeds for any value
+    // equal to 0 or 1. The broker re-encoded outgoing request params through
+    // that bridge, so `initialize`'s `protocolVersion: 1` was rewritten to
+    // `true` and every ACP agent rejected the attach with -32602 Invalid params.
+    @Test func encodableIntegerParamsSurviveAsNumbers() throws {
+        struct Payload: Encodable { let protocolVersion: Int }
+
+        #expect(try ACPBrokerJSONValue(encodable: Payload(protocolVersion: 1))
+            == .object(["protocolVersion": .number(1)]))
+        #expect(try ACPBrokerJSONValue(encodable: Payload(protocolVersion: 0))
+            == .object(["protocolVersion": .number(0)]))
+        #expect(try ACPBrokerJSONValue(encodable: Payload(protocolVersion: 2))
+            == .object(["protocolVersion": .number(2)]))
+    }
+
+    // Guard the fix from over-correcting: genuine JSON booleans must stay bool.
+    @Test func encodableBooleansStayBooleans() throws {
+        struct Payload: Encodable { let enabled: Bool; let disabled: Bool }
+
+        #expect(try ACPBrokerJSONValue(encodable: Payload(enabled: true, disabled: false))
+            == .object(["enabled": .bool(true), "disabled": .bool(false)]))
+    }
+
     @Test func startOpensAndAttachesBroker() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [])

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -22,7 +22,10 @@ struct ACPBrokerClientTests {
 
     // Guard the fix from over-correcting: genuine JSON booleans must stay bool.
     @Test func encodableBooleansStayBooleans() throws {
-        struct Payload: Encodable { let enabled: Bool; let disabled: Bool }
+        struct Payload: Encodable {
+            let enabled: Bool
+            let disabled: Bool
+        }
 
         #expect(try ACPBrokerJSONValue(encodable: Payload(enabled: true, disabled: false))
             == .object(["enabled": .bool(true), "disabled": .bool(false)]))


### PR DESCRIPTION
## Problem

Since v0.11.5, attaching to ACP chat sessions fails with `ACP session attach failed: ACP error -32602: Invalid params`, across **all providers** (codex, claude, opencode) and for **most chats**. It did not happen in v0.11.4.

## Root cause

The local broker (introduced in #826) routes every request through `ACPBrokerClient`, which re-encodes outgoing params via `JSONSerialization` in `ACPBrokerJSONValue.init(jsonObject:)`. That `switch` matched `Bool` before `Int`:

```swift
case let value as Bool:
    self = .bool(value)
case let value as Int:
    self = .number(Double(value))
```

`JSONSerialization` boxes every JSON number as an `NSNumber`, and Foundation's `NSNumber → Bool` bridge succeeds for any value equal to `0` or `1`. So the `initialize` request's `protocolVersion: 1` was rewritten to `true`. Every conformant ACP agent validates `protocolVersion` as a number, so it rejected the request with `-32602` — before `session/new` was ever reached. Because the broker is the mandatory transport for all locally-spawned agents since #826, every fresh `initialize` was affected regardless of provider.

`mcpServers` (including the built-in `alas` server) is unaffected — it's all strings and round-trips losslessly.

## Fix

Collapse the numeric cases into a single `NSNumber` case and use `CFBoolean`'s distinct `CFTypeID` to tell genuine JSON booleans apart from numbers before mapping. Booleans stay boolean; `0`/`1`/`2`… stay numbers.

## Tests

- `encodableIntegerParamsSurviveAsNumbers` — regression guard: `protocolVersion: 1` encodes to `.number(1)`, not `.bool(true)`.
- `encodableBooleansStayBooleans` — ensures the fix doesn't over-correct real booleans.

`AlasTests/ACPBrokerClientTests` passes 25/25 locally (arm64).