### PR TITLE
fix(acp): cache streamed message indices

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1234,6 +1234,7 @@
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
 		F1AB5B4DF8A59DF85D585058 /* RemoteWeb in Resources */ = {isa = PBXBuildFile; fileRef = B586C7A794B846F3AD9228BD /* RemoteWeb */; };
 		F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */; };
+		F22A776D791ABA7A584B4C18 /* ACPTranscriptMessageIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E26C51ACE48A35EB4CD463 /* ACPTranscriptMessageIndexTests.swift */; };
 		F2385B8730E9D1F47C7FA423 /* ReviewChangesRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C9EEDB5A71C5FAE2D0E42B /* ReviewChangesRail.swift */; };
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
 		F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */; };
@@ -1668,6 +1669,7 @@
 		4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionScope.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
 		44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPromptTests.swift; sourceTree = "<group>"; };
+		44E26C51ACE48A35EB4CD463 /* ACPTranscriptMessageIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMessageIndexTests.swift; sourceTree = "<group>"; };
 		44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextBuilder.swift; sourceTree = "<group>"; };
 		45413FEBB779051893272FC7 /* CommitPrimaryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPrimaryAction.swift; sourceTree = "<group>"; };
 		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
@@ -4210,6 +4212,7 @@
 				0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */,
 				3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */,
 				A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */,
+				44E26C51ACE48A35EB4CD463 /* ACPTranscriptMessageIndexTests.swift */,
 				F84BC1A10866A165EA321719 /* ACPTranscriptTests.swift */,
 				7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */,
 				8EA9CC6DA19BF2D0FD8FBDF3 /* AlasCLIEnvInjectionTests.swift */,
@@ -5942,6 +5945,7 @@
 				A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */,
 				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,
 				6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */,
