### PR TITLE
fix(acp): throttle streaming text row publishes to display rate

### DIFF
--- a/Alas/Sources/ACP/Session/ACPStreamingText.swift
+++ b/Alas/Sources/ACP/Session/ACPStreamingText.swift
@@ -11,17 +11,42 @@ import Combine
 /// share the same buffer compare equal even as the text grows, so the
 /// transcript-array diff doesn't fire on streaming. The inner row view
 /// observes the buffer directly via @ObservedObject and re-renders
-/// when `value` changes.
+/// when the buffer publishes.
+///
+/// `value` is NOT `@Published`: the string mutates synchronously on every
+/// `append` (so any reader sees the latest text immediately), but the
+/// SwiftUI-facing `objectWillChange` publish is throttled to display rate
+/// via `ACPTranscript.streamingTickAction`. Without this, a fast agent
+/// response forces one full agent-row re-render — which re-runs
+/// `ACPMarkdownBlockCache.update` + `ACPMarkdownText.parse(tail)` — per
+/// streaming chunk (potentially hundreds/sec). Mirrors the `streamingTick`
+/// throttle from #823, which coalesces whole-list invalidation but does
+/// not cover this per-row buffer publish. A trailing-edge drain guarantees
+/// the final chunk of a burst still renders within one throttle interval.
 @MainActor
 final class StreamingText: ObservableObject {
-    @Published private(set) var value: String
+    private(set) var value: String
     private(set) var utf8Length: Int
     private(set) var revision: UInt64 = 0
     private(set) var lastAppendedSuffix: String?
 
+    /// Wall-clock time (`ProcessInfo.systemUptime`) of the last publish.
+    private var lastPublish: TimeInterval = 0
+    /// Trailing-edge publish scheduled when a chunk arrives inside the
+    /// throttle window; guarantees the last chunk of a burst renders.
+    private var drainTask: Task<Void, Never>?
+
+    #if DEBUG
+    private(set) var publishCountForTests = 0
+    #endif
+
     init(_ initial: String = "") {
         self.value = initial
         self.utf8Length = initial.utf8.count
+    }
+
+    deinit {
+        drainTask?.cancel()
     }
 
     func append(_ s: String) {
@@ -29,6 +54,35 @@ final class StreamingText: ObservableObject {
         utf8Length += s.utf8.count
         revision &+= 1
         lastAppendedSuffix = s
+        scheduleThrottledPublish()
+    }
+
+    private func scheduleThrottledPublish() {
+        let now = ProcessInfo.processInfo.systemUptime
+        switch ACPTranscript.streamingTickAction(
+            elapsedSincePublish: now - lastPublish,
+            hasPendingDrain: drainTask != nil
+        ) {
+        case .publishNow:
+            publish(at: now)
+        case .scheduleDrain(let delay):
+            drainTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                guard let self, !Task.isCancelled else { return }
+                self.drainTask = nil
+                self.publish(at: ProcessInfo.processInfo.systemUptime)
+            }
+        case .drop:
+            break
+        }
+    }
+
+    private func publish(at time: TimeInterval) {
+        lastPublish = time
+        #if DEBUG
+        publishCountForTests += 1
+        #endif
+        objectWillChange.send()
     }
 }
 

--- a/AlasTests/ACP/Session/ACPStreamingTextTests.swift
+++ b/AlasTests/ACP/Session/ACPStreamingTextTests.swift
@@ -41,4 +41,38 @@ struct ACPStreamingTextTests {
         let rhs = ACPMessage.agent(id: id, StreamingText("hi"))
         #expect(lhs != rhs)
     }
+
+    @Test("a synchronous burst of chunks coalesces into a single publish")
+    func synchronousBurstCoalescesPublishes() async {
+        let t = StreamingText()
+
+        // A tight loop appends far faster than the throttle interval, so
+        // every chunk lands inside one window: the first publishes
+        // immediately, the second schedules a trailing drain, and the
+        // rest are dropped until that drain fires.
+        for _ in 0..<200 {
+            t.append("x")
+        }
+
+        #expect(t.value.count == 200)
+        #expect(t.revision == 200)
+        #expect(t.publishCountForTests == 1)
+    }
+
+    @Test("the trailing chunk of a burst is eventually delivered")
+    func trailingChunkDeliveredAfterDrain() async throws {
+        let t = StreamingText()
+
+        t.append("a")
+        t.append("b")
+        // Only the first append published synchronously; the second is
+        // pending on the trailing-edge drain.
+        #expect(t.publishCountForTests == 1)
+
+        try await Task.sleep(nanoseconds: 120_000_000)
+
+        // The drain fired, delivering a publish for the coalesced tail.
+        #expect(t.publishCountForTests == 2)
+        #expect(t.value == "ab")
+    }
 }


### PR DESCRIPTION
## What

Throttle the per-row `StreamingText` publish to display rate so a streaming
agent reply no longer re-parses its markdown tail on every chunk.

Closes #835.

## Why

`AgentMessageRow` (and `ACPThoughtView`) observe `StreamingText` via
`@ObservedObject`, and `StreamingText.value` was `@Published`. Every streaming
chunk therefore published a change and forced a full row re-render, which
re-runs `ACPMarkdownBlockCache.update` and `ACPMarkdownText.parse(tail)` over
the entire un-promoted tail. A fast agent emits chunks far faster than the
display refreshes, so this fired potentially hundreds of times per second — the
dominant per-chunk main-thread cost described in the issue.

The #823 fix throttled `streamingTick` (whole-list invalidation) but not this
per-row buffer publish, which is exactly what the issue calls out.

## How

- `value` is now a plain stored property. It still mutates synchronously on
  every `append`, so any reader (e.g. `ACPSession`, `ACPThoughtView`) always
  sees the latest text immediately.
- The SwiftUI-facing `objectWillChange` publish is throttled to display rate,
  reusing the already-tested pure decision function
  `ACPTranscript.streamingTickAction` from #823. A trailing-edge drain
  guarantees the final chunk of a burst still renders within one throttle
  interval, so no text is ever lost or left unrendered.

This coalesces a burst of chunks into at most ~30 row re-renders/sec instead of
one per chunk, mirroring how #823 was resolved.

## Scope note

The issue lists two further directions — in-fence stable promotion and a
lazy/identity-keyed block list. This PR intentionally lands only the throttle,
which is the dominant, low-risk fix and directly targets "the per-row buffer
publish still fires per chunk":

- **In-fence promotion** cannot preserve the single rendered code block without
  either splitting it into multiple cards (a visual regression) or an
  append-only code renderer (a larger architectural change that per repo
  guidelines needs an explicit plan). Because a growing live code block must be
  re-materialised to display it, promotion yields no per-frame asymptotic win
  once publishes are already throttled.
- The block list already uses positional identity (`id: \.offset`), which is
  stable for the frozen prefix; switching to `LazyVStack` risks scroll
  regressions for a marginal gain after throttling.

Happy to follow up on either in a separate PR if desired.

## Testing

- New `ACPStreamingTextTests`: a synchronous burst of 200 appends coalesces to a
  single publish while `value`/`revision` still reflect every chunk; the
  trailing chunk of a burst is delivered via the drain.
- Existing `ACPStreamingTextTests`, `ACPMarkdownBlockCacheTests`,
  `ACPTranscriptTests`, `ACPTranscriptChangeLogTests`,
  `ACPMessageListPaginationTests` pass locally (arm64).
