### PR TITLE
fix(acp): transcript tail restore oscillation

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -66,6 +66,7 @@ struct ACPMessageList: View {
     /// constant here is safe even with multiple transcript lists mounted at
     /// once (e.g. across windows).
     private static let scrollSpaceName = "acp-message-list"
+    private static let contentShrinkBookmarkResetDebounceNanoseconds: UInt64 = 50_000_000
 
     /// Window-sliced, plan-filtered list of rows to render. The slice
     /// bounds first-paint cost on long transcripts (`visibleHead` is
@@ -259,6 +260,10 @@ struct ACPMessageList: View {
                 .onDisappear {
                     scrollBook.pendingTailScrollTask?.cancel()
                     scrollBook.pendingTailScrollTask = nil
+                    scrollBook.pendingContentGrowthTailRestore = nil
+                    scrollBook.pendingContentShrinkResetTask?.cancel()
+                    scrollBook.pendingContentShrinkResetTask = nil
+                    scrollBook.contentShrinkBookmarkResetState = .none
                 }
                 .onChange(of: viewport.size.height) { _, _ in
                     restoreTailIfNeeded(proxy: proxy, animated: false)
@@ -336,13 +341,15 @@ struct ACPMessageList: View {
         }
     }
 
-    private func scrollToTail(proxy: ScrollViewProxy, animated: Bool) {
+    @discardableResult
+    private func scrollToTail(proxy: ScrollViewProxy, animated: Bool) -> Bool {
+        let pendingContentGrowthTailRestore = scrollBook.pendingContentGrowthTailRestore
         scrollBook.pendingTailScrollTask?.cancel()
         scrollBook.pendingTailScrollTask = nil
         let distance = scrollBook.lastScrollProbe.map {
             max(0, $0.contentHeight - $0.viewportHeight - $0.minY)
         }
-        guard Self.shouldPerformTailScroll(distanceFromBottom: distance) else { return }
+        guard Self.shouldPerformTailScroll(distanceFromBottom: distance) else { return false }
         scrollBook.isRestoringTail = true
         let scroll = {
             proxy.scrollTo("__composer_spacer__", anchor: .bottom)
@@ -366,13 +373,49 @@ struct ACPMessageList: View {
                 releaseRestoring()
             }
         }
+        if let pendingContentGrowthTailRestore {
+            scrollBook.lastContentGrowthTailRestoreSourceHeight = pendingContentGrowthTailRestore.sourceHeight
+            scrollBook.lastContentGrowthTailRestoreHeight = pendingContentGrowthTailRestore.targetHeight
+            scrollBook.contentShrinkBookmarkResetState = Self.contentShrinkBookmarkResetStateAfterScheduledTailScroll(
+                didScroll: true,
+                hasContentGrowthRestore: true,
+                currentState: scrollBook.contentShrinkBookmarkResetState
+            )
+            scrollBook.pendingContentGrowthTailRestore = nil
+        }
+        return true
     }
 
-    private func scheduleTailScroll(proxy: ScrollViewProxy, animated: Bool) {
+    private func scheduleTailScroll(
+        proxy: ScrollViewProxy,
+        animated: Bool,
+        contentGrowthRestore: ACPContentGrowthTailRestore? = nil
+    ) {
+        if Self.shouldStoreContentGrowthRestoreBeforeCoalescing(
+            hasPendingTailScroll: scrollBook.pendingTailScrollTask != nil,
+            hasContentGrowthRestore: contentGrowthRestore != nil
+        ) {
+            scrollBook.pendingContentGrowthTailRestore = Self.mergedContentGrowthTailRestore(
+                existing: scrollBook.pendingContentGrowthTailRestore,
+                new: contentGrowthRestore
+            )
+            scrollBook.pendingContentShrinkResetTask?.cancel()
+            scrollBook.pendingContentShrinkResetTask = nil
+        }
         guard Self.shouldScheduleTailScroll(hasPendingTailScroll: scrollBook.pendingTailScrollTask != nil) else {
             return
         }
         scrollBook.pendingTailScrollTask?.cancel()
+        if contentGrowthRestore != nil {
+            scrollBook.pendingContentShrinkResetTask?.cancel()
+            scrollBook.pendingContentShrinkResetTask = nil
+        }
+        scrollBook.pendingContentGrowthTailRestore = Self.mergedContentGrowthTailRestore(
+            existing: scrollBook.pendingContentGrowthTailRestore,
+            new: contentGrowthRestore
+        )
+        scrollBook.pendingTailScrollGeneration &+= 1
+        let scheduledGeneration = scrollBook.pendingTailScrollGeneration
         scrollBook.pendingTailScrollTask = Task { @MainActor in
             await Task.yield()
             guard !Task.isCancelled,
@@ -380,10 +423,33 @@ struct ACPMessageList: View {
                     followsTranscriptTail: session.followsTranscriptTail
                   )
             else {
-                scrollBook.pendingTailScrollTask = nil
+                if ACPMessageList.shouldClearScheduledTailScrollBookkeeping(
+                    scheduledGeneration: scheduledGeneration,
+                    currentGeneration: scrollBook.pendingTailScrollGeneration
+                ) {
+                    scrollBook.pendingTailScrollTask = nil
+                    scrollBook.pendingContentGrowthTailRestore = nil
+                }
                 return
             }
-            scrollToTail(proxy: proxy, animated: animated)
+            let pendingContentGrowthTailRestore = scrollBook.pendingContentGrowthTailRestore
+            let didScroll = scrollToTail(proxy: proxy, animated: animated)
+            if didScroll, let pendingContentGrowthTailRestore {
+                scrollBook.lastContentGrowthTailRestoreSourceHeight = pendingContentGrowthTailRestore.sourceHeight
+                scrollBook.lastContentGrowthTailRestoreHeight = pendingContentGrowthTailRestore.targetHeight
+            }
+            scrollBook.contentShrinkBookmarkResetState = ACPMessageList.contentShrinkBookmarkResetStateAfterScheduledTailScroll(
+                didScroll: didScroll,
+                hasContentGrowthRestore: pendingContentGrowthTailRestore != nil,
+                currentState: scrollBook.contentShrinkBookmarkResetState
+            )
+            if ACPMessageList.shouldClearScheduledTailScrollBookkeeping(
+                scheduledGeneration: scheduledGeneration,
+                currentGeneration: scrollBook.pendingTailScrollGeneration
+            ) {
+                scrollBook.pendingTailScrollTask = nil
+                scrollBook.pendingContentGrowthTailRestore = nil
+            }
         }
     }
 
@@ -464,6 +530,12 @@ struct ACPMessageList: View {
             session.followsTranscriptTail = false
             scrollBook.pendingTailScrollTask?.cancel()
             scrollBook.pendingTailScrollTask = nil
+            scrollBook.pendingContentGrowthTailRestore = nil
+            scrollBook.pendingContentShrinkResetTask?.cancel()
+            scrollBook.pendingContentShrinkResetTask = nil
+            scrollBook.contentShrinkBookmarkResetState = .none
+            scrollBook.lastContentGrowthTailRestoreSourceHeight = nil
+            scrollBook.lastContentGrowthTailRestoreHeight = nil
             let lookup = visibleMessageLookup
             // Tail-follow no longer maintains `latestTopVisibleAnchor` on every
             // row callback (see `handleModernRowFrame`), so compute it here,
@@ -757,15 +829,75 @@ struct ACPMessageList: View {
         viewportHeight: CGFloat,
         newMinY: CGFloat,
         followsTranscriptTail: Bool,
-        isRestoring: Bool
+        isRestoring: Bool,
+        contentShrinkBookmarkResetState: ACPContentShrinkBookmarkResetState = .none,
+        lastRestoreSourceContentHeight: CGFloat? = nil,
+        lastRestoredContentHeight: CGFloat? = nil
     ) -> Bool {
         guard !isRestoring else { return false }
         guard followsTranscriptTail else { return false }
         guard newContentHeight > previousContentHeight + ACPScrollDirectionClassifier.upwardEpsilon else {
             return false
         }
+        if let lastRestoreSourceContentHeight,
+           let lastRestoredContentHeight,
+           abs(previousContentHeight - lastRestoreSourceContentHeight) <= ACPScrollDirectionClassifier.bottomTolerance,
+           newContentHeight <= lastRestoredContentHeight + ACPScrollDirectionClassifier.bottomTolerance {
+            guard contentShrinkBookmarkResetState == .verified else {
+                return false
+            }
+        }
         let distanceFromBottom = max(0, newContentHeight - viewportHeight - newMinY)
         return distanceFromBottom > ACPScrollDirectionClassifier.bottomTolerance
+    }
+
+    nonisolated static func shouldResetContentGrowthTailRestoreAfterShrink(
+        previousContentHeight: CGFloat,
+        newContentHeight: CGFloat,
+        viewportHeight: CGFloat,
+        newMinY: CGFloat,
+        followsTranscriptTail: Bool,
+        isRestoring: Bool,
+        hasPendingTailScroll: Bool,
+        lastRestoredContentHeight: CGFloat?
+    ) -> Bool {
+        guard followsTranscriptTail else { return false }
+        guard !hasPendingTailScroll else { return false }
+        guard let lastRestoredContentHeight else { return false }
+        guard previousContentHeight > newContentHeight + ACPScrollDirectionClassifier.bottomTolerance else {
+            return false
+        }
+        guard newContentHeight < lastRestoredContentHeight - ACPScrollDirectionClassifier.bottomTolerance else {
+            return false
+        }
+        let distanceFromBottom = max(0, newContentHeight - viewportHeight - newMinY)
+        return distanceFromBottom <= ACPScrollDirectionClassifier.bottomTolerance
+    }
+
+    nonisolated static func shouldApplyDeferredContentShrinkBookmarkReset(
+        expectedContentHeight: CGFloat,
+        latestContentHeight: CGFloat,
+        latestViewportHeight: CGFloat,
+        latestMinY: CGFloat,
+        followsTranscriptTail: Bool,
+        isRestoring: Bool,
+        hasPendingTailScroll: Bool
+    ) -> Bool {
+        guard followsTranscriptTail else { return false }
+        guard !hasPendingTailScroll else { return false }
+        guard abs(latestContentHeight - expectedContentHeight) <= ACPScrollDirectionClassifier.bottomTolerance else {
+            return false
+        }
+        let distanceFromBottom = max(0, latestContentHeight - latestViewportHeight - latestMinY)
+        return distanceFromBottom <= ACPScrollDirectionClassifier.bottomTolerance
+    }
+
+    nonisolated static func shouldUseScrollProbeForDeferredShrinkReset(
+        latestProbeGeneration: UInt64,
+        scheduledProbeGeneration: UInt64,
+        didDebounce: Bool
+    ) -> Bool {
+        didDebounce || latestProbeGeneration > scheduledProbeGeneration
     }
 
     /// Whether `scrollToTail` should actually issue `proxy.scrollTo`. A
@@ -804,6 +936,48 @@ struct ACPMessageList: View {
 
     nonisolated static func shouldScheduleTailScroll(hasPendingTailScroll: Bool) -> Bool {
         !hasPendingTailScroll
+    }
+
+    nonisolated static func shouldStoreContentGrowthRestoreBeforeCoalescing(
+        hasPendingTailScroll: Bool,
+        hasContentGrowthRestore: Bool
+    ) -> Bool {
+        hasPendingTailScroll && hasContentGrowthRestore
+    }
+
+    nonisolated static func mergedContentGrowthTailRestore(
+        existing: ACPContentGrowthTailRestore?,
+        new: ACPContentGrowthTailRestore?
+    ) -> ACPContentGrowthTailRestore? {
+        guard let new else { return nil }
+        guard let existing else { return new }
+        return ACPContentGrowthTailRestore(
+            sourceHeight: min(existing.sourceHeight, new.sourceHeight),
+            targetHeight: max(existing.targetHeight, new.targetHeight)
+        )
+    }
+
+    nonisolated static func shouldClearScheduledTailScrollBookkeeping(
+        scheduledGeneration: UInt64,
+        currentGeneration: UInt64
+    ) -> Bool {
+        scheduledGeneration == currentGeneration
+    }
+
+    nonisolated static func shouldClearContentShrinkResetBookkeeping(
+        scheduledGeneration: UInt64,
+        currentGeneration: UInt64
+    ) -> Bool {
+        scheduledGeneration == currentGeneration
+    }
+
+    nonisolated static func contentShrinkBookmarkResetStateAfterScheduledTailScroll(
+        didScroll: Bool,
+        hasContentGrowthRestore: Bool,
+        currentState: ACPContentShrinkBookmarkResetState
+    ) -> ACPContentShrinkBookmarkResetState {
+        guard didScroll, hasContentGrowthRestore else { return currentState }
+        return .none
     }
 
     nonisolated static func shouldRestoreTailAfterViewportWidthChange(
@@ -994,8 +1168,13 @@ struct ACPMessageList: View {
     ) {
         // Always current for `scrollToTail`'s idempotency check below, even
         // when none of the branches in this function fire.
+        scrollBook.scrollGeometryGeneration &+= 1
         scrollBook.lastScrollProbe = ACPScrollProbe(
-            minY: newMinY, viewportHeight: viewportHeight, contentHeight: contentHeight)
+            generation: scrollBook.scrollGeometryGeneration,
+            minY: newMinY,
+            viewportHeight: viewportHeight,
+            contentHeight: contentHeight
+        )
         // Tail-follow pause/resume — reuse the shared classifier so the rules
         // match the legacy observer exactly. `NSApp.currentEvent` reports the
         // most recently processed event, not necessarily the cause of this
@@ -1039,19 +1218,32 @@ struct ACPMessageList: View {
             )
         case .noChange: break
         }
+        scheduleContentShrinkBookmarkResetIfNeeded(
+            previousContentHeight: previousContentHeight,
+            contentHeight: contentHeight,
+            viewportHeight: viewportHeight,
+            newMinY: newMinY
+        )
         if Self.shouldRestoreTailAfterContentGrowth(
             previousContentHeight: previousContentHeight,
             newContentHeight: contentHeight,
             viewportHeight: viewportHeight,
             newMinY: newMinY,
             followsTranscriptTail: session.followsTranscriptTail,
-            isRestoring: scrollBook.isRestoringTail
+            isRestoring: scrollBook.isRestoringTail,
+            contentShrinkBookmarkResetState: scrollBook.contentShrinkBookmarkResetState,
+            lastRestoreSourceContentHeight: scrollBook.lastContentGrowthTailRestoreSourceHeight,
+            lastRestoredContentHeight: scrollBook.lastContentGrowthTailRestoreHeight
         ) {
             scheduleTailScroll(
                 proxy: proxy,
                 animated: Self.shouldAnimateTailScroll(
                     trigger: .contentGrowth,
                     streamingState: session.transcript.streamingState
+                ),
+                contentGrowthRestore: ACPContentGrowthTailRestore(
+                    sourceHeight: previousContentHeight,
+                    targetHeight: contentHeight
                 )
             )
             return
@@ -1071,6 +1263,95 @@ struct ACPMessageList: View {
         guard now.timeIntervalSince(scrollBook.lastHeadStepAt) > headStepDebounceInterval else { return }
         scrollBook.lastHeadStepAt = now
         stepHeadBackPreservingScroll(proxy: proxy)
+    }
+
+    private func scheduleContentShrinkBookmarkResetIfNeeded(
+        previousContentHeight: CGFloat,
+        contentHeight: CGFloat,
+        viewportHeight: CGFloat,
+        newMinY: CGFloat
+    ) {
+        guard Self.shouldResetContentGrowthTailRestoreAfterShrink(
+            previousContentHeight: previousContentHeight,
+            newContentHeight: contentHeight,
+            viewportHeight: viewportHeight,
+            newMinY: newMinY,
+            followsTranscriptTail: session.followsTranscriptTail,
+            isRestoring: scrollBook.isRestoringTail,
+            hasPendingTailScroll: scrollBook.pendingTailScrollTask != nil,
+            lastRestoredContentHeight: scrollBook.lastContentGrowthTailRestoreHeight
+        ) else { return }
+
+        scrollBook.pendingContentShrinkResetTask?.cancel()
+        scrollBook.contentShrinkBookmarkResetState = .pending
+        scrollBook.pendingContentShrinkResetGeneration &+= 1
+        let scheduledGeneration = scrollBook.pendingContentShrinkResetGeneration
+        let scheduledProbeGeneration = scrollBook.scrollGeometryGeneration
+        scrollBook.pendingContentShrinkResetTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: Self.contentShrinkBookmarkResetDebounceNanoseconds)
+            defer {
+                if ACPMessageList.shouldClearContentShrinkResetBookkeeping(
+                    scheduledGeneration: scheduledGeneration,
+                    currentGeneration: scrollBook.pendingContentShrinkResetGeneration
+                ) {
+                    scrollBook.pendingContentShrinkResetTask = nil
+                }
+            }
+            guard !Task.isCancelled else {
+                if ACPMessageList.shouldClearContentShrinkResetBookkeeping(
+                    scheduledGeneration: scheduledGeneration,
+                    currentGeneration: scrollBook.pendingContentShrinkResetGeneration
+                ) {
+                    scrollBook.contentShrinkBookmarkResetState = .none
+                }
+                return
+            }
+            guard let latestProbe = scrollBook.lastScrollProbe else {
+                if ACPMessageList.shouldClearContentShrinkResetBookkeeping(
+                    scheduledGeneration: scheduledGeneration,
+                    currentGeneration: scrollBook.pendingContentShrinkResetGeneration
+                ) {
+                    scrollBook.contentShrinkBookmarkResetState = .none
+                }
+                return
+            }
+            guard Self.shouldUseScrollProbeForDeferredShrinkReset(
+                latestProbeGeneration: latestProbe.generation,
+                scheduledProbeGeneration: scheduledProbeGeneration,
+                didDebounce: true
+            ) else {
+                if ACPMessageList.shouldClearContentShrinkResetBookkeeping(
+                    scheduledGeneration: scheduledGeneration,
+                    currentGeneration: scrollBook.pendingContentShrinkResetGeneration
+                ) {
+                    scrollBook.contentShrinkBookmarkResetState = .none
+                }
+                return
+            }
+            guard Self.shouldApplyDeferredContentShrinkBookmarkReset(
+                expectedContentHeight: contentHeight,
+                latestContentHeight: latestProbe.contentHeight,
+                latestViewportHeight: latestProbe.viewportHeight,
+                latestMinY: latestProbe.minY,
+                followsTranscriptTail: session.followsTranscriptTail,
+                isRestoring: scrollBook.isRestoringTail,
+                hasPendingTailScroll: scrollBook.pendingTailScrollTask != nil
+            ) else {
+                if ACPMessageList.shouldClearContentShrinkResetBookkeeping(
+                    scheduledGeneration: scheduledGeneration,
+                    currentGeneration: scrollBook.pendingContentShrinkResetGeneration
+                ) {
+                    scrollBook.contentShrinkBookmarkResetState = .none
+                }
+                return
+            }
+            if ACPMessageList.shouldClearContentShrinkResetBookkeeping(
+                scheduledGeneration: scheduledGeneration,
+                currentGeneration: scrollBook.pendingContentShrinkResetGeneration
+            ) {
+                scrollBook.contentShrinkBookmarkResetState = .verified
+            }
+        }
     }
 
     nonisolated static func shouldStepHeadBackFromGeometry(
@@ -1260,6 +1541,17 @@ private final class ACPMutableScrollAnchor {
     var value: String?
 }
 
+struct ACPContentGrowthTailRestore: Equatable {
+    let sourceHeight: CGFloat
+    let targetHeight: CGFloat
+}
+
+enum ACPContentShrinkBookmarkResetState {
+    case none
+    case pending
+    case verified
+}
+
 /// Non-observed bookkeeping for scroll/restore callbacks. These values are
 /// only read from callbacks (never from `body`), so keeping them in plain
 /// `@State` value storage would buy nothing except a full-list invalidation
@@ -1273,12 +1565,25 @@ private final class ACPTranscriptScrollBookkeeping {
     var lastHeadStepAt: Date = .distantPast
     var lastTailStepAt: Date = .distantPast
     var pendingTailScrollTask: Task<Void, Never>?
+    var pendingTailScrollGeneration: UInt64 = 0
+    var pendingContentGrowthTailRestore: ACPContentGrowthTailRestore?
+    var pendingContentShrinkResetTask: Task<Void, Never>?
+    var pendingContentShrinkResetGeneration: UInt64 = 0
+    var contentShrinkBookmarkResetState: ACPContentShrinkBookmarkResetState = .none
+    var scrollGeometryGeneration: UInt64 = 0
     /// Most recent modern-path scroll geometry, refreshed on every
     /// `handleScrollGeometry` call. Lets programmatic scrolls (`scrollToTail`)
     /// check whether the viewport is already at rest before issuing another
     /// `proxy.scrollTo`, so a redundant scroll doesn't retrigger the geometry
     /// callback that scheduled it.
     var lastScrollProbe: ACPScrollProbe?
+    /// Highest content height that has already scheduled an automatic tail
+    /// restore from the content-growth path. Lazy stack estimates can
+    /// oscillate between two heights; remembering the restored height makes
+    /// that path converge instead of scheduling again on every low-to-high
+    /// estimate flip.
+    var lastContentGrowthTailRestoreSourceHeight: CGFloat?
+    var lastContentGrowthTailRestoreHeight: CGFloat?
 }
 
 /// Non-observed cache for the modern per-row geometry callbacks. SwiftUI's
@@ -1436,6 +1741,7 @@ private struct ACPTranscriptScrollTracking: ViewModifier {
         if #available(macOS 15, *) {
             content.onScrollGeometryChange(for: ACPScrollProbe.self) { geo in
                 ACPScrollProbe(
+                    generation: 0,
                     minY: geo.visibleRect.minY,
                     viewportHeight: geo.visibleRect.height,
                     contentHeight: geo.contentSize.height)
@@ -1462,6 +1768,7 @@ private struct ACPTranscriptScrollTracking: ViewModifier {
 /// macOS 15 availability — the `ScrollGeometry` reference is confined to the
 /// `#available` branch above.
 private struct ACPScrollProbe: Equatable {
+    var generation: UInt64
     var minY: CGFloat
     var viewportHeight: CGFloat
     var contentHeight: CGFloat

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -100,6 +100,278 @@ struct ACPMessageListPaginationTests {
         ))
     }
 
+    @Test("content height oscillation schedules one tail restore")
+    func contentHeightOscillationSchedulesOneTailRestore() {
+        let viewportHeight: CGFloat = 600
+        let lowEstimatedHeight: CGFloat = 5_000
+        let highEstimatedHeight: CGFloat = 5_220
+        let oldTailOffset = lowEstimatedHeight - viewportHeight
+
+        #expect(ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: lowEstimatedHeight,
+            newContentHeight: highEstimatedHeight,
+            viewportHeight: viewportHeight,
+            newMinY: oldTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false
+        ))
+
+        #expect(!ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: lowEstimatedHeight,
+            newContentHeight: highEstimatedHeight,
+            viewportHeight: viewportHeight,
+            newMinY: oldTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false,
+            lastRestoreSourceContentHeight: lowEstimatedHeight,
+            lastRestoredContentHeight: highEstimatedHeight
+        ))
+
+        #expect(ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: highEstimatedHeight,
+            newContentHeight: highEstimatedHeight + ACPScrollDirectionClassifier.bottomTolerance + 1,
+            viewportHeight: viewportHeight,
+            newMinY: oldTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false,
+            lastRestoreSourceContentHeight: lowEstimatedHeight,
+            lastRestoredContentHeight: highEstimatedHeight
+        ))
+    }
+
+    @Test("content growth can restore after a real content shrink")
+    func contentGrowthCanRestoreAfterRealContentShrink() {
+        let viewportHeight: CGFloat = 600
+        let previousRestoredHeight: CGFloat = 5_220
+        let previousRestoreSourceHeight: CGFloat = 5_000
+        let shrunkenHeight: CGFloat = 4_800
+        let regrownHeight: CGFloat = 5_000
+        let shrunkenTailOffset = shrunkenHeight - viewportHeight
+
+        #expect(ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: shrunkenHeight,
+            newContentHeight: regrownHeight,
+            viewportHeight: viewportHeight,
+            newMinY: shrunkenTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false,
+            lastRestoreSourceContentHeight: previousRestoreSourceHeight,
+            lastRestoredContentHeight: previousRestoredHeight
+        ))
+    }
+
+    @Test("settled content shrink resets the content growth restore bookmark")
+    func settledContentShrinkResetsContentGrowthRestoreBookmark() {
+        let viewportHeight: CGFloat = 600
+        let previousRestoredHeight: CGFloat = 5_220
+        let shrunkenHeight: CGFloat = 5_000
+        let shrunkenTailOffset = shrunkenHeight - viewportHeight
+
+        #expect(ACPMessageList.shouldResetContentGrowthTailRestoreAfterShrink(
+            previousContentHeight: previousRestoredHeight,
+            newContentHeight: shrunkenHeight,
+            viewportHeight: viewportHeight,
+            newMinY: shrunkenTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: true,
+            hasPendingTailScroll: false,
+            lastRestoredContentHeight: previousRestoredHeight
+        ))
+
+        #expect(ACPMessageList.shouldApplyDeferredContentShrinkBookmarkReset(
+            expectedContentHeight: shrunkenHeight,
+            latestContentHeight: shrunkenHeight,
+            latestViewportHeight: viewportHeight,
+            latestMinY: shrunkenTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: true,
+            hasPendingTailScroll: false
+        ))
+
+        #expect(ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: shrunkenHeight,
+            newContentHeight: previousRestoredHeight,
+            viewportHeight: viewportHeight,
+            newMinY: shrunkenTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false,
+            lastRestoreSourceContentHeight: nil,
+            lastRestoredContentHeight: nil
+        ))
+    }
+
+    @Test("estimate oscillation does not apply deferred shrink reset")
+    func estimateOscillationDoesNotApplyDeferredShrinkReset() {
+        let viewportHeight: CGFloat = 600
+        let highEstimatedHeight: CGFloat = 5_220
+        let lowEstimatedHeight: CGFloat = 5_000
+        let highTailOffset = highEstimatedHeight - viewportHeight
+
+        #expect(!ACPMessageList.shouldApplyDeferredContentShrinkBookmarkReset(
+            expectedContentHeight: lowEstimatedHeight,
+            latestContentHeight: highEstimatedHeight,
+            latestViewportHeight: viewportHeight,
+            latestMinY: highTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false,
+            hasPendingTailScroll: false
+        ))
+    }
+
+    @Test("pending shrink reset keeps same oscillation bookmark active")
+    func pendingShrinkResetKeepsSameOscillationBookmarkActive() {
+        let viewportHeight: CGFloat = 600
+        let lowHeight: CGFloat = 5_000
+        let highHeight: CGFloat = 5_220
+        let lowTailOffset = lowHeight - viewportHeight
+
+        #expect(!ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: lowHeight,
+            newContentHeight: highHeight,
+            viewportHeight: viewportHeight,
+            newMinY: lowTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false,
+            contentShrinkBookmarkResetState: .pending,
+            lastRestoreSourceContentHeight: lowHeight,
+            lastRestoredContentHeight: highHeight
+        ))
+    }
+
+    @Test("verified shrink reset allows same source regrowth restore")
+    func verifiedShrinkResetAllowsSameSourceRegrowthRestore() {
+        let viewportHeight: CGFloat = 600
+        let lowHeight: CGFloat = 5_000
+        let highHeight: CGFloat = 5_220
+        let lowTailOffset = lowHeight - viewportHeight
+
+        #expect(ACPMessageList.shouldRestoreTailAfterContentGrowth(
+            previousContentHeight: lowHeight,
+            newContentHeight: highHeight,
+            viewportHeight: viewportHeight,
+            newMinY: lowTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false,
+            contentShrinkBookmarkResetState: .verified,
+            lastRestoreSourceContentHeight: lowHeight,
+            lastRestoredContentHeight: highHeight
+        ))
+    }
+
+    @Test("content growth restore is stored before coalescing a pending tail scroll")
+    func contentGrowthRestoreIsStoredBeforeCoalescingPendingTailScroll() {
+        #expect(ACPMessageList.shouldStoreContentGrowthRestoreBeforeCoalescing(
+            hasPendingTailScroll: true,
+            hasContentGrowthRestore: true
+        ))
+        #expect(!ACPMessageList.shouldStoreContentGrowthRestoreBeforeCoalescing(
+            hasPendingTailScroll: false,
+            hasContentGrowthRestore: true
+        ))
+        #expect(!ACPMessageList.shouldStoreContentGrowthRestoreBeforeCoalescing(
+            hasPendingTailScroll: true,
+            hasContentGrowthRestore: false
+        ))
+    }
+
+    @Test("coalesced content growth restore preserves lowest source height")
+    func coalescedContentGrowthRestorePreservesLowestSourceHeight() {
+        let existing = ACPContentGrowthTailRestore(sourceHeight: 5_000, targetHeight: 5_100)
+        let next = ACPContentGrowthTailRestore(sourceHeight: 5_100, targetHeight: 5_220)
+        let lowerNext = ACPContentGrowthTailRestore(sourceHeight: 5_000, targetHeight: 5_050)
+
+        #expect(ACPMessageList.mergedContentGrowthTailRestore(existing: existing, new: next) == ACPContentGrowthTailRestore(
+            sourceHeight: 5_000,
+            targetHeight: 5_220
+        ))
+        #expect(ACPMessageList.mergedContentGrowthTailRestore(existing: next, new: lowerNext) == ACPContentGrowthTailRestore(
+            sourceHeight: 5_000,
+            targetHeight: 5_220
+        ))
+        #expect(ACPMessageList.mergedContentGrowthTailRestore(existing: nil, new: next) == next)
+        #expect(ACPMessageList.mergedContentGrowthTailRestore(existing: existing, new: nil) == nil)
+    }
+
+    @Test("scheduled tail task clears bookkeeping only for its own generation")
+    func scheduledTailTaskClearsBookkeepingOnlyForOwnGeneration() {
+        #expect(ACPMessageList.shouldClearScheduledTailScrollBookkeeping(
+            scheduledGeneration: 4,
+            currentGeneration: 4
+        ))
+        #expect(!ACPMessageList.shouldClearScheduledTailScrollBookkeeping(
+            scheduledGeneration: 4,
+            currentGeneration: 5
+        ))
+    }
+
+    @Test("shrink reset task clears bookkeeping only for its own generation")
+    func shrinkResetTaskClearsBookkeepingOnlyForOwnGeneration() {
+        #expect(ACPMessageList.shouldClearContentShrinkResetBookkeeping(
+            scheduledGeneration: 8,
+            currentGeneration: 8
+        ))
+        #expect(!ACPMessageList.shouldClearContentShrinkResetBookkeeping(
+            scheduledGeneration: 8,
+            currentGeneration: 9
+        ))
+    }
+
+    @Test("verified shrink reset is consumed only after growth restore scrolls")
+    func verifiedShrinkResetIsConsumedOnlyAfterGrowthRestoreScrolls() {
+        #expect(ACPMessageList.contentShrinkBookmarkResetStateAfterScheduledTailScroll(
+            didScroll: false,
+            hasContentGrowthRestore: true,
+            currentState: .verified
+        ) == .verified)
+        #expect(ACPMessageList.contentShrinkBookmarkResetStateAfterScheduledTailScroll(
+            didScroll: true,
+            hasContentGrowthRestore: true,
+            currentState: .verified
+        ) == .none)
+        #expect(ACPMessageList.contentShrinkBookmarkResetStateAfterScheduledTailScroll(
+            didScroll: true,
+            hasContentGrowthRestore: false,
+            currentState: .verified
+        ) == .verified)
+    }
+
+    @Test("deferred shrink reset accepts small settled height drift at bottom")
+    func deferredShrinkResetAcceptsSmallSettledHeightDriftAtBottom() {
+        let viewportHeight: CGFloat = 600
+        let expectedContentHeight: CGFloat = 5_000
+        let latestContentHeight: CGFloat = 5_001
+        let latestTailOffset = latestContentHeight - viewportHeight
+
+        #expect(ACPMessageList.shouldApplyDeferredContentShrinkBookmarkReset(
+            expectedContentHeight: expectedContentHeight,
+            latestContentHeight: latestContentHeight,
+            latestViewportHeight: viewportHeight,
+            latestMinY: latestTailOffset,
+            followsTranscriptTail: true,
+            isRestoring: false,
+            hasPendingTailScroll: false
+        ))
+    }
+
+    @Test("deferred shrink reset requires a later geometry probe or debounce")
+    func deferredShrinkResetRequiresLaterGeometryProbeOrDebounce() {
+        #expect(!ACPMessageList.shouldUseScrollProbeForDeferredShrinkReset(
+            latestProbeGeneration: 12,
+            scheduledProbeGeneration: 12,
+            didDebounce: false
+        ))
+        #expect(ACPMessageList.shouldUseScrollProbeForDeferredShrinkReset(
+            latestProbeGeneration: 12,
+            scheduledProbeGeneration: 12,
+            didDebounce: true
+        ))
+        #expect(ACPMessageList.shouldUseScrollProbeForDeferredShrinkReset(
+            latestProbeGeneration: 13,
+            scheduledProbeGeneration: 12,
+            didDebounce: false
+        ))
+    }
+
     @Test("streaming tail scrolls do not animate")
     func streamingTailScrollsDoNotAnimate() {
         #expect(!ACPMessageList.shouldAnimateTailScroll(


### PR DESCRIPTION
## Summary

Fixes a self-sustaining SwiftUI layout livelock in the ACP transcript tail-follow path. LazyVStack content-height estimates can oscillate during transcript layout; the old content-growth predicate treated each low-to-high estimate flip as fresh growth and kept scheduling tail restoration.

## Root Cause

ACPTranscriptScrollTracking observes contentSize.height during layout. When the transcript is following the tail, handleScrollGeometry called shouldRestoreTailAfterContentGrowth for any content-height increase. With lazy row estimates, height can alternate between two values, causing repeated scheduleTailScroll calls and another layout pass.

## Changes

- Remember the source and target content heights for completed content-growth tail restores.
- Commit that bookmark only after a tail scroll actually issues proxy.scrollTo, including direct restoreTailIfNeeded scrolls that cancel a queued restore task.
- Preserve pending content-growth restore metadata when growth coalesces into an already scheduled tail scroll, keeping the lowest observed source height and highest target height.
- Guard scheduled tail-scroll cleanup with a generation token so stale canceled tasks cannot clear newer pending growth metadata.
- Suppress repeated restores for the same low/high estimate pair while a shrink reset is pending.
- Promote shrink resets to verified only after either a later scroll-geometry sample or a real debounce still shows the shrunken content settled at the tail; small settled-height drift within bottom tolerance is accepted.
- Allow bottom shrink observations and deferred verification while a programmatic tail restore is active so a settled shrink is not dropped solely because isRestoringTail has not been released yet.
- Consume verified shrink state only after a scheduled content-growth restore actually scrolls, so skipped deferred restores can retry.
- Guard deferred shrink-reset cleanup with a generation token so stale canceled reset tasks cannot erase newer pending or verified shrink state.
- Add Swift Testing regression coverage for oscillation suppression, shrink/regrowth, deferred shrink reset, coalesced growth metadata, pending-reset suppression, verified-reset regrowth behavior, stale task cleanup, verified-state consumption, lowest-source coalescing, max-target coalescing, settled shrink-height drift, later-probe-or-debounce verification, and shrink observations/verification during tail restore.

## Validation

- xcodegen
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPMessageListPaginationTests test
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build

The local full macOS test command was also attempted earlier in this PR loop, but xcodebuild became idle without a child test process or log progress after several minutes and was interrupted. GitHub Actions remains the full workflow gate for the PR.
