### PR TITLE
fix(acp): poll broker in background for the whole connection lifetime

### DIFF
--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -62,10 +62,26 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var deferredOrderedAckCursors: Set<ACPBrokerEventCursor> = []
     private var dispatchedEventCursors: Set<ACPBrokerEventCursor> = []
     private var turnState: ACPBrokerTurnState = .idle
-    private var activeTurnPollingTask: Task<Void, Never>?
+    private var backgroundPollingTask: Task<Void, Never>?
+    private let backgroundPollActiveIntervalNanoseconds: UInt64
+    private let backgroundPollIdleIntervalNanoseconds: UInt64
     private var lastQueuedDurableState: ACPBrokerDurableState?
     private var pendingDurableStates: [ACPBrokerDurableState] = []
     private var isDrainingDurableStates = false
+
+    /// Interval used while `turnState` needs active polling (sending,
+    /// streaming, awaiting input, cancelling).
+    static let defaultBackgroundPollActiveIntervalNanoseconds: UInt64 = 50_000_000
+    /// Interval used otherwise. The broker is pull-only: `attachAndReplay`
+    /// only runs from `start()`, from `send()`/`notify()`, and from this
+    /// background loop. A turn the agent resumes on its own — an SDK-queued
+    /// follow-up message, a stop-hook continuation, a `/loop`-style wakeup —
+    /// produces events with nobody pulling them, because nothing in Alas
+    /// issued the RPC that would trigger a pull. Without this idle-rate
+    /// poll, those events sit in the broker's durable log until the next
+    /// user prompt replays the whole backlog at once — the transcript
+    /// looks frozen for however long the agent kept going on its own.
+    static let defaultBackgroundPollIdleIntervalNanoseconds: UInt64 = 2_000_000_000
 
     var yieldedUpdateCount: Int {
         stateLock.lock()
@@ -90,6 +106,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         operationKeyPrefix: String,
         initialBrokerGeneration: ACPBrokerGeneration? = nil,
         initialAcknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
+        backgroundPollActiveIntervalNanoseconds: UInt64 = ACPBrokerClient.defaultBackgroundPollActiveIntervalNanoseconds,
+        backgroundPollIdleIntervalNanoseconds: UInt64 = ACPBrokerClient.defaultBackgroundPollIdleIntervalNanoseconds,
         onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil,
         onTurnStateChanged: (@Sendable (ACPBrokerTurnState) -> Void)? = nil
     ) {
@@ -103,6 +121,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         self.operationKeyPrefix = operationKeyPrefix
         self.initialBrokerGeneration = initialBrokerGeneration
         self.acknowledgedCursor = initialAcknowledgedCursor
+        self.backgroundPollActiveIntervalNanoseconds = backgroundPollActiveIntervalNanoseconds
+        self.backgroundPollIdleIntervalNanoseconds = backgroundPollIdleIntervalNanoseconds
         self.onDurableStateChanged = onDurableStateChanged
         self.onTurnStateChanged = onTurnStateChanged
 
@@ -150,10 +170,8 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             resetAcknowledgedCursor()
         }
         setSnapshot(opened.snapshot)
-        let snapshot = try await attachAndReplay()
-        if opened.adopted {
-            startActiveTurnPollingIfNeeded(snapshot: snapshot)
-        }
+        _ = try await attachAndReplay()
+        startBackgroundPolling()
         return opened
     }
 
