### PR TITLE
fix(acp): incremental ACP transcript plan caching

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -295,7 +295,7 @@ final class ACPSession: ObservableObject, Identifiable {
         // of the user message instead of being dropped. The runner persists
         // from the pre-call message count, so the flushed rows are saved too.
         _ = flushPendingReplayCandidates()
-        transcript.messages.append(.user(
+        transcript.appendMessage(.user(
             id: UUID(),
             messageId: nil,
             text: text,
@@ -414,7 +414,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 Self.extractTerminalIds(items),
                 Self.extractMetadataTerminalIds(payload.metadata, includeExit: payload.content == nil))
             let rawOutputAssets = Self.extractRawOutputAssets(payload.rawOutput)
-            transcript.messages.append(.toolCall(.init(
+            transcript.appendMessage(.toolCall(.init(
                 toolCallId: payload.toolCallId,
                 title: payload.title,
                 kind: payload.kind,
@@ -451,14 +451,12 @@ final class ACPSession: ObservableObject, Identifiable {
             // the current turn (i.e. sits after the latest user prompt).
             // Otherwise append a fresh plan so the previous turn's plan
             // stays at its original position and the new one is current.
-            let lastUserIdx = transcript.messages.lastIndex { if case .user = $0 { return true } else { return false } } ?? -1
-            let currentTurnPlanIdx = transcript.messages.lastIndex { if case .plan = $0 { return true } else { return false } }
-                .flatMap { $0 > lastUserIdx ? $0 : nil }
-            if let i = currentTurnPlanIdx, case .plan(let existingId, _) = transcript.messages[i] {
-                transcript.messages[i] = .plan(id: existingId, items)
+            if let i = transcript.currentPlanMessageIndex,
+               case .plan(let existingId, _) = transcript.messages[i] {
+                transcript.replaceMessage(at: i, with: .plan(id: existingId, items))
                 return [i]
             } else {
-                transcript.messages.append(.plan(id: UUID(), items))
+                transcript.appendMessage(.plan(id: UUID(), items))
                 didAppendTranscriptMessage()
                 transcript.completedOutputBoundaryMessageIds.removeAll()
                 return [transcript.messages.count - 1]
@@ -530,7 +528,7 @@ final class ACPSession: ObservableObject, Identifiable {
             case .user:
                 continue
             }
-            transcript.messages.append(message)
+            transcript.appendMessage(message)
             didAppendTranscriptMessage()
             indices.insert(transcript.messages.count - 1)
         }
@@ -699,7 +697,7 @@ final class ACPSession: ObservableObject, Identifiable {
         // A system notice closes the current output run; materialise any held
         // replay candidate first so it keeps its place ahead of the notice.
         flushPendingReplayCandidates()
-        transcript.messages.append(.systemNotice(id: UUID(), text: text))
+        transcript.appendMessage(.systemNotice(id: UUID(), text: text))
         didAppendTranscriptMessage()
     }
 
@@ -710,13 +708,13 @@ final class ACPSession: ObservableObject, Identifiable {
         // candidate first so text that arrived before the edit stays ahead of
         // it. This path does not flow through `apply`, so it must flush here.
         flushPendingReplayCandidates()
-        transcript.messages.append(.fileEdit(id: UUID(), edit))
+        transcript.appendMessage(.fileEdit(id: UUID(), edit))
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
     }
 
     func replaceTranscriptMessages(_ messages: [ACPMessage]) {
-        transcript.messages = messagesPreservingToolCallContentRevisions(messages)
+        transcript.replaceMessages(with: messagesPreservingToolCallContentRevisions(messages))
         rebuildToolCallIndices()
     }
 
@@ -750,7 +748,7 @@ final class ACPSession: ObservableObject, Identifiable {
     /// pre-tail messages after the UI has already painted the tail.
     func prependTranscriptMessages(_ older: [ACPMessage]) {
         guard !older.isEmpty else { return }
-        transcript.messages.insert(contentsOf: older, at: 0)
+        transcript.prependMessages(older)
         // Rebuild tool-call indices because every prior entry's index just
         // shifted by `older.count`. Cheaper than offsetting in place: the
         // cache is dictionary-typed, so a full rebuild is O(N) and avoids
@@ -972,7 +970,7 @@ final class ACPSession: ObservableObject, Identifiable {
             if case .toolCall(var tc) = transcript.messages[i],
                tc.status == "in_progress" || tc.status == "pending" {
                 tc.status = "canceled"
-                transcript.messages[i] = .toolCall(tc)
+                transcript.replaceMessage(at: i, with: .toolCall(tc))
                 changed.append(i)
             }
         }
@@ -1579,12 +1577,12 @@ final class ACPSession: ObservableObject, Identifiable {
                 || isReconciledEchoChunk {
                 return i
             }
-            transcript.messages[i] = .user(
+            transcript.replaceMessage(at: i, with: .user(
                 id: id,
                 messageId: existingMessageId,
                 text: mergedText,
                 attachments: mergedAttachments,
-                delegatedSource: delegatedSource)
+                delegatedSource: delegatedSource))
             if let existingMessageId {
                 liveUserChunkMessageIds.insert(existingMessageId)
             }
@@ -1596,12 +1594,12 @@ final class ACPSession: ObservableObject, Identifiable {
            case .user(let id, let existingMessageId, let text, let attachments, let delegatedSource) = transcript.messages[i] {
             if existingMessageId == nil {
                 if let messageId {
-                    transcript.messages[i] = .user(
+                    transcript.replaceMessage(at: i, with: .user(
                         id: id,
                         messageId: messageId,
                         text: text,
                         attachments: Self.mergingAttachments(attachments, newAttachments),
-                        delegatedSource: delegatedSource)
+                        delegatedSource: delegatedSource))
                     reconciledLocalUserPromptMessageIds.insert(messageId)
                     transcript.noteStreamingChange(at: i)
                 } else {
@@ -1619,12 +1617,12 @@ final class ACPSession: ObservableObject, Identifiable {
             if text == mergedText && attachments == mergedAttachments {
                 return i
             }
-            transcript.messages[i] = .user(
+            transcript.replaceMessage(at: i, with: .user(
                 id: id,
                 messageId: existingMessageId,
                 text: mergedText,
                 attachments: mergedAttachments,
-                delegatedSource: delegatedSource)
+                delegatedSource: delegatedSource))
             transcript.noteStreamingChange(at: i)
             return i
         }
@@ -1643,7 +1641,7 @@ final class ACPSession: ObservableObject, Identifiable {
             // replayed user chunk never materialises a still-buffered chunk.
             flushedReplayIndices = flushPendingReplayCandidates()
             let id = UUID()
-            transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
+            transcript.appendMessage(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
             if let messageId {
                 liveUserChunkMessageIds.insert(messageId)
             } else {
@@ -1658,7 +1656,7 @@ final class ACPSession: ObservableObject, Identifiable {
         // candidates first so they keep their place ahead of the prompt.
         flushedReplayIndices = flushPendingReplayCandidates()
         let id = UUID()
-        transcript.messages.append(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
+        transcript.appendMessage(.user(id: id, messageId: messageId, text: addition, attachments: newAttachments))
         if let messageId {
             liveUserChunkMessageIds.insert(messageId)
         } else {
@@ -1775,10 +1773,10 @@ final class ACPSession: ObservableObject, Identifiable {
         switch transcript.messages[i] {
         case .agent(let id, _, let buf):
             buf.append(suffix)
-            transcript.messages[i] = .agent(id: id, messageId: messageId, buf)
+            transcript.replaceMessage(at: i, with: .agent(id: id, messageId: messageId, buf))
         case .thought(let id, _, let buf):
             buf.append(suffix)
-            transcript.messages[i] = .thought(id: id, messageId: messageId, buf)
+            transcript.replaceMessage(at: i, with: .thought(id: id, messageId: messageId, buf))
         default:
             return nil
         }
@@ -1896,7 +1894,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if replayKind == .agent {
             flushedReplayIndices.formUnion(flushPendingReplayCandidates(kinds: [.thought]))
         }
-        transcript.messages.append(makeNew(newMessageText))
+        transcript.appendMessage(makeNew(newMessageText))
         didAppendTranscriptMessage()
         return transcript.messages.count - 1
     }
@@ -1988,7 +1986,7 @@ final class ACPSession: ObservableObject, Identifiable {
            case .toolCall(var tc) = transcript.messages[i],
            tc.toolCallId == id {
             mutate(&tc)
-            transcript.messages[i] = .toolCall(tc)
+            transcript.replaceMessage(at: i, with: .toolCall(tc))
             return i
         }
 
@@ -1996,7 +1994,7 @@ final class ACPSession: ObservableObject, Identifiable {
             if case .toolCall(var tc) = transcript.messages[i], tc.toolCallId == id {
                 toolCallIndices[id] = i
                 mutate(&tc)
-                transcript.messages[i] = .toolCall(tc)
+                transcript.replaceMessage(at: i, with: .toolCall(tc))
                 return i
             }
         }

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -11,10 +11,23 @@ final class ACPTranscript: ObservableObject {
     @Published var messages: [ACPMessage] = [] {
         didSet {
             messagesGeneration &+= 1
-            refreshPlanCaches()
+            updatePlanCaches(for: pendingMessagesMutation)
+            pendingMessagesMutation = nil
             recordMessagesDiff(old: oldValue)
         }
     }
+    private enum MessagesMutation {
+        case append(ACPMessage)
+        case replace(index: Int, old: ACPMessage, new: ACPMessage)
+        case prepend(count: Int)
+        case planNeutral
+    }
+    private var pendingMessagesMutation: MessagesMutation?
+    private var latestPlanMessageIndex: Int?
+    private var latestUserMessageIndex: Int?
+    #if DEBUG
+    private(set) var planCacheRebuildCountForTests = 0
+    #endif
     /// Bumped on every `messages` array mutation. Non-published: consumed by
     /// value caches (visible-rows lookup) that must invalidate when the array
     /// changes, without adding another objectWillChange source.
@@ -123,22 +136,115 @@ final class ACPTranscript: ObservableObject {
         streamingTickDrain = nil
     }
 
-    private func refreshPlanCaches() {
-        var newCurrentPlan: [ACPMessage.PlanItem]?
-        for m in messages.reversed() {
-            if case .user = m { break }
-            if case .plan(_, let items) = m {
-                newCurrentPlan = items
-                break
-            }
-        }
+    // MARK: - Incremental plan caches
 
-        var newLatestPlan: [ACPMessage.PlanItem]?
-        for m in messages.reversed() {
-            if case .plan(_, let items) = m {
-                newLatestPlan = items.isEmpty ? nil : items
+    /// Production mutation entry points carry enough context for plan caches
+    /// to update in O(1). Direct `messages` assignments remain supported for
+    /// restore/test call sites and safely rebuild both indices once.
+    var currentPlanMessageIndex: Int? {
+        guard let latestPlanMessageIndex,
+              latestPlanMessageIndex > (latestUserMessageIndex ?? -1) else {
+            return nil
+        }
+        return latestPlanMessageIndex
+    }
+
+    func appendMessage(_ message: ACPMessage) {
+        pendingMessagesMutation = .append(message)
+        messages.append(message)
+    }
+
+    func replaceMessage(at index: Int, with message: ACPMessage) {
+        let old = messages[index]
+        pendingMessagesMutation = .replace(index: index, old: old, new: message)
+        messages[index] = message
+    }
+
+    func replaceMessages(with newMessages: [ACPMessage]) {
+        messages = newMessages
+    }
+
+    func prependMessages(_ older: [ACPMessage]) {
+        guard !older.isEmpty else { return }
+        pendingMessagesMutation = .prepend(count: older.count)
+        messages.insert(contentsOf: older, at: 0)
+    }
+
+    private func updatePlanCaches(for mutation: MessagesMutation?) {
+        switch mutation {
+        case .append(let message):
+            let index = messages.count - 1
+            if case .user = message {
+                latestUserMessageIndex = index
+            } else if case .plan = message {
+                latestPlanMessageIndex = index
+            }
+            publishPlanCaches()
+        case .replace(let index, let old, let new):
+            switch (old, new) {
+            case (.user, .user):
+                break
+            case (.plan, .plan):
+                if index == latestPlanMessageIndex {
+                    publishPlanCaches()
+                }
+            case (.user, _), (_, .user), (.plan, _), (_, .plan):
+                rebuildPlanCaches()
+            default:
                 break
             }
+        case .prepend(let count):
+            latestPlanMessageIndex = latestPlanMessageIndex.map { $0 + count }
+            latestUserMessageIndex = latestUserMessageIndex.map { $0 + count }
+            if latestPlanMessageIndex == nil {
+                latestPlanMessageIndex = messages[..<count].lastIndex {
+                    if case .plan = $0 { return true }
+                    return false
+                }
+            }
+            if latestUserMessageIndex == nil {
+                latestUserMessageIndex = messages[..<count].lastIndex {
+                    if case .user = $0 { return true }
+                    return false
+                }
+            }
+            publishPlanCaches()
+        case .planNeutral:
+            break
+        case nil:
+            rebuildPlanCaches()
+        }
+    }
+
+    private func rebuildPlanCaches() {
+        #if DEBUG
+        planCacheRebuildCountForTests += 1
+        #endif
+        latestPlanMessageIndex = messages.lastIndex {
+            if case .plan = $0 { return true }
+            return false
+        }
+        latestUserMessageIndex = messages.lastIndex {
+            if case .user = $0 { return true }
+            return false
+        }
+        publishPlanCaches()
+    }
+
+    private func publishPlanCaches() {
+        let newCurrentPlan: [ACPMessage.PlanItem]?
+        if let index = currentPlanMessageIndex,
+           case .plan(_, let items) = messages[index] {
+            newCurrentPlan = items
+        } else {
+            newCurrentPlan = nil
+        }
+        let newLatestPlan: [ACPMessage.PlanItem]?
+        if let index = latestPlanMessageIndex,
+           case .plan(_, let items) = messages[index] {
+            newLatestPlan = items.isEmpty ? nil : items
+        } else {
+            newLatestPlan = nil
         }
         if currentPlan != newCurrentPlan {
             currentPlan = newCurrentPlan
@@ -306,9 +412,7 @@ final class ACPTranscript: ObservableObject {
         guard insertedCount > 0 else { return }
         let shiftedHead = max(0, min(visibleHead + insertedCount, messages.count))
         let shiftedTail = visibleTail.map { max(shiftedHead, min($0 + insertedCount, messages.count)) }
-        for i in 0..<shiftedHead {
-            trimHiddenMessage(at: i)
-        }
+        trimHiddenMessages(in: [0..<shiftedHead])
         visibleHead = shiftedHead
         visibleTail = shiftedTail
     }
@@ -322,29 +426,41 @@ final class ACPTranscript: ObservableObject {
         let clampedTail = newTail.map { max(clampedHead, min($0, messages.count)) }
         let normalizedTail = clampedTail
         guard clampedHead != visibleHead || normalizedTail != visibleTail else { return }
+        var rangesToTrim: [Range<Int>] = []
         if clampedHead > visibleHead {
-            for i in visibleHead..<clampedHead {
-                trimHiddenMessage(at: i)
-            }
+            rangesToTrim.append(visibleHead..<clampedHead)
         }
         let oldTail = visibleTailBound
         let newTail = normalizedTail ?? messages.count
         if newTail < oldTail {
-            for i in newTail..<oldTail {
-                trimHiddenMessage(at: i)
-            }
+            rangesToTrim.append(newTail..<oldTail)
         }
+        trimHiddenMessages(in: rangesToTrim)
         visibleHead = clampedHead
         visibleTail = normalizedTail
     }
 
-    private func trimHiddenMessage(at index: Int) {
-        markdownCaches.removeValue(forKey: messages[index].stableId)
-        if case .toolCall(var tc) = messages[index] {
-            if tc.status != "in_progress", tc.status != "pending" {
-                tc.truncateForOffWindow()
-                messages[index] = .toolCall(tc)
+    private func trimHiddenMessages(in ranges: [Range<Int>]) {
+        guard !ranges.isEmpty else { return }
+        var updatedMessages = messages
+        var didChangeMessages = false
+        for range in ranges {
+            for index in range {
+                markdownCaches.removeValue(forKey: updatedMessages[index].stableId)
+                if case .toolCall(var tc) = updatedMessages[index],
+                   tc.status != "in_progress", tc.status != "pending" {
+                    let revision = tc.contentRevision
+                    tc.truncateForOffWindow()
+                    if tc.contentRevision != revision {
+                        updatedMessages[index] = .toolCall(tc)
+                        didChangeMessages = true
+                    }
+                }
             }
+        }
+        if didChangeMessages {
+            pendingMessagesMutation = .planNeutral
+            messages = updatedMessages
         }
     }
 

--- a/AlasTests/ACP/Session/ACPSessionToolCallTruncationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionToolCallTruncationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import Testing
 @testable import Alas
 
@@ -26,6 +27,39 @@ struct ACPSessionToolCallTruncationTests {
         } else {
             Issue.record("expected toolCall at index 0")
         }
+    }
+
+    @Test("setVisibleHead batches completed tool-call truncations into one messages update")
+    func batchesCompletedTruncations() {
+        let t = ACPTranscript()
+        for index in 0..<5 {
+            let toolCall = ACPMessage.ToolCall(
+                toolCallId: "tc\(index)",
+                title: "read",
+                status: "completed",
+                content: bigContent(),
+                preview: "aaa…",
+                locations: []
+            )
+            t.appendMessage(.toolCall(toolCall))
+        }
+        t.appendMessage(.systemNotice(id: UUID(), text: "later"))
+        var messagesUpdateCount = 0
+        let cancellable = t.$messages.dropFirst().sink { _ in
+            messagesUpdateCount += 1
+        }
+
+        t.setVisibleHead(5)
+
+        #expect(messagesUpdateCount == 1)
+        for index in 0..<5 {
+            guard case .toolCall(let toolCall) = t.messages[index] else {
+                Issue.record("expected toolCall at index \(index)")
+                continue
+            }
+            #expect(toolCall.isContentTruncated)
+        }
+        cancellable.cancel()
     }
 
     @Test("prepending hidden older messages truncates completed tool calls")

--- a/AlasTests/ACP/Session/ACPTranscriptCurrentPlanTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptCurrentPlanTests.swift
@@ -119,4 +119,36 @@ struct ACPTranscriptCurrentPlanTests {
         }
         #expect(session.transcript.currentPlan == [ACPMessage.PlanItem(content: "step", status: "in_progress")])
     }
+
+    @Test("production tool-call updates do not rebuild plan caches")
+    func toolCallUpdatesDoNotRebuildPlanCaches() {
+        let transcript = ACPTranscript()
+        let planItems = [ACPMessage.PlanItem(content: "step", status: "in_progress")]
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "tool",
+            title: "Read",
+            status: "in_progress",
+            content: "",
+            preview: "",
+            locations: []
+        )
+        transcript.replaceMessages(with: [
+            .user(id: UUID(), text: "go", attachments: []),
+            .plan(id: UUID(), planItems),
+            .toolCall(toolCall)
+        ])
+        let rebuildCount = transcript.planCacheRebuildCountForTests
+
+        for update in 0..<100 {
+            toolCall.content = "update \(update)"
+            transcript.replaceMessage(at: 2, with: .toolCall(toolCall))
+        }
+
+        let updatedPlanItems = [ACPMessage.PlanItem(content: "step", status: "completed")]
+        transcript.replaceMessage(at: 1, with: .plan(id: UUID(), updatedPlanItems))
+
+        #expect(transcript.planCacheRebuildCountForTests == rebuildCount)
+        #expect(transcript.currentPlan == updatedPlanItems)
+        #expect(transcript.latestPlan == updatedPlanItems)
+    }
 }


### PR DESCRIPTION
## Summary

- track the latest plan and user message indices incrementally for production transcript mutations
- use the cached current-plan index when applying plan updates
- batch off-window tool-call truncation into a single transcript publication
- add regressions covering cache rebuild avoidance and batched trimming

## Root cause

`messages.didSet` scanned the transcript backward for both plan caches on every append and element replacement. Tool streaming therefore made cache maintenance O(n) per update, and trim loops multiplied that cost by publishing once per row.

Closes #837

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused ACP transcript plan/window/truncation test suites
- full suite: 5,797 passed and 4 skipped; the remaining 8 local failures were opt-in SSH integration tests requiring `ALAS_SSH_INTEGRATION=1`