### PR TITLE
feat(gg): add optional git-gud stacked diffs integration (phase 1)

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -764,6 +764,7 @@
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
 		97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */; };
 		981730A24BE369F4AE9012F3 /* ChatPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3986789560012DF861565F12 /* ChatPaneTests.swift */; };
+		985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */; };
 		98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */; };
 		98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */; };
 		98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */; };
@@ -947,6 +948,7 @@
 		B8BF059C5C2090AFBB56A5BC /* GitServicePullTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */; };
 		B8C893DFB0965CB7EB0AFD10 /* DiffContextExpansion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF71AF50DF50AA4158A96177 /* DiffContextExpansion.swift */; };
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
+		B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */; };
 		B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */; };
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
 		B9D15679A5E813254E1DDCB6 /* ProviderReviewMutationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */; };
@@ -1786,6 +1788,7 @@
 		58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentController.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
 		59F17DE68E81565014FC9454 /* RemoteHelperWatchSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperWatchSession.swift; sourceTree = "<group>"; };
+		59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackChipModelTests.swift; sourceTree = "<group>"; };
 		5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		5A2EFB5253073D6A4A328FE0 /* RemoteConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConnection.swift; sourceTree = "<group>"; };
 		5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModel.swift; sourceTree = "<group>"; };
@@ -2487,6 +2490,7 @@
 		E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilderTests.swift; sourceTree = "<group>"; };
 		E7D9230E4E0DD70D689F40DD /* SpacePagerIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacePagerIndicatorTests.swift; sourceTree = "<group>"; };
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
+		E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackChip.swift; sourceTree = "<group>"; };
 		E8272ACF30256E328519815C /* SQLiteDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabaseTests.swift; sourceTree = "<group>"; };
 		E87C04CBE6911062CBE1134E /* ReviewHandoffProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewHandoffProgress.swift; sourceTree = "<group>"; };
 		E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-new-response-with-config-options.json"; sourceTree = "<group>"; };
@@ -4541,6 +4545,7 @@
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
+				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
 				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
 				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
@@ -4790,6 +4795,7 @@
 			children = (
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
+				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
 				ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
 				B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */,
@@ -5492,6 +5498,7 @@
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
+				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
 				4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
 				DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */,
@@ -6142,6 +6149,7 @@
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
+				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,
 				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 		6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */; };
 		6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */; };
 		6E1462FC9F25C4ED43DF8DF8 /* ACPSessionOrchestrationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F019D14D6FEFFE084FA498 /* ACPSessionOrchestrationPolicyTests.swift */; };
+		6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */; };
 		6E52521BCD52ED8DB496E74B /* CompletionDocumentationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */; };
 		6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
@@ -1224,6 +1225,7 @@
 		EAEB68B3A06AEA14BC8E2985 /* ChangesPreparationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD2F573498740A7DECCA3C /* ChangesPreparationModelTests.swift */; };
 		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
 		EBED65EE62760994B7C6010F /* SSHHostSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */; };
+		EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79485A502B7856609349A138 /* GGInstallController.swift */; };
 		EC2C564EBA85B494489DF323 /* CursorModelVariantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */; };
 		EC3209AD2538061259084545 /* ACPTerminalMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */; };
 		EC9A9B3211CFE0B652F5CA83 /* MemoryDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */; };
@@ -1825,6 +1827,7 @@
 		606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalIntegrationActionsTests.swift; sourceTree = "<group>"; };
 		60C99F8D1A0A37DC4A6DBAEE /* ACPAdapterInstallCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstallCoordinator.swift; sourceTree = "<group>"; };
 		60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderValidationTests.swift; sourceTree = "<group>"; };
+		611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInstallControllerTests.swift; sourceTree = "<group>"; };
 		615B4D8618F0BDEAEB216942 /* DraftReviewRequestDiffSessionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftReviewRequestDiffSessionBuilder.swift; sourceTree = "<group>"; };
 		6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModelBuilderTests.swift; sourceTree = "<group>"; };
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
@@ -1939,6 +1942,7 @@
 		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = .build/ghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
 		784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecentsTests.swift; sourceTree = "<group>"; };
 		792BD8DAE4AAED201252C9E2 /* ProjectMCPServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerTests.swift; sourceTree = "<group>"; };
+		79485A502B7856609349A138 /* GGInstallController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInstallController.swift; sourceTree = "<group>"; };
 		7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstaller.swift; sourceTree = "<group>"; };
 		795056B6AD803D2B555FC866 /* RightPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStore.swift; sourceTree = "<group>"; };
 		79624D3718BCE5CC605F0D6D /* DraftReviewRequestTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftReviewRequestTabView.swift; sourceTree = "<group>"; };
@@ -4544,6 +4548,7 @@
 				14CAEDA53AADBCE77C694E7B /* CodeHostModelsTests.swift */,
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
+				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
 				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
 				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
@@ -4793,6 +4798,7 @@
 		F5C77776D026943017AF4190 /* GG */ = {
 			isa = PBXGroup;
 			children = (
+				79485A502B7856609349A138 /* GGInstallController.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
@@ -5496,6 +5502,7 @@
 				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
+				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
@@ -6148,6 +6155,7 @@
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
+				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,
 				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		208E237B41BA6F234151683D /* HTTPRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA7CD14A8FA2D335A59B062 /* HTTPRequestParser.swift */; };
 		209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */; };
 		20BEEDF1A7F5A549B299C9D5 /* CodexACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A203964F9055BEF3F6142684 /* CodexACPInstallerTests.swift */; };
+		2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */; };
 		21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */; };
 		214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98D0A96093087BF4C284053 /* AlasSlider.swift */; };
 		2189980F65E927A18CB9360D /* ACPSessionsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */; };
@@ -401,6 +402,7 @@
 		4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */; };
 		4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02E429B37288215EBC89571 /* CommitHeaderView.swift */; };
 		4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */; };
+		4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */; };
 		4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */; };
 		4C31A14595F4AE906BFE67D2 /* ACPAgentProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3692D5EB4BCA66AB702D43 /* ACPAgentProfiles.swift */; };
 		4C3DFB4EDC26169A6D63E05E /* SSHConfigParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A2C5C173D2D9870A9C274 /* SSHConfigParserTests.swift */; };
@@ -1866,6 +1868,7 @@
 		6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceCreatedAtTests.swift; sourceTree = "<group>"; };
 		6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchOpsMenu.swift; sourceTree = "<group>"; };
 		6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecNpmPackageTests.swift; sourceTree = "<group>"; };
+		6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackGateTests.swift; sourceTree = "<group>"; };
 		6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModelTests.swift; sourceTree = "<group>"; };
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProvider.swift; sourceTree = "<group>"; };
@@ -2160,6 +2163,7 @@
 		AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentAgentModelTests.swift; sourceTree = "<group>"; };
 		AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModelsTests.swift; sourceTree = "<group>"; };
 		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
+		ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackGate.swift; sourceTree = "<group>"; };
 		ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentView.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
@@ -4532,6 +4536,7 @@
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
+				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
 				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */,
@@ -4780,6 +4785,7 @@
 			children = (
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
+				ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
 			);
 			path = GG;
@@ -5480,6 +5486,7 @@
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
+				4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
@@ -6128,6 +6135,7 @@
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
+				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -848,6 +848,7 @@
 		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
 		A8D21135BA6C2542E3820E19 /* TreeSitterHTML in Frameworks */ = {isa = PBXBuildFile; productRef = E1F30BF52DCE8CD60F19C921 /* TreeSitterHTML */; };
 		A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */; };
+		A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */; };
 		A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */; };
 		A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF32A1544E13321E9E223AFF /* DiffPaneView.swift */; };
 		A975EADB16D1050CA973B5B3 /* ACPSlashPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B7BC45B64591618784F650 /* ACPSlashPickerTests.swift */; };
@@ -950,6 +951,7 @@
 		BACDEEE3791E66405294B328 /* ACPFirstRunConnectingPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */; };
+		BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4836677A0E66A8ADD2D9E89A /* GGConfigCodableTests.swift */; };
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
 		BB7A00188B3BD4C729E0D8E6 /* RemoteTranscriptSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */; };
 		BB924C35D21B87B46A47C5FA /* ACPAdapterTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818B29F6B58D4FFC80603AAD /* ACPAdapterTarget.swift */; };
@@ -1453,6 +1455,7 @@
 		1B0785F1FFC8008C74009584 /* session-update-available-models.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-available-models.json"; sourceTree = "<group>"; };
 		1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStashTests.swift; sourceTree = "<group>"; };
 		1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServicePullTests.swift; sourceTree = "<group>"; };
+		1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGProjectMode.swift; sourceTree = "<group>"; };
 		1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHIntegrationTests.swift; sourceTree = "<group>"; };
 		1CA759D2C99D1FEE3C67A1BA /* RemoteImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageCacheTests.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
@@ -1687,6 +1690,7 @@
 		472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerHydrationTests.swift; sourceTree = "<group>"; };
 		4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstallerTests.swift; sourceTree = "<group>"; };
 		47DEF5C084FA32A781ABDADD /* ReviewTargetPaletteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTargetPaletteModel.swift; sourceTree = "<group>"; };
+		4836677A0E66A8ADD2D9E89A /* GGConfigCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGConfigCodableTests.swift; sourceTree = "<group>"; };
 		48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProviderVerdictTests.swift; sourceTree = "<group>"; };
 		4865995B2D4B92166321201F /* CommitContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilder.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
@@ -2925,6 +2929,7 @@
 				B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */,
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */,
+				4836677A0E66A8ADD2D9E89A /* GGConfigCodableTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
 				6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */,
@@ -4773,6 +4778,7 @@
 		F5C77776D026943017AF4190 /* GG */ = {
 			isa = PBXGroup;
 			children = (
+				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
 			);
@@ -5472,6 +5478,7 @@
 				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
+				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
@@ -6119,6 +6126,7 @@
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
+				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		3C8FAA4464E4D928F1DC6C91 /* session-new-response-with-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */; };
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
 		3CEE8409AAAAAE34D469B19D /* RemoteHelperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42BD0252E4292E53150CB8C /* RemoteHelperClient.swift */; };
+		3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9160AF4DDD35E2A02262D868 /* GGService.swift */; };
 		3CFC291E5868CCD147D573E7 /* ACPAdapterUpdateBannerDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */; };
 		3D32D8FA2A63B3C2080B9E3A /* DiffReviewRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BECCB29ED6324C55C541D54 /* DiffReviewRail.swift */; };
 		3D561C5EDA7AAB4831CA58CF /* RemoteProjectCollisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */; };
@@ -610,6 +611,7 @@
 		7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */; };
 		7A7A04035A83C4AD9ED5897D /* ProjectAvatarPresetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */; };
 		7A816022DD913BC76F5EBA7F /* InstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */; };
+		7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */; };
 		7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3814D8B30EBB9991F3388A /* ACPMarkdownInlineRenderer.swift */; };
 		7ACFA19EA43966431D906F55 /* TreeSitterPHP in Frameworks */ = {isa = PBXBuildFile; productRef = 78020033FC689A2BCDF51DED /* TreeSitterPHP */; };
 		7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CA79B71B4AA72697392702 /* NumstatParser.swift */; };
@@ -1551,6 +1553,7 @@
 		2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstallerTests.swift; sourceTree = "<group>"; };
 		2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeChangeGroupTests.swift; sourceTree = "<group>"; };
 		2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstallerTests.swift; sourceTree = "<group>"; };
+		2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGServiceTests.swift; sourceTree = "<group>"; };
 		2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModels.swift; sourceTree = "<group>"; };
 		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
@@ -2036,6 +2039,7 @@
 		90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLFSBlobResolver.swift; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
+		9160AF4DDD35E2A02262D868 /* GGService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGService.swift; sourceTree = "<group>"; };
 		91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictToolbar.swift; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
@@ -4522,6 +4526,7 @@
 				14CAEDA53AADBCE77C694E7B /* CodeHostModelsTests.swift */,
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
+				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
 				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */,
@@ -4768,6 +4773,7 @@
 		F5C77776D026943017AF4190 /* GG */ = {
 			isa = PBXGroup;
 			children = (
+				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
 			);
 			path = GG;
@@ -5466,6 +5472,7 @@
 				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
+				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
@@ -6112,6 +6119,7 @@
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
+				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -866,6 +866,7 @@
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
 		AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
+		AB3BD2843C0923FD0E30458C /* CommitsSectionTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5B0671AB91057B6B196EBD /* CommitsSectionTitleTests.swift */; };
 		AB4B19ECC0C3D7242ECD42C6 /* DiffReviewInlineFeedbackActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */; };
 		AB81A1DA27A87F7C7E49D9CF /* ACPPlanChecklist.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */; };
 		AB8B755B315E94BDF0BD937B /* TreeSitterRust in Frameworks */ = {isa = PBXBuildFile; productRef = 8007CCE96A65B912CE519EF0 /* TreeSitterRust */; };
@@ -2355,6 +2356,7 @@
 		CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBanner.swift; sourceTree = "<group>"; };
 		CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeView3WayLayoutTests.swift; sourceTree = "<group>"; };
 		CE47FEB79311AC99E61C3AF6 /* MergeResultPaneRenderPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeResultPaneRenderPlanTests.swift; sourceTree = "<group>"; };
+		CE5B0671AB91057B6B196EBD /* CommitsSectionTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionTitleTests.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesManagerTests.swift; sourceTree = "<group>"; };
 		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
@@ -2891,6 +2893,7 @@
 				6D46BDE72E52818061452ECB /* CommitRowTests.swift */,
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
 				8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */,
+				CE5B0671AB91057B6B196EBD /* CommitsSectionTitleTests.swift */,
 				A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */,
 				AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */,
 				A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */,
@@ -6094,6 +6097,7 @@
 				575A4296D86E77D00A1E66A7 /* CommitTabViewTests.swift in Sources */,
 				17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */,
 				4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */,
+				AB3BD2843C0923FD0E30458C /* CommitsSectionTitleTests.swift in Sources */,
 				6E52521BCD52ED8DB496E74B /* CompletionDocumentationRendererTests.swift in Sources */,
 				DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */,
 				CDE156FA8E19E85437E79908 /* CompletionFeatureTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -419,6 +419,7 @@
 		4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		4F2BB7482C39B07F5E35E9D1 /* RemoteMessageWireJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD68C6A69930BE0F9437AAE /* RemoteMessageWireJSON.swift */; };