@@ -245,7 +263,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func shutdown() async {
-        cancelActiveTurnPolling()
+        cancelBackgroundPolling()
         if let generation = try? currentGeneration() {
             _ = try? await service.close(ACPBrokerCloseParams(brokerId: brokerId, generation: generation))
         }
@@ -253,7 +271,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func detach() async {
-        cancelActiveTurnPolling()
+        cancelBackgroundPolling()
         if let generation = try? currentGeneration() {
             _ = try? await service.detach(ACPBrokerDetachParams(brokerId: brokerId, generation: generation))
         }
@@ -290,28 +308,31 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         return attached.snapshot
     }
 
-    private func startActiveTurnPollingIfNeeded(snapshot: ACPBrokerSnapshot) {
-        guard snapshot.turnState.needsActiveTurnPolling else { return }
+    /// Runs for the whole connection lifetime (`start()` through
+    /// `shutdown()`/`detach()`), not just while a turn is active — see the
+    /// doc comment on `defaultBackgroundPollIdleIntervalNanoseconds` for why
+    /// a poll-only-while-active loop isn't enough. Idempotent: a second call
+    /// while a loop is already running is a no-op.
+    private func startBackgroundPolling() {
         stateLock.lock()
-        if activeTurnPollingTask != nil {
+        if backgroundPollingTask != nil {
             stateLock.unlock()
             return
         }
-        activeTurnPollingTask = Task { [weak self] in
-            await self?.pollActiveTurn()
+        backgroundPollingTask = Task { [weak self] in
+            await self?.runBackgroundPolling()
         }
         stateLock.unlock()
     }
 
-    private func pollActiveTurn() async {
-        defer { clearActiveTurnPollingTask() }
+    private func runBackgroundPolling() async {
+        defer { clearBackgroundPollingTask() }
         while !Task.isCancelled {
             do {
-                try await Task.sleep(for: .milliseconds(50))
-                let snapshot = try await attachAndReplay()
-                if !snapshot.turnState.needsActiveTurnPolling {
-                    return
-                }
+                try await Task.sleep(nanoseconds: currentBackgroundPollIntervalNanoseconds())
+                _ = try await attachAndReplay()
+            } catch is CancellationError {
+                return
             } catch {
                 finishStreams()
                 return
@@ -319,17 +340,25 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         }
     }
 
-    private func cancelActiveTurnPolling() {
+    private func currentBackgroundPollIntervalNanoseconds() -> UInt64 {
         stateLock.lock()
-        let task = activeTurnPollingTask
-        activeTurnPollingTask = nil
+        defer { stateLock.unlock() }
+        return turnState.needsActiveTurnPolling
+            ? backgroundPollActiveIntervalNanoseconds
+            : backgroundPollIdleIntervalNanoseconds
+    }
+
+    private func cancelBackgroundPolling() {
+        stateLock.lock()
+        let task = backgroundPollingTask
+        backgroundPollingTask = nil
         stateLock.unlock()
         task?.cancel()
     }
 
-    private func clearActiveTurnPollingTask() {
+    private func clearBackgroundPollingTask() {
         stateLock.lock()
-        activeTurnPollingTask = nil
+        backgroundPollingTask = nil
         stateLock.unlock()
     }
 
@@ -387,7 +416,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 elicitationCompletionsCont.yield(decoded)
             }
         case "adapter/exit":
-            cancelActiveTurnPolling()
+            cancelBackgroundPolling()
             finishStreams()
         default:
             break

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -229,13 +229,24 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         // a queued retry the caller abandoned) — protecting those
         // unconditionally would leave them "unacknowledged" forever with no
         // call left to release them, permanently blocking every later ack.
+        //
+        // This defer only ever releases the registration above, never the
+        // cursor itself. An earlier version also force-acked the cursor
+        // here whenever this call exited without handing a response to its
+        // caller — but the operation can have genuinely SUCCEEDED at the
+        // broker while THIS call still fails for an unrelated reason (e.g.
+        // the `attachAndReplay()` right after a successful/replayed
+        // `service.send()` throws on its own transient RPC hiccup). Acking
+        // in that case tells the broker it may prune the completed
+        // operation (the helper only retains completions above the acked
+        // cursor) even though the caller never received the result — and
+        // the queued-send retry path reuses the same operationKey on
+        // non-JSONRPC failures, expecting the broker to still have it
+        // cached. The only path allowed to ack is the one below that
+        // actually hands a response back, via `durableConsumptionAcknowledgement`.
         beginAwaitingOperationCompletion(operationKey)
-        var releasedToCaller = false
         defer {
             endAwaitingOperationCompletion(operationKey)
-            if !releasedToCaller, let cursor = currentOperationCompletionCursor(for: operationKey) {
-                ackResponse(cursor: cursor)
-            }
         }
         while true {
             let result = try await service.send(ACPBrokerSendParams(
@@ -257,7 +268,6 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             }
             clearPendingOutboundRequest(id: result.requestId.jsonRPCID)
             let cursor = currentOperationCompletionCursor(for: operationKey)
-            releasedToCaller = true
             return ACPResponse(
                 body: try (result.result ?? .null).data,
                 durableConsumptionAcknowledgement: { [weak self] in

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -58,6 +58,10 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var pendingInboundCursors: [JSONRPCID: ACPBrokerEventCursor] = [:]
     private var pendingOutboundRequestIds: Set<JSONRPCID> = []
     private var operationCompletionCursors: [ACPBrokerOperationKey: ACPBrokerEventCursor] = [:]
+    /// Ref-counted (not a plain `Set`) so two calls that happen to share an
+    /// explicit `brokerOperationKey` — unlikely, but the type permits it —
+    /// don't have one call's exit clear the flag out from under the other.
+    private var awaitedOperationKeyRefCounts: [ACPBrokerOperationKey: Int] = [:]
     private var unacknowledgedDurableEventCursors: Set<ACPBrokerEventCursor> = []
     private var deferredOrderedAckCursors: Set<ACPBrokerEventCursor> = []
     private var dispatchedEventCursors: Set<ACPBrokerEventCursor> = []
@@ -184,17 +188,24 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         let operationKey = request.brokerOperationKey.map(ACPBrokerOperationKey.init(rawValue:))
             ?? nextOperationKey(method: request.method)
         let params = try ACPBrokerJSONValue(encodable: request.params)
-        // `dispatch()`'s `.operationCompleted` handler eagerly protects this
-        // operation's completion cursor the moment ANY caller observes it
-        // (including the background poller, independently of this call).
-        // Every exit below other than the successful return must release
-        // that protection here — otherwise a completion this call never
-        // hands off (error, cancellation) would stay "unacknowledged"
-        // forever, permanently blocking later acks. The successful path
-        // hands the release off to the caller instead, via
-        // `durableConsumptionAcknowledgement`.
+        // Registering here, before the first `service.send()`, tells
+        // `dispatch()`'s `.operationCompleted` handler that a live call is
+        // waiting on this operationKey, so it protects the completion's
+        // cursor from `ackAfterEarlierDurableEvents` the moment ANY caller
+        // observes it (including the background poller, independently of
+        // this call) — closing the race where a later durable event could
+        // otherwise be acked past a completion this call hasn't caught up
+        // to yet. Only registered operationKeys get that protection: an
+        // adopted broker's replay can include a completion for an
+        // operationKey nothing here will ever call `send()` for again
+        // (`initialize`/`session/new` served from `cachedResponse` above, or
+        // a queued retry the caller abandoned) — protecting those
+        // unconditionally would leave them "unacknowledged" forever with no
+        // call left to release them, permanently blocking every later ack.
+        beginAwaitingOperationCompletion(operationKey)
         var releasedToCaller = false
         defer {
+            endAwaitingOperationCompletion(operationKey)
             if !releasedToCaller, let cursor = currentOperationCompletionCursor(for: operationKey) {
                 ackResponse(cursor: cursor)
             }
@@ -460,20 +471,27 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             // Protect this cursor from `ackAfterEarlierDurableEvents`
             // immediately, at the moment ANY caller observes it — not only
             // once `send()`'s own retry loop gets around to noticing it.
-            // With the background poller now
-            // running continuously (previously it only ran during an
-            // adopted session's active turn), it can dispatch this same
-            // event on a call completely independent of the `send()` call
-            // that's actually waiting on it. In the window before that
-            // `send()` call catches up, a later durable event (e.g. the
-            // next streamed chunk) could otherwise be acked immediately —
-            // `ackAfterEarlierDurableEvents` only defers when it already
-            // knows an earlier cursor is unconsumed — advancing
-            // `acknowledgedCursor` past this one before its response was
-            // ever handed back. `send()` releases this via a `defer` on
-            // every exit path (success, error, cancellation), so it can't
-            // be left tracked forever for a call that did run.
-            unacknowledgedDurableEventCursors.insert(event.cursor)
+            // With the background poller now running continuously
+            // (previously it only ran during an adopted session's active
+            // turn), it can dispatch this same event on a call completely
+            // independent of the `send()` call that's actually waiting on
+            // it. In the window before that `send()` call catches up, a
+            // later durable event (e.g. the next streamed chunk) could
+            // otherwise be acked immediately — `ackAfterEarlierDurableEvents`
+            // only defers when it already knows an earlier cursor is
+            // unconsumed — advancing `acknowledgedCursor` past this one
+            // before its response was ever handed back.
+            //
+            // Only do this when `send()` actually registered interest in
+            // this operationKey (see `beginAwaitingOperationCompletion`):
+            // an adopted broker's replay can include a completion for an
+            // operationKey nothing here will ever call `send()` for again,
+            // and protecting that unconditionally would leave it
+            // "unacknowledged" forever with no call left to release it,
+            // permanently blocking every later ack.
+            if awaitedOperationKeyRefCounts[operationKey] != nil {
+                unacknowledgedDurableEventCursors.insert(event.cursor)
+            }
             stateLock.unlock()
         case .turnStateChanged(let state):
             setTurnState(state)
@@ -829,6 +847,24 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private func clearPendingOutboundRequest(id: JSONRPCID) {
         stateLock.lock()
         pendingOutboundRequestIds.remove(id)
+        stateLock.unlock()
+    }
+
+    private func beginAwaitingOperationCompletion(_ operationKey: ACPBrokerOperationKey) {
+        stateLock.lock()
+        awaitedOperationKeyRefCounts[operationKey, default: 0] += 1
+        stateLock.unlock()
+    }
+
+    private func endAwaitingOperationCompletion(_ operationKey: ACPBrokerOperationKey) {
+        stateLock.lock()
+        if let count = awaitedOperationKeyRefCounts[operationKey] {
+            if count <= 1 {
+                awaitedOperationKeyRefCounts.removeValue(forKey: operationKey)
+            } else {
+                awaitedOperationKeyRefCounts[operationKey] = count - 1
+            }
+        }
         stateLock.unlock()
     }
 

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -62,6 +62,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var deferredOrderedAckCursors: Set<ACPBrokerEventCursor> = []
     private var dispatchedEventCursors: Set<ACPBrokerEventCursor> = []
     private var turnState: ACPBrokerTurnState = .idle
+    private var isTerminated = false
     private var backgroundPollingTask: Task<Void, Never>?
     private let backgroundPollActiveIntervalNanoseconds: UInt64
     private let backgroundPollIdleIntervalNanoseconds: UInt64
@@ -279,6 +280,20 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     private func finishStreams() {
+        // Marks the connection as permanently done. Every path that ends
+        // streaming (explicit shutdown/detach, an `adapter/exit` replayed
+        // mid-`attachAndReplay`, or the poll loop's own error handler) routes
+        // through here, so this is the one place that reliably knows the
+        // connection is dead — including the startup-exit ordering where
+        // `attachAndReplay()` inside `start()` replays `adapter/exit` and
+        // calls this *before* `start()` reaches `startBackgroundPolling()`.
+        // Without this flag, `startBackgroundPolling()` would still create a
+        // fresh poller for the already-dead connection, since the exit
+        // handler's own `cancelBackgroundPolling()` call has nothing to
+        // cancel yet at that point.
+        stateLock.lock()
+        isTerminated = true
+        stateLock.unlock()
         updatesCont.finish()
         permsCont.finish()
         questionsCont.finish()
@@ -315,7 +330,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     /// while a loop is already running is a no-op.
     private func startBackgroundPolling() {
         stateLock.lock()
-        if backgroundPollingTask != nil {
+        if isTerminated || backgroundPollingTask != nil {
             stateLock.unlock()
             return
         }

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -242,8 +242,12 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         // cursor) even though the caller never received the result — and
         // the queued-send retry path reuses the same operationKey on
         // non-JSONRPC failures, expecting the broker to still have it
-        // cached. The only path allowed to ack is the one below that
-        // actually hands a response back, via `durableConsumptionAcknowledgement`.
+        // cached. Two paths actually ack a cursor now: the success return
+        // below, via `durableConsumptionAcknowledgement`, once the caller
+        // consumes it; and the terminal-JSON-RPC-error branch below, which
+        // acks immediately — unlike an incidental local failure, a
+        // `result.error` IS this operationKey's final outcome, so no
+        // retry with the same key is coming to ack it later.
         beginAwaitingOperationCompletion(operationKey)
         defer {
             endAwaitingOperationCompletion(operationKey)
@@ -260,6 +264,22 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             try await attachAndReplay()
             if let error = result.error {
                 clearPendingOutboundRequest(id: result.requestId.jsonRPCID)
+                // A terminal JSON-RPC error IS this operationKey's final,
+                // authoritative outcome — unlike an incidental failure
+                // elsewhere in this call (the case the surrounding defer
+                // deliberately no longer acks for, see above), there is no
+                // successful result a caller could still receive for this
+                // operationKey, so nothing else will ever call
+                // `ackResponse` for it. The `attachAndReplay()` just above
+                // may have already dispatched this exact completion (with
+                // its error outcome) and, since this call registered
+                // interest before the RPC, protected its cursor — ack it
+                // now or it stays "unacknowledged" forever, deferring every
+                // later durable event behind a completion nobody is coming
+                // back for.
+                if let cursor = currentOperationCompletionCursor(for: operationKey) {
+                    ackResponse(cursor: cursor)
+                }
                 throw ACPClientError.jsonrpc(error)
             }
             if result.pending == true && result.result == nil {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -184,6 +184,21 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         let operationKey = request.brokerOperationKey.map(ACPBrokerOperationKey.init(rawValue:))
             ?? nextOperationKey(method: request.method)
         let params = try ACPBrokerJSONValue(encodable: request.params)
+        // `dispatch()`'s `.operationCompleted` handler eagerly protects this
+        // operation's completion cursor the moment ANY caller observes it
+        // (including the background poller, independently of this call).
+        // Every exit below other than the successful return must release
+        // that protection here — otherwise a completion this call never
+        // hands off (error, cancellation) would stay "unacknowledged"
+        // forever, permanently blocking later acks. The successful path
+        // hands the release off to the caller instead, via
+        // `durableConsumptionAcknowledgement`.
+        var releasedToCaller = false
+        defer {
+            if !releasedToCaller, let cursor = currentOperationCompletionCursor(for: operationKey) {
+                ackResponse(cursor: cursor)
+            }
+        }
         while true {
             let result = try await service.send(ACPBrokerSendParams(
                 brokerId: brokerId,
@@ -204,9 +219,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             }
             clearPendingOutboundRequest(id: result.requestId.jsonRPCID)
             let cursor = currentOperationCompletionCursor(for: operationKey)
-            if let cursor {
-                trackDeferredResponse(cursor: cursor)
-            }
+            releasedToCaller = true
             return ACPResponse(
                 body: try (result.result ?? .null).data,
                 durableConsumptionAcknowledgement: { [weak self] in
@@ -444,6 +457,23 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         case .operationCompleted(let operationKey, _):
             stateLock.lock()
             operationCompletionCursors[operationKey] = event.cursor
+            // Protect this cursor from `ackAfterEarlierDurableEvents`
+            // immediately, at the moment ANY caller observes it — not only
+            // once `send()`'s own retry loop gets around to noticing it.
+            // With the background poller now
+            // running continuously (previously it only ran during an
+            // adopted session's active turn), it can dispatch this same
+            // event on a call completely independent of the `send()` call
+            // that's actually waiting on it. In the window before that
+            // `send()` call catches up, a later durable event (e.g. the
+            // next streamed chunk) could otherwise be acked immediately —
+            // `ackAfterEarlierDurableEvents` only defers when it already
+            // knows an earlier cursor is unconsumed — advancing
+            // `acknowledgedCursor` past this one before its response was
+            // ever handed back. `send()` releases this via a `defer` on
+            // every exit path (success, error, cancellation), so it can't
+            // be left tracked forever for a call that did run.
+            unacknowledgedDurableEventCursors.insert(event.cursor)
             stateLock.unlock()
         case .turnStateChanged(let state):
             setTurnState(state)
@@ -666,12 +696,6 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         unacknowledgedDurableEventCursors.remove(cursor)
         stateLock.unlock()
         ackAfterEarlierDurableEvents(cursor: cursor)
-    }
-
-    private func trackDeferredResponse(cursor: ACPBrokerEventCursor) {
-        stateLock.lock()
-        unacknowledgedDurableEventCursors.insert(cursor)
-        stateLock.unlock()
     }
 
     private func ackAfterEarlierDurableEvents(cursor: ACPBrokerEventCursor) {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -264,7 +264,17 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func shutdown() async {
-        await cancelBackgroundPollingAndAwait()
+        // Mark terminated BEFORE anything else, not after: the background
+        // poller's `service.attach()` call goes through `RemoteHelperClient`,
+        // which waits on the helper's stdio pipe with no read timeout. If
+        // the helper or broker is wedged, awaiting that poller here would
+        // hang shutdown() forever and the close RPC below would never even
+        // be attempted. `attachAndReplay()`'s `isConnectionTerminated()`
+        // guard (see there) already makes any such in-flight response safe
+        // to ignore whenever it eventually resolves, so there's nothing to
+        // gain from waiting for it — only cancel and move on.
+        markTerminated()
+        cancelBackgroundPolling()
         if let generation = try? currentGeneration() {
             _ = try? await service.close(ACPBrokerCloseParams(brokerId: brokerId, generation: generation))
         }
@@ -272,28 +282,33 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func detach() async {
-        await cancelBackgroundPollingAndAwait()
+        markTerminated()
+        cancelBackgroundPolling()
         if let generation = try? currentGeneration() {
             _ = try? await service.detach(ACPBrokerDetachParams(brokerId: brokerId, generation: generation))
         }
         finishStreams()
     }
 
-    private func finishStreams() {
-        // Marks the connection as permanently done. Every path that ends
-        // streaming (explicit shutdown/detach, an `adapter/exit` replayed
-        // mid-`attachAndReplay`, or the poll loop's own error handler) routes
-        // through here, so this is the one place that reliably knows the
-        // connection is dead — including the startup-exit ordering where
-        // `attachAndReplay()` inside `start()` replays `adapter/exit` and
-        // calls this *before* `start()` reaches `startBackgroundPolling()`.
-        // Without this flag, `startBackgroundPolling()` would still create a
-        // fresh poller for the already-dead connection, since the exit
-        // handler's own `cancelBackgroundPolling()` call has nothing to
-        // cancel yet at that point.
+    /// Marks the connection as permanently done. Every path that ends
+    /// streaming (explicit shutdown/detach, an `adapter/exit` replayed
+    /// mid-`attachAndReplay`, or the poll loop's own error handler) sets
+    /// this, so it's the one flag that reliably reflects whether the
+    /// connection is dead — including the startup-exit ordering where
+    /// `attachAndReplay()` inside `start()` replays `adapter/exit` and
+    /// marks termination *before* `start()` reaches `startBackgroundPolling()`.
+    /// Without this flag, `startBackgroundPolling()` would still create a
+    /// fresh poller for the already-dead connection, since the exit
+    /// handler's own `cancelBackgroundPolling()` call has nothing to cancel
+    /// yet at that point. Idempotent — safe to call more than once.
+    private func markTerminated() {
         stateLock.lock()
         isTerminated = true
         stateLock.unlock()
+    }
+
+    private func finishStreams() {
+        markTerminated()
         updatesCont.finish()
         permsCont.finish()
         questionsCont.finish()
@@ -387,38 +402,20 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     /// Requests cancellation without waiting for the current iteration to
-    /// unwind. Safe to call from *inside* the poller's own task (the
-    /// `adapter/exit` handler runs synchronously as part of
-    /// `runBackgroundPolling()`'s own `attachAndReplay()` call) — unlike
-    /// `cancelBackgroundPollingAndAwait()`, this never awaits the task it
-    /// just cancelled, so it can't deadlock on itself.
+    /// unwind — `Task.cancel()` can't interrupt an in-flight, non-
+    /// cancellation-aware `attachAndReplay()` anyway (see
+    /// `isConnectionTerminated()`'s doc comment in `attachAndReplay()`), so
+    /// there's nothing to gain from awaiting it, and awaiting a helper RPC
+    /// with no read timeout would risk hanging the caller forever. Safe to
+    /// call from *inside* the poller's own task too (the `adapter/exit`
+    /// handler runs synchronously as part of `runBackgroundPolling()`'s own
+    /// `attachAndReplay()` call) since it never awaits the task it cancels.
     private func cancelBackgroundPolling() {
-        _ = requestBackgroundPollingCancellation()
-    }
-
-    /// Cancels and waits for the poller to fully unwind before returning.
-    /// `Task.cancel()` alone doesn't help here: the poller's underlying
-    /// `attachAndReplay()` awaits a helper RPC that isn't cancellation-aware,
-    /// so a cancelled-but-in-flight iteration still runs to completion and
-    /// dispatches whatever it received (`onTurnStateChanged`/
-    /// `onDurableStateChanged` are plain closures, not gated by
-    /// `finishStreams()`'s stream-`finish()` calls). Without awaiting it
-    /// here, `shutdown()`/`detach()` could return while that dispatch is
-    /// still racing to land, delivering updates for a connection the app
-    /// already believes is torn down. Only safe to call from a task other
-    /// than the poller's own (`shutdown()`/`detach()` always are) — awaiting
-    /// the poller from within itself would hang forever.
-    private func cancelBackgroundPollingAndAwait() async {
-        await requestBackgroundPollingCancellation()?.value
-    }
-
-    private func requestBackgroundPollingCancellation() -> Task<Void, Never>? {
         stateLock.lock()
         let task = backgroundPollingTask
         backgroundPollingTask = nil
         stateLock.unlock()
         task?.cancel()
-        return task
     }
 
     private func clearBackgroundPollingTask() {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -160,6 +160,33 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         terminalsCont = t
     }
 
+    /// Pre-registers operationKeys the caller still expects a result for,
+    /// so `start()`'s own initial replay protects their completion cursors
+    /// even though no live `send()` call has happened yet in this process.
+    /// Must be called before `start()`.
+    ///
+    /// Needed for a queued prompt that was `.sending` when the app last
+    /// quit: restoring the queue resets it to `.pending`, but reuses the
+    /// same `brokerOperationKey` (see `QueuedPrompt.normalizedAfterRestore()`
+    /// / `brokerOperationKey`), and the broker may have already completed
+    /// it before the crash. The app's queue flusher is guard-enforced to
+    /// only retry it after `start()` returns and the runner registers —
+    /// but `start()`'s own replay can reveal that completion first, and
+    /// without this, nothing protects its cursor in the gap: a later
+    /// durable event could be acked past it before the flusher's retry
+    /// ever calls `send()` for it. Callers pass every `brokerOperationKey`
+    /// in the session's restored queue (not just `.pending` ones);
+    /// pre-registering a key the broker never actually completed an
+    /// operation for is inert — `dispatch()` only consults this set when it
+    /// sees a matching `.operationCompleted` event.
+    func preRegisterAwaitedOperationKeys(_ operationKeys: some Sequence<String>) {
+        stateLock.lock()
+        for key in operationKeys {
+            awaitedOperationKeyRefCounts[ACPBrokerOperationKey(rawValue: key), default: 0] += 1
+        }
+        stateLock.unlock()
+    }
+
     @discardableResult
     func start() async throws -> ACPBrokerOpenResult {
         let opened = try await service.open(ACPBrokerOpenParams(

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -264,7 +264,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func shutdown() async {
-        cancelBackgroundPolling()
+        await cancelBackgroundPollingAndAwait()
         if let generation = try? currentGeneration() {
             _ = try? await service.close(ACPBrokerCloseParams(brokerId: brokerId, generation: generation))
         }
@@ -272,7 +272,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     }
 
     func detach() async {
-        cancelBackgroundPolling()
+        await cancelBackgroundPollingAndAwait()
         if let generation = try? currentGeneration() {
             _ = try? await service.detach(ACPBrokerDetachParams(brokerId: brokerId, generation: generation))
         }
@@ -363,12 +363,39 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             : backgroundPollIdleIntervalNanoseconds
     }
 
+    /// Requests cancellation without waiting for the current iteration to
+    /// unwind. Safe to call from *inside* the poller's own task (the
+    /// `adapter/exit` handler runs synchronously as part of
+    /// `runBackgroundPolling()`'s own `attachAndReplay()` call) — unlike
+    /// `cancelBackgroundPollingAndAwait()`, this never awaits the task it
+    /// just cancelled, so it can't deadlock on itself.
     private func cancelBackgroundPolling() {
+        _ = requestBackgroundPollingCancellation()
+    }
+
+    /// Cancels and waits for the poller to fully unwind before returning.
+    /// `Task.cancel()` alone doesn't help here: the poller's underlying
+    /// `attachAndReplay()` awaits a helper RPC that isn't cancellation-aware,
+    /// so a cancelled-but-in-flight iteration still runs to completion and
+    /// dispatches whatever it received (`onTurnStateChanged`/
+    /// `onDurableStateChanged` are plain closures, not gated by
+    /// `finishStreams()`'s stream-`finish()` calls). Without awaiting it
+    /// here, `shutdown()`/`detach()` could return while that dispatch is
+    /// still racing to land, delivering updates for a connection the app
+    /// already believes is torn down. Only safe to call from a task other
+    /// than the poller's own (`shutdown()`/`detach()` always are) — awaiting
+    /// the poller from within itself would hang forever.
+    private func cancelBackgroundPollingAndAwait() async {
+        await requestBackgroundPollingCancellation()?.value
+    }
+
+    private func requestBackgroundPollingCancellation() -> Task<Void, Never>? {
         stateLock.lock()
         let task = backgroundPollingTask
         backgroundPollingTask = nil
         stateLock.unlock()
         task?.cancel()
+        return task
     }
 
     private func clearBackgroundPollingTask() {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -312,6 +312,23 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             generation: generation,
             acknowledgedCursor: cursor
         ))
+        // The connection may have ended (`adapter/exit`, `shutdown()`,
+        // `detach()`) while this specific `service.attach()` call was in
+        // flight on some OTHER task — the helper RPC isn't cancellation-
+        // aware, so e.g. a foreground `send()` that just observed the exit
+        // (and cancelled the background poller) can't stop the poller's own
+        // already-in-flight call from resolving with a stale, pre-exit
+        // snapshot. Applying it now would fire `onTurnStateChanged` /
+        // `onDurableStateChanged` — plain closures, not gated by
+        // `finishStreams()`'s stream `finish()` calls — with stale data for
+        // a connection every caller already believes is torn down
+        // (`ACPSessionManager`'s handler mutates the session and can flip a
+        // disconnected session's streaming state back to live). Once
+        // terminated, no attach response may be applied, no matter which
+        // task's in-flight call it arrives from.
+        guard !isConnectionTerminated() else {
+            return attached.snapshot
+        }
         setSnapshot(attached.snapshot)
         let pendingRequestIds = Set(attached.snapshot.pendingRequests.map(\.requestId))
         for event in attached.events {
@@ -321,6 +338,12 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             dispatchPendingRequest(request, cursor: attached.snapshot.acknowledgedCursor)
         }
         return attached.snapshot
+    }
+
+    private func isConnectionTerminated() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return isTerminated
     }
 
     /// Runs for the whole connection lifetime (`start()` through

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1590,6 +1590,15 @@ final class ACPSessionManager: ObservableObject {
                 }
             }
         )
+        // The restored queue may still hold a `.pending` item that was
+        // `.sending` when the app last quit (see `QueuedPrompt.
+        // normalizedAfterRestore()`) — its `brokerOperationKey` didn't
+        // change, and the broker may have already completed it before the
+        // crash. Register it before start() so that replay can't have its
+        // completion cursor acked past before the queue flusher (which only
+        // runs once this function returns and the runner is registered)
+        // gets a chance to claim it.
+        client.preRegisterAwaitedOperationKeys(session.queue.map(\.brokerOperationKey))
         try await client.start()
         Self.applyBrokerTurnState(client.currentTurnState, to: session)
         return ACPConnection(client: client)

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -942,6 +942,92 @@ struct ACPBrokerClientTests {
         #expect(recorder.records().isEmpty)
     }
 
+    // Regression (code review on #853, P1): with the background poller now
+    // running continuously, it can dispatch an operation's
+    // `operationCompleted` event on its OWN independent attach() call,
+    // completely decoupled from whichever `send()` call is actually
+    // waiting on that operation. Before this fix, the completion's cursor
+    // wasn't protected from `ackAfterEarlierDurableEvents` until `send()`'s
+    // own retry loop caught up — so a later durable event (e.g. the next
+    // streamed chunk) dispatched by that same poller could be acked
+    // immediately in the meantime, advancing past the completion's cursor
+    // before `send()` ever got the chance to hand its result back. This
+    // reproduces exactly that: the poller alone (no live `send()` yet)
+    // delivers the completion, then a later chunk, and only afterwards
+    // does the matching `send()` call show up to claim it.
+    @Test func operationCompletionIsProtectedBeforeSendClaimsIt() async throws {
+        let service = MockBrokerService()
+        let operationKey = "queued-prompt:test:0:session/prompt"
+        await service.enqueueAttach(events: [], turnState: .idle)
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .operationCompleted(
+                    operationKey: ACPBrokerOperationKey(rawValue: operationKey),
+                    outcome: ACPBrokerRPCOutcome(
+                        result: .object(["stopReason": .string("end_turn")]),
+                        error: nil
+                    )
+                )
+            )
+        ], turnState: .idle)
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("next chunk")
+                            ])
+                        ])
+                    ])
+                )
+            )
+        ], turnState: .idle)
+        let client = makeClient(
+            service: service,
+            backgroundPollIdleIntervalNanoseconds: 20_000_000
+        )
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+
+        try await client.start()
+        let update = try await updateTask.value
+        update.durableConsumptionAcknowledgement?()
+
+        // Without the fix, nothing protects the completion's cursor yet
+        // (no send() call has run for it), so this ack would go through
+        // immediately instead of deferring.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await service.acks.isEmpty)
+
+        // The original send() for that operation finally catches up.
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 9),
+            replayed: false,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: false
+        ))
+        await service.enqueueAttach(events: [], turnState: .idle)
+        let response = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")]),
+            brokerOperationKey: operationKey
+        ))
+        response.acknowledgeDurableConsumption()
+
+        try await waitUntil {
+            await service.acks.map(\.cursor) == [
+                ACPBrokerEventCursor(rawValue: 2),
+                ACPBrokerEventCursor(rawValue: 3)
+            ]
+        }
+    }
+
     @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -945,20 +945,29 @@ struct ACPBrokerClientTests {
     // Regression (code review on #853, P1): with the background poller now
     // running continuously, it can dispatch an operation's
     // `operationCompleted` event on its OWN independent attach() call,
-    // completely decoupled from whichever `send()` call is actually
-    // waiting on that operation. Before this fix, the completion's cursor
-    // wasn't protected from `ackAfterEarlierDurableEvents` until `send()`'s
-    // own retry loop caught up — so a later durable event (e.g. the next
-    // streamed chunk) dispatched by that same poller could be acked
-    // immediately in the meantime, advancing past the completion's cursor
-    // before `send()` ever got the chance to hand its result back. This
-    // reproduces exactly that: the poller alone (no live `send()` yet)
-    // delivers the completion, then a later chunk, and only afterwards
-    // does the matching `send()` call show up to claim it.
-    @Test func operationCompletionIsProtectedBeforeSendClaimsIt() async throws {
+    // completely decoupled from the `send()` call actually waiting on that
+    // operation. Before this fix, the completion's cursor wasn't protected
+    // from `ackAfterEarlierDurableEvents` until `send()`'s own retry loop
+    // caught up — so a later durable event (e.g. the next streamed chunk,
+    // dispatched by that same poller) could be acked immediately in the
+    // meantime, advancing past the completion's cursor before `send()`
+    // ever got the chance to hand its result back. Reproduces exactly
+    // that: `send()` is already running (registered, mid pending-retry
+    // sleep) when the poller's own, independent attach() delivers both the
+    // completion and the next chunk.
+    @Test func operationCompletionIsProtectedWhileSendIsMidRetry() async throws {
         let service = MockBrokerService()
         let operationKey = "queued-prompt:test:0:session/prompt"
         await service.enqueueAttach(events: [], turnState: .idle)
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 9),
+            replayed: false,
+            pending: true
+        ))
+        // send()'s own attachAndReplay right after that pending result.
+        await service.enqueueAttach(events: [], turnState: .idle)
+        // The background poller's next scheduled attach, landing while
+        // send() is asleep in its (fixed, 50ms) pending-retry wait.
         await service.enqueueAttach(events: [
             ACPBrokerEvent(
                 cursor: ACPBrokerEventCursor(rawValue: 2),
@@ -969,9 +978,7 @@ struct ACPBrokerClientTests {
                         error: nil
                     )
                 )
-            )
-        ], turnState: .idle)
-        await service.enqueueAttach(events: [
+            ),
             ACPBrokerEvent(
                 cursor: ACPBrokerEventCursor(rawValue: 3),
                 kind: .adapterNotification(
@@ -989,6 +996,14 @@ struct ACPBrokerClientTests {
                 )
             )
         ], turnState: .idle)
+        // send()'s second service.send() call, after its retry sleep.
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 9),
+            replayed: true,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: false
+        ))
+        await service.enqueueAttach(events: [], turnState: .idle)
         let client = makeClient(
             service: service,
             backgroundPollIdleIntervalNanoseconds: 20_000_000
@@ -996,28 +1011,24 @@ struct ACPBrokerClientTests {
         let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
 
         try await client.start()
+        let sendTask = Task {
+            try await client.send(ACPRequest(
+                method: "session/prompt",
+                params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")]),
+                brokerOperationKey: operationKey
+            ))
+        }
+
         let update = try await updateTask.value
         update.durableConsumptionAcknowledgement?()
 
-        // Without the fix, nothing protects the completion's cursor yet
-        // (no send() call has run for it), so this ack would go through
-        // immediately instead of deferring.
-        try await Task.sleep(for: .milliseconds(50))
+        // send() is still asleep in its fixed 50ms pending-retry wait; the
+        // completion it registered interest in at entry must still be
+        // protected, so this ack has to defer rather than go through.
+        try await Task.sleep(for: .milliseconds(30))
         #expect(await service.acks.isEmpty)
 
-        // The original send() for that operation finally catches up.
-        await service.enqueueSendResult(ACPBrokerSendResult(
-            requestId: ACPBrokerAdapterRequestID(rawValue: 9),
-            replayed: false,
-            result: .object(["stopReason": .string("end_turn")]),
-            pending: false
-        ))
-        await service.enqueueAttach(events: [], turnState: .idle)
-        let response = try await client.send(ACPRequest(
-            method: "session/prompt",
-            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")]),
-            brokerOperationKey: operationKey
-        ))
+        let response = try await sendTask.value
         response.acknowledgeDurableConsumption()
 
         try await waitUntil {
@@ -1025,6 +1036,58 @@ struct ACPBrokerClientTests {
                 ACPBrokerEventCursor(rawValue: 2),
                 ACPBrokerEventCursor(rawValue: 3)
             ]
+        }
+    }
+
+    // Regression (code review on #853, P1, second finding): protecting
+    // every operationCompleted cursor unconditionally (the first version of
+    // the fix above) broke on an adopted broker's replay, or any queued
+    // retry the caller abandoned — nothing in this process will ever call
+    // send() again for that operationKey, so the cursor would stay
+    // "unacknowledged" forever with no call left to release it, and every
+    // later ack would defer permanently. Only a completion a live send()
+    // call actually registered interest in may be protected.
+    @Test func unclaimedOperationCompletionDoesNotBlockLaterAcks() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .operationCompleted(
+                    operationKey: ACPBrokerOperationKey(rawValue: "abandoned-operation"),
+                    outcome: ACPBrokerRPCOutcome(
+                        result: .object(["stopReason": .string("end_turn")]),
+                        error: nil
+                    )
+                )
+            ),
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("hello")
+                            ])
+                        ])
+                    ])
+                )
+            )
+        ])
+        let client = makeClient(service: service)
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+
+        try await client.start()
+        let update = try await updateTask.value
+        update.durableConsumptionAcknowledgement?()
+
+        // Must not be stuck deferring behind a completion nobody will ever
+        // claim.
+        try await waitUntil {
+            await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 3)]
         }
     }
 

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -1249,6 +1249,55 @@ struct ACPBrokerClientTests {
         }
     }
 
