### PR TITLE
fix(acp): preserve brokers across helper restarts

### DIFF
--- a/Alas/Sources/ACP/Broker/LocalACPBrokerService.swift
+++ b/Alas/Sources/ACP/Broker/LocalACPBrokerService.swift
@@ -37,7 +37,8 @@ actor LocalACPBrokerService {
                     executable: binary,
                     arguments: ["serve"],
                     environment: nil,
-                    framing: .newline
+                    framing: .newline,
+                    terminationScope: .processOnly
                 )
             }
         )

--- a/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
+++ b/Alas/Sources/JSONRPC/JSONRPCStdioTransport.swift
@@ -6,6 +6,11 @@ enum JSONRPCFraming {
     case newline         // ACP-style one-JSON-object-per-line
 }
 
+enum JSONRPCProcessTerminationScope: Equatable {
+    case processOnly
+    case processTree
+}
+
 protocol JSONRPCStdioTransporting: AnyObject, Sendable {
     var incoming: AsyncStream<JSONRPCStdioTransport.Incoming> { get }
     var requestIDPrefix: String? { get }
@@ -51,6 +56,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
     private let stdout = Pipe()
     private let stderr = Pipe()
     private let framing: JSONRPCFraming
+    private let terminationScope: JSONRPCProcessTerminationScope
     private var contentLengthFramer = JSONRPCFramer()
     private var newlineFramer = JSONRPCNewlineFramer()
     private let lock = NSLock()
@@ -77,9 +83,11 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         arguments: [String],
         environment: [String: String]?,
         framing: JSONRPCFraming = .contentLength,
-        replaceEnv: Bool = false
+        replaceEnv: Bool = false,
+        terminationScope: JSONRPCProcessTerminationScope = .processTree
     ) {
         self.framing = framing
+        self.terminationScope = terminationScope
         var cont: AsyncStream<Incoming>.Continuation!
         self.incoming = AsyncStream { c in cont = c }
         self.continuation = cont
@@ -127,7 +135,7 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         process.terminationHandler = { [weak self] p in
             guard let self else { return }
             let pid = p.processIdentifier
-            if pid > 0 {
+            if self.terminationScope == .processTree, pid > 0 {
                 // Last chance to reach same-group descendants that were
                 // spawned after the most recent tracker tick. Later shutdown
                 // paths avoid group signaling once the root pid can be stale.
@@ -140,13 +148,16 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
             self.lock.unlock()
             self.refreshLock.unlock()
             self.cancelDescendantForkObservers()
-            for d in Self.currentlyMatching(cachedTargets) {
-                _ = Darwin.kill(d.pid, SIGTERM)
+            if self.terminationScope == .processTree {
+                for d in Self.currentlyMatching(cachedTargets) {
+                    _ = Darwin.kill(d.pid, SIGTERM)
+                }
             }
             self.continuation?.yield(.exited(p.terminationStatus))
             self.continuation?.finish()
         }
         try process.run()
+        guard terminationScope == .processTree else { return }
         // Move the child into its own process group so signals from
         // `terminate()` can be delivered to the whole tree via
         // `kill(-pid, …)`. Foundation's Process doesn't expose
@@ -183,6 +194,13 @@ final class JSONRPCStdioTransport: @unchecked Sendable, JSONRPCStdioTransporting
         let targets = orphanedDescendants
         lock.unlock()
         refreshLock.unlock()
+
+        guard terminationScope == .processTree else {
+            if process.isRunning {
+                process.terminate()
+            }
+            return
+        }
 
         if rootAlive {
             // Root is still alive: a process-group signal reaches the

--- a/AlasTests/Code/LSP/LSPTransportTests.swift
+++ b/AlasTests/Code/LSP/LSPTransportTests.swift
@@ -87,6 +87,15 @@ struct ProcessTransportTerminationTests {
         #expect(source.serializesRootExitWithDescendantRefresh())
     }
 
+    @Test("Local ACP helper termination preserves detached broker supervisors")
+    func localACPHelperPreservesBrokerSupervisors() throws {
+        let transportSource = try source(named: "JSONRPC/JSONRPCStdioTransport.swift")
+        let brokerSource = try source(named: "ACP/Broker/LocalACPBrokerService.swift")
+
+        #expect(transportSource.contains("terminationScope == .processTree"))
+        #expect(brokerSource.contains("terminationScope: .processOnly"))
+    }
+
     private func source(named path: String) throws -> String {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()


### PR DESCRIPTION
## Summary

- add an explicit process-only termination scope to the JSON-RPC stdio transport
- use that scope for the local ACP broker-control helper
- preserve the existing process-tree cleanup behavior for all other transports
- add regression coverage for the local broker transport configuration

## Root cause

The local helper launches each durable ACP broker supervisor as a detached descendant. The generic stdio transport still tracked that supervisor and killed it individually when the helper channel exited or restarted. A subsequent helper process found the stale broker socket and failed with `Remote helper error -32072: broker connect failed: Connection refused (os error 61)`.

## Impact

Local ACP chats no longer lose their broker supervisor when the control helper restarts, so in-flight and persisted sessions remain reachable across helper channel churn.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused `ProcessTransportTerminationTests` pass
- AlasHelper Rust suite: 76 passed
- full macOS test run: 5,786 passed; only the 8 opt-in `SSHIntegrationTests` failed because `ALAS_SSH_INTEGRATION=1` was not set