+		4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */; };
 		4FD9E5FFB4C75850CF7B2FE7 /* StagedDiffLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */; };
 		4FE322C88A2B06C317DDA9B5 /* ReviewSessionTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */; };
 		5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */; };
@@ -2238,6 +2239,7 @@
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
 		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
 		B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileAccessTests.swift; sourceTree = "<group>"; };
+		BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneGGStackTests.swift; sourceTree = "<group>"; };
 		BA59378FB8733DBAC67592A3 /* RemotePairingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingServiceTests.swift; sourceTree = "<group>"; };
 		BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileChip.swift; sourceTree = "<group>"; };
 		BA9D3F3FFE39D7E29827D83D /* TabsManagerReviewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewSessionTests.swift; sourceTree = "<group>"; };
@@ -3047,6 +3049,7 @@
 				4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */,
 				A2506BDBA9F67B6516CE2BEF /* ReviewTargetPaletteModelTests.swift */,
 				B87101C6F8F27B57AEDC187D /* ReviewThreadWriteTests.swift */,
+				BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */,
@@ -6327,6 +6330,7 @@
 				14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */,
 				D4DE0AC014387E216A904D2E /* ReviewTargetPaletteModelTests.swift in Sources */,
 				1ACB56B9AA0EC3C1C2AF5E18 /* ReviewThreadWriteTests.swift in Sources */,
+				4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				019EE52A9C64CF5D15AD9AF2 /* RightPaneStateContentFingerprintTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -628,6 +628,7 @@
 		7DAAFE51C9C35BADB78B4A30 /* SSHIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */; };
 		7DEFB0A61614D65F509A11AE /* ImageDiffDifferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
+		7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */; };
 		7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7EC95A2AAEFE78B51D9F599A /* ACPPlanSidebarVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */; };
@@ -732,6 +733,7 @@
 		929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */; };
 		92EEAFAEFB3E637FB72174A8 /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 2B4C3DD473FF121828FD3CA5 /* TreeSitterYAML */; };
 		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
+		93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */; };
 		9409E946054E7D837A479137 /* ReviewLoopDrawerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */; };
 		9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */; };
 		94354D17B0FEF3F0046B452A /* ACPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */; };
@@ -1988,6 +1990,7 @@
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
 		86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStreamTests.swift; sourceTree = "<group>"; };
+		86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackModels.swift; sourceTree = "<group>"; };
 		8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownTextBareURLTests.swift; sourceTree = "<group>"; };
 		87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariants.swift; sourceTree = "<group>"; };
 		881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputer.swift; sourceTree = "<group>"; };
@@ -2139,6 +2142,7 @@
 		A8EFC853C0D2EB4AC2B01D9E /* GitService+ImageDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ImageDiff.swift"; sourceTree = "<group>"; };
 		A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunner.swift; sourceTree = "<group>"; };
 		A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacePagerIndicator.swift; sourceTree = "<group>"; };
+		A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackModelsTests.swift; sourceTree = "<group>"; };
 		A98D0A96093087BF4C284053 /* AlasSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasSlider.swift; sourceTree = "<group>"; };
 		AA6486CAD3FE633F9B6F4ABF /* MCPAttachmentPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPAttachmentPlanner.swift; sourceTree = "<group>"; };
 		AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstallerTests.swift; sourceTree = "<group>"; };
@@ -4048,6 +4052,7 @@
 			isa = PBXGroup;
 			children = (
 				4414ED76A2D75BCEE0905775 /* CodeHost */,
+				F5C77776D026943017AF4190 /* GG */,
 			);
 			path = Integrations;
 			sourceTree = "<group>";
@@ -4517,6 +4522,7 @@
 				14CAEDA53AADBCE77C694E7B /* CodeHostModelsTests.swift */,
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
+				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
@@ -4757,6 +4763,14 @@
 				2E0640C3A1916254E7527AA3 /* Zmx */,
 			);
 			path = Terminal;
+			sourceTree = "<group>";
+		};
+		F5C77776D026943017AF4190 /* GG */ = {
+			isa = PBXGroup;
+			children = (
+				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
+			);
+			path = GG;
 			sourceTree = "<group>";
 		};
 		F96AD5C7794128224DD2020B /* Icons */ = {
@@ -5452,6 +5466,7 @@
 				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
+				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
 				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,
@@ -6097,6 +6112,7 @@
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
+				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,
 				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1125,6 +1125,7 @@
 		DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9E527A76820947F426A8 /* ACPFilesystem.swift */; };
 		DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */; };
 		DADDDA3FA289B52415EF4379 /* ACPDelayedHoverVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */; };
+		DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */; };
 		DB199FBEEABBC119FB26E32A /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
 		DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */; };
 		DB305015BF666EEE0F9C7BAB /* ACPFileEditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D7631D754795D16E946440 /* ACPFileEditCard.swift */; };
@@ -2212,6 +2213,7 @@
 		B5DC5AC55D5FF5BF7FECAD2F /* ACPRemoteLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteLaunch.swift; sourceTree = "<group>"; };
 		B5E898E9F7E2680132FF54D4 /* ACPSelectChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChip.swift; sourceTree = "<group>"; };
 		B65018D176CD2E52A3999CF0 /* AlasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackSummaryStore.swift; sourceTree = "<group>"; };
 		B6F6E707551671670D8CBA38 /* AgentLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLogoView.swift; sourceTree = "<group>"; };
 		B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSidebarContrastTests.swift; sourceTree = "<group>"; };
 		B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGenerator.swift; sourceTree = "<group>"; };
@@ -4787,6 +4789,7 @@
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
+				B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */,
 			);
 			path = GG;
 			sourceTree = "<group>";