+    // Regression (code review on #853, P1, fifth finding): the flip side
+    // of the fix above. A terminal JSON-RPC error (`result.error`) IS this
+    // operationKey's final, authoritative outcome — unlike an incidental
+    // local failure elsewhere in the call, no retry with the same key is
+    // coming back to ack it. `attachAndReplay()` right before the error
+    // check can have already dispatched (and, since this call registered
+    // interest first, protected) that exact completion's cursor; if send()
+    // just throws without acking it, it stays "unacknowledged" forever and
+    // every later durable event defers behind it, so the broker cursor
+    // never advances again after this failure.
+    @Test func sendAcksCompletionOnTerminalJSONRPCError() async throws {
+        let service = MockBrokerService()
+        let operationKey = "queued-prompt:test:0:session/prompt"
+        await service.enqueueAttach(events: [])
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 9),
+            replayed: false,
+            error: JSONRPCError(code: -32000, message: "boom", data: nil)
+        ))
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .operationCompleted(
+                    operationKey: ACPBrokerOperationKey(rawValue: operationKey),
+                    outcome: ACPBrokerRPCOutcome(
+                        result: nil,
+                        error: JSONRPCError(code: -32000, message: "boom", data: nil)
+                    )
+                )
+            )
+        ])
+        let client = makeClient(service: service)
+
+        try await client.start()
+        await #expect(throws: (any Error).self) {
+            _ = try await client.send(ACPRequest(
+                method: "session/prompt",
+                params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")]),
+                brokerOperationKey: operationKey
+            ))
+        }
+
+        // Must not be stuck deferring behind an errored operation nobody
+        // is coming back for.
+        try await waitUntil {
+            await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)]
+        }
+    }
+
     @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -839,6 +839,45 @@ struct ACPBrokerClientTests {
         await client.shutdown()
     }
 
