### PR TITLE
fix(integrations): code-host authentication for SSH workspaces 

### DIFF
--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -40,13 +40,44 @@ extension CodeHostCommandRunning {
 
 struct ProcessCodeHostCommandRunner: CodeHostCommandRunning {
     func run(_ executable: String, args: [String], cwd: URL?, stdin: String?) async throws -> ProcessResult {
-        try await Process.run(
-            "/usr/bin/env",
-            args: [executable] + args,
-            cwd: cwd,
-            env: Process.gitEnv(),
+        let invocation = CodeHostCommandInvocation.build(
+            executable: executable,
+            args: args,
+            cwd: cwd
+        )
+        return try await Process.run(
+            invocation.executable,
+            args: invocation.args,
+            cwd: invocation.cwd,
+            env: invocation.env,
             stdin: stdin
         )
+    }
+}
+
+struct CodeHostCommandInvocation: Equatable {
+    let executable: String
+    let args: [String]
+    let cwd: URL?
+    let env: [String: String]?
+
+    static func build(executable: String, args: [String], cwd: URL?) -> Self {
+        guard let cwd,
+              let host = RemoteHostRegistry.shared.host(forPath: cwd.path)
+        else {
+            return Self(
+                executable: "/usr/bin/env",
+                args: [executable] + args,
+                cwd: cwd,
+                env: Process.gitEnv()
+            )
+        }
+
+        let command = (["env", "GIT_OPTIONAL_LOCKS=0", "LC_ALL=C", executable] + args)
+            .map(SSHCommand.shellQuote)
+            .joined(separator: " ")
+        let remote = RemoteExec.invocation(host: host, cwd: cwd.path, command: command)
+        return Self(executable: remote.executable, args: remote.args, cwd: nil, env: nil)
     }
 }
 
@@ -54,7 +85,7 @@ protocol CodeHostProvider: Sendable {
     var kind: CodeHostKind { get }
     var capabilities: CodeHostProviderCapabilities { get }
 
-    func isAvailable() async -> Bool
+    func isAvailable(cwd: URL) async -> Bool
     func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool
     func currentReviewRequest(
         remote: CodeHostRemote,

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -251,9 +251,9 @@ struct GitHubCLIProvider: CodeHostProvider {
         self.runner = runner
     }
 
-    func isAvailable() async -> Bool {
+    func isAvailable(cwd: URL) async -> Bool {
         do {
-            let result = try await runner.run("gh", args: ["--version"], cwd: nil)
+            let result = try await runner.run("gh", args: ["--version"], cwd: cwd)
             return result.exitCode == 0
         } catch {
             return false

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -16,9 +16,9 @@ struct GitLabCLIProvider: CodeHostProvider {
         self.runner = runner
     }
 
-    func isAvailable() async -> Bool {
+    func isAvailable(cwd: URL) async -> Bool {
         do {
-            let result = try await runner.run("glab", args: ["--version"], cwd: nil)
+            let result = try await runner.run("glab", args: ["--version"], cwd: cwd)
             return result.exitCode == 0
         } catch {
             return false

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -264,7 +264,7 @@ final class ReviewLoopState {
             return
         }
 
-        let providerAvailable = await provider.isAvailable()
+        let providerAvailable = await provider.isAvailable(cwd: worktreePath)
         guard isCurrentRefresh(generation) else { return }
         guard providerAvailable else {
             snapshot = ReviewLoopSnapshot(

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -55,6 +55,31 @@ struct CodeHostProviderTests {
         #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "/custom/provider/bin:/usr/bin:/bin")
     }
 
+    @Test func commandInvocationRoutesRemoteWorkspaceThroughSSH() throws {
+        let cwd = URL(fileURLWithPath: "/srv/alas-code-host-invocation-test")
+        RemoteHostRegistry.shared.register(root: cwd.path, host: "code-host-devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: cwd.path) }
+
+        let invocation = CodeHostCommandInvocation.build(
+            executable: "gh",
+            args: ["auth", "status", "--hostname", "github.com"],
+            cwd: cwd
+        )
+
+        #expect(invocation.executable == SSHCommand.executable)
+        #expect(invocation.cwd == nil)
+        #expect(invocation.env == nil)
+        #expect(invocation.args.contains("code-host-devbox"))
+        let script = try #require(invocation.args.last)
+        let command = [
+            "env", "GIT_OPTIONAL_LOCKS=0", "LC_ALL=C",
+            "gh", "auth", "status", "--hostname", "github.com",
+        ]
+            .map(SSHCommand.shellQuote)
+            .joined(separator: " ")
+        #expect(script == SSHCommand.remoteScript(cwd: cwd.path, command: command))
+    }
+
     @Test func defaultEvidenceMethodsUseSummaryData() async throws {
         let remote = CodeHostRemote(
             kind: .github,
@@ -203,7 +228,7 @@ struct CodeHostProviderTests {
         let kind: CodeHostKind
         let capabilities: CodeHostProviderCapabilities = .readOnly
 
-        func isAvailable() async -> Bool {
+        func isAvailable(cwd: URL) async -> Bool {
             true
         }
 

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -178,10 +178,10 @@ struct GitHubCLIProviderTests {
             ProcessResult(exitCode: 1, stdout: "", stderr: "missing"),
         ])
 
-        #expect(await GitHubCLIProvider(runner: successRunner).isAvailable())
-        #expect(await GitHubCLIProvider(runner: failureRunner).isAvailable() == false)
+        #expect(await GitHubCLIProvider(runner: successRunner).isAvailable(cwd: Self.cwd))
+        #expect(await GitHubCLIProvider(runner: failureRunner).isAvailable(cwd: Self.cwd) == false)
         #expect(await successRunner.commands == [
-            FakeRunner.Command(executable: "gh", args: ["--version"], cwd: nil),
+            FakeRunner.Command(executable: "gh", args: ["--version"], cwd: Self.cwd),
         ])
     }
 

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -12,10 +12,10 @@ struct GitLabCLIProviderTests {
             ProcessResult(exitCode: 1, stdout: "", stderr: "missing"),
         ])
 
-        #expect(await GitLabCLIProvider(runner: successRunner).isAvailable())
-        #expect(await GitLabCLIProvider(runner: failureRunner).isAvailable() == false)
+        #expect(await GitLabCLIProvider(runner: successRunner).isAvailable(cwd: Self.cwd))
+        #expect(await GitLabCLIProvider(runner: failureRunner).isAvailable(cwd: Self.cwd) == false)
         #expect(await successRunner.commands == [
-            FakeRunner.Command(executable: "glab", args: ["--version"], cwd: nil),
+            FakeRunner.Command(executable: "glab", args: ["--version"], cwd: Self.cwd),
         ])
     }
 

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -1214,7 +1214,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
         self.rerunError = rerunError
     }
 
-    func isAvailable() async -> Bool {
+    func isAvailable(cwd: URL) async -> Bool {
         available
     }
 

--- a/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDiffLoaderTests.swift
@@ -257,7 +257,7 @@ struct ReviewRequestDiffLoaderTests {
 private struct FakeDiffProvider: CodeHostProvider {
     let diff: String
     var kind: CodeHostKind = .github
-    func isAvailable() async -> Bool { true }
+    func isAvailable(cwd: URL) async -> Bool { true }
     func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
     func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? { nil }
     func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL { URL(fileURLWithPath: "/tmp/pr") }

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -203,7 +203,7 @@ struct ReviewSessionLoaderTests {
         let kind: CodeHostKind = .github
         let diff: String
 
-        func isAvailable() async -> Bool { true }
+        func isAvailable(cwd: URL) async -> Bool { true }
         func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
         func currentReviewRequest(
             remote: CodeHostRemote,

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -1620,7 +1620,7 @@ struct ReviewSessionTabViewTests {
         let kind: CodeHostKind
         let result: ProviderReviewPublishResult
 
-        func isAvailable() async -> Bool { true }
+        func isAvailable(cwd: URL) async -> Bool { true }
         func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
         func currentReviewRequest(
             remote: CodeHostRemote,
@@ -1710,7 +1710,7 @@ struct ReviewSessionTabViewTests {
             return recordedPublishRequests
         }
 
-        func isAvailable() async -> Bool { true }
+        func isAvailable(cwd: URL) async -> Bool { true }
         func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
         func currentReviewRequest(
             remote: CodeHostRemote,


### PR DESCRIPTION
## Summary

- route GitHub and GitLab CLI commands through the registered SSH host for remote workspaces
- make provider availability checks workspace-aware
- preserve locale, git lock, argument quoting, and stdin behavior across remote execution
- add regression coverage for SSH command routing

## Root cause

The changes pane detected the remote repository correctly, but launched `gh` and `glab` locally with the remote filesystem path as `cwd`. That process launch failed before the authentication probe ran, and the failure was surfaced as **Auth needed**.

## Impact

GitHub and GitLab status, review, and action commands now execute on the same remote host as the SSH workspace. Local workspaces retain the existing local execution path.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused provider suites: 167 tests passed
- non-opt-in full suite: 5,785 tests passed, 4 skipped

The unfiltered suite additionally discovers eight localhost SSH integration tests that are intentionally gated on `ALAS_SSH_INTEGRATION=1`; Xcode does not forward that shell variable into this scheme's test host.