### PR TITLE
fix(perf): Improve wrapped diff scroll performance

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -618,6 +618,7 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var shouldResetHorizontalOrigin = false
     private var wraps = false
     private var appliedTextLayoutConfiguration: TextLayoutConfiguration?
+    private var lastAppliedTextViewWidth: CGFloat?
     private var textLayoutConfigurationApplicationCount = 0
     private var horizontalScrollerVisibilityChangeCount = 0
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
@@ -925,11 +926,15 @@ final class DiffPaneTextScrollView: NSScrollView {
         }
         applyTextLayoutConfigurationIfNeeded(configuration)
         let finalTextViewWidth = textViewWidth()
-        if !configuration.wraps, abs(textView.frame.width - finalTextViewWidth) > 0.5 {
+        if !configuration.wraps,
+           let lastAppliedTextViewWidth,
+           abs(lastAppliedTextViewWidth - finalTextViewWidth) > 0.5
+        {
             textView.invalidateDiffRowGeometry()
         }
         let measuredDocumentHeight = documentHeight
         setTextViewSize(width: finalTextViewWidth, height: measuredDocumentHeight)
+        lastAppliedTextViewWidth = finalTextViewWidth
         if shouldResetHorizontalOrigin {
             resetHorizontalOriginToLeading()
             shouldResetHorizontalOrigin = false

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -290,10 +290,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
             theme: theme,
             lspContext: lspContext.map(UpdateSignature.LSPContextSignature.init)
         )
-        guard signature != lastUpdateSignature else {
-            needsLayout = true
-            return
-        }
+        guard signature != lastUpdateSignature else { return }
         lastUpdateSignature = signature
 
         self.layoutMode = layoutMode
@@ -490,10 +487,7 @@ final class DiffPaneTextDocumentContainerView: NSView {
             theme: theme,
             lspContext: lspContext.map(UpdateSignature.LSPContextSignature.init)
         )
-        guard signature != lastRowsUpdateSignature else {
-            needsLayout = true
-            return
-        }
+        guard signature != lastRowsUpdateSignature else { return }
         lastRowsUpdateSignature = signature
 
         self.layoutMode = layoutMode

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -603,6 +603,11 @@ final class DiffPaneTextDocumentContainerView: NSView {
 final class DiffPaneTextScrollView: NSScrollView {
     private static let unwrappedTextContainerWidth: CGFloat = 1_000_000
 
+    private struct TextLayoutConfiguration: Equatable {
+        let wraps: Bool
+        let contentWidth: CGFloat
+    }
+
     private let textView: DiffPaneCodeTextView
     private var lineLabels: [String] = []
     private var rowKinds: [DiffDisplayRow.Kind] = []
@@ -612,6 +617,9 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var synchronizedRowLineHeights: [CGFloat?] = []
     private var shouldResetHorizontalOrigin = false
     private var wraps = false
+    private var appliedTextLayoutConfiguration: TextLayoutConfiguration?
+    private var textLayoutConfigurationApplicationCount = 0
+    private var horizontalScrollerVisibilityChangeCount = 0
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
     private var theme: Theme?
     var activeCommentHighlight: DiffReviewCommentHighlight? {
@@ -645,6 +653,14 @@ final class DiffPaneTextScrollView: NSScrollView {
         return max(measuredTextHeight() + textView.textContainerInset.height * 2, fallbackTextHeight())
     }
 
+    var textLayoutConfigurationApplicationCountForTesting: Int {
+        textLayoutConfigurationApplicationCount
+    }
+
+    var horizontalScrollerVisibilityChangeCountForTesting: Int {
+        horizontalScrollerVisibilityChangeCount
+    }
+
     override init(frame frameRect: NSRect) {
         let storage = NSTextStorage()
         let layoutManager = NSLayoutManager()
@@ -665,7 +681,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         drawsBackground = false
         borderType = .noBorder
         hasVerticalScroller = false
-        hasHorizontalScroller = true
+        setHorizontalScrollerVisible(true)
         autohidesScrollers = true
         scrollerStyle = .overlay
         documentView = textView
@@ -702,6 +718,13 @@ final class DiffPaneTextScrollView: NSScrollView {
         fatalError("not used")
     }
 
+    override func setFrameSize(_ newSize: NSSize) {
+        let wasSuppressingFrameWidthGeometryInvalidation = textView.suppressesFrameWidthGeometryInvalidation
+        textView.suppressesFrameWidthGeometryInvalidation = true
+        super.setFrameSize(newSize)
+        textView.suppressesFrameWidthGeometryInvalidation = wasSuppressingFrameWidthGeometryInvalidation
+    }
+
     func update(
         document: DiffPaneTextDocumentBuilder.CodeDocument,
         lineLabels: [String],
@@ -730,7 +753,7 @@ final class DiffPaneTextScrollView: NSScrollView {
         self.font = font
         self.theme = theme
         self.onContextExpansion = onContextExpansion
-        hasHorizontalScroller = !wraps
+        setHorizontalScrollerVisible(!wraps)
 
         textView.textStorage?.setAttributedString(document.attributedString)
         textView.font = font
@@ -884,16 +907,25 @@ final class DiffPaneTextScrollView: NSScrollView {
     }
 
     override func layout() {
+        let wasSuppressingFrameWidthGeometryInvalidation = textView.suppressesFrameWidthGeometryInvalidation
+        textView.suppressesFrameWidthGeometryInvalidation = true
+        defer {
+            textView.suppressesFrameWidthGeometryInvalidation = wasSuppressingFrameWidthGeometryInvalidation
+        }
+
         super.layout()
-        hasHorizontalScroller = !wraps
         tile()
-        configureTextContainer()
-        textView.frame = NSRect(
-            x: 0,
-            y: 0,
-            width: textViewWidth(),
-            height: documentHeight
-        )
+        let configuration = desiredTextLayoutConfiguration()
+        let configurationChanged = !textLayoutConfigurationMatches(configuration)
+        if configurationChanged, configuration.wraps {
+            setTextViewSize(
+                width: max(contentView.bounds.width, 1),
+                height: textView.frame.height
+            )
+        }
+        applyTextLayoutConfigurationIfNeeded(configuration)
+        let measuredDocumentHeight = documentHeight
+        setTextViewSize(width: textViewWidth(), height: measuredDocumentHeight)
         if shouldResetHorizontalOrigin {
             resetHorizontalOriginToLeading()
             shouldResetHorizontalOrigin = false
@@ -916,8 +948,10 @@ final class DiffPaneTextScrollView: NSScrollView {
         clipBounds.size = clipFrame.size
         contentView.bounds = clipBounds
         if wraps {
-            configureTextContainer()
-            textView.frame.size.width = max(clipFrame.width, 1)
+            setTextViewSizeSuppressingFrameWidthGeometryInvalidation(
+                width: max(clipFrame.width, 1),
+                height: textView.frame.height
+            )
         }
         ruler.frame = NSRect(
             x: 0,
@@ -942,20 +976,64 @@ final class DiffPaneTextScrollView: NSScrollView {
         super.scrollWheel(with: event)
     }
 
-    private func configureTextContainer() {
-        let contentWidth = max(contentView.bounds.width - textView.textContainerInset.width * 2, 1)
-        textView.isHorizontallyResizable = !wraps
+    private func desiredTextLayoutConfiguration() -> TextLayoutConfiguration {
+        TextLayoutConfiguration(
+            wraps: wraps,
+            contentWidth: max(contentView.bounds.width - textView.textContainerInset.width * 2, 1)
+        )
+    }
+
+    private func applyTextLayoutConfigurationIfNeeded(_ configuration: TextLayoutConfiguration) {
+        guard !textLayoutConfigurationMatches(configuration) else { return }
+
+        textView.invalidateDiffRowGeometry()
+        textView.isHorizontallyResizable = !configuration.wraps
         textView.minSize = .zero
         textView.maxSize = NSSize(
-            width: wraps ? contentWidth : Self.unwrappedTextContainerWidth,
+            width: configuration.wraps ? configuration.contentWidth : Self.unwrappedTextContainerWidth,
             height: CGFloat.greatestFiniteMagnitude
         )
-        textView.textContainer?.widthTracksTextView = wraps
+        textView.textContainer?.widthTracksTextView = false
         textView.textContainer?.heightTracksTextView = false
         textView.textContainer?.containerSize = NSSize(
-            width: wraps ? contentWidth : Self.unwrappedTextContainerWidth,
+            width: configuration.wraps ? configuration.contentWidth : Self.unwrappedTextContainerWidth,
             height: CGFloat.greatestFiniteMagnitude
         )
+        appliedTextLayoutConfiguration = configuration
+        textLayoutConfigurationApplicationCount += 1
+    }
+
+    private func textLayoutConfigurationMatches(_ configuration: TextLayoutConfiguration) -> Bool {
+        guard let appliedTextLayoutConfiguration else { return false }
+        return appliedTextLayoutConfiguration.wraps == configuration.wraps
+            && abs(appliedTextLayoutConfiguration.contentWidth - configuration.contentWidth) <= 0.5
+    }
+
+    private func setTextViewSize(width: CGFloat, height: CGFloat) {
+        var size = textView.frame.size
+        if abs(size.width - width) > 0.5 {
+            size.width = width
+        }
+        if abs(size.height - height) > 0.5 {
+            size.height = height
+        }
+        guard size != textView.frame.size else { return }
+        textView.setFrameSize(size)
+    }
+
+    private func setTextViewSizeSuppressingFrameWidthGeometryInvalidation(width: CGFloat, height: CGFloat) {
+        let wasSuppressingFrameWidthGeometryInvalidation = textView.suppressesFrameWidthGeometryInvalidation
+        textView.suppressesFrameWidthGeometryInvalidation = true
+        defer {
+            textView.suppressesFrameWidthGeometryInvalidation = wasSuppressingFrameWidthGeometryInvalidation
+        }
+        setTextViewSize(width: width, height: height)
+    }
+
+    private func setHorizontalScrollerVisible(_ visible: Bool) {
+        guard hasHorizontalScroller != visible else { return }
+        hasHorizontalScroller = visible
+        horizontalScrollerVisibilityChangeCount += 1
     }
 
     private func textViewWidth() -> CGFloat {
@@ -1061,6 +1139,7 @@ final class DiffPaneCodeTextView: NSTextView {
     private var lspController: DiffPaneLSPController?
     private var cachedRowGeometry: RowGeometry?
     private var rowGeometryComputationCount = 0
+    var suppressesFrameWidthGeometryInvalidation = false
     private var hoverExpansionTarget: ExpansionTarget? {
         didSet { if hoverExpansionTarget != oldValue { needsDisplay = true } }
     }
@@ -1208,7 +1287,7 @@ final class DiffPaneCodeTextView: NSTextView {
     override func setFrameSize(_ newSize: NSSize) {
         let oldSize = frame.size
         super.setFrameSize(newSize)
-        if abs(oldSize.width - newSize.width) > 0.5 {
+        if !suppressesFrameWidthGeometryInvalidation, abs(oldSize.width - newSize.width) > 0.5 {
             invalidateDiffRowGeometry()
         }
     }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -618,7 +618,7 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var shouldResetHorizontalOrigin = false
     private var wraps = false
     private var appliedTextLayoutConfiguration: TextLayoutConfiguration?
-    private var lastAppliedTextViewWidth: CGFloat?
+    private var rowGeometryPresentationWidth: CGFloat?
     private var textLayoutConfigurationApplicationCount = 0
     private var horizontalScrollerVisibilityChangeCount = 0
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
@@ -926,15 +926,18 @@ final class DiffPaneTextScrollView: NSScrollView {
         }
         applyTextLayoutConfigurationIfNeeded(configuration)
         let finalTextViewWidth = textViewWidth()
-        if !configuration.wraps,
-           let lastAppliedTextViewWidth,
-           abs(lastAppliedTextViewWidth - finalTextViewWidth) > 0.5
-        {
+        let presentationWidthChanged = !configuration.wraps
+            && rowGeometryPresentationWidth.map { abs($0 - finalTextViewWidth) > 0.5 } == true
+        setTextViewSize(width: finalTextViewWidth, height: textView.frame.height)
+        if presentationWidthChanged {
             textView.invalidateDiffRowGeometry()
         }
+        let geometryWillBeMeasured = !textView.hasCachedDiffRowGeometry
         let measuredDocumentHeight = documentHeight
         setTextViewSize(width: finalTextViewWidth, height: measuredDocumentHeight)
-        lastAppliedTextViewWidth = finalTextViewWidth
+        if geometryWillBeMeasured {
+            rowGeometryPresentationWidth = finalTextViewWidth
+        }
         if shouldResetHorizontalOrigin {
             resetHorizontalOriginToLeading()
             shouldResetHorizontalOrigin = false
@@ -1205,6 +1208,10 @@ final class DiffPaneCodeTextView: NSTextView {
 
     var rowGeometryComputationCountForTesting: Int {
         rowGeometryComputationCount
+    }
+
+    var hasCachedDiffRowGeometry: Bool {
+        cachedRowGeometry != nil
     }
 
     var lineTones: [DiffPaneLineTone] = [] {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -605,7 +605,7 @@ final class DiffPaneTextScrollView: NSScrollView {
 
     private struct TextLayoutConfiguration: Equatable {
         let wraps: Bool
-        let contentWidth: CGFloat
+        let containerWidth: CGFloat
     }
 
     private let textView: DiffPaneCodeTextView
@@ -924,8 +924,12 @@ final class DiffPaneTextScrollView: NSScrollView {
             )
         }
         applyTextLayoutConfigurationIfNeeded(configuration)
+        let finalTextViewWidth = textViewWidth()
+        if !configuration.wraps, abs(textView.frame.width - finalTextViewWidth) > 0.5 {
+            textView.invalidateDiffRowGeometry()
+        }
         let measuredDocumentHeight = documentHeight
-        setTextViewSize(width: textViewWidth(), height: measuredDocumentHeight)
+        setTextViewSize(width: finalTextViewWidth, height: measuredDocumentHeight)
         if shouldResetHorizontalOrigin {
             resetHorizontalOriginToLeading()
             shouldResetHorizontalOrigin = false
@@ -979,7 +983,9 @@ final class DiffPaneTextScrollView: NSScrollView {
     private func desiredTextLayoutConfiguration() -> TextLayoutConfiguration {
         TextLayoutConfiguration(
             wraps: wraps,
-            contentWidth: max(contentView.bounds.width - textView.textContainerInset.width * 2, 1)
+            containerWidth: wraps
+                ? max(contentView.bounds.width - textView.textContainerInset.width * 2, 1)
+                : Self.unwrappedTextContainerWidth
         )
     }
 
@@ -990,13 +996,13 @@ final class DiffPaneTextScrollView: NSScrollView {
         textView.isHorizontallyResizable = !configuration.wraps
         textView.minSize = .zero
         textView.maxSize = NSSize(
-            width: configuration.wraps ? configuration.contentWidth : Self.unwrappedTextContainerWidth,
+            width: configuration.containerWidth,
             height: CGFloat.greatestFiniteMagnitude
         )
         textView.textContainer?.widthTracksTextView = false
         textView.textContainer?.heightTracksTextView = false
         textView.textContainer?.containerSize = NSSize(
-            width: configuration.wraps ? configuration.contentWidth : Self.unwrappedTextContainerWidth,
+            width: configuration.containerWidth,
             height: CGFloat.greatestFiniteMagnitude
         )
         appliedTextLayoutConfiguration = configuration
@@ -1006,12 +1012,12 @@ final class DiffPaneTextScrollView: NSScrollView {
     private func textLayoutConfigurationMatches(_ configuration: TextLayoutConfiguration) -> Bool {
         guard let appliedTextLayoutConfiguration else { return false }
         return appliedTextLayoutConfiguration.wraps == configuration.wraps
-            && abs(appliedTextLayoutConfiguration.contentWidth - configuration.contentWidth) <= 0.5
+            && abs(appliedTextLayoutConfiguration.containerWidth - configuration.containerWidth) <= 0.5
     }
 
     private func setTextViewSize(width: CGFloat, height: CGFloat) {
         var size = textView.frame.size
-        if abs(size.width - width) > 0.5 {
+        if size.width != width {
             size.width = width
         }
         if abs(size.height - height) > 0.5 {

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1738,11 +1738,11 @@ final class DiffPaneCodeTextView: NSTextView {
     private func drawLineBackgrounds(in dirtyRect: NSRect) {
         guard let theme else { return }
         let rowRects = diffRowRects()
-        for (index, rowRect) in rowRects.enumerated() {
+        for index in rowRects.indicesIntersecting(dirtyRect) {
             guard lineTones.indices.contains(index) else { continue }
+            let rowRect = rowRects[index]
             let tone = lineTones[index]
             guard tone != .context else { continue }
-            guard rowRect.intersects(dirtyRect) else { continue }
 
             rowFill(for: tone, theme: theme).setFill()
             rowRect.fill()
@@ -2700,6 +2700,15 @@ private extension DiffPaneTextDocumentBuilder.LineMetadata {
 }
 
 extension Array where Element == NSRect {
+    func indicesIntersecting(_ rect: NSRect) -> Range<Int> {
+        guard !isEmpty, rect.height > 0 else { return 0..<0 }
+
+        let start = lowerBound { $0.maxY > rect.minY }
+        let end = lowerBound { $0.minY >= rect.maxY }
+        guard start < end else { return 0..<0 }
+        return start..<end
+    }
+
     func binarySearchRow(containing point: NSPoint) -> Int? {
         var low = 0
         var high = count - 1
@@ -2718,5 +2727,19 @@ extension Array where Element == NSRect {
             }
         }
         return nil
+    }
+
+    private func lowerBound(where predicate: (NSRect) -> Bool) -> Int {
+        var low = 0
+        var high = count
+        while low < high {
+            let mid = low + (high - low) / 2
+            if predicate(self[mid]) {
+                high = mid
+            } else {
+                low = mid + 1
+            }
+        }
+        return low
     }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3753,14 +3753,43 @@ let second = true
     @Test func unwrappedOuterWidthChangeKeepsFixedTextLayoutConfiguration() throws {
         let scrollView = makeLongTextScrollView(width: 220, wraps: false)
         scrollView.layout()
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        _ = codeView.diffRowRects()
         let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+        let geometryComputations = codeView.rowGeometryComputationCountForTesting
+        let textViewWidth = codeView.frame.width
 
         scrollView.setFrameSize(NSSize(width: 280, height: 120))
         scrollView.needsLayout = true
         scrollView.layout()
 
         #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
+        #expect(codeView.frame.width == textViewWidth)
+        #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
         #expect(scrollView.hasHorizontalScroller)
+    }
+
+    @Test func unwrappedPresentationWidthChangeRecomputesRowGeometryOnce() throws {
+        let scrollView = makeTextScrollView(
+            width: 220,
+            wraps: false,
+            lines: ["let value = 1", "return value"]
+        )
+        scrollView.layout()
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        _ = codeView.diffRowRects()
+        let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+        let geometryComputations = codeView.rowGeometryComputationCountForTesting
+        let textViewWidth = codeView.frame.width
+        codeView.autoresizingMask = []
+
+        scrollView.setFrameSize(NSSize(width: 280, height: 120))
+        scrollView.needsLayout = true
+        scrollView.layout()
+
+        #expect(codeView.frame.width > textViewWidth + 0.5)
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
+        #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations + 1)
     }
 
     @Test func changingFromWrappedToUnwrappedReconfiguresLayoutAndScrollerOnce() throws {
@@ -4223,17 +4252,41 @@ let second = true
     }
 
     private func makeLongTextScrollView(width: CGFloat, height: CGFloat = 120, wraps: Bool) -> DiffPaneTextScrollView {
-        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: width, height: height))
-        updateLongTextScrollView(scrollView, wraps: wraps)
-        return scrollView
+        makeTextScrollView(
+            width: width,
+            height: height,
+            wraps: wraps,
+            lines: [
+                "let firstValue = service.fetchAnIntentionallyLongValueForWrappedLayoutTesting()",
+                "let secondValue = service.fetchAnotherIntentionallyLongValueForWrappedLayoutTesting()",
+            ]
+        )
     }
 
     private func updateLongTextScrollView(_ scrollView: DiffPaneTextScrollView, wraps: Bool) {
+        updateTextScrollView(
+            scrollView,
+            wraps: wraps,
+            lines: [
+                "let firstValue = service.fetchAnIntentionallyLongValueForWrappedLayoutTesting()",
+                "let secondValue = service.fetchAnotherIntentionallyLongValueForWrappedLayoutTesting()",
+            ]
+        )
+    }
+
+    private func makeTextScrollView(
+        width: CGFloat,
+        height: CGFloat = 120,
+        wraps: Bool,
+        lines: [String]
+    ) -> DiffPaneTextScrollView {
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        updateTextScrollView(scrollView, wraps: wraps, lines: lines)
+        return scrollView
+    }
+
+    private func updateTextScrollView(_ scrollView: DiffPaneTextScrollView, wraps: Bool, lines: [String]) {
         let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        let lines = [
-            "let firstValue = service.fetchAnIntentionallyLongValueForWrappedLayoutTesting()",
-            "let secondValue = service.fetchAnotherIntentionallyLongValueForWrappedLayoutTesting()",
-        ]
         let text = lines.joined(separator: "\n")
         var location = 0
         let metadata = lines.map { line in

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3729,6 +3729,43 @@ let second = true
         #expect(codeView.rowGeometryComputationCountForTesting == 2)
     }
 
+    @Test func identicalDiffDocumentContainerUpdateDoesNotRequestLayout() throws {
+        let group = try #require(model().groups.first)
+        let container = DiffPaneTextDocumentContainerView(
+            frame: NSRect(x: 0, y: 0, width: 700, height: 300)
+        )
+
+        func update() {
+            container.update(
+                group: group,
+                expandedCollapsedRowIDs: [],
+                layoutMode: .stacked,
+                wrapLines: true,
+                showWhitespace: false,
+                fileExtension: "swift",
+                font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+                theme: theme(),
+                lspContext: nil
+            )
+        }
+
+        update()
+        container.layoutSubtreeIfNeeded()
+        #expect(!container.needsLayout)
+
+        let codeView = try #require(allSubviews(of: container)
+            .compactMap { $0 as? DiffPaneCodeTextView }
+            .first(where: isEffectivelyVisible))
+        _ = codeView.diffRowRects()
+        let geometryComputations = codeView.rowGeometryComputationCountForTesting
+
+        update()
+
+        #expect(!container.needsLayout)
+        container.layoutSubtreeIfNeeded()
+        #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
+    }
+
     @Test func stableWidthLayoutAppliesTextLayoutConfigurationOnce() throws {
         let scrollView = makeLongTextScrollView(width: 220, wraps: true)
 

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3750,6 +3750,19 @@ let second = true
         #expect(scrollView.horizontalScrollerVisibilityChangeCountForTesting == visibilityChangesAfterUpdate)
     }
 
+    @Test func unwrappedOuterWidthChangeKeepsFixedTextLayoutConfiguration() throws {
+        let scrollView = makeLongTextScrollView(width: 220, wraps: false)
+        scrollView.layout()
+        let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+
+        scrollView.setFrameSize(NSSize(width: 280, height: 120))
+        scrollView.needsLayout = true
+        scrollView.layout()
+
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
+        #expect(scrollView.hasHorizontalScroller)
+    }
+
     @Test func changingFromWrappedToUnwrappedReconfiguresLayoutAndScrollerOnce() throws {
         let scrollView = makeLongTextScrollView(width: 220, wraps: true)
         scrollView.layout()
@@ -3773,12 +3786,15 @@ let second = true
         let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
         let geometryComputations = codeView.rowGeometryComputationCountForTesting
         let contentWidth = scrollView.contentView.bounds.width
+        // Exercise the scroll view's frame assignment rather than incidental clip-view autoresizing.
+        codeView.autoresizingMask = []
 
         scrollView.setFrameSize(NSSize(width: 220.3, height: 120))
         scrollView.needsLayout = true
         scrollView.layout()
 
         #expect(scrollView.contentView.bounds.width > contentWidth)
+        #expect(abs(codeView.frame.width - scrollView.contentView.bounds.width) < 0.001)
         #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
         #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
     }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -8,6 +8,20 @@ import Testing
 struct DiffPaneViewTests {
     private func theme() -> Theme { try! ThemeStore().current }
 
+    @Test func diffRowRectsReturnOnlyIndicesIntersectingDirtyVerticalRange() {
+        let rows = [
+            NSRect(x: 0, y: 0, width: 100, height: 10),
+            NSRect(x: 0, y: 10, width: 100, height: 10),
+            NSRect(x: 0, y: 20, width: 100, height: 10),
+            NSRect(x: 0, y: 30, width: 100, height: 10),
+        ]
+
+        #expect(rows.indicesIntersecting(NSRect(x: 0, y: 10, width: 100, height: 10)) == 1..<2)
+        #expect(rows.indicesIntersecting(NSRect(x: 0, y: 9, width: 100, height: 12)) == 0..<3)
+        #expect(rows.indicesIntersecting(NSRect(x: 0, y: 40, width: 100, height: 10)).isEmpty)
+        #expect([NSRect]().indicesIntersecting(.zero).isEmpty)
+    }
+
     private func model() -> DiffDisplayModel {
         DiffDisplayModelBuilder.build(
             diff: parsedDiff(),

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3781,7 +3781,6 @@ let second = true
         let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
         let geometryComputations = codeView.rowGeometryComputationCountForTesting
         let textViewWidth = codeView.frame.width
-        codeView.autoresizingMask = []
 
         scrollView.setFrameSize(NSSize(width: 280, height: 120))
         scrollView.needsLayout = true
@@ -3790,11 +3789,18 @@ let second = true
         #expect(codeView.frame.width > textViewWidth + 0.5)
         #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
         #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations + 1)
+        let rowRect = try #require(codeView.diffRowRects().first)
+        let firstLineFragmentRect = try #require(codeView.diffFirstLineFragmentRects().first)
+        let presentationWidth = presentationGeometryWidth(of: codeView)
+        #expect(abs(rowRect.width - presentationWidth) < 0.001)
+        #expect(abs(firstLineFragmentRect.width - presentationWidth) < 0.001)
     }
 
     @Test func changingFromWrappedToUnwrappedReconfiguresLayoutAndScrollerOnce() throws {
         let scrollView = makeLongTextScrollView(width: 220, wraps: true)
         scrollView.layout()
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        _ = codeView.diffRowRects()
         let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
         let visibilityChanges = scrollView.horizontalScrollerVisibilityChangeCountForTesting
 
@@ -3805,6 +3811,45 @@ let second = true
         #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications + 1)
         #expect(scrollView.horizontalScrollerVisibilityChangeCountForTesting == visibilityChanges + 1)
         #expect(scrollView.hasHorizontalScroller)
+        let rowRect = try #require(codeView.diffRowRects().first)
+        let firstLineFragmentRect = try #require(codeView.diffFirstLineFragmentRects().first)
+        let presentationWidth = presentationGeometryWidth(of: codeView)
+        #expect(abs(rowRect.width - presentationWidth) < 0.001)
+        #expect(abs(firstLineFragmentRect.width - presentationWidth) < 0.001)
+    }
+
+    @Test func cumulativeUnwrappedWidthChangeRecomputesGeometryFromCachedPresentationWidth() throws {
+        let scrollView = makeTextScrollView(
+            width: 220,
+            wraps: false,
+            lines: ["let value = 1", "return value"]
+        )
+        scrollView.layout()
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        _ = codeView.diffRowRects()
+        let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+        let geometryComputations = codeView.rowGeometryComputationCountForTesting
+        let presentationWidth = codeView.frame.width
+
+        scrollView.setFrameSize(NSSize(width: 220.3, height: 120))
+        scrollView.needsLayout = true
+        scrollView.layout()
+        let subToleranceWidth = codeView.frame.width
+
+        #expect(subToleranceWidth > presentationWidth)
+        #expect(subToleranceWidth <= presentationWidth + 0.5)
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
+        #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
+
+        scrollView.setFrameSize(NSSize(width: 220.6, height: 120))
+        scrollView.needsLayout = true
+        scrollView.layout()
+
+        #expect(codeView.frame.width > presentationWidth + 0.5)
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
+        #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations + 1)
+        let rowRect = try #require(codeView.diffRowRects().first)
+        #expect(abs(rowRect.width - presentationGeometryWidth(of: codeView)) < 0.001)
     }
 
     @Test func subHalfPointOuterWidthChangeKeepsAppliedConfigurationAndRowGeometry() throws {
@@ -4261,6 +4306,10 @@ let second = true
                 "let secondValue = service.fetchAnotherIntentionallyLongValueForWrappedLayoutTesting()",
             ]
         )
+    }
+
+    private func presentationGeometryWidth(of codeView: DiffPaneCodeTextView) -> CGFloat {
+        max(codeView.bounds.width, codeView.visibleRect.width)
     }
 
     private func updateLongTextScrollView(_ scrollView: DiffPaneTextScrollView, wraps: Bool) {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3729,6 +3729,99 @@ let second = true
         #expect(codeView.rowGeometryComputationCountForTesting == 2)
     }
 
+    @Test func stableWidthLayoutAppliesTextLayoutConfigurationOnce() throws {
+        let scrollView = makeLongTextScrollView(width: 220, wraps: true)
+
+        scrollView.layout()
+        scrollView.layout()
+        scrollView.layout()
+
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == 1)
+    }
+
+    @Test func stableLayoutDoesNotReassignHorizontalScrollerVisibility() throws {
+        let scrollView = makeLongTextScrollView(width: 220, wraps: true)
+        let visibilityChangesAfterUpdate = scrollView.horizontalScrollerVisibilityChangeCountForTesting
+
+        scrollView.layout()
+        scrollView.layout()
+        scrollView.layout()
+
+        #expect(scrollView.horizontalScrollerVisibilityChangeCountForTesting == visibilityChangesAfterUpdate)
+    }
+
+    @Test func changingFromWrappedToUnwrappedReconfiguresLayoutAndScrollerOnce() throws {
+        let scrollView = makeLongTextScrollView(width: 220, wraps: true)
+        scrollView.layout()
+        let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+        let visibilityChanges = scrollView.horizontalScrollerVisibilityChangeCountForTesting
+
+        updateLongTextScrollView(scrollView, wraps: false)
+        scrollView.layout()
+        scrollView.layout()
+
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications + 1)
+        #expect(scrollView.horizontalScrollerVisibilityChangeCountForTesting == visibilityChanges + 1)
+        #expect(scrollView.hasHorizontalScroller)
+    }
+
+    @Test func subHalfPointOuterWidthChangeKeepsAppliedConfigurationAndRowGeometry() throws {
+        let scrollView = makeLongTextScrollView(width: 220, wraps: true)
+        scrollView.layout()
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        _ = codeView.diffRowRects()
+        let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+        let geometryComputations = codeView.rowGeometryComputationCountForTesting
+        let contentWidth = scrollView.contentView.bounds.width
+
+        scrollView.setFrameSize(NSSize(width: 220.3, height: 120))
+        scrollView.needsLayout = true
+        scrollView.layout()
+
+        #expect(scrollView.contentView.bounds.width > contentWidth)
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
+        #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
+    }
+
+    @Test func cumulativeWidthChangeUsesLastAppliedConfigurationAndRecomputesGeometryOnce() throws {
+        let scrollView = makeLongTextScrollView(width: 220, wraps: true)
+        scrollView.layout()
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        _ = codeView.diffRowRects()
+        let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+        let geometryComputations = codeView.rowGeometryComputationCountForTesting
+        let contentWidth = scrollView.contentView.bounds.width
+
+        scrollView.setFrameSize(NSSize(width: 220.3, height: 120))
+        scrollView.needsLayout = true
+        scrollView.layout()
+        scrollView.setFrameSize(NSSize(width: 220.6, height: 120))
+        scrollView.needsLayout = true
+        scrollView.layout()
+
+        #expect(scrollView.contentView.bounds.width > contentWidth + 0.5)
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications + 1)
+        #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations + 1)
+    }
+
+    @Test func heightOnlyOuterResizeKeepsWidthDependentLayoutCaches() throws {
+        let scrollView = makeLongTextScrollView(width: 220, wraps: true)
+        scrollView.layout()
+        let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+        _ = codeView.diffRowRects()
+        let configurationApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+        let geometryComputations = codeView.rowGeometryComputationCountForTesting
+        let textViewWidth = codeView.frame.width
+
+        scrollView.setFrameSize(NSSize(width: 220, height: 180))
+        scrollView.needsLayout = true
+        scrollView.layout()
+
+        #expect(codeView.frame.width == textViewWidth)
+        #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == configurationApplications)
+        #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
+    }
+
     @Test func diffPaneLineNumberRulerCachesMappedRowGeometryForVisibleLookups() throws {
         let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
         let lines = (1...80).map { "let value\($0) = \($0)" }
@@ -4111,6 +4204,43 @@ let second = true
 
         textView.mouseExited(with: exitEvent)
         #expect(NSCursor.current != NSCursor.pointingHand)
+    }
+
+    private func makeLongTextScrollView(width: CGFloat, height: CGFloat = 120, wraps: Bool) -> DiffPaneTextScrollView {
+        let scrollView = DiffPaneTextScrollView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        updateLongTextScrollView(scrollView, wraps: wraps)
+        return scrollView
+    }
+
+    private func updateLongTextScrollView(_ scrollView: DiffPaneTextScrollView, wraps: Bool) {
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let lines = [
+            "let firstValue = service.fetchAnIntentionallyLongValueForWrappedLayoutTesting()",
+            "let secondValue = service.fetchAnotherIntentionallyLongValueForWrappedLayoutTesting()",
+        ]
+        let text = lines.joined(separator: "\n")
+        var location = 0
+        let metadata = lines.map { line in
+            defer { location += (line as NSString).length + 1 }
+            return DiffPaneTextDocumentBuilder.LineMetadata(
+                kind: .context,
+                range: NSRange(location: location, length: (line as NSString).length)
+            )
+        }
+        let document = DiffPaneTextDocumentBuilder.CodeDocument(
+            attributedString: NSAttributedString(string: text, attributes: [.font: font]),
+            lines: metadata
+        )
+
+        scrollView.update(
+            document: document,
+            lineLabels: ["1", "2"],
+            wraps: wraps,
+            font: font,
+            theme: theme(),
+            lspContext: nil,
+            allowedLSPSide: .new
+        )
     }
 
     private func makeDiffPaneCodeTextView(string: String, metadata: [DiffPaneTextDocumentBuilder.LineMetadata] = []) -> DiffPaneCodeTextView {

--- a/docs/superpowers/plans/2026-07-19-wrapped-diff-scroll-performance.md
+++ b/docs/superpowers/plans/2026-07-19-wrapped-diff-scroll-performance.md
@@ -1,0 +1,653 @@
+# Wrapped Diff Scroll Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop stable-width wrapped diff scrolling from repeatedly reconfiguring TextKit, relaying out unchanged diff documents, and scanning offscreen rows during custom drawing.
+
+**Architecture:** Keep the shared TextKit 1 renderer and its existing SwiftUI/AppKit boundaries. Add an effective-width configuration cache inside `DiffPaneTextScrollView`, make identical container updates skip layout, and reuse ordered row geometry to derive dirty row ranges in logarithmic time.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AppKit TextKit 1 (`NSTextView`, `NSLayoutManager`, `NSTextContainer`), Swift Testing (`import Testing`), XcodeGen.
+
+---
+
+## Source Design
+
+`docs/superpowers/specs/2026-07-19-wrapped-diff-scroll-performance-design.md`
+
+## File Structure
+
+- Modify `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift`
+  - Own the stable text-layout configuration and its application counter in
+    `DiffPaneTextScrollView`.
+  - Keep identical document-container updates from scheduling layout.
+  - Add ordered-row dirty-range lookup and use it for custom backgrounds.
+- Modify `AlasTests/DiffPaneViewTests.swift`
+  - Add real AppKit regression tests beside the existing wrapping, split-row,
+    and geometry-cache tests.
+
+No new source file or `project.yml` entry is required. Do not modify host views:
+all single-file, commit, and multi-file review surfaces already use this shared
+renderer.
+
+## Shared Rules
+
+- Use test-driven development. Add one failing behavior test, run it and verify
+  the expected failure, then add only the implementation required to pass it.
+- Prefix shell commands with `rtk`.
+- Preserve exact wrapping, selection, gutters, LSP behavior, context expansion,
+  comments, highlights, and split-row alignment.
+- Keep the split-height live-lock protections in `synchronizeRowHeights` intact.
+- Counters are internal test accessors only; do not log or persist metrics.
+- Do not add agent attribution to code, docs, commits, or PR text.
+- Commit after each task.
+
+### Task 1: Cache Effective TextKit Layout Configuration
+
+**Files:**
+- Modify: `AlasTests/DiffPaneViewTests.swift` near the existing
+  `wrappedDiffTextScrollPaneDoesNotAllowHorizontalOffset` and
+  `diffPaneCodeTextViewCachesMeasuredRowGeometry` tests
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift:603-992`
+
+- [ ] **Step 1: Add a test helper for a wrapped text scroll view**
+
+Add this private helper to `DiffPaneViewTests` near the other renderer helpers.
+It avoids duplicating document construction in the new tests:
+
+```swift
+private func makeTextScrollView(
+    width: CGFloat = 220,
+    wraps: Bool = true
+) throws -> DiffPaneTextScrollView {
+    let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    let lines = [
+        "let first = \"This line is intentionally long enough to wrap across several visual fragments.\"",
+        "let second = \"This line is also long enough to exercise stable wrapped layout.\"",
+    ]
+    let text = lines.joined(separator: "\n")
+    var location = 0
+    let metadata = lines.map { line in
+        defer { location += (line as NSString).length + 1 }
+        return DiffPaneTextDocumentBuilder.LineMetadata(
+            kind: .context,
+            range: NSRange(location: location, length: (line as NSString).length)
+        )
+    }
+    let document = DiffPaneTextDocumentBuilder.CodeDocument(
+        attributedString: NSAttributedString(
+            string: text,
+            attributes: [
+                .font: font,
+                .paragraphStyle: CenterTypography.paragraphStyle(),
+            ]
+        ),
+        lines: metadata
+    )
+    let scrollView = DiffPaneTextScrollView(
+        frame: NSRect(x: 0, y: 0, width: width, height: 180)
+    )
+    scrollView.update(
+        document: document,
+        lineLabels: ["1", "2"],
+        wraps: wraps,
+        font: font,
+        theme: theme(),
+        lspContext: nil,
+        allowedLSPSide: .new
+    )
+    return scrollView
+}
+```
+
+- [ ] **Step 2: Add failing stable-layout and wrap-transition tests**
+
+```swift
+@Test func wrappedTextLayoutConfigurationIsNotReappliedAtStableWidth() throws {
+    let scrollView = try makeTextScrollView()
+    scrollView.layoutSubtreeIfNeeded()
+    let initialApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+    let initialScrollerChanges = scrollView.horizontalScrollerVisibilityChangeCountForTesting
+    #expect(initialApplications == 1)
+
+    for _ in 0..<5 {
+        scrollView.needsLayout = true
+        scrollView.layoutSubtreeIfNeeded()
+    }
+
+    #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == initialApplications)
+    #expect(scrollView.horizontalScrollerVisibilityChangeCountForTesting == initialScrollerChanges)
+}
+
+@Test func togglingTextWrapAppliesConfigurationAndPreservesScrollerState() throws {
+    let scrollView = try makeTextScrollView(wraps: true)
+    scrollView.layoutSubtreeIfNeeded()
+    let wrappedApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+    let wrappedScrollerChanges = scrollView.horizontalScrollerVisibilityChangeCountForTesting
+    #expect(!scrollView.hasHorizontalScroller)
+
+    let replacement = try makeTextScrollView(wraps: false)
+    let replacementView = try #require(replacement.documentView as? DiffPaneCodeTextView)
+    let storage = try #require(replacementView.textStorage)
+    scrollView.update(
+        document: .init(
+            attributedString: storage,
+            lines: replacementView.lineMetadata
+        ),
+        lineLabels: ["1", "2"],
+        wraps: false,
+        font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+        theme: theme(),
+        lspContext: nil,
+        allowedLSPSide: .new
+    )
+    scrollView.layoutSubtreeIfNeeded()
+
+    #expect(scrollView.hasHorizontalScroller)
+    #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == wrappedApplications + 1)
+    #expect(scrollView.horizontalScrollerVisibilityChangeCountForTesting == wrappedScrollerChanges + 1)
+}
+```
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffPaneViewTests/wrappedTextLayoutConfigurationIsNotReappliedAtStableWidth \
+  -only-testing:AlasTests/DiffPaneViewTests/togglingTextWrapAppliesConfigurationAndPreservesScrollerState test
+```
+
+Expected: FAIL to compile because
+`textLayoutConfigurationApplicationCountForTesting` does not exist.
+
+- [ ] **Step 4: Implement the minimal effective-configuration cache**
+
+In `DiffPaneTextScrollView`, add a compact private configuration value with
+exact equality for this first cycle, plus an internal read-only counter:
+
+```swift
+private struct TextLayoutConfiguration: Equatable {
+    let wraps: Bool
+    let contentWidth: CGFloat
+}
+
+private var appliedTextLayoutConfiguration: TextLayoutConfiguration?
+private(set) var textLayoutConfigurationApplicationCountForTesting = 0
+private(set) var horizontalScrollerVisibilityChangeCountForTesting = 0
+```
+
+Replace `configureTextContainer()` with an idempotent method. Use exact
+configuration equality in this first implementation step; width tolerance is a
+separate failing test and implementation below:
+
+```swift
+@discardableResult
+private func applyTextLayoutConfigurationIfNeeded() -> Bool {
+    let contentWidth = max(
+        contentView.bounds.width - textView.textContainerInset.width * 2,
+        1
+    )
+    let desired = TextLayoutConfiguration(wraps: wraps, contentWidth: contentWidth)
+    if desired == appliedTextLayoutConfiguration {
+        return false
+    }
+
+    appliedTextLayoutConfiguration = desired
+    textLayoutConfigurationApplicationCountForTesting += 1
+    let containerWidth = wraps ? contentWidth : Self.unwrappedTextContainerWidth
+
+    textView.isHorizontallyResizable = !wraps
+    textView.minSize = .zero
+    textView.maxSize = NSSize(
+        width: containerWidth,
+        height: CGFloat.greatestFiniteMagnitude
+    )
+    textView.textContainer?.widthTracksTextView = wraps
+    textView.textContainer?.heightTracksTextView = false
+    textView.textContainer?.containerSize = NSSize(
+        width: containerWidth,
+        height: CGFloat.greatestFiniteMagnitude
+    )
+    textView.invalidateDiffRowGeometry()
+    return true
+}
+```
+
+Call `applyTextLayoutConfigurationIfNeeded()` after tiling has established the
+content width. Remove the wrapped-only configuration call from `tile()` so one
+layout pass does not apply configuration from two call sites.
+
+Replace direct horizontal-scroller assignments with an idempotent helper called
+from `update(document:...)`:
+
+```swift
+private func applyHorizontalScrollerVisibilityIfNeeded() {
+    let desired = !wraps
+    guard hasHorizontalScroller != desired else { return }
+    hasHorizontalScroller = desired
+    horizontalScrollerVisibilityChangeCountForTesting += 1
+}
+```
+
+Remove `hasHorizontalScroller = !wraps` from `layout()`. The stable-layout and
+wrap-transition tests now prove that scroller state changes once per actual
+transition and is not reassigned by layout.
+
+Do not reset `appliedTextLayoutConfiguration` on every document update: setting
+the attributed string already invalidates document layout, while the cached
+value represents only width and wrapping. A wrap-mode or effective-width change
+will fail the comparison naturally.
+
+- [ ] **Step 5: Run the focused test and verify GREEN**
+
+Run the command from Step 3.
+
+Expected: PASS with exactly one configuration application across repeated
+stable-width layout passes and one additional application for the wrap-mode
+transition.
+
+- [ ] **Step 6: Add a failing width-tolerance test and geometry regressions**
+
+```swift
+@Test func wrappedTextLayoutConfigurationTracksLastAppliedWidth() throws {
+    let scrollView = try makeTextScrollView(width: 220)
+    scrollView.layoutSubtreeIfNeeded()
+    let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+    _ = codeView.diffRowRects()
+    let initialApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+    let initialGeometryComputations = codeView.rowGeometryComputationCountForTesting
+
+    scrollView.setFrameSize(NSSize(width: 220.3, height: 180))
+    scrollView.layoutSubtreeIfNeeded()
+    #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == initialApplications)
+    _ = codeView.diffRowRects()
+    #expect(codeView.rowGeometryComputationCountForTesting == initialGeometryComputations)
+
+    scrollView.setFrameSize(NSSize(width: 220.6, height: 180))
+    scrollView.layoutSubtreeIfNeeded()
+    #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == initialApplications + 1)
+    _ = codeView.diffRowRects()
+    #expect(codeView.rowGeometryComputationCountForTesting == initialGeometryComputations + 1)
+}
+
+@Test func wrappedTextHeightOnlyResizeKeepsWidthDependentGeometry() throws {
+    let scrollView = try makeTextScrollView(width: 220)
+    scrollView.layoutSubtreeIfNeeded()
+    let codeView = try #require(scrollView.documentView as? DiffPaneCodeTextView)
+    _ = codeView.diffRowRects()
+    let initialApplications = scrollView.textLayoutConfigurationApplicationCountForTesting
+    let initialGeometryComputations = codeView.rowGeometryComputationCountForTesting
+
+    scrollView.setFrameSize(NSSize(width: 220, height: 260))
+    scrollView.layoutSubtreeIfNeeded()
+    _ = codeView.diffRowRects()
+
+    #expect(scrollView.textLayoutConfigurationApplicationCountForTesting == initialApplications)
+    #expect(codeView.rowGeometryComputationCountForTesting == initialGeometryComputations)
+}
+```
+
+- [ ] **Step 7: Run the new tests and verify RED, then make the minimal fixes**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffPaneViewTests/wrappedTextLayoutConfigurationTracksLastAppliedWidth \
+  -only-testing:AlasTests/DiffPaneViewTests/wrappedTextHeightOnlyResizeKeepsWidthDependentGeometry test
+```
+
+Expected before the minimal fixes: the width-tolerance test FAILS because the
+exact-equality implementation applies the 0.3-point width change.
+
+Replace exact equality with a `matches` method using the 0.5-point tolerance
+from the design. Compare against `appliedTextLayoutConfiguration`, which stores
+the last width actually applied, so the cumulative move from 220 to 220.6
+eventually reconfigures.
+
+Remove `.width` from `textView.autoresizingMask`; `DiffPaneTextScrollView.layout`
+must be the sole owner of document-view width. Use this explicit order in the
+layout pass:
+
+1. Call `super.layout()` and tile the ruler/content view.
+2. Derive the desired `TextLayoutConfiguration` without mutating TextKit.
+3. If the configuration meaningfully changed and wrapping is enabled, update
+   the text view to the desired content-view width while retaining its current
+   height. This invalidates row geometry before it is read.
+4. Apply the text-container configuration if needed. A second cache
+   invalidation here is harmless because geometry has not yet been computed.
+5. Read `documentHeight`, which computes exact row geometry once for the new
+   width/container configuration.
+6. Set the final text-view frame. In wrapped mode its width already matches, so
+   this is a height-only change and `DiffPaneCodeTextView.setFrameSize` does not
+   invalidate width-dependent geometry. In unwrapped mode, preserve the
+   existing measured-text-width behavior; the fixed million-point container
+   width means document-view frame width does not change line fragmentation.
+
+Factor configuration derivation out of the applying method so Steps 2 and 3 do
+not require mutating `appliedTextLayoutConfiguration` early:
+
+```swift
+let desiredConfiguration = textLayoutConfiguration()
+let configurationChanged = !desiredConfiguration.matches(appliedTextLayoutConfiguration)
+if configurationChanged, desiredConfiguration.wraps {
+    setTextViewWidthIfNeeded(max(contentView.bounds.width, 1))
+}
+applyTextLayoutConfigurationIfNeeded(desiredConfiguration)
+let desiredFrame = NSRect(
+    x: 0,
+    y: 0,
+    width: textViewWidth(),
+    height: documentHeight
+)
+setTextViewFrameIfNeeded(desiredFrame)
+```
+
+The optional-aware `matches` helper should return false when there is no applied
+configuration. Frame helpers use the same 0.5-point tolerance. Do not invalidate
+row geometry after `documentHeight` for the same meaningful wrapped-width
+transition. Re-run both tests until PASS; the `+1` geometry assertion verifies
+this ordering.
+
+- [ ] **Step 8: Run the renderer test suite**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffPaneViewTests test
+```
+
+Expected: PASS, including existing wrapped continuation, gutter, horizontal
+origin, and split synchronization regressions.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift AlasTests/DiffPaneViewTests.swift
+rtk git commit -m "perf(diff): cache wrapped text layout configuration"
+```
+
+### Task 2: Make Identical Container Updates True Layout No-Ops
+
+**Files:**
+- Modify: `AlasTests/DiffPaneViewTests.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift:240-395`
+  and `:450-565`
+
+- [ ] **Step 1: Add a failing identical-update regression test**
+
+Use the direct container API so the test isolates AppKit invalidation from
+SwiftUI scheduling:
+
+```swift
+@Test func identicalDiffDocumentContainerUpdateDoesNotRequestLayout() throws {
+    let group = try #require(model().groups.first)
+    let container = DiffPaneTextDocumentContainerView(
+        frame: NSRect(x: 0, y: 0, width: 700, height: 300)
+    )
+
+    func update() {
+        container.update(
+            group: group,
+            expandedCollapsedRowIDs: [],
+            layoutMode: .stacked,
+            wrapLines: true,
+            showWhitespace: false,
+            fileExtension: "swift",
+            font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+            theme: theme(),
+            lspContext: nil
+        )
+    }
+
+    update()
+    container.layoutSubtreeIfNeeded()
+    #expect(!container.needsLayout)
+
+    let codeView = try #require(allSubviews(of: container)
+        .compactMap { $0 as? DiffPaneCodeTextView }
+        .first(where: isEffectivelyVisible))
+    _ = codeView.diffRowRects()
+    let geometryComputations = codeView.rowGeometryComputationCountForTesting
+
+    update()
+
+    #expect(!container.needsLayout)
+    container.layoutSubtreeIfNeeded()
+    #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
+}
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffPaneViewTests/identicalDiffDocumentContainerUpdateDoesNotRequestLayout test
+```
+
+Expected: FAIL at `#expect(!container.needsLayout)` after the second update,
+because the identical-signature branch currently sets `needsLayout = true`.
+
+- [ ] **Step 3: Remove redundant layout requests from both update paths**
+
+In both `update(group:...)` and `update(rows:...)`, retain callback,
+selection-availability, context-expansion, and active-highlight assignments
+before signature comparison. Replace:
+
+```swift
+guard signature != lastUpdateSignature else {
+    needsLayout = true
+    return
+}
+```
+
+with:
+
+```swift
+guard signature != lastUpdateSignature else { return }
+```
+
+Apply the same change to `lastRowsUpdateSignature`. Do not move live callback or
+highlight assignments behind the guard. Those properties already invalidate
+display where needed and must remain current without rebuilding the document.
+
+- [ ] **Step 4: Run the focused test and renderer suite**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffPaneViewTests/identicalDiffDocumentContainerUpdateDoesNotRequestLayout test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffPaneViewTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift AlasTests/DiffPaneViewTests.swift
+rtk git commit -m "perf(diff): skip unchanged document layout"
+```
+
+### Task 3: Bound Custom Drawing To Dirty Rows
+
+**Files:**
+- Modify: `AlasTests/DiffPaneViewTests.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift:1600-1650`
+  and the ordered `Array<NSRect>` helpers near the end of the file
+
+- [ ] **Step 1: Add failing row-range lookup tests**
+
+```swift
+@Test func diffRowRectsReturnOnlyIndicesIntersectingDirtyVerticalRange() {
+    let rows = [
+        NSRect(x: 0, y: 0, width: 100, height: 10),
+        NSRect(x: 0, y: 10, width: 100, height: 10),
+        NSRect(x: 0, y: 20, width: 100, height: 10),
+        NSRect(x: 0, y: 30, width: 100, height: 10),
+    ]
+
+    #expect(rows.indicesIntersecting(NSRect(x: 0, y: 10, width: 100, height: 10)) == 1..<2)
+    #expect(rows.indicesIntersecting(NSRect(x: 0, y: 9, width: 100, height: 12)) == 0..<3)
+    #expect(rows.indicesIntersecting(NSRect(x: 0, y: 40, width: 100, height: 10)).isEmpty)
+    #expect([NSRect]().indicesIntersecting(.zero).isEmpty)
+}
+```
+
+The first assertion locks the current `NSRect.intersects` boundary semantics:
+rows that merely touch the dirty rectangle at an edge are excluded.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffPaneViewTests/diffRowRectsReturnOnlyIndicesIntersectingDirtyVerticalRange test
+```
+
+Expected: FAIL to compile because `indicesIntersecting` does not exist.
+
+- [ ] **Step 3: Implement ordered dirty-range lookup**
+
+Add an internal helper alongside `binarySearchRow(containing:)`:
+
+```swift
+func indicesIntersecting(_ rect: NSRect) -> Range<Int> {
+    guard !isEmpty, rect.height > 0 else { return 0..<0 }
+
+    let start = lowerBound { $0.maxY > rect.minY }
+    let end = lowerBound { $0.minY >= rect.maxY }
+    guard start < end else { return 0..<0 }
+    return start..<end
+}
+
+private func lowerBound(where predicate: (NSRect) -> Bool) -> Int {
+    var low = 0
+    var high = count
+    while low < high {
+        let mid = low + (high - low) / 2
+        if predicate(self[mid]) {
+            high = mid
+        } else {
+            low = mid + 1
+        }
+    }
+    return low
+}
+```
+
+The helper assumes the existing invariant that row rectangles are ordered and
+non-overlapping vertically.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the command from Step 2. Expected: PASS.
+
+- [ ] **Step 5: Use the range in text background drawing**
+
+Change `DiffPaneCodeTextView.drawLineBackgrounds(in:)` from enumerating every
+row and checking `rowRect.intersects(dirtyRect)` to:
+
+```swift
+let rowRects = diffRowRects()
+for index in rowRects.indicesIntersecting(dirtyRect) {
+    guard lineTones.indices.contains(index) else { continue }
+    let rowRect = rowRects[index]
+    let tone = lineTones[index]
+    guard tone != .context else { continue }
+    // Keep the existing fill, hatch, and expansion-pill drawing unchanged.
+}
+```
+
+Keep active-comment-highlight drawing after the loop. Do not add a second
+geometry cache or outer SwiftUI scroll observer.
+
+- [ ] **Step 6: Run focused and full diff renderer tests**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffPaneViewTests test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/DiffReviewSurfaceTests \
+  -only-testing:AlasTests/DiffSelectableTextTests \
+  -only-testing:AlasTests/CommitTabViewTests \
+  -only-testing:AlasTests/ReviewChangesTabViewTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift AlasTests/DiffPaneViewTests.swift
+rtk git commit -m "perf(diff): bound custom drawing to dirty rows"
+```
+
+### Task 4: Required Verification And Manual Profiling
+
+**Files:**
+- No planned source changes
+- Modify tests or production only if verification exposes a regression, using a
+  new failing test before the fix
+
+- [ ] **Step 1: Regenerate the Xcode project**
+
+```bash
+rtk xcodegen
+```
+
+Expected: success. Because `project.yml` is unchanged, `Alas.xcodeproj` should
+not acquire a semantic diff. Inspect and do not commit unrelated generated
+churn.
+
+- [ ] **Step 2: Build the macOS app**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0 with no new warnings from the modified files.
+
+- [ ] **Step 3: Run the complete test suite**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Inspect the final diff**
+
+```bash
+rtk git status --short
+rtk git diff --check
+rtk git diff --stat HEAD~3..HEAD
+```
+
+Expected: clean whitespace check; only the shared renderer and its tests changed
+across implementation commits. Preserve the already-committed spec and plan.
+
+- [ ] **Step 5: Manually profile representative wrapped panes**
+
+Open a large single-file diff, commit diff, and multi-file review diff. For each,
+scroll in both split and stacked layouts with wrapping enabled. Confirm:
+
+- stable-width scrolling does not increase the configuration-application or
+  row-geometry counters after initial layout/materialization
+- wrapped continuation text remains visible and gutters align
+- split old/new logical rows remain aligned
+- selection, comments, highlights, expansion controls, and LSP hover/click
+  behavior remain intact
+- toggling wrapping and resizing recompute exact heights without scroll jumps
+
+If Instruments is available, compare main-thread layout samples before and
+after. The acceptance criterion is elimination of repeated stable-width TextKit
+configuration/layout work, not a specific machine-dependent frame-time number.
+
+- [ ] **Step 6: Commit any verification-only test adjustment**
+
+Only if Step 3 or Step 5 required a test-first correction:
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift AlasTests/DiffPaneViewTests.swift
+rtk git commit -m "test(diff): cover wrapped layout regression"
+```

--- a/docs/superpowers/specs/2026-07-19-wrapped-diff-scroll-performance-design.md
+++ b/docs/superpowers/specs/2026-07-19-wrapped-diff-scroll-performance-design.md
@@ -1,0 +1,275 @@
+---
+title: "Wrapped diff scroll performance"
+date: 2026-07-19
+project: alas
+phase: design
+prior_art:
+  - docs/superpowers/specs/2026-07-07-center-diff-scroll-performance-design.md
+  - Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+  - Alas/Sources/Center/Diff/DiffPaneView.swift
+  - Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+---
+
+## TL;DR
+
+Improve scrolling performance when diff line wrapping is enabled in both
+single-file and multi-file diff surfaces, in both split and stacked layouts.
+Keep the current renderer and behavior. Make the AppKit text renderer apply
+width-sensitive TextKit configuration only when its effective configuration
+changes, make unchanged SwiftUI updates true no-ops, and bound custom drawing
+to rows intersecting the visible or dirty region.
+
+## Context
+
+All affected surfaces eventually render code through
+`DiffPaneTextDocumentContainerView` and `DiffPaneTextScrollView`. Each code pane
+uses an `NSTextView`, `NSLayoutManager`, and `NSTextContainer`. The vertical
+scroll is owned by an outer SwiftUI `ScrollView`; the nested AppKit scroll view
+exists for the code pane, its line-number ruler, and unwrapped horizontal
+scrolling.
+
+Wrapping increases the number of TextKit line fragments. The current AppKit
+layout path repeatedly assigns wrapping and container-size properties even
+when the wrap mode and effective code width have not changed. It also asks
+unchanged `NSViewRepresentable` updates to lay out again. A subsequent layout
+reads full-document row geometry for document height and, in split mode, row
+height synchronization. Reapplying an identical container configuration can
+therefore turn an otherwise redundant parent layout pass into wrapped-text
+layout work.
+
+The text view caches computed row geometry, but custom background drawing
+still scans the complete row-rect array before rejecting rows outside the dirty
+region. The ruler already has lower-bound helpers for visible rows; the text
+background path should use the same bounded lookup principle.
+
+These are shared-renderer costs, matching the reported slowdown across:
+
+- single-file diff and commit panes
+- multi-file review panes
+- split layout
+- stacked layout
+
+## Goals
+
+- Make wrapped scrolling smooth enough that it no longer exhibits the severe
+  stalls seen in current diff panes.
+- Prevent an unchanged AppKit update or layout pass from invalidating TextKit
+  layout.
+- Preserve exact wrapping and row heights at the current pane width.
+- Preserve split-pane row alignment.
+- Preserve text selection, line selection, line numbers, context expansion,
+  comment highlights, LSP interactions, whitespace display, and horizontal
+  scrolling when wrapping is disabled.
+- Apply the improvement to every surface using the shared diff text renderer.
+- Add deterministic regression coverage for the invalidation behavior rather
+  than relying only on wall-clock timing.
+
+## Non-Goals
+
+- Do not replace TextKit 1 or migrate the renderer to TextKit 2.
+- Do not introduce `NSCollectionView`, custom text drawing, or a new vertical
+  virtualization system.
+- Do not split hunks into additional text documents; that could change text
+  selection across artificial chunk boundaries.
+- Do not change diff parsing, syntax highlighting, context expansion, inline
+  feedback placement, or review-stream selection behavior.
+- Do not approximate wrapped heights or defer visible layout in a way that
+  causes scroll-position jumps.
+- Do not set a brittle time-based unit-test threshold for AppKit performance.
+
+## Design
+
+### Stable Text Layout Configuration
+
+`DiffPaneTextScrollView` will own a compact value describing the TextKit
+configuration currently applied to its text view and text container. The value
+will include only inputs that affect line fragmentation:
+
+- whether lines wrap
+- effective code width after subtracting the text inset
+- the unwrapped container-width policy
+
+Font and document changes already flow through `update(document:...)`, replace
+the attributed string, and invalidate layout independently. They do not need to
+be duplicated in the width-configuration value.
+
+The scroll view will derive the desired configuration after tiling establishes
+the effective content width. It will compare that value with the last applied
+configuration before changing any of these properties:
+
+- `isHorizontallyResizable`
+- `maxSize`
+- `textContainer.widthTracksTextView`
+- `textContainer.containerSize`
+- horizontal-scroller visibility
+
+If the value is unchanged, the configuration method returns without assigning
+TextKit properties. A meaningful width or wrap-mode change applies the new
+configuration once and invalidates width-dependent row geometry once.
+
+The comparison will use the project's existing half-point layout tolerance so
+subpixel frame noise does not repeatedly reflow wrapped text. The applied width
+must still be the actual current effective width when a change exceeds that
+tolerance.
+
+### Layout Passes
+
+`DiffPaneTextScrollView.layout()` will keep the existing order required by the
+line ruler and text frame:
+
+1. allow `NSScrollView` to tile its content and ruler
+2. derive and conditionally apply the effective text configuration
+3. measure document height from cached row geometry
+4. update the text view frame only when its size meaningfully changes
+5. reset the horizontal origin only after a document or wrap-mode update that
+   requested it
+
+The implementation should not explicitly tile the same scroll view multiple
+times in one layout pass unless AppKit requires it for a demonstrated geometry
+dependency. Any retained extra tiling call must not reapply text-container
+configuration.
+
+`DiffPaneTextDocumentContainerView.update` currently marks the container as
+needing layout when its render signature is identical. The identical-signature
+path will instead update only callbacks or transient interaction inputs that
+must remain current and then return without requesting layout. Render inputs
+that affect the document, theme, width behavior, or LSP context continue to
+take the existing rebuild path.
+
+Callback and active-highlight assignments occur before signature comparison
+today and remain live. If an interaction input needs display without document
+layout, its existing property observer should request display directly.
+
+### Row Geometry
+
+`DiffPaneCodeTextView` remains the source of truth for row rectangles and first
+line-fragment rectangles. Its cached geometry remains valid until one of these
+events:
+
+- attributed text or line metadata changes
+- line tones or synchronized paragraph heights change
+- the effective text width changes beyond the layout tolerance
+- the text view receives a meaningful frame-width change
+
+Scrolling alone must not invalidate this cache. Container height changes with
+an unchanged width must not invalidate it either.
+
+The split renderer will continue to measure both sides and synchronize each
+logical row to the greater height. Existing protections against the
+split-height synchronization live-lock remain intact. This work must not
+reintroduce unconditional paragraph-style writes.
+
+### Visible Custom Drawing
+
+`DiffPaneCodeTextView.drawLineBackgrounds(in:)` will locate the first and last
+row rectangles intersecting the dirty rectangle using lower-bound or binary
+search over the ordered cached geometry. It will iterate only that row range.
+Add/delete fills, placeholder hatching, expandable-context controls, and the
+active comment highlight retain their current appearance and hit geometry.
+
+The line-number ruler will continue to render only visible rows. Shared helpers
+may be extracted for row-range lookup if that removes duplication without
+changing ownership. Drawing optimization must not create a second row-geometry
+cache with different invalidation semantics.
+
+The dirty rectangle supplied by AppKit remains authoritative for the text
+view. The implementation does not need SwiftUI scroll-position state or a new
+outer-scroll observer merely to calculate visible rows.
+
+## Data Flow
+
+1. SwiftUI creates or updates a shared diff document representable.
+2. The container compares the new render signature with the last applied
+   signature.
+3. An unchanged signature updates interaction closures/state only and returns
+   without scheduling layout.
+4. A changed signature rebuilds the attributed document and marks the scroll
+   view for layout as today.
+5. During layout, the scroll view derives the effective code width after the
+   ruler has been tiled.
+6. The cached text-layout configuration suppresses identical TextKit property
+   assignments.
+7. Row geometry is computed once for the resulting document and width, then
+   reused for height, split synchronization, drawing, ruler labels, and hit
+   testing.
+8. During scrolling, AppKit draws only the dirty row range while the cached
+   geometry remains valid.
+
+## Correctness And Failure Handling
+
+No new asynchronous work or user-visible error state is introduced. If the
+configuration cache is empty, the renderer applies the full configuration. If
+the pane changes width, wrap mode, document, or font, the renderer follows the
+normal layout path and recomputes exact geometry.
+
+The optimization must fail toward doing necessary work: an uncertain
+configuration comparison should reconfigure and remeasure rather than reuse
+geometry at the wrong width. Debug counters used by tests must not affect
+release behavior or persist diagnostics.
+
+## Instrumentation
+
+Add narrow debug/test-only counters or observable test accessors for:
+
+- effective text-layout configuration applications
+- row-geometry computations
+- optionally, container or scroll-view layout passes if needed to prove the
+  unchanged-update behavior
+
+The counters are evidence for tests and local profiling. They are not product
+analytics and must not emit logs during normal use.
+
+## Testing
+
+Use Swift Testing and real AppKit objects. Tests should cover:
+
+- repeated wrapped layout at an unchanged width applies text-container
+  configuration only once
+- a meaningful width change applies a new configuration and recomputes row
+  geometry
+- a sub-tolerance width change does not reconfigure TextKit
+- toggling wrap mode applies a new configuration and preserves horizontal
+  scroller behavior
+- an identical container update does not request another layout pass or
+  recompute row geometry
+- height-only frame changes do not invalidate width-dependent geometry
+- wrapped stacked documents keep exact line and document heights
+- wrapped split documents keep paired logical rows aligned
+- custom background row-range lookup includes every intersecting boundary row
+  and excludes offscreen rows
+- existing wrapped continuation glyph, gutter, selection, expansion, comment
+  highlight, and split synchronization regression tests continue to pass
+
+The test suite should assert work counts or state transitions, not elapsed
+milliseconds. A focused performance harness may record layout/configuration
+counts for a large synthetic diff, but it should remain deterministic.
+
+## Verification
+
+Run the required project verification:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Manually compare wrapped and unwrapped scrolling in:
+
+- a large single-file diff
+- a large commit diff
+- a multi-file review diff
+- split and stacked layouts
+
+Use Instruments or debug counters to confirm scrolling no longer causes
+repeated TextKit configuration applications or row-geometry recomputation at a
+stable width. Visual verification must confirm there are no row-alignment,
+gutter, clipping, selection, or scroll-position regressions.
+
+## Rollout
+
+This is a single shared-renderer change with no migration or configuration
+flag. If profiling after the change still shows material wrapped-text cost, the
+next investigation should evaluate bounded hunk chunking or a viewport-driven
+AppKit renderer as a separate design, because both carry larger interaction and
+selection tradeoffs.

--- a/docs/superpowers/specs/2026-07-19-wrapped-diff-scroll-performance-design.md
+++ b/docs/superpowers/specs/2026-07-19-wrapped-diff-scroll-performance-design.md
@@ -110,7 +110,9 @@ configuration once and invalidates width-dependent row geometry once.
 The comparison will use the project's existing half-point layout tolerance so
 subpixel frame noise does not repeatedly reflow wrapped text. The applied width
 must still be the actual current effective width when a change exceeds that
-tolerance.
+tolerance. Compare against the last width actually applied to TextKit, not the
+immediately preceding requested width, so cumulative sub-tolerance changes
+eventually reconfigure once their total difference exceeds the tolerance.
 
 ### Layout Passes
 


### PR DESCRIPTION
## Summary
- Cache effective wrapped TextKit layout configuration to avoid repeated stable-width reconfiguration.
- Skip layout work for identical diff document updates while keeping live callbacks and highlights current.
- Bound custom diff background drawing to dirty row ranges instead of scanning all rows.

## Test Plan
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/DiffSelectableTextTests -only-testing:AlasTests/CommitTabViewTests -only-testing:AlasTests/ReviewChangesTabViewTests test`
- `rtk git diff --check`

## Note
The full local suite command `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was attempted and hung in the `Alas --no-parallel` test host after roughly 10 minutes. Focused diff-pane and related renderer suites passed.