+    // Regression (code review on #853): `shutdown()`/`detach()` only marked
+    // the background poller's task cancelled without waiting for it to
+    // unwind. `Task.cancel()` doesn't abort an in-flight, non-cancellation-
+    // aware RPC await, so a poll iteration already inside `attachAndReplay()`
+    // ran to completion and dispatched its results — including firing
+    // `onTurnStateChanged`, a plain closure unaffected by `finishStreams()` —
+    // after `shutdown()` had already returned to its caller, who by then
+    // believes the connection is fully torn down. `shutdown()`/`detach()`
+    // must not return before that in-flight dispatch has landed.
+    @Test func shutdownAwaitsInFlightPollBeforeReturning() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [], turnState: .idle)
+        await service.enqueueAttach(
+            events: [],
+            turnState: .streaming,
+            // Stands in for a slow, non-cancellation-aware helper RPC that's
+            // still in flight when shutdown() fires.
+            delayNanoseconds: 150_000_000
+        )
+        let recorder = SyncTurnStateRecorder()
+        let client = makeClient(
+            service: service,
+            backgroundPollIdleIntervalNanoseconds: 20_000_000,
+            onTurnStateChanged: { state in recorder.append(state) }
+        )
+
+        try await client.start()
+        // The idle-rate poll's second attach() call should be in flight
+        // (sleeping inside the mock) by now, but not yet resolved.
+        try await Task.sleep(for: .milliseconds(60))
+        #expect(recorder.records().isEmpty)
+
+        await client.shutdown()
+
+        // If shutdown() returned before the in-flight iteration's dispatch
+        // landed, this would still be empty here.
+        #expect(recorder.records() == [.streaming])
+    }
+
     @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [
@@ -990,6 +1029,30 @@ private actor TurnStateSink {
     }
 }
 
