### PR TITLE
fix(acp): incremental toolCallUpdate content processing (#843)

### DIFF
--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -250,15 +250,25 @@ enum ACPMessage: Equatable {
         /// until then `appliedStrippedRaw` stays empty.
         var appliedOpeningFenceUnterminated: Bool = false
         /// In-memory-only cache of the previous content items array, used
-        /// to verify that the first `appliedItemCount` items are unchanged
+        /// to verify that the first `appliedItemCount` items' STRUCTURED
+        /// content (images, resource-links, terminals, diffs) is unchanged
         /// before taking the suffix-only fast path. `flatten` ignores
-        /// images/resource-links/terminals, so equal flattened text does
-        /// NOT imply the structured items are the same — an in-place
-        /// replacement (e.g. `[text, image(old)]` -> `[text, image(new)]`)
-        /// would otherwise skip `extractAssets`/`extractTerminalIds`. COW
-        /// keeps the storage cost minimal; the prefix comparison is
-        /// O(appliedItemCount) which is bounded by the items count.
+        /// those item kinds, so equal flattened text does NOT imply the
+        /// structured items are the same — an in-place replacement (e.g.
+        /// `[text, image(old)]` -> `[text, image(new)]`) would otherwise
+        /// skip `extractAssets`/`extractTerminalIds`. Only structured
+        /// items are compared; text items are allowed to grow in place
+        /// (the common cumulative shape `[text("a")]` -> `[text("ab")]`)
+        /// so the suffix path still fires. COW keeps storage cheap.
         var appliedItemsSnapshot: [ACPToolCallContent] = []
+        /// In-memory-only flag: whether `stripWrappingFence` actually
+        /// stripped an opening fence line from `appliedRawContent`. The
+        /// trailing-fence strip in `stripTrailingFenceLine` must only
+        /// run when an opening fence was recognized — ordinary tool
+        /// output whose final line happens to be `` ``` `` must NOT be
+        /// dropped. Mirrors `stripWrappingFence`'s `isOpeningFence`
+        /// guard.
+        var appliedOpeningFenceStripped: Bool = false
 
         /// Replace `content` with its first `truncatedTailBytes` characters
         /// and mark the message as truncated. No-op if already truncated.
@@ -278,6 +288,7 @@ enum ACPMessage: Equatable {
             appliedStrippedRaw = ""
             appliedOpeningFenceUnterminated = false
             appliedItemsSnapshot = []
+            appliedOpeningFenceStripped = false
         }
 
         init(toolCallId: String, title: String, kind: String? = nil,

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -209,6 +209,47 @@ enum ACPMessage: Equatable {
         /// user expands.
         static let truncatedTailBytes: Int = 4096
 
+        /// In-memory-only cache of the last fully-applied flattened raw
+        /// content (before fence stripping), used by
+        /// `applyToolCallUpdateFields`/`applyToolCallPayloadFields` to
+        /// detect prefix-extension updates and process only the appended
+        /// suffix. Adapters that stream tool output re-emit the full
+        /// cumulative content on every `tool_call_update`, so without
+        /// this cache each update re-runs `stripWrappingFence`,
+        /// `previewLine`, `extractAssets`, and `extractTerminalIds` over
+        /// the whole growing body — O(m·k) total work for m bytes across k
+        /// updates. Never encoded: restored rows start with a nil cache
+        /// and take the full-reprocess path once, which is fine.
+        var appliedRawContent: String? = nil
+        /// In-memory-only count of `ACPToolCallContent` items already
+        /// processed for asset/terminal-id extraction. Pairs with
+        /// `appliedRawContent`: when the next update's flattened content
+        /// has the previous as a prefix, items 0..<appliedItemCount are
+        /// already accounted for and only the tail is scanned.
+        var appliedItemCount: Int = 0
+        /// In-memory-only record of the `isFinal` value used the last time
+        /// `appliedRawContent` was computed. The trailing-fence strip step
+        /// in `stripWrappingFence` depends on `isFinal`, so when an update
+        /// arrives with identical content but a different `isFinal` (e.g.
+        /// the snapshot flips to `completed` without the body changing)
+        /// we must re-strip the tail; otherwise the identical-content fast
+        /// path can skip everything.
+        var appliedIsFinal: Bool = false
+        /// In-memory-only cache of the last stripped-raw content (after
+        /// the opening fence line was removed, before the trailing-fence
+        /// strip). The next suffix-only update appends to THIS, not to
+        /// `tc.content` (which may have a trailing fence stripped if the
+        /// last apply was `isFinal`). Without it, the opening fence's
+        /// separator newline would be double-counted when the fence line
+        /// arrived alone (e.g. `"```swift"` then `"\nlet x = 1"`).
+        var appliedStrippedRaw: String = ""
+        /// In-memory-only flag: the opening fence line was seen but had
+        /// no trailing newline yet (the first chunk was a partial fence
+        /// line like `"```swift"`). The next suffix's first newline
+        /// terminates the fence line and starts the stripped-raw body;
+        /// until then `appliedStrippedRaw` stays empty.
+        var appliedOpeningFenceUnterminated: Bool = false
+
         /// Replace `content` with its first `truncatedTailBytes` characters
         /// and mark the message as truncated. No-op if already truncated.
         mutating func truncateForOffWindow() {
@@ -218,6 +259,14 @@ enum ACPMessage: Equatable {
                 contentRevision &+= 1
             }
             isContentTruncated = true
+            // The in-memory content no longer matches `appliedRawContent`,
+            // so the next update can't take the suffix-only path: drop the
+            // cache and let it reprocess fully (restoring the complete body).
+            appliedRawContent = nil
+            appliedItemCount = 0
+            appliedIsFinal = false
+            appliedStrippedRaw = ""
+            appliedOpeningFenceUnterminated = false
         }
 
         init(toolCallId: String, title: String, kind: String? = nil,

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -249,6 +249,16 @@ enum ACPMessage: Equatable {
         /// terminates the fence line and starts the stripped-raw body;
         /// until then `appliedStrippedRaw` stays empty.
         var appliedOpeningFenceUnterminated: Bool = false
+        /// In-memory-only cache of the previous content items array, used
+        /// to verify that the first `appliedItemCount` items are unchanged
+        /// before taking the suffix-only fast path. `flatten` ignores
+        /// images/resource-links/terminals, so equal flattened text does
+        /// NOT imply the structured items are the same — an in-place
+        /// replacement (e.g. `[text, image(old)]` -> `[text, image(new)]`)
+        /// would otherwise skip `extractAssets`/`extractTerminalIds`. COW
+        /// keeps the storage cost minimal; the prefix comparison is
+        /// O(appliedItemCount) which is bounded by the items count.
+        var appliedItemsSnapshot: [ACPToolCallContent] = []
 
         /// Replace `content` with its first `truncatedTailBytes` characters
         /// and mark the message as truncated. No-op if already truncated.
@@ -267,6 +277,7 @@ enum ACPMessage: Equatable {
             appliedIsFinal = false
             appliedStrippedRaw = ""
             appliedOpeningFenceUnterminated = false
+            appliedItemsSnapshot = []
         }
 
         init(toolCallId: String, title: String, kind: String? = nil,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -715,7 +715,11 @@ final class ACPSession: ObservableObject, Identifiable {
                 suffix: suffix,
                 openingFenceUnterminated: tc.appliedOpeningFenceUnterminated)
             let newStripped: String
-            if isFinal {
+            if isFinal && tc.appliedOpeningFenceStripped {
+                // Only strip a trailing fence line when an opening fence
+                // was actually recognized. Ordinary tool output whose
+                // final line happens to be "```" must NOT be dropped —
+                // `stripWrappingFence` guards the same way.
                 newStripped = Self.stripTrailingFenceLine(newStrippedRaw)
             } else {
                 newStripped = newStrippedRaw
@@ -813,19 +817,26 @@ final class ACPSession: ObservableObject, Identifiable {
         tc.appliedStrippedRaw = strippedRaw
         tc.appliedOpeningFenceUnterminated = Self.openingFenceUnterminated(
             raw: raw, strippedRaw: strippedRaw)
+        // Track whether an opening fence was actually stripped: the
+        // suffix path's trailing-fence strip must only run when the
+        // opening fence was recognized.
+        let firstLine = raw.split(separator: "\n", omittingEmptySubsequences: false).first.map(String.init) ?? raw
+        tc.appliedOpeningFenceStripped = Self.isOpeningFence(firstLine)
         tc.appliedItemsSnapshot = items
     }
 
-    /// Whether the first `count` items of `items` match the first
-    /// `count` items of `snapshot`. Used to guard the suffix-only fast
-    /// path: `flatten` ignores images/resource-links/terminals, so equal
-    /// flattened text does NOT imply the structured items are the same.
-    /// An in-place replacement (e.g. `[text, image(old)]` ->
-    /// `[text, image(new)]`) or an insertion before the suffix
-    /// (`[text("run")]` -> `[terminal("t1"), text("running")]`) would
-    /// otherwise skip `extractAssets`/`extractTerminalIds` for the
-    /// changed items. Cost is O(count) — bounded by the previous item
-    /// count, which is small for typical adapter snapshots.
+    /// Whether the first `count` items of `items` have the same
+    /// STRUCTURED content (images, resource-links, terminals, diffs) as
+    /// the first `count` items of `snapshot`. Text items are NOT compared
+    /// element-wise: in the common cumulative streaming shape the single
+    /// text item grows in place (`[text("a")]` -> `[text("ab")]`), and
+    /// comparing it would force a full reprocess on every update,
+    /// defeating the suffix-only fast path. Since `flatten` ignores
+    /// non-text items, equal flattened text plus equal structured items
+    /// guarantees the items array is consistent with the previous apply.
+    /// An in-place image replacement (image(old) -> image(new)) or a
+    /// terminal inserted before the text both change a structured item
+    /// and are detected here. Cost is O(count).
     private static func prefixItemsUnchanged(
         items: [ACPToolCallContent],
         snapshot: [ACPToolCallContent],
@@ -836,9 +847,44 @@ final class ACPSession: ObservableObject, Identifiable {
             return false
         }
         for i in 0..<count {
-            if items[i] != snapshot[i] { return false }
+            if !Self.structuredContentEqual(items[i], snapshot[i]) {
+                return false
+            }
         }
         return true
+    }
+
+    /// Whether two `ACPToolCallContent` items have the same structured
+    /// payload. Text items are treated as equal (the text is allowed to
+    /// grow — the flattened-raw prefix check guards the text content).
+    /// Images, resource-links, resources, terminals, and diffs are
+    /// compared exactly — a change to any of those must force a full
+    /// reprocess so `extractAssets`/`extractTerminalIds` re-scan.
+    private static func structuredContentEqual(
+        _ lhs: ACPToolCallContent,
+        _ rhs: ACPToolCallContent
+    ) -> Bool {
+        switch (lhs, rhs) {
+        case (.content(.text), .content(.text)):
+            return true
+        case (.terminal(let a), .terminal(let b)):
+            return a == b
+        case (.diff(let p1, let o1, let n1), .diff(let p2, let o2, let n2)):
+            return p1 == p2 && o1 == o2 && n1 == n2
+        case (.content(.image(let d1, let u1, let m1)),
+              .content(.image(let d2, let u2, let m2))):
+            return d1 == d2 && u1 == u2 && m1 == m2
+        case (.content(.resourceLink(let u1, let n1)),
+              .content(.resourceLink(let u2, let n2))):
+            return u1 == u2 && n1 == n2
+        case (.content(.resource(let u1, let m1, _)),
+              .content(.resource(let u2, let m2, _))):
+            return u1 == u2 && m1 == m2
+        case (.unknown, .unknown):
+            return true
+        default:
+            return false
+        }
     }
 
     /// Whether the first line of `strippedRaw` is complete — i.e. the

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -657,11 +657,16 @@ final class ACPSession: ObservableObject, Identifiable {
         to tc: inout ACPMessage.ToolCall
     ) {
         let raw = Self.flatten(items)
-        if let prev = tc.appliedRawContent, raw == prev {
+        if let prev = tc.appliedRawContent, raw == prev, items.count == tc.appliedItemCount {
             if isFinal == tc.appliedIsFinal {
-                // Content unchanged AND same isFinal — nothing to do for the
-                // content body. `rawOutputAssets` were already merged into
-                // `tc.assets` by the caller's rawOutput handling, so we're done.
+                // Content unchanged, item count unchanged, AND same isFinal —
+                // nothing to do for the content body. `rawOutputAssets` were
+                // already merged into `tc.assets` by the caller's rawOutput
+                // handling, so we're done.
+                // Item count guard: `flatten` ignores images/resource-links/
+                // terminals, so two updates with the same flattened text but
+                // different structured items (e.g. a newly added screenshot)
+                // must NOT skip `extractAssets`/`extractTerminalIds`.
                 return
             }
             // Same content but `isFinal` flipped (e.g. status transitioned to
@@ -675,13 +680,22 @@ final class ACPSession: ObservableObject, Identifiable {
         }
         if let prev = tc.appliedRawContent, !prev.isEmpty, raw.hasPrefix(prev),
            !tc.appliedIsFinal,
-           items.count >= tc.appliedItemCount {
+           items.count >= tc.appliedItemCount,
+           !Self.previousRawWasPartialFence(prev) {
             // Suffix-only fast path. The new flattened raw is the previous
             // one with `suffix` appended; `appliedStrippedRaw` is the body
             // after opening-fence removal. We extend that body by the suffix
             // (handling the Case where the opening fence line arrived
             // unterminated in the previous chunk) and, if `isFinal`, apply
             // the trailing-fence strip to the resulting body.
+            //
+            // `previousRawWasPartialFence` guard: if the previous raw was a
+            // PARTIAL opening fence (e.g. "``" — not yet a complete fence
+            // line), `stripWrappingFence` did NOT strip it, so
+            // `appliedStrippedRaw` still contains the partial fence. The
+            // suffix might complete the fence line, which the legacy full
+            // reprocess would now recognize and strip. Fall to full
+            // reprocess in that case.
             let suffix = String(raw.dropFirst(prev.count))
             let (newStrippedRaw, unterminated) = Self.extendStrippedRaw(
                 prev: tc.appliedStrippedRaw,
@@ -715,8 +729,16 @@ final class ACPSession: ObservableObject, Identifiable {
             let preservedRawOutputAssets = rawOutputAssets.isEmpty
                 ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
                 : rawOutputAssets
+            // Preserve content assets from items already processed (they
+            // may still be present in the cumulative snapshot even when
+            // `newItemSlice` is empty — e.g. an image item that stays while
+            // a text item grows in place). Merge the existing image/resource
+            // assets with the new ones; `mergeAssets` dedups by value.
+            let existingContentAssets = Self.contentAssetsFromItems(
+                items, prefix: tc.appliedItemCount)
             tc.assets = Self.mergeAssets(
-                Self.extractAssets(newItemSlice), preservedRawOutputAssets)
+                Self.mergeAssets(existingContentAssets, Self.extractAssets(newItemSlice)),
+                preservedRawOutputAssets)
             tc.appliedRawContent = raw
             tc.appliedItemCount = items.count
             tc.appliedIsFinal = isFinal
@@ -767,6 +789,44 @@ final class ACPSession: ObservableObject, Identifiable {
         tc.appliedStrippedRaw = strippedRaw
         tc.appliedOpeningFenceUnterminated = Self.openingFenceUnterminated(
             raw: raw, strippedRaw: strippedRaw)
+    }
+
+    /// Whether `previousRaw` is a PARTIAL opening fence — a prefix of
+    /// `"```"` that is not yet a complete fence line (e.g. `` ` `` or
+    /// `` `` ``). `isOpeningFence` requires the full `` ``` `` prefix, so
+    /// `stripWrappingFence` did NOT strip these; the suffix might complete
+    /// the fence, which the legacy full reprocess would now recognize and
+    /// strip. The suffix-only fast path must fall to full reprocess in
+    /// that case so the wrapper fence is removed.
+    private static func previousRawWasPartialFence(_ previousRaw: String) -> Bool {
+        // ````` <= previousRaw < ``` — i.e. starts with ` but is not a
+        // complete opening fence line. A complete fence line either has
+        // a newline after the fence, or is exactly ```(+language) with no
+        // newline (handled by `appliedOpeningFenceUnterminated`).
+        // Partial: 1 or 2 backticks, or 3+ backticks NOT forming a valid
+        // fence (e.g. "````x" with non-tag chars). Simplest check: any
+        // prefix of "```" (1 or 2 backticks) is partial.
+        guard !previousRaw.isEmpty else { return false }
+        let prefix = String("```".prefix(previousRaw.count))
+        // If previousRaw starts with a backtick but isOpeningFence fails,
+        // it's partial. isOpeningFence requires "```" prefix.
+        if previousRaw.hasPrefix("`") && !isOpeningFence(previousRaw) {
+            return true
+        }
+        return false
+    }
+
+    /// Extract content assets (images, resource links, resources) from
+    /// the first `prefix` items of `items`, for preserving across suffix
+    /// updates. Used when `newItemSlice` is empty but the cumulative
+    /// snapshot still carries content assets from earlier items.
+    private static func contentAssetsFromItems(
+        _ items: [ACPToolCallContent],
+        prefix: Int
+    ) -> [ACPMessage.ToolCallAsset] {
+        let count = min(prefix, items.count)
+        guard count > 0 else { return [] }
+        return Self.extractAssets(Array(items[0..<count]))
     }
 
     /// Extend `prev` (the previously stripped-raw body, after opening

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -718,8 +718,13 @@ final class ACPSession: ObservableObject, Identifiable {
             // reprocess would now recognize and strip. Fall to full
             // reprocess in that case.
             let suffix = String(raw.dropFirst(prev.count))
+            // When the opening fence is unterminated, `appliedStrippedRaw`
+            // is empty and `extendStrippedRaw` needs the previous raw
+            // fence line to re-validate. Otherwise it appends to
+            // `appliedStrippedRaw` (the stripped body).
+            let extendBase = tc.appliedOpeningFenceUnterminated ? prev : tc.appliedStrippedRaw
             let (newStrippedRaw, unterminated, needsFullReprocess) = Self.extendStrippedRaw(
-                prev: tc.appliedStrippedRaw,
+                previousRaw: extendBase,
                 suffix: suffix,
                 openingFenceUnterminated: tc.appliedOpeningFenceUnterminated)
             if needsFullReprocess {
@@ -961,37 +966,53 @@ final class ACPSession: ObservableObject, Identifiable {
     /// false positive and incremental stripping can't safely proceed —
     /// `needsFullReprocess` returns true so the caller falls back.
     private static func extendStrippedRaw(
-        prev: String,
+        previousRaw: String,
         suffix: String,
         openingFenceUnterminated: Bool
     ) -> (strippedRaw: String, unterminated: Bool, needsFullReprocess: Bool) {
         if openingFenceUnterminated {
             if let newlineRange = suffix.range(of: "\n") {
                 let after = String(suffix[newlineRange.upperBound...])
-                // The completed fence line is `suffix[..<newline]`. We
-                // can't see the original partial line here, but we CAN
-                // re-validate by re-running stripWrappingFence on the full
-                // body — which is exactly what full reprocess does. If
-                // the completed line is still a valid isOpeningFence, the
-                // incremental path is safe; otherwise the partial fence
-                // was a false positive and we must fall back.
-                let completedLine = String(suffix[..<newlineRange.lowerBound])
+                // The completed fence line is `previousRaw + suffix[..<newline]`.
+                // Re-validate against `isOpeningFence`: if it grew into a
+                // form that is NOT a valid opening fence (e.g. "```{.swift}"
+                // where `{` is not in the allowed tag character set), the
+                // partial fence was a false positive and we must fall back
+                // to full reprocess so the line is kept in the body.
+                let completedLine = previousRaw + String(suffix[..<newlineRange.lowerBound])
                 if Self.isOpeningFence(completedLine) {
                     return (after, false, false)
                 }
-                // The completed line is NOT a valid opening fence (e.g.
-                // "```{.swift}" or "``` c"). The previous chunk's partial
-                // fence was a false positive. Fall back to full reprocess.
                 return ("", false, true)
             }
-            // The opening fence line is still being built. The body stays
-            // empty. We could re-validate the growing line here, but the
-            // common case is a valid tag prefix ("```sw" -> "```swift"),
-            // and a false positive (e.g. "```{") is caught on the next
-            // update when the line completes. Keep waiting.
-            return ("", true, false)
+            // No newline yet: the opening fence line is still being built.
+            // Re-validate the growing line: if it can no longer be a valid
+            // opening fence (e.g. "```{" — the `{` is not a valid tag
+            // character), the partial fence was a false positive and we
+            // must fall back so the line is kept in the body. Otherwise
+            // keep waiting for more characters.
+            let growingLine = previousRaw + suffix
+            if Self.couldBeOpeningFencePrefix(growingLine) {
+                return ("", true, false)
+            }
+            return ("", false, true)
         }
-        return (prev + suffix, false, false)
+        // `previousRaw` is not used in the non-unterminated path; the
+        // caller passes the stripped-raw body as the accumulator.
+        return (previousRaw + suffix, false, false)
+    }
+
+    /// Whether `s` is a prefix of a potential opening fence line — i.e.
+    /// it starts with `` ``` `` and the rest (so far) is all valid tag
+    /// characters. Used by `extendStrippedRaw` to decide whether a
+    /// still-growing line should keep waiting for more characters before
+    /// being classified as a fence. A line like `` ```sw `` is a prefix
+    /// of `` ```swift `` (valid), while `` ```{.swift} `` is not (the
+    /// `{` disqualifies it even though it starts with `` ``` ``).
+    private static func couldBeOpeningFencePrefix(_ s: String) -> Bool {
+        guard s.hasPrefix("```") else { return false }
+        let rest = s.dropFirst(3)
+        return rest.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" || $0 == "+" || $0 == "-" }
     }
 
     /// Whether `raw` starts with an opening fence line that has no

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -906,14 +906,24 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    /// Whether the first line of `strippedRaw` is complete — i.e. the
-    /// body contains a newline, so the first line won't grow further.
-    /// Used to decide whether `preview`/`contentLanguage` (derived from
-    /// the first line) need recomputing on a suffix update. While the
-    /// first line is still being built (no newline yet), each suffix can
-    /// extend it and change the preview/fence-language.
+    /// Whether the first line of `strippedRaw` is stable — i.e. the body
+    /// has a non-empty first line followed by a newline, so the preview
+    /// (first non-empty line) and fence language (first line) won't change
+    /// on a suffix update. Used to decide whether `preview`/
+    /// `contentLanguage` need recomputing. While the first line is still
+    /// being built (no newline yet) or the first line is empty (the
+    /// preview may come from a LATER line), each suffix can extend or
+    /// start the first non-empty line and change the preview/fence.
     private static func firstLineIsComplete(_ strippedRaw: String) -> Bool {
-        strippedRaw.firstIndex(of: "\n") != nil || strippedRaw.isEmpty
+        // Find the first newline. Everything before it is the first line.
+        // If there's no newline, the first line is still growing.
+        guard let newlineIndex = strippedRaw.firstIndex(of: "\n") else {
+            return false
+        }
+        let firstLine = strippedRaw[..<newlineIndex]
+        // An empty first line means the preview comes from a later line
+        // which may not have arrived yet. Keep recomputing.
+        return !firstLine.isEmpty
     }
 
     /// Whether `previousRaw` is a PARTIAL opening fence — a prefix of

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -927,28 +927,24 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     /// Whether `previousRaw` is a PARTIAL opening fence — a prefix of
-    /// `"```"` that is not yet a complete fence line (e.g. `` ` `` or
-    /// `` `` ``). `isOpeningFence` requires the full `` ``` `` prefix, so
-    /// `stripWrappingFence` did NOT strip these; the suffix might complete
-    /// the fence, which the legacy full reprocess would now recognize and
-    /// strip. The suffix-only fast path must fall to full reprocess in
-    /// that case so the wrapper fence is removed.
+    /// a potential `` ``` `` fence line that could still grow into a
+    /// valid opening fence with more characters. Only returns true for
+    /// strings that are strict prefixes of `` ``` `` (1 or 2 backticks)
+    /// or `` ``` `` followed by valid tag characters (letters, digits,
+    /// `_`, `+`, `-`) without a newline. A string like `` `cmd` `` (inline
+    /// code) or `` ```{ `` (invalid tag) is NOT a partial fence — it can
+    /// never become a valid opening fence, so the suffix path is safe.
+    /// `isOpeningFence` (complete fence) is handled separately by
+    /// `appliedOpeningFenceUnterminated`; this guard is for the case
+    /// where the previous raw was NOT recognized as a fence at all but
+    /// could still become one.
     private static func previousRawWasPartialFence(_ previousRaw: String) -> Bool {
-        // ````` <= previousRaw < ``` — i.e. starts with ` but is not a
-        // complete opening fence line. A complete fence line either has
-        // a newline after the fence, or is exactly ```(+language) with no
-        // newline (handled by `appliedOpeningFenceUnterminated`).
-        // Partial: 1 or 2 backticks, or 3+ backticks NOT forming a valid
-        // fence (e.g. "````x" with non-tag chars). Simplest check: any
-        // prefix of "```" (1 or 2 backticks) is partial.
         guard !previousRaw.isEmpty else { return false }
-        let prefix = String("```".prefix(previousRaw.count))
-        // If previousRaw starts with a backtick but isOpeningFence fails,
-        // it's partial. isOpeningFence requires "```" prefix.
-        if previousRaw.hasPrefix("`") && !isOpeningFence(previousRaw) {
-            return true
-        }
-        return false
+        // A complete opening fence (with or without a newline) is handled
+        // by `appliedOpeningFenceUnterminated` / `appliedOpeningFenceStripped`.
+        // Here we only care about fence PREFIXES that weren't yet recognized.
+        if Self.isOpeningFence(previousRaw) { return false }
+        return Self.couldBeOpeningFencePrefix(previousRaw)
     }
 
     /// Extract content assets (images, resource links, resources) from
@@ -1013,13 +1009,18 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     /// Whether `s` is a prefix of a potential opening fence line — i.e.
-    /// it starts with `` ``` `` and the rest (so far) is all valid tag
-    /// characters. Used by `extendStrippedRaw` to decide whether a
-    /// still-growing line should keep waiting for more characters before
-    /// being classified as a fence. A line like `` ```sw `` is a prefix
-    /// of `` ```swift `` (valid), while `` ```{.swift} `` is not (the
-    /// `{` disqualifies it even though it starts with `` ``` ``).
+    /// it is a strict prefix of `` ``` `` (1 or 2 backticks) OR it starts
+    /// with `` ``` `` and the rest (so far) is all valid tag characters.
+    /// Used by `extendStrippedRaw` to decide whether a still-growing line
+    /// should keep waiting for more characters before being classified
+    /// as a fence. A line like `` ```sw `` is a prefix of `` ```swift ``
+    /// (valid), while `` ```{.swift} `` is not (the `{` disqualifies it
+    /// even though it starts with `` ``` ``). A line like `` `cmd` `` is
+    /// not a fence prefix (the `c` after the first backtick means it can
+    /// never become `` ``` ``).
     private static func couldBeOpeningFencePrefix(_ s: String) -> Bool {
+        // 1 or 2 backticks: strict prefix of "```".
+        if s == "`" || s == "``" { return true }
         guard s.hasPrefix("```") else { return false }
         let rest = s.dropFirst(3)
         return rest.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" || $0 == "+" || $0 == "-" }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -695,6 +695,7 @@ final class ACPSession: ObservableObject, Identifiable {
            !tc.appliedIsFinal,
            items.count >= tc.appliedItemCount,
            prefixItemsUnchanged,
+           !metadataChanged,
            !Self.previousRawWasPartialFence(prev) {
             // Suffix-only fast path. The new flattened raw is the previous
             // one with `suffix` appended; `appliedStrippedRaw` is the body

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -661,11 +661,18 @@ final class ACPSession: ObservableObject, Identifiable {
             items: items, snapshot: tc.appliedItemsSnapshot, count: tc.appliedItemCount)
         if let prev = tc.appliedRawContent, raw == prev,
            items.count == tc.appliedItemCount, prefixItemsUnchanged {
-            if isFinal == tc.appliedIsFinal {
+            if isFinal == tc.appliedIsFinal && rawOutputAssets.isEmpty {
                 // Content unchanged, item count unchanged, prefix items
-                // unchanged, AND same isFinal — nothing to do for the
-                // content body. `rawOutputAssets` were already merged into
-                // `tc.assets` by the caller's rawOutput handling.
+                // unchanged, same isFinal, AND no new raw-output assets —
+                // nothing to do for the content body. `rawOutputAssets`
+                // is empty when this update carries no new `rawOutput`,
+                // so the caller's rawOutput handling left `tc.assets`
+                // consistent with the previous apply. If rawOutput DID
+                // change, `rawOutputAssets` is non-empty and we fall
+                // through to full reprocess so `tc.assets` is rebuilt
+                // from content + the new rawOutput (matching the legacy
+                // semantics where `reprocessToolCallContentFull` replaces
+                // `tc.assets` rather than merging into the stale set).
                 // Item-count + prefix-items guards: `flatten` ignores
                 // images/resource-links/terminals, so equal flattened text
                 // does NOT imply the structured items are the same —

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -657,16 +657,21 @@ final class ACPSession: ObservableObject, Identifiable {
         to tc: inout ACPMessage.ToolCall
     ) {
         let raw = Self.flatten(items)
-        if let prev = tc.appliedRawContent, raw == prev, items.count == tc.appliedItemCount {
+        let prefixItemsUnchanged = Self.prefixItemsUnchanged(
+            items: items, snapshot: tc.appliedItemsSnapshot, count: tc.appliedItemCount)
+        if let prev = tc.appliedRawContent, raw == prev,
+           items.count == tc.appliedItemCount, prefixItemsUnchanged {
             if isFinal == tc.appliedIsFinal {
-                // Content unchanged, item count unchanged, AND same isFinal —
-                // nothing to do for the content body. `rawOutputAssets` were
-                // already merged into `tc.assets` by the caller's rawOutput
-                // handling, so we're done.
-                // Item count guard: `flatten` ignores images/resource-links/
-                // terminals, so two updates with the same flattened text but
-                // different structured items (e.g. a newly added screenshot)
-                // must NOT skip `extractAssets`/`extractTerminalIds`.
+                // Content unchanged, item count unchanged, prefix items
+                // unchanged, AND same isFinal — nothing to do for the
+                // content body. `rawOutputAssets` were already merged into
+                // `tc.assets` by the caller's rawOutput handling.
+                // Item-count + prefix-items guards: `flatten` ignores
+                // images/resource-links/terminals, so equal flattened text
+                // does NOT imply the structured items are the same —
+                // an added screenshot (count grows) or an in-place
+                // replacement (count same, item differs) would otherwise
+                // skip `extractAssets`/`extractTerminalIds`.
                 return
             }
             // Same content but `isFinal` flipped (e.g. status transitioned to
@@ -681,6 +686,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if let prev = tc.appliedRawContent, !prev.isEmpty, raw.hasPrefix(prev),
            !tc.appliedIsFinal,
            items.count >= tc.appliedItemCount,
+           prefixItemsUnchanged,
            !Self.previousRawWasPartialFence(prev) {
             // Suffix-only fast path. The new flattened raw is the previous
             // one with `suffix` appended; `appliedStrippedRaw` is the body
@@ -688,6 +694,13 @@ final class ACPSession: ObservableObject, Identifiable {
             // (handling the Case where the opening fence line arrived
             // unterminated in the previous chunk) and, if `isFinal`, apply
             // the trailing-fence strip to the resulting body.
+            //
+            // `prefixItemsUnchanged` guard: if any of the first
+            // `appliedItemCount` items changed (in-place replacement, or a
+            // terminal inserted before the text item), the suffix path's
+            // `newItemSlice` would miss the structured change. Fall to full
+            // reprocess so `extractAssets`/`extractTerminalIds` see the
+            // current items.
             //
             // `previousRawWasPartialFence` guard: if the previous raw was a
             // PARTIAL opening fence (e.g. "``" — not yet a complete fence
@@ -709,10 +722,20 @@ final class ACPSession: ObservableObject, Identifiable {
             }
             tc.replaceContent(newStripped)
             tc.isContentTruncated = false
-            if tc.preview == nil {
+            // Refresh `preview`/`contentLanguage` when the first line is
+            // still incomplete. `previewLine` is the first non-empty line;
+            // once the first line is complete (followed by a newline or
+            // EOF), the preview is stable. But if the previous preview was
+            // derived from a partial first line (e.g. "bui" from "bui"),
+            // and the suffix extends that first line (e.g. "lding\n..."),
+            // the preview must be recomputed. Detect this: if the previous
+            // `appliedStrippedRaw` had no newline, the first line was
+            // incomplete and we recompute. Once a newline exists in
+            // `appliedStrippedRaw`, the first line is stable.
+            if tc.preview == nil || !Self.firstLineIsComplete(tc.appliedStrippedRaw) {
                 tc.preview = Self.previewLine(newStripped)
             }
-            if tc.contentLanguage == nil {
+            if tc.contentLanguage == nil || !Self.firstLineIsComplete(tc.appliedStrippedRaw) {
                 tc.contentLanguage = Self.wrappingFenceLanguage(raw)
             }
             let newItemSlice: [ACPToolCallContent]
@@ -744,6 +767,7 @@ final class ACPSession: ObservableObject, Identifiable {
             tc.appliedIsFinal = isFinal
             tc.appliedStrippedRaw = newStrippedRaw
             tc.appliedOpeningFenceUnterminated = unterminated
+            tc.appliedItemsSnapshot = items
             return
         }
         Self.reprocessToolCallContentFull(
@@ -789,6 +813,42 @@ final class ACPSession: ObservableObject, Identifiable {
         tc.appliedStrippedRaw = strippedRaw
         tc.appliedOpeningFenceUnterminated = Self.openingFenceUnterminated(
             raw: raw, strippedRaw: strippedRaw)
+        tc.appliedItemsSnapshot = items
+    }
+
+    /// Whether the first `count` items of `items` match the first
+    /// `count` items of `snapshot`. Used to guard the suffix-only fast
+    /// path: `flatten` ignores images/resource-links/terminals, so equal
+    /// flattened text does NOT imply the structured items are the same.
+    /// An in-place replacement (e.g. `[text, image(old)]` ->
+    /// `[text, image(new)]`) or an insertion before the suffix
+    /// (`[text("run")]` -> `[terminal("t1"), text("running")]`) would
+    /// otherwise skip `extractAssets`/`extractTerminalIds` for the
+    /// changed items. Cost is O(count) — bounded by the previous item
+    /// count, which is small for typical adapter snapshots.
+    private static func prefixItemsUnchanged(
+        items: [ACPToolCallContent],
+        snapshot: [ACPToolCallContent],
+        count: Int
+    ) -> Bool {
+        guard count > 0 else { return true }
+        guard items.count >= count, snapshot.count >= count else {
+            return false
+        }
+        for i in 0..<count {
+            if items[i] != snapshot[i] { return false }
+        }
+        return true
+    }
+
+    /// Whether the first line of `strippedRaw` is complete — i.e. the
+    /// body contains a newline, so the first line won't grow further.
+    /// Used to decide whether `preview`/`contentLanguage` (derived from
+    /// the first line) need recomputing on a suffix update. While the
+    /// first line is still being built (no newline yet), each suffix can
+    /// extend it and change the preview/fence-language.
+    private static func firstLineIsComplete(_ strippedRaw: String) -> Bool {
+        strippedRaw.firstIndex(of: "\n") != nil || strippedRaw.isEmpty
     }
 
     /// Whether `previousRaw` is a PARTIAL opening fence — a prefix of

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -620,6 +620,7 @@ final class ACPSession: ObservableObject, Identifiable {
             isFinal: Self.isFinalStatus(payload.status),
             rawOutputAssets: rawOutputAssets,
             rawOutputChanged: payload.rawOutput != nil,
+            metadataChanged: payload.metadata != nil,
             to: &tc)
     }
 
@@ -656,6 +657,7 @@ final class ACPSession: ObservableObject, Identifiable {
         isFinal: Bool,
         rawOutputAssets: [ACPMessage.ToolCallAsset],
         rawOutputChanged: Bool,
+        metadataChanged: Bool,
         to tc: inout ACPMessage.ToolCall
     ) {
         let raw = Self.flatten(items)
@@ -663,23 +665,21 @@ final class ACPSession: ObservableObject, Identifiable {
             items: items, snapshot: tc.appliedItemsSnapshot, count: tc.appliedItemCount)
         if let prev = tc.appliedRawContent, raw == prev,
            items.count == tc.appliedItemCount, prefixItemsUnchanged {
-            if isFinal == tc.appliedIsFinal && !rawOutputChanged && rawOutputAssets.isEmpty {
+            if isFinal == tc.appliedIsFinal && !rawOutputChanged && rawOutputAssets.isEmpty && !metadataChanged {
                 // Content unchanged, item count unchanged, prefix items
-                // unchanged, same isFinal, AND rawOutput did not change —
-                // nothing to do for the content body. `rawOutputChanged`
-                // guards the case where the update carried a new
-                // `rawOutput` that produced no image assets but replaced
-                // an earlier image-producing rawOutput: the caller already
-                // updated `tc.rawOutput` and merged (empty) rawOutputAssets,
-                // but the old image is still in `tc.assets`. Full reprocess
-                // rebuilds `tc.assets` from content + the new rawOutput,
-                // dropping the stale image.
+                // unchanged, same isFinal, no rawOutput change, AND no
+                // metadata change — nothing to do for the content body.
+                // `rawOutputChanged` / `metadataChanged` guard the cases
+                // where the update carried a new `rawOutput` or `_meta`
+                // that changed terminal ids / assets even though the
+                // flattened text is identical: the caller already merged
+                // the new values, but the old terminal ids / stale image
+                // are still in `tc.terminalIds` / `tc.assets`. Full
+                // reprocess rebuilds from the current content + metadata
+                // + rawOutput, matching the legacy semantics.
                 // Item-count + prefix-items guards: `flatten` ignores
                 // images/resource-links/terminals, so equal flattened text
-                // does NOT imply the structured items are the same —
-                // an added screenshot (count grows) or an in-place
-                // replacement (count same, item differs) would otherwise
-                // skip `extractAssets`/`extractTerminalIds`.
+                // does NOT imply the structured items are the same.
                 return
             }
             // Same content but `isFinal` flipped (e.g. status transitioned to
@@ -1099,6 +1099,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 isFinal: Self.isFinalStatus(tc.status),
                 rawOutputAssets: rawOutputAssets,
                 rawOutputChanged: update.rawOutput != nil,
+                metadataChanged: update.metadata != nil,
                 to: &tc)
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1102,6 +1102,22 @@ final class ACPSession: ObservableObject, Identifiable {
                 rawOutputChanged: update.rawOutput != nil,
                 metadataChanged: update.metadata != nil,
                 to: &tc)
+        } else if update.rawOutput != nil || update.metadata != nil {
+            // Side-channel-only update (no content) changed `tc.assets` /
+            // `tc.terminalIds` via the rawOutput/metadata handling above.
+            // Invalidate the content cache so a later duplicate-content
+            // snapshot does NOT take the identical-text skip (which would
+            // miss the side-channel changes). The next content update
+            // falls to full reprocess, rebuilding `tc.assets` /
+            // `tc.terminalIds` from the current content + rawOutput +
+            // metadata — matching the legacy semantics.
+            tc.appliedRawContent = nil
+            tc.appliedItemCount = 0
+            tc.appliedIsFinal = false
+            tc.appliedStrippedRaw = ""
+            tc.appliedOpeningFenceUnterminated = false
+            tc.appliedOpeningFenceStripped = false
+            tc.appliedItemsSnapshot = []
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -615,9 +615,134 @@ final class ACPSession: ObservableObject, Identifiable {
             }
             return
         }
+        Self.applyToolCallContent(
+            items: items,
+            isFinal: Self.isFinalStatus(payload.status),
+            rawOutputAssets: rawOutputAssets,
+            to: &tc)
+    }
+
+    /// Apply a `tool_call`/`tool_call_update` content payload to `tc`,
+    /// taking the suffix-only fast path when the new flattened raw content
+    /// is a prefix-extension of the previously applied one.
+    ///
+    /// Adapters that stream tool output re-emit the full cumulative content
+    /// on every update, so the i-th update carries ~i/k · m bytes and the
+    /// naive full-reprocess path is O(m·k) total work. Here we cache the
+    /// last fully-applied flattened raw content on `tc` and:
+    ///
+    /// - When `raw` equals the cache AND `isFinal` is unchanged: nothing
+    ///   changed, skip all content reprocessing (no `replaceContent`, no
+    ///   `previewLine`, no fence strip, no asset/terminal scan).
+    /// - When the cache is a non-empty prefix of `raw`, the previous apply
+    ///   was not `isFinal`, and items are append-only: suffix-only fast
+    ///   path. The new stripped-raw body is `appliedStrippedRaw + suffix`
+    ///   (with the opening-fence-unterminated boundary adjustment); the
+    ///   `isFinal` trailing-fence strip runs on the single final update.
+    ///   `preview` and `contentLanguage` depend only on the first line,
+    ///   so they are computed once and reused. Assets and terminal ids are
+    ///   scanned only over the items beyond `tc.appliedItemCount`;
+    ///   `mergeAssets`/`mergeTerminalIds` dedup.
+    /// - Otherwise (first apply, divergent content, appending to a
+    ///   finalized snapshot, or post-truncation restore): full reprocess,
+    ///   exactly the legacy path, and refresh the cache.
+    ///
+    /// `isFinal` is computed by the caller from the relevant status field
+    /// (`tc.status` for `toolCallUpdate`, `payload.status` for the initial
+    /// `toolCall`) so the trailing-fence strip matches the legacy semantics.
+    private static func applyToolCallContent(
+        items: [ACPToolCallContent],
+        isFinal: Bool,
+        rawOutputAssets: [ACPMessage.ToolCallAsset],
+        to tc: inout ACPMessage.ToolCall
+    ) {
         let raw = Self.flatten(items)
-        let full = Self.stripWrappingFence(raw,
-                                           isFinal: Self.isFinalStatus(payload.status))
+        if let prev = tc.appliedRawContent, raw == prev {
+            if isFinal == tc.appliedIsFinal {
+                // Content unchanged AND same isFinal — nothing to do for the
+                // content body. `rawOutputAssets` were already merged into
+                // `tc.assets` by the caller's rawOutput handling, so we're done.
+                return
+            }
+            // Same content but `isFinal` flipped (e.g. status transitioned to
+            // completed without the body changing): the trailing-fence strip
+            // may need to run. Full reprocess is safe and rare (one update
+            // per tool call at most).
+            Self.reprocessToolCallContentFull(
+                raw: raw, items: items, isFinal: isFinal,
+                rawOutputAssets: rawOutputAssets, to: &tc)
+            return
+        }
+        if let prev = tc.appliedRawContent, !prev.isEmpty, raw.hasPrefix(prev),
+           !tc.appliedIsFinal,
+           items.count >= tc.appliedItemCount {
+            // Suffix-only fast path. The new flattened raw is the previous
+            // one with `suffix` appended; `appliedStrippedRaw` is the body
+            // after opening-fence removal. We extend that body by the suffix
+            // (handling the Case where the opening fence line arrived
+            // unterminated in the previous chunk) and, if `isFinal`, apply
+            // the trailing-fence strip to the resulting body.
+            let suffix = String(raw.dropFirst(prev.count))
+            let (newStrippedRaw, unterminated) = Self.extendStrippedRaw(
+                prev: tc.appliedStrippedRaw,
+                suffix: suffix,
+                openingFenceUnterminated: tc.appliedOpeningFenceUnterminated)
+            let newStripped: String
+            if isFinal {
+                newStripped = Self.stripTrailingFenceLine(newStrippedRaw)
+            } else {
+                newStripped = newStrippedRaw
+            }
+            tc.replaceContent(newStripped)
+            tc.isContentTruncated = false
+            if tc.preview == nil {
+                tc.preview = Self.previewLine(newStripped)
+            }
+            if tc.contentLanguage == nil {
+                tc.contentLanguage = Self.wrappingFenceLanguage(raw)
+            }
+            let newItemSlice: [ACPToolCallContent]
+            if tc.appliedItemCount < items.count {
+                newItemSlice = Array(items[tc.appliedItemCount..<items.count])
+            } else {
+                newItemSlice = []
+            }
+            tc.terminalIds = Self.mergeTerminalIds(
+                Self.mergeTerminalIds(
+                    tc.terminalIds,
+                    Self.extractTerminalIds(newItemSlice)),
+                Self.extractMetadataTerminalIds(tc.metadata, includeExit: false))
+            let preservedRawOutputAssets = rawOutputAssets.isEmpty
+                ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
+                : rawOutputAssets
+            tc.assets = Self.mergeAssets(
+                Self.extractAssets(newItemSlice), preservedRawOutputAssets)
+            tc.appliedRawContent = raw
+            tc.appliedItemCount = items.count
+            tc.appliedIsFinal = isFinal
+            tc.appliedStrippedRaw = newStrippedRaw
+            tc.appliedOpeningFenceUnterminated = unterminated
+            return
+        }
+        Self.reprocessToolCallContentFull(
+            raw: raw, items: items, isFinal: isFinal,
+            rawOutputAssets: rawOutputAssets, to: &tc)
+    }
+
+    /// Full reprocess path: the legacy behaviour, plus refresh the
+    /// `appliedRawContent`/`appliedItemCount`/`appliedIsFinal`/
+    /// `appliedStrippedRaw`/`appliedOpeningFenceUnterminated` cache so the
+    /// next update can take the suffix-only fast path. Extracted from
+    /// `applyToolCallPayloadFields`/`applyToolCallUpdateFields` so both
+    /// share one implementation.
+    private static func reprocessToolCallContentFull(
+        raw: String,
+        items: [ACPToolCallContent],
+        isFinal: Bool,
+        rawOutputAssets: [ACPMessage.ToolCallAsset],
+        to tc: inout ACPMessage.ToolCall
+    ) {
+        let full = Self.stripWrappingFence(raw, isFinal: isFinal)
         tc.replaceContent(full)
         tc.isContentTruncated = false
         tc.preview = Self.previewLine(full)
@@ -629,6 +754,79 @@ final class ACPSession: ObservableObject, Identifiable {
             ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
             : rawOutputAssets
         tc.assets = Self.mergeAssets(Self.extractAssets(items), preservedRawOutputAssets)
+        tc.appliedRawContent = raw
+        tc.appliedItemCount = items.count
+        tc.appliedIsFinal = isFinal
+        // Derive the stripped-raw (opening fence removed, trailing fence
+        // NOT removed) and whether the opening fence line is still
+        // unterminated. `stripWrappingFence` with isFinal=false returns
+        // exactly the stripped-raw; if the raw starts with an opening
+        // fence and has no newline, the stripped-raw is empty and the
+        // fence is unterminated.
+        let strippedRaw = Self.stripWrappingFence(raw, isFinal: false)
+        tc.appliedStrippedRaw = strippedRaw
+        tc.appliedOpeningFenceUnterminated = Self.openingFenceUnterminated(
+            raw: raw, strippedRaw: strippedRaw)
+    }
+
+    /// Extend `prev` (the previously stripped-raw body, after opening
+    /// fence removal) by `suffix` (the newly arrived raw tail). Returns
+    /// the new stripped-raw body and the updated `openingFenceUnterminated`
+    /// flag. When the previous chunk left the opening fence line
+    /// unterminated (e.g. `"```swift"` with no newline), the first newline
+    /// in `suffix` terminates that line and the body begins after it;
+    /// until then the body stays empty.
+    private static func extendStrippedRaw(
+        prev: String,
+        suffix: String,
+        openingFenceUnterminated: Bool
+    ) -> (strippedRaw: String, unterminated: Bool) {
+        if openingFenceUnterminated {
+            if let newlineRange = suffix.range(of: "\n") {
+                let after = suffix[newlineRange.upperBound...]
+                return (String(after), false)
+            }
+            // The opening fence line is still being built (e.g. more
+            // language-tag characters arrived). The body stays empty.
+            return ("", true)
+        }
+        return (prev + suffix, false)
+    }
+
+    /// Whether `raw` starts with an opening fence line that has no
+    /// terminating newline (so the next suffix's first newline will
+    /// end the fence line and start the stripped-raw body, rather than
+    /// being a content separator).
+    private static func openingFenceUnterminated(raw: String, strippedRaw: String) -> Bool {
+        // No newline at all: if this is an opening fence line, it's
+        // unterminated; otherwise (no fence, single-line body) it's not.
+        guard raw.firstIndex(of: "\n") != nil else {
+            return Self.isOpeningFence(raw)
+        }
+        // A newline exists: any opening fence is terminated (even if the
+        // body after it is still empty).
+        return false
+    }
+
+    /// Apply only the trailing-fence-strip step of `stripWrappingFence` to
+    /// `body` (the stripped-raw content, opening fence already removed).
+    /// Mirrors the `isFinal` branch: trim trailing empty lines, drop a
+    /// trailing `"```"` line if present, otherwise restore the trimmed
+    /// empties. Used by the suffix-only fast path on the single update
+    /// that flips `isFinal` to true; cost is O(body), once per tool call.
+    private static func stripTrailingFenceLine(_ body: String) -> String {
+        var lines = body.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var trailingEmpty = 0
+        while let last = lines.last, last.isEmpty {
+            lines.removeLast()
+            trailingEmpty += 1
+        }
+        if lines.last == "```" {
+            lines.removeLast()
+        } else {
+            for _ in 0..<trailingEmpty { lines.append("") }
+        }
+        return lines.joined(separator: "\n")
     }
 
     private static func applyToolCallUpdateFields(
@@ -663,20 +861,11 @@ final class ACPSession: ObservableObject, Identifiable {
                 }
                 return
             }
-            let raw = Self.flatten(content)
-            let full = Self.stripWrappingFence(raw,
-                                               isFinal: Self.isFinalStatus(tc.status))
-            tc.replaceContent(full)
-            tc.isContentTruncated = false
-            tc.preview = Self.previewLine(full)
-            tc.contentLanguage = Self.wrappingFenceLanguage(raw)
-            tc.terminalIds = Self.mergeTerminalIds(
-                Self.extractTerminalIds(content),
-                Self.extractMetadataTerminalIds(tc.metadata, includeExit: false))
-            let preservedRawOutputAssets = rawOutputAssets.isEmpty
-                ? Self.extractStoredRawOutputAssets(tc.rawOutput, existingAssets: tc.assets)
-                : rawOutputAssets
-            tc.assets = Self.mergeAssets(Self.extractAssets(content), preservedRawOutputAssets)
+            Self.applyToolCallContent(
+                items: content,
+                isFinal: Self.isFinalStatus(tc.status),
+                rawOutputAssets: rawOutputAssets,
+                to: &tc)
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -619,6 +619,7 @@ final class ACPSession: ObservableObject, Identifiable {
             items: items,
             isFinal: Self.isFinalStatus(payload.status),
             rawOutputAssets: rawOutputAssets,
+            rawOutputChanged: payload.rawOutput != nil,
             to: &tc)
     }
 
@@ -654,6 +655,7 @@ final class ACPSession: ObservableObject, Identifiable {
         items: [ACPToolCallContent],
         isFinal: Bool,
         rawOutputAssets: [ACPMessage.ToolCallAsset],
+        rawOutputChanged: Bool,
         to tc: inout ACPMessage.ToolCall
     ) {
         let raw = Self.flatten(items)
@@ -661,18 +663,17 @@ final class ACPSession: ObservableObject, Identifiable {
             items: items, snapshot: tc.appliedItemsSnapshot, count: tc.appliedItemCount)
         if let prev = tc.appliedRawContent, raw == prev,
            items.count == tc.appliedItemCount, prefixItemsUnchanged {
-            if isFinal == tc.appliedIsFinal && rawOutputAssets.isEmpty {
+            if isFinal == tc.appliedIsFinal && !rawOutputChanged && rawOutputAssets.isEmpty {
                 // Content unchanged, item count unchanged, prefix items
-                // unchanged, same isFinal, AND no new raw-output assets —
-                // nothing to do for the content body. `rawOutputAssets`
-                // is empty when this update carries no new `rawOutput`,
-                // so the caller's rawOutput handling left `tc.assets`
-                // consistent with the previous apply. If rawOutput DID
-                // change, `rawOutputAssets` is non-empty and we fall
-                // through to full reprocess so `tc.assets` is rebuilt
-                // from content + the new rawOutput (matching the legacy
-                // semantics where `reprocessToolCallContentFull` replaces
-                // `tc.assets` rather than merging into the stale set).
+                // unchanged, same isFinal, AND rawOutput did not change —
+                // nothing to do for the content body. `rawOutputChanged`
+                // guards the case where the update carried a new
+                // `rawOutput` that produced no image assets but replaced
+                // an earlier image-producing rawOutput: the caller already
+                // updated `tc.rawOutput` and merged (empty) rawOutputAssets,
+                // but the old image is still in `tc.assets`. Full reprocess
+                // rebuilds `tc.assets` from content + the new rawOutput,
+                // dropping the stale image.
                 // Item-count + prefix-items guards: `flatten` ignores
                 // images/resource-links/terminals, so equal flattened text
                 // does NOT imply the structured items are the same —
@@ -717,10 +718,16 @@ final class ACPSession: ObservableObject, Identifiable {
             // reprocess would now recognize and strip. Fall to full
             // reprocess in that case.
             let suffix = String(raw.dropFirst(prev.count))
-            let (newStrippedRaw, unterminated) = Self.extendStrippedRaw(
+            let (newStrippedRaw, unterminated, needsFullReprocess) = Self.extendStrippedRaw(
                 prev: tc.appliedStrippedRaw,
                 suffix: suffix,
                 openingFenceUnterminated: tc.appliedOpeningFenceUnterminated)
+            if needsFullReprocess {
+                Self.reprocessToolCallContentFull(
+                    raw: raw, items: items, isFinal: isFinal,
+                    rawOutputAssets: rawOutputAssets, to: &tc)
+                return
+            }
             let newStripped: String
             if isFinal && tc.appliedOpeningFenceStripped {
                 // Only strip a trailing fence line when an opening fence
@@ -944,26 +951,47 @@ final class ACPSession: ObservableObject, Identifiable {
 
     /// Extend `prev` (the previously stripped-raw body, after opening
     /// fence removal) by `suffix` (the newly arrived raw tail). Returns
-    /// the new stripped-raw body and the updated `openingFenceUnterminated`
-    /// flag. When the previous chunk left the opening fence line
-    /// unterminated (e.g. `"```swift"` with no newline), the first newline
-    /// in `suffix` terminates that line and the body begins after it;
-    /// until then the body stays empty.
+    /// the new stripped-raw body, the updated `openingFenceUnterminated`
+    /// flag, and whether the extension can be taken incrementally. When
+    /// the previous chunk left the opening fence line unterminated, the
+    /// first newline in `suffix` completes it; the completed line is
+    /// re-validated against `isOpeningFence`. If it grew into a form
+    /// that is NOT a valid opening fence (e.g. `` ```{.swift} `` where
+    /// `{` is not in the allowed tag character set), the line was a
+    /// false positive and incremental stripping can't safely proceed —
+    /// `needsFullReprocess` returns true so the caller falls back.
     private static func extendStrippedRaw(
         prev: String,
         suffix: String,
         openingFenceUnterminated: Bool
-    ) -> (strippedRaw: String, unterminated: Bool) {
+    ) -> (strippedRaw: String, unterminated: Bool, needsFullReprocess: Bool) {
         if openingFenceUnterminated {
             if let newlineRange = suffix.range(of: "\n") {
-                let after = suffix[newlineRange.upperBound...]
-                return (String(after), false)
+                let after = String(suffix[newlineRange.upperBound...])
+                // The completed fence line is `suffix[..<newline]`. We
+                // can't see the original partial line here, but we CAN
+                // re-validate by re-running stripWrappingFence on the full
+                // body — which is exactly what full reprocess does. If
+                // the completed line is still a valid isOpeningFence, the
+                // incremental path is safe; otherwise the partial fence
+                // was a false positive and we must fall back.
+                let completedLine = String(suffix[..<newlineRange.lowerBound])
+                if Self.isOpeningFence(completedLine) {
+                    return (after, false, false)
+                }
+                // The completed line is NOT a valid opening fence (e.g.
+                // "```{.swift}" or "``` c"). The previous chunk's partial
+                // fence was a false positive. Fall back to full reprocess.
+                return ("", false, true)
             }
-            // The opening fence line is still being built (e.g. more
-            // language-tag characters arrived). The body stays empty.
-            return ("", true)
+            // The opening fence line is still being built. The body stays
+            // empty. We could re-validate the growing line here, but the
+            // common case is a valid tag prefix ("```sw" -> "```swift"),
+            // and a false positive (e.g. "```{") is caught on the next
+            // update when the line completes. Keep waiting.
+            return ("", true, false)
         }
-        return (prev + suffix, false)
+        return (prev + suffix, false, false)
     }
 
     /// Whether `raw` starts with an opening fence line that has no
@@ -1038,6 +1066,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 items: content,
                 isFinal: Self.isFinalStatus(tc.status),
                 rawOutputAssets: rawOutputAssets,
+                rawOutputChanged: update.rawOutput != nil,
                 to: &tc)
         }
     }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3058,4 +3058,116 @@ struct ACPSessionTests {
             #expect(tc.preview == "let x = 1")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("toolCallUpdate with same text and item count but replaced image reprocesses assets")
+    func toolCallUpdateSameTextReplacedImageReprocessesAssets() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-replaced-img", title: "screenshot", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update: text + image(old).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-replaced-img", status: "in_progress",
+            content: [
+                .content(.text("same")),
+                .content(.image(data: "old-img", uri: nil, mimeType: "image/png"))
+            ])))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.assets == [
+                ACPMessage.ToolCallAsset.image(data: "old-img", mimeType: "image/png")
+            ], "assets after first=\(tc1.assets)")
+        }
+        // Second update: text + image(new) — same item count, same
+        // flattened text, but the image was replaced in place. The
+        // identical-text fast path must detect the structured change and
+        // reprocess to pick up the new asset (replacing the old one, matching
+        // the legacy full-reprocess semantics).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-replaced-img", status: "in_progress",
+            content: [
+                .content(.text("same")),
+                .content(.image(data: "new-img", uri: nil, mimeType: "image/png"))
+            ])))
+        if case .toolCall(let tc2) = session.transcript.messages[0] {
+            #expect(tc2.content == "same")
+            #expect(tc2.assets == [
+                ACPMessage.ToolCallAsset.image(data: "new-img", mimeType: "image/png")
+            ], "assets after second=\(tc2.assets)")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed toolCallUpdate refreshes preview while the first line is still being built")
+    func toolCallUpdateStreamingRefreshesPreviewForPartialFirstLine() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-partial-first-line", title: "run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: a partial first line "bui" (no newline yet).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-partial-first-line", status: "in_progress",
+            content: [.content(.text("bui"))])))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.preview == "bui", "preview=\(tc1.preview ?? "nil")")
+        }
+        // Second chunk: the first line is completed to "building" and a
+        // newline starts the second line. The preview must be refreshed
+        // from "bui" to "building".
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-partial-first-line", status: "in_progress",
+            content: [.content(.text("building\nsecond line"))])))
+        if case .toolCall(let tc2) = session.transcript.messages[0] {
+            #expect(tc2.content == "building\nsecond line")
+            #expect(tc2.preview == "building", "preview=\(tc2.preview ?? "nil")")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed toolCallUpdate refreshes fence language while the tag is still being built")
+    func toolCallUpdateStreamingRefreshesFenceLanguageForPartialTag() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-partial-tag", title: "read", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: opening fence with a partial language tag "```c".
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-partial-tag", status: "in_progress",
+            content: [.content(.text("```c\nint x = 1;"))])))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.contentLanguage == "c", "lang=\(tc1.contentLanguage ?? "nil")")
+        }
+        // Second chunk: the tag is completed to "cpp". The fence language
+        // must be refreshed from "c" to "cpp".
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-partial-tag", status: "in_progress",
+            content: [.content(.text("```cpp\nint x = 1;\nint y = 2;"))])))
+        if case .toolCall(let tc2) = session.transcript.messages[0] {
+            #expect(tc2.content == "int x = 1;\nint y = 2;")
+            #expect(tc2.contentLanguage == "cpp", "lang=\(tc2.contentLanguage ?? "nil")")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed toolCallUpdate with terminal inserted before text reprocesses terminals")
+    func toolCallUpdateStreamingTerminalInsertedBeforeTextReprocesses() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-term-insert", title: "bash", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update: text only.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-term-insert", status: "in_progress",
+            content: [.content(.text("run"))])))
+        // Second update: a terminal is inserted BEFORE the text item, and
+        // the text grows. The suffix path's `newItemSlice` (starting at
+        // the old item count) would miss the terminal; the prefix-items
+        // guard must detect the restructure and fall to full reprocess.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-term-insert", status: "completed",
+            content: [
+                .terminal(terminalId: "t1"),
+                .content(.text("running"))
+            ])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "running")
+            #expect(tc.terminalIds == ["t1"], "terminalIds=\(tc.terminalIds)")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3414,4 +3414,41 @@ struct ACPSessionTests {
             #expect(tc2.terminalIds.contains("m2"), "after second: \(tc2.terminalIds)")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("toolCallUpdate suffix path with metadata change falls to full reprocess")
+    func toolCallUpdateSuffixPathWithMetadataChangeFallsToFullReprocess() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-suffix-meta", title: "bash", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update: text + metadata terminal m1.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-suffix-meta", status: "in_progress",
+            content: [.content(.text("run"))],
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("m1"),
+                    "data": AnyCodable("out\n")
+                ])
+            ]))))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.terminalIds == ["m1"], "after first: \(tc1.terminalIds)")
+        }
+        // Second update: text grows (suffix path) AND metadata changes to
+        // terminal m2. The suffix path must fall to full reprocess so
+        // `tc.terminalIds` is rebuilt from the current metadata.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-suffix-meta", status: "completed",
+            content: [.content(.text("running"))],
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("m2"),
+                    "data": AnyCodable("more\n")
+                ])
+            ]))))
+        if case .toolCall(let tc2) = session.transcript.messages[0] {
+            #expect(tc2.content == "running")
+            #expect(tc2.terminalIds.contains("m2"), "after second: \(tc2.terminalIds)")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -2953,4 +2953,109 @@ struct ACPSessionTests {
             #expect(tc.status == "completed")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("streamed text-growing item preserves earlier content assets across suffix updates")
+    func toolCallUpdateStreamingTextGrowthPreservesEarlierAssets() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-asset-preserve", title: "screenshot", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: text + image (two items).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-asset-preserve", status: "in_progress",
+            content: [
+                .content(.text("a")),
+                .content(.image(data: "img-bytes", uri: nil, mimeType: "image/png"))
+            ])))
+        // Second chunk: the SAME image item, but the text item grew in place
+        // (text "a" -> "ab"). Items count is still 2; the suffix path's
+        // `newItemSlice` is empty, so the image must be preserved from the
+        // previous apply, not dropped.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-asset-preserve", status: "completed",
+            content: [
+                .content(.text("ab")),
+                .content(.image(data: "img-bytes", uri: nil, mimeType: "image/png"))
+            ])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "ab")
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "img-bytes", mimeType: "image/png")
+            ])
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("toolCallUpdate with same text but newly added image asset extracts the asset")
+    func toolCallUpdateSameTextNewAssetExtractsAsset() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-same-text-asset", title: "screenshot", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update establishes the text + cache.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-same-text-asset", status: "in_progress",
+            content: [.content(.text("same"))])))
+        // Second update re-sends the same flattened text but adds a new
+        // image asset, with the SAME status (in_progress) so `isFinal`
+        // doesn't flip and force a full reprocess. The identical-text fast
+        // path must NOT skip asset extraction for the newly added item.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-same-text-asset", status: "in_progress",
+            content: [
+                .content(.text("same")),
+                .content(.image(data: "new-img", uri: nil, mimeType: "image/png"))
+            ])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "same")
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "new-img", mimeType: "image/png")
+            ], "assets=\(tc.assets)")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("toolCallUpdate with same text but newly added terminal id extracts the terminal id")
+    func toolCallUpdateSameTextNewTerminalExtractsTerminalId() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-same-text-term", title: "bash", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update establishes the text + cache.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-same-text-term", status: "in_progress",
+            content: [.content(.text("running"))])))
+        // Second update re-sends the same text but adds a terminal item,
+        // with the SAME status (in_progress) so `isFinal` doesn't flip.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-same-text-term", status: "in_progress",
+            content: [
+                .content(.text("running")),
+                .terminal(terminalId: "term-late")
+            ])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "running")
+            #expect(tc.terminalIds == ["term-late"], "terminalIds=\(tc.terminalIds)")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed partial opening fence then completion strips the wrapper fence")
+    func toolCallUpdateStreamingPartialFenceThenCompletionStripsFence() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-partial-fence", title: "read", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // Partial opening fence (not yet a complete fence line: "``" is not
+        // recognized by `isOpeningFence` which requires "```" prefix).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-partial-fence", status: "in_progress",
+            content: [.content(.text("``"))])))
+        // Completion: the full opening fence plus code.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-partial-fence", status: "completed",
+            content: [.content(.text("```swift\nlet x = 1\n```"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "let x = 1")
+            #expect(tc.contentLanguage == "swift")
+            #expect(tc.preview == "let x = 1")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3246,4 +3246,60 @@ struct ACPSessionTests {
             ], "after second: \(tc2.assets)")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("toolCallUpdate with same text and rawOutput clearing image drops stale asset")
