### PR TITLE
fix(remote-web): show loading screen instead of disconnected flash on initial load

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -18,6 +18,9 @@ let pairingPromise = null;
 let pairingController = null;
 const initialReconnectDelay = 1500;
 const maxReconnectDelay = 30000;
+let everConnected = false;      // has any onopen fired this page load? separates "loading" from "disconnected"
+let escalationTimer = null;     // fires after a continuous not-connected grace window, then shows the alarming gate
+const GRACE_MS = 5000;          // total not-connected budget before escalating "Connecting…" → "Can't reach Alas"
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
 let lastSentText = null;        // text of the most recent sendPrompt, kept so a server promptRejected can restore it instead of losing the message
 let lastSentAttachments = [];   // images of the most recent sendPrompt, restored alongside the text on promptRejected
@@ -41,15 +44,50 @@ const ATTACH_CAP = 10 * 1000 * 1000;   // 10 MB running total — matches the se
 // state ∈ {connecting, ok, bad} drives the chip's dot/border color via [data-state].
 function setStatus(s, state) { const e = $("status"); e.textContent = s; e.dataset.state = state || "connecting"; }
 function showGate(title, msg, retry) {
+  $("gate").classList.remove("connecting");   // default to the plain (alarming/pairing) look
   $("gate-title").textContent = title;
   $("gate-msg").textContent = msg;
   $("gate-retry").classList.toggle("hidden", !retry);
   $("gate").classList.remove("hidden");
 }
-function hideGate() { $("gate").classList.add("hidden"); }
+function hideGate() {
+  $("gate").classList.add("hidden");
+  $("gate").classList.remove("connecting");
+}
 
 function showUnreachableGate() {
   showGate("Can't reach Alas", "Make sure your Mac is awake, Alas is running, and this device is on the same Wi-Fi or tailnet.", true);
+}
+
+// Neutral loading overlay shown while we're still trying to reach the Mac for
+// the first time. Reuses the gate DOM; the `connecting` class swaps the icon
+// for a spinner (see style.css) and there is no "Try again" button.
+function showConnectingGate() {
+  showGate("Connecting…", "Reaching your Mac…", false);
+  $("gate").classList.add("connecting");
+}
+
+// Single continuous-not-connected timer: armed once and NOT reset per retry, so
+// the grace period is a total budget across attempts rather than per-attempt.
+function armEscalation() {
+  if (escalationTimer) return;
+  escalationTimer = setTimeout(() => {
+    escalationTimer = null;
+    showUnreachableGate();
+  }, GRACE_MS);
+}
+function clearEscalation() {
+  if (escalationTimer) {
+    clearTimeout(escalationTimer);
+    escalationTimer = null;
+  }
+}
+
+// Pure: what should a socket close reflect, given whether we ever connected?
+//   "loading"      → still on initial load: show the neutral Connecting overlay
+//   "reconnecting" → mid-session drop: keep the transcript, just flag the chip
+function closeState(everConnectedFlag) {
+  return everConnectedFlag ? "reconnecting" : "loading";
 }
 
 function scheduleReconnect() {
@@ -72,7 +110,10 @@ function retryConnection() {
     pairingPromise = null;
   }
   reconnectDelay = initialReconnectDelay;
-  setStatus("Connecting...", "connecting");
+  clearEscalation();               // start a fresh grace budget for the manual retry
+  setStatus("Connecting…", "connecting");
+  showConnectingGate();
+  armEscalation();
   connect();
 }
 
@@ -125,8 +166,9 @@ async function connect() {
     token = await ensureToken();
   } catch (err) {
     if (attempt !== connectAttempt) return;
-    if (err && err.message === "net") scheduleReconnect();
-    return;   // no code/token yet (or pairing failed); status is set — wait for the user
+    if (err && err.message === "net") { scheduleReconnect(); return; }   // keep escalation armed; retrying
+    clearEscalation();   // pairing / no-token is a user-action state, not an outage — cancel the doom timer
+    return;              // status/gate already set by ensureToken — wait for the user
   }
   if (attempt !== connectAttempt) return;
   if (ws) { try { ws.close(); } catch (_) {} }   // drop any prior (possibly half-open) socket