+/// Records synchronously, unlike `TurnStateSink` (an actor, so callers hop
+/// through a detached `Task` to append — fine for `waitUntil`-style polling,
+/// but useless for proving something happened-before a specific instant, since
+/// the detached `Task` may not have run yet even after that instant passes).
+/// `onTurnStateChanged` is invoked synchronously from within the broker
+/// client's own async context, so a plain lock-protected recorder lets a test
+/// assert exactly what's landed by the time a specific `await` returns.
+private final class SyncTurnStateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedStates: [ACPBrokerTurnState] = []
+
+    func append(_ state: ACPBrokerTurnState) {
+        lock.lock()
+        recordedStates.append(state)
+        lock.unlock()
+    }
+
+    func records() -> [ACPBrokerTurnState] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedStates
+    }
+}
+
 private actor MockBrokerService: ACPBrokerServicing {
     var opened: [ACPBrokerOpenParams] = []
     var attached: [ACPBrokerAttachParams] = []
@@ -1010,14 +1073,16 @@ private actor MockBrokerService: ACPBrokerServicing {
         snapshotPendingRequests: [ACPBrokerPendingRequest]? = nil,
         snapshotJournalTail: ACPBrokerEventCursor? = nil,
         snapshotOperations: [ACPBrokerOperationSnapshot] = [],
-        turnState: ACPBrokerTurnState = .idle
+        turnState: ACPBrokerTurnState = .idle,
+        delayNanoseconds: UInt64 = 0
     ) {
         attachReplies.append(AttachReply(
             events: events,
             snapshotPendingRequests: snapshotPendingRequests,
             snapshotJournalTail: snapshotJournalTail,
             snapshotOperations: snapshotOperations,
-            turnState: turnState
+            turnState: turnState,
+            delayNanoseconds: delayNanoseconds
         ))
     }
 
@@ -1045,6 +1110,21 @@ private actor MockBrokerService: ACPBrokerServicing {
     func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
         attached.append(params)
         let reply = attachReplies.isEmpty ? AttachReply(events: []) : attachReplies.removeFirst()
+        if reply.delayNanoseconds > 0 {
+            // `Task.sleep` honors cooperative cancellation, which would
+            // defeat the point of this delay: it exists to stand in for a
+            // real helper RPC (`withCheckedThrowingContinuation`-based, not
+            // cancellation-aware), so the caller's task being cancelled
+            // must NOT cut this short — a `DispatchQueue` timer behind a
+            // raw continuation genuinely can't be cancelled from here.
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                DispatchQueue.global().asyncAfter(
+                    deadline: .now() + .nanoseconds(Int(reply.delayNanoseconds))
+                ) {
+                    continuation.resume()
+                }
+            }
+        }
         let events = reply.events
         let tail = reply.snapshotJournalTail ?? events.map(\.cursor).max() ?? params.acknowledgedCursor
         return ACPBrokerAttachResult(
@@ -1145,19 +1225,22 @@ private actor MockBrokerService: ACPBrokerServicing {
         let snapshotJournalTail: ACPBrokerEventCursor?
         let snapshotOperations: [ACPBrokerOperationSnapshot]
         let turnState: ACPBrokerTurnState
+        let delayNanoseconds: UInt64
 
         init(
             events: [ACPBrokerEvent],
             snapshotPendingRequests: [ACPBrokerPendingRequest]? = nil,
             snapshotJournalTail: ACPBrokerEventCursor? = nil,
             snapshotOperations: [ACPBrokerOperationSnapshot] = [],
-            turnState: ACPBrokerTurnState = .idle
+            turnState: ACPBrokerTurnState = .idle,
+            delayNanoseconds: UInt64 = 0
         ) {
             self.events = events
             self.snapshotPendingRequests = snapshotPendingRequests
             self.snapshotJournalTail = snapshotJournalTail
             self.snapshotOperations = snapshotOperations
             self.turnState = turnState
+            self.delayNanoseconds = delayNanoseconds
         }
     }
 }

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -745,8 +745,70 @@ struct ACPBrokerClientTests {
         }
         try await waitUntil { await service.attached.count == 3 }
         try await waitUntil { await turnStateSink.records() == [.streaming, .completed] }
+        // Background polling never stops outright once the turn completes
+        // (see `backgroundPollingDiscoversSelfContinuedTurnWithoutAnySend`),
+        // but it drops to the idle-rate interval, which comfortably outlasts
+        // this window — so no further attach call lands within it.
         try await Task.sleep(for: .milliseconds(120))
         #expect(await service.attached.count == 3)
+        await client.shutdown()
+    }
+
+    // Regression: the broker is pull-only, and until this fix
+    // `startActiveTurnPollingIfNeeded` only ever ran once, from an
+    // *adopted* `start()`. A freshly-opened session (the common case) that
+    // goes idle after its first exchange had nothing left pulling —  an SDK
+    // that resumed itself (queued follow-up, stop-hook continuation, a
+    // `/loop`-style wakeup) with no further `send()`/`notify()` from Alas
+    // would stream events into the broker's durable log with nobody
+    // watching, and the transcript looked frozen until the next user
+    // prompt replayed the whole backlog. This exercises the idle-rate
+    // background poll picking up that self-started turn on its own.
+    @Test func backgroundPollingDiscoversSelfContinuedTurnWithoutAnySend() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [], turnState: .idle)
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("still working")
+                            ])
+                        ])
+                    ])
+                )
+            )
+        ], turnState: .streaming)
+        let turnStateSink = TurnStateSink()
+        let client = makeClient(
+            service: service,
+            // Small override so the test doesn't wait out the production
+            // 2s idle interval; still comfortably below the default 50ms
+            // active interval the client switches to once it observes
+            // `.streaming`, so there's no race with a follow-up poll.
+            backgroundPollIdleIntervalNanoseconds: 20_000_000,
+            onTurnStateChanged: { state in
+                Task { await turnStateSink.append(state) }
+            }
+        )
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+
+        try await client.start()
+
+        let update = try await updateTask.value
+        if case .agentMessageChunk(let chunk) = update.update {
+            #expect(chunk.content == .text("still working"))
+        } else {
+            Issue.record("expected agent message chunk")
+        }
+        try await waitUntil { await turnStateSink.records() == [.streaming] }
+        await client.shutdown()
     }
 
     @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
