### PR TITLE
fix(lsp): Bound sourcekit xcrun availability probe

### DIFF
--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -269,23 +269,19 @@ struct LanguageServerAvailability {
         }
     }
 
-    nonisolated private static func xcrunFind(_ tool: String) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
-        process.arguments = ["--find", tool]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
-            return output.isEmpty ? nil : output
-        } catch {
-            return nil
-        }
+    nonisolated static func xcrunFind(
+        _ tool: String,
+        runner: SubprocessRunner = .system,
+        timeout: TimeInterval = 5
+    ) -> String? {
+        let result = runner.run(
+            URL(fileURLWithPath: "/usr/bin/xcrun"),
+            ["--find", tool],
+            ProcessInfo.processInfo.environment,
+            timeout
+        )
+        guard result.exitCode == 0 else { return nil }
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return output.isEmpty ? nil : output
     }
 }

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -112,10 +112,11 @@ final class WorkspaceLSPManager: DocumentFormatter {
     private let makeClient: (_ executable: URL, _ arguments: [String], _ environment: [String: String], _ language: String, _ rootURI: String) -> LSPClient
 
     /// Cached per-language availability so the status badge doesn't re-run
-    /// `LanguageServerAvailability.status(for:)` — which can spawn
-    /// `xcrun --find sourcekit-lsp` synchronously on the main actor — on
-    /// every SwiftUI breadcrumb re-render. Cleared whenever the registry
-    /// changes (the only thing that can change the answer).
+    /// `LanguageServerAvailability.status(for:)` on every SwiftUI breadcrumb
+    /// re-render. Swift `sourcekit-lsp` can fall back to a bounded `xcrun
+    /// --find` probe, so render-adjacent callers should still reuse the cached
+    /// result. Cleared whenever the registry changes (the only thing that can
+    /// change the answer).
     private let makeAvailability: () -> LanguageServerAvailability
     private var cachedAvailability: LanguageServerAvailability
     private var availabilityCache: [String: LanguageServerAvailability.Status] = [:]
@@ -148,10 +149,11 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// caching the result. Designed for hot-path callers like the status
     /// badge resolver.
     ///
-    /// Missing Swift `sourcekit-lsp` is cached too: that resolution can fall
-    /// back to `xcrun --find`, so negative results must not be re-probed from
-    /// render-adjacent status badge paths. Other `.notInstalled` statuses
-    /// continue to re-probe so manual installs outside Alas are picked up.
+    /// Missing Swift `sourcekit-lsp` is cached too: that resolution can still
+    /// fall back to bounded `xcrun --find`, so negative results must not be
+    /// re-probed from render-adjacent status badge paths. Other
+    /// `.notInstalled` statuses continue to re-probe so manual installs outside
+    /// Alas are picked up.
     /// Runtime installs explicitly invalidate the language below.
     /// `.blockedByGatekeeper` still re-probes because remediation can flip
     /// without changing the registry.

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -124,6 +124,49 @@ struct LanguageServerAvailabilityTests {
         #expect(spawn!.arguments == ["--flag"])
     }
 
+    @Test("xcrun find uses bounded runner and parses successful output")
+    nonisolated func xcrunFindUsesBoundedRunner() {
+        var observedExecutable: URL?
+        var observedArguments: [String] = []
+        var observedEnvironment: [String: String] = [:]
+        var observedTimeout: TimeInterval?
+        let xcrunPath = """
+        /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp
+        """
+        let runner = SubprocessRunner { executable, arguments, environment, timeout in
+            observedExecutable = executable
+            observedArguments = arguments
+            observedEnvironment = environment
+            observedTimeout = timeout
+            return SubprocessRunner.Result(exitCode: 0, stdout: xcrunPath, stderr: "")
+        }
+
+        let resolved = LanguageServerAvailability.xcrunFind(
+            "sourcekit-lsp",
+            runner: runner,
+            timeout: 1.25
+        )
+
+        #expect(resolved == xcrunPath.trimmingCharacters(in: .whitespacesAndNewlines))
+        #expect(observedExecutable?.path == "/usr/bin/xcrun")
+        #expect(observedArguments == ["--find", "sourcekit-lsp"])
+        #expect(observedEnvironment == ProcessInfo.processInfo.environment)
+        #expect(observedTimeout == 1.25)
+    }
+
+    @Test("xcrun find timeout is treated as missing")
+    nonisolated func xcrunFindTimeoutIsMissing() {
+        let runner = SubprocessRunner { _, _, _, _ in
+            SubprocessRunner.Result(exitCode: nil, stdout: "", stderr: "")
+        }
+
+        #expect(LanguageServerAvailability.xcrunFind(
+            "sourcekit-lsp",
+            runner: runner,
+            timeout: 1.25
+        ) == nil)
+    }
+
     @Test("spawnArguments uses resolved absolute path from PATH")
     func spawnArgumentsPathCommand() throws {
         let dir = try temporaryDirectory()


### PR DESCRIPTION
## Summary
- Bound the Swift `sourcekit-lsp` `xcrun --find` fallback with the existing subprocess timeout runner.
- Treat timed-out or failed xcrun probes as missing so the main actor cannot block indefinitely.
- Added regression coverage for the bounded xcrun runner path and timeout handling.

## Root cause
`LanguageServerAvailability` used a raw `Process.waitUntilExit()` for `/usr/bin/xcrun --find sourcekit-lsp` without a timeout. Main-actor callers such as Settings -> Code and editor status probes could therefore beachball indefinitely when Command Line Tools were missing or misconfigured.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerAvailabilityTests test`
- `git diff --check`

Note: a local full `xcodebuild ... test` invocation hung twice before starting `xctest`, with Xcode also reporting a CoreSimulator version warning despite a macOS destination. Focused regression tests and the app build passed locally.

Fixes #844