+    func toolCallUpdateSameTextRawOutputClearsImageDropsStale() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-clear", title: "image", kind: "other", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update: text + rawOutput image.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-clear", status: "in_progress",
+            content: [.content(.text("same"))],
+            rawOutput: AnyCodable(["data": AnyCodable("img-a"), "mime_type": AnyCodable("image/png")]))))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.assets == [
+                ACPMessage.ToolCallAsset.image(data: "img-a", mimeType: "image/png")
+            ], "after first: \(tc1.assets)")
+        }
+        // Second update: same text + same status, but rawOutput replaced
+        // with a non-image result (no assets). The identical-text fast
+        // path must fall to full reprocess so the stale image is dropped.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-clear", status: "in_progress",
+            content: [.content(.text("same"))],
+            rawOutput: AnyCodable(["text": AnyCodable("done")]))))
+        if case .toolCall(let tc2) = session.transcript.messages[0] {
+            #expect(tc2.assets == [], "after second: \(tc2.assets)")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed partial fence completing to an invalid fence tag falls to full reprocess")
+    func toolCallUpdateStreamingPartialFenceInvalidTagFallsToFullReprocess() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-invalid-tag", title: "read", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: a valid-looking opening fence prefix "```".
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-invalid-tag", status: "in_progress",
+            content: [.content(.text("```"))])))
+        // Second chunk: the fence line completes to "```{.swift}" which
+        // isOpeningFence REJECTS (the `{` is not a valid tag character).
+        // The suffix path must fall to full reprocess so the line is kept
+        // in the body (not stripped as a fence).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-invalid-tag", status: "completed",
+            content: [.content(.text("```{.swift}\nlet x = 1\n```"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            // The first line "```{.swift}" is NOT a valid opening fence
+            // (isOpeningFence rejects `{`), so stripWrappingFence leaves
+            // it in the content. The trailing "```" is also NOT stripped.
+            // Note: `wrappingFenceLanguage` is more permissive than
+            // `isOpeningFence` and still extracts "swift" from the tag —
+            // that's the legacy behavior too.
+            #expect(tc.content == "```{.swift}\nlet x = 1\n```")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3326,4 +3326,29 @@ struct ACPSessionTests {
             #expect(tc.content == "```{\nbody")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("streamed toolCallUpdate refreshes preview when the first line is empty then filled")
+    func toolCallUpdateStreamingEmptyFirstLineThenFilledRefreshesPreview() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-empty-first", title: "run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: a leading blank line (first line is empty).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-empty-first", status: "in_progress",
+            content: [.content(.text("\n"))])))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.preview == nil, "preview after first=\(tc1.preview ?? "nil")")
+        }
+        // Second chunk: the second line fills in. The preview must be
+        // recomputed from the now-non-empty second line (which becomes the
+        // first non-empty line for `previewLine`).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-empty-first", status: "completed",
+            content: [.content(.text("\nactual first line"))])))
+        if case .toolCall(let tc2) = session.transcript.messages[0] {
+            #expect(tc2.content == "\nactual first line")
+            #expect(tc2.preview == "actual first line", "preview=\(tc2.preview ?? "nil")")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3302,4 +3302,28 @@ struct ACPSessionTests {
             #expect(tc.content == "```{.swift}\nlet x = 1\n```")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("streamed partial fence growing to invalid tag without newline falls to full reprocess")
+    func toolCallUpdateStreamingPartialFenceInvalidNoNewlineFallsToFullReprocess() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-invalid-no-newline", title: "read", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: a valid-looking opening fence prefix "```".
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-invalid-no-newline", status: "in_progress",
+            content: [.content(.text("```"))])))
+        // Second chunk: the fence line grows to "```{" (still no newline).
+        // `{` is not a valid tag character, so couldBeOpeningFencePrefix
+        // returns false and the suffix path falls to full reprocess,
+        // keeping the line in the body.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-invalid-no-newline", status: "completed",
+            content: [.content(.text("```{\nbody"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            // "```{" is NOT a valid opening fence, so stripWrappingFence
+            // leaves it in the content.
+            #expect(tc.content == "```{\nbody")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3351,4 +3351,26 @@ struct ACPSessionTests {
             #expect(tc2.preview == "actual first line", "preview=\(tc2.preview ?? "nil")")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("streamed inline-code first chunk does not trigger partial-fence full reprocess")
+    func toolCallUpdateStreamingInlineCodeDoesNotTriggerPartialFenceReprocess() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-inline", title: "run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: inline code starting with a backtick — NOT a partial
+        // opening fence (it can never become "```" + valid tag).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-inline", status: "in_progress",
+            content: [.content(.text("`cmd` ran"))])))
+        // Second chunk: the log grows. The suffix-only fast path must fire
+        // (previousRawWasPartialFence returns false for "`cmd` ran").
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-inline", status: "completed",
+            content: [.content(.text("`cmd` ran successfully"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "`cmd` ran successfully")
+            #expect(tc.preview == "`cmd` ran successfully")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3215,4 +3215,35 @@ struct ACPSessionTests {
             #expect(tc.preview == "abcdefghij")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("toolCallUpdate with same text but replaced rawOutput rebuilds assets")
+    func toolCallUpdateSameTextReplacedRawOutputRebuildsAssets() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-raw-replace", title: "image", kind: "other", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update: text + rawOutput image A.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-replace", status: "in_progress",
+            content: [.content(.text("same"))],
+            rawOutput: AnyCodable(["data": AnyCodable("img-a"), "mime_type": AnyCodable("image/png")]))))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.assets == [
+                ACPMessage.ToolCallAsset.image(data: "img-a", mimeType: "image/png")
+            ], "after first: \(tc1.assets)")
+        }
+        // Second update: same text + same status, but rawOutput replaced
+        // with image B. The identical-text fast path must fall to full
+        // reprocess so `tc.assets` is rebuilt from content + the new
+        // rawOutput (replacing image A, not accumulating it).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-raw-replace", status: "in_progress",
+            content: [.content(.text("same"))],
+            rawOutput: AnyCodable(["data": AnyCodable("img-b"), "mime_type": AnyCodable("image/png")]))))
+        if case .toolCall(let tc2) = session.transcript.messages[0] {
+            #expect(tc2.assets == [
+                ACPMessage.ToolCallAsset.image(data: "img-b", mimeType: "image/png")
+            ], "after second: \(tc2.assets)")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3170,4 +3170,49 @@ struct ACPSessionTests {
             #expect(tc.terminalIds == ["t1"], "terminalIds=\(tc.terminalIds)")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("streamed toolCallUpdate does not strip a trailing fence line when there is no opening fence")
+    func toolCallUpdateStreamingNoOpeningFenceKeepsTrailingFenceLine() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-no-opening-fence", title: "run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: ordinary log output (no opening fence).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-no-opening-fence", status: "in_progress",
+            content: [.content(.text("log line\n```"))])))
+        // Final chunk: the log grows, ending with a line of three
+        // backticks that is NOT a closing fence (there was no opening
+        // fence). The suffix path must NOT strip the trailing "```".
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-no-opening-fence", status: "completed",
+            content: [.content(.text("log line\n```\nmore output"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "log line\n```\nmore output")
+            #expect(tc.preview == "log line")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed single text item growing takes the suffix path (regression)")
+    func toolCallUpdateStreamingSingleTextItemGrowingTakesSuffixPath() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-growing-text", title: "run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // Adapter sends a single text content item that grows on each
+        // update (the common cumulative shape). The suffix-only fast path
+        // must fire on each update; this is a regression test for the
+        // `prefixItemsUnchanged` guard which previously compared text
+        // items element-wise and forced a full reprocess every update.
+        let chunks = ["a", "ab", "abc", "abcdef", "abcdefghij"]
+        for chunk in chunks {
+            session.apply(.toolCallUpdate(.init(
+                toolCallId: "tc-growing-text", status: "in_progress",
+                content: [.content(.text(chunk))])))
+        }
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "abcdefghij")
+            #expect(tc.preview == "abcdefghij")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -2800,4 +2800,157 @@ struct ACPSessionTests {
             #expect(tc.contentLanguage == nil)
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("streamed toolCallUpdate suffix chunks accumulate into the full content")
+    func toolCallUpdateStreamingSuffixAccumulates() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-stream", title: "run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // Adapter sends the full cumulative content on each update.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-stream", status: "in_progress",
+            content: [.content(.text("line one\n"))])))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-stream", status: "in_progress",
+            content: [.content(.text("line one\nline two\n"))])))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-stream", status: "in_progress",
+            content: [.content(.text("line one\nline two\nline three\n"))])))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-stream", status: "completed",
+            content: [.content(.text("line one\nline two\nline three\n"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "line one\nline two\nline three\n")
+            #expect(tc.preview == "line one")
+            #expect(tc.status == "completed")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed toolCallUpdate strips wrapping fence across suffix chunks")
+    func toolCallUpdateStreamingFenceStripsAcrossChunks() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-fence-stream", title: "read", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // Opening fence arrives alone.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-fence-stream", status: "in_progress",
+            content: [.content(.text("```swift"))])))
+        // First line of code arrives.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-fence-stream", status: "in_progress",
+            content: [.content(.text("```swift\nlet x = 1"))])))
+        // More code arrives.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-fence-stream", status: "in_progress",
+            content: [.content(.text("```swift\nlet x = 1\nlet y = 2"))])))
+        // Closing fence arrives with final status.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-fence-stream", status: "completed",
+            content: [.content(.text("```swift\nlet x = 1\nlet y = 2\n```"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "let x = 1\nlet y = 2")
+            #expect(tc.contentLanguage == "swift")
+            #expect(tc.preview == "let x = 1")
+            #expect(tc.status == "completed")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed toolCallUpdate preserves assets declared across suffix chunks")
+    func toolCallUpdateStreamingAssetsAcrossChunks() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-asset-stream", title: "screenshot", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First chunk: text + an image asset.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-asset-stream", status: "in_progress",
+            content: [
+                .content(.text("captured")),
+                .content(.image(data: "first-bytes", uri: nil, mimeType: "image/png"))
+            ])))
+        // Second chunk: same text+image plus a second image (cumulative snapshot).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-asset-stream", status: "completed",
+            content: [
+                .content(.text("captured")),
+                .content(.image(data: "first-bytes", uri: nil, mimeType: "image/png")),
+                .content(.image(data: nil, uri: "file:///tmp/second.png", mimeType: "image/png"))
+            ])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "captured")
+            #expect(tc.assets == [
+                ACPMessage.ToolCallAsset.image(data: "first-bytes", mimeType: "image/png"),
+                ACPMessage.ToolCallAsset.image(
+                    data: nil, uri: "file:///tmp/second.png", mimeType: "image/png", name: "second.png")
+            ])
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("streamed toolCallUpdate preserves terminal ids declared across suffix chunks")
+    func toolCallUpdateStreamingTerminalIdsAcrossChunks() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-term-stream", title: "bash", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-term-stream", status: "in_progress",
+            content: [
+                .terminal(terminalId: "term-a"),
+                .content(.text("starting"))
+            ])))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-term-stream", status: "completed",
+            content: [
+                .terminal(terminalId: "term-a"),
+                .content(.text("starting\nfinished")),
+                .terminal(terminalId: "term-b")
+            ])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "starting\nfinished")
+            #expect(tc.terminalIds == ["term-a", "term-b"])
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("toolCallUpdate with identical cumulative content does not bump contentRevision")
+    func toolCallUpdateIdenticalContentDoesNotBumpRevision() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-identical", title: "run", kind: "execute", status: "in_progress",
+            content: [.content(.text("same output"))])))
+        guard case .toolCall(let initial) = session.transcript.messages[0] else {
+            Issue.record("expected toolCall message")
+            return
+        }
+        let revisionBefore = initial.contentRevision
+        // Adapter re-sends the same cumulative content (e.g. a status-only
+        // update that happens to also include the content snapshot).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-identical", status: "completed",
+            content: [.content(.text("same output"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.contentRevision == revisionBefore)
+            #expect(tc.content == "same output")
+            #expect(tc.status == "completed")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("toolCallUpdate with divergent content (non-prefix) reprocesses fully")
+    func toolCallUpdateDivergentContentReprocessesFully() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-divergent", title: "run", kind: "execute", status: "in_progress",
+            content: [.content(.text("first output\n"))])))
+        // The next update carries entirely different content (not a prefix
+        // extension). The full reprocess path must replace content.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-divergent", status: "completed",
+            content: [.content(.text("completely different output\n"))])))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "completely different output\n")
+            #expect(tc.preview == "completely different output")
+            #expect(tc.status == "completed")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3451,4 +3451,39 @@ struct ACPSessionTests {
             #expect(tc2.terminalIds.contains("m2"), "after second: \(tc2.terminalIds)")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("side-channel rawOutput-only update invalidates content cache for next same-content update")