@@ -802,6 +864,7 @@ struct ACPBrokerClientTests {
         service: MockBrokerService,
         initialBrokerGeneration: ACPBrokerGeneration? = nil,
         initialAcknowledgedCursor: ACPBrokerEventCursor = ACPBrokerEventCursor(rawValue: 0),
+        backgroundPollIdleIntervalNanoseconds: UInt64 = ACPBrokerClient.defaultBackgroundPollIdleIntervalNanoseconds,
         onTurnStateChanged: (@Sendable (ACPBrokerTurnState) -> Void)? = nil,
         onDurableStateChanged: (@Sendable (ACPBrokerDurableState) -> Void)? = nil
     ) -> ACPBrokerClient {
@@ -816,6 +879,7 @@ struct ACPBrokerClientTests {
             operationKeyPrefix: "op-prefix",
             initialBrokerGeneration: initialBrokerGeneration,
             initialAcknowledgedCursor: initialAcknowledgedCursor,
+            backgroundPollIdleIntervalNanoseconds: backgroundPollIdleIntervalNanoseconds,
             onDurableStateChanged: onDurableStateChanged,
             onTurnStateChanged: onTurnStateChanged
         )

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -1091,6 +1091,84 @@ struct ACPBrokerClientTests {
         }
     }
 
+    // Regression (code review on #853, P1, third finding): a queued prompt
+    // that was `.sending` when the app last quit gets reset to `.pending`
+    // on restore but reuses the same `brokerOperationKey` — the broker may
+    // have already completed it before the crash. `start()`'s own initial
+    // replay can reveal that completion before the queue flusher (which
+    // only runs once `start()` returns and the runner registers) ever
+    // calls `send()` for it again, so with no live call yet, the "only
+    // protect if awaited" fix above would leave it unprotected — exactly
+    // like the abandoned-operation case, but this one WILL be retried.
+    // `preRegisterAwaitedOperationKeys` closes that gap by registering
+    // interest before `start()` runs at all.
+    @Test func preRegisteredOperationKeyProtectsCompletionReplayedDuringStart() async throws {
+        let service = MockBrokerService()
+        let operationKey = "queued-prompt:test-uuid:0:session/prompt"
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .operationCompleted(
+                    operationKey: ACPBrokerOperationKey(rawValue: operationKey),
+                    outcome: ACPBrokerRPCOutcome(
+                        result: .object(["stopReason": .string("end_turn")]),
+                        error: nil
+                    )
+                )
+            ),
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .adapterNotification(
+                    method: "session/update",
+                    params: .object([
+                        "sessionId": .string("remote-1"),
+                        "update": .object([
+                            "sessionUpdate": .string("agent_message_chunk"),
+                            "content": .object([
+                                "type": .string("text"),
+                                "text": .string("hello")
+                            ])
+                        ])
+                    ])
+                )
+            )
+        ])
+        let client = makeClient(service: service)
+        client.preRegisterAwaitedOperationKeys([operationKey])
+        let updateTask = Task { try await nextUpdate(from: client.incomingUpdates) }
+
+        try await client.start()
+        let update = try await updateTask.value
+        update.durableConsumptionAcknowledgement?()
+
+        // Must defer: pre-registration protects this completion even
+        // though no live send() call has run in this process yet.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await service.acks.isEmpty)
+
+        // The queue flusher's retry finally catches up.
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 9),
+            replayed: false,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: false
+        ))
+        await service.enqueueAttach(events: [], turnState: .idle)
+        let response = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")]),
+            brokerOperationKey: operationKey
+        ))
+        response.acknowledgeDurableConsumption()
+
+        try await waitUntil {
+            await service.acks.map(\.cursor) == [
+                ACPBrokerEventCursor(rawValue: 2),
+                ACPBrokerEventCursor(rawValue: 3)
+            ]
+        }
+    }
+
     @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -280,6 +280,34 @@ struct ACPBrokerClientTests {
         #expect(await finishedTask.value == true)
     }
 