@@ -5488,6 +5491,7 @@
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
+				DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
 				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -533,8 +533,13 @@ final class AppState {
 
         // Probe gg CLI availability once at startup so the stacked-diffs
         // gate (RightPaneStore.ggGateProvider) has an answer by the time
-        // the first right pane activates.
+        // the first right pane activates. Wait for the login-shell PATH
+        // resolution kicked off above first — otherwise a gg installed only
+        // via Homebrew (not on the process's own PATH, e.g. launched from
+        // Finder/Dock) can probe as "not installed" and stay stuck there,
+        // since a non-force probe short-circuits once `hasProbed` is set.
         Task { @MainActor in
+            await ShellEnvResolver.shared.waitUntilResolved()
             await GGAvailability.shared.probe()
         }
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -530,6 +530,13 @@ final class AppState {
         // hasn't finished by the first git command, gitEnv() falls back to the
         // process PATH (same behaviour as before).
         ShellEnvResolver.shared.resolve()
+
+        // Probe gg CLI availability once at startup so the stacked-diffs
+        // gate (RightPaneStore.ggGateProvider) has an answer by the time
+        // the first right pane activates.
+        Task { @MainActor in
+            await GGAvailability.shared.probe()
+        }
     }
 
     /// All worktree IDs currently known to the projects manager (including

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -538,9 +538,14 @@ final class AppState {
         // via Homebrew (not on the process's own PATH, e.g. launched from
         // Finder/Dock) can probe as "not installed" and stay stuck there,
         // since a non-force probe short-circuits once `hasProbed` is set.
-        Task { @MainActor in
+        // A right pane can activate and evaluate the gate before this probe
+        // resolves — it sees `isInstalled == false` and clears/skips its
+        // stack. Re-evaluate every cached pane once the probe lands so a
+        // real stack doesn't stay rendered as plain commits.
+        Task { @MainActor [weak self] in
             await ShellEnvResolver.shared.waitUntilResolved()
             await GGAvailability.shared.probe()
+            self?.rightPaneStore.reevaluateGGGates()
         }
     }
 

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -158,6 +158,13 @@ final class ProjectsManager {
         }
     }
 
+    /// Sets the per-project stacked-diffs mode. Callers persist via
+    /// `AppState.saveProjects()`.
+    func setGGMode(projectId: String, mode: GGProjectMode) {
+        guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return }
+        projects[idx].ggMode = mode
+    }
+
     func reorderProject(fromIndex: Int, toIndex: Int) {
         guard projects.indices.contains(fromIndex),
               projects.indices.contains(toIndex),

--- a/Alas/Sources/Git/ShellEnvResolver.swift
+++ b/Alas/Sources/Git/ShellEnvResolver.swift
@@ -5,6 +5,7 @@ final class ShellEnvResolver {
 
     private let lock = NSLock()
     private var _resolvedPath: String?
+    private var resolveTask: Task<Void, Never>?
 
     var resolvedPath: String? {
         get {
@@ -20,12 +21,27 @@ final class ShellEnvResolver {
     }
 
     func resolve() {
-        Task {
+        let task = Task {
             let path = await Self.discoverShellPath()
             lock.lock()
             _resolvedPath = path
             lock.unlock()
         }
+        lock.lock()
+        resolveTask = task
+        lock.unlock()
+    }
+
+    /// Awaits the in-flight PATH resolution started by `resolve()`, if any.
+    /// Returns immediately when resolution already finished or never started.
+    /// Callers that need the login-shell PATH before probing an external CLI
+    /// (e.g. `gg`) should await this instead of racing `resolve()`'s
+    /// fire-and-forget Task.
+    func waitUntilResolved() async {
+        lock.lock()
+        let task = resolveTask
+        lock.unlock()
+        await task?.value
     }
 
     private static func discoverShellPath() async -> String? {

--- a/Alas/Sources/Integrations/GG/GGInstallController.swift
+++ b/Alas/Sources/Integrations/GG/GGInstallController.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Observation
+
+/// Drives the "Install gg…" flow in Settings → Changes. Runs Homebrew
+/// headless and re-probes availability on success, following the LSP
+/// install-nudge pattern.
+@MainActor
+@Observable
+final class GGInstallController {
+    enum Phase: Equatable {
+        case idle, running, succeeded
+        case failed(String)
+    }
+
+    private(set) var phase: Phase = .idle
+
+    private let runInstall: @Sendable () async throws -> ProcessResult
+    /// Returns whether gg is on PATH after the install. Injectable for tests.
+    private let reprobe: @MainActor () async -> Bool
+
+    init(
+        runInstall: @escaping @Sendable () async throws -> ProcessResult = {
+            try await Process.run(
+                "/usr/bin/env",
+                args: ["brew", "install", "mrmans0n/tap/gg-stack"],
+                env: Process.gitEnv(),
+                timeout: 600
+            )
+        },
+        reprobe: @escaping @MainActor () async -> Bool = {
+            await GGAvailability.shared.probe(force: true)
+            return GGAvailability.shared.isInstalled
+        }
+    ) {
+        self.runInstall = runInstall
+        self.reprobe = reprobe
+    }
+
+    func install() {
+        Task { await installAndWait() }
+    }
+
+    func installAndWait() async {
+        guard phase != .running else { return }
+        phase = .running
+        do {
+            let result = try await runInstall()
+            guard result.exitCode == 0 else {
+                let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                phase = .failed(stderr.isEmpty ? "brew exited with code \(result.exitCode)." : stderr)
+                return
+            }
+            phase = await reprobe() ? .succeeded : .failed("gg is still not on PATH after install.")
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGProjectMode.swift
+++ b/Alas/Sources/Integrations/GG/GGProjectMode.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Per-project stacked-diffs mode.
+/// - `auto` (default): enabled when the repo's main worktree has
+///   `.git/gg/config.json`.
+/// - `on`: skip the config-file check (still requires a stack-shaped branch).
+/// - `off`: hide all gg UI for this project.
+enum GGProjectMode: String, Codable, Equatable, CaseIterable {
+    case off, auto, on
+}

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Observation
+
+/// Injectable gg process runner, mirroring `CodeHostCommandRunning` so
+/// tests can fake CLI output. Local-only in phase 1 (no SSH rewrite).
+protocol GGCommandRunning: Sendable {
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult
+}
+
+struct ProcessGGCommandRunner: GGCommandRunning {
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        try await Process.run(
+            "/usr/bin/env",
+            args: ["gg"] + args,
+            cwd: cwd,
+            env: Process.gitEnv()
+        )
+    }
+}
+
+/// Stateless read-only facade over the gg CLI (peer to `GitService`).
+struct GGService {
+    var runner: GGCommandRunning = ProcessGGCommandRunner()
+
+    /// Returns the gg version string ("0.9.8") or nil when gg is not
+    /// installed / not on the login-shell PATH.
+    func probeVersion() async -> String? {
+        guard let result = try? await runner.run(args: ["--version"], cwd: nil),
+              result.exitCode == 0
+        else { return nil }
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        // "gg 0.9.8" → "0.9.8"
+        return output.split(separator: " ").last.map(String.init)
+    }
+
+    /// Loads the current branch's stack via `gg ls --json`. Returns nil
+    /// when the branch is not a gg stack (gg emits the all-stacks shape).
+    func currentStack(worktreePath: String) async throws -> GGStack? {
+        let result: ProcessResult
+        do {
+            result = try await runner.run(
+                args: ["ls", "--json"],
+                cwd: URL(fileURLWithPath: worktreePath)
+            )
+        } catch let error as GGServiceError {
+            throw error
+        } catch {
+            throw GGServiceError.commandFailed(stderr: String(describing: error))
+        }
+        guard result.exitCode == 0 else {
+            if result.exitCode == 127 { throw GGServiceError.cliMissing }
+            throw GGServiceError.commandFailed(
+                stderr: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+        return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8)).stack
+    }
+}
+
+/// Session-cached gg availability, probed once at startup and re-probed
+/// (force) after the Settings install flow completes.
+@MainActor
+@Observable
+final class GGAvailability {
+    static let shared = GGAvailability()
+
+    private(set) var version: String?
+    private(set) var hasProbed = false
+
+    var isInstalled: Bool { version != nil }
+
+    func probe(service: GGService = GGService(), force: Bool = false) async {
+        if hasProbed && !force { return }
+        version = await service.probeVersion()
+        hasProbed = true
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGStackChip.swift
+++ b/Alas/Sources/Integrations/GG/GGStackChip.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Presentation model for a stack entry's PR/MR chip. Pure so the
+/// label/color mapping is unit-testable without rendering.
+struct GGStackChipModel: Equatable {
+    let label: String
+    let colorToken: String
+
+    static func model(for entry: GGStackEntry, kind: CodeHostKind?) -> GGStackChipModel? {
+        guard let number = entry.prNumber else { return nil }
+        let prefix = kind == .gitlab ? "!" : "#"
+        let label = "\(prefix)\(number)" + (entry.approved ? " ✓" : "")
+        let token: String
+        switch entry.prState {
+        case .open: token = "add"
+        case .merged: token = "accent"
+        case .draft: token = "fg-muted"
+        case .closed: token = "del"
+        case nil: token = "fg-faint"
+        }
+        return GGStackChipModel(label: label, colorToken: token)
+    }
+}
+
+/// Capsule chip styled after `BehindChip` (CommitsSectionView.swift).
+struct GGStackChip: View {
+    let model: GGStackChipModel
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        let tint = theme.color(model.colorToken)
+        Text(model.label)
+            .font(.system(size: 9.5, weight: .semibold))
+            .lineLimit(1)
+            .foregroundColor(tint)
+            .padding(.horizontal, 6).padding(.vertical, 1)
+            .background(tint.opacity(0.12))
+            .clipShape(Capsule())
+    }
+}
+
+/// Tiny CI state dot shown next to the chip.
+struct GGCIDot: View {
+    let status: GGCIStatus?
+    @Environment(\.theme) private var theme
+
+    private var token: String {
+        switch status {
+        case .success: return "add"
+        case .failed: return "del"
+        case .pending, .running: return "caution"
+        case .canceled, .unknown, nil: return "fg-faint"
+        }
+    }
+
+    var body: some View {
+        Circle()
+            .fill(theme.color(token))
+            .frame(width: 6, height: 6)
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGStackGate.swift
+++ b/Alas/Sources/Integrations/GG/GGStackGate.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Pure gating logic for the stacked-diffs integration. UI renders only
+/// when every gate passes: master toggle → gg installed → per-project
+/// mode → the current branch is actually stack-shaped.
+enum GGStackGate {
+    /// Gate 3 (auto mode): the repo's main worktree carries gg config.
+    /// `repoPath` is the project's primary checkout, where `.git` is a
+    /// real directory (linked worktrees have a `.git` file instead).
+    static func repoHasGGConfig(repoPath: String) -> Bool {
+        let path = (repoPath as NSString).appendingPathComponent(".git/gg/config.json")
+        return FileManager.default.fileExists(atPath: path)
+    }
+
+    /// Gates 1–3 combined for a project.
+    static func projectEnabled(
+        masterEnabled: Bool,
+        ggInstalled: Bool,
+        mode: GGProjectMode,
+        repoPath: String
+    ) -> Bool {
+        guard masterEnabled, ggInstalled else { return false }
+        switch mode {
+        case .off: return false
+        case .on: return true
+        case .auto: return repoHasGGConfig(repoPath: repoPath)
+        }
+    }
+
+    /// Gate 4: any commit ahead of base carries a `GG-ID:` trailer line.
+    /// Pure check over already-loaded commit bodies — no extra git call.
+    static func isStackShaped(commits: [CommitInfo]) -> Bool {
+        commits.contains { commit in
+            commit.body.split(whereSeparator: \.isNewline).contains {
+                $0.trimmingCharacters(in: .whitespaces).hasPrefix("GG-ID:")
+            }
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGStackGate.swift
+++ b/Alas/Sources/Integrations/GG/GGStackGate.swift
@@ -4,12 +4,53 @@ import Foundation
 /// when every gate passes: master toggle → gg installed → per-project
 /// mode → the current branch is actually stack-shaped.
 enum GGStackGate {
-    /// Gate 3 (auto mode): the repo's main worktree carries gg config.
-    /// `repoPath` is the project's primary checkout, where `.git` is a
-    /// real directory (linked worktrees have a `.git` file instead).
+    /// Gate 3 (auto mode): the repo's common git dir carries gg config.
+    /// `repoPath` is a project's checkout path, which is not guaranteed to
+    /// be the primary one — a project can be added from a linked worktree,
+    /// where `.git` is a file (`gitdir: <path>`) rather than a directory.
+    /// gg itself stores config at `<commondir>/gg/config.json` (mirrors
+    /// `repo.commondir()` in gg's own source), so resolve the same way
+    /// instead of assuming `<repoPath>/.git` is the config's home.
     static func repoHasGGConfig(repoPath: String) -> Bool {
-        let path = (repoPath as NSString).appendingPathComponent(".git/gg/config.json")
+        guard let commonGitDir = commonGitDir(repoPath: repoPath) else { return false }
+        let path = (commonGitDir as NSString).appendingPathComponent("gg/config.json")
         return FileManager.default.fileExists(atPath: path)
+    }
+
+    /// Resolves the shared git directory for `repoPath`: itself when `.git`
+    /// is a real directory (primary checkout), or — for a linked worktree,
+    /// where `.git` is a file pointing at a private per-worktree dir under
+    /// `<commondir>/worktrees/<name>` — the directory named by that private
+    /// dir's `commondir` file.
+    private static func commonGitDir(repoPath: String) -> String? {
+        let dotGitPath = (repoPath as NSString).appendingPathComponent(".git")
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: dotGitPath, isDirectory: &isDirectory) else {
+            return nil
+        }
+        if isDirectory.boolValue {
+            return dotGitPath
+        }
+        guard let contents = try? String(contentsOfFile: dotGitPath, encoding: .utf8),
+              let gitdirLine = contents.split(whereSeparator: \.isNewline)
+                  .first(where: { $0.hasPrefix("gitdir:") })
+        else {
+            return nil
+        }
+        let rawPath = gitdirLine.dropFirst("gitdir:".count).trimmingCharacters(in: .whitespaces)
+        let privateGitDir = resolvedPath(rawPath, relativeTo: repoPath)
+        let commondirFile = (privateGitDir as NSString).appendingPathComponent("commondir")
+        guard let commondirContents = try? String(contentsOfFile: commondirFile, encoding: .utf8) else {
+            return privateGitDir
+        }
+        let relativeCommonDir = commondirContents.trimmingCharacters(in: .whitespacesAndNewlines)
+        return resolvedPath(relativeCommonDir, relativeTo: privateGitDir)
+    }
+
+    private static func resolvedPath(_ path: String, relativeTo base: String) -> String {
+        let ns = path as NSString
+        let absolute = ns.isAbsolutePath ? ns as String : (base as NSString).appendingPathComponent(path)
+        return (absolute as NSString).standardizingPath
     }
 
     /// Gates 1–3 combined for a project.

--- a/Alas/Sources/Integrations/GG/GGStackGate.swift
+++ b/Alas/Sources/Integrations/GG/GGStackGate.swift
@@ -54,13 +54,21 @@ enum GGStackGate {
     }
 
     /// Gates 1–3 combined for a project.
+    /// - Parameter isRemoteProject: true when the project is a registered
+    ///   SSH destination rather than a local checkout. gg's runner is
+    ///   local-only (`/usr/bin/env gg`), unlike git's own process wrapper,
+    ///   which rewrites invocations to SSH for registered remote hosts —
+    ///   running gg against a remote path either fails repeatedly or, if
+    ///   the same path coincidentally exists locally too, reads an
+    ///   unrelated repo. Fail closed regardless of mode.
     static func projectEnabled(
         masterEnabled: Bool,
         ggInstalled: Bool,
         mode: GGProjectMode,
-        repoPath: String
+        repoPath: String,
+        isRemoteProject: Bool
     ) -> Bool {
-        guard masterEnabled, ggInstalled else { return false }
+        guard masterEnabled, ggInstalled, !isRemoteProject else { return false }
         switch mode {
         case .off: return false
         case .on: return true

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// Errors from the gg CLI integration. Mirrors `CodeHostProviderError`
+/// shape but scoped to the gg tool, which is not a forge provider.
+enum GGServiceError: Error, Equatable {
+    case cliMissing
+    case commandFailed(stderr: String)
+    case malformedOutput(String)
+    case unsupportedSchema(Int)
+}
+
+/// Decoded envelope of `gg ls --json` / `gg log --json`. When the current
+/// branch is a stack, gg emits `{"version":1,"stack":{...}}`; off-stack it
+/// emits an all-stacks shape with no `stack` key, which decodes here as
+/// `stack == nil`.
+struct GGStackSnapshot: Decodable, Equatable {
+    static let supportedSchemaVersion = 1
+    let version: Int
+    let stack: GGStack?
+
+    static func decode(fromJSON data: Data) throws -> GGStackSnapshot {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let snapshot: GGStackSnapshot
+        do {
+            snapshot = try decoder.decode(GGStackSnapshot.self, from: data)
+        } catch {
+            throw GGServiceError.malformedOutput(String(describing: error))
+        }
+        guard snapshot.version <= supportedSchemaVersion else {
+            throw GGServiceError.unsupportedSchema(snapshot.version)
+        }
+        return snapshot
+    }
+}
+
+struct GGStack: Decodable, Equatable {
+    let name: String
+    let base: String
+    let totalCommits: Int
+    let syncedCommits: Int
+    let currentPosition: Int?
+    let behindBase: Int?
+    let entries: [GGStackEntry]
+
+    var summary: GGStackSummary {
+        GGStackSummary(
+            merged: entries.filter { $0.prState == .merged }.count,
+            total: totalCommits
+        )
+    }
+
+    /// gg reports abbreviated SHAs; Alas commit lists carry full 40-char
+    /// SHAs. Match on whichever is the prefix of the other.
+    func entry(matchingCommitSHA sha: String) -> GGStackEntry? {
+        entries.first { sha.hasPrefix($0.sha) || $0.sha.hasPrefix(sha) }
+    }
+}
+
+enum GGPRState: String, Equatable {
+    case open, merged, closed, draft
+}
+
+enum GGCIStatus: String, Equatable {
+    case pending, running, success, failed, canceled, unknown
+}
+
+struct GGStackEntry: Decodable, Equatable, Identifiable {
+    /// Stable identity across rebases/amends: the GG-ID trailer when
+    /// present, the (rewriting) SHA otherwise.
+    var id: String { ggId ?? sha }
+    let position: Int
+    let sha: String
+    let title: String
+    let ggId: String?
+    let ggParent: String?
+    let prNumber: Int?
+    let prState: GGPRState?
+    let approved: Bool
+    let ciStatus: GGCIStatus?
+    let isCurrent: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case position, sha, title, ggId, ggParent, prNumber, prState,
+             approved, ciStatus, isCurrent
+    }
+
+    init(
+        position: Int,
+        sha: String,
+        title: String,
+        ggId: String? = nil,
+        ggParent: String? = nil,
+        prNumber: Int? = nil,
+        prState: GGPRState? = nil,
+        approved: Bool = false,
+        ciStatus: GGCIStatus? = nil,
+        isCurrent: Bool = false
+    ) {
+        self.position = position
+        self.sha = sha
+        self.title = title
+        self.ggId = ggId
+        self.ggParent = ggParent
+        self.prNumber = prNumber
+        self.prState = prState
+        self.approved = approved
+        self.ciStatus = ciStatus
+        self.isCurrent = isCurrent
+    }
+
+    // Tolerant decode: unknown enum strings and future fields must not
+    // fail the whole snapshot — fall back per-field instead.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        position = try c.decode(Int.self, forKey: .position)
+        sha = try c.decode(String.self, forKey: .sha)
+        title = try c.decode(String.self, forKey: .title)
+        ggId = try? c.decode(String.self, forKey: .ggId)
+        ggParent = try? c.decode(String.self, forKey: .ggParent)
+        prNumber = try? c.decode(Int.self, forKey: .prNumber)
+        prState = (try? c.decode(String.self, forKey: .prState))
+            .flatMap(GGPRState.init(rawValue:))
+        approved = (try? c.decode(Bool.self, forKey: .approved)) ?? false
+        ciStatus = (try? c.decode(String.self, forKey: .ciStatus))
+            .flatMap(GGCIStatus.init(rawValue:))
+        isCurrent = (try? c.decode(Bool.self, forKey: .isCurrent)) ?? false
+    }
+}
+
+/// Compact merged/total pair for the sidebar worktree badge.
+struct GGStackSummary: Equatable {
+    let merged: Int
+    let total: Int
+}

--- a/Alas/Sources/Integrations/GG/GGStackSummaryStore.swift
+++ b/Alas/Sources/Integrations/GG/GGStackSummaryStore.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Observation
+
+/// Worktree path → stack summary, written by each RightPaneState after a
+/// stack load and read by the sidebar badge. Phase-1 limitation: only
+/// worktrees whose right pane has been activated have a badge.
+@MainActor
+@Observable
+final class GGStackSummaryStore {
+    static let shared = GGStackSummaryStore()
+    var summaries: [String: GGStackSummary] = [:]
+}

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -325,11 +325,14 @@ struct AppConfig: Codable, Equatable {
         var diffLayoutMode: DiffLayoutMode
         var diffWrapLines: Bool
         var diffShowWhitespace: Bool
+        /// Master switch for the gg stacked-diffs integration. On by
+        /// default — without gg installed the later gates hide all UI.
+        var stackedDiffsEnabled: Bool = true
 
         enum CodingKeys: String, CodingKey {
             case aiToolId, prompt, reviewRequestPrompt, mergeBulkResolvePrompt,
                  mergeSingleResolvePrompt, comparisonMode,
-                 diffLayoutMode, diffWrapLines, diffShowWhitespace
+                 diffLayoutMode, diffWrapLines, diffShowWhitespace, stackedDiffsEnabled
         }
     }
 
@@ -700,6 +703,8 @@ extension AppConfig {
                 diffWrapLines: diffWrapLines,
                 diffShowWhitespace: diffShowWhitespace
             )
+            changes.stackedDiffsEnabled =
+                (try? changesContainer.decode(Bool.self, forKey: .stackedDiffsEnabled)) ?? true
         } else {
             changes = Changes(
                 aiToolId: "none",

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -98,11 +98,13 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var worktreeDefaultLauncherMode: AppConfig.LauncherMode?
     /// SSH destination when this project lives on another machine.
     var host: String?
+    /// Per-project stacked-diffs (gg) mode. Defaults to `.auto`.
+    var ggMode: GGProjectMode = .auto
 
     enum CodingKeys: String, CodingKey {
         case id, name, path, color, icon, addedAt, hiddenWorktreePaths, worktreeOrder,
              worktreeOrderIsManual, startupScripts,
-             mcpServers, worktreeOpenAfterCreate, worktreeDefaultLauncherMode, host
+             mcpServers, worktreeOpenAfterCreate, worktreeDefaultLauncherMode, host, ggMode
     }
 
     init(
@@ -160,6 +162,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         worktreeOpenAfterCreate = try? c.decode(Bool.self, forKey: .worktreeOpenAfterCreate)
         worktreeDefaultLauncherMode = try? c.decode(AppConfig.LauncherMode.self, forKey: .worktreeDefaultLauncherMode)
         host = try? c.decode(String.self, forKey: .host)
+        ggMode = (try? c.decode(GGProjectMode.self, forKey: .ggMode)) ?? .auto
     }
 
     func encode(to encoder: Encoder) throws {
@@ -178,5 +181,6 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         try c.encodeIfPresent(worktreeOpenAfterCreate, forKey: .worktreeOpenAfterCreate)
         try c.encodeIfPresent(worktreeDefaultLauncherMode, forKey: .worktreeDefaultLauncherMode)
         try c.encodeIfPresent(host, forKey: .host)
+        try c.encode(ggMode, forKey: .ggMode)
     }
 }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -204,7 +204,9 @@ struct ChangesTabView: View {
                     rps.selectBaseBranch(branch)
                 },
                 onOpenBaseBranchSelector: { Task { @MainActor in await rps.fetchBranches() } },
-                rps: rps
+                rps: rps,
+                ggStack: rps.ggStack,
+                stackCodeHostKind: rps.commitRemote?.kind
             )
         }
     }

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -17,6 +17,9 @@ struct CommitRow: View {
     var onReview: (() -> Void)? = nil
     var onCherryPick: (() -> Void)? = nil
     var onRevert: (() -> Void)? = nil
+    /// Stack entry for this commit when the branch is a gg stack.
+    var stackEntry: GGStackEntry? = nil
+    var codeHostKind: CodeHostKind? = nil
 
     @Environment(\.theme) private var theme
     @StateObject private var copyFeedback = CopyFeedbackState()
@@ -38,6 +41,15 @@ struct CommitRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .opacity(stackEntry?.prState == .merged ? 0.55 : 1)
+        .background(alignment: .leading) {
+            if stackEntry?.isCurrent == true {
+                Rectangle()
+                    .fill(theme.color("accent"))
+                    .frame(width: 2)
+                    .cornerRadius(1)
+            }
+        }
         .copyFeedbackOverlay(message: copyFeedback.message)
         .contextMenu {
             ForEach(Self.leadingContextMenuActions(canEdit: onEdit != nil, canReview: onReview != nil), id: \.self) { action in
@@ -149,6 +161,15 @@ struct CommitRow: View {
                 .font(.system(size: 12))
                 .foregroundColor(theme.color("fg"))
                 .lineLimit(2)
+            if let stackEntry {
+                Spacer(minLength: 4)
+                if stackEntry.prNumber != nil {
+                    GGCIDot(status: stackEntry.ciStatus)
+                }
+                if let chip = GGStackChipModel.model(for: stackEntry, kind: codeHostKind) {
+                    GGStackChip(model: chip)
+                }
+            }
             Spacer(minLength: 0)
         }
     }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -111,7 +111,7 @@ struct CommitsSectionView: View {
             }
         } header: {
             SectionHeader(
-                title: ggStack.map { "Stack · \($0.name)" } ?? "Commits",
+                title: Self.sectionTitle(ggStack: ggStack, commitsEmpty: commits.isEmpty),
                 count: totalCount,
                 expanded: expanded,
                 onToggle: { expanded.toggle() }
@@ -150,6 +150,17 @@ struct CommitsSectionView: View {
     private var totalCount: Int? {
         let n = commits.count + olderCommits.count
         return n == 0 ? nil : n
+    }
+
+    /// `ggStack` can be loaded (feeding the sidebar badge) while `commits`
+    /// — the section's *display* list, filtered by the user's comparison
+    /// mode — is empty: e.g. a fully-synced stack under "Branch upstream"
+    /// mode, where the list is `@{u}..HEAD`. Rows only render when
+    /// `commits` is non-empty, so a "Stack · …" header over the generic
+    /// empty placeholder would promise content that isn't there — fall
+    /// back to the plain title instead.
+    static func sectionTitle(ggStack: GGStack?, commitsEmpty: Bool) -> String {
+        (commitsEmpty ? nil : ggStack).map { "Stack · \($0.name)" } ?? "Commits"
     }
 
     @ViewBuilder

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -99,6 +99,8 @@ struct CommitsSectionView: View {
     let onSelectBaseBranch: (String) -> Void
     let onOpenBaseBranchSelector: () -> Void
     let rps: RightPaneState
+    let ggStack: GGStack?
+    let stackCodeHostKind: CodeHostKind?
 
     @Environment(\.theme) private var theme
 
@@ -109,7 +111,7 @@ struct CommitsSectionView: View {
             }
         } header: {
             SectionHeader(
-                title: "Commits",
+                title: ggStack.map { "Stack · \($0.name)" } ?? "Commits",
                 count: totalCount,
                 expanded: expanded,
                 onToggle: { expanded.toggle() }
@@ -165,7 +167,9 @@ struct CommitsSectionView: View {
                     onEdit: { onEdit(commit) },
                     onReview: { onReview(commit) },
                     onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
-                    onRevert: { rps.runRevert(sha: commit.sha) }
+                    onRevert: { rps.runRevert(sha: commit.sha) },
+                    stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),
+                    codeHostKind: stackCodeHostKind
                 )
             }
         } else if olderCommits.isEmpty {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -114,6 +114,9 @@ final class RightPaneState {
     // Exposed (not `private`) so tests can seed/inspect it via `@testable
     // import` without a real git repo driving `refresh()`.
     var ggStackCommitsKey: String? = nil
+    /// Off-critical-path gg stack load. Cancelled+restarted per refresh so a
+    /// slow `gg ls --json` never blocks the Changes-pane snapshot.
+    private var ggStackRefreshTask: Task<Void, Never>? = nil
 
     // Sync-nudge state. All fields are in-memory only; nothing is
     // persisted to AppConfig. Two independent conditions:
@@ -338,6 +341,8 @@ final class RightPaneState {
         remoteHelperSession?.stop()
         remoteHelperSession = nil
         remoteEventDebouncer.cancel()
+        ggStackRefreshTask?.cancel()
+        ggStackRefreshTask = nil
     }
 
     private func startRemoteHelperWatching() {
@@ -688,7 +693,8 @@ final class RightPaneState {
             let mergedFileTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
             if self.fileTree != mergedFileTree { self.fileTree = mergedFileTree }
             if self.commits != commits { self.commits = commits }
-            await refreshGGStack()
+            ggStackRefreshTask?.cancel()
+            ggStackRefreshTask = Task { @MainActor [weak self] in await self?.refreshGGStack() }
             if self.comparisonRef != ref { self.comparisonRef = ref }
             let preferredCommitRemoteRef = ref ?? baseBranch
             let commitRemote = CodeHostRemoteDetector.detect(
@@ -788,12 +794,35 @@ final class RightPaneState {
         guard key != ggStackCommitsKey else { return }
         // Failure degrades to the plain commits section, never an error UI.
         let stack = try? await ggService.currentStack(worktreePath: worktree.path.path)
+        // A newer refresh superseded this one — its own `refreshGGStack` call
+        // will write the current state; writing here would race it with a
+        // stale result.
+        if Task.isCancelled { return }
         ggStackCommitsKey = key
         if ggStack != stack { ggStack = stack }
         let summary = stack?.summary
         if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
             GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
         }
+    }
+
+    /// Re-run the gg gate immediately (e.g. after a Settings toggle) rather
+    /// than waiting for the next watcher-driven refresh. Resets the
+    /// commits-key so the gate is fully re-evaluated even when commits are
+    /// unchanged, then reloads or clears stack state. Returns the
+    /// underlying task so tests can await completion; production call
+    /// sites ignore the return value.
+    @MainActor
+    @discardableResult
+    func reevaluateGGGate() -> Task<Void, Never> {
+        ggStackCommitsKey = nil
+        ggStackRefreshTask?.cancel()
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.refreshGGStack()
+        }
+        ggStackRefreshTask = task
+        return task
     }
 
     func markSnapshotUnknown() {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -794,17 +794,25 @@ final class RightPaneState {
         // manual-refresh hook can come with the phase-2 drawer).
         let key = commits.map(\.sha).joined(separator: "|")
         guard key != ggStackCommitsKey else { return }
-        // Failure degrades to the plain commits section, never an error UI.
-        let stack = try? await ggService.currentStack(worktreePath: worktree.path.path)
-        // A newer refresh superseded this one — its own `refreshGGStack` call
-        // will write the current state; writing here would race it with a
-        // stale result.
-        if Task.isCancelled { return }
-        ggStackCommitsKey = key
-        if ggStack != stack { ggStack = stack }
-        let summary = stack?.summary
-        if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
-            GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
+        do {
+            let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
+            // A newer refresh superseded this one — its own `refreshGGStack`
+            // call will write the current state; writing here would race it
+            // with a stale result.
+            if Task.isCancelled { return }
+            ggStackCommitsKey = key
+            if ggStack != stack { ggStack = stack }
+            let summary = stack?.summary
+            if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
+                GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
+            }
+        } catch {
+            // A transient gg/provider failure (gh/glab auth hiccup, network
+            // blip, etc.) must not poison the commits-key cache — leave it
+            // untouched so the next refresh retries instead of being skipped
+            // by the unchanged-key guard above. Whatever was already
+            // rendered (nil on first load, last-good stack on a later
+            // refresh) stays as-is; never surface an error UI.
         }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -112,11 +112,13 @@ final class RightPaneState {
     /// performRefresh fires continuously from the file watcher — so only
     /// re-query gg when the commit set actually changed.
     // Exposed (not `private`) so tests can seed/inspect it via `@testable
-    // import` without a real git repo driving `refresh()`.
-    var ggStackCommitsKey: String? = nil
+    // import` without a real git repo driving `refresh()`. Bookkeeping only,
+    // never read by a view — kept out of observation to avoid invalidation
+    // churn on the hot refresh path.
+    @ObservationIgnored var ggStackCommitsKey: String? = nil
     /// Off-critical-path gg stack load. Cancelled+restarted per refresh so a
     /// slow `gg ls --json` never blocks the Changes-pane snapshot.
-    private var ggStackRefreshTask: Task<Void, Never>? = nil
+    @ObservationIgnored private var ggStackRefreshTask: Task<Void, Never>? = nil
 
     // Sync-nudge state. All fields are in-memory only; nothing is
     // persisted to AppConfig. Two independent conditions:

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -817,9 +817,21 @@ final class RightPaneState {
             // A transient gg/provider failure (gh/glab auth hiccup, network
             // blip, etc.) must not poison the commits-key cache — leave it
             // untouched so the next refresh retries instead of being skipped
-            // by the unchanged-key guard above. Whatever was already
-            // rendered (nil on first load, last-good stack on a later
-            // refresh) stays as-is; never surface an error UI.
+            // by the unchanged-key guard above. But whatever `ggStack`
+            // currently holds was loaded for a *different* key (the guard
+            // above only lets us reach this point when the key changed) —
+            // e.g. the previous branch's stack, if the user just checked
+            // out a different stack-shaped branch and this fetch for it
+            // failed. Rendering it against the now-different `commits`
+            // would misattribute its header, PR chips, and sidebar badge
+            // to the wrong branch, so clear it and degrade to plain
+            // commits rather than show stale, mismatched data.
+            if Task.isCancelled { return }
+            guard snapshotGeneration == snapshotInvalidationGeneration else { return }
+            if ggStack != nil { ggStack = nil }
+            if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
+                GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+            }
         }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -111,7 +111,9 @@ final class RightPaneState {
     /// --json` hits the forge API (best-effort PR-state refresh), and
     /// performRefresh fires continuously from the file watcher — so only
     /// re-query gg when the commit set actually changed.
-    private var ggStackCommitsKey: String? = nil
+    // Exposed (not `private`) so tests can seed/inspect it via `@testable
+    // import` without a real git repo driving `refresh()`.
+    var ggStackCommitsKey: String? = nil
 
     // Sync-nudge state. All fields are in-memory only; nothing is
     // persisted to AppConfig. Two independent conditions:
@@ -765,8 +767,10 @@ final class RightPaneState {
         }
     }
 
+    // Not `private` so tests can call it directly against injected
+    // `commits` / `ggService` without needing a real git repo + watcher.
     @MainActor
-    private func refreshGGStack() async {
+    func refreshGGStack() async {
         let gated = ggGateProvider?() ?? false
         guard gated, GGStackGate.isStackShaped(commits: commits) else {
             ggStackCommitsKey = nil

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -790,10 +790,14 @@ final class RightPaneState {
             return
         }
         // `gg ls --json` reaches out to gh/glab for PR state — skip when
-        // the commit set is unchanged since the last query. PR-state churn
-        // from the outside world refreshes on the next commits change (a
-        // manual-refresh hook can come with the phase-2 drawer).
-        let key = commits.map(\.sha).joined(separator: "|")
+        // the branch and commit set are unchanged since the last query. PR-
+        // state churn from the outside world refreshes on the next commits
+        // change (a manual-refresh hook can come with the phase-2 drawer).
+        // The branch is part of the key because `gg ls` answers for the
+        // *current* branch — a checkout to a different branch that happens
+        // to share the same commits (e.g. right after `git checkout -b`)
+        // must not reuse the old branch's cached stack.
+        let key = "\(currentBranch)|" + commits.map(\.sha).joined(separator: "|")
         guard key != ggStackCommitsKey else { return }
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -107,6 +107,16 @@ final class RightPaneState {
     /// gg installed, per-project mode) against app-level state.
     var ggGateProvider: (@MainActor () -> Bool)? = nil
     var ggService = GGService()
+    /// Commits ahead of base used for the gg stack-shape check and cache
+    /// key — deliberately NOT the display `commits` list. `commits` follows
+    /// the user's chosen comparison mode, and under "Branch upstream" it is
+    /// `@{u}..HEAD`: once a stack is fully pushed (`gg sync` already ran),
+    /// that list is empty even though the branch still carries GG-ID
+    /// commits relative to its stack base. This tracks the review-loop's
+    /// base-relative commit set instead (`GitService.BaseResolution
+    /// .forReviewLoopBase`, computed in `performRefresh`), which never
+    /// resolves to upstream and so always reflects true stack membership.
+    @ObservationIgnored var ggStackSourceCommits: [CommitInfo] = []
     /// SHA-set key of the last commits list gg was queried for. `gg ls
     /// --json` hits the forge API (best-effort PR-state refresh), and
     /// performRefresh fires continuously from the file watcher — so only
@@ -695,6 +705,7 @@ final class RightPaneState {
             let mergedFileTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
             if self.fileTree != mergedFileTree { self.fileTree = mergedFileTree }
             if self.commits != commits { self.commits = commits }
+            self.ggStackSourceCommits = reviewLoopBaseResult?.commits ?? commits
             ggStackRefreshTask?.cancel()
             ggStackRefreshTask = Task { @MainActor [weak self] in await self?.refreshGGStack() }
             if self.comparisonRef != ref { self.comparisonRef = ref }
@@ -776,12 +787,13 @@ final class RightPaneState {
     }
 
     // Not `private` so tests can call it directly against injected
-    // `commits` / `ggService` without needing a real git repo + watcher.
+    // `ggStackSourceCommits` / `ggService` without needing a real git repo +
+    // watcher.
     @MainActor
     func refreshGGStack() async {
         let snapshotGeneration = snapshotInvalidationGeneration
         let gated = ggGateProvider?() ?? false
-        guard gated, GGStackGate.isStackShaped(commits: commits) else {
+        guard gated, GGStackGate.isStackShaped(commits: ggStackSourceCommits) else {
             ggStackCommitsKey = nil
             if ggStack != nil { ggStack = nil }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
@@ -797,7 +809,7 @@ final class RightPaneState {
         // *current* branch — a checkout to a different branch that happens
         // to share the same commits (e.g. right after `git checkout -b`)
         // must not reuse the old branch's cached stack.
-        let key = "\(currentBranch)|" + commits.map(\.sha).joined(separator: "|")
+        let key = "\(currentBranch)|" + ggStackSourceCommits.map(\.sha).joined(separator: "|")
         guard key != ggStackCommitsKey else { return }
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
@@ -874,11 +886,12 @@ final class RightPaneState {
         fileTree = []
         commits = []
         olderCommits = []
-        // gg stack state is derived from `commits` above — reset it here
-        // too, and cancel any in-flight load, so a delayed or failed
-        // refresh after this invalidation can't leave a stale "Stack · …"
+        // gg stack state is derived from commits above — reset it here too,
+        // and cancel any in-flight load, so a delayed or failed refresh
+        // after this invalidation can't leave a stale "Stack · …"
         // header/sidebar badge rendered against the now-empty commit list.
         ggStackRefreshTask?.cancel()
+        ggStackSourceCommits = []
         ggStackCommitsKey = nil
         if ggStack != nil { ggStack = nil }
         if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -815,19 +815,24 @@ final class RightPaneState {
             }
         } catch {
             // A transient gg/provider failure (gh/glab auth hiccup, network
-            // blip, etc.) must not poison the commits-key cache — leave it
-            // untouched so the next refresh retries instead of being skipped
-            // by the unchanged-key guard above. But whatever `ggStack`
-            // currently holds was loaded for a *different* key (the guard
-            // above only lets us reach this point when the key changed) —
-            // e.g. the previous branch's stack, if the user just checked
-            // out a different stack-shaped branch and this fetch for it
-            // failed. Rendering it against the now-different `commits`
-            // would misattribute its header, PR chips, and sidebar badge
-            // to the wrong branch, so clear it and degrade to plain
-            // commits rather than show stale, mismatched data.
+            // blip, etc.) must not cache the *failed* key `key` — it stays
+            // unset so the next refresh for it retries instead of being
+            // skipped by the unchanged-key guard above. But whatever
+            // `ggStack` currently holds was loaded for the *previous*
+            // cached key (the guard above only lets us reach this point
+            // when `key` differs from it) — e.g. the previous branch's
+            // stack, if the user just checked out a different stack-shaped
+            // branch and this fetch for it failed. Rendering it against the
+            // now-different `commits` would misattribute its header, PR
+            // chips, and sidebar badge to the wrong branch, so clear it and
+            // degrade to plain commits. Clearing `ggStackCommitsKey` too
+            // (not just leaving it at the previous key) matters just as
+            // much: leaving it would make the guard above wrongly treat a
+            // later return to that same branch/commit set as "already
+            // cached" and skip re-fetching the now-cleared stack.
             if Task.isCancelled { return }
             guard snapshotGeneration == snapshotInvalidationGeneration else { return }
+            ggStackCommitsKey = nil
             if ggStack != nil { ggStack = nil }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -100,6 +100,19 @@ final class RightPaneState {
     var hasMoreOlder: Bool = true
     var isLoadingOlder: Bool = false
 
+    /// Current gg stack for this worktree's branch; nil when gating fails
+    /// or the branch is not a stack. Loaded during performRefresh.
+    var ggStack: GGStack? = nil
+    /// Injected by RightPaneStore — resolves gates 1–3 (master toggle,
+    /// gg installed, per-project mode) against app-level state.
+    var ggGateProvider: (@MainActor () -> Bool)? = nil
+    var ggService = GGService()
+    /// SHA-set key of the last commits list gg was queried for. `gg ls
+    /// --json` hits the forge API (best-effort PR-state refresh), and
+    /// performRefresh fires continuously from the file watcher — so only
+    /// re-query gg when the commit set actually changed.
+    private var ggStackCommitsKey: String? = nil
+
     // Sync-nudge state. All fields are in-memory only; nothing is
     // persisted to AppConfig. Two independent conditions:
     //   - behindBase: HEAD is behind the trunk base (origin/main).
@@ -673,6 +686,7 @@ final class RightPaneState {
             let mergedFileTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
             if self.fileTree != mergedFileTree { self.fileTree = mergedFileTree }
             if self.commits != commits { self.commits = commits }
+            await refreshGGStack()
             if self.comparisonRef != ref { self.comparisonRef = ref }
             let preferredCommitRemoteRef = ref ?? baseBranch
             let commitRemote = CodeHostRemoteDetector.detect(
@@ -748,6 +762,33 @@ final class RightPaneState {
             // `self.changes` at its last successful value, which presented as
             // an empty Changes pane when the very first refresh failed.
             logger.error("refresh failed for worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    @MainActor
+    private func refreshGGStack() async {
+        let gated = ggGateProvider?() ?? false
+        guard gated, GGStackGate.isStackShaped(commits: commits) else {
+            ggStackCommitsKey = nil
+            if ggStack != nil { ggStack = nil }
+            if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
+                GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+            }
+            return
+        }
+        // `gg ls --json` reaches out to gh/glab for PR state — skip when
+        // the commit set is unchanged since the last query. PR-state churn
+        // from the outside world refreshes on the next commits change (a
+        // manual-refresh hook can come with the phase-2 drawer).
+        let key = commits.map(\.sha).joined(separator: "|")
+        guard key != ggStackCommitsKey else { return }
+        // Failure degrades to the plain commits section, never an error UI.
+        let stack = try? await ggService.currentStack(worktreePath: worktree.path.path)
+        ggStackCommitsKey = key
+        if ggStack != stack { ggStack = stack }
+        let summary = stack?.summary
+        if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
         }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -779,6 +779,7 @@ final class RightPaneState {
     // `commits` / `ggService` without needing a real git repo + watcher.
     @MainActor
     func refreshGGStack() async {
+        let snapshotGeneration = snapshotInvalidationGeneration
         let gated = ggGateProvider?() ?? false
         guard gated, GGStackGate.isStackShaped(commits: commits) else {
             ggStackCommitsKey = nil
@@ -796,10 +797,12 @@ final class RightPaneState {
         guard key != ggStackCommitsKey else { return }
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
-            // A newer refresh superseded this one — its own `refreshGGStack`
-            // call will write the current state; writing here would race it
-            // with a stale result.
+            // A newer refresh, or a `markSnapshotUnknown()` invalidation,
+            // superseded this one — its own `refreshGGStack` call (or the
+            // invalidation's own reset) will write the current state;
+            // writing here would race it with a stale result.
             if Task.isCancelled { return }
+            guard snapshotGeneration == snapshotInvalidationGeneration else { return }
             ggStackCommitsKey = key
             if ggStack != stack { ggStack = stack }
             let summary = stack?.summary
@@ -850,6 +853,16 @@ final class RightPaneState {
         fileTree = []
         commits = []
         olderCommits = []
+        // gg stack state is derived from `commits` above — reset it here
+        // too, and cancel any in-flight load, so a delayed or failed
+        // refresh after this invalidation can't leave a stale "Stack · …"
+        // header/sidebar badge rendered against the now-empty commit list.
+        ggStackRefreshTask?.cancel()
+        ggStackCommitsKey = nil
+        if ggStack != nil { ggStack = nil }
+        if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+        }
         comparisonRef = nil
         commitRemote = nil
         primaryCommitRemote = nil

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -162,7 +162,8 @@ final class RightPaneStore {
                     masterEnabled: true,
                     ggInstalled: true,
                     mode: project.ggMode,
-                    repoPath: project.path
+                    repoPath: project.path,
+                    isRemoteProject: project.host != nil
                 )
             }
 

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -258,6 +258,15 @@ final class RightPaneStore {
         states[worktreeId]?.markSnapshotUnknown()
     }
 
+    /// Re-evaluate the gg gate across all cached right-pane states after a
+    /// stacked-diffs config change in Settings (master toggle or a
+    /// project's ggMode), so stale stack styling and the sidebar badge
+    /// clear/reload immediately instead of waiting for the next
+    /// watcher-driven refresh.
+    func reevaluateGGGates() {
+        for state in states.values { state.reevaluateGGGate() }
+    }
+
     func commitEditorComparisonRef(worktreeId: String) -> String? {
         guard let state = states[worktreeId] else { return nil }
         return state.comparisonRef

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -150,6 +150,21 @@ final class RightPaneStore {
                 )
                 app.tabs.activate(worktreeId: id, tabId: tab.id)
             }
+            new.ggGateProvider = { [weak self] in
+                guard let app = self?.appState else { return false }
+                guard app.config.changes.stackedDiffsEnabled,
+                      GGAvailability.shared.isInstalled,
+                      let project = app.projectsManager.projects.first(
+                        where: { $0.id == worktree.projectId }
+                      )
+                else { return false }
+                return GGStackGate.projectEnabled(
+                    masterEnabled: true,
+                    ggInstalled: true,
+                    mode: project.ggMode,
+                    repoPath: project.path
+                )
+            }
 
             if shouldDeferInitialRefresh {
                 new.baseBranchProbeTask = Task { @MainActor [weak self, weak new] in

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -201,7 +201,7 @@ struct ChangesPane: View {
             HStack(spacing: 8) {
                 Text(message)
                     .font(.system(size: 11))
-                    .foregroundColor(theme.color("warning"))
+                    .foregroundColor(theme.color("warn"))
                     .lineLimit(2)
                 AlasButton(title: "Retry", style: .normal) { ggInstall.install() }
             }

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -121,6 +121,15 @@ struct ChangesPane: View {
             .padding(.horizontal, 32).padding(.vertical, 24)
         }
         .task { await GGAvailability.shared.probe() }
+        .onChange(of: ggInstall.phase) { _, newPhase in
+            // Right-pane states that already evaluated the gate while gg was
+            // absent are otherwise never asked to re-check it, so an install
+            // completed with a pane open would leave the stack UI missing
+            // until an unrelated refresh happened to fire.
+            if newPhase == .succeeded {
+                state.rightPaneStore.reevaluateGGGates()
+            }
+        }
     }
 
     private var comparisonModeDescription: String {

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -120,7 +120,15 @@ struct ChangesPane: View {
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
         }
-        .task { await GGAvailability.shared.probe() }
+        .task {
+            // Wait for the login-shell PATH first, same as the startup probe
+            // in AppState — otherwise opening Settings early (e.g. right
+            // after a Finder/Dock launch) can win the race and cache a
+            // Homebrew-only `gg` as missing before PATH resolution finishes,
+            // since this is a non-force probe and `hasProbed` latches.
+            await ShellEnvResolver.shared.waitUntilResolved()
+            await GGAvailability.shared.probe()
+        }
         .onChange(of: ggInstall.phase) { _, newPhase in
             // Right-pane states that already evaluated the gate while gg was
             // absent are otherwise never asked to re-check it, so an install

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -74,6 +74,9 @@ struct ChangesPane: View {
                             .toggleStyle(.switch)
                             .labelsHidden()
                             .disabled(!GGAvailability.shared.isInstalled)
+                            .onChange(of: state.config.changes.stackedDiffsEnabled) { _, _ in
+                                state.rightPaneStore.reevaluateGGGates()
+                            }
                     }
                     SettingsRow(
                         name: "Per project",
@@ -204,6 +207,7 @@ struct ChangesPane: View {
             set: { newMode in
                 state.projectsManager.setGGMode(projectId: project.id, mode: newMode)
                 _ = state.saveProjects()
+                state.rightPaneStore.reevaluateGGGates()
             }
         )
     }

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -4,6 +4,7 @@ struct ChangesPane: View {
     @Bindable var state: AppState
     @Environment(\.theme) var theme
     @Environment(\.openWindow) private var openWindow
+    @State private var ggInstall = GGInstallController()
 
     var body: some View {
         ScrollView {
@@ -56,6 +57,45 @@ struct ChangesPane: View {
                     }
                 }
 
+                SettingsGroup(title: "Stacked diffs") {
+                    SettingsRow(
+                        name: "git-gud (gg)",
+                        desc: GGAvailability.shared.isInstalled
+                            ? "Stack-aware commits section, synced from gg."
+                            : "Installs via Homebrew: brew install mrmans0n/tap/gg-stack"
+                    ) {
+                        ggStatusControl
+                    }
+                    SettingsRow(
+                        name: "Enable stacked diffs",
+                        desc: "Master switch. Off hides all gg UI everywhere."
+                    ) {
+                        Toggle("", isOn: state.bind(\.changes.stackedDiffsEnabled))
+                            .toggleStyle(.switch)
+                            .labelsHidden()
+                            .disabled(!GGAvailability.shared.isInstalled)
+                    }
+                    SettingsRow(
+                        name: "Per project",
+                        desc: "Auto enables gg UI when the repo's main worktree has .git/gg/config.json."
+                    ) {
+                        EmptyView()
+                    }
+                    ForEach(state.projectsManager.projects) { project in
+                        SettingsRow(name: project.name, desc: "") {
+                            Picker("", selection: ggModeBinding(project)) {
+                                Text("Off").tag(GGProjectMode.off)
+                                Text("Auto").tag(GGProjectMode.auto)
+                                Text("On").tag(GGProjectMode.on)
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+                            .disabled(!GGAvailability.shared.isInstalled
+                                      || !state.config.changes.stackedDiffsEnabled)
+                        }
+                    }
+                }
+
                 SettingsGroup(title: "Merge conflicts") {
                     SettingsRow(name: "Bulk resolve prompt",
                                 desc: "Sent to the agent CWD'd at the worktree when the user clicks 'Resolve all with agent'. The agent uses its own tools to enumerate, reconcile, and stage every conflicted file.") {
@@ -77,6 +117,7 @@ struct ChangesPane: View {
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
         }
+        .task { await GGAvailability.shared.probe() }
     }
 
     private var comparisonModeDescription: String {
@@ -124,6 +165,47 @@ struct ChangesPane: View {
         }
         .pickerStyle(.menu)
         .settingsDropdownFrame()
+    }
+
+    @ViewBuilder
+    private var ggStatusControl: some View {
+        switch ggInstall.phase {
+        case .running:
+            HStack(spacing: 6) {
+                Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
+                Text("Installing…")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+        case .failed(let message):
+            HStack(spacing: 8) {
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("warning"))
+                    .lineLimit(2)
+                AlasButton(title: "Retry", style: .normal) { ggInstall.install() }
+            }
+        case .idle, .succeeded:
+            if let version = GGAvailability.shared.version {
+                Text("gg \(version)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg-muted"))
+            } else {
+                AlasButton(title: "Install gg…", style: .normal) { ggInstall.install() }
+            }
+        }
+    }
+
+    private func ggModeBinding(_ project: ProjectConfig) -> Binding<GGProjectMode> {
+        Binding(
+            get: {
+                state.projectsManager.projects.first { $0.id == project.id }?.ggMode ?? .auto
+            },
+            set: { newMode in
+                state.projectsManager.setGGMode(projectId: project.id, mode: newMode)
+                _ = state.saveProjects()
+            }
+        )
     }
 }
 

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -48,6 +48,10 @@ struct WorktreeRowView: View {
         }
     }
 
+    private var stackSummary: GGStackSummary? {
+        GGStackSummaryStore.shared.summaries[worktree.path.path]
+    }
+
     var body: some View {
         ZStack(alignment: .leading) {
             if isSelected {
@@ -92,6 +96,12 @@ struct WorktreeRowView: View {
                             Text("−\(worktree.deletedLines)")
                                 .font(.system(size: 10.5, design: .monospaced))
                                 .foregroundColor(theme.color("del"))
+                        }
+                        if let stack = stackSummary {
+                            Text("▲ \(stack.merged)/\(stack.total)")
+                                .font(.system(size: 10.5, design: .monospaced))
+                                .foregroundColor(theme.color("accent"))
+                                .help("gg stack · \(stack.merged) of \(stack.total) entries merged")
                         }
                         if let summary = harnessSummary {
                             Spacer()

--- a/AlasTests/CommitsSectionTitleTests.swift
+++ b/AlasTests/CommitsSectionTitleTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import Alas
+
+struct CommitsSectionTitleTests {
+    private func stack(name: String = "nacho/stack") -> GGStack {
+        GGStack(
+            name: name, base: "main", totalCommits: 1, syncedCommits: 1,
+            currentPosition: nil, behindBase: nil, entries: []
+        )
+    }
+
+    @Test func plainCommitsWhenNoStack() {
+        #expect(CommitsSectionView.sectionTitle(ggStack: nil, commitsEmpty: false) == "Commits")
+        #expect(CommitsSectionView.sectionTitle(ggStack: nil, commitsEmpty: true) == "Commits")
+    }
+
+    @Test func stackTitleWhenStackPresentAndCommitsNonEmpty() {
+        #expect(
+            CommitsSectionView.sectionTitle(ggStack: stack(), commitsEmpty: false)
+                == "Stack · nacho/stack"
+        )
+    }
+
+    /// A synced stack under "Branch upstream" comparison mode loads
+    /// `ggStack` (feeding the sidebar badge) while the display `commits`
+    /// list is empty. The header must not promise "Stack · …" content that
+    /// the (empty) body can't render.
+    @Test func plainCommitsWhenStackPresentButCommitsEmpty() {
+        #expect(CommitsSectionView.sectionTitle(ggStack: stack(), commitsEmpty: true) == "Commits")
+    }
+}

--- a/AlasTests/GGConfigCodableTests.swift
+++ b/AlasTests/GGConfigCodableTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGConfigCodableTests {
+    @Test func projectConfigGGModeDefaultsToAutoWhenMissing() throws {
+        let json = """
+        {"id": "p1", "name": "alas", "path": "/tmp/alas", "color": "teal",
+         "addedAt": 700000000}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let project = try decoder.decode(ProjectConfig.self, from: Data(json.utf8))
+        #expect(project.ggMode == .auto)
+    }
+
+    @Test func projectConfigGGModeRoundTrips() throws {
+        var project = ProjectConfig(
+            id: "p1", name: "alas", path: "/tmp/alas", color: "teal", addedAt: Date()
+        )
+        project.ggMode = .on
+        let data = try JSONEncoder().encode(project)
+        let decoded = try JSONDecoder().decode(ProjectConfig.self, from: data)
+        #expect(decoded.ggMode == .on)
+    }
+
+    @Test func stackedDiffsEnabledDefaultsTrueOnLegacyConfig() throws {
+        // Simulate a config written before `stackedDiffsEnabled` existed by
+        // encoding the defaults and stripping the key from the changes
+        // section before decoding. `AppConfig.init(from:)` requires other
+        // top-level keys, so a bare minimal JSON literal isn't decodable.
+        let defaultsData = try JSONEncoder().encode(AppConfig.defaults)
+        var root = try JSONSerialization.jsonObject(with: defaultsData) as! [String: Any]
+        var changesSection = root["changes"] as! [String: Any]
+        changesSection.removeValue(forKey: "stackedDiffsEnabled")
+        root["changes"] = changesSection
+        let legacyData = try JSONSerialization.data(withJSONObject: root)
+
+        let config = try JSONDecoder().decode(AppConfig.self, from: legacyData)
+        #expect(config.changes.stackedDiffsEnabled)
+    }
+
+    @Test func stackedDiffsEnabledRoundTrips() throws {
+        var config = AppConfig.defaults
+        config.changes.stackedDiffsEnabled = false
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(!decoded.changes.stackedDiffsEnabled)
+    }
+}

--- a/AlasTests/Integrations/GGInstallControllerTests.swift
+++ b/AlasTests/Integrations/GGInstallControllerTests.swift
@@ -7,7 +7,10 @@ struct GGInstallControllerTests {
         var probed = false
         let controller = GGInstallController(
             runInstall: { ProcessResult(exitCode: 0, stdout: "installed", stderr: "") },
-            reprobe: { probed = true; return true }
+            reprobe: {
+                probed = true
+                return true
+            }
         )
         await controller.installAndWait()
         #expect(controller.phase == .succeeded)

--- a/AlasTests/Integrations/GGInstallControllerTests.swift
+++ b/AlasTests/Integrations/GGInstallControllerTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct GGInstallControllerTests {
+    @Test func successfulInstallReachesSucceededAndReprobes() async {
+        var probed = false
+        let controller = GGInstallController(
+            runInstall: { ProcessResult(exitCode: 0, stdout: "installed", stderr: "") },
+            reprobe: { probed = true; return true }
+        )
+        await controller.installAndWait()
+        #expect(controller.phase == .succeeded)
+        #expect(probed)
+    }
+
+    @Test func brewFailureSurfacesStderr() async {
+        let controller = GGInstallController(
+            runInstall: { ProcessResult(exitCode: 1, stdout: "", stderr: "no tap") },
+            reprobe: { true }
+        )
+        await controller.installAndWait()
+        #expect(controller.phase == .failed("no tap"))
+    }
+
+    @Test func installedButNotOnPathFails() async {
+        let controller = GGInstallController(
+            runInstall: { ProcessResult(exitCode: 0, stdout: "", stderr: "") },
+            reprobe: { false }
+        )
+        await controller.installAndWait()
+        #expect(controller.phase == .failed("gg is still not on PATH after install."))
+    }
+}

--- a/AlasTests/Integrations/GGServiceTests.swift
+++ b/AlasTests/Integrations/GGServiceTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import Alas
+
+private struct FakeGGRunner: GGCommandRunning {
+    let result: ProcessResult
+    private let recorded: RecordedArgs
+
+    final class RecordedArgs: @unchecked Sendable {
+        var args: [String] = []
+        var cwd: URL?
+    }
+
+    init(result: ProcessResult, recorded: RecordedArgs = RecordedArgs()) {
+        self.result = result
+        self.recorded = recorded
+    }
+
+    var lastArgs: [String] { recorded.args }
+    var lastCwd: URL? { recorded.cwd }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        recorded.args = args
+        recorded.cwd = cwd
+        return result
+    }
+}
+
+struct GGServiceTests {
+    @Test func probeVersionParsesOutput() async {
+        let runner = FakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: "gg 0.9.8\n", stderr: "")
+        )
+        let service = GGService(runner: runner)
+        #expect(await service.probeVersion() == "0.9.8")
+        #expect(runner.lastArgs == ["--version"])
+    }
+
+    @Test func probeVersionReturnsNilWhenMissing() async {
+        let runner = FakeGGRunner(
+            result: ProcessResult(exitCode: 127, stdout: "", stderr: "gg: command not found")
+        )
+        #expect(await GGService(runner: runner).probeVersion() == nil)
+    }
+
+    @Test func currentStackDecodesStack() async throws {
+        let runner = FakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        let service = GGService(runner: runner)
+        let stack = try await service.currentStack(worktreePath: "/tmp/wt")
+        #expect(stack?.name == "agent-inbox")
+        #expect(runner.lastArgs == ["ls", "--json"])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
+    }
+
+    @Test func currentStackReturnsNilOffStack() async throws {
+        let runner = FakeGGRunner(
+            result: ProcessResult(
+                exitCode: 0,
+                stdout: #"{"version": 1, "current_stack": null, "stacks": []}"#,
+                stderr: ""
+            )
+        )
+        let stack = try await GGService(runner: runner).currentStack(worktreePath: "/tmp/wt")
+        #expect(stack == nil)
+    }
+
+    @Test func currentStackMapsExit127ToCliMissing() async {
+        let runner = FakeGGRunner(
+            result: ProcessResult(exitCode: 127, stdout: "", stderr: "not found")
+        )
+        await #expect(throws: GGServiceError.cliMissing) {
+            _ = try await GGService(runner: runner).currentStack(worktreePath: "/tmp/wt")
+        }
+    }
+
+    @Test func currentStackMapsNonzeroExitToCommandFailed() async {
+        let runner = FakeGGRunner(
+            result: ProcessResult(exitCode: 1, stdout: "", stderr: "boom")
+        )
+        await #expect(throws: GGServiceError.commandFailed(stderr: "boom")) {
+            _ = try await GGService(runner: runner).currentStack(worktreePath: "/tmp/wt")
+        }
+    }
+}

--- a/AlasTests/Integrations/GGStackChipModelTests.swift
+++ b/AlasTests/Integrations/GGStackChipModelTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import Alas
+
+struct GGStackChipModelTests {
+    private func entry(
+        prNumber: Int? = 840,
+        prState: GGPRState? = .open,
+        approved: Bool = false
+    ) -> GGStackEntry {
+        GGStackEntry(
+            position: 1, sha: "abc1234", title: "t",
+            prNumber: prNumber, prState: prState, approved: approved
+        )
+    }
+
+    @Test func noChipWithoutPRNumber() {
+        #expect(GGStackChipModel.model(for: entry(prNumber: nil), kind: .github) == nil)
+    }
+
+    @Test func githubUsesHashPrefixGitlabUsesBang() {
+        #expect(GGStackChipModel.model(for: entry(), kind: .github)?.label == "#840")
+        #expect(GGStackChipModel.model(for: entry(), kind: .gitlab)?.label == "!840")
+        #expect(GGStackChipModel.model(for: entry(), kind: nil)?.label == "#840")
+    }
+
+    @Test func approvedAddsCheckmark() {
+        #expect(GGStackChipModel.model(for: entry(approved: true), kind: .github)?.label == "#840 ✓")
+    }
+
+    @Test func stateMapsToColorToken() {
+        #expect(GGStackChipModel.model(for: entry(prState: .open), kind: .github)?.colorToken == "add")
+        #expect(GGStackChipModel.model(for: entry(prState: .merged), kind: .github)?.colorToken == "accent")
+        #expect(GGStackChipModel.model(for: entry(prState: .draft), kind: .github)?.colorToken == "fg-muted")
+        #expect(GGStackChipModel.model(for: entry(prState: .closed), kind: .github)?.colorToken == "del")
+        #expect(GGStackChipModel.model(for: entry(prState: nil), kind: .github)?.colorToken == "fg-faint")
+    }
+}

--- a/AlasTests/Integrations/GGStackGateTests.swift
+++ b/AlasTests/Integrations/GGStackGateTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGStackGateTests {
+    private func makeRepo(withGGConfig: Bool) throws -> String {
+        let dir = NSTemporaryDirectory() + "gg-gate-" + UUID().uuidString
+        let ggDir = dir + "/.git/gg"
+        try FileManager.default.createDirectory(
+            atPath: withGGConfig ? ggDir : dir + "/.git",
+            withIntermediateDirectories: true
+        )
+        if withGGConfig {
+            FileManager.default.createFile(atPath: ggDir + "/config.json", contents: Data("{}".utf8))
+        }
+        return dir
+    }
+
+    private func commit(body: String) -> CommitInfo {
+        CommitInfo(
+            sha: String(repeating: "a", count: 40), shortSha: "aaaaaaa",
+            author: "Test", authorInitials: "T", date: Date(),
+            subject: "subject", body: body, conventionalTag: nil,
+            filesChanged: 1, insertions: 1, deletions: 0
+        )
+    }
+
+    @Test func detectsGGConfigFile() throws {
+        #expect(GGStackGate.repoHasGGConfig(repoPath: try makeRepo(withGGConfig: true)))
+        #expect(!GGStackGate.repoHasGGConfig(repoPath: try makeRepo(withGGConfig: false)))
+    }
+
+    @Test func projectEnabledMatrix() throws {
+        let ggRepo = try makeRepo(withGGConfig: true)
+        let plainRepo = try makeRepo(withGGConfig: false)
+        // Master off / gg missing kill everything.
+        #expect(!GGStackGate.projectEnabled(masterEnabled: false, ggInstalled: true, mode: .on, repoPath: ggRepo))
+        #expect(!GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: false, mode: .on, repoPath: ggRepo))
+        // off always hides; on always allows; auto follows the config file.
+        #expect(!GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .off, repoPath: ggRepo))
+        #expect(GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .on, repoPath: plainRepo))
+        #expect(GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .auto, repoPath: ggRepo))
+        #expect(!GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .auto, repoPath: plainRepo))
+    }
+
+    @Test func stackShapeRequiresGGIDTrailer() {
+        let stacked = commit(body: "Some detail.\n\nGG-ID: abc123\nGG-Parent: def456")
+        let plain = commit(body: "Just a normal body mentioning GG-ID: in prose? No — mid-line doesn't count.")
+        #expect(GGStackGate.isStackShaped(commits: [plain, stacked]))
+        #expect(!GGStackGate.isStackShaped(commits: [plain]))
+        #expect(!GGStackGate.isStackShaped(commits: []))
+    }
+}

--- a/AlasTests/Integrations/GGStackGateTests.swift
+++ b/AlasTests/Integrations/GGStackGateTests.swift
@@ -16,6 +16,23 @@ struct GGStackGateTests {
         return dir
     }
 
+    /// Builds a primary checkout with a real `.git` directory (optionally
+    /// carrying gg config) plus a linked worktree whose `.git` is a *file*
+    /// pointing at a private per-worktree dir under
+    /// `<main>/.git/worktrees/<name>`, itself carrying a `commondir` file
+    /// that points back to `<main>/.git` — mirroring real `git worktree add`
+    /// output. Returns (mainRepoPath, linkedWorktreePath).
+    private func makeRepoWithLinkedWorktree(withGGConfig: Bool) throws -> (main: String, linked: String) {
+        let main = try makeRepo(withGGConfig: withGGConfig)
+        let linked = NSTemporaryDirectory() + "gg-gate-linked-" + UUID().uuidString
+        let privateGitDir = main + "/.git/worktrees/feature"
+        try FileManager.default.createDirectory(atPath: privateGitDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: linked, withIntermediateDirectories: true)
+        try "../..".write(toFile: privateGitDir + "/commondir", atomically: true, encoding: .utf8)
+        try "gitdir: \(privateGitDir)".write(toFile: linked + "/.git", atomically: true, encoding: .utf8)
+        return (main, linked)
+    }
+
     private func commit(body: String) -> CommitInfo {
         CommitInfo(
             sha: String(repeating: "a", count: 40), shortSha: "aaaaaaa",
@@ -41,6 +58,15 @@ struct GGStackGateTests {
         #expect(GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .on, repoPath: plainRepo))
         #expect(GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .auto, repoPath: ggRepo))
         #expect(!GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .auto, repoPath: plainRepo))
+    }
+
+    @Test func detectsGGConfigThroughLinkedWorktreeCommonDir() throws {
+        let (mainWithConfig, linkedWithConfig) = try makeRepoWithLinkedWorktree(withGGConfig: true)
+        #expect(GGStackGate.repoHasGGConfig(repoPath: mainWithConfig))
+        #expect(GGStackGate.repoHasGGConfig(repoPath: linkedWithConfig))
+
+        let (_, linkedWithoutConfig) = try makeRepoWithLinkedWorktree(withGGConfig: false)
+        #expect(!GGStackGate.repoHasGGConfig(repoPath: linkedWithoutConfig))
     }
 
     @Test func stackShapeRequiresGGIDTrailer() {

--- a/AlasTests/Integrations/GGStackGateTests.swift
+++ b/AlasTests/Integrations/GGStackGateTests.swift
@@ -51,13 +51,37 @@ struct GGStackGateTests {
         let ggRepo = try makeRepo(withGGConfig: true)
         let plainRepo = try makeRepo(withGGConfig: false)
         // Master off / gg missing kill everything.
-        #expect(!GGStackGate.projectEnabled(masterEnabled: false, ggInstalled: true, mode: .on, repoPath: ggRepo))
-        #expect(!GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: false, mode: .on, repoPath: ggRepo))
+        #expect(!GGStackGate.projectEnabled(
+            masterEnabled: false, ggInstalled: true, mode: .on, repoPath: ggRepo, isRemoteProject: false
+        ))
+        #expect(!GGStackGate.projectEnabled(
+            masterEnabled: true, ggInstalled: false, mode: .on, repoPath: ggRepo, isRemoteProject: false
+        ))
         // off always hides; on always allows; auto follows the config file.
-        #expect(!GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .off, repoPath: ggRepo))
-        #expect(GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .on, repoPath: plainRepo))
-        #expect(GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .auto, repoPath: ggRepo))
-        #expect(!GGStackGate.projectEnabled(masterEnabled: true, ggInstalled: true, mode: .auto, repoPath: plainRepo))
+        #expect(!GGStackGate.projectEnabled(
+            masterEnabled: true, ggInstalled: true, mode: .off, repoPath: ggRepo, isRemoteProject: false
+        ))
+        #expect(GGStackGate.projectEnabled(
+            masterEnabled: true, ggInstalled: true, mode: .on, repoPath: plainRepo, isRemoteProject: false
+        ))
+        #expect(GGStackGate.projectEnabled(
+            masterEnabled: true, ggInstalled: true, mode: .auto, repoPath: ggRepo, isRemoteProject: false
+        ))
+        #expect(!GGStackGate.projectEnabled(
+            masterEnabled: true, ggInstalled: true, mode: .auto, repoPath: plainRepo, isRemoteProject: false
+        ))
+    }
+
+    /// gg's runner is local-only, unlike git's own process wrapper, which
+    /// rewrites invocations to SSH for registered remote hosts. A remote
+    /// project must never enable gg, regardless of mode.
+    @Test func remoteProjectIsAlwaysDisabledRegardlessOfMode() throws {
+        let ggRepo = try makeRepo(withGGConfig: true)
+        for mode: GGProjectMode in [.off, .auto, .on] {
+            #expect(!GGStackGate.projectEnabled(
+                masterEnabled: true, ggInstalled: true, mode: mode, repoPath: ggRepo, isRemoteProject: true
+            ))
+        }
     }
 
     @Test func detectsGGConfigThroughLinkedWorktreeCommonDir() throws {

--- a/AlasTests/Integrations/GGStackModelsTests.swift
+++ b/AlasTests/Integrations/GGStackModelsTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGStackModelsTests {
+    static let fixture = """
+    {
+      "version": 1,
+      "stack": {
+        "name": "agent-inbox",
+        "base": "main",
+        "total_commits": 3,
+        "synced_commits": 2,
+        "current_position": 3,
+        "behind_base": null,
+        "entries": [
+          {"position": 1, "sha": "aaaaaaa", "title": "chore: config plumbing",
+           "gg_id": "id-1", "gg_parent": null, "pr_number": 837, "pr_state": "merged",
+           "approved": true, "ci_status": "success", "is_current": false,
+           "in_merge_train": false, "merge_train_position": null},
+          {"position": 2, "sha": "bbbbbbb", "title": "feat: stack section UI",
+           "gg_id": "id-2", "gg_parent": "id-1", "pr_number": 840, "pr_state": "open",
+           "approved": true, "ci_status": "running", "is_current": false,
+           "in_merge_train": false, "merge_train_position": null},
+          {"position": 3, "sha": "ccccccc", "title": "feat: sidebar badge",
+           "gg_id": "id-3", "gg_parent": "id-2", "pr_number": null, "pr_state": null,
+           "approved": false, "ci_status": null, "is_current": true,
+           "in_merge_train": false, "merge_train_position": null}
+        ]
+      }
+    }
+    """
+
+    @Test func decodesSingleStackResponse() throws {
+        let snapshot = try GGStackSnapshot.decode(fromJSON: Data(Self.fixture.utf8))
+        let stack = try #require(snapshot.stack)
+        #expect(stack.name == "agent-inbox")
+        #expect(stack.base == "main")
+        #expect(stack.totalCommits == 3)
+        #expect(stack.syncedCommits == 2)
+        #expect(stack.currentPosition == 3)
+        #expect(stack.entries.count == 3)
+        let first = stack.entries[0]
+        #expect(first.prNumber == 837)
+        #expect(first.prState == .merged)
+        #expect(first.ciStatus == .success)
+        #expect(first.approved)
+        #expect(first.id == "id-1")
+        #expect(stack.entries[2].prState == nil)
+        #expect(stack.entries[2].isCurrent)
+    }
+
+    @Test func nonStackResponseDecodesWithNilStack() throws {
+        let json = #"{"version": 1, "current_stack": null, "stacks": []}"#
+        let snapshot = try GGStackSnapshot.decode(fromJSON: Data(json.utf8))
+        #expect(snapshot.stack == nil)
+    }
+
+    @Test func unknownEnumStringsDecodeAsNil() throws {
+        let json = Self.fixture
+            .replacingOccurrences(of: "\"merged\"", with: "\"locked\"")
+            .replacingOccurrences(of: "\"success\"", with: "\"exploded\"")
+        let snapshot = try GGStackSnapshot.decode(fromJSON: Data(json.utf8))
+        let stack = try #require(snapshot.stack)
+        #expect(stack.entries[0].prState == nil)
+        #expect(stack.entries[0].ciStatus == nil)
+    }
+
+    @Test func unsupportedSchemaVersionThrows() {
+        let json = #"{"version": 99, "stack": null}"#
+        #expect(throws: GGServiceError.unsupportedSchema(99)) {
+            _ = try GGStackSnapshot.decode(fromJSON: Data(json.utf8))
+        }
+    }
+
+    @Test func summaryCountsMergedEntries() throws {
+        let snapshot = try GGStackSnapshot.decode(fromJSON: Data(Self.fixture.utf8))
+        let summary = try #require(snapshot.stack?.summary)
+        #expect(summary.merged == 1)
+        #expect(summary.total == 3)
+    }
+
+    @Test func entryMatchesFullCommitSHAByPrefix() throws {
+        let snapshot = try GGStackSnapshot.decode(fromJSON: Data(Self.fixture.utf8))
+        let stack = try #require(snapshot.stack)
+        let full = "bbbbbbb" + String(repeating: "0", count: 33)
+        #expect(stack.entry(matchingCommitSHA: full)?.prNumber == 840)
+        #expect(stack.entry(matchingCommitSHA: "ddddddd") == nil)
+    }
+}

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -165,6 +165,43 @@ struct RightPaneGGStackTests {
         #expect(runner.callCount == 2)
     }
 
+    /// A stack loaded for one branch must not keep rendering after the user
+    /// switches to a different stack-shaped branch and the reload for it
+    /// fails transiently — the stale stack no longer matches `commits`.
+    @Test func failedReloadClearsStaleStackFromDifferentBranch() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+
+        let okRunner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: okRunner)
+        state.ggGateProvider = { true }
+        state.currentBranch = "nacho/stack-a"
+        state.commits = [commit(sha: String(repeating: "i", count: 40), stackShaped: true)]
+        await state.refreshGGStack()
+        #expect(state.ggStack != nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] != nil)
+
+        let throwingRunner = ThrowingFakeGGRunner()
+        state.ggService = GGService(runner: throwingRunner)
+        state.currentBranch = "nacho/stack-b"
+        state.commits = [commit(sha: String(repeating: "j", count: 40), stackShaped: true)]
+        await state.refreshGGStack()
+
+        #expect(throwingRunner.callCount == 1)
+        #expect(state.ggStack == nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+
+        // The failed branch-B key must not have been cached (it stays at
+        // whatever branch-A's successful load left it at, which is neither
+        // nil nor branch B's key) — retrying must re-invoke gg rather than
+        // being skipped by the unchanged-key guard.
+        #expect(state.ggStackCommitsKey != "nacho/stack-b|" + String(repeating: "j", count: 40))
+        await state.refreshGGStack()
+        #expect(throwingRunner.callCount == 2)
+    }
+
     /// `gg ls --json` answers for the *current* branch, so a checkout to a
     /// different branch that happens to share the same commit SHAs (e.g.
     /// right after `git checkout -b` from the same HEAD) must not reuse the

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -165,6 +165,29 @@ struct RightPaneGGStackTests {
         #expect(runner.callCount == 2)
     }
 
+    /// `gg ls --json` answers for the *current* branch, so a checkout to a
+    /// different branch that happens to share the same commit SHAs (e.g.
+    /// right after `git checkout -b` from the same HEAD) must not reuse the
+    /// previous branch's cached stack via the unchanged-commits guard.
+    @Test func branchChangeWithSameCommitsReinvokesCLI() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.currentBranch = "nacho/stack-a"
+        state.commits = [commit(sha: String(repeating: "h", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(runner.callCount == 1)
+
+        state.currentBranch = "nacho/stack-b"
+        await state.refreshGGStack()
+        #expect(runner.callCount == 2)
+    }
+
     /// `markSnapshotUnknown()` resets `commits` along with the rest of the
     /// snapshot; gg stack state derives from `commits`, so it must be reset
     /// in lockstep or a delayed/failed refresh after invalidation can leave

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -193,13 +193,53 @@ struct RightPaneGGStackTests {
         #expect(state.ggStack == nil)
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
 
-        // The failed branch-B key must not have been cached (it stays at
-        // whatever branch-A's successful load left it at, which is neither
-        // nil nor branch B's key) — retrying must re-invoke gg rather than
-        // being skipped by the unchanged-key guard.
-        #expect(state.ggStackCommitsKey != "nacho/stack-b|" + String(repeating: "j", count: 40))
+        // The cache key is reset (not left at branch A's stale key, and not
+        // set to branch B's failed key) — retrying must re-invoke gg rather
+        // than being skipped by the unchanged-key guard either way.
+        #expect(state.ggStackCommitsKey == nil)
         await state.refreshGGStack()
         #expect(throwingRunner.callCount == 2)
+    }
+
+    /// The cache key must be reset (not left pointing at the last
+    /// *successful* key) when a later reload fails and clears `ggStack` —
+    /// otherwise returning to that prior branch/commit set would hit the
+    /// unchanged-key guard and skip re-fetching the now-cleared stack,
+    /// leaving the UI stuck showing plain commits.
+    @Test func failedReloadAllowsRefetchOnReturnToPriorBranch() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let commitsA = [commit(sha: String(repeating: "k", count: 40), stackShaped: true)]
+
+        let firstRunner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: firstRunner)
+        state.ggGateProvider = { true }
+        state.currentBranch = "nacho/stack-a"
+        state.commits = commitsA
+        await state.refreshGGStack()
+        #expect(state.ggStack != nil)
+
+        let throwingRunner = ThrowingFakeGGRunner()
+        state.ggService = GGService(runner: throwingRunner)
+        state.currentBranch = "nacho/stack-b"
+        state.commits = [commit(sha: String(repeating: "l", count: 40), stackShaped: true)]
+        await state.refreshGGStack()
+        #expect(state.ggStack == nil)
+
+        // Back to branch A with the exact same commits as the first,
+        // successful load — must re-fetch, not be skipped as "unchanged".
+        let secondRunner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: secondRunner)
+        state.currentBranch = "nacho/stack-a"
+        state.commits = commitsA
+        await state.refreshGGStack()
+
+        #expect(secondRunner.callCount == 1)
+        #expect(state.ggStack != nil)
     }
 
     /// `gg ls --json` answers for the *current* branch, so a checkout to a

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -19,6 +19,17 @@ private final class CountingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
     }
 }
 
+/// Always throws, simulating a transient gg/provider failure (e.g. a gh/glab
+/// auth hiccup) rather than a real "not a stack" result.
+private final class ThrowingFakeGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var callCount = 0
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        callCount += 1
+        throw GGServiceError.commandFailed(stderr: "boom")
+    }
+}
+
 @MainActor
 struct RightPaneGGStackTests {
     private func makeWorktree() -> Worktree {
@@ -129,5 +140,28 @@ struct RightPaneGGStackTests {
 
         #expect(state.ggStack == nil)
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+    }
+
+    /// A thrown gg failure must not cache the commits key — otherwise a
+    /// transient error (auth hiccup, network blip) permanently skips retries
+    /// for that commit set via the unchanged-key guard, even after the
+    /// underlying problem clears up.
+    @Test func transientFailureDoesNotPoisonCommitsKeyCache() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let runner = ThrowingFakeGGRunner()
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.commits = [commit(sha: String(repeating: "f", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(runner.callCount == 1)
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackCommitsKey == nil)
+
+        // Same commit set again — since the key was never cached, this must
+        // retry rather than being skipped by the unchanged-key guard.
+        await state.refreshGGStack()
+        #expect(runner.callCount == 2)
     }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -103,4 +103,31 @@ struct RightPaneGGStackTests {
         await state.refreshGGStack()
         #expect(runner.callCount == 2)
     }
+
+    /// `reevaluateGGGate()` must clear stale stack state immediately when the
+    /// gate flips closed (e.g. the Settings master toggle goes off), rather
+    /// than waiting for the next watcher-driven refresh. `reevaluateGGGate()`
+    /// returns its underlying fire-and-forget task so the test can await it
+    /// deterministically instead of racing the MainActor scheduler.
+    @Test func reevaluateGGGateClearsStackWhenGateClosed() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.commits = [commit(sha: String(repeating: "e", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(state.ggStack != nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] != nil)
+
+        // Simulate the master toggle going off in Settings.
+        state.ggGateProvider = { false }
+        await state.reevaluateGGGate().value
+
+        #expect(state.ggStack == nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+    }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import Alas
+
+/// Counts `run(...)` calls so tests can assert `refreshGGStack()` skips the
+/// gg CLI when gated closed / not stack-shaped, and dedupes when the commit
+/// set is unchanged since the last query.
+private final class CountingFakeGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var callCount = 0
+    let result: ProcessResult
+
+    init(result: ProcessResult) {
+        self.result = result
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        callCount += 1
+        return result
+    }
+}
+
+@MainActor
+struct RightPaneGGStackTests {
+    private func makeWorktree() -> Worktree {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-stack-\(UUID().uuidString)")
+        return Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "test-project",
+            name: "feature",
+            branch: "feature",
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    private func commit(sha: String, stackShaped: Bool) -> CommitInfo {
+        CommitInfo(
+            sha: sha, shortSha: String(sha.prefix(7)),
+            author: "Test", authorInitials: "T", date: Date(),
+            subject: "subject",
+            body: stackShaped ? "Some detail.\n\nGG-ID: abc123\nGG-Parent: def456" : "Just a plain commit body.",
+            conventionalTag: nil,
+            filesChanged: 1, insertions: 1, deletions: 0
+        )
+    }
+
+    @Test func gateClosedSkipsCLIAndClearsStack() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { false }
+        state.commits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 0)
+        #expect(state.ggStack == nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+    }
+
+    @Test func notStackShapedSkipsCLIAndClearsStack() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.commits = [commit(sha: String(repeating: "b", count: 40), stackShaped: false)]
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 0)
+        #expect(state.ggStack == nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+    }
+
+    @Test func unchangedCommitSetDoesNotReinvokeCLI() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.commits = [commit(sha: String(repeating: "c", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(runner.callCount == 1)
+        #expect(state.ggStack != nil)
+
+        // Same commit set (same fingerprint) — must not hit the CLI again.
+        await state.refreshGGStack()
+        #expect(runner.callCount == 1)
+
+        // Changing the commit set (new fingerprint) — must re-query.
+        state.commits = [commit(sha: String(repeating: "d", count: 40), stackShaped: true)]
+        await state.refreshGGStack()
+        #expect(runner.callCount == 2)
+    }
+}

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -57,6 +57,63 @@ struct RightPaneGGStackTests {
         )
     }
 
+    /// A real repo with `main` pushed to a bare remote, then a `nacho/stack`
+    /// branch carrying one GG-ID-trailered commit — also fully pushed, so
+    /// `@{u}` == HEAD and the branch has nothing left unpushed.
+    private func createSyncedStackRepoWithUpstream() async throws -> (worktree: URL, root: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-stack-upstream-\(UUID().uuidString)")
+        let remote = root.appendingPathComponent("remote.git")
+        let worktree = root.appendingPathComponent("clone")
+        try FileManager.default.createDirectory(at: remote, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "--bare", "-b", "main"], cwd: remote)
+        _ = try await Process.git(["clone", "-q", remote.path, worktree.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: worktree)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: worktree)
+        try "base\n".write(to: worktree.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: worktree)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: worktree)
+        _ = try await Process.git(["checkout", "-q", "-b", "nacho/stack"], cwd: worktree)
+        try "stack\n".write(to: worktree.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: worktree)
+        _ = try await Process.git(
+            ["commit", "-q", "-m", "feat: stack work", "-m", "GG-ID: abc123\nGG-Parent: def456"],
+            cwd: worktree
+        )
+        _ = try await Process.git(["push", "-q", "-u", "origin", "nacho/stack"], cwd: worktree)
+        return (worktree, root)
+    }
+
+    /// A gg stack that's already fully pushed (`gg sync` already ran) must
+    /// still be detected under "Branch upstream" comparison mode. There the
+    /// *display* `commits` list is `@{u}..HEAD` — empty once synced — but
+    /// `ggStackSourceCommits` (fed by the review-loop base resolution,
+    /// which never uses upstream) must still reflect the branch's GG-ID
+    /// commit relative to `main`, or the stack-shape gate would incorrectly
+    /// treat a synced stack as "not a stack" and clear the UI.
+    @Test func performRefreshPopulatesGGStackSourceCommitsUnderBranchUpstreamMode() async throws {
+        let (repo, root) = try await createSyncedStackRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let wt = Worktree(
+            id: Worktree.makeId(path: repo),
+            projectId: "test-project",
+            name: "nacho/stack",
+            branch: "nacho/stack",
+            path: repo,
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.comparisonMode = .branchUpstream
+
+        await state.refresh()
+
+        #expect(state.commits.isEmpty)
+        #expect(!state.ggStackSourceCommits.isEmpty)
+        #expect(GGStackGate.isStackShaped(commits: state.ggStackSourceCommits))
+    }
+
     @Test func gateClosedSkipsCLIAndClearsStack() async throws {
         let wt = makeWorktree()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
@@ -65,7 +122,7 @@ struct RightPaneGGStackTests {
         )
         state.ggService = GGService(runner: runner)
         state.ggGateProvider = { false }
-        state.commits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
 
@@ -82,7 +139,7 @@ struct RightPaneGGStackTests {
         )
         state.ggService = GGService(runner: runner)
         state.ggGateProvider = { true }
-        state.commits = [commit(sha: String(repeating: "b", count: 40), stackShaped: false)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "b", count: 40), stackShaped: false)]
 
         await state.refreshGGStack()
 
@@ -99,7 +156,7 @@ struct RightPaneGGStackTests {
         )
         state.ggService = GGService(runner: runner)
         state.ggGateProvider = { true }
-        state.commits = [commit(sha: String(repeating: "c", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "c", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
         #expect(runner.callCount == 1)
@@ -110,7 +167,7 @@ struct RightPaneGGStackTests {
         #expect(runner.callCount == 1)
 
         // Changing the commit set (new fingerprint) — must re-query.
-        state.commits = [commit(sha: String(repeating: "d", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "d", count: 40), stackShaped: true)]
         await state.refreshGGStack()
         #expect(runner.callCount == 2)
     }
@@ -128,7 +185,7 @@ struct RightPaneGGStackTests {
         )
         state.ggService = GGService(runner: runner)
         state.ggGateProvider = { true }
-        state.commits = [commit(sha: String(repeating: "e", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "e", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
         #expect(state.ggStack != nil)
@@ -152,7 +209,7 @@ struct RightPaneGGStackTests {
         let runner = ThrowingFakeGGRunner()
         state.ggService = GGService(runner: runner)
         state.ggGateProvider = { true }
-        state.commits = [commit(sha: String(repeating: "f", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "f", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
         #expect(runner.callCount == 1)
@@ -178,7 +235,7 @@ struct RightPaneGGStackTests {
         state.ggService = GGService(runner: okRunner)
         state.ggGateProvider = { true }
         state.currentBranch = "nacho/stack-a"
-        state.commits = [commit(sha: String(repeating: "i", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "i", count: 40), stackShaped: true)]
         await state.refreshGGStack()
         #expect(state.ggStack != nil)
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] != nil)
@@ -186,7 +243,7 @@ struct RightPaneGGStackTests {
         let throwingRunner = ThrowingFakeGGRunner()
         state.ggService = GGService(runner: throwingRunner)
         state.currentBranch = "nacho/stack-b"
-        state.commits = [commit(sha: String(repeating: "j", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "j", count: 40), stackShaped: true)]
         await state.refreshGGStack()
 
         #expect(throwingRunner.callCount == 1)
@@ -217,14 +274,14 @@ struct RightPaneGGStackTests {
         state.ggService = GGService(runner: firstRunner)
         state.ggGateProvider = { true }
         state.currentBranch = "nacho/stack-a"
-        state.commits = commitsA
+        state.ggStackSourceCommits = commitsA
         await state.refreshGGStack()
         #expect(state.ggStack != nil)
 
         let throwingRunner = ThrowingFakeGGRunner()
         state.ggService = GGService(runner: throwingRunner)
         state.currentBranch = "nacho/stack-b"
-        state.commits = [commit(sha: String(repeating: "l", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "l", count: 40), stackShaped: true)]
         await state.refreshGGStack()
         #expect(state.ggStack == nil)
 
@@ -235,7 +292,7 @@ struct RightPaneGGStackTests {
         )
         state.ggService = GGService(runner: secondRunner)
         state.currentBranch = "nacho/stack-a"
-        state.commits = commitsA
+        state.ggStackSourceCommits = commitsA
         await state.refreshGGStack()
 
         #expect(secondRunner.callCount == 1)
@@ -255,7 +312,7 @@ struct RightPaneGGStackTests {
         state.ggService = GGService(runner: runner)
         state.ggGateProvider = { true }
         state.currentBranch = "nacho/stack-a"
-        state.commits = [commit(sha: String(repeating: "h", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "h", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
         #expect(runner.callCount == 1)
@@ -278,7 +335,7 @@ struct RightPaneGGStackTests {
         )
         state.ggService = GGService(runner: runner)
         state.ggGateProvider = { true }
-        state.commits = [commit(sha: String(repeating: "g", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "g", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
         #expect(state.ggStack != nil)

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -164,4 +164,30 @@ struct RightPaneGGStackTests {
         await state.refreshGGStack()
         #expect(runner.callCount == 2)
     }
+
+    /// `markSnapshotUnknown()` resets `commits` along with the rest of the
+    /// snapshot; gg stack state derives from `commits`, so it must be reset
+    /// in lockstep or a delayed/failed refresh after invalidation can leave
+    /// a stale "Stack · …" header/sidebar badge rendered against an emptied
+    /// commit list.
+    @Test func markSnapshotUnknownClearsStackState() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.commits = [commit(sha: String(repeating: "g", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(state.ggStack != nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] != nil)
+
+        state.markSnapshotUnknown()
+
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackCommitsKey == nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Detects gg stacks (four-gate chain: master toggle → gg installed → per-project Off/Auto/On → branch is stack-shaped) and stays fully invisible/inert without gg
- Visualizes stacks in the Commits section (PR/MR chips, CI dots, dimmed merged entries) and a sidebar `▲ merged/total` badge
- Adds Settings → Changes → "Stacked diffs" with a Homebrew install flow and per-project mode picker
- gg stack loading runs off the critical refresh path (fire-and-forget, cancellable) and re-gates reactively when settings change

## Test plan
- [x] `xcodegen && xcodebuild ... build` — clean, 0 errors
- [x] All 7 new gg suites (29 tests) pass: GGStackModelsTests, GGServiceTests, GGConfigCodableTests, GGStackGateTests, GGStackChipModelTests, GGInstallControllerTests, RightPaneGGStackTests
- [x] Existing AppConfig/ProjectConfig codable suites pass — no regression
- [x] Per-task spec+quality review, plus a whole-branch review (no Critical/security issues; two Important findings fixed and re-reviewed clean)
- [ ] CI full suite