### PR TITLE
fix(zmx): Avoid blocking terminate all on zmx ls

### DIFF
--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -319,25 +319,58 @@ final class TerminalService {
         }
         let client = zmxClient
         for session in additionalSessions {
-            let names = Self.sessionNamesForCleanup(
-                worktreeId: session.worktreeId,
-                projectPath: session.projectPath,
-                leafId: session.leafId,
-                zmxClient: client
-            )
+            let scoped = ZmxSessionName.derive(worktreeId: session.worktreeId, leafId: session.leafId)
             if let host = Self.remoteHostForCleanup(worktreeId: session.worktreeId, projectPath: session.projectPath) {
-                remoteNamesByHost[host, default: []].formUnion(names)
+                remoteNamesByHost[host, default: []].insert(scoped)
             } else {
-                localNames.formUnion(names)
+                localNames.insert(scoped)
             }
         }
         dispatchTrackedKill {
             for name in localNames {
                 client.killSession(name: name)
             }
+            let localAdditionalSessions = additionalSessions.filter {
+                Self.remoteHostForCleanup(worktreeId: $0.worktreeId, projectPath: $0.projectPath) == nil
+            }
+            let localLegacySessionInfos = localAdditionalSessions.isEmpty ? [] : client.listSessionInfos()
+            for session in localAdditionalSessions {
+                let scoped = ZmxSessionName.derive(worktreeId: session.worktreeId, leafId: session.leafId)
+                let legacyNames = Self.sessionNamesForCleanup(
+                    worktreeId: session.worktreeId,
+                    projectPath: session.projectPath,
+                    leafId: session.leafId,
+                    legacySessionInfos: localLegacySessionInfos
+                ).filter { $0 != scoped }
+                guard !legacyNames.isEmpty else { continue }
+                for name in legacyNames {
+                    client.killSession(name: name)
+                }
+            }
             for (host, names) in remoteNamesByHost {
                 for name in names {
                     await Self.killRemoteSession(host: host, name: name)
+                }
+            }
+            let remoteAdditionalSessionsByHost = Dictionary(grouping: additionalSessions.compactMap { session -> (String, TerminalSessionIdentity)? in
+                guard let host = Self.remoteHostForCleanup(worktreeId: session.worktreeId, projectPath: session.projectPath) else {
+                    return nil
+                }
+                return (host, session)
+            }, by: \.0)
+            for (host, pairs) in remoteAdditionalSessionsByHost {
+                let remoteSessionInfos = await Self.remoteSessionInfos(host: host)
+                for (_, session) in pairs {
+                    let scoped = ZmxSessionName.derive(worktreeId: session.worktreeId, leafId: session.leafId)
+                    let legacyNames = Self.sessionNamesForCleanup(
+                        worktreeId: session.worktreeId,
+                        projectPath: session.projectPath,
+                        leafId: session.leafId,
+                        legacySessionInfos: remoteSessionInfos
+                    ).filter { $0 != scoped }
+                    for name in legacyNames {
+                        await Self.killRemoteSession(host: host, name: name)
+                    }
                 }
             }
         }
@@ -385,6 +418,18 @@ final class TerminalService {
             command: RemoteTerminalScript.zmxBatchCommand(["kill", name]),
             timeout: 10
         )