@@ -135,6 +177,8 @@ async function connect() {
   ws = socket;
   socket.onopen = () => {
     if (socket !== ws) return;
+    everConnected = true;
+    clearEscalation();
     setStatus("Connected", "ok");
     hideGate();
     if (reconnectTimer) {
@@ -152,9 +196,17 @@ async function connect() {
   };
   socket.onclose = () => {
     if (socket !== ws) return;
-    setStatus("Reconnecting...", "bad");
     failCreateOnDisconnect();
-    showUnreachableGate();
+    if (closeState(everConnected) === "loading") {
+      // Initial load still in progress — keep the neutral loading overlay up
+      // instead of flashing the alarming "Can't reach Alas" screen.
+      setStatus("Connecting…", "connecting");
+      showConnectingGate();
+    } else {
+      // Mid-session drop — keep the transcript visible; only the chip changes.
+      setStatus("Reconnecting...", "bad");
+    }
+    armEscalation();     // no-op if already armed → grace stays a total budget
     scheduleReconnect();
   };
   socket.onmessage = (e) => {
@@ -2266,4 +2318,7 @@ if (vp) {
   syncViewport();
 }
 
+setStatus("Connecting…", "connecting");
+showConnectingGate();
+armEscalation();
 connect();

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -20,6 +20,7 @@ const initialReconnectDelay = 1500;
 const maxReconnectDelay = 30000;
 let everConnected = false;      // has any onopen fired this page load? separates "loading" from "disconnected"
 let escalationTimer = null;     // fires after a continuous not-connected grace window, then shows the alarming gate
+let escalated = false;          // true once the grace window elapsed and the alarming gate is showing
 const GRACE_MS = 5000;          // total not-connected budget before escalating "Connecting…" → "Can't reach Alas"
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
 let lastSentText = null;        // text of the most recent sendPrompt, kept so a server promptRejected can restore it instead of losing the message
@@ -70,9 +71,10 @@ function showConnectingGate() {
 // Single continuous-not-connected timer: armed once and NOT reset per retry, so
 // the grace period is a total budget across attempts rather than per-attempt.
 function armEscalation() {
-  if (escalationTimer) return;
+  if (escalationTimer || escalated) return;   // don't re-arm while pending, or after we've already escalated
   escalationTimer = setTimeout(() => {
     escalationTimer = null;
+    escalated = true;
     showUnreachableGate();
   }, GRACE_MS);
 }
@@ -81,6 +83,7 @@ function clearEscalation() {
     clearTimeout(escalationTimer);
     escalationTimer = null;
   }
+  escalated = false;
 }
 
 // Pure: what should a socket close reflect, given whether we ever connected?
@@ -199,12 +202,15 @@ async function connect() {
     failCreateOnDisconnect();
     if (closeState(everConnected) === "loading") {
       // Initial load still in progress — keep the neutral loading overlay up
-      // instead of flashing the alarming "Can't reach Alas" screen.
-      setStatus("Connecting…", "connecting");
-      showConnectingGate();
+      // instead of flashing the alarming "Can't reach Alas" screen. Once we've
+      // escalated, leave the alarming gate up rather than flapping back to it.
+      if (!escalated) {
+        setStatus("Connecting…", "connecting");
+        showConnectingGate();
+      }
     } else {
       // Mid-session drop — keep the transcript visible; only the chip changes.
-      setStatus("Reconnecting...", "bad");
+      setStatus("Reconnecting…", "bad");
     }
     armEscalation();     // no-op if already armed → grace stays a total budget
     scheduleReconnect();

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=37" />
+  <link rel="stylesheet" href="/style.css?v=38" />
 </head>
 <body>
   <header id="bar">
@@ -131,7 +131,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=59"></script>
+  <script src="/app.js?v=60"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -190,6 +190,20 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 #gate-retry { margin-top: 18px; padding: 11px 20px; border: 0.5px solid color-mix(in oklab, var(--accent) 55%, transparent); border-radius: 10px; background: color-mix(in oklab, var(--accent) 18%, transparent); color: var(--fg); font-size: 15px; font-weight: 600; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 #gate-retry:active { background: color-mix(in oklab, var(--accent) 26%, transparent); }
 
+/* Connecting variant: swap the ⚠ glyph for a spinner while we're still loading. */
+#gate.connecting .gate-icon {
+  box-sizing: border-box;
+  font-size: 0;                 /* hide the ⚠ glyph */
+  width: 34px;
+  height: 34px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  border: 3px solid var(--bg-4);
+  border-top-color: var(--accent);
+  animation: gate-spin 0.8s linear infinite;
+}
+@keyframes gate-spin { to { transform: rotate(360deg); } }
+
 /* Bottom sheets (permission / question) */
 .sheet { position: fixed; inset: 0; background: rgba(0,0,0,.5); display: flex; align-items: flex-end; z-index: 10; }
 .sheet-card { background: var(--bg-2); width: 100%; padding: 18px 16px calc(18px + env(safe-area-inset-bottom)); border-radius: 16px 16px 0 0; border-top: 0.5px solid var(--line); }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v37";
+const CACHE_NAME = "alas-remote-shell-v38";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=37",
-  "/app.js?v=59",
+  "/style.css?v=38",
+  "/app.js?v=60",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -48,11 +48,11 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=59"#))
-        #expect(html.contains(#"/style.css?v=37"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v37";"#))
-        #expect(sw.contains(#""/app.js?v=59""#))
-        #expect(sw.contains(#""/style.css?v=37""#))
+        #expect(html.contains(#"/app.js?v=60"#))
+        #expect(html.contains(#"/style.css?v=38"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v38";"#))
+        #expect(sw.contains(#""/app.js?v=60""#))
+        #expect(sw.contains(#""/style.css?v=38""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -65,11 +65,11 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=59"#))
-        #expect(html.contains(#"/style.css?v=37"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v37";"#))
-        #expect(sw.contains(#""/app.js?v=59""#))
-        #expect(sw.contains(#""/style.css?v=37""#))
+        #expect(html.contains(#"/app.js?v=60"#))
+        #expect(html.contains(#"/style.css?v=38"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v38";"#))
+        #expect(sw.contains(#""/app.js?v=60""#))
+        #expect(sw.contains(#""/style.css?v=38""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -110,8 +110,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-state-active"))
         #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=59"))
-        #expect(html.contains("/style.css?v=37"))
+        #expect(html.contains("/app.js?v=60"))
+        #expect(html.contains("/style.css?v=38"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -136,8 +136,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=59""#))
-        #expect(sw.contains(#""/style.css?v=37""#))
+        #expect(sw.contains(#""/app.js?v=60""#))
+        #expect(sw.contains(#""/style.css?v=38""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {
@@ -285,9 +285,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v37"))
-        #expect(sw.contains("/app.js?v=59"))
-        #expect(html.contains("app.js?v=59"))
+        #expect(sw.contains("alas-remote-shell-v38"))
+        #expect(sw.contains("/app.js?v=60"))
+        #expect(html.contains("app.js?v=60"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the


### PR DESCRIPTION
## Problem

On the remote web, loading an already-paired site flashed the alarming **"Can't reach Alas / Try again"** disconnected screen for a few seconds before content appeared.

Root cause: `socket.onclose` showed that gate unconditionally. Per the WebSocket spec, `onclose` fires even when the initial handshake never completed — so on a fresh load, a slightly slow `/ws` connection (mobile radio waking, LAN/tailnet latency, server not yet accepting) closed the first socket before `onopen`, painting the disconnected screen immediately. The reconnect backoff then held it there until a retry succeeded.

## Fix

Distinguish **loading** (never connected yet this page load) from **disconnected** (was connected, then dropped), via an `everConnected` flag, and escalate to the alarming gate only after a ~5s grace period (a *total* continuous-not-connected budget, not per-retry).

- **Normal load** → brief neutral "Connecting…" spinner → content. No alarming flash.
- **Mac genuinely unreachable at load** → spinner for ~5s → "Can't reach Alas / Try again", and it stays put.
- **Mid-session blip** → transcript stays visible, only a "Reconnecting…" status chip; the full gate appears only after ~5s of sustained failure.
- **"Try again"** → back to the spinner with a fresh grace budget.

Implemented with a single escalation timer (`GRACE_MS = 5000`), an `escalated` one-way latch (reset on a successful connect or manual retry), a `showConnectingGate()` variant reusing the existing gate overlay, a pure `closeState()` helper, and a `#gate.connecting` spinner in CSS. Service-worker `CACHE_NAME` and pinned asset versions bumped so installed PWAs pick up the new `app.js` / `style.css`.

## Testing

The remote-web client is vanilla JS with no JS test harness in the repo (native tests use Swift Testing), so verification was `node --check` (syntax) plus code-level review of the connection state machine. The following runtime scenarios should be walked in the app before merge:

1. Normal load (Mac up) → brief "Connecting…", no alarming flash.
2. Mac off at load → "Connecting…" ~5s → "Can't reach Alas / Try again" (stays stable).
3. Mid-session Wi-Fi blip → transcript stays, "Reconnecting…" chip, recovers with no overlay.
4. Mid-session sustained drop → chip ~5s → full gate over content.
5. "Try again" → returns to "Connecting…", restarts the budget.

## Out of scope

`pairWithCode()`'s `/pair` network-failure still shows the alarming gate immediately — that's the QR-pairing flow, not the already-paired load path this PR targets.
