### PR TITLE
fix(acp): bound live terminal tail rendering

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1163,7 +1163,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if replace { return true }
         if replayCreatedMetadataTerminalIds.contains(terminalId) { return true }
         if let terminal = terminalHost.terminal(id: terminalId),
-           !terminal.buffer.isEmpty || terminal.exitStatus != nil {
+           terminal.retainedByteCount > 0 || terminal.exitStatus != nil {
             return false
         }
         replayCreatedMetadataTerminalIds.insert(terminalId)

--- a/Alas/Sources/ACP/Terminal/ACPTerminal.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminal.swift
@@ -4,14 +4,23 @@ import Combine
 
 /// Wraps one agent-spawned subprocess. Owns the merged stdout+stderr
 /// rolling buffer (capped at 1 MiB), captures the exit status, and
-/// publishes a "buffer changed" signal so UI subscribers can re-render
-/// the live tail without polling.
+/// publishes a display-rate-limited terminal tail for the transcript UI.
 @MainActor
 final class ACPTerminal: ObservableObject {
-    /// 1 MiB internal cap. Independent from the agent-supplied
-    /// `outputByteLimit`, which only governs what we return via
-    /// `terminal/output` — never how much we keep around for the UI.
+    /// 1 MiB protocol-output cap. Independent from the agent-supplied
+    /// `outputByteLimit`; the transcript UI keeps its own smaller tail.
     static let internalBufferCap = 1 << 20
+    /// The transcript row is at most 300 points tall. Retaining a 64 KiB
+    /// parsed display tail gives users ample scrollback without laying out
+    /// the entire protocol buffer on every refresh.
+    nonisolated static let displayByteLimit = 64 << 10
+    nonisolated static let displayRefreshMinInterval: TimeInterval = 1.0 / 30.0
+
+    enum DisplayRefreshAction: Equatable {
+        case publishNow
+        case scheduleDrain(after: TimeInterval)
+        case drop
+    }
 
     let id: String
     let createdAt: Date
@@ -19,9 +28,20 @@ final class ACPTerminal: ObservableObject {
     private let normalizesCRLF: Bool
 
     @Published private(set) var cwd: String?
-    @Published private(set) var buffer: Data = Data()
-    @Published private(set) var truncated: Bool = false
+    /// Full protocol buffer. This is intentionally not `@Published`: raw pipe
+    /// chunks must not invalidate SwiftUI. `displayRevision` below is the
+    /// coalesced UI signal.
+    var buffer: Data { Data(bufferStorage[bufferStart...]) }
+    var retainedByteCount: Int { bufferStorage.count - bufferStart }
+    private var bufferStorage = Data()
+    private var bufferStart = 0
+    private(set) var truncated: Bool = false
     @Published private(set) var exitStatus: ACPTerminalExitStatus?
+    @Published private(set) var displayRevision: UInt64 = 0
+    private(set) var displayRuns: [AttributedRun] = []
+    private var displayTail: ANSITailBuffer
+    private var lastDisplayPublish = -Double.greatestFiniteMagnitude
+    private var displayDrain: Task<Void, Never>?
     /// Flipped by `release()`. The host uses this to reject further
     /// `terminal/*` protocol calls against this id while still letting
     /// the UI render the retained buffer.
@@ -77,6 +97,7 @@ final class ACPTerminal: ObservableObject {
         self.createdAt = Date()
         self.cwd = cwd
         self.normalizesCRLF = normalizesCRLF
+        self.displayTail = ANSITailBuffer(byteLimit: Self.displayByteLimit)
         // Cap against the internal buffer so an agent can't ask us to
         // return more than we ever retain. Floor at 1 so callers that
         // pass 0 or negative don't trip divide-by-zero / nonsense math
@@ -139,6 +160,7 @@ final class ACPTerminal: ObservableObject {
         self.cwd = cwd
         self.outputByteLimit = max(1, min(outputByteLimit, Self.internalBufferCap))
         self.normalizesCRLF = false
+        self.displayTail = ANSITailBuffer(byteLimit: Self.displayByteLimit)
         self.process = nil
         self.pipe = nil
     }
@@ -431,7 +453,9 @@ final class ACPTerminal: ObservableObject {
     func appendMetadataOutput(_ data: Data, replace: Bool) {
         guard !isProcessBacked else { return }
         if replace {
-            buffer.removeAll(keepingCapacity: true)
+            bufferStorage.removeAll(keepingCapacity: true)
+            bufferStart = 0
+            displayTail.reset()
             truncated = false
         }
         appendChunk(data)
@@ -443,6 +467,7 @@ final class ACPTerminal: ObservableObject {
             exitStatus = status
             return
         }
+        publishDisplayNow()
         exitStatus = status
         onExit?()
         let waiters = exitWaiters
@@ -459,10 +484,11 @@ final class ACPTerminal: ObservableObject {
     ///    multibyte codepoints aren't split mid-sequence.
     func snapshot(byteLimit: Int) -> (text: String, truncated: Bool) {
         let limit = max(1, min(byteLimit, Self.internalBufferCap))
-        let didTruncate = buffer.count > limit
+        let retained = buffer
+        let didTruncate = retained.count > limit
         let slice: Data
         if didTruncate {
-            let all = [UInt8](buffer)
+            let all = [UInt8](retained)
             var start = all.count - limit
             // Lookback for an unterminated CSI escape. CSI param bytes
             // are 0x30..0x3F; finals are 0x40..0x7E. If we find an ESC
@@ -492,7 +518,7 @@ final class ACPTerminal: ObservableObject {
             }
             slice = Data(all[start ..< all.count])
         } else {
-            slice = buffer
+            slice = retained
         }
         // Strip ANSI for the JSON response (agents shouldn't see escape codes).
         var stream = ANSIStream()
@@ -528,17 +554,19 @@ final class ACPTerminal: ObservableObject {
     }
 
     private func appendChunk(_ chunk: Data) {
-        buffer.append(chunk)
-        if buffer.count > Self.internalBufferCap {
-            let drop = buffer.count - Self.internalBufferCap
-            buffer.removeFirst(drop)
+        displayTail.feed(chunk)
+        bufferStorage.append(chunk)
+        if retainedByteCount > Self.internalBufferCap {
+            let drop = retainedByteCount - Self.internalBufferCap
+            bufferStart += drop
             // The bulk drop may have landed mid-codepoint. Advance the
             // start past any leading UTF-8 continuation bytes so the
             // buffer always begins on a valid character boundary —
             // snapshot/output paths can then trust the invariant even
             // when no further truncation is needed at read time.
-            while let first = buffer.first, (first & 0xC0) == 0x80 {
-                buffer.removeFirst(1)
+            while bufferStart < bufferStorage.count,
+                  (bufferStorage[bufferStart] & 0xC0) == 0x80 {
+                bufferStart += 1
             }
             // The drop may have ALSO landed mid-ANSI-escape. Unlike
             // snapshot, we can't look backwards for the ESC byte (it
@@ -549,14 +577,23 @@ final class ACPTerminal: ObservableObject {
             // short window. Cursor-move finals are intentionally NOT
             // included to avoid eating bytes like `12A` in real text.
             stripLeadingPartialSGR()
-            truncated = true
+            if !truncated { truncated = true }
+
+            // Advance a logical start for each chunk, then compact only after
+            // a full cap's worth of discarded storage has accumulated. This
+            // amortizes the 1 MiB copy instead of memmoving it per pipe chunk.
+            if bufferStart >= Self.internalBufferCap {
+                bufferStorage = Data(bufferStorage[bufferStart...])
+                bufferStart = 0
+            }
         }
+        noteDisplayChange()
     }
 
     private func stripLeadingPartialSGR() {
         var n = 0
-        while n < min(buffer.count, 16) {
-            let b = buffer[buffer.startIndex + n]
+        while n < min(retainedByteCount, 16) {
+            let b = bufferStorage[bufferStart + n]
             if (b >= 0x30 && b <= 0x3F) {  // CSI param byte
                 n += 1
                 continue
@@ -568,7 +605,47 @@ final class ACPTerminal: ObservableObject {
             n = 0
             break
         }
-        if n > 0 { buffer.removeFirst(n) }
+        if n > 0 { bufferStart += n }
+    }
+
+    nonisolated static func displayRefreshAction(
+        elapsedSincePublish: TimeInterval,
+        hasPendingDrain: Bool,
+        minInterval: TimeInterval = displayRefreshMinInterval
+    ) -> DisplayRefreshAction {
+        if hasPendingDrain { return .drop }
+        if elapsedSincePublish >= minInterval { return .publishNow }
+        return .scheduleDrain(after: minInterval - elapsedSincePublish)
+    }
+
+    private func noteDisplayChange() {
+        let now = ProcessInfo.processInfo.systemUptime
+        switch Self.displayRefreshAction(
+            elapsedSincePublish: now - lastDisplayPublish,
+            hasPendingDrain: displayDrain != nil
+        ) {
+        case .publishNow:
+            publishDisplayNow(at: now)
+        case .scheduleDrain(let delay):
+            displayDrain = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .seconds(delay))
+                guard let self, !Task.isCancelled else { return }
+                self.displayDrain = nil
+                self.publishDisplayNow()
+            }
+        case .drop:
+            break
+        }
+    }
+
+    private func publishDisplayNow(
+        at now: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) {
+        displayDrain?.cancel()
+        displayDrain = nil
+        lastDisplayPublish = now
+        displayRuns = displayTail.runs
+        displayRevision &+= 1
     }
 
     private func handleExit(status: ACPTerminalExitStatus) async {
@@ -594,6 +671,7 @@ final class ACPTerminal: ObservableObject {
             try? await Task.sleep(for: .milliseconds(50))
         }
         pipe.fileHandleForReading.readabilityHandler = nil
+        publishDisplayNow()
         exitStatus = status
         onExit?()
         let waiters = exitWaiters

--- a/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
@@ -121,7 +121,7 @@ final class ACPTerminalHost: ObservableObject {
     }
 
     var retainedByteEstimate: UInt64 {
-        terminals.values.reduce(0) { $0 &+ UInt64($1.buffer.count) }
+        terminals.values.reduce(0) { $0 &+ UInt64($1.retainedByteCount) }
     }
 
     func updateContext(sessionCwd: String, sessionEnv: [String: String], sessionRemoteHost: String? = nil) {

--- a/Alas/Sources/ACP/Terminal/ANSIStream.swift
+++ b/Alas/Sources/ACP/Terminal/ANSIStream.swift
@@ -25,6 +25,123 @@ enum ANSIColor: Equatable {
     case rgb(red: Int, green: Int, blue: Int)
 }
 
+/// Bounded, incrementally parsed ANSI output for live terminal rendering.
+/// The parser consumes each pipe byte exactly once while this buffer retains
+/// only the tail that can reasonably be displayed in the transcript row.
+struct ANSITailBuffer {
+    private var stream = ANSIStream()
+    private var output: ANSIOutputBuffer
+
+    init(byteLimit: Int) {
+        output = ANSIOutputBuffer(byteLimit: max(1, byteLimit))
+    }
+
+    var runs: [AttributedRun] { output.runs }
+    var retainedByteCount: Int { output.retainedByteCount }
+
+    mutating func feed(_ data: Data) {
+        output.apply(stream.feedEvents(data))
+    }
+
+    mutating func reset() {
+        stream = ANSIStream()
+        output.reset()
+    }
+}
+
+private enum ANSIStreamEvent {
+    case text(AttributedRun)
+    case carriageReturn
+}
+
+/// Applies parser events to rendered runs. Keeping this separate from the
+/// byte parser lets `ANSIStream.feed` preserve its snapshot API while the live
+/// terminal tail keeps state across chunks, including CR progress redraws.
+private struct ANSIOutputBuffer {
+    let byteLimit: Int
+    private(set) var runs: [AttributedRun] = []
+    private(set) var retainedByteCount = 0
+    private var currentLineStart = 0
+
+    init(byteLimit: Int) {
+        self.byteLimit = byteLimit
+    }
+
+    mutating func reset() {
+        runs.removeAll(keepingCapacity: true)
+        retainedByteCount = 0
+        currentLineStart = 0
+    }
+
+    mutating func apply(_ events: [ANSIStreamEvent]) {
+        for event in events {
+            switch event {
+            case .text(let run):
+                append(run)
+            case .carriageReturn:
+                guard currentLineStart < runs.count else { continue }
+                for run in runs[currentLineStart...] {
+                    retainedByteCount -= run.text.utf8.count
+                }
+                runs.removeSubrange(currentLineStart...)
+            }
+        }
+        trimToByteLimit()
+    }
+
+    private mutating func append(_ run: AttributedRun) {
+        guard !run.text.isEmpty else { return }
+        retainedByteCount += run.text.utf8.count
+
+        // Do not merge the first run after a newline into the preceding run.
+        // A later carriage return must be able to discard only the current
+        // logical line, even when both lines share identical attributes.
+        if currentLineStart < runs.count,
+           runs.last?.attributes == run.attributes {
+            runs[runs.count - 1].text.append(run.text)
+        } else {
+            runs.append(run)
+        }
+
+        if run.text.last == "\n" {
+            currentLineStart = runs.count
+        }
+    }
+
+    private mutating func trimToByteLimit() {
+        let excess = retainedByteCount - byteLimit
+        guard excess > 0 else { return }
+
+        var bytesToDrop = excess
+        var fullRunsToDrop = 0
+        while fullRunsToDrop < runs.count {
+            let runBytes = runs[fullRunsToDrop].text.utf8.count
+            if runBytes > bytesToDrop { break }
+            bytesToDrop -= runBytes
+            retainedByteCount -= runBytes
+            fullRunsToDrop += 1
+        }
+
+        if fullRunsToDrop > 0 {
+            runs.removeSubrange(0..<fullRunsToDrop)
+            currentLineStart = max(0, currentLineStart - fullRunsToDrop)
+        }
+
+        guard bytesToDrop > 0, !runs.isEmpty else { return }
+        let bytes = Array(runs[0].text.utf8)
+        var start = min(bytesToDrop, bytes.count)
+        while start < bytes.count, (bytes[start] & 0xC0) == 0x80 {
+            start += 1
+        }
+        runs[0].text = String(decoding: bytes[start...], as: UTF8.self)
+        retainedByteCount -= start
+        if runs[0].text.isEmpty {
+            runs.removeFirst()
+            currentLineStart = max(0, currentLineStart - 1)
+        }
+    }
+}
+
 /// Stateful byte-stream parser. Caller feeds raw bytes from a process
 /// pipe and receives runs of styled text. Maintains parser state
 /// across calls so that escape sequences split mid-stream still
@@ -35,7 +152,7 @@ struct ANSIStream {
     private var state: State = .text
     private var attributes = ANSIAttributes()
     private var currentLine: String = ""
-    private var emitted: [AttributedRun] = []
+    private var events: [ANSIStreamEvent] = []
     private var paramBuf: String = ""
     /// Bytes accepted in `.text` state, decoded as UTF-8 in batches at
     /// safe boundaries. Multibyte sequences (è, emoji, etc.) would
@@ -43,19 +160,14 @@ struct ANSIStream {
     /// sequence split across two `feed()` calls stays here until the
     /// continuation bytes arrive.
     private var textBytes: [UInt8] = []
-    /// Index in `emitted` where the current logical line started. A CR
-    /// (line restart) discards everything from this point onward —
-    /// covers the case where a colored progress line was already split
-    /// into runs by an SGR change before the CR arrives.
-    private var emittedLineStart: Int = 0
-
     mutating func feed(_ data: Data) -> [AttributedRun] {
-        emitted.removeAll(keepingCapacity: true)
-        // `emittedLineStart` indexes into `emitted`. Each feed returns a
-        // fresh `emitted` array, so the marker must reset to 0 — runs
-        // emitted in earlier feeds have already been handed off to the
-        // caller, and CR can only truncate what's in the current batch.
-        emittedLineStart = 0
+        var output = ANSIOutputBuffer(byteLimit: .max)
+        output.apply(feedEvents(data))
+        return output.runs
+    }
+
+    fileprivate mutating func feedEvents(_ data: Data) -> [ANSIStreamEvent] {
+        events.removeAll(keepingCapacity: true)
         let bytes = [UInt8](data)
         var i = 0
         while i < bytes.count {
@@ -75,7 +187,7 @@ struct ANSIStream {
             i += 1
         }
         flushCurrentLine()
-        return emitted
+        return events
     }
 
     private mutating func handleTextByte(_ b: UInt8) {
@@ -85,23 +197,15 @@ struct ANSIStream {
             flushCurrentLine()
             state = .esc
         case 0x0D:                      // CR — line restart
-            // Drop the partially-buffered tail AND any colored runs the
-            // SGR path already emitted for this line. Without the
-            // emitted-run truncation, `\u{1B}[31m10%\r\u{1B}[32m20%`
-            // would leave the red `10%` behind alongside the new green
-            // `20%` instead of overwriting it.
-            textBytes.removeAll(keepingCapacity: true)
-            currentLine.removeAll(keepingCapacity: true)
-            if emittedLineStart < emitted.count {
-                emitted.removeSubrange(emittedLineStart ..< emitted.count)
-            }
+            flushTextBytes()
+            flushCurrentLine()
+            events.append(.carriageReturn)
         case 0x07, 0x08:                // BEL, BS — drop
             return
         case 0x0A:                      // LF — keep, commit line, advance marker
             textBytes.append(b)
             flushTextBytes()
             flushCurrentLine()
-            emittedLineStart = emitted.count
         case 0x09, 0x20 ... 0x7E:       // TAB, printable ASCII
             textBytes.append(b)
         default:                        // UTF-8 lead / continuation byte
@@ -203,7 +307,7 @@ struct ANSIStream {
     private mutating func flushCurrentLine() {
         flushTextBytes()
         if !currentLine.isEmpty {
-            emitted.append(AttributedRun(text: currentLine, attributes: attributes))
+            events.append(.text(AttributedRun(text: currentLine, attributes: attributes)))
             currentLine.removeAll(keepingCapacity: true)
         }
     }

--- a/Alas/Sources/ACP/Terminal/ANSIStream.swift
+++ b/Alas/Sources/ACP/Terminal/ANSIStream.swift
@@ -147,7 +147,11 @@ private struct ANSIOutputBuffer {
 /// across calls so that escape sequences split mid-stream still
 /// decode correctly.
 struct ANSIStream {
-    private enum State { case text, esc, csiParams, oscString, oscST }
+    private enum State { case text, esc, csiParams, csiDiscard, oscString, oscST }
+    /// CSI parameter strings are normally tiny. Malformed streams may never
+    /// send a final byte, so bound retained parser state independently from
+    /// the rendered tail and discard the rest of an oversized sequence.
+    private static let maxCSIParameterBytes = 64
 
     private var state: State = .text
     private var attributes = ANSIAttributes()
@@ -179,6 +183,8 @@ struct ANSIStream {
                 handleEscByte(b)
             case .csiParams:
                 handleCsiParamByte(b)
+            case .csiDiscard:
+                handleCsiDiscardByte(b)
             case .oscString:
                 handleOscByte(b)
             case .oscST:
@@ -270,7 +276,12 @@ struct ANSIStream {
         // compatibility; final byte is 0x40..0x7E.
         switch b {
         case 0x30...0x3F:               // param
-            paramBuf.append(Character(UnicodeScalar(b)))
+            if paramBuf.utf8.count < Self.maxCSIParameterBytes {
+                paramBuf.append(Character(UnicodeScalar(b)))
+            } else {
+                paramBuf.removeAll(keepingCapacity: true)
+                state = .csiDiscard
+            }
         case 0x40...0x7E:               // final
             if b == 0x6D {              // 'm' → SGR
                 applySGR(paramBuf)
@@ -281,6 +292,14 @@ struct ANSIStream {
         default:
             // 0x20..0x2F intermediates: accept and continue.
             break
+        }
+    }
+
+    private mutating func handleCsiDiscardByte(_ b: UInt8) {
+        // Ignore an oversized malformed CSI until its final byte. This keeps
+        // parser memory bounded while resynchronizing before ordinary text.
+        if b >= 0x40, b <= 0x7E {
+            state = .text
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPTerminalTailView.swift
+++ b/Alas/Sources/ACP/UI/ACPTerminalTailView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// Bottom-anchored live tail of a single ACP terminal. Subscribed via
-/// `@ObservedObject` so it re-renders on every buffer flush. Max
-/// height is 300 px; the user can scroll up to see earlier output.
+/// Bottom-anchored live tail of a single ACP terminal. Raw pipe chunks are
+/// parsed incrementally by `ACPTerminal`; this view receives a bounded tail
+/// at display rate. Max height is 300 px.
 struct ACPTerminalTailView: View {
     let terminalId: String
     let host: ACPTerminalHost
@@ -36,7 +36,7 @@ private struct TerminalLiveBody: View {
                         .id("BOTTOM")
                 }
                 .frame(maxHeight: 300)
-                .onChange(of: terminal.buffer) { _, _ in
+                .onChange(of: terminal.displayRevision) { _, _ in
                     proxy.scrollTo("BOTTOM", anchor: .bottom)
                 }
             }
@@ -48,24 +48,29 @@ private struct TerminalLiveBody: View {
     }
 
     private func parsedAttributed() -> AttributedString {
-        var stream = ANSIStream()
-        let runs = stream.feed(terminal.buffer)
-        var out = AttributedString()
-        for run in runs {
-            var s = AttributedString(run.text)
-            s.font = .system(size: 11.5, design: .monospaced)
+        let runs = terminal.displayRuns
+        var out = AttributedString(runs.lazy.map(\.text).joined())
+        var lowerBound = out.startIndex
+        for run in runs where !run.text.isEmpty {
+            let upperBound = out.characters.index(lowerBound, offsetBy: run.text.count)
+            var font = Font.system(size: 11.5, design: .monospaced)
+            if run.attributes.bold {
+                font = .system(size: 11.5, weight: .bold, design: .monospaced)
+            }
+            if run.attributes.italic { font = font.italic() }
+            out[lowerBound..<upperBound].font = font
             if let c = run.attributes.foreground.swiftUIColor(theme: theme) {
-                s.foregroundColor = c
+                out[lowerBound..<upperBound].foregroundColor = c
             } else {
-                s.foregroundColor = theme.color("fg-muted")
+                out[lowerBound..<upperBound].foregroundColor = theme.color("fg-muted")
             }
             if let bg = run.attributes.background.swiftUIColor(theme: theme) {
-                s.backgroundColor = bg
+                out[lowerBound..<upperBound].backgroundColor = bg
             }
-            if run.attributes.bold { s.font = .system(size: 11.5, weight: .bold, design: .monospaced) }
-            if run.attributes.italic { s.font = (s.font ?? .system(size: 11.5, design: .monospaced)).italic() }
-            if run.attributes.underline { s.underlineStyle = .single }
-            out += s
+            if run.attributes.underline {
+                out[lowerBound..<upperBound].underlineStyle = .single
+            }
+            lowerBound = upperBound
         }
         return out
     }

--- a/AlasTests/ACP/Terminal/ACPTerminalTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalTests.swift
@@ -340,6 +340,36 @@ struct ACPTerminalTests {
         #expect(footprintGrowth < 32 * 1024 * 1024)
     }
 
+    @Test("display refresh action coalesces chunks to display rate")
+    func displayRefreshActionCoalesces() {
+        typealias T = ACPTerminal
+        #expect(T.displayRefreshAction(elapsedSincePublish: 1, hasPendingDrain: false) == .publishNow)
+        #expect(T.displayRefreshAction(elapsedSincePublish: 0.01, hasPendingDrain: false)
+            == .scheduleDrain(after: T.displayRefreshMinInterval - 0.01))
+        #expect(T.displayRefreshAction(elapsedSincePublish: 1, hasPendingDrain: true) == .drop)
+    }
+
+    @Test("metadata output publishes a coalesced trailing display update")
+    func metadataOutputCoalescesDisplayUpdates() async throws {
+        let t = ACPTerminal(metadataId: "display", cwd: nil)
+        t.appendMetadataOutput(Data("first".utf8), replace: false)
+        let firstRevision = t.displayRevision
+        #expect(firstRevision == 1)
+        #expect(t.displayRuns.map(\.text).joined() == "first")
+
+        for _ in 0..<20 {
+            t.appendMetadataOutput(Data("x".utf8), replace: false)
+        }
+        #expect(t.displayRevision == firstRevision)
+
+        let deadline = Date().addingTimeInterval(1)
+        while t.displayRevision == firstRevision, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(t.displayRevision == firstRevision &+ 1)
+        #expect(t.displayRuns.map(\.text).joined() == "first" + String(repeating: "x", count: 20))
+    }
+
     @Test("descendant cleanup snapshots and validates off the main actor")
     func descendantCleanupRunsOffMainActor() throws {
         let source = try acpTerminalSource()

--- a/AlasTests/ACP/Terminal/ANSIStreamTests.swift
+++ b/AlasTests/ACP/Terminal/ANSIStreamTests.swift
@@ -137,4 +137,44 @@ struct ANSIStreamTests {
         let e = runs.first { $0.text == "é" }
         #expect(e?.attributes.foreground == .red)
     }
+
+    @Test("incremental tail preserves parser state across chunks")
+    func incrementalTailPreservesState() {
+        var tail = ANSITailBuffer(byteLimit: 1024)
+        tail.feed(Data("\u{1B}[3".utf8))
+        tail.feed(Data("1mred".utf8))
+
+        #expect(tail.runs.map(\.text).joined() == "red")
+        #expect(tail.runs.allSatisfy { $0.attributes.foreground == .red })
+    }
+
+    @Test("incremental tail applies carriage-return redraw across chunks")
+    func incrementalTailCarriageReturnAcrossChunks() {
+        var tail = ANSITailBuffer(byteLimit: 1024)
+        tail.feed(Data("complete\nprogress 10%".utf8))
+        tail.feed(Data("\rprogress 90%".utf8))
+
+        #expect(tail.runs.map(\.text).joined() == "complete\nprogress 90%")
+    }
+
+    @Test("incremental tail stays within its byte limit")
+    func incrementalTailIsBounded() {
+        var tail = ANSITailBuffer(byteLimit: 8)
+        tail.feed(Data("1234\n".utf8))
+        tail.feed(Data("567890".utf8))
+
+        #expect(tail.retainedByteCount <= 8)
+        #expect(tail.runs.map(\.text).joined() == "4\n567890")
+    }
+
+    @Test("incremental tail truncation keeps a UTF-8 boundary")
+    func incrementalTailUTF8Boundary() {
+        var tail = ANSITailBuffer(byteLimit: 9)
+        tail.feed(Data("x🎉🎉🎉".utf8))
+        let text = tail.runs.map(\.text).joined()
+
+        #expect(tail.retainedByteCount <= 9)
+        #expect(text == "🎉🎉")
+        #expect(!text.contains("\u{FFFD}"))
+    }
 }

--- a/AlasTests/ACP/Terminal/ANSIStreamTests.swift
+++ b/AlasTests/ACP/Terminal/ANSIStreamTests.swift
@@ -177,4 +177,17 @@ struct ANSIStreamTests {
         #expect(text == "🎉🎉")
         #expect(!text.contains("\u{FFFD}"))
     }
+
+    @Test("incremental parser bounds an unterminated CSI parameter string")
+    func incrementalTailBoundsMalformedCSI() {
+        var tail = ANSITailBuffer(byteLimit: 1024)
+        tail.feed(Data("\u{1B}[".utf8))
+        for _ in 0..<20 {
+            tail.feed(Data(String(repeating: "1;", count: 100).utf8))
+        }
+        tail.feed(Data("mvisible".utf8))
+
+        #expect(tail.runs.map(\.text).joined() == "visible")
+        #expect(tail.runs.allSatisfy { $0.attributes == .default })
+    }
 }


### PR DESCRIPTION
Closes #834.

## What changed

- parse ACP terminal output incrementally instead of reparsing the retained 1 MiB buffer on every pipe chunk
- retain a bounded 64 KiB parsed display tail and publish UI revisions at up to 30 Hz with trailing delivery
- build the terminal `AttributedString` from one joined string and apply attributes by range
- make rolling protocol-buffer compaction amortized instead of shifting 1 MiB per chunk after rollover
- add coverage for split ANSI and UTF-8 sequences, cross-chunk carriage-return redraws, tail bounds, and display-update coalescing

## Impact

Chatty subprocess output no longer causes per-chunk O(buffer) parsing, equality checks, scrolling, and layout. The full 1 MiB protocol tail remains available to `terminal/output`, while the 300-point transcript row renders a bounded display tail.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused `ANSIStreamTests` and `ACPTerminalTests`
- full test suite: 5,792 passed and 4 skipped; the remaining 8 failures are the opt-in `SSHIntegrationTests` requiring `ALAS_SSH_INTEGRATION=1`