+    // Regression (code review on #853): `start()` called `startBackgroundPolling()`
+    // unconditionally after its initial `attachAndReplay()`, even when that
+    // same replay already delivered `adapter/exit` and finished the streams.
+    // The exit handler's own `cancelBackgroundPolling()` had nothing to
+    // cancel yet at that point (the poller didn't exist), so the very next
+    // line created a fresh poller for an already-dead connection — leaking
+    // it and its idle-rate `attach` traffic forever, since nothing else was
+    // going to call `shutdown()`/`detach()` on a connection that failed
+    // before ever being handed to a runner.
+    @Test func startupExitDoesNotLeaveBackgroundPollerRunning() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .adapterNotification(
+                    method: "adapter/exit",
+                    params: .object(["unexpected": .bool(true)])
+                )
+            )
+        ])
+        let client = makeClient(service: service, backgroundPollIdleIntervalNanoseconds: 20_000_000)
+
+        try await client.start()
+        try await Task.sleep(for: .milliseconds(80))
+
+        #expect(await service.attached.count == 1)
+    }
+
     @Test func shutdownClosesBrokerGeneration() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [])

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -839,16 +839,22 @@ struct ACPBrokerClientTests {
         await client.shutdown()
     }
 
-    // Regression (code review on #853): `shutdown()`/`detach()` only marked
-    // the background poller's task cancelled without waiting for it to
-    // unwind. `Task.cancel()` doesn't abort an in-flight, non-cancellation-
-    // aware RPC await, so a poll iteration already inside `attachAndReplay()`
-    // ran to completion and dispatched its results — including firing
-    // `onTurnStateChanged`, a plain closure unaffected by `finishStreams()` —
-    // after `shutdown()` had already returned to its caller, who by then
-    // believes the connection is fully torn down. `shutdown()`/`detach()`
-    // must not return before that in-flight dispatch has landed.
-    @Test func shutdownAwaitsInFlightPollBeforeReturning() async throws {
+    // Regression (code review on #853, two rounds): `shutdown()`/`detach()`
+    // first tried marking the poller cancelled and moving on immediately,
+    // which let an in-flight, non-cancellation-aware `attachAndReplay()`
+    // dispatch a stale result after teardown. The next fix made
+    // `shutdown()`/`detach()` await that in-flight iteration before
+    // returning — but the underlying helper RPC has no read timeout, so a
+    // wedged helper/broker would hang teardown forever and the close/detach
+    // RPC would never even be attempted. The actual fix is
+    // `attachAndReplay()`'s `isConnectionTerminated()` guard: mark the
+    // connection terminated immediately (before cancelling or awaiting
+    // anything), so a stale in-flight response is safely dropped whenever
+    // it eventually resolves, and `shutdown()`/`detach()` never need to
+    // wait for it. This proves both halves: shutdown() returns promptly
+    // (doesn't block out the in-flight delay), and the stale response is
+    // never dispatched even after it does resolve.
+    @Test func shutdownReturnsPromptlyAndDropsStaleInFlightPollResult() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [], turnState: .idle)
         await service.enqueueAttach(
@@ -869,13 +875,19 @@ struct ACPBrokerClientTests {
         // The idle-rate poll's second attach() call should be in flight
         // (sleeping inside the mock) by now, but not yet resolved.
         try await Task.sleep(for: .milliseconds(60))
+
+        let shutdownStart = ContinuousClock.now
+        await client.shutdown()
+        let shutdownElapsed = ContinuousClock.now - shutdownStart
+
+        // Must not have blocked out anywhere near the in-flight delay.
+        #expect(shutdownElapsed < .milliseconds(100))
         #expect(recorder.records().isEmpty)
 
-        await client.shutdown()
-
-        // If shutdown() returned before the in-flight iteration's dispatch
-        // landed, this would still be empty here.
-        #expect(recorder.records() == [.streaming])
+        // Outlast the delayed attach's resolution and confirm its stale
+        // `.streaming` never gets applied post-termination.
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(recorder.records().isEmpty)
     }
 
     // Regression (code review on #853): a foreground send()/notify() can

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -878,6 +878,58 @@ struct ACPBrokerClientTests {
         #expect(recorder.records() == [.streaming])
     }
 
+    // Regression (code review on #853): a foreground send()/notify() can
+    // observe adapter/exit and cancel the background poller while the
+    // poller's OWN attach() call is already independently in flight. The
+    // cancel doesn't stop that non-cancellation-aware call from resolving
+    // later with a stale, pre-exit snapshot; without a termination gate on
+    // applying it, that stale snapshot would fire onTurnStateChanged after
+    // the connection is already torn down.
+    @Test func staleInFlightPollResultIsDroppedAfterConcurrentExit() async throws {
+        let service = MockBrokerService()
+        await service.enqueueAttach(events: [], turnState: .idle)
+        await service.enqueueAttach(
+            events: [],
+            turnState: .streaming,
+            delayNanoseconds: 200_000_000
+        )
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 4),
+            replayed: false,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: nil
+        ))
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 3),
+                kind: .adapterNotification(
+                    method: "adapter/exit",
+                    params: .object(["unexpected": .bool(true)])
+                )
+            )
+        ])
+        let recorder = SyncTurnStateRecorder()
+        let client = makeClient(
+            service: service,
+            backgroundPollIdleIntervalNanoseconds: 20_000_000,
+            onTurnStateChanged: { state in recorder.append(state) }
+        )
+
+        try await client.start()
+        // Let the poller's second attach() begin and enter its 200ms delay
+        // before the foreground send() observes the exit.
+        try await Task.sleep(for: .milliseconds(60))
+        _ = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")])
+        ))
+        // Outlast the poller's delayed response (resolves ~200ms after it
+        // started, i.e. ~220ms after start()).
+        try await Task.sleep(for: .milliseconds(250))
+
+        #expect(recorder.records().isEmpty)
+    }
+
     @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -1169,6 +1169,86 @@ struct ACPBrokerClientTests {
         }
     }
 