+				F22A776D791ABA7A584B4C18 /* ACPTranscriptMessageIndexTests.swift in Sources */,
 				2F1165AE6FD339D03943C182 /* ACPTranscriptRowContentTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -197,8 +197,6 @@ final class ACPSession: ObservableObject, Identifiable {
     var remoteSessionId: String?
     @Published var queue: [QueuedPrompt] = []
     @Published var steerUndo: SteerUndoState?
-    private var toolCallIndices: [String: Int] = [:]
-
     struct SteerUndoState: Equatable {
         /// Unique per-snapshot id used by SwiftUI for view diffing — letting
         /// us reset the 5s timer-task whenever a new steer happens before
@@ -363,7 +361,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 text: txt,
                 messageId: chunk.messageId,
                 replayKind: .agent,
-                locateByMessageId: { id in messageIndex(messageId: id, kind: .agent) },
+                locateByMessageId: { id in transcript.messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
                 replayCandidateMatches: { text in existingMessageContains(kind: .agent, text) },
                 adoptContinuation: { candidate in
@@ -393,7 +391,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 text: txt,
                 messageId: chunk.messageId,
                 replayKind: .thought,
-                locateByMessageId: { id in messageIndex(messageId: id, kind: .thought) },
+                locateByMessageId: { id in transcript.messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
                 replayCandidateMatches: { text in existingMessageContains(kind: .thought, text) },
                 adoptContinuation: { candidate in
@@ -715,7 +713,6 @@ final class ACPSession: ObservableObject, Identifiable {
 
     func replaceTranscriptMessages(_ messages: [ACPMessage]) {
         transcript.replaceMessages(with: messagesPreservingToolCallContentRevisions(messages))
-        rebuildToolCallIndices()
     }
 
     private func messagesPreservingToolCallContentRevisions(_ messages: [ACPMessage]) -> [ACPMessage] {
@@ -749,11 +746,6 @@ final class ACPSession: ObservableObject, Identifiable {
     func prependTranscriptMessages(_ older: [ACPMessage]) {
         guard !older.isEmpty else { return }
         transcript.prependMessages(older)
-        // Rebuild tool-call indices because every prior entry's index just
-        // shifted by `older.count`. Cheaper than offsetting in place: the
-        // cache is dictionary-typed, so a full rebuild is O(N) and avoids
-        // any chance of drift if a streaming update lands mid-shift.
-        rebuildToolCallIndices()
         // Keep the visible window anchored to the tail the user is already
         // looking at while trimming newly-hidden historical tool output.
         transcript.shiftVisibleHeadAfterPrepending(older.count)
@@ -1536,21 +1528,8 @@ final class ACPSession: ObservableObject, Identifiable {
         case thought
     }
 
-    private func messageIndex(messageId: String, kind: TextMessageKind) -> Int? {
-        transcript.messages.firstIndex { message in
-            switch (kind, message) {
-            case (.user, .user(_, let existing, _, _, _)),
-                 (.agent, .agent(_, let existing, _)),
-                 (.thought, .thought(_, let existing, _)):
-                return existing == messageId
-            default:
-                return false
-            }
-        }
-    }
-
     private func appendUserChunk(text addition: String, attachments newAttachments: [ACPMessage.Attachment], messageId: String?, flushedReplayIndices: inout Set<Int>) -> Int? {
-        let located = messageId.flatMap { messageIndex(messageId: $0, kind: .user) }
+        let located = messageId.flatMap { transcript.messageIndex(messageId: $0, kind: .user) }
         if let i = located,
            case .user(let id, let existingMessageId, let text, let attachments, let delegatedSource) = transcript.messages[i] {
             let mergedAttachments = Self.mergingAttachments(attachments, newAttachments)
@@ -1981,31 +1960,14 @@ final class ACPSession: ObservableObject, Identifiable {
     }
     /// Returns the index of the matching tool call, or nil if no match.
     private func updateToolCall(id: String, _ mutate: (inout ACPMessage.ToolCall) -> Void) -> Int? {
-        if let i = toolCallIndices[id],
-           transcript.messages.indices.contains(i),
-           case .toolCall(var tc) = transcript.messages[i],
-           tc.toolCallId == id {
-            mutate(&tc)
-            transcript.replaceMessage(at: i, with: .toolCall(tc))
-            return i
-        }
-
-        for i in transcript.messages.indices {
-            if case .toolCall(var tc) = transcript.messages[i], tc.toolCallId == id {
-                toolCallIndices[id] = i
-                mutate(&tc)
-                transcript.replaceMessage(at: i, with: .toolCall(tc))
-                return i
-            }
-        }
-        return nil
+        guard let i = transcript.toolCallIndex(toolCallId: id),
+              case .toolCall(var toolCall) = transcript.messages[i] else { return nil }
+        mutate(&toolCall)
+        transcript.replaceMessage(at: i, with: .toolCall(toolCall))
+        return i
     }
 
     private func didAppendTranscriptMessage() {
-        let index = transcript.messages.count - 1
-        if case .toolCall(let tc) = transcript.messages[index] {
-            toolCallIndices[tc.toolCallId] = index
-        }
         advanceRenderWindowIfFollowingTail()
     }
 
@@ -2014,15 +1976,6 @@ final class ACPSession: ObservableObject, Identifiable {
         contextRecoveryExpiryTask?.cancel()
         contextRecoveryExpiryTask = nil
         contextRecoveryStatus = nil
-    }
-
-    private func rebuildToolCallIndices() {
-        toolCallIndices.removeAll(keepingCapacity: true)
-        for i in transcript.messages.indices {
-            if case .toolCall(let tc) = transcript.messages[i] {
-                toolCallIndices[tc.toolCallId] = i
-            }
-        }
     }
 
     private func advanceRenderWindowIfFollowingTail() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -465,12 +465,7 @@ final class ACPSessionRunner {
         switch update {
         case .agentMessageChunk(let chunk):
             if let messageId = chunk.messageId,
-               let index = messages.firstIndex(where: { message in
-                   if case .agent(_, let id, _) = message {
-                       return id == messageId
-                   }
-                   return false
-               }) {
+               let index = session.transcript.messageIndex(messageId: messageId, kind: .agent) {
                 return [index]
             }
             return messages.indices.reversed().first { index in
@@ -481,12 +476,7 @@ final class ACPSessionRunner {
             }.map { [$0] } ?? []
         case .agentThoughtChunk(let chunk):
             if let messageId = chunk.messageId,
-               let index = messages.firstIndex(where: { message in
-                   if case .thought(_, let id, _) = message {
-                       return id == messageId
-                   }
-                   return false
-               }) {
+               let index = session.transcript.messageIndex(messageId: messageId, kind: .thought) {
                 return [index]
             }
             return messages.indices.reversed().first { index in
@@ -496,12 +486,7 @@ final class ACPSessionRunner {
                 return false
             }.map { [$0] } ?? []
         case .toolCallUpdate(let update):
-            return messages.firstIndex { message in
-                if case .toolCall(let toolCall) = message {
-                    return toolCall.toolCallId == update.toolCallId
-                }
-                return false
-            }.map { [$0] } ?? []
+            return session.transcript.toolCallIndex(toolCallId: update.toolCallId).map { [$0] } ?? []
         case .toolCall, .userMessageChunk, .plan, .availableModelsUpdate,
              .currentModeUpdate, .currentModelUpdate, .sessionInfoUpdate,
              .sessionConfigOptionsUpdate, .availableCommandsUpdate,

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -12,6 +12,7 @@ final class ACPTranscript: ObservableObject {
         didSet {
             messagesGeneration &+= 1
             updatePlanCaches(for: pendingMessagesMutation)
+            updateMessageIndexCaches(for: pendingMessagesMutation)
             pendingMessagesMutation = nil
             recordMessagesDiff(old: oldValue)
         }
@@ -25,8 +26,20 @@ final class ACPTranscript: ObservableObject {
     private var pendingMessagesMutation: MessagesMutation?
     private var latestPlanMessageIndex: Int?
     private var latestUserMessageIndex: Int?
+    enum TextMessageKind: Hashable {
+        case user
+        case agent
+        case thought
+    }
+    private struct TextMessageKey: Hashable {
+        let kind: TextMessageKind
+        let messageId: String
+    }
+    private var textMessageIndices: [TextMessageKey: Int] = [:]
+    private var toolCallIndices: [String: Int] = [:]
     #if DEBUG
     private(set) var planCacheRebuildCountForTests = 0
+    private(set) var messageIndexCacheRebuildCountForTests = 0
     #endif
     /// Bumped on every `messages` array mutation. Non-published: consumed by
     /// value caches (visible-rows lookup) that must invalidate when the array
@@ -138,9 +151,9 @@ final class ACPTranscript: ObservableObject {
 
     // MARK: - Incremental plan caches
 
-    /// Production mutation entry points carry enough context for plan caches
-    /// to update in O(1). Direct `messages` assignments remain supported for
-    /// restore/test call sites and safely rebuild both indices once.
+    /// Production mutation entry points carry enough context for plan and
+    /// message-index caches to update in O(1). Direct `messages` assignments
+    /// remain supported for restore/test call sites and safely rebuild once.
     var currentPlanMessageIndex: Int? {
         guard let latestPlanMessageIndex,
               latestPlanMessageIndex > (latestUserMessageIndex ?? -1) else {
@@ -168,6 +181,106 @@ final class ACPTranscript: ObservableObject {
         guard !older.isEmpty else { return }
         pendingMessagesMutation = .prepend(count: older.count)
         messages.insert(contentsOf: older, at: 0)
+    }
+
+    func messageIndex(messageId: String, kind: TextMessageKind) -> Int? {
+        textMessageIndices[TextMessageKey(kind: kind, messageId: messageId)]
+    }
+
+    func toolCallIndex(toolCallId: String) -> Int? {
+        toolCallIndices[toolCallId]
+    }
+
+    // MARK: - Incremental message index caches
+
+    private func updateMessageIndexCaches(for mutation: MessagesMutation?) {
+        switch mutation {
+        case .append(let message):
+            cacheMessageIndex(messages.count - 1, for: message)
+        case .replace(let index, let old, let new):
+            let oldTextKey = textMessageKey(for: old)
+            let newTextKey = textMessageKey(for: new)
+            if oldTextKey != newTextKey {
+                if let oldTextKey, textMessageIndices[oldTextKey] == index {
+                    textMessageIndices.removeValue(forKey: oldTextKey)
+                    restoreTextMessageIndex(for: oldTextKey)
+                }
+                if let newTextKey,
+                   textMessageIndices[newTextKey].map({ index < $0 }) ?? true {
+                    textMessageIndices[newTextKey] = index
+                }
+            }
+
+            let oldToolCallId = toolCallId(for: old)
+            let newToolCallId = toolCallId(for: new)
+            if oldToolCallId != newToolCallId {
+                if let oldToolCallId, toolCallIndices[oldToolCallId] == index {
+                    toolCallIndices.removeValue(forKey: oldToolCallId)
+                    restoreToolCallIndex(for: oldToolCallId)
+                }
+                if let newToolCallId,
+                   toolCallIndices[newToolCallId].map({ index < $0 }) ?? true {
+                    toolCallIndices[newToolCallId] = index
+                }
+            }
+        case .planNeutral:
+            break
+        case .prepend, nil:
+            rebuildMessageIndexCaches()
+        }
+    }
+
+    private func rebuildMessageIndexCaches() {
+        #if DEBUG
+        messageIndexCacheRebuildCountForTests += 1
+        #endif
+        textMessageIndices.removeAll(keepingCapacity: true)
+        toolCallIndices.removeAll(keepingCapacity: true)
+        for index in messages.indices {
+            cacheMessageIndex(index, for: messages[index])
+        }
+    }
+
+    private func cacheMessageIndex(_ index: Int, for message: ACPMessage) {
+        if let key = textMessageKey(for: message), textMessageIndices[key] == nil {
+            textMessageIndices[key] = index
+        }
+        if let toolCallId = toolCallId(for: message), toolCallIndices[toolCallId] == nil {
+            toolCallIndices[toolCallId] = index
+        }
+    }
+
+    /// Message ids are expected to be unique within their kind, but retain
+    /// the old first-match behavior if malformed/restored data contains a
+    /// duplicate and the cached first occurrence changes identity.
+    private func restoreTextMessageIndex(for key: TextMessageKey) {
+        if let index = messages.indices.first(where: { textMessageKey(for: messages[$0]) == key }) {
+            textMessageIndices[key] = index
+        }
+    }
+
+    private func restoreToolCallIndex(for toolCallId: String) {
+        if let index = messages.indices.first(where: { self.toolCallId(for: messages[$0]) == toolCallId }) {
+            toolCallIndices[toolCallId] = index
+        }
+    }
+
+    private func textMessageKey(for message: ACPMessage) -> TextMessageKey? {
+        switch message {
+        case .user(_, let messageId?, _, _, _):
+            TextMessageKey(kind: .user, messageId: messageId)
+        case .agent(_, let messageId?, _):
+            TextMessageKey(kind: .agent, messageId: messageId)
+        case .thought(_, let messageId?, _):
+            TextMessageKey(kind: .thought, messageId: messageId)
+        default:
+            nil
+        }
+    }
+
+    private func toolCallId(for message: ACPMessage) -> String? {
+        guard case .toolCall(let toolCall) = message else { return nil }
+        return toolCall.toolCallId
     }
 
     private func updatePlanCaches(for mutation: MessagesMutation?) {

--- a/AlasTests/ACP/Session/ACPTranscriptMessageIndexTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptMessageIndexTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscript message indices")
+struct ACPTranscriptMessageIndexTests {
+    @Test("direct replacement rebuilds text and tool-call indices")
+    func directReplacementRebuildsIndices() {
+        let transcript = ACPTranscript()
+        let toolCall = ACPMessage.ToolCall(
+            toolCallId: "tool-1",
+            title: "Read",
+            status: "in_progress",
+            content: "",
+            preview: "",
+            locations: []
+        )
+
+        transcript.messages = [
+            .systemNotice(id: UUID(), text: "before"),
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("answer")),
+            .thought(id: UUID(), messageId: "thought-1", StreamingText("reasoning")),
+            .user(id: UUID(), messageId: "user-1", text: "prompt", attachments: []),
+            .toolCall(toolCall)
+        ]
+
+        #expect(transcript.messageIndex(messageId: "agent-1", kind: .agent) == 1)
+        #expect(transcript.messageIndex(messageId: "thought-1", kind: .thought) == 2)
+        #expect(transcript.messageIndex(messageId: "user-1", kind: .user) == 3)
+        #expect(transcript.toolCallIndex(toolCallId: "tool-1") == 4)
+    }
+
+    @Test("append and same-identity replacement update indices without rebuilding")
+    func productionMutationsStayIncremental() {
+        let transcript = ACPTranscript()
+        let rebuildCount = transcript.messageIndexCacheRebuildCountForTests
+        var toolCall = ACPMessage.ToolCall(
+            toolCallId: "tool-1",
+            title: "Read",
+            status: "in_progress",
+            content: "",
+            preview: "",
+            locations: []
+        )
+
+        transcript.appendMessage(.agent(
+            id: UUID(),
+            messageId: "agent-1",
+            StreamingText("first")
+        ))
+        transcript.replaceMessage(at: 0, with: .agent(
+            id: UUID(),
+            messageId: "agent-1",
+            StreamingText("updated")
+        ))
+        transcript.appendMessage(.toolCall(toolCall))
+        toolCall.content = "updated"
+        transcript.replaceMessage(at: 1, with: .toolCall(toolCall))
+
+        #expect(transcript.messageIndex(messageId: "agent-1", kind: .agent) == 0)
+        #expect(transcript.toolCallIndex(toolCallId: "tool-1") == 1)
+        #expect(transcript.messageIndexCacheRebuildCountForTests == rebuildCount)
+    }
+
+    @Test("streamed chunks reuse the cached message index")
+    func streamedChunksReuseIndex() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        for chunk in 0..<100 {
+            session.apply(.agentMessageChunk(.init(
+                messageId: "agent-1",
+                content: .text("\(chunk) ")
+            )))
+        }
+
+        #expect(session.transcript.messages.count == 1)
+        #expect(session.transcript.messageIndex(messageId: "agent-1", kind: .agent) == 0)
+        #expect(session.transcript.messageIndexCacheRebuildCountForTests == 0)
+    }
+
+    @Test("prepending shifts cached indices")
+    func prependRebuildsShiftedIndices() {
+        let transcript = ACPTranscript()
+        transcript.appendMessage(.agent(
+            id: UUID(),
+            messageId: "agent-1",
+            StreamingText("answer")
+        ))
+        let rebuildCount = transcript.messageIndexCacheRebuildCountForTests
+
+        transcript.prependMessages([
+            .user(id: UUID(), messageId: "user-1", text: "prompt", attachments: [])
+        ])
+
+        #expect(transcript.messageIndex(messageId: "user-1", kind: .user) == 0)
+        #expect(transcript.messageIndex(messageId: "agent-1", kind: .agent) == 1)
+        #expect(transcript.messageIndexCacheRebuildCountForTests == rebuildCount + 1)
+    }
+}


### PR DESCRIPTION
## Summary

- add incremental `messageId → index` and `toolCallId → index` caches to `ACPTranscript`
- reuse the shared caches from streamed message application and runner-side persisted-base capture
- keep cache updates O(1) for append/replace mutations and rebuild only for whole-array replacement or prepend hydration
- add regression coverage for restore, streaming, replacement, tool-call, and prepend paths

## Root cause

Each modern ACP agent/thought chunk performed a forward scan in both `ACPSessionRunner` and `ACPSession`. Tool-call persistence capture also bypassed the existing session cache. As transcripts grew, the per-chunk O(n) scans saturated the main actor.

## Impact

Streamed message and tool-call lookups are now O(1) in the steady state, removing the transcript-length multiplier from high-frequency updates.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused `ACPTranscriptMessageIndexTests`
- `ACPSessionTests`
- full suite: 5,802 tests passed; eight opt-in SSH integration tests require `ALAS_SSH_INTEGRATION=1`
- unrelated `ACPTerminalTests/releaseReachesOrphans` timing failure passed on isolated retry

Fixes #842