+    }
+
+    nonisolated static func remoteSessionInfos(host: String) async -> [ZmxSessionInfo] {
+        guard let result = try? await RemoteExec.run(
+            host: host,
+            cwd: nil,
+            command: RemoteTerminalScript.zmxBatchCommand(["ls"]),
+            timeout: 10
+        ), result.exitCode == 0 else {
+            return []
+        }
+        return ZmxClient.parseSessionInfos(result.stdout)
     }
 
     nonisolated static func remoteHostForCleanup(worktreeId: String, projectPath: String?) -> String? {
@@ -608,10 +653,24 @@ final class TerminalService {
         leafId: String,
         zmxClient: ZmxClient
     ) -> [String] {
+        sessionNamesForCleanup(
+            worktreeId: worktreeId,
+            projectPath: projectPath,
+            leafId: leafId,
+            legacySessionInfos: zmxClient.listSessionInfos()
+        )
+    }
+
+    nonisolated private static func sessionNamesForCleanup(
+        worktreeId: String,
+        projectPath: String?,
+        leafId: String,
+        legacySessionInfos: [ZmxSessionInfo]
+    ) -> [String] {
         let scoped = ZmxSessionName.derive(worktreeId: worktreeId, leafId: leafId)
         let legacy = ZmxSessionName.legacy(leafId: leafId)
         let roots = [worktreeId] + (projectPath.map { [$0] } ?? [])
-        guard legacySessionBelongsToKnownRoot(legacy, roots: roots, zmxClient: zmxClient) else {
+        guard legacySessionBelongsToKnownRoot(legacy, roots: roots, sessionInfos: legacySessionInfos) else {
             return [scoped]
         }
         return [scoped, legacy]

--- a/Alas/Sources/Terminal/Zmx/ZmxClient.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxClient.swift
@@ -121,7 +121,11 @@ final class ZmxClient: Sendable {
             }
             return []
         }
-        return result.stdout
+        return Self.parseSessionInfos(result.stdout)
+    }
+
+    static func parseSessionInfos(_ stdout: String) -> [ZmxSessionInfo] {
+        stdout
             .split(separator: "\n", omittingEmptySubsequences: true)
             .compactMap { parseSessionInfoLine(String($0)) }
     }
@@ -144,7 +148,7 @@ final class ZmxClient: Sendable {
         return inherited
     }
 
-    private func parseSessionInfoLine(_ line: String) -> ZmxSessionInfo? {
+    private static func parseSessionInfoLine(_ line: String) -> ZmxSessionInfo? {
         let fields = line
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(separator: "\t", omittingEmptySubsequences: true)

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -24,6 +24,44 @@ private final class RecordingRunner: @unchecked Sendable {
     }
 }
 
+private final class SlowListRunner: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var calls: [RecordingRunner.Call] = []
+    private let listDelay: TimeInterval
+    private let listResult: SubprocessRunner.Result
+
+    init(listDelay: TimeInterval, listResult: SubprocessRunner.Result) {
+        self.listDelay = listDelay
+        self.listResult = listResult
+    }
+
+    func runner() -> SubprocessRunner {
+        SubprocessRunner { exe, args, _, _ in
+            self.lock.lock()
+            self.calls.append(RecordingRunner.Call(executable: exe, args: args))
+            self.lock.unlock()
+
+            if args == ["ls"] {
+                Thread.sleep(forTimeInterval: self.listDelay)
+                return self.listResult
+            }
+            return SubprocessRunner.Result(exitCode: 0, stdout: "", stderr: "")
+        }
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls.count
+    }
+
+    var callArgs: [[String]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls.map(\.args)
+    }
+}
+
 private func makeZmxEnv(available: Bool = true) -> ZmxEnv {
     ZmxEnv(
         binaryURL: available
@@ -398,12 +436,62 @@ struct TerminalServiceZmxTests {
         ])
         await waitForCalls(recorder, count: 2) { $0.calls.count }
         #expect(recorder.calls.map(\.args) == [
-            ["ls"],
             [
                 "kill",
                 ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-A"),
             ],
+            ["ls"],
         ])
+    }
+
+    @Test
+    func terminateAllDoesNotBlockCallerWhileResolvingAdditionalLegacySessions() async {
+        let runner = SlowListRunner(
+            listDelay: 0.35,
+            listResult: .init(
+                exitCode: 0,
+                stdout: """
+                  name=alas-leaf-persisted-A\tpid=1\tclients=0\tcreated=1\tstart_dir=/tmp/repo\tcmd=/bin/zsh -l
+                  name=alas-leaf-persisted-B\tpid=2\tclients=0\tcreated=1\tstart_dir=/tmp/repo/subdir\tcmd=/bin/zsh -l
+
+                """,
+                stderr: ""
+            )
+        )
+        let client = ZmxClient(env: makeZmxEnv(available: true), runner: runner.runner())
+        let service = TerminalService(zmxClient: client)
+
+        let started = Date()
+        service.terminateAll(additionalSessions: [
+            TerminalSessionIdentity(worktreeId: "/tmp/wt", projectPath: "/tmp/repo", leafId: "leaf-persisted-A"),
+            TerminalSessionIdentity(worktreeId: "/tmp/wt", projectPath: "/tmp/repo", leafId: "leaf-persisted-B"),
+        ])
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(elapsed < 0.15)
+
+        await waitForCalls(runner, count: 1, timeout: 0.15) { $0.callCount }
+        let expectedFirstKills = Set([
+            [
+                "kill",
+                ZmxSessionName.derive(worktreeId: "/tmp/wt", leafId: "leaf-persisted-A"),
+            ],
+            [
+                "kill",
+                ZmxSessionName.derive(worktreeId: "/tmp/wt", leafId: "leaf-persisted-B"),
+            ],
+        ])
+        #expect(runner.callArgs.first.map { expectedFirstKills.contains($0) } == true)
+
+        await waitForCalls(runner, count: 5, timeout: 2.0) { $0.callCount }
+        #expect(runner.callArgs.filter { $0 == ["ls"] }.count == 1)
+        #expect(Set(runner.callArgs) == Set([
+            ["ls"],
+            ["kill", ZmxSessionName.derive(worktreeId: "/tmp/wt", leafId: "leaf-persisted-A")],
+            ["kill", "alas-leaf-persisted-A"],
+            ["kill", ZmxSessionName.derive(worktreeId: "/tmp/wt", leafId: "leaf-persisted-B")],
+            ["kill", "alas-leaf-persisted-B"],
+        ]))
     }
 
     // MARK: sweepOrphans — boot-time cleanup


### PR DESCRIPTION
## Summary

Fixes #836 by moving persisted terminal session legacy-name resolution for `terminateAll(additionalSessions:)` into the existing detached zmx kill sweep.

The cleanup path now reuses one `zmx ls` result for all additional sessions instead of running a blocking `listSessionInfos()` call once per persisted session on the caller's MainActor path.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TerminalServiceZmxTests test`

Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was also run locally and reached the test suite, but failed in the existing localhost SSH integration tests.