+    // Regression (code review on #853, P1, fourth finding): send()'s
+    // defer used to force-ack the completion cursor whenever the call
+    // exited without handing a response to its caller. But the operation
+    // can have genuinely succeeded at the broker while THIS call still
+    // fails for an unrelated reason — e.g. the attachAndReplay() right
+    // after a successful/replayed service.send() throws on its own
+    // transient hiccup. Acking there tells the broker it may prune the
+    // completed operation even though the caller never got the result, and
+    // the queued-send retry path reuses the same operationKey on
+    // non-JSONRPC failures — so the retry would be treated as a fresh
+    // prompt instead of replaying the already-completed one. Confirms no
+    // ack happens when send() throws this way, and that a subsequent
+    // successful retry for the same key still acks correctly once the
+    // caller actually consumes it.
+    @Test func sendDoesNotAckCompletionWhenFollowUpAttachFails() async throws {
+        let service = MockBrokerService()
+        let operationKey = "queued-prompt:test:0:session/prompt"
+        // The completion is already known before send() ever runs — e.g.
+        // via pre-registration + start()'s own replay, matching the
+        // restored-queue scenario above.
+        await service.enqueueAttach(events: [
+            ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: 2),
+                kind: .operationCompleted(
+                    operationKey: ACPBrokerOperationKey(rawValue: operationKey),
+                    outcome: ACPBrokerRPCOutcome(
+                        result: .object(["stopReason": .string("end_turn")]),
+                        error: nil
+                    )
+                )
+            )
+        ])
+        // service.send() itself succeeds (replaying the already-completed
+        // operation)...
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 9),
+            replayed: true,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: false
+        ))
+        // ...but the attachAndReplay() immediately after it throws.
+        await service.enqueueAttach(events: [], shouldThrow: true)
+        let client = makeClient(service: service)
+        client.preRegisterAwaitedOperationKeys([operationKey])
+
+        try await client.start()
+        await #expect(throws: (any Error).self) {
+            _ = try await client.send(ACPRequest(
+                method: "session/prompt",
+                params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")]),
+                brokerOperationKey: operationKey
+            ))
+        }
+
+        // The already-known completion must NOT have been acked away just
+        // because this call failed for an unrelated reason.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await service.acks.isEmpty)
+
+        // A later retry for the same operationKey succeeds normally and
+        // still acks it correctly once actually consumed.
+        await service.enqueueSendResult(ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: 9),
+            replayed: true,
+            result: .object(["stopReason": .string("end_turn")]),
+            pending: false
+        ))
+        await service.enqueueAttach(events: [], turnState: .idle)
+        let response = try await client.send(ACPRequest(
+            method: "session/prompt",
+            params: ACPSessionPromptParams(sessionId: "remote-1", prompt: [.text("hi")]),
+            brokerOperationKey: operationKey
+        ))
+        response.acknowledgeDurableConsumption()
+
+        try await waitUntil {
+            await service.acks.map(\.cursor) == [ACPBrokerEventCursor(rawValue: 2)]
+        }
+    }
+
     @Test func replayedResolvedPendingRequestIsNotYieldedAgain() async throws {
         let service = MockBrokerService()
         await service.enqueueAttach(events: [
@@ -1365,7 +1445,8 @@ private actor MockBrokerService: ACPBrokerServicing {
         snapshotJournalTail: ACPBrokerEventCursor? = nil,
         snapshotOperations: [ACPBrokerOperationSnapshot] = [],
         turnState: ACPBrokerTurnState = .idle,
-        delayNanoseconds: UInt64 = 0
+        delayNanoseconds: UInt64 = 0,
+        shouldThrow: Bool = false
     ) {
         attachReplies.append(AttachReply(
             events: events,
@@ -1373,7 +1454,8 @@ private actor MockBrokerService: ACPBrokerServicing {
             snapshotJournalTail: snapshotJournalTail,
             snapshotOperations: snapshotOperations,
             turnState: turnState,
-            delayNanoseconds: delayNanoseconds
+            delayNanoseconds: delayNanoseconds,
+            shouldThrow: shouldThrow
         ))
     }
 
@@ -1415,6 +1497,9 @@ private actor MockBrokerService: ACPBrokerServicing {
                     continuation.resume()
                 }
             }
+        }
+        if reply.shouldThrow {
+            throw MockBrokerServiceError.injected
         }
         let events = reply.events
         let tail = reply.snapshotJournalTail ?? events.map(\.cursor).max() ?? params.acknowledgedCursor
@@ -1517,6 +1602,7 @@ private actor MockBrokerService: ACPBrokerServicing {
         let snapshotOperations: [ACPBrokerOperationSnapshot]
         let turnState: ACPBrokerTurnState
         let delayNanoseconds: UInt64
+        let shouldThrow: Bool
 
         init(
             events: [ACPBrokerEvent],
@@ -1524,7 +1610,8 @@ private actor MockBrokerService: ACPBrokerServicing {
             snapshotJournalTail: ACPBrokerEventCursor? = nil,
             snapshotOperations: [ACPBrokerOperationSnapshot] = [],
             turnState: ACPBrokerTurnState = .idle,
-            delayNanoseconds: UInt64 = 0
+            delayNanoseconds: UInt64 = 0,
+            shouldThrow: Bool = false
         ) {
             self.events = events
             self.snapshotPendingRequests = snapshotPendingRequests
@@ -1532,6 +1619,11 @@ private actor MockBrokerService: ACPBrokerServicing {
             self.snapshotOperations = snapshotOperations
             self.turnState = turnState
             self.delayNanoseconds = delayNanoseconds
+            self.shouldThrow = shouldThrow
         }
     }
+}
+
+private enum MockBrokerServiceError: Error {
+    case injected
 }


### PR DESCRIPTION
## Summary
- The ACP broker is pull-only: `attachAndReplay` only ran from `start()`, from `send()`/`notify()`, and from a poller that started only for adopted brokers and stopped for good the first time the turn went non-active.
- A turn the agent resumes on its own (an SDK-queued follow-up message, a stop-hook continuation, a `/loop`-style wakeup) streamed events into the broker's durable log with nobody pulling them — the transcript looked frozen (sometimes for tens of minutes) until the next user prompt replayed the whole backlog at once.
- Replaces the adopted-only, self-terminating poller with a single background loop that runs for the connection's whole lifetime (`start()` → `shutdown()`/`detach()`), polling fast (50ms) while a turn is active and slow (2s) otherwise, so self-continued turns get discovered without any explicit send from Alas.

## Test plan
- [x] Added `backgroundPollingDiscoversSelfContinuedTurnWithoutAnySend` regression test, and updated `adoptedActiveTurnPollsForLaterEventsAfterStart` to reflect that background polling no longer stops outright once a turn completes (it drops to idle rate instead).
- [x] `xcodebuild -only-testing:AlasTests/ACPBrokerClientTests test` — 26/26 pass, both before and after rebasing onto latest `main`.