+    func toolCallUpdateSideChannelRawOutputInvalidatesCache() async {
+        let session = ACPSession(id: "s", agentId: "bridge", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-side", title: "image", kind: "other", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update: text + rawOutput image A.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-side", status: "in_progress",
+            content: [.content(.text("same"))],
+            rawOutput: AnyCodable(["data": AnyCodable("img-a"), "mime_type": AnyCodable("image/png")]))))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.assets == [
+                ACPMessage.ToolCallAsset.image(data: "img-a", mimeType: "image/png")
+            ], "after first: \(tc1.assets)")
+        }
+        // Side-channel update: rawOutput changes to image B, no content.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-side", status: "in_progress",
+            rawOutput: AnyCodable(["data": AnyCodable("img-b"), "mime_type": AnyCodable("image/png")]))))
+        // Third update: same content "same" as the first, no rawOutput.
+        // The cache was invalidated by the side-channel update, so this
+        // falls to full reprocess and rebuilds tc.assets from content +
+        // the current rawOutput (image B), dropping the stale image A.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-side", status: "in_progress",
+            content: [.content(.text("same"))])))
+        if case .toolCall(let tc3) = session.transcript.messages[0] {
+            #expect(tc3.content == "same")
+            #expect(tc3.assets == [
+                ACPMessage.ToolCallAsset.image(data: "img-b", mimeType: "image/png")
+            ], "after third: \(tc3.assets)")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -3373,4 +3373,45 @@ struct ACPSessionTests {
             #expect(tc.preview == "`cmd` ran successfully")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("toolCallUpdate with same text but changed metadata terminal id reprocesses")
+    func toolCallUpdateSameTextChangedMetadataTerminalReprocesses() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-meta-term", title: "bash", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        // First update: text + metadata terminal m1.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-meta-term", status: "in_progress",
+            content: [.content(.text("running"))],
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("m1"),
+                    "data": AnyCodable("out\n")
+                ])
+            ]))))
+        if case .toolCall(let tc1) = session.transcript.messages[0] {
+            #expect(tc1.terminalIds == ["m1"], "after first: \(tc1.terminalIds)")
+        }
+        // Second update: same text + same status, but metadata changed to
+        // terminal m2. The identical-text fast path must fall to full
+        // reprocess so `tc.terminalIds` is rebuilt from the current metadata
+        // (adding m2, keeping m1 via merge — matching legacy semantics).
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-meta-term", status: "in_progress",
+            content: [.content(.text("running"))],
+            metadata: AnyCodable([
+                "terminal_output_delta": AnyCodable([
+                    "terminal_id": AnyCodable("m2"),
+                    "data": AnyCodable("more\n")
+                ])
+            ]))))
+        if case .toolCall(let tc2) = session.transcript.messages[0] {
+            // The metadata's terminal_output_delta was overwritten by
+            // mergeMetadata, so the rebuilt terminalIds contains m2 (the
+            // current metadata terminal). This matches the legacy
+            // full-reprocess semantics.
+            #expect(tc2.terminalIds.contains("m2"), "after second: \(tc2.terminalIds)")
+        } else { Issue.record("expected toolCall message") }
+    }
 }


### PR DESCRIPTION
## Problem

Adapters that stream tool output emit repeated `toolCallUpdate`s carrying the **full cumulative** content, and Alas re-processes all of it on each one — `flatten`, `stripWrappingFence`, `previewLine`, `extractAssets`, `extractTerminalIds`, and `replaceContent` each run O(content) per update, and the `messages.didSet` chain fires on every update.

For a command producing `m` bytes across `k` updates, total work is O(m·k): each update is progressively more expensive. A long-running chatty command (huge test log, verbose build) makes late updates arbitrarily costly, all on the main actor.

Closes #843.

## Fix

Cache the last fully-applied flattened raw content (and the stripped-raw body + opening-fence-unterminated flag) on `ACPMessage.ToolCall`. On each `toolCallUpdate`/`toolCall` content payload:

- **Identical content, same `isFinal`:** skip all content reprocessing (no `replaceContent`, no `previewLine`, no fence strip, no asset/terminal scan).
- **Prefix extension (suffix-only fast path):** the new flattened raw has the previous one as a prefix, the previous apply was not `isFinal`, and items are append-only. Process only the appended suffix:
  - The new stripped-raw body is `appliedStrippedRaw + suffix`, with an opening-fence-unterminated boundary adjustment so a fence line that arrived alone (`"```swift"`) then continued (`"\nlet x = 1"`) doesn't double-count the separator newline.
  - `preview` and `contentLanguage` depend only on the first line, so they are computed once and reused.
  - Assets and terminal ids are scanned only over the items beyond `appliedItemCount`; `mergeAssets`/`mergeTerminalIds` dedup.
  - The `isFinal` trailing-fence strip runs once, on the single update that flips `isFinal` to true.
- **Otherwise** (first apply, divergent content, appending to a finalized snapshot, or post-truncation restore): full reprocess — exactly the legacy path — and refresh the cache.

`truncateForOffWindow` invalidates the cache so a subsequent update restores the full body via the full-reprocess path.

The cache fields are in-memory only: they are not encoded, excluded from `Equatable`/`Hashable`, and restored rows start with an empty cache and take the full-reprocess path once.

## Tests

New tests in `ACPSessionTests`:
- streamed suffix chunks accumulate into the full content
- streamed fence strips across suffix chunks (including the unterminated-opening-fence boundary)
- streamed assets declared across suffix chunks are preserved (with dedup)
- streamed terminal ids declared across suffix chunks preserve declaration order
- identical cumulative content does not bump `contentRevision`
- divergent (non-prefix) content reprocesses fully

All existing `ACPSessionTests`, `ACPTranscriptTests`, `ACPSessionRunnerTests`, `ACPSessionStoreTests`, `ACPMessageTests`, and `ACPMessageWireTests` continue to pass.