### PR TITLE
feat(gg): Add GG stack actions and drawer

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -704,6 +704,7 @@
 		89E952C361337F8D9FB279D5 /* IconSymbolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705B34DF3EE049FA52E8ECFB /* IconSymbolTests.swift */; };
 		89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8802F19E02CED256495755 /* ACPTerminalTests.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
+		8ADC05EBB9FE7D278508A941 /* GGStackReadinessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */; };
 		8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */; };
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
 		8B2A37F58F2C7D842204A596 /* ImageDiffOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */; };
@@ -1045,6 +1046,7 @@
 		C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */; };
 		CA4CE5E97DB02330A1151245 /* ACPSetupCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */; };
 		CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */; };
+		CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */; };
 		CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */; };
 		CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */; };
 		CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */; };
@@ -1740,6 +1742,7 @@
 		4D4F87B7B6F4A6E6ED882F1F /* HarnessConfigAutoRunTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessConfigAutoRunTests.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4D5734FB0E75909C5E9DBD7D /* AppState+ReviewPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+ReviewPalette.swift"; sourceTree = "<group>"; };
+		4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackReadinessModel.swift; sourceTree = "<group>"; };
 		4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-agent-chunk.json"; sourceTree = "<group>"; };
 		4D974BDA7FAE214495278557 /* ACPUserInputPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserInputPrompt.swift; sourceTree = "<group>"; };
 		4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPProcessLiveness.swift; sourceTree = "<group>"; };
@@ -2559,6 +2562,7 @@
 		F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-blocks.json"; sourceTree = "<group>"; };
 		F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreTests.swift; sourceTree = "<group>"; };
 		F0D567F7F894902AD192D220 /* mason-lsps.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "mason-lsps.json"; sourceTree = "<group>"; };
+		F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackReadinessModelTests.swift; sourceTree = "<group>"; };
 		F12340A649892955245BECB7 /* DefinitionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionFeature.swift; sourceTree = "<group>"; };
 		F125642F0AD2F6755B5E067B /* ACPDelegatedPromptSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelegatedPromptSource.swift; sourceTree = "<group>"; };
 		F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffTabView.swift; sourceTree = "<group>"; };
@@ -4575,6 +4579,7 @@
 				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
 				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
 				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
+				F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
@@ -4828,6 +4833,7 @@
 				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
 				ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
+				4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */,
 				B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */,
 			);
 			path = GG;
@@ -5534,6 +5540,7 @@
 				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
 				4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
+				8ADC05EBB9FE7D278508A941 /* GGStackReadinessModel.swift in Sources */,
 				DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
@@ -6192,6 +6199,7 @@
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,
 				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
+				CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,
 				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1240,6 +1240,7 @@
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE02460865C6A4ED1046B13F /* AgentLifecycleEventMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */; };
 		EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE09B83A747269494B206F23 /* UpdateThrottle.swift */; };
+		EE4A552DB5EF6559CA1A5AE0 /* GGStackActionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
 		EEB1E9992AB101D398909EFA /* DiffFeedbackLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4128039056F417E483AB4DC /* DiffFeedbackLaneTests.swift */; };
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
@@ -1270,6 +1271,7 @@
 		F53E906F828DEFF6A41C46BA /* RemotePollCadenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807FC0DF3AE4C069E77F85B6 /* RemotePollCadenceTests.swift */; };
 		F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */; };
 		F57297D50FC237F7993F7B81 /* ACPSelectChipMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */; };
+		F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */; };
 		F64E588419012161F690ACB7 /* ProviderReviewOriginalPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC7D68CD8300C0F6766AED0 /* ProviderReviewOriginalPathResolverTests.swift */; };
@@ -1536,6 +1538,7 @@
 		29D7631D754795D16E946440 /* ACPFileEditCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileEditCard.swift; sourceTree = "<group>"; };
 		29FCCD153F9C2AF78A7B2E47 /* ACPMessageGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageGutter.swift; sourceTree = "<group>"; };
 		2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabState.swift; sourceTree = "<group>"; };
+		2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackActionState.swift; sourceTree = "<group>"; };
 		2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownLiveStyler.swift; sourceTree = "<group>"; };
 		2AF8084388AF564A1907548C /* RemoteNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNetworkTests.swift; sourceTree = "<group>"; };
 		2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActions.swift; sourceTree = "<group>"; };
@@ -1967,6 +1970,7 @@
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionsButton.swift; sourceTree = "<group>"; };
 		7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewAutoPairTests.swift; sourceTree = "<group>"; };
+		7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackActionStateTests.swift; sourceTree = "<group>"; };
 		7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeatureTests.swift; sourceTree = "<group>"; };
 		7D223B9B905C2BBEFDE50E36 /* MemoryDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnostics.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
@@ -4567,6 +4571,7 @@
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
+				7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */,
 				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
 				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
 				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
@@ -4819,6 +4824,7 @@
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
+				2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */,
 				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
 				ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
@@ -5524,6 +5530,7 @@
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
+				F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */,
 				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
 				4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
@@ -6181,6 +6188,7 @@
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
+				EE4A552DB5EF6559CA1A5AE0 /* GGStackActionStateTests.swift in Sources */,
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,
 				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1105,6 +1105,7 @@
 		D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */; };
 		D49FD01D96C6B00C3683FBCA /* ChatPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D2C54087C4501C3E7793FE /* ChatPane.swift */; };
 		D4DE0AC014387E216A904D2E /* ReviewTargetPaletteModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2506BDBA9F67B6516CE2BEF /* ReviewTargetPaletteModelTests.swift */; };
+		D4E6BD88D38563AF45E79C83 /* RightPaneGGLandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */; };
 		D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */; };
 		D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */; };
 		D56C78F4D6A2BDFDF5A05B55 /* ACPSessionRunnerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */; };
@@ -2094,6 +2095,7 @@
 		942B0DCA09E1297D9380C58C /* AppQuitAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppQuitAction.swift; sourceTree = "<group>"; };
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
 		94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibility.swift; sourceTree = "<group>"; };
+		94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneGGLandTests.swift; sourceTree = "<group>"; };
 		94D30693F45966ED1456811E /* ACPSessionHydrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrator.swift; sourceTree = "<group>"; };
 		9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAction.swift; sourceTree = "<group>"; };
 		955B9084309744F3B9A44CBC /* ACPUserInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserInput.swift; sourceTree = "<group>"; };
@@ -3078,6 +3080,7 @@
 				4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */,
 				A2506BDBA9F67B6516CE2BEF /* ReviewTargetPaletteModelTests.swift */,
 				B87101C6F8F27B57AEDC187D /* ReviewThreadWriteTests.swift */,
+				94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */,
 				BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
@@ -6386,6 +6389,7 @@
 				14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */,
 				D4DE0AC014387E216A904D2E /* ReviewTargetPaletteModelTests.swift in Sources */,
 				1ACB56B9AA0EC3C1C2AF5E18 /* ReviewThreadWriteTests.swift in Sources */,
+				D4E6BD88D38563AF45E79C83 /* RightPaneGGLandTests.swift in Sources */,
 				4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -300,6 +300,7 @@
 		3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */; };
 		3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E265B0C6F314FC80DB18053D /* RecommendedLanguageCatalog.swift */; };
 		3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2498E56CBAF84CB67166C /* HarnessKind.swift */; };
+		3AFEB19356A2BC5E7B6E1E4A /* GGStackDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7860DF249939BC7FC1EBD76 /* GGStackDrawer.swift */; };
 		3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B450918CC98255AD9170586 /* AppearancePane.swift */; };
 		3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */; };
 		3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */; };
@@ -2433,6 +2434,7 @@
 		D7331F53100D12A0DDFD6B1D /* RemoteFileSearchGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileSearchGateTests.swift; sourceTree = "<group>"; };
 		D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewScrollSpy.swift; sourceTree = "<group>"; };
 		D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailability.swift; sourceTree = "<group>"; };
+		D7860DF249939BC7FC1EBD76 /* GGStackDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackDrawer.swift; sourceTree = "<group>"; };
 		D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreePoll.swift; sourceTree = "<group>"; };
 		D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigCodeInstallTests.swift; sourceTree = "<group>"; };
 		D8D583586BC5171D2FE91F6C /* ReviewScopeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelection.swift; sourceTree = "<group>"; };
@@ -4834,6 +4836,7 @@
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */,
 				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
+				D7860DF249939BC7FC1EBD76 /* GGStackDrawer.swift */,
 				ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
 				4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */,
@@ -5541,6 +5544,7 @@
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */,
 				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
+				3AFEB19356A2BC5E7B6E1E4A /* GGStackDrawer.swift in Sources */,
 				4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
 				8ADC05EBB9FE7D278508A941 /* GGStackReadinessModel.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -815,6 +815,7 @@
 		9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
 		9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */; };
+		A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */; };
 		A03338AC85E6EC8201D56F95 /* TreeSitterGo in Frameworks */ = {isa = PBXBuildFile; productRef = DB0D87DDDAD70492540E6906 /* TreeSitterGo */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
 		A05391FF4907AB0870A79C02 /* ReviewEvidenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */; };
@@ -1723,6 +1724,7 @@
 		4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClientTests.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
 		4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTabBar.swift; sourceTree = "<group>"; };
+		4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGCommandRunningStreamingTests.swift; sourceTree = "<group>"; };
 		4BECCB29ED6324C55C541D54 /* DiffReviewRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRail.swift; sourceTree = "<group>"; };
 		4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionTests.swift; sourceTree = "<group>"; };
 		4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTargetTests.swift; sourceTree = "<group>"; };
@@ -4561,6 +4563,7 @@
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				1A25C83033616FE27526C945 /* GGActionEventsTests.swift */,
+				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
@@ -6173,6 +6176,7 @@
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */,
+				A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2975A1465CA308E9766521F2 /* NotificationService.swift */; };
+		0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A25C83033616FE27526C945 /* GGActionEventsTests.swift */; };
 		00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */; };
 		00ED86F7E72AFBF6C8DD69C7 /* GitInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
@@ -156,6 +157,7 @@
 		1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */; };
 		1ED78A36E993D85D0DD1E3CC /* ACPSessionUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */; };
 		1F3AA3B31A896A0608970906 /* AppConfigHarnessMCPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9261D66BAD364C3EEAB4DA /* AppConfigHarnessMCPTests.swift */; };
+		1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F0EED235328724082B570B /* GGActionEvents.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		1F84796DE0ABC832C0303B27 /* ACPSessionStoreDedupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */; };
 		1F860C66D658B0DA5A0599F6 /* RemoteZmxInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */; };
@@ -1459,6 +1461,7 @@
 		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
+		1A25C83033616FE27526C945 /* GGActionEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGActionEventsTests.swift; sourceTree = "<group>"; };
 		1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridgeTests.swift; sourceTree = "<group>"; };
 		1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatus.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
@@ -2554,6 +2557,7 @@
 		F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStreamingTextTests.swift; sourceTree = "<group>"; };
 		F18E4AD4B92330FB085C821C /* FileDeviceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDeviceStore.swift; sourceTree = "<group>"; };
 		F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetectorTests.swift; sourceTree = "<group>"; };
+		F1F0EED235328724082B570B /* GGActionEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGActionEvents.swift; sourceTree = "<group>"; };
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalog.swift; sourceTree = "<group>"; };
 		F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesScrollSpyTests.swift; sourceTree = "<group>"; };
@@ -4554,6 +4558,7 @@
 				14CAEDA53AADBCE77C694E7B /* CodeHostModelsTests.swift */,
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
+				1A25C83033616FE27526C945 /* GGActionEventsTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
 				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
@@ -4804,6 +4809,7 @@
 		F5C77776D026943017AF4190 /* GG */ = {
 			isa = PBXGroup;
 			children = (
+				F1F0EED235328724082B570B /* GGActionEvents.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
@@ -5508,6 +5514,7 @@
 				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
+				1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
@@ -6162,6 +6169,7 @@
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
+				0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -868,6 +868,7 @@
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
 		AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
+		AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */; };
 		AB3BD2843C0923FD0E30458C /* CommitsSectionTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5B0671AB91057B6B196EBD /* CommitsSectionTitleTests.swift */; };
 		AB4B19ECC0C3D7242ECD42C6 /* DiffReviewInlineFeedbackActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */; };
 		AB81A1DA27A87F7C7E49D9CF /* ACPPlanChecklist.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */; };
@@ -1935,6 +1936,7 @@
 		743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolver.swift; sourceTree = "<group>"; };
 		749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSingleResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		74D394D40BC9060833DD640A /* LSPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstaller.swift; sourceTree = "<group>"; };
+		7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGServiceActionsTests.swift; sourceTree = "<group>"; };
 		7544FD20BC61E587CAFAC099 /* AgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistry.swift; sourceTree = "<group>"; };
 		7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkConflictResolveReport.swift; sourceTree = "<group>"; };
 		75DFDC1BD30B1D1CC469D54C /* ZmxEnvTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxEnvTests.swift; sourceTree = "<group>"; };
@@ -4560,6 +4562,7 @@
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				1A25C83033616FE27526C945 /* GGActionEventsTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
+				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
 				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
 				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
@@ -6172,6 +6175,7 @@
 				0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
+				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,
 				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -639,6 +639,7 @@
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
 		7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */; };
 		7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */; };
+		7E5819BACB71C38AA2B3A80E /* ChangesTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA0432FB3F35FC9780718C8 /* ChangesTabViewTests.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7EC95A2AAEFE78B51D9F599A /* ACPPlanSidebarVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */; };
 		7F2D2A9180110871CFF58192 /* ProjectIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */; };
@@ -2462,6 +2463,7 @@
 		DE2F61CCAFB23F6C394ACD8D /* ACPAdapterInstallCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstallCoordinatorTests.swift; sourceTree = "<group>"; };
 		DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetectorTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
+		DEA0432FB3F35FC9780718C8 /* ChangesTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTabViewTests.swift; sourceTree = "<group>"; };
 		DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessionsTests.swift; sourceTree = "<group>"; };
 		DF0CB94DB8949712B0274413 /* RemoteStatusFingerprintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteStatusFingerprintTests.swift; sourceTree = "<group>"; };
 		DF32A1544E13321E9E223AFF /* DiffPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneView.swift; sourceTree = "<group>"; };
@@ -2893,6 +2895,7 @@
 				652C404D30685CB2FE79BD81 /* BaseResolutionMappingTests.swift */,
 				D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */,
 				71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */,
+				DEA0432FB3F35FC9780718C8 /* ChangesTabViewTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				3986789560012DF861565F12 /* ChatPaneTests.swift */,
@@ -6106,6 +6109,7 @@
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				EAEB68B3A06AEA14BC8E2985 /* ChangesPreparationModelTests.swift in Sources */,
+				7E5819BACB71C38AA2B3A80E /* ChangesTabViewTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
 				57C5E087A453B384485B4EE2 /* ChatFontCatalogTests.swift in Sources */,
 				981730A24BE369F4AE9012F3 /* ChatPaneTests.swift in Sources */,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -432,6 +432,23 @@ private struct RootPresentationHandlers: ViewModifier {
                 stack: state.rightPaneStore.stateWithPendingGGLand()?.ggStack
             ))
         }
+        .confirmationDialog(
+            "Clean all merged stacks?",
+            isPresented: Binding(
+                get: { state.rightPaneStore.stateWithPendingGGCleanAll() != nil },
+                set: { if !$0 { state.rightPaneStore.stateWithPendingGGCleanAll()?.cancelGGCleanAll() } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Clean all merged stacks", role: .destructive) {
+                state.rightPaneStore.stateWithPendingGGCleanAll()?.performGGCleanAll()
+            }
+            Button("Cancel", role: .cancel) {
+                state.rightPaneStore.stateWithPendingGGCleanAll()?.cancelGGCleanAll()
+            }
+        } message: {
+            Text("Remove every merged gg stack and associated worktree in this repository.")
+        }
         .alert(
             "Merge failed",
             isPresented: Binding(

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -411,6 +411,27 @@ private struct RootPresentationHandlers: ViewModifier {
         } message: { snapshot in
             Text(RightPaneState.mergeConfirmationMessage(for: snapshot.reviewRequest))
         }
+        .confirmationDialog(
+            "Land stack?",
+            isPresented: Binding(
+                get: { state.rightPaneStore.stateWithPendingGGLand() != nil },
+                set: { if !$0 { state.rightPaneStore.stateWithPendingGGLand()?.cancelGGLand() } }
+            ),
+            titleVisibility: .visible,
+            presenting: state.rightPaneStore.stateWithPendingGGLand()?.pendingGGLand
+        ) { _ in
+            Button("Land", role: .destructive) {
+                state.rightPaneStore.stateWithPendingGGLand()?.performGGLand()
+            }
+            Button("Cancel", role: .cancel) {
+                state.rightPaneStore.stateWithPendingGGLand()?.cancelGGLand()
+            }
+        } message: { request in
+            Text(RightPaneState.ggLandConfirmationMessage(
+                for: request,
+                stack: state.rightPaneStore.stateWithPendingGGLand()?.ggStack
+            ))
+        }
         .alert(
             "Merge failed",
             isPresented: Binding(

--- a/Alas/Sources/Helpers/LineBuffer.swift
+++ b/Alas/Sources/Helpers/LineBuffer.swift
@@ -4,18 +4,22 @@ import Foundation
 /// content is held until either more data arrives or `flush()` is called.
 final class LineBuffer: @unchecked Sendable {
     private let lock = NSLock()
-    private var pending: String = ""
+    private var pending = Data()
 
     func feed(_ chunk: String) -> [String] {
+        feed(Data(chunk.utf8))
+    }
+
+    func feed(_ data: Data) -> [String] {
         lock.lock()
         defer { lock.unlock() }
-        pending += chunk
+        pending.append(data)
         var out: [String] = []
-        while let newlineRange = pending.range(of: "\n") {
-            var line = String(pending[..<newlineRange.lowerBound])
-            if line.hasSuffix("\r") { line.removeLast() }
-            out.append(line)
-            pending.removeSubrange(pending.startIndex...newlineRange.lowerBound)
+        while let newlineIndex = pending.firstIndex(of: 0x0A) {
+            var line = Data(pending[..<newlineIndex])
+            if line.last == 0x0D { line.removeLast() }
+            out.append(String(decoding: line, as: UTF8.self))
+            pending.removeSubrange(pending.startIndex...newlineIndex)
         }
         return out
     }
@@ -24,8 +28,8 @@ final class LineBuffer: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         if pending.isEmpty { return nil }
-        let tail = pending
-        pending = ""
+        let tail = String(decoding: pending, as: UTF8.self)
+        pending.removeAll()
         return tail
     }
 }

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -68,6 +68,16 @@ struct CodeHostRemote: Equatable, Sendable {
             return webURL.appendingPathComponent("-").appendingPathComponent("commit").appendingPathComponent(sha)
         }
     }
+
+    func reviewRequestURL(number: Int) -> URL {
+        switch kind {
+        case .github:
+            return webURL.appendingPathComponent("pull").appendingPathComponent("\(number)")
+        case .gitlab:
+            return webURL.appendingPathComponent("-")
+                .appendingPathComponent("merge_requests").appendingPathComponent("\(number)")
+        }
+    }
 }
 
 struct CodeHostProviderCapabilities: Equatable, Sendable {

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -27,10 +27,18 @@ enum GGSyncEvent: Equatable {
         let event = object["event"] as? String ?? (eventObject["entries"] == nil ? "" : "summary")
         guard !event.isEmpty else { return nil }
         func int(_ key: String) -> Int? { eventObject[key] as? Int }
+        func message(from error: Any?) -> String? {
+            guard let error, !(error is NSNull) else { return nil }
+            if let string = error as? String, !string.isEmpty { return string }
+            if let object = error as? [String: Any] {
+                if let message = object["message"] as? String, !message.isEmpty { return message }
+                if let nested = message(from: object["error"]) { return nested }
+            }
+            return String(describing: error)
+        }
         func message(default fallback: String) -> String {
             if let message = eventObject["message"] as? String, !message.isEmpty { return message }
-            if let error = eventObject["error"] as? String, !error.isEmpty { return error }
-            if let error = eventObject["error"], !(error is NSNull) { return String(describing: error) }
+            if let error = message(from: eventObject["error"]) { return error }
             return fallback
         }
         switch event {
@@ -57,9 +65,9 @@ enum GGSyncEvent: Equatable {
         case "summary":
             if let entries = eventObject["entries"] as? [[String: Any]] {
                 for entry in entries {
-                    if let error = entry["error"], !(error is NSNull) {
+                    if let error = message(from: entry["error"]) {
                         let prefix = (entry["position"] as? Int).map { "[\($0)] " } ?? ""
-                        return .error(message: prefix + String(describing: error))
+                        return .error(message: prefix + error)
                     }
                 }
             }
@@ -75,6 +83,43 @@ enum GGSyncEvent: Equatable {
     }
 }
 
+enum GGActionErrorMessage {
+    static func parse(fromJSON data: Data) -> String? {
+        guard let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { return nil }
+        if let line = String(data: data, encoding: .utf8),
+           case .error(let message) = GGSyncEvent.parse(line: line)
+        {
+            return message
+        }
+        return parse(from: object)
+    }
+
+    static func parse(from object: [String: Any]) -> String? {
+        if let message = message(from: object["error"]) { return message }
+        if let land = object["land"] as? [String: Any], let message = parse(from: land) { return message }
+        if let sync = object["sync"] as? [String: Any], let message = parse(from: sync) { return message }
+        if let entries = object["entries"] as? [[String: Any]] {
+            for entry in entries {
+                if let message = message(from: entry["error"]) {
+                    let prefix = (entry["position"] as? Int).map { "[\($0)] " } ?? ""
+                    return prefix + message
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func message(from error: Any?) -> String? {
+        guard let error, !(error is NSNull) else { return nil }
+        if let string = error as? String, !string.isEmpty { return string }
+        if let object = error as? [String: Any] {
+            if let message = object["message"] as? String, !message.isEmpty { return message }
+            if let nested = message(from: object["error"]) { return nested }
+        }
+        return String(describing: error)
+    }
+}
+
 /// Decoded result of `gg land … --json`.
 struct GGLandResult: Equatable {
     let landed: [GGLandedEntry]
@@ -85,11 +130,8 @@ struct GGLandResult: Equatable {
     }
 
     static func decode(fromJSON data: Data) throws -> GGLandResult {
-        if let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-           let land = object["land"] as? [String: Any],
-           let error = land["error"], !(error is NSNull)
-        {
-            throw GGServiceError.commandFailed(stderr: String(describing: error))
+        if let message = GGActionErrorMessage.parse(fromJSON: data) {
+            throw GGServiceError.commandFailed(stderr: message)
         }
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A single streamed event from `gg sync --json --stream`. Parsed per line;
+/// A single streamed event from `gg sync --jsonl`. Parsed per line;
 /// unknown/blank/malformed lines yield nil and are skipped (tolerant, like
 /// the phase-1 stack models).
 enum GGSyncEvent: Equatable {

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A single streamed event from `gg sync --jsonl`. Parsed per line;
+/// A single streamed event from `gg sync --json --stream`. Parsed per line;
 /// unknown/blank/malformed lines yield nil and are skipped (tolerant, like
 /// the phase-1 stack models).
 enum GGSyncEvent: Equatable {

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// A single streamed event from `gg sync --jsonl`. Parsed per line;
+/// unknown/blank/malformed lines yield nil and are skipped (tolerant, like
+/// the phase-1 stack models).
+enum GGSyncEvent: Equatable {
+    case start(totalEntries: Int)
+    case entryStarted(position: Int, title: String)
+    case pushStarted(position: Int)
+    case pushDone(position: Int, forced: Bool)
+    case prCreated(position: Int, prNumber: Int, prURL: String?, draft: Bool)
+    case summary
+    case error(message: String)
+
+    static func parse(line: String) -> GGSyncEvent? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8),
+              let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let event = object["event"] as? String
+        else { return nil }
+
+        func int(_ key: String) -> Int? { object[key] as? Int }
+        switch event {
+        case "start":
+            guard let total = int("total_entries") else { return nil }
+            return .start(totalEntries: total)
+        case "entry_started":
+            guard let pos = int("position"), let title = object["title"] as? String else { return nil }
+            return .entryStarted(position: pos, title: title)
+        case "push_started":
+            guard let pos = int("position") else { return nil }
+            return .pushStarted(position: pos)
+        case "push_done":
+            guard let pos = int("position") else { return nil }
+            return .pushDone(position: pos, forced: object["forced"] as? Bool ?? false)
+        case "pr_created":
+            guard let pos = int("position"), let number = int("pr_number") else { return nil }
+            return .prCreated(
+                position: pos,
+                prNumber: number,
+                prURL: object["pr_url"] as? String,
+                draft: object["draft"] as? Bool ?? false
+            )
+        case "summary":
+            return .summary
+        case "error":
+            return .error(message: object["message"] as? String ?? "gg reported an error")
+        default:
+            return nil
+        }
+    }
+}
+
+/// Decoded result of `gg land … --json`.
+struct GGLandResult: Equatable {
+    let landed: [GGLandedEntry]
+
+    private struct Envelope: Decodable {
+        struct Land: Decodable { let landed: [GGLandedEntry] }
+        let land: Land
+    }
+
+    static func decode(fromJSON data: Data) throws -> GGLandResult {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+            let envelope = try decoder.decode(Envelope.self, from: data)
+            return GGLandResult(landed: envelope.land.landed)
+        } catch {
+            throw GGServiceError.malformedOutput(String(describing: error))
+        }
+    }
+}
+
+struct GGLandedEntry: Equatable, Decodable {
+    let position: Int
+    let prNumber: Int?
+}

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -15,11 +15,18 @@ enum GGSyncEvent: Equatable {
     static func parse(line: String) -> GGSyncEvent? {
         let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8),
-              let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-              let event = object["event"] as? String
+              let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
         else { return nil }
 
+        let event = object["event"] as? String ?? (object["entries"] == nil ? "" : "summary")
+        guard !event.isEmpty else { return nil }
         func int(_ key: String) -> Int? { object[key] as? Int }
+        func message(default fallback: String) -> String {
+            if let message = object["message"] as? String, !message.isEmpty { return message }
+            if let error = object["error"] as? String, !error.isEmpty { return error }
+            if let error = object["error"], !(error is NSNull) { return String(describing: error) }
+            return fallback
+        }
         switch event {
         case "start":
             guard let total = int("total_entries") else { return nil }
@@ -42,10 +49,21 @@ enum GGSyncEvent: Equatable {
                 draft: object["draft"] as? Bool ?? false
             )
         case "summary":
+            if let entries = object["entries"] as? [[String: Any]] {
+                for entry in entries {
+                    if let error = entry["error"], !(error is NSNull) {
+                        let prefix = (entry["position"] as? Int).map { "[\($0)] " } ?? ""
+                        return .error(message: prefix + String(describing: error))
+                    }
+                }
+            }
             return .summary
         case "error":
-            return .error(message: object["message"] as? String ?? "gg reported an error")
+            return .error(message: message(default: "gg reported an error"))
         default:
+            if event.hasSuffix("_error") {
+                return .error(message: message(default: "gg reported \(event)"))
+            }
             return nil
         }
     }
@@ -61,6 +79,12 @@ struct GGLandResult: Equatable {
     }
 
     static func decode(fromJSON data: Data) throws -> GGLandResult {
+        if let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+           let land = object["land"] as? [String: Any],
+           let error = land["error"], !(error is NSNull)
+        {
+            throw GGServiceError.commandFailed(stderr: String(describing: error))
+        }
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         do {

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -18,13 +18,19 @@ enum GGSyncEvent: Equatable {
               let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
         else { return nil }
 
-        let event = object["event"] as? String ?? (object["entries"] == nil ? "" : "summary")
+        let eventObject: [String: Any]
+        if object["event"] == nil, let sync = object["sync"] as? [String: Any] {
+            eventObject = sync
+        } else {
+            eventObject = object
+        }
+        let event = object["event"] as? String ?? (eventObject["entries"] == nil ? "" : "summary")
         guard !event.isEmpty else { return nil }
-        func int(_ key: String) -> Int? { object[key] as? Int }
+        func int(_ key: String) -> Int? { eventObject[key] as? Int }
         func message(default fallback: String) -> String {
-            if let message = object["message"] as? String, !message.isEmpty { return message }
-            if let error = object["error"] as? String, !error.isEmpty { return error }
-            if let error = object["error"], !(error is NSNull) { return String(describing: error) }
+            if let message = eventObject["message"] as? String, !message.isEmpty { return message }
+            if let error = eventObject["error"] as? String, !error.isEmpty { return error }
+            if let error = eventObject["error"], !(error is NSNull) { return String(describing: error) }
             return fallback
         }
         switch event {
@@ -32,7 +38,7 @@ enum GGSyncEvent: Equatable {
             guard let total = int("total_entries") else { return nil }
             return .start(totalEntries: total)
         case "entry_started":
-            guard let pos = int("position"), let title = object["title"] as? String else { return nil }
+            guard let pos = int("position"), let title = eventObject["title"] as? String else { return nil }
             return .entryStarted(position: pos, title: title)
         case "push_started":
             guard let pos = int("position") else { return nil }
@@ -45,11 +51,11 @@ enum GGSyncEvent: Equatable {
             return .prCreated(
                 position: pos,
                 prNumber: number,
-                prURL: object["pr_url"] as? String,
-                draft: object["draft"] as? Bool ?? false
+                prURL: eventObject["pr_url"] as? String,
+                draft: eventObject["draft"] as? Bool ?? false
             )
         case "summary":
-            if let entries = object["entries"] as? [[String: Any]] {
+            if let entries = eventObject["entries"] as? [[String: Any]] {
                 for entry in entries {
                     if let error = entry["error"], !(error is NSNull) {
                         let prefix = (entry["position"] as? Int).map { "[\($0)] " } ?? ""

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -5,6 +5,38 @@ import Observation
 /// tests can fake CLI output. Local-only in phase 1 (no SSH rewrite).
 protocol GGCommandRunning: Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult
+    /// Streams stdout lines as they arrive (for `gg sync --jsonl`). Finishes
+    /// with `.commandFailed`/`.cliMissing` on a non-zero exit.
+    func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error>
+}
+
+extension GGCommandRunning {
+    /// Default: buffer the whole command then split into lines. Good enough
+    /// for tests and any non-streaming conformer; `ProcessGGCommandRunner`
+    /// overrides this with a truly incremental implementation.
+    func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let result = try await run(args: args, cwd: cwd)
+                    for line in result.stdout.split(separator: "\n", omittingEmptySubsequences: true) {
+                        continuation.yield(String(line))
+                    }
+                    if result.exitCode == 0 {
+                        continuation.finish()
+                    } else if result.exitCode == 127 {
+                        continuation.finish(throwing: GGServiceError.cliMissing)
+                    } else {
+                        continuation.finish(throwing: GGServiceError.commandFailed(
+                            stderr: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                        ))
+                    }
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
 }
 
 struct ProcessGGCommandRunner: GGCommandRunning {
@@ -15,6 +47,52 @@ struct ProcessGGCommandRunner: GGCommandRunning {
             cwd: cwd,
             env: Process.gitEnv()
         )
+    }
+
+    func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["gg"] + args
+            if let cwd { process.currentDirectoryURL = cwd }
+            process.environment = Process.gitEnv()
+            let outPipe = Pipe()
+            let errPipe = Pipe()
+            process.standardOutput = outPipe
+            process.standardError = errPipe
+
+            let buffer = LineBuffer()
+            outPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    handle.readabilityHandler = nil
+                    if let tail = buffer.flush() { continuation.yield(tail) }
+                } else {
+                    let chunk = String(decoding: data, as: UTF8.self)
+                    for line in buffer.feed(chunk) { continuation.yield(line) }
+                }
+            }
+            process.terminationHandler = { proc in
+                let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                if proc.terminationStatus == 0 {
+                    continuation.finish()
+                } else if proc.terminationStatus == 127 {
+                    continuation.finish(throwing: GGServiceError.cliMissing)
+                } else {
+                    continuation.finish(throwing: GGServiceError.commandFailed(
+                        stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                    ))
+                }
+            }
+            do {
+                try process.run()
+            } catch {
+                continuation.finish(throwing: GGServiceError.commandFailed(stderr: error.localizedDescription))
+            }
+            continuation.onTermination = { _ in
+                if process.isRunning { process.terminate() }
+            }
+        }
     }
 }
 
@@ -54,6 +132,67 @@ struct GGService {
             )
         }
         return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8)).stack
+    }
+
+    /// Streams `gg sync --jsonl` events. Non-`GGSyncEvent` lines are skipped.
+    func sync(worktreePath: String) -> AsyncThrowingStream<GGSyncEvent, Error> {
+        let lines = runner.runStreaming(args: ["sync", "--jsonl"], cwd: URL(fileURLWithPath: worktreePath))
+        return AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    for try await line in lines {
+                        if let event = GGSyncEvent.parse(line: line) { continuation.yield(event) }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Lands ready entries (bottom-up). `until` lands up to a target
+    /// (position/GG-ID/SHA); nil lands all currently-approved entries.
+    func land(worktreePath: String, until: String?) async throws -> GGLandResult {
+        let args: [String] = until.map { ["land", "--until", $0, "--json"] } ?? ["land", "--all", "--json"]
+        let result = try await runChecked(args: args, worktreePath: worktreePath)
+        return try GGLandResult.decode(fromJSON: Data(result.stdout.utf8))
+    }
+
+    func clean(worktreePath: String) async throws {
+        _ = try await runChecked(args: ["clean"], worktreePath: worktreePath)
+    }
+
+    func continueOp(worktreePath: String) async throws {
+        _ = try await runChecked(args: ["continue"], worktreePath: worktreePath)
+    }
+
+    func abortOp(worktreePath: String) async throws {
+        _ = try await runChecked(args: ["abort"], worktreePath: worktreePath)
+    }
+
+    func checkout(worktreePath: String, target: String) async throws {
+        _ = try await runChecked(args: ["mv", target], worktreePath: worktreePath)
+    }
+
+    /// Runs a gg command and maps a non-zero exit to `GGServiceError`, the
+    /// same way `currentStack` does.
+    private func runChecked(args: [String], worktreePath: String) async throws -> ProcessResult {
+        let result: ProcessResult
+        do {
+            result = try await runner.run(args: args, cwd: URL(fileURLWithPath: worktreePath))
+        } catch let error as GGServiceError {
+            throw error
+        } catch {
+            throw GGServiceError.commandFailed(stderr: String(describing: error))
+        }
+        guard result.exitCode == 0 else {
+            if result.exitCode == 127 { throw GGServiceError.cliMissing }
+            throw GGServiceError.commandFailed(
+                stderr: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+        return result
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -288,11 +288,11 @@ struct GGService {
                             if let event = GGSyncEvent.parse(line: line) { continuation.yield(event) }
                         }
                     } else {
-                        _ = try await runChecked(
+                        let result = try await runChecked(
                             args: ["sync", "--json", "--no-rebase-check"],
                             worktreePath: worktreePath
                         )
-                        continuation.yield(.summary)
+                        continuation.yield(GGSyncEvent.parse(line: result.stdout) ?? .summary)
                     }
                     continuation.finish()
                 } catch {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -6,7 +6,7 @@ import Observation
 /// tests can fake CLI output. Local-only in phase 1 (no SSH rewrite).
 protocol GGCommandRunning: Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult
-/// Streams stdout lines as they arrive (for `gg sync --json --stream`). Finishes
+/// Streams stdout lines as they arrive (for `gg sync --jsonl`). Finishes
     /// with `.commandFailed`/`.cliMissing` on a non-zero exit.
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error>
 }
@@ -321,15 +321,15 @@ struct GGService {
         return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8)).stack
     }
 
-    /// Streams sync events when `gg sync --json --stream` is supported; older gg
+    /// Streams sync events when `gg sync --jsonl` is supported; older gg
     /// builds fall back to `--json` and yield a summary event on success.
     func sync(worktreePath: String) -> AsyncThrowingStream<GGSyncEvent, Error> {
         return AsyncThrowingStream { continuation in
             Task {
                 do {
-                    if await syncSupportsJSONStream() {
+                    if await syncSupportsJSONL() {
                         let lines = runner.runStreaming(
-                            args: ["sync", "--json", "--stream"],
+                            args: ["sync", "--jsonl"],
                             cwd: URL(fileURLWithPath: worktreePath)
                         )
                         for try await line in lines {
@@ -362,11 +362,11 @@ struct GGService {
         _ = try await runChecked(args: ["clean", "--all"], worktreePath: worktreePath)
     }
 
-    private func syncSupportsJSONStream() async -> Bool {
+    private func syncSupportsJSONL() async -> Bool {
         guard let result = try? await runner.run(args: ["sync", "--help"], cwd: nil),
               result.exitCode == 0
         else { return false }
-        return result.stdout.contains("--json") && result.stdout.contains("--stream")
+        return result.stdout.contains("--jsonl")
     }
 
     func continueOp(worktreePath: String) async throws {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -266,6 +266,9 @@ struct GGService {
         }
         guard result.exitCode == 0 else {
             if result.exitCode == 127 { throw GGServiceError.cliMissing }
+            if let message = GGActionErrorMessage.parse(fromJSON: Data(result.stdout.utf8)) {
+                throw GGServiceError.commandFailed(stderr: message)
+            }
             throw GGServiceError.commandFailed(
                 stderr: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             )
@@ -346,6 +349,9 @@ struct GGService {
         }
         guard result.exitCode == 0 else {
             if result.exitCode == 127 { throw GGServiceError.cliMissing }
+            if let message = GGActionErrorMessage.parse(fromJSON: Data(result.stdout.utf8)) {
+                throw GGServiceError.commandFailed(stderr: message)
+            }
             throw GGServiceError.commandFailed(
                 stderr: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             )

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -273,17 +273,26 @@ struct GGService {
         return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8)).stack
     }
 
-    /// Streams `gg sync --jsonl` events. Non-`GGSyncEvent` lines are skipped.
+    /// Streams sync events when `gg sync --jsonl` is supported; older gg
+    /// builds fall back to `--json` and yield a summary event on success.
     func sync(worktreePath: String) -> AsyncThrowingStream<GGSyncEvent, Error> {
-        let lines = runner.runStreaming(
-            args: ["sync", "--jsonl", "--no-rebase-check"],
-            cwd: URL(fileURLWithPath: worktreePath)
-        )
         return AsyncThrowingStream { continuation in
             Task {
                 do {
-                    for try await line in lines {
-                        if let event = GGSyncEvent.parse(line: line) { continuation.yield(event) }
+                    if await syncSupportsJSONL() {
+                        let lines = runner.runStreaming(
+                            args: ["sync", "--jsonl", "--no-rebase-check"],
+                            cwd: URL(fileURLWithPath: worktreePath)
+                        )
+                        for try await line in lines {
+                            if let event = GGSyncEvent.parse(line: line) { continuation.yield(event) }
+                        }
+                    } else {
+                        _ = try await runChecked(
+                            args: ["sync", "--json", "--no-rebase-check"],
+                            worktreePath: worktreePath
+                        )
+                        continuation.yield(.summary)
                     }
                     continuation.finish()
                 } catch {
@@ -303,6 +312,13 @@ struct GGService {
 
     func clean(worktreePath: String) async throws {
         _ = try await runChecked(args: ["clean", "--all"], worktreePath: worktreePath)
+    }
+
+    private func syncSupportsJSONL() async -> Bool {
+        guard let result = try? await runner.run(args: ["sync", "--help"], cwd: nil),
+              result.exitCode == 0
+        else { return false }
+        return result.stdout.contains("--jsonl")
     }
 
     func continueOp(worktreePath: String) async throws {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -77,11 +77,23 @@ struct ProcessGGCommandRunner: GGCommandRunning {
 
             let buffer = LineBuffer()
             let stderrAccum = StderrAccumulator()
+            // `terminationHandler` and these readability handlers are two
+            // independent dispatch mechanisms with no ordering guarantee
+            // between them: the child exiting does not imply the kernel has
+            // already delivered the final EOF read to our handlers. Without
+            // an explicit latch, `terminationHandler` can call
+            // `continuation.finish()` before the stdout handler has flushed
+            // `LineBuffer`'s trailing partial line (or before stderr has
+            // appended its last chunk) — `finish()` makes any later `yield`
+            // a silent no-op, so that last line is dropped, not delayed.
+            // Mirrors `Process+Git.swift`'s `ByteAccumulator` EOF latch.
+            let stdoutEOF = EOFLatch()
             outPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
                 if data.isEmpty {
                     handle.readabilityHandler = nil
                     if let tail = buffer.flush() { continuation.yield(tail) }
+                    stdoutEOF.markClosed()
                 } else {
                     let chunk = String(decoding: data, as: UTF8.self)
                     for line in buffer.feed(chunk) { continuation.yield(line) }
@@ -96,19 +108,29 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                 let data = handle.availableData
                 if data.isEmpty {
                     handle.readabilityHandler = nil
+                    stderrAccum.markClosed()
                 } else {
                     stderrAccum.append(data)
                 }
             }
             process.terminationHandler = { proc in
-                if proc.terminationStatus == 0 {
-                    continuation.finish()
-                } else if proc.terminationStatus == 127 {
-                    continuation.finish(throwing: GGServiceError.cliMissing)
-                } else {
-                    continuation.finish(throwing: GGServiceError.commandFailed(
-                        stderr: stderrAccum.text().trimmingCharacters(in: .whitespacesAndNewlines)
-                    ))
+                let status = proc.terminationStatus
+                Task {
+                    // Bound the wait the same way `Process+Git.swift` does:
+                    // a stuck handler (e.g. a wedged dispatch queue) must
+                    // not hang the stream forever.
+                    async let outClosed = stdoutEOF.waitForClose(timeoutNanoseconds: 2_000_000_000)
+                    async let errClosed = stderrAccum.waitForClose(timeoutNanoseconds: 2_000_000_000)
+                    _ = await (outClosed, errClosed)
+                    if status == 0 {
+                        continuation.finish()
+                    } else if status == 127 {
+                        continuation.finish(throwing: GGServiceError.cliMissing)
+                    } else {
+                        continuation.finish(throwing: GGServiceError.commandFailed(
+                            stderr: stderrAccum.text().trimmingCharacters(in: .whitespacesAndNewlines)
+                        ))
+                    }
                 }
             }
             do {
@@ -136,18 +158,74 @@ struct ProcessGGCommandRunner: GGCommandRunning {
     }
 }
 
+/// EOF latch for a `FileHandle.readabilityHandler`: `markClosed()` from the
+/// handler's EOF branch (empty `availableData`), `waitForClose(timeoutNanoseconds:)`
+/// from an awaiter that must not proceed until EOF has actually been
+/// observed. Latches `closed` so a waiter arriving after EOF (handler raced
+/// ahead) returns immediately, and bounds the wait with a timeout so a
+/// stuck handler can't hang the caller forever. Mirrors `Process+Git.swift`'s
+/// `ByteAccumulator` (kept separate here since that type is file-private).
+private final class EOFLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var closed = false
+    private var waiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+
+    func markClosed() {
+        lock.lock()
+        let conts = Array(waiters.values)
+        waiters = [:]
+        closed = true
+        lock.unlock()
+        for c in conts { c.resume(returning: true) }
+    }
+
+    func waitForClose(timeoutNanoseconds: UInt64) async -> Bool {
+        await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            lock.lock()
+            if closed {
+                lock.unlock()
+                cont.resume(returning: true)
+                return
+            }
+            let id = UUID()
+            waiters[id] = cont
+            lock.unlock()
+            Task {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                self.resumeTimedOutWaiter(id: id)
+            }
+        }
+    }
+
+    private func resumeTimedOutWaiter(id: UUID) {
+        lock.lock()
+        guard let cont = waiters.removeValue(forKey: id) else {
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+        cont.resume(returning: false)
+    }
+}
+
 /// Thread-safe accumulator for stderr bytes read incrementally off a
-/// readability handler. Mirrors `Process+Git.swift`'s `ByteAccumulator`
-/// (kept separate here since that type is file-private and this call site
-/// only needs the final text, not EOF-latching).
+/// readability handler, composed with an `EOFLatch` so callers can wait
+/// until the handler has actually observed EOF before reading `text()`.
 private final class StderrAccumulator: @unchecked Sendable {
     private let lock = NSLock()
     private var data = Data()
+    private let eof = EOFLatch()
 
     func append(_ chunk: Data) {
         lock.lock()
         data.append(chunk)
         lock.unlock()
+    }
+
+    func markClosed() { eof.markClosed() }
+
+    func waitForClose(timeoutNanoseconds: UInt64) async -> Bool {
+        await eof.waitForClose(timeoutNanoseconds: timeoutNanoseconds)
     }
 
     func text() -> String {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -329,7 +329,7 @@ struct GGService {
                 do {
                     if await syncSupportsJSONL() {
                         let lines = runner.runStreaming(
-                            args: ["sync", "--jsonl", "--no-rebase-check"],
+                            args: ["sync", "--jsonl"],
                             cwd: URL(fileURLWithPath: worktreePath)
                         )
                         for try await line in lines {
@@ -337,7 +337,7 @@ struct GGService {
                         }
                     } else {
                         let result = try await runChecked(
-                            args: ["sync", "--json", "--no-rebase-check"],
+                            args: ["sync", "--json"],
                             worktreePath: worktreePath
                         )
                         continuation.yield(GGSyncEvent.parse(line: result.stdout) ?? .summary)

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Observation
 
@@ -53,7 +54,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
     }
 
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
-        Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv())
+        Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv(), timeout: Self.commandTimeout)
     }
 
     /// Pipe-lifecycle core of `runStreaming`, parameterized on the
@@ -65,7 +66,8 @@ struct ProcessGGCommandRunner: GGCommandRunning {
         executable: String,
         args: [String],
         cwd: URL?,
-        env: [String: String]?
+        env: [String: String]?,
+        timeout: TimeInterval = Process.defaultTimeout
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             let process = Process()
@@ -80,6 +82,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
 
             let buffer = LineBuffer()
             let stderrAccum = StderrAccumulator()
+            let timeoutState = GGStreamingTimeoutState()
             // `terminationHandler` and these readability handlers are two
             // independent dispatch mechanisms with no ordering guarantee
             // between them: the child exiting does not imply the kernel has
@@ -98,8 +101,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     if let tail = buffer.flush() { continuation.yield(tail) }
                     stdoutEOF.markClosed()
                 } else {
-                    let chunk = String(decoding: data, as: UTF8.self)
-                    for line in buffer.feed(chunk) { continuation.yield(line) }
+                    for line in buffer.feed(data) { continuation.yield(line) }
                 }
             }
             // Drain stderr incrementally as it arrives rather than blocking
@@ -125,7 +127,9 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     async let outClosed = stdoutEOF.waitForClose(timeoutNanoseconds: 2_000_000_000)
                     async let errClosed = stderrAccum.waitForClose(timeoutNanoseconds: 2_000_000_000)
                     _ = await (outClosed, errClosed)
-                    if status == 0 {
+                    if timeoutState.didTimeOut {
+                        continuation.finish(throwing: ProcessError.timedOut(executable: executable, args: args, seconds: timeout))
+                    } else if status == 0 {
                         continuation.finish()
                     } else if status == 127 {
                         continuation.finish(throwing: GGServiceError.cliMissing)
@@ -144,6 +148,18 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                 continuation.finish(throwing: GGServiceError.commandFailed(stderr: error.localizedDescription))
                 return
             }
+            let watchdog = Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                if Task.isCancelled { return }
+                if process.isRunning {
+                    timeoutState.markTimedOut()
+                    fputs(
+                        "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
+                        stderr
+                    )
+                    terminateGGStreamingProcessWithEscalation(process)
+                }
+            }
             // Close the parent's copy of the pipe write ends now that the
             // child has dup'd them. Without this, the kernel keeps
             // reporting "writers still open" on the read side and the
@@ -153,11 +169,37 @@ struct ProcessGGCommandRunner: GGCommandRunning {
             try? outPipe.fileHandleForWriting.close()
             try? errPipe.fileHandleForWriting.close()
             continuation.onTermination = { _ in
+                watchdog.cancel()
                 if process.isRunning { process.terminate() }
                 outPipe.fileHandleForReading.readabilityHandler = nil
                 errPipe.fileHandleForReading.readabilityHandler = nil
             }
         }
+    }
+}
+
+private func terminateGGStreamingProcessWithEscalation(_ process: Process) {
+    process.terminate()
+    let pid = process.processIdentifier
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2) {
+        if process.isRunning { kill(pid, SIGKILL) }
+    }
+}
+
+private final class GGStreamingTimeoutState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var timedOut = false
+
+    func markTimedOut() {
+        lock.lock()
+        timedOut = true
+        lock.unlock()
+    }
+
+    var didTimeOut: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return timedOut
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -50,18 +50,33 @@ struct ProcessGGCommandRunner: GGCommandRunning {
     }
 
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
+        Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv())
+    }
+
+    /// Pipe-lifecycle core of `runStreaming`, parameterized on the
+    /// executable/args so tests can exercise the readability-handler /
+    /// write-end-close pattern against a trivial subprocess (e.g.
+    /// `/bin/sh -c ...`) without depending on the `gg` binary being
+    /// installed.
+    static func streamProcess(
+        executable: String,
+        args: [String],
+        cwd: URL?,
+        env: [String: String]?
+    ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = ["gg"] + args
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = args
             if let cwd { process.currentDirectoryURL = cwd }
-            process.environment = Process.gitEnv()
+            if let env { process.environment = env }
             let outPipe = Pipe()
             let errPipe = Pipe()
             process.standardOutput = outPipe
             process.standardError = errPipe
 
             let buffer = LineBuffer()
+            let stderrAccum = StderrAccumulator()
             outPipe.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
                 if data.isEmpty {
@@ -72,27 +87,73 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     for line in buffer.feed(chunk) { continuation.yield(line) }
                 }
             }
+            // Drain stderr incrementally as it arrives rather than blocking
+            // on it in the termination handler — see `Process+Git.swift`'s
+            // `run(_:args:...)` for the same pattern and why it matters: a
+            // chatty child can fill the ~64KB pipe buffer and block its own
+            // `write()` (and therefore its own exit) if nobody is reading.
+            errPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    handle.readabilityHandler = nil
+                } else {
+                    stderrAccum.append(data)
+                }
+            }
             process.terminationHandler = { proc in
-                let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
                 if proc.terminationStatus == 0 {
                     continuation.finish()
                 } else if proc.terminationStatus == 127 {
                     continuation.finish(throwing: GGServiceError.cliMissing)
                 } else {
                     continuation.finish(throwing: GGServiceError.commandFailed(
-                        stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                        stderr: stderrAccum.text().trimmingCharacters(in: .whitespacesAndNewlines)
                     ))
                 }
             }
             do {
                 try process.run()
             } catch {
+                outPipe.fileHandleForReading.readabilityHandler = nil
+                errPipe.fileHandleForReading.readabilityHandler = nil
                 continuation.finish(throwing: GGServiceError.commandFailed(stderr: error.localizedDescription))
+                return
             }
+            // Close the parent's copy of the pipe write ends now that the
+            // child has dup'd them. Without this, the kernel keeps
+            // reporting "writers still open" on the read side and the
+            // readability handlers never see EOF after the child exits —
+            // the stream would hang forever waiting for a termination that
+            // already happened.
+            try? outPipe.fileHandleForWriting.close()
+            try? errPipe.fileHandleForWriting.close()
             continuation.onTermination = { _ in
                 if process.isRunning { process.terminate() }
+                outPipe.fileHandleForReading.readabilityHandler = nil
+                errPipe.fileHandleForReading.readabilityHandler = nil
             }
         }
+    }
+}
+
+/// Thread-safe accumulator for stderr bytes read incrementally off a
+/// readability handler. Mirrors `Process+Git.swift`'s `ByteAccumulator`
+/// (kept separate here since that type is file-private and this call site
+/// only needs the final text, not EOF-latching).
+private final class StderrAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    func text() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(decoding: data, as: UTF8.self)
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -305,7 +305,7 @@ struct GGService {
     /// Lands ready entries (bottom-up). `until` lands up to a target
     /// (position/GG-ID/SHA); nil lands all currently-approved entries.
     func land(worktreePath: String, until: String?) async throws -> GGLandResult {
-        let args: [String] = until.map { ["land", "--until", $0, "--json"] } ?? ["land", "--all", "--json"]
+        let args: [String] = until.map { ["land", "--until", $0, "--json", "--no-clean"] } ?? ["land", "--all", "--json", "--no-clean"]
         let result = try await runChecked(args: args, worktreePath: worktreePath)
         return try GGLandResult.decode(fromJSON: Data(result.stdout.utf8))
     }

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -40,12 +40,15 @@ extension GGCommandRunning {
 }
 
 struct ProcessGGCommandRunner: GGCommandRunning {
+    private static let commandTimeout: TimeInterval = 600
+
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         try await Process.run(
             "/usr/bin/env",
             args: ["gg"] + args,
             cwd: cwd,
-            env: Process.gitEnv()
+            env: Process.gitEnv(),
+            timeout: Self.commandTimeout
         )
     }
 

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -6,7 +6,7 @@ import Observation
 /// tests can fake CLI output. Local-only in phase 1 (no SSH rewrite).
 protocol GGCommandRunning: Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult
-    /// Streams stdout lines as they arrive (for `gg sync --jsonl`). Finishes
+/// Streams stdout lines as they arrive (for `gg sync --json --stream`). Finishes
     /// with `.commandFailed`/`.cliMissing` on a non-zero exit.
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error>
 }
@@ -321,15 +321,15 @@ struct GGService {
         return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8)).stack
     }
 
-    /// Streams sync events when `gg sync --jsonl` is supported; older gg
+    /// Streams sync events when `gg sync --json --stream` is supported; older gg
     /// builds fall back to `--json` and yield a summary event on success.
     func sync(worktreePath: String) -> AsyncThrowingStream<GGSyncEvent, Error> {
         return AsyncThrowingStream { continuation in
             Task {
                 do {
-                    if await syncSupportsJSONL() {
+                    if await syncSupportsJSONStream() {
                         let lines = runner.runStreaming(
-                            args: ["sync", "--jsonl"],
+                            args: ["sync", "--json", "--stream"],
                             cwd: URL(fileURLWithPath: worktreePath)
                         )
                         for try await line in lines {
@@ -362,11 +362,11 @@ struct GGService {
         _ = try await runChecked(args: ["clean", "--all"], worktreePath: worktreePath)
     }
 
-    private func syncSupportsJSONL() async -> Bool {
+    private func syncSupportsJSONStream() async -> Bool {
         guard let result = try? await runner.run(args: ["sync", "--help"], cwd: nil),
               result.exitCode == 0
         else { return false }
-        return result.stdout.contains("--jsonl")
+        return result.stdout.contains("--json") && result.stdout.contains("--stream")
     }
 
     func continueOp(worktreePath: String) async throws {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -275,7 +275,10 @@ struct GGService {
 
     /// Streams `gg sync --jsonl` events. Non-`GGSyncEvent` lines are skipped.
     func sync(worktreePath: String) -> AsyncThrowingStream<GGSyncEvent, Error> {
-        let lines = runner.runStreaming(args: ["sync", "--jsonl"], cwd: URL(fileURLWithPath: worktreePath))
+        let lines = runner.runStreaming(
+            args: ["sync", "--jsonl", "--no-rebase-check"],
+            cwd: URL(fileURLWithPath: worktreePath)
+        )
         return AsyncThrowingStream { continuation in
             Task {
                 do {
@@ -299,7 +302,7 @@ struct GGService {
     }
 
     func clean(worktreePath: String) async throws {
-        _ = try await runChecked(args: ["clean"], worktreePath: worktreePath)
+        _ = try await runChecked(args: ["clean", "--all"], worktreePath: worktreePath)
     }
 
     func continueOp(worktreePath: String) async throws {

--- a/Alas/Sources/Integrations/GG/GGStackActionState.swift
+++ b/Alas/Sources/Integrations/GG/GGStackActionState.swift
@@ -6,6 +6,13 @@ enum GGStackActionKind: Equatable {
     case sync, land, clean, continueOp, abortOp, checkout
 }
 
+/// What a confirmed `land` should do: land everything currently landable, or
+/// stop at a specific entry the user picked from the stack drawer.
+enum GGLandRequest: Equatable {
+    case ready
+    case until(entryId: String, title: String)
+}
+
 /// A gg operation left paused on a conflict (rebase-in-progress), awaiting
 /// `gg continue` / `gg abort`.
 struct GGPausedOperation: Equatable {

--- a/Alas/Sources/Integrations/GG/GGStackActionState.swift
+++ b/Alas/Sources/Integrations/GG/GGStackActionState.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Observation
+
+/// Which gg mutation is running / paused.
+enum GGStackActionKind: Equatable {
+    case sync, land, clean, continueOp, abortOp, checkout
+}
+
+/// A gg operation left paused on a conflict (rebase-in-progress), awaiting
+/// `gg continue` / `gg abort`.
+struct GGPausedOperation: Equatable {
+    let pausedBy: GGStackActionKind
+}
+
+/// Per-worktree observable backing the stack-mode drawer's actions. The
+/// stack-mode analogue of `ReviewLoopState`'s in-flight/error surface.
+@MainActor
+@Observable
+final class GGStackActionState {
+    private(set) var inFlightAction: GGStackActionKind?
+    private(set) var syncProgress: [GGSyncEvent] = []
+    private(set) var lastError: String?
+    private(set) var pausedOperation: GGPausedOperation?
+
+    /// Returns false when another action is already running (one at a time).
+    func beginAction(_ action: GGStackActionKind) -> Bool {
+        guard inFlightAction == nil else { return false }
+        inFlightAction = action
+        return true
+    }
+
+    func endAction(_ action: GGStackActionKind) {
+        guard inFlightAction == action else { return }
+        inFlightAction = nil
+    }
+
+    func appendSyncEvent(_ event: GGSyncEvent) { syncProgress.append(event) }
+    func clearSyncProgress() { if !syncProgress.isEmpty { syncProgress = [] } }
+    func setError(_ message: String) { lastError = message }
+    func clearError() { if lastError != nil { lastError = nil } }
+    func setPaused(_ paused: GGPausedOperation) { if pausedOperation != paused { pausedOperation = paused } }
+    func clearPaused() { if pausedOperation != nil { pausedOperation = nil } }
+}

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -9,7 +9,11 @@ struct GGStackDrawer: View {
 
     private var model: GGStackReadinessModel? {
         if let stack = rps.ggStack {
-            return GGStackReadinessModel.make(stack: stack, action: rps.ggActionState)
+            return GGStackReadinessModel.make(
+                stack: stack,
+                action: rps.ggActionState,
+                liveBehindBase: rps.behindBase?.count
+            )
         }
         return GGStackReadinessModel.makePausedFallback(action: rps.ggActionState)
     }

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -42,18 +42,19 @@ struct GGStackDrawer: View {
     @ViewBuilder
     private func expandedBody(_ model: GGStackReadinessModel) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            if !model.progressRows.isEmpty {
-                VStack(alignment: .leading, spacing: 2) {
-                    ForEach(Array(model.progressRows.enumerated()), id: \.offset) { _, row in
-                        Text(row).font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
-                    }
+            if model.isPaused {
+                if !model.progressRows.isEmpty { progressList(model) }
+                Text("A gg operation is paused on conflicts. Resolve them in the Conflicts section, then Continue — or Abort to roll back.")
+                    .font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+                    .fixedSize(horizontal: false, vertical: true)
+                if let err = rps.ggActionState.lastError {
+                    Text(err).font(.system(size: 11)).foregroundColor(theme.color("warn")).lineLimit(3)
                 }
+                actionRow(model)
+                factsView(model)
+            } else if !model.progressRows.isEmpty {
+                progressList(model)
             } else {
-                if model.isPaused {
-                    Text("A gg operation is paused on conflicts. Resolve them in the Conflicts section, then Continue — or Abort to roll back.")
-                        .font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
-                        .fixedSize(horizontal: false, vertical: true)
-                }
                 if let err = rps.ggActionState.lastError {
                     Text(err).font(.system(size: 11)).foregroundColor(theme.color("warn")).lineLimit(3)
                 }
@@ -62,6 +63,14 @@ struct GGStackDrawer: View {
             }
         }
         .padding(.horizontal, 10).padding(.bottom, 10)
+    }
+
+    private func progressList(_ model: GGStackReadinessModel) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(model.progressRows.enumerated()), id: \.offset) { _, row in
+                Text(row).font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+            }
+        }
     }
 
     private func actionRow(_ model: GGStackReadinessModel) -> some View {

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+struct GGStackDrawer: View {
+    @Bindable var rps: RightPaneState
+    let appState: AppState
+
+    @Environment(\.theme) private var theme
+    @State private var expanded = false
+
+    private var model: GGStackReadinessModel? {
+        rps.ggStack.map { GGStackReadinessModel.make(stack: $0, action: rps.ggActionState) }
+    }
+
+    var body: some View {
+        if let model {
+            VStack(spacing: 0) {
+                Rectangle().fill(theme.color("accent").opacity(0.24)).frame(height: 1)
+                collapsedRow(model)
+                if expanded { expandedBody(model) }
+            }
+            .background(theme.color("bg-1").opacity(0.97))
+        }
+    }
+
+    private func collapsedRow(_ model: GGStackReadinessModel) -> some View {
+        HStack(spacing: 7) {
+            Circle().fill(theme.color(model.isPaused ? "warn" : "accent")).frame(width: 6, height: 6)
+            Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
+            Text(model.title.uppercased())
+                .font(.system(size: 10.5, weight: .semibold)).tracking(0.5)
+                .foregroundColor(theme.color("fg-muted")).lineLimit(1).truncationMode(.middle)
+            Spacer(minLength: 6)
+            Text(model.summaryChip)
+                .font(.system(size: 10.5, weight: .medium)).foregroundColor(theme.color("fg-dim"))
+            Icon(name: expanded ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+        }
+        .padding(.horizontal, 10).padding(.vertical, 7)
+        .contentShape(Rectangle())
+        .onTapGesture { expanded.toggle() }
+    }
+
+    @ViewBuilder
+    private func expandedBody(_ model: GGStackReadinessModel) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if !model.progressRows.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(model.progressRows.enumerated()), id: \.offset) { _, row in
+                        Text(row).font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+                    }
+                }
+            } else {
+                if model.isPaused {
+                    Text("A gg operation is paused on conflicts. Resolve them in the Conflicts section, then Continue — or Abort to roll back.")
+                        .font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let err = rps.ggActionState.lastError {
+                    Text(err).font(.system(size: 11)).foregroundColor(theme.color("warn")).lineLimit(3)
+                }
+                actionRow(model)
+                factsView(model)
+            }
+        }
+        .padding(.horizontal, 10).padding(.bottom, 10)
+    }
+
+    private func actionRow(_ model: GGStackReadinessModel) -> some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 8) {
+                ForEach(model.actions) { action in
+                    Button {
+                        if action.kind == .land { rps.requestGGLand(.ready) }
+                        else { rps.onGGStackAction(action.kind, appState: appState) }
+                    } label: {
+                        HStack(spacing: 6) {
+                            if action.isInFlight { Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10) }
+                            Text(action.title).font(.system(size: 11.5, weight: .semibold)).lineLimit(1)
+                        }
+                        .foregroundColor(action.emphasis == .primary ? theme.color("bg-0") : theme.color("fg-muted"))
+                        .padding(.horizontal, 10).frame(height: 26)
+                        .background(action.emphasis == .primary ? theme.color("accent") : theme.color("bg-3").opacity(0.72))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!action.isEnabled)
+                    .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private func factsView(_ model: GGStackReadinessModel) -> some View {
+        VStack(spacing: 4) {
+            ForEach(model.facts) { fact in
+                HStack(spacing: 8) {
+                    Text(fact.label).font(.system(size: 10.5)).foregroundColor(theme.color("fg-faint"))
+                    Spacer(minLength: 8)
+                    Text(fact.value).font(.system(size: 10.5, weight: .semibold)).foregroundColor(theme.color("fg-dim"))
+                }
+                .padding(.horizontal, 7).frame(height: 22)
+                .background(RoundedRectangle(cornerRadius: 5).fill(theme.color("bg-2").opacity(0.48)))
+            }
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -12,10 +12,23 @@ struct GGStackDrawer: View {
             return GGStackReadinessModel.make(
                 stack: stack,
                 action: rps.ggActionState,
-                liveBehindBase: rps.behindBase?.count
+                liveBehindBase: Self.liveBehindBaseOverride(
+                    stack: stack,
+                    selectedBaseBranch: rps.baseBranch,
+                    behindBase: rps.behindBase
+                )
             )
         }
         return GGStackReadinessModel.makePausedFallback(action: rps.ggActionState)
+    }
+
+    static func liveBehindBaseOverride(
+        stack: GGStack,
+        selectedBaseBranch: String,
+        behindBase: GitService.BehindStatus?
+    ) -> Int? {
+        guard selectedBaseBranch == stack.base else { return nil }
+        return behindBase?.count
     }
 
     var body: some View {

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -8,7 +8,10 @@ struct GGStackDrawer: View {
     @State private var expanded = false
 
     private var model: GGStackReadinessModel? {
-        rps.ggStack.map { GGStackReadinessModel.make(stack: $0, action: rps.ggActionState) }
+        if let stack = rps.ggStack {
+            return GGStackReadinessModel.make(stack: stack, action: rps.ggActionState)
+        }
+        return GGStackReadinessModel.makePausedFallback(action: rps.ggActionState)
     }
 
     var body: some View {

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -16,6 +16,10 @@ struct GGStackDrawer: View {
                     stack: stack,
                     selectedBaseBranch: rps.baseBranch,
                     behindBase: rps.behindBase
+                ),
+                hasBlockingGitOperation: Self.hasBlockingGitOperation(
+                    mergeOperation: rps.mergeOp.current,
+                    pausedGGOperation: rps.ggActionState.pausedOperation
                 )
             )
         }
@@ -29,6 +33,13 @@ struct GGStackDrawer: View {
     ) -> Int? {
         guard selectedBaseBranch == stack.base else { return nil }
         return behindBase?.count
+    }
+
+    static func hasBlockingGitOperation(
+        mergeOperation: MergeOperation?,
+        pausedGGOperation: GGPausedOperation?
+    ) -> Bool {
+        mergeOperation != nil && pausedGGOperation == nil
     }
 
     var body: some View {

--- a/Alas/Sources/Integrations/GG/GGStackGate.swift
+++ b/Alas/Sources/Integrations/GG/GGStackGate.swift
@@ -4,6 +4,8 @@ import Foundation
 /// when every gate passes: master toggle → gg installed → per-project
 /// mode → the current branch is actually stack-shaped.
 enum GGStackGate {
+    private static let alasOperationMarkerName = "alas-gg-operation"
+
     /// Gate 3 (auto mode): the repo's common git dir carries gg config.
     /// `repoPath` is a project's checkout path, which is not guaranteed to
     /// be the primary one — a project can be added from a linked worktree,
@@ -30,6 +32,21 @@ enum GGStackGate {
         return markers.contains {
             FileManager.default.fileExists(atPath: (gitDir as NSString).appendingPathComponent($0))
         }
+    }
+
+    static func alasGGOperationInProgress(repoPath: String) -> Bool {
+        guard let markerPath = alasGGOperationMarkerPath(repoPath: repoPath) else { return false }
+        return FileManager.default.fileExists(atPath: markerPath)
+    }
+
+    static func markAlasGGOperationInProgress(repoPath: String) {
+        guard let markerPath = alasGGOperationMarkerPath(repoPath: repoPath) else { return }
+        FileManager.default.createFile(atPath: markerPath, contents: Data())
+    }
+
+    static func clearAlasGGOperationInProgress(repoPath: String) {
+        guard let markerPath = alasGGOperationMarkerPath(repoPath: repoPath) else { return }
+        try? FileManager.default.removeItem(atPath: markerPath)
     }
 
     /// Resolves the shared git directory for `repoPath`: itself when `.git`
@@ -72,6 +89,12 @@ enum GGStackGate {
         }
         let rawPath = gitdirLine.dropFirst("gitdir:".count).trimmingCharacters(in: .whitespaces)
         return resolvedPath(rawPath, relativeTo: repoPath)
+    }
+
+    private static func alasGGOperationMarkerPath(repoPath: String) -> String? {
+        worktreeGitDir(repoPath: repoPath).map {
+            ($0 as NSString).appendingPathComponent(alasOperationMarkerName)
+        }
     }
 
     private static func resolvedPath(_ path: String, relativeTo base: String) -> String {

--- a/Alas/Sources/Integrations/GG/GGStackGate.swift
+++ b/Alas/Sources/Integrations/GG/GGStackGate.swift
@@ -17,12 +17,45 @@ enum GGStackGate {
         return FileManager.default.fileExists(atPath: path)
     }
 
+    /// True when a git rebase/merge/cherry-pick/revert is in progress in the
+    /// worktree — i.e. a gg `sync`/`land` paused on a conflict. `gg ls
+    /// --json` cannot report this, so the drawer's Continue/Abort state is
+    /// driven by this cheap filesystem probe and self-corrects each refresh.
+    /// Uses `worktreeGitDir`, not `commonGitDir`: these markers are written
+    /// to the private per-worktree git dir, not the dir shared across
+    /// worktrees.
+    static func operationInProgress(repoPath: String) -> Bool {
+        guard let gitDir = worktreeGitDir(repoPath: repoPath) else { return false }
+        let markers = ["rebase-merge", "rebase-apply", "MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD"]
+        return markers.contains {
+            FileManager.default.fileExists(atPath: (gitDir as NSString).appendingPathComponent($0))
+        }
+    }
+
     /// Resolves the shared git directory for `repoPath`: itself when `.git`
     /// is a real directory (primary checkout), or — for a linked worktree,
     /// where `.git` is a file pointing at a private per-worktree dir under
     /// `<commondir>/worktrees/<name>` — the directory named by that private
     /// dir's `commondir` file.
     private static func commonGitDir(repoPath: String) -> String? {
+        guard let gitDir = worktreeGitDir(repoPath: repoPath) else { return nil }
+        let commondirFile = (gitDir as NSString).appendingPathComponent("commondir")
+        guard let commondirContents = try? String(contentsOfFile: commondirFile, encoding: .utf8) else {
+            return gitDir
+        }
+        let relativeCommonDir = commondirContents.trimmingCharacters(in: .whitespacesAndNewlines)
+        return resolvedPath(relativeCommonDir, relativeTo: gitDir)
+    }
+
+    /// Resolves the *private*, per-checkout git directory for `repoPath`:
+    /// itself when `.git` is a real directory (primary checkout — there is
+    /// no separate private dir; the checkout's own `.git` holds all local
+    /// state), or — for a linked worktree — the directory named by the
+    /// `.git` file's `gitdir:` line, *without* following it on to the
+    /// shared `commondir`. This is where git actually writes per-worktree
+    /// state such as a paused `rebase-merge`, unlike `commonGitDir`, which
+    /// resolves through to the dir shared across all worktrees.
+    private static func worktreeGitDir(repoPath: String) -> String? {
         let dotGitPath = (repoPath as NSString).appendingPathComponent(".git")
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: dotGitPath, isDirectory: &isDirectory) else {
@@ -38,13 +71,7 @@ enum GGStackGate {
             return nil
         }
         let rawPath = gitdirLine.dropFirst("gitdir:".count).trimmingCharacters(in: .whitespaces)
-        let privateGitDir = resolvedPath(rawPath, relativeTo: repoPath)
-        let commondirFile = (privateGitDir as NSString).appendingPathComponent("commondir")
-        guard let commondirContents = try? String(contentsOfFile: commondirFile, encoding: .utf8) else {
-            return privateGitDir
-        }
-        let relativeCommonDir = commondirContents.trimmingCharacters(in: .whitespacesAndNewlines)
-        return resolvedPath(relativeCommonDir, relativeTo: privateGitDir)
+        return resolvedPath(rawPath, relativeTo: repoPath)
     }
 
     private static func resolvedPath(_ path: String, relativeTo base: String) -> String {

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -9,6 +9,18 @@ enum GGServiceError: Error, Equatable {
     case unsupportedSchema(Int)
 }
 
+extension GGServiceError {
+    /// User-facing message for the stack drawer's error strip.
+    var userMessage: String {
+        switch self {
+        case .cliMissing: return "gg is not installed."
+        case .commandFailed(let stderr): return stderr.isEmpty ? "gg command failed." : stderr
+        case .malformedOutput(let message): return message
+        case .unsupportedSchema(let version): return "Unsupported gg output (schema \(version))."
+        }
+    }
+}
+
 /// Decoded envelope of `gg ls --json` / `gg log --json`. When the current
 /// branch is a stack, gg emits `{"version":1,"stack":{...}}`; off-stack it
 /// emits an all-stacks shape with no `stack` key, which decodes here as

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -84,6 +84,27 @@ struct GGStackReadinessModel: Equatable {
         )
     }
 
+    @MainActor
+    static func makePausedFallback(action: GGStackActionState) -> GGStackReadinessModel? {
+        guard action.pausedOperation != nil else { return nil }
+        let inFlight = action.inFlightAction
+        let busy = inFlight != nil
+        let syncIsRelevant = inFlight == .sync || action.pausedOperation?.pausedBy == .sync
+        return GGStackReadinessModel(
+            title: "Stack operation",
+            summaryChip: "paused",
+            facts: [],
+            actions: [
+                Action(kind: .continueOp, title: "Continue", isEnabled: !busy,
+                       isInFlight: inFlight == .continueOp, emphasis: .primary),
+                Action(kind: .abortOp, title: "Abort", isEnabled: !busy,
+                       isInFlight: inFlight == .abortOp, emphasis: .normal),
+            ],
+            progressRows: syncIsRelevant ? progressRows(from: action.syncProgress) : [],
+            isPaused: true
+        )
+    }
+
     private static func progressRows(from events: [GGSyncEvent]) -> [String] {
         events.compactMap { event in
             switch event {

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -68,7 +68,7 @@ struct GGStackReadinessModel: Equatable {
                        isInFlight: inFlight == .sync, emphasis: .primary),
                 Action(kind: .land, title: "Land ready", isEnabled: !busy && landReady,
                        isInFlight: inFlight == .land, emphasis: .normal),
-                Action(kind: .clean, title: "Clean", isEnabled: !busy && hasMerged,
+                Action(kind: .clean, title: "Clean all", isEnabled: !busy && hasMerged,
                        isInFlight: inFlight == .clean, emphasis: .normal),
             ]
         }

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -59,10 +59,11 @@ struct GGStackReadinessModel: Equatable {
                        isInFlight: inFlight == .abortOp, emphasis: .normal),
             ]
         } else {
+            let canSync = behind == 0
             let canCheckLandReadiness = stack.entries.contains { $0.prState == .open }
             let hasMerged = merged > 0
             actions = [
-                Action(kind: .sync, title: "Sync stack", isEnabled: !busy,
+                Action(kind: .sync, title: "Sync stack", isEnabled: !busy && canSync,
                        isInFlight: inFlight == .sync, emphasis: .primary),
                 Action(kind: .land, title: "Land ready", isEnabled: !busy && canCheckLandReadiness,
                        isInFlight: inFlight == .land, emphasis: .normal),

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -31,14 +31,15 @@ struct GGStackReadinessModel: Equatable {
     static func make(
         stack: GGStack,
         action: GGStackActionState,
-        liveBehindBase: Int? = nil
+        liveBehindBase: Int? = nil,
+        hasBlockingGitOperation: Bool = false
     ) -> GGStackReadinessModel {
         let merged = stack.entries.filter { $0.prState == .merged }.count
         let unsynced = max(0, stack.totalCommits - stack.syncedCommits)
         let behind = liveBehindBase ?? stack.behindBase ?? 0
         let isPaused = action.pausedOperation != nil
         let inFlight = action.inFlightAction
-        let busy = inFlight != nil
+        let busy = inFlight != nil || hasBlockingGitOperation
 
         let summaryChip: String = {
             if isPaused { return "paused" }

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -73,12 +73,13 @@ struct GGStackReadinessModel: Equatable {
             ]
         }
 
+        let syncIsRelevant = inFlight == .sync || action.pausedOperation?.pausedBy == .sync
         return GGStackReadinessModel(
             title: "Stack · \(stack.name)",
             summaryChip: summaryChip,
             facts: facts,
             actions: actions,
-            progressRows: progressRows(from: action.syncProgress),
+            progressRows: syncIsRelevant ? progressRows(from: action.syncProgress) : [],
             isPaused: isPaused
         )
     }

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Pure presentation model for the stack-mode drawer. Computes the title,
+/// summary chip, fact rows, action buttons (+ enablement), and live sync
+/// progress rows from the stack and its action state. No I/O — unit-tested.
+struct GGStackReadinessModel: Equatable {
+    struct Fact: Equatable, Identifiable {
+        let label: String
+        let value: String
+        var id: String { label }
+    }
+
+    struct Action: Equatable, Identifiable {
+        enum Emphasis: Equatable { case primary, normal }
+        let kind: GGStackActionKind
+        let title: String
+        let isEnabled: Bool
+        let isInFlight: Bool
+        let emphasis: Emphasis
+        var id: String { "\(kind)" }
+    }
+
+    let title: String
+    let summaryChip: String
+    let facts: [Fact]
+    let actions: [Action]
+    let progressRows: [String]
+    let isPaused: Bool
+
+    @MainActor
+    static func make(stack: GGStack, action: GGStackActionState) -> GGStackReadinessModel {
+        let merged = stack.entries.filter { $0.prState == .merged }.count
+        let unsynced = max(0, stack.totalCommits - stack.syncedCommits)
+        let behind = stack.behindBase ?? 0
+        let isPaused = action.pausedOperation != nil
+        let inFlight = action.inFlightAction
+        let busy = inFlight != nil
+
+        let summaryChip: String = {
+            if isPaused { return "paused" }
+            if unsynced > 0 { return "\(unsynced) unsynced" }
+            if behind > 0 { return "↓\(behind) behind" }
+            return "\(merged)/\(stack.totalCommits) merged"
+        }()
+
+        let facts: [Fact] = [
+            Fact(label: "Entries", value: "\(stack.totalCommits)"),
+            Fact(label: "Merged", value: "\(merged)"),
+            Fact(label: "Unsynced", value: "\(unsynced)"),
+            Fact(label: "Behind base", value: "\(behind)"),
+        ]
+
+        let actions: [Action]
+        if isPaused {
+            actions = [
+                Action(kind: .continueOp, title: "Continue", isEnabled: !busy,
+                       isInFlight: inFlight == .continueOp, emphasis: .primary),
+                Action(kind: .abortOp, title: "Abort", isEnabled: !busy,
+                       isInFlight: inFlight == .abortOp, emphasis: .normal),
+            ]
+        } else {
+            let landReady = stack.entries.contains {
+                $0.prState == .open && $0.approved && $0.ciStatus == .success
+            }
+            let hasMerged = merged > 0
+            actions = [
+                Action(kind: .sync, title: "Sync stack", isEnabled: !busy,
+                       isInFlight: inFlight == .sync, emphasis: .primary),
+                Action(kind: .land, title: "Land ready", isEnabled: !busy && landReady,
+                       isInFlight: inFlight == .land, emphasis: .normal),
+                Action(kind: .clean, title: "Clean", isEnabled: !busy && hasMerged,
+                       isInFlight: inFlight == .clean, emphasis: .normal),
+            ]
+        }
+
+        return GGStackReadinessModel(
+            title: "Stack · \(stack.name)",
+            summaryChip: summaryChip,
+            facts: facts,
+            actions: actions,
+            progressRows: progressRows(from: action.syncProgress),
+            isPaused: isPaused
+        )
+    }
+
+    private static func progressRows(from events: [GGSyncEvent]) -> [String] {
+        events.compactMap { event in
+            switch event {
+            case .start(let total): return "Syncing \(total) entr\(total == 1 ? "y" : "ies")…"
+            case .entryStarted(let pos, let title): return "[\(pos)] \(title)"
+            case .pushStarted(let pos): return "[\(pos)] pushing…"
+            case .pushDone(let pos, _): return "[\(pos)] pushed"
+            case .prCreated(let pos, let number, _, _): return "[\(pos)] PR #\(number)"
+            case .summary: return nil
+            case .error(let message): return "Error: \(message)"
+            }
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -59,14 +59,12 @@ struct GGStackReadinessModel: Equatable {
                        isInFlight: inFlight == .abortOp, emphasis: .normal),
             ]
         } else {
-            let landReady = stack.entries.contains {
-                $0.prState == .open && $0.approved && $0.ciStatus == .success
-            }
+            let canCheckLandReadiness = stack.entries.contains { $0.prState == .open }
             let hasMerged = merged > 0
             actions = [
                 Action(kind: .sync, title: "Sync stack", isEnabled: !busy,
                        isInFlight: inFlight == .sync, emphasis: .primary),
-                Action(kind: .land, title: "Land ready", isEnabled: !busy && landReady,
+                Action(kind: .land, title: "Land ready", isEnabled: !busy && canCheckLandReadiness,
                        isInFlight: inFlight == .land, emphasis: .normal),
                 Action(kind: .clean, title: "Clean all", isEnabled: !busy && hasMerged,
                        isInFlight: inFlight == .clean, emphasis: .normal),

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -28,10 +28,14 @@ struct GGStackReadinessModel: Equatable {
     let isPaused: Bool
 
     @MainActor
-    static func make(stack: GGStack, action: GGStackActionState) -> GGStackReadinessModel {
+    static func make(
+        stack: GGStack,
+        action: GGStackActionState,
+        liveBehindBase: Int? = nil
+    ) -> GGStackReadinessModel {
         let merged = stack.entries.filter { $0.prState == .merged }.count
         let unsynced = max(0, stack.totalCommits - stack.syncedCommits)
-        let behind = stack.behindBase ?? 0
+        let behind = liveBehindBase ?? stack.behindBase ?? 0
         let isPaused = action.pausedOperation != nil
         let inFlight = action.inFlightAction
         let busy = inFlight != nil

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -216,13 +216,7 @@ struct ChangesTabView: View {
                     NSWorkspace.shared.open(url)
                 },
                 onGGLandUntil: { entry in rps.requestGGLand(.until(entryId: entry.id, title: entry.title)) },
-                onGGCheckout: { entry in
-                    Task { @MainActor in
-                        try? await rps.ggService.checkout(worktreePath: rps.worktree.path.path, target: entry.id)
-                        await rps.refresh()
-                        _ = rps.reevaluateGGGate()
-                    }
-                }
+                onGGCheckout: { entry in rps.requestGGCheckout(target: entry.id) }
             )
         }
     }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -39,7 +39,7 @@ struct ChangesTabView: View {
             ScrollView {
                 scrollContent
             }
-            if rps.ggStack != nil || rps.ggActionState.pausedOperation != nil {
+            if isGGDrawerActive {
                 GGStackDrawer(rps: rps, appState: appState)
             } else {
                 ReviewLoopDrawer(
@@ -49,6 +49,10 @@ struct ChangesTabView: View {
                 )
             }
         }
+    }
+
+    private var isGGDrawerActive: Bool {
+        Self.shouldShowGGDrawer(stack: rps.ggStack, pausedGGOperation: rps.ggActionState.pausedOperation)
     }
 
     private var scrollContent: some View {
@@ -95,7 +99,10 @@ struct ChangesTabView: View {
                 onDismissBulkReport: { rps.dismissBulkResolveReport() }
             )
 
-            if preparationModel.isVisible {
+            if Self.shouldShowChangesPreparationCard(
+                preparationIsVisible: preparationModel.isVisible,
+                ggDrawerIsActive: isGGDrawerActive
+            ) {
                 ChangesPreparationCard(
                     model: preparationModel,
                     onReviewChanges: openReviewChangesTab,
@@ -228,6 +235,17 @@ struct ChangesTabView: View {
         pausedGGOperation: GGPausedOperation?
     ) -> Bool {
         mergeOperation != nil && pausedGGOperation == nil
+    }
+
+    static func shouldShowGGDrawer(stack: GGStack?, pausedGGOperation: GGPausedOperation?) -> Bool {
+        stack != nil || pausedGGOperation != nil
+    }
+
+    static func shouldShowChangesPreparationCard(
+        preparationIsVisible: Bool,
+        ggDrawerIsActive: Bool
+    ) -> Bool {
+        preparationIsVisible && !ggDrawerIsActive
     }
 
     private var hasDraftTab: Bool {

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -210,7 +210,19 @@ struct ChangesTabView: View {
                 onOpenBaseBranchSelector: { Task { @MainActor in await rps.fetchBranches() } },
                 rps: rps,
                 ggStack: rps.ggStack,
-                stackCodeHostKind: rps.commitRemote?.kind
+                stackCodeHostKind: rps.commitRemote?.kind,
+                onGGOpenPR: { entry in
+                    guard let number = entry.prNumber, let url = rps.commitRemote?.reviewRequestURL(number: number) else { return }
+                    NSWorkspace.shared.open(url)
+                },
+                onGGLandUntil: { entry in rps.requestGGLand(.until(entryId: entry.id, title: entry.title)) },
+                onGGCheckout: { entry in
+                    Task { @MainActor in
+                        try? await rps.ggService.checkout(worktreePath: rps.worktree.path.path, target: entry.id)
+                        await rps.refresh()
+                        _ = rps.reevaluateGGGate()
+                    }
+                }
             )
         }
     }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -39,11 +39,15 @@ struct ChangesTabView: View {
             ScrollView {
                 scrollContent
             }
-            ReviewLoopDrawer(
-                state: rps.reviewLoop,
-                canOpenAgentHandoff: rps.canOpenReviewLoopHandoff(appState: appState),
-                onAction: { action in rps.handleReviewReadinessAction(action, appState: appState) }
-            )
+            if rps.ggStack != nil {
+                GGStackDrawer(rps: rps, appState: appState)
+            } else {
+                ReviewLoopDrawer(
+                    state: rps.reviewLoop,
+                    canOpenAgentHandoff: rps.canOpenReviewLoopHandoff(appState: appState),
+                    onAction: { action in rps.handleReviewReadinessAction(action, appState: appState) }
+                )
+            }
         }
     }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -220,9 +220,11 @@ struct ChangesTabView: View {
                 rps: rps,
                 ggStack: rps.ggStack,
                 stackCodeHostKind: rps.commitRemote?.kind,
-                onGGOpenPR: { entry in
-                    guard let number = entry.prNumber, let url = rps.commitRemote?.reviewRequestURL(number: number) else { return }
-                    NSWorkspace.shared.open(url)
+                onGGOpenPR: rps.commitRemote.map { remote in
+                    { entry in
+                        guard let number = entry.prNumber else { return }
+                        NSWorkspace.shared.open(remote.reviewRequestURL(number: number))
+                    }
                 },
                 onGGLandUntil: { entry in rps.requestGGLand(.until(entryId: entry.id, title: entry.title)) },
                 onGGCheckout: { entry in rps.requestGGCheckout(target: entry.id) }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -62,7 +62,9 @@ struct ChangesTabView: View {
                 .padding(.top, 6)
             }
 
-            if let op = rps.mergeOp.current {
+            if let op = rps.mergeOp.current,
+               Self.shouldShowGenericOperationCard(mergeOperation: op, pausedGGOperation: rps.ggActionState.pausedOperation)
+            {
                 OperationCard(
                     operation: op,
                     hasUnresolvedConflicts: !conflicts.isEmpty,
@@ -219,6 +221,13 @@ struct ChangesTabView: View {
                 onGGCheckout: { entry in rps.requestGGCheckout(target: entry.id) }
             )
         }
+    }
+
+    static func shouldShowGenericOperationCard(
+        mergeOperation: MergeOperation?,
+        pausedGGOperation: GGPausedOperation?
+    ) -> Bool {
+        mergeOperation != nil && pausedGGOperation == nil
     }
 
     private var hasDraftTab: Bool {

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -39,7 +39,7 @@ struct ChangesTabView: View {
             ScrollView {
                 scrollContent
             }
-            if rps.ggStack != nil {
+            if rps.ggStack != nil || rps.ggActionState.pausedOperation != nil {
                 GGStackDrawer(rps: rps, appState: appState)
             } else {
                 ReviewLoopDrawer(

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -17,6 +17,9 @@ struct CommitRow: View {
     var onReview: (() -> Void)? = nil
     var onCherryPick: (() -> Void)? = nil
     var onRevert: (() -> Void)? = nil
+    var onGGOpenPR: (() -> Void)? = nil
+    var onGGLandUntil: (() -> Void)? = nil
+    var onGGCheckout: (() -> Void)? = nil
     /// Stack entry for this commit when the branch is a gg stack.
     var stackEntry: GGStackEntry? = nil
     var codeHostKind: CodeHostKind? = nil
@@ -67,6 +70,18 @@ struct CommitRow: View {
             Button("Copy Commit Message") { copyMessage() }
             if let onOpenRemote {
                 Button("Open Commit on Remote") { onOpenRemote() }
+            }
+            if stackEntry != nil {
+                Divider()
+                if let onGGOpenPR, stackEntry?.prNumber != nil {
+                    Button("Open \(codeHostKind?.reviewRequestLabel ?? "PR")") { onGGOpenPR() }
+                }
+                if let onGGCheckout {
+                    Button("Checkout Entry") { onGGCheckout() }
+                }
+                if let onGGLandUntil {
+                    Button("Land Until Here…") { onGGLandUntil() }
+                }
             }
             if onCherryPick != nil {
                 Divider()

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -101,6 +101,9 @@ struct CommitsSectionView: View {
     let rps: RightPaneState
     let ggStack: GGStack?
     let stackCodeHostKind: CodeHostKind?
+    let onGGOpenPR: (GGStackEntry) -> Void
+    let onGGLandUntil: (GGStackEntry) -> Void
+    let onGGCheckout: (GGStackEntry) -> Void
 
     @Environment(\.theme) private var theme
 
@@ -179,6 +182,9 @@ struct CommitsSectionView: View {
                     onReview: { onReview(commit) },
                     onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
                     onRevert: { rps.runRevert(sha: commit.sha) },
+                    onGGOpenPR: ggStack?.entry(matchingCommitSHA: commit.sha).map { e in { onGGOpenPR(e) } },
+                    onGGLandUntil: ggStack?.entry(matchingCommitSHA: commit.sha).map { e in { onGGLandUntil(e) } },
+                    onGGCheckout: ggStack?.entry(matchingCommitSHA: commit.sha).map { e in { onGGCheckout(e) } },
                     stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),
                     codeHostKind: stackCodeHostKind
                 )

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -166,6 +166,18 @@ struct CommitsSectionView: View {
         (commitsEmpty ? nil : ggStack).map { "Stack · \($0.name)" } ?? "Commits"
     }
 
+    static func ggRowMutationsEnabled(
+        inFlightAction: GGStackActionKind?,
+        mergeOperation: MergeOperation?,
+        pausedGGOperation: GGPausedOperation?
+    ) -> Bool {
+        inFlightAction == nil
+            && !GGStackDrawer.hasBlockingGitOperation(
+                mergeOperation: mergeOperation,
+                pausedGGOperation: pausedGGOperation
+            )
+    }
+
     @ViewBuilder
     private var expandedBody: some View {
         // 1. Worktree commits ("your work") OR today's empty placeholder.
@@ -183,8 +195,8 @@ struct CommitsSectionView: View {
                     onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
                     onRevert: { rps.runRevert(sha: commit.sha) },
                     onGGOpenPR: ggStack?.entry(matchingCommitSHA: commit.sha).flatMap { e in onGGOpenPR.map { openPR in { openPR(e) } } },
-                    onGGLandUntil: ggStack?.entry(matchingCommitSHA: commit.sha).map { e in { onGGLandUntil(e) } },
-                    onGGCheckout: ggStack?.entry(matchingCommitSHA: commit.sha).map { e in { onGGCheckout(e) } },
+                    onGGLandUntil: ggLandUntilAction(for: commit),
+                    onGGCheckout: ggCheckoutAction(for: commit),
                     stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),
                     codeHostKind: stackCodeHostKind
                 )
@@ -245,6 +257,24 @@ struct CommitsSectionView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
+    }
+
+    private var ggRowMutationsEnabled: Bool {
+        Self.ggRowMutationsEnabled(
+            inFlightAction: rps.ggActionState.inFlightAction,
+            mergeOperation: rps.mergeOp.current,
+            pausedGGOperation: rps.ggActionState.pausedOperation
+        )
+    }
+
+    private func ggLandUntilAction(for commit: CommitInfo) -> (() -> Void)? {
+        guard ggRowMutationsEnabled, let entry = ggStack?.entry(matchingCommitSHA: commit.sha) else { return nil }
+        return { onGGLandUntil(entry) }
+    }
+
+    private func ggCheckoutAction(for commit: CommitInfo) -> (() -> Void)? {
+        guard ggRowMutationsEnabled, let entry = ggStack?.entry(matchingCommitSHA: commit.sha) else { return nil }
+        return { onGGCheckout(entry) }
     }
 
     private func openRemoteAction(for commit: CommitInfo, remote: CodeHostRemote?) -> (() -> Void)? {

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -101,7 +101,7 @@ struct CommitsSectionView: View {
     let rps: RightPaneState
     let ggStack: GGStack?
     let stackCodeHostKind: CodeHostKind?
-    let onGGOpenPR: (GGStackEntry) -> Void
+    let onGGOpenPR: ((GGStackEntry) -> Void)?
     let onGGLandUntil: (GGStackEntry) -> Void
     let onGGCheckout: (GGStackEntry) -> Void
 
@@ -182,7 +182,7 @@ struct CommitsSectionView: View {
                     onReview: { onReview(commit) },
                     onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
                     onRevert: { rps.runRevert(sha: commit.sha) },
-                    onGGOpenPR: ggStack?.entry(matchingCommitSHA: commit.sha).map { e in { onGGOpenPR(e) } },
+                    onGGOpenPR: ggStack?.entry(matchingCommitSHA: commit.sha).flatMap { e in onGGOpenPR.map { openPR in { openPR(e) } } },
                     onGGLandUntil: ggStack?.entry(matchingCommitSHA: commit.sha).map { e in { onGGLandUntil(e) } },
                     onGGCheckout: ggStack?.entry(matchingCommitSHA: commit.sha).map { e in { onGGCheckout(e) } },
                     stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -212,6 +212,7 @@ final class RightPaneState {
     var mergeError: String? = nil
     var mergeQueuedMessage: String? = nil
     var pendingGGLand: GGLandRequest? = nil
+    var pendingGGCleanAll: Bool = false
 
     /// True while the workspace-level agent invocation is running.
     /// Surfaced in the Conflicts section header as a spinner; the
@@ -796,24 +797,18 @@ final class RightPaneState {
     // watcher.
     @MainActor
     func refreshGGStack() async {
-        // Reconcile paused-operation state from a git-level probe before
-        // anything else: it's a cheap filesystem read, independent of the
-        // gg query below and of whether the gate/stack-shape checks pass, so
-        // Continue/Abort stay accurate even across app restarts and terminal
-        // interventions (`gg ls --json` can't report a paused rebase, and a
-        // stack that stops being gated must still clear a stale flag).
-        reconcilePausedOperation()
-
         let snapshotGeneration = snapshotInvalidationGeneration
         let gated = ggGateProvider?() ?? false
         guard gated, GGStackGate.isStackShaped(commits: ggStackSourceCommits) else {
             ggStackCommitsKey = nil
+            ggActionState.clearPaused()
             if ggStack != nil { ggStack = nil }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
             }
             return
         }
+        reconcilePausedOperation()
         // `gg ls --json` reaches out to gh/glab for PR state — skip when
         // the branch and commit set are unchanged since the last query. PR-
         // state churn from the outside world refreshes on the next commits
@@ -911,7 +906,7 @@ final class RightPaneState {
         case .sync:
             runGGSync()
         case .clean:
-            runGGSimpleAction(.clean) { try await self.ggService.clean(worktreePath: self.worktree.path.path) }
+            requestGGCleanAll()
         case .continueOp:
             runGGSimpleAction(.continueOp) { try await self.ggService.continueOp(worktreePath: self.worktree.path.path) }
         case .abortOp:
@@ -925,6 +920,13 @@ final class RightPaneState {
 
     func requestGGLand(_ request: GGLandRequest) { pendingGGLand = request }
     func cancelGGLand() { pendingGGLand = nil }
+    func requestGGCleanAll() { pendingGGCleanAll = true }
+    func cancelGGCleanAll() { pendingGGCleanAll = false }
+    func performGGCleanAll() {
+        guard pendingGGCleanAll else { return }
+        pendingGGCleanAll = false
+        runGGSimpleAction(.clean) { try await self.ggService.clean(worktreePath: self.worktree.path.path) }
+    }
 
     /// Checks out a stack entry (`gg mv <target>`), routed through
     /// `runGGSimpleAction` so it gets the same busy-gating, error-surfacing,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -903,7 +903,8 @@ final class RightPaneState {
     /// Dispatches a stack-drawer action kind to its gg mutation. `.land`
     /// stages a confirmation (see `requestGGLand`/`performGGLand`) rather
     /// than mutating directly, and `.checkout` is dispatched directly by the
-    /// entry menu (Task 9) instead of going through this dispatcher.
+    /// entry menu (Task 9) via `requestGGCheckout` instead of going through
+    /// this dispatcher.
     @MainActor
     func onGGStackAction(_ kind: GGStackActionKind, appState: AppState) {
         switch kind {
@@ -924,6 +925,14 @@ final class RightPaneState {
 
     func requestGGLand(_ request: GGLandRequest) { pendingGGLand = request }
     func cancelGGLand() { pendingGGLand = nil }
+
+    /// Checks out a stack entry (`gg mv <target>`), routed through
+    /// `runGGSimpleAction` so it gets the same busy-gating, error-surfacing,
+    /// and post-action refresh as every other gg mutation.
+    @MainActor
+    func requestGGCheckout(target: String) {
+        runGGSimpleAction(.checkout) { try await self.ggService.checkout(worktreePath: self.worktree.path.path, target: target) }
+    }
 
     /// Pure landability check used both to stage the confirmation and to
     /// re-verify against a freshly re-fetched stack before mutating.

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -888,7 +888,11 @@ final class RightPaneState {
     /// operation. Plain git conflicts use the same marker files and must keep
     /// their regular recovery UI.
     private func reconcilePausedOperation() {
-        if GGStackGate.operationInProgress(repoPath: worktree.path.path),
+        let operationInProgress = GGStackGate.operationInProgress(repoPath: worktree.path.path)
+        if !operationInProgress {
+            GGStackGate.clearAlasGGOperationInProgress(repoPath: worktree.path.path)
+        }
+        if operationInProgress,
            ggActionState.inFlightAction != nil
                || ggActionState.pausedOperation != nil
                || GGStackGate.alasGGOperationInProgress(repoPath: worktree.path.path)

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -212,6 +212,7 @@ final class RightPaneState {
     var mergeError: String? = nil
     var mergeQueuedMessage: String? = nil
     var pendingGGLand: GGLandRequest? = nil
+    @ObservationIgnored private var pendingGGLandStackFingerprint: String? = nil
     var pendingGGCleanAll: Bool = false
 
     /// True while the workspace-level agent invocation is running.
@@ -935,8 +936,15 @@ final class RightPaneState {
         }
     }
 
-    func requestGGLand(_ request: GGLandRequest) { pendingGGLand = request }
-    func cancelGGLand() { pendingGGLand = nil }
+    func requestGGLand(_ request: GGLandRequest) {
+        pendingGGLand = request
+        pendingGGLandStackFingerprint = ggStack.map(Self.ggLandStackFingerprint)
+    }
+
+    func cancelGGLand() {
+        pendingGGLand = nil
+        pendingGGLandStackFingerprint = nil
+    }
     func requestGGCleanAll() { pendingGGCleanAll = true }
     func cancelGGCleanAll() { pendingGGCleanAll = false }
     func performGGCleanAll() {
@@ -987,6 +995,19 @@ final class RightPaneState {
         return entries
     }
 
+    static func ggLandStackFingerprint(_ stack: GGStack) -> String {
+        let entryFingerprint = stack.entries
+            .sorted(by: { $0.position < $1.position })
+            .map { "\($0.position):\($0.id):\($0.sha)" }
+            .joined(separator: "|")
+        return "\(stack.name)|\(stack.base)|\(entryFingerprint)"
+    }
+
+    static func ggLandStackMatchesPendingConfirmation(_ stack: GGStack, fingerprint: String?) -> Bool {
+        guard let fingerprint else { return false }
+        return ggLandStackFingerprint(stack) == fingerprint
+    }
+
     static func ggLandConfirmationMessage(for request: GGLandRequest, stack: GGStack?) -> String {
         switch request {
         case .ready:
@@ -1000,7 +1021,9 @@ final class RightPaneState {
     @MainActor
     func performGGLand() {
         guard let request = pendingGGLand else { return }
+        let confirmedStackFingerprint = pendingGGLandStackFingerprint
         pendingGGLand = nil
+        pendingGGLandStackFingerprint = nil
         guard ggActionState.beginAction(.land) else { return }
         GGStackGate.markAlasGGOperationInProgress(repoPath: worktree.path.path)
         ggActionState.clearError()
@@ -1018,7 +1041,10 @@ final class RightPaneState {
                 // Re-verify against a fresh stack before mutating (defends a
                 // stale dialog), mirroring performMerge.
                 let fresh = try await ggService.currentStack(worktreePath: worktree.path.path)
-                guard let fresh, ggLandTargetStillLandable(request, in: fresh) else {
+                guard let fresh,
+                      Self.ggLandStackMatchesPendingConfirmation(fresh, fingerprint: confirmedStackFingerprint),
+                      ggLandTargetStillLandable(request, in: fresh)
+                else {
                     ggActionState.setError("This stack is no longer ready to land.")
                     return
                 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -107,6 +107,10 @@ final class RightPaneState {
     /// gg installed, per-project mode) against app-level state.
     var ggGateProvider: (@MainActor () -> Bool)? = nil
     var ggService = GGService()
+    /// Backing store for the stack drawer's mutation UI (in-flight action,
+    /// sync progress, paused/error state). Not snapshot-derived, so
+    /// `markSnapshotUnknown()` does not reset it.
+    let ggActionState = GGStackActionState()
     /// Commits ahead of base used for the gg stack-shape check and cache
     /// key — deliberately NOT the display `commits` list. `commits` follows
     /// the user's chosen comparison mode, and under "Branch upstream" it is
@@ -791,6 +795,14 @@ final class RightPaneState {
     // watcher.
     @MainActor
     func refreshGGStack() async {
+        // Reconcile paused-operation state from a git-level probe before
+        // anything else: it's a cheap filesystem read, independent of the
+        // gg query below and of whether the gate/stack-shape checks pass, so
+        // Continue/Abort stay accurate even across app restarts and terminal
+        // interventions (`gg ls --json` can't report a paused rebase, and a
+        // stack that stops being gated must still clear a stale flag).
+        reconcilePausedOperation()
+
         let snapshotGeneration = snapshotInvalidationGeneration
         let gated = ggGateProvider?() ?? false
         guard gated, GGStackGate.isStackShaped(commits: ggStackSourceCommits) else {
@@ -869,6 +881,88 @@ final class RightPaneState {
         }
         ggStackRefreshTask = task
         return task
+    }
+
+    /// Pure filesystem probe → `ggActionState.pausedOperation` sync. Split
+    /// out of `refreshGGStack()` so it runs unconditionally on every entry
+    /// (including the gate-closed / not-stack-shaped early return), not just
+    /// on a successful `gg ls --json` fetch — the paused marker is written
+    /// by git itself, not by gg, so it can appear or disappear independent
+    /// of gating and of whether the gg query even runs.
+    private func reconcilePausedOperation() {
+        if GGStackGate.operationInProgress(repoPath: worktree.path.path) {
+            if ggActionState.pausedOperation == nil {
+                ggActionState.setPaused(GGPausedOperation(pausedBy: ggActionState.inFlightAction ?? .sync))
+            }
+        } else {
+            ggActionState.clearPaused()
+        }
+    }
+
+    /// Dispatches a stack-drawer action kind to its gg mutation. `.land` is
+    /// routed straight to the confirmation flow (Task 7) and `.checkout` is
+    /// dispatched directly by the entry menu (Task 9) — neither goes through
+    /// this dispatcher.
+    @MainActor
+    func onGGStackAction(_ kind: GGStackActionKind, appState: AppState) {
+        switch kind {
+        case .sync:
+            runGGSync()
+        case .clean:
+            runGGSimpleAction(.clean) { try await self.ggService.clean(worktreePath: self.worktree.path.path) }
+        case .continueOp:
+            runGGSimpleAction(.continueOp) { try await self.ggService.continueOp(worktreePath: self.worktree.path.path) }
+        case .abortOp:
+            runGGSimpleAction(.abortOp) { try await self.ggService.abortOp(worktreePath: self.worktree.path.path) }
+        case .land, .checkout:
+            break
+        }
+    }
+
+    private func runGGSync() {
+        guard ggActionState.beginAction(.sync) else { return }
+        ggActionState.clearError()
+        ggActionState.clearSyncProgress()
+        Task { @MainActor in
+            defer {
+                ggActionState.endAction(.sync)
+                Task { @MainActor in
+                    await self.refresh()
+                    _ = self.reevaluateGGGate()
+                }
+            }
+            do {
+                for try await event in ggService.sync(worktreePath: worktree.path.path) {
+                    ggActionState.appendSyncEvent(event)
+                    if case .error(let message) = event { ggActionState.setError(message) }
+                }
+            } catch let error as GGServiceError {
+                ggActionState.setError(error.userMessage)
+            } catch {
+                ggActionState.setError(error.localizedDescription)
+            }
+        }
+    }
+
+    private func runGGSimpleAction(_ kind: GGStackActionKind, _ body: @escaping () async throws -> Void) {
+        guard ggActionState.beginAction(kind) else { return }
+        ggActionState.clearError()
+        Task { @MainActor in
+            defer {
+                ggActionState.endAction(kind)
+                Task { @MainActor in
+                    await self.refresh()
+                    _ = self.reevaluateGGGate()
+                }
+            }
+            do {
+                try await body()
+            } catch let error as GGServiceError {
+                ggActionState.setError(error.userMessage)
+            } catch {
+                ggActionState.setError(error.localizedDescription)
+            }
+        }
     }
 
     func markSnapshotUnknown() {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -211,6 +211,7 @@ final class RightPaneState {
     var pendingMerge: ReviewLoopSnapshot? = nil
     var mergeError: String? = nil
     var mergeQueuedMessage: String? = nil
+    var pendingGGLand: GGLandRequest? = nil
 
     /// True while the workspace-level agent invocation is running.
     /// Surfaced in the Conflicts section header as a spinner; the
@@ -899,10 +900,10 @@ final class RightPaneState {
         }
     }
 
-    /// Dispatches a stack-drawer action kind to its gg mutation. `.land` is
-    /// routed straight to the confirmation flow (Task 7) and `.checkout` is
-    /// dispatched directly by the entry menu (Task 9) — neither goes through
-    /// this dispatcher.
+    /// Dispatches a stack-drawer action kind to its gg mutation. `.land`
+    /// stages a confirmation (see `requestGGLand`/`performGGLand`) rather
+    /// than mutating directly, and `.checkout` is dispatched directly by the
+    /// entry menu (Task 9) instead of going through this dispatcher.
     @MainActor
     func onGGStackAction(_ kind: GGStackActionKind, appState: AppState) {
         switch kind {
@@ -914,8 +915,66 @@ final class RightPaneState {
             runGGSimpleAction(.continueOp) { try await self.ggService.continueOp(worktreePath: self.worktree.path.path) }
         case .abortOp:
             runGGSimpleAction(.abortOp) { try await self.ggService.abortOp(worktreePath: self.worktree.path.path) }
-        case .land, .checkout:
+        case .checkout:
             break
+        case .land:
+            requestGGLand(.ready)
+        }
+    }
+
+    func requestGGLand(_ request: GGLandRequest) { pendingGGLand = request }
+    func cancelGGLand() { pendingGGLand = nil }
+
+    /// Pure landability check used both to stage the confirmation and to
+    /// re-verify against a freshly re-fetched stack before mutating.
+    func ggLandTargetStillLandable(_ request: GGLandRequest, in stack: GGStack) -> Bool {
+        switch request {
+        case .ready:
+            return stack.entries.contains { $0.prState == .open && $0.approved && $0.ciStatus == .success }
+        case .until(let entryId, _):
+            return stack.entries.contains { $0.id == entryId }
+        }
+    }
+
+    static func ggLandConfirmationMessage(for request: GGLandRequest, stack: GGStack?) -> String {
+        switch request {
+        case .ready:
+            let n = stack?.entries.filter { $0.prState == .open && $0.approved && $0.ciStatus == .success }.count ?? 0
+            return "Merge \(n) approved, passing PR\(n == 1 ? "" : "s") from the bottom of the stack."
+        case .until(_, let title):
+            return "Land the stack up to and including \u{201C}\(title)\u{201D}."
+        }
+    }
+
+    @MainActor
+    func performGGLand() {
+        guard let request = pendingGGLand else { return }
+        pendingGGLand = nil
+        guard ggActionState.beginAction(.land) else { return }
+        ggActionState.clearError()
+        Task { @MainActor in
+            defer {
+                ggActionState.endAction(.land)
+                Task { @MainActor in
+                    await self.refresh()
+                    _ = self.reevaluateGGGate()
+                }
+            }
+            do {
+                // Re-verify against a fresh stack before mutating (defends a
+                // stale dialog), mirroring performMerge.
+                let fresh = try await ggService.currentStack(worktreePath: worktree.path.path)
+                guard let fresh, ggLandTargetStillLandable(request, in: fresh) else {
+                    ggActionState.setError("This stack is no longer ready to land.")
+                    return
+                }
+                let until: String? = { if case .until(let id, _) = request { return id } else { return nil } }()
+                _ = try await ggService.land(worktreePath: worktree.path.path, until: until)
+            } catch let error as GGServiceError {
+                ggActionState.setError(error.userMessage)
+            } catch {
+                ggActionState.setError(error.localizedDescription)
+            }
         }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -801,7 +801,11 @@ final class RightPaneState {
         let gated = ggGateProvider?() ?? false
         guard gated, GGStackGate.isStackShaped(commits: ggStackSourceCommits) else {
             ggStackCommitsKey = nil
-            ggActionState.clearPaused()
+            if gated, shouldPreservePausedOperationOutsideStackShape() {
+                reconcilePausedOperation()
+            } else {
+                ggActionState.clearPaused()
+            }
             if ggStack != nil { ggStack = nil }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
@@ -879,12 +883,9 @@ final class RightPaneState {
         return task
     }
 
-    /// Pure filesystem probe → `ggActionState.pausedOperation` sync. Split
-    /// out of `refreshGGStack()` so it runs unconditionally on every entry
-    /// (including the gate-closed / not-stack-shaped early return), not just
-    /// on a successful `gg ls --json` fetch — the paused marker is written
-    /// by git itself, not by gg, so it can appear or disappear independent
-    /// of gating and of whether the gg query even runs.
+    /// Pure filesystem probe → `ggActionState.pausedOperation` sync. Runs
+    /// after the GG gates pass, or while preserving an already-known/active
+    /// GG operation whose stack shape temporarily disappeared mid-conflict.
     private func reconcilePausedOperation() {
         if GGStackGate.operationInProgress(repoPath: worktree.path.path) {
             if ggActionState.pausedOperation == nil {
@@ -893,6 +894,14 @@ final class RightPaneState {
         } else {
             ggActionState.clearPaused()
         }
+    }
+
+    private func shouldPreservePausedOperationOutsideStackShape() -> Bool {
+        guard GGStackGate.operationInProgress(repoPath: worktree.path.path) else { return false }
+        return ggActionState.inFlightAction != nil
+            || ggActionState.pausedOperation != nil
+            || ggStack != nil
+            || GGStackGate.repoHasGGConfig(repoPath: worktree.path.path)
     }
 
     /// Dispatches a stack-drawer action kind to its gg mutation. `.land`

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -960,7 +960,7 @@ final class RightPaneState {
         case .ready:
             return stack.entries.contains(where: Self.ggEntryIsReadyToLand)
         case .until(let entryId, _):
-            return stack.entries.contains { $0.id == entryId }
+            return stack.entries.contains { $0.id == entryId && Self.ggEntryIsReadyToLand($0) }
         }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -889,7 +889,9 @@ final class RightPaneState {
     /// their regular recovery UI.
     private func reconcilePausedOperation() {
         if GGStackGate.operationInProgress(repoPath: worktree.path.path),
-           ggActionState.inFlightAction != nil || ggActionState.pausedOperation != nil
+           ggActionState.inFlightAction != nil
+               || ggActionState.pausedOperation != nil
+               || GGStackGate.alasGGOperationInProgress(repoPath: worktree.path.path)
         {
             if ggActionState.pausedOperation == nil {
                 ggActionState.setPaused(GGPausedOperation(pausedBy: ggActionState.inFlightAction ?? .sync))
@@ -903,6 +905,7 @@ final class RightPaneState {
         guard GGStackGate.operationInProgress(repoPath: worktree.path.path) else { return false }
         return ggActionState.inFlightAction != nil
             || ggActionState.pausedOperation != nil
+            || GGStackGate.alasGGOperationInProgress(repoPath: worktree.path.path)
     }
 
     /// Dispatches a stack-drawer action kind to its gg mutation. `.land`
@@ -972,10 +975,12 @@ final class RightPaneState {
         guard let request = pendingGGLand else { return }
         pendingGGLand = nil
         guard ggActionState.beginAction(.land) else { return }
+        GGStackGate.markAlasGGOperationInProgress(repoPath: worktree.path.path)
         ggActionState.clearError()
         Task { @MainActor in
             defer {
                 preservePausedGGOperationIfNeeded()
+                clearAlasGGOperationMarkerIfComplete()
                 ggActionState.endAction(.land)
                 Task { @MainActor in
                     await self.refresh()
@@ -1002,11 +1007,13 @@ final class RightPaneState {
 
     private func runGGSync() {
         guard ggActionState.beginAction(.sync) else { return }
+        GGStackGate.markAlasGGOperationInProgress(repoPath: worktree.path.path)
         ggActionState.clearError()
         ggActionState.clearSyncProgress()
         Task { @MainActor in
             defer {
                 preservePausedGGOperationIfNeeded()
+                clearAlasGGOperationMarkerIfComplete()
                 ggActionState.endAction(.sync)
                 Task { @MainActor in
                     await self.refresh()
@@ -1028,10 +1035,12 @@ final class RightPaneState {
 
     private func runGGSimpleAction(_ kind: GGStackActionKind, _ body: @escaping () async throws -> Void) {
         guard ggActionState.beginAction(kind) else { return }
+        GGStackGate.markAlasGGOperationInProgress(repoPath: worktree.path.path)
         ggActionState.clearError()
         Task { @MainActor in
             defer {
                 preservePausedGGOperationIfNeeded()
+                clearAlasGGOperationMarkerIfComplete()
                 ggActionState.endAction(kind)
                 Task { @MainActor in
                     await self.refresh()
@@ -1054,6 +1063,12 @@ final class RightPaneState {
               ggActionState.pausedOperation == nil
         else { return }
         ggActionState.setPaused(GGPausedOperation(pausedBy: action))
+    }
+
+    private func clearAlasGGOperationMarkerIfComplete() {
+        if !GGStackGate.operationInProgress(repoPath: worktree.path.path) {
+            GGStackGate.clearAlasGGOperationInProgress(repoPath: worktree.path.path)
+        }
     }
 
     func markSnapshotUnknown() {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -958,7 +958,7 @@ final class RightPaneState {
     func ggLandTargetStillLandable(_ request: GGLandRequest, in stack: GGStack) -> Bool {
         switch request {
         case .ready:
-            return stack.entries.contains(where: Self.ggEntryIsReadyToLand)
+            return !Self.ggLandReadyPrefix(in: stack).isEmpty
         case .until(let entryId, _):
             guard let target = stack.entries.first(where: { $0.id == entryId }),
                   Self.ggEntryIsReadyToLand(target)
@@ -977,10 +977,20 @@ final class RightPaneState {
         entry.prState == .merged || ggEntryIsReadyToLand(entry)
     }
 
+    static func ggLandReadyPrefix(in stack: GGStack) -> [GGStackEntry] {
+        var entries: [GGStackEntry] = []
+        for entry in stack.entries.sorted(by: { $0.position < $1.position }) {
+            if entry.prState == .merged { continue }
+            guard ggEntryIsReadyToLand(entry) else { break }
+            entries.append(entry)
+        }
+        return entries
+    }
+
     static func ggLandConfirmationMessage(for request: GGLandRequest, stack: GGStack?) -> String {
         switch request {
         case .ready:
-            let n = stack?.entries.filter(Self.ggEntryIsReadyToLand).count ?? 0
+            let n = stack.map { Self.ggLandReadyPrefix(in: $0).count } ?? 0
             return "Merge \(n) approved, passing PR\(n == 1 ? "" : "s") from the bottom of the stack."
         case .until(_, let title):
             return "Land the stack up to and including \u{201C}\(title)\u{201D}."

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1016,9 +1016,9 @@ final class RightPaneState {
                     if case .error(let message) = event { ggActionState.setError(message) }
                 }
             } catch let error as GGServiceError {
-                ggActionState.setError(error.userMessage)
+                if ggActionState.lastError == nil { ggActionState.setError(error.userMessage) }
             } catch {
-                ggActionState.setError(error.localizedDescription)
+                if ggActionState.lastError == nil { ggActionState.setError(error.localizedDescription) }
             }
         }
     }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -884,10 +884,13 @@ final class RightPaneState {
     }
 
     /// Pure filesystem probe → `ggActionState.pausedOperation` sync. Runs
-    /// after the GG gates pass, or while preserving an already-known/active
-    /// GG operation whose stack shape temporarily disappeared mid-conflict.
+    /// after the GG gates pass, but only for an already-known/active GG
+    /// operation. Plain git conflicts use the same marker files and must keep
+    /// their regular recovery UI.
     private func reconcilePausedOperation() {
-        if GGStackGate.operationInProgress(repoPath: worktree.path.path) {
+        if GGStackGate.operationInProgress(repoPath: worktree.path.path),
+           ggActionState.inFlightAction != nil || ggActionState.pausedOperation != nil
+        {
             if ggActionState.pausedOperation == nil {
                 ggActionState.setPaused(GGPausedOperation(pausedBy: ggActionState.inFlightAction ?? .sync))
             }
@@ -900,8 +903,6 @@ final class RightPaneState {
         guard GGStackGate.operationInProgress(repoPath: worktree.path.path) else { return false }
         return ggActionState.inFlightAction != nil
             || ggActionState.pausedOperation != nil
-            || ggStack != nil
-            || GGStackGate.repoHasGGConfig(repoPath: worktree.path.path)
     }
 
     /// Dispatches a stack-drawer action kind to its gg mutation. `.land`

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -958,16 +958,20 @@ final class RightPaneState {
     func ggLandTargetStillLandable(_ request: GGLandRequest, in stack: GGStack) -> Bool {
         switch request {
         case .ready:
-            return stack.entries.contains { $0.prState == .open && $0.approved && $0.ciStatus == .success }
+            return stack.entries.contains(where: Self.ggEntryIsReadyToLand)
         case .until(let entryId, _):
             return stack.entries.contains { $0.id == entryId }
         }
     }
 
+    static func ggEntryIsReadyToLand(_ entry: GGStackEntry) -> Bool {
+        entry.prState == .open && entry.approved && (entry.ciStatus == nil || entry.ciStatus == .success)
+    }
+
     static func ggLandConfirmationMessage(for request: GGLandRequest, stack: GGStack?) -> String {
         switch request {
         case .ready:
-            let n = stack?.entries.filter { $0.prState == .open && $0.approved && $0.ciStatus == .success }.count ?? 0
+            let n = stack?.entries.filter(Self.ggEntryIsReadyToLand).count ?? 0
             return "Merge \(n) approved, passing PR\(n == 1 ? "" : "s") from the bottom of the stack."
         case .until(_, let title):
             return "Land the stack up to and including \u{201C}\(title)\u{201D}."

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -975,6 +975,7 @@ final class RightPaneState {
         ggActionState.clearError()
         Task { @MainActor in
             defer {
+                preservePausedGGOperationIfNeeded()
                 ggActionState.endAction(.land)
                 Task { @MainActor in
                     await self.refresh()
@@ -1005,6 +1006,7 @@ final class RightPaneState {
         ggActionState.clearSyncProgress()
         Task { @MainActor in
             defer {
+                preservePausedGGOperationIfNeeded()
                 ggActionState.endAction(.sync)
                 Task { @MainActor in
                     await self.refresh()
@@ -1029,6 +1031,7 @@ final class RightPaneState {
         ggActionState.clearError()
         Task { @MainActor in
             defer {
+                preservePausedGGOperationIfNeeded()
                 ggActionState.endAction(kind)
                 Task { @MainActor in
                     await self.refresh()
@@ -1043,6 +1046,14 @@ final class RightPaneState {
                 ggActionState.setError(error.localizedDescription)
             }
         }
+    }
+
+    private func preservePausedGGOperationIfNeeded() {
+        guard GGStackGate.operationInProgress(repoPath: worktree.path.path),
+              let action = ggActionState.inFlightAction,
+              ggActionState.pausedOperation == nil
+        else { return }
+        ggActionState.setPaused(GGPausedOperation(pausedBy: action))
     }
 
     func markSnapshotUnknown() {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1008,6 +1008,15 @@ final class RightPaneState {
         return ggLandStackFingerprint(stack) == fingerprint
     }
 
+    static func ggLandUntilTarget(for request: GGLandRequest, in stack: GGStack) -> String? {
+        switch request {
+        case .ready:
+            return ggLandReadyPrefix(in: stack).last?.id
+        case .until(let entryId, _):
+            return entryId
+        }
+    }
+
     static func ggLandConfirmationMessage(for request: GGLandRequest, stack: GGStack?) -> String {
         switch request {
         case .ready:
@@ -1048,7 +1057,10 @@ final class RightPaneState {
                     ggActionState.setError("This stack is no longer ready to land.")
                     return
                 }
-                let until: String? = { if case .until(let id, _) = request { return id } else { return nil } }()
+                guard let until = Self.ggLandUntilTarget(for: request, in: fresh) else {
+                    ggActionState.setError("This stack is no longer ready to land.")
+                    return
+                }
                 _ = try await ggService.land(worktreePath: worktree.path.path, until: until)
             } catch let error as GGServiceError {
                 ggActionState.setError(error.userMessage)

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -960,12 +960,21 @@ final class RightPaneState {
         case .ready:
             return stack.entries.contains(where: Self.ggEntryIsReadyToLand)
         case .until(let entryId, _):
-            return stack.entries.contains { $0.id == entryId && Self.ggEntryIsReadyToLand($0) }
+            guard let target = stack.entries.first(where: { $0.id == entryId }),
+                  Self.ggEntryIsReadyToLand(target)
+            else { return false }
+            return stack.entries
+                .filter { $0.position < target.position }
+                .allSatisfy(Self.ggEntryDoesNotBlockLand)
         }
     }
 
     static func ggEntryIsReadyToLand(_ entry: GGStackEntry) -> Bool {
         entry.prState == .open && entry.approved && (entry.ciStatus == nil || entry.ciStatus == .success)
+    }
+
+    static func ggEntryDoesNotBlockLand(_ entry: GGStackEntry) -> Bool {
+        entry.prState == .merged || ggEntryIsReadyToLand(entry)
     }
 
     static func ggLandConfirmationMessage(for request: GGLandRequest, stack: GGStack?) -> String {

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -324,4 +324,11 @@ final class RightPaneStore {
     func stateWithPendingGGLand() -> RightPaneState? {
         states.values.first { $0.pendingGGLand != nil }
     }
+
+    /// The first cached state with a pending gg clean-all confirmation.
+    /// Mirrors the other cross-worktree confirmations so changing selection
+    /// while the dialog is open resolves the state that requested it.
+    func stateWithPendingGGCleanAll() -> RightPaneState? {
+        states.values.first { $0.pendingGGCleanAll }
+    }
 }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -315,4 +315,13 @@ final class RightPaneStore {
     func stateWithPendingMerge() -> RightPaneState? {
         states.values.first { $0.pendingMerge != nil }
     }
+
+    /// The first cached state with a pending gg-land confirmation, if any.
+    /// Mirrors `stateWithPendingMerge` for the same reason: the confirmation
+    /// dialog (see RootView) must resolve its owning state through this
+    /// rather than the current selection, so switching worktrees while the
+    /// dialog is open can't cancel the wrong state and strand `pendingGGLand`.
+    func stateWithPendingGGLand() -> RightPaneState? {
+        states.values.first { $0.pendingGGLand != nil }
+    }
 }

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct ChangesTabViewTests {
+    @Test func genericOperationCardHiddenDuringPausedGGOperation() {
+        let operation = MergeOperation.merge(sourceBranch: "main")
+
+        #expect(ChangesTabView.shouldShowGenericOperationCard(
+            mergeOperation: operation,
+            pausedGGOperation: nil
+        ))
+        #expect(!ChangesTabView.shouldShowGenericOperationCard(
+            mergeOperation: operation,
+            pausedGGOperation: GGPausedOperation(pausedBy: .sync)
+        ))
+        #expect(!ChangesTabView.shouldShowGenericOperationCard(
+            mergeOperation: nil,
+            pausedGGOperation: nil
+        ))
+    }
+}

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -19,4 +19,39 @@ struct ChangesTabViewTests {
             pausedGGOperation: nil
         ))
     }
+
+    @Test func changesPreparationCardHiddenWhenGGDrawerIsActive() {
+        #expect(ChangesTabView.shouldShowChangesPreparationCard(
+            preparationIsVisible: true,
+            ggDrawerIsActive: false
+        ))
+        #expect(!ChangesTabView.shouldShowChangesPreparationCard(
+            preparationIsVisible: true,
+            ggDrawerIsActive: true
+        ))
+        #expect(!ChangesTabView.shouldShowChangesPreparationCard(
+            preparationIsVisible: false,
+            ggDrawerIsActive: false
+        ))
+    }
+
+    @Test func ggDrawerActiveForStackOrPausedOperation() {
+        #expect(!ChangesTabView.shouldShowGGDrawer(stack: nil, pausedGGOperation: nil))
+        #expect(ChangesTabView.shouldShowGGDrawer(
+            stack: GGStack(
+                name: "feat",
+                base: "main",
+                totalCommits: 0,
+                syncedCommits: 0,
+                currentPosition: nil,
+                behindBase: nil,
+                entries: []
+            ),
+            pausedGGOperation: nil
+        ))
+        #expect(ChangesTabView.shouldShowGGDrawer(
+            stack: nil,
+            pausedGGOperation: GGPausedOperation(pausedBy: .sync)
+        ))
+    }
 }

--- a/AlasTests/CommitsSectionTitleTests.swift
+++ b/AlasTests/CommitsSectionTitleTests.swift
@@ -28,4 +28,27 @@ struct CommitsSectionTitleTests {
     @Test func plainCommitsWhenStackPresentButCommitsEmpty() {
         #expect(CommitsSectionView.sectionTitle(ggStack: stack(), commitsEmpty: true) == "Commits")
     }
+
+    @Test func ggRowMutationsFollowDrawerBusyGate() {
+        #expect(CommitsSectionView.ggRowMutationsEnabled(
+            inFlightAction: nil,
+            mergeOperation: nil,
+            pausedGGOperation: nil
+        ))
+        #expect(!CommitsSectionView.ggRowMutationsEnabled(
+            inFlightAction: .sync,
+            mergeOperation: nil,
+            pausedGGOperation: nil
+        ))
+        #expect(!CommitsSectionView.ggRowMutationsEnabled(
+            inFlightAction: nil,
+            mergeOperation: .merge(sourceBranch: "main"),
+            pausedGGOperation: nil
+        ))
+        #expect(CommitsSectionView.ggRowMutationsEnabled(
+            inFlightAction: nil,
+            mergeOperation: .merge(sourceBranch: "main"),
+            pausedGGOperation: GGPausedOperation(pausedBy: .sync)
+        ))
+    }
 }

--- a/AlasTests/Integrations/CodeHostModelsTests.swift
+++ b/AlasTests/Integrations/CodeHostModelsTests.swift
@@ -57,6 +57,15 @@ struct CodeHostModelsTests {
         #expect(ReviewCheckBucket.pass.severity > ReviewCheckBucket.skipping.severity)
     }
 
+    @Test func reviewRequestURLPerKind() {
+        let gh = CodeHostRemote(kind: .github, host: "github.com", owner: "o", repository: "r",
+                                remoteName: "origin", webURL: URL(string: "https://github.com/o/r")!)
+        #expect(gh.reviewRequestURL(number: 42).absoluteString == "https://github.com/o/r/pull/42")
+        let gl = CodeHostRemote(kind: .gitlab, host: "gitlab.com", owner: "o", repository: "r",
+                                remoteName: "origin", webURL: URL(string: "https://gitlab.com/o/r")!)
+        #expect(gl.reviewRequestURL(number: 42).absoluteString == "https://gitlab.com/o/r/-/merge_requests/42")
+    }
+
     @Test func reviewRequestDisplayIdentityUsesProviderAndNumber() {
         let request = makeReviewRequest(reviewDecision: .reviewRequired)
 

--- a/AlasTests/Integrations/GGActionEventsTests.swift
+++ b/AlasTests/Integrations/GGActionEventsTests.swift
@@ -22,6 +22,8 @@ struct GGActionEventsTests {
             == .error(message: "push failed"))
         #expect(GGSyncEvent.parse(line: #"{"event":"summary","entries":[{"position":2,"error":"PR failed"}]}"#)
             == .error(message: "[2] PR failed"))
+        #expect(GGSyncEvent.parse(line: #"{"version":1,"sync":{"entries":[{"position":3,"error":"push failed"}]}}"#)
+            == .error(message: "[3] push failed"))
     }
 
     @Test func skipsBlankUnknownAndMalformedLines() {

--- a/AlasTests/Integrations/GGActionEventsTests.swift
+++ b/AlasTests/Integrations/GGActionEventsTests.swift
@@ -55,6 +55,12 @@ struct GGActionEventsTests {
         }
     }
 
+    @Test func extractsActionErrorMessagesFromNestedJSON() {
+        #expect(GGActionErrorMessage.parse(fromJSON: Data(#"{"error":{"message":"top failure"}}"#.utf8)) == "top failure")
+        #expect(GGActionErrorMessage.parse(fromJSON: Data(#"{"land":{"error":{"message":"land blocked"}}}"#.utf8)) == "land blocked")
+        #expect(GGActionErrorMessage.parse(fromJSON: Data(#"{"sync":{"entries":[{"position":4,"error":{"message":"push blocked"}}]}}"#.utf8)) == "[4] push blocked")
+    }
+
     @Test func landDecodeThrowsMalformedOnGarbage() {
         #expect(throws: GGServiceError.self) {
             _ = try GGLandResult.decode(fromJSON: Data("nonsense".utf8))

--- a/AlasTests/Integrations/GGActionEventsTests.swift
+++ b/AlasTests/Integrations/GGActionEventsTests.swift
@@ -18,6 +18,10 @@ struct GGActionEventsTests {
             == .summary)
         #expect(GGSyncEvent.parse(line: #"{"event":"error","message":"boom"}"#)
             == .error(message: "boom"))
+        #expect(GGSyncEvent.parse(line: #"{"event":"push_error","position":1,"message":"push failed"}"#)
+            == .error(message: "push failed"))
+        #expect(GGSyncEvent.parse(line: #"{"event":"summary","entries":[{"position":2,"error":"PR failed"}]}"#)
+            == .error(message: "[2] PR failed"))
     }
 
     @Test func skipsBlankUnknownAndMalformedLines() {
@@ -40,6 +44,13 @@ struct GGActionEventsTests {
     @Test func decodesLandResultWithEmptyLanded() throws {
         let json = #"{"version":1,"land":{"stack":"s","base":"main","landed":[]}}"#
         #expect(try GGLandResult.decode(fromJSON: Data(json.utf8)).landed.isEmpty)
+    }
+
+    @Test func landDecodeThrowsWhenJSONContainsError() {
+        let json = #"{"version":1,"land":{"stack":"s","base":"main","landed":[],"error":"not approved"}}"#
+        #expect(throws: GGServiceError.commandFailed(stderr: "not approved")) {
+            _ = try GGLandResult.decode(fromJSON: Data(json.utf8))
+        }
     }
 
     @Test func landDecodeThrowsMalformedOnGarbage() {

--- a/AlasTests/Integrations/GGActionEventsTests.swift
+++ b/AlasTests/Integrations/GGActionEventsTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGActionEventsTests {
+    @Test func parsesEachSyncEventVariant() {
+        #expect(GGSyncEvent.parse(line: #"{"version":1,"command":"sync","event":"start","total_entries":2}"#)
+            == .start(totalEntries: 2))
+        #expect(GGSyncEvent.parse(line: #"{"command":"sync","event":"entry_started","position":1,"title":"Add feature"}"#)
+            == .entryStarted(position: 1, title: "Add feature"))
+        #expect(GGSyncEvent.parse(line: #"{"event":"push_started","position":1}"#)
+            == .pushStarted(position: 1))
+        #expect(GGSyncEvent.parse(line: #"{"event":"push_done","position":1,"forced":false}"#)
+            == .pushDone(position: 1, forced: false))
+        #expect(GGSyncEvent.parse(line: #"{"event":"pr_created","position":1,"pr_number":42,"pr_url":"https://x/pull/42","draft":false}"#)
+            == .prCreated(position: 1, prNumber: 42, prURL: "https://x/pull/42", draft: false))
+        #expect(GGSyncEvent.parse(line: #"{"event":"summary","stack":"s","base":"main","entries":[]}"#)
+            == .summary)
+        #expect(GGSyncEvent.parse(line: #"{"event":"error","message":"boom"}"#)
+            == .error(message: "boom"))
+    }
+
+    @Test func skipsBlankUnknownAndMalformedLines() {
+        #expect(GGSyncEvent.parse(line: "") == nil)
+        #expect(GGSyncEvent.parse(line: "   ") == nil)
+        #expect(GGSyncEvent.parse(line: #"{"event":"future_thing","position":9}"#) == nil)
+        #expect(GGSyncEvent.parse(line: "not json at all") == nil)
+        #expect(GGSyncEvent.parse(line: #"{"no_event_field":true}"#) == nil)
+    }
+
+    @Test func decodesLandResult() throws {
+        let json = #"{"version":1,"land":{"stack":"s","base":"main","landed":[{"position":1,"pr_number":42},{"position":2,"pr_number":43}]}}"#
+        let result = try GGLandResult.decode(fromJSON: Data(json.utf8))
+        #expect(result.landed == [
+            GGLandedEntry(position: 1, prNumber: 42),
+            GGLandedEntry(position: 2, prNumber: 43),
+        ])
+    }
+
+    @Test func decodesLandResultWithEmptyLanded() throws {
+        let json = #"{"version":1,"land":{"stack":"s","base":"main","landed":[]}}"#
+        #expect(try GGLandResult.decode(fromJSON: Data(json.utf8)).landed.isEmpty)
+    }
+
+    @Test func landDecodeThrowsMalformedOnGarbage() {
+        #expect(throws: GGServiceError.self) {
+            _ = try GGLandResult.decode(fromJSON: Data("nonsense".utf8))
+        }
+    }
+}

--- a/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
+++ b/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import Alas
+
+/// Exercises `ProcessGGCommandRunner`'s pipe-lifecycle handling (readability
+/// handlers on both stdout/stderr, closing the parent's write ends after
+/// `process.run()`) against a trivial `/bin/sh` subprocess. This does not
+/// depend on the `gg` binary being installed.
+///
+/// Every test wraps its `for try await` consumption in a timeout so a
+/// regression back to the missing-write-end-close deadlock (or a blocking
+/// `readDataToEndOfFile` on stderr) fails the test visibly instead of
+/// hanging the suite forever.
+struct GGCommandRunningStreamingTests {
+    private func collectWithTimeout(
+        _ stream: AsyncThrowingStream<String, Error>,
+        seconds: UInt64 = 5
+    ) async throws -> [String] {
+        try await withThrowingTaskGroup(of: [String].self) { group in
+            group.addTask {
+                var lines: [String] = []
+                for try await line in stream { lines.append(line) }
+                return lines
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+                throw TimeoutError()
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private struct TimeoutError: Error {}
+
+    @Test func streamsStdoutLinesInOrderAndFinishesOnCleanExit() async throws {
+        let script = "printf 'one\\ntwo\\nthree\\n'"
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", script],
+            cwd: nil,
+            env: nil
+        )
+        let lines = try await collectWithTimeout(stream)
+        #expect(lines == ["one", "two", "three"])
+    }
+
+    @Test func nonZeroExitSurfacesCommandFailedWithAccumulatedStderr() async throws {
+        let script = "echo boom 1>&2; exit 3"
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", script],
+            cwd: nil,
+            env: nil
+        )
+        await #expect(throws: GGServiceError.commandFailed(stderr: "boom")) {
+            _ = try await collectWithTimeout(stream)
+        }
+    }
+
+    @Test func exit127MapsToCLIMissing() async throws {
+        let script = "exit 127"
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", script],
+            cwd: nil,
+            env: nil
+        )
+        await #expect(throws: GGServiceError.cliMissing) {
+            _ = try await collectWithTimeout(stream)
+        }
+    }
+
+    /// A chatty-stderr child (larger than the ~64KB pipe buffer) must not
+    /// deadlock the child's own exit. Regresses the "no readability handler
+    /// on stderr" finding: without draining stderr incrementally, the
+    /// child's `write()` blocks once the pipe fills, it never exits, and
+    /// this test times out.
+    @Test func largeStderrDoesNotDeadlockChildExit() async throws {
+        // ~200KB of stderr output, comfortably over the OS pipe buffer.
+        // `head`'s own stdout (not `yes`'s) is redirected to stderr so the
+        // pipe still carries `yes`'s output into `head`'s stdin.
+        let script = "yes boom | head -c 200000 1>&2; exit 1"
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", script],
+            cwd: nil,
+            env: nil
+        )
+        await #expect(throws: GGServiceError.self) {
+            _ = try await collectWithTimeout(stream, seconds: 10)
+        }
+    }
+}

--- a/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
+++ b/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
@@ -46,6 +46,31 @@ struct GGCommandRunningStreamingTests {
         #expect(lines == ["one", "two", "three"])
     }
 
+    @Test func preservesUTF8ScalarsSplitAcrossReads() async throws {
+        let script = "printf '\\303'; sleep 0.1; printf '\\251\\n'"
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", script],
+            cwd: nil,
+            env: nil
+        )
+        let lines = try await collectWithTimeout(stream)
+        #expect(lines == ["é"])
+    }
+
+    @Test func streamingRunTimesOutHungProcess() async throws {
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", "sleep 2"],
+            cwd: nil,
+            env: nil,
+            timeout: 0.1
+        )
+        await #expect(throws: ProcessError.self) {
+            _ = try await collectWithTimeout(stream)
+        }
+    }
+
     @Test func nonZeroExitSurfacesCommandFailedWithAccumulatedStderr() async throws {
         let script = "echo boom 1>&2; exit 3"
         let stream = ProcessGGCommandRunner.streamProcess(

--- a/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
+++ b/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
@@ -77,6 +77,28 @@ struct GGCommandRunningStreamingTests {
     /// on stderr" finding: without draining stderr incrementally, the
     /// child's `write()` blocks once the pipe fills, it never exits, and
     /// this test times out.
+    /// `process.terminationHandler` and the stdout/stderr readability
+    /// handlers are two independent async dispatch mechanisms with no
+    /// ordering guarantee between them. A trailing unterminated line only
+    /// gets flushed from `LineBuffer` on EOF — if the termination handler
+    /// finished the continuation before that EOF flush happened, `c` would
+    /// be silently dropped (`yield` is a documented no-op after `finish()`).
+    /// Writing the last line with no trailing newline immediately before
+    /// `exit 0` (no delay) is the most race-prone shape: it maximizes the
+    /// chance the child has already exited by the time the readability
+    /// handler gets scheduled to drain the final chunk.
+    @Test func trailingUnterminatedLineSurvivesTerminationRace() async throws {
+        let script = "printf 'a\\nb\\nc'; exit 0"
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", script],
+            cwd: nil,
+            env: nil
+        )
+        let lines = try await collectWithTimeout(stream)
+        #expect(lines == ["a", "b", "c"])
+    }
+
     @Test func largeStderrDoesNotDeadlockChildExit() async throws {
         // ~200KB of stderr output, comfortably over the OS pipe buffer.
         // `head`'s own stdout (not `yes`'s) is redirected to stderr so the

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -71,7 +71,7 @@ struct GGServiceActionsTests {
 
     @Test func syncFallbackSurfacesJSONSummaryErrors() async throws {
         let runner = RecordingGGRunner(
-            stdout: #"{"event":"summary","entries":[{"position":1,"error":"push failed"}]}"#,
+            stdout: #"{"version":1,"sync":{"entries":[{"position":1,"error":"push failed"}]}}"#,
             syncHelpStdout: "--json"
         )
         let service = GGService(runner: runner)
@@ -90,7 +90,7 @@ struct GGServiceActionsTests {
         )
         let result = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: nil)
         #expect(result.landed == [GGLandedEntry(position: 1, prNumber: 9)])
-        #expect(runner.lastArgs == ["land", "--all", "--json"])
+        #expect(runner.lastArgs == ["land", "--all", "--json", "--no-clean"])
     }
 
     @Test func landUntilSendsUntilTarget() async throws {
@@ -98,7 +98,7 @@ struct GGServiceActionsTests {
             stdout: #"{"version":1,"land":{"stack":"s","base":"main","landed":[]}}"#
         )
         _ = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: "c-abc")
-        #expect(runner.lastArgs == ["land", "--until", "c-abc", "--json"])
+        #expect(runner.lastArgs == ["land", "--until", "c-abc", "--json", "--no-clean"])
     }
 
     @Test func landMapsExit127ToCliMissing() async {

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -57,7 +57,7 @@ struct GGServiceActionsTests {
     }
 
     @Test func syncFallsBackToJSONWhenJSONLIsUnsupported() async throws {
-        let runner = RecordingGGRunner(stdout: #"{"version":1}"#, syncHelpStdout: "--json")
+        let runner = RecordingGGRunner(stdout: #"{"event":"summary","entries":[]}"#, syncHelpStdout: "--json")
         let service = GGService(runner: runner)
 
         var events: [GGSyncEvent] = []
@@ -67,6 +67,21 @@ struct GGServiceActionsTests {
 
         #expect(events == [.summary])
         #expect(runner.calls == [["sync", "--help"], ["sync", "--json", "--no-rebase-check"]])
+    }
+
+    @Test func syncFallbackSurfacesJSONSummaryErrors() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"event":"summary","entries":[{"position":1,"error":"push failed"}]}"#,
+            syncHelpStdout: "--json"
+        )
+        let service = GGService(runner: runner)
+
+        var events: [GGSyncEvent] = []
+        for try await event in service.sync(worktreePath: "/tmp/wt") {
+            events.append(event)
+        }
+
+        #expect(events == [.error(message: "[1] push failed")])
     }
 
     @Test func landAllSendsAllFlagAndDecodes() async throws {

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -6,18 +6,25 @@ private final class RecordingGGRunner: GGCommandRunning, @unchecked Sendable {
     var stdout: String
     var exitCode: Int32
     var stderr: String
+    var syncHelpStdout: String
     private(set) var lastArgs: [String] = []
     private(set) var lastCwd: URL?
+    private(set) var calls: [[String]] = []
 
-    init(stdout: String = "", exitCode: Int32 = 0, stderr: String = "") {
+    init(stdout: String = "", exitCode: Int32 = 0, stderr: String = "", syncHelpStdout: String = "--jsonl") {
         self.stdout = stdout
         self.exitCode = exitCode
         self.stderr = stderr
+        self.syncHelpStdout = syncHelpStdout
     }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        calls.append(args)
         lastArgs = args
         lastCwd = cwd
+        if args == ["sync", "--help"] {
+            return ProcessResult(exitCode: 0, stdout: syncHelpStdout, stderr: "")
+        }
         return ProcessResult(exitCode: exitCode, stdout: stdout, stderr: stderr)
     }
 }
@@ -47,6 +54,19 @@ struct GGServiceActionsTests {
         ])
         #expect(runner.lastArgs == ["sync", "--jsonl", "--no-rebase-check"])
         #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
+    }
+
+    @Test func syncFallsBackToJSONWhenJSONLIsUnsupported() async throws {
+        let runner = RecordingGGRunner(stdout: #"{"version":1}"#, syncHelpStdout: "--json")
+        let service = GGService(runner: runner)
+
+        var events: [GGSyncEvent] = []
+        for try await event in service.sync(worktreePath: "/tmp/wt") {
+            events.append(event)
+        }
+
+        #expect(events == [.summary])
+        #expect(runner.calls == [["sync", "--help"], ["sync", "--json", "--no-rebase-check"]])
     }
 
     @Test func landAllSendsAllFlagAndDecodes() async throws {

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -52,7 +52,7 @@ struct GGServiceActionsTests {
             .prCreated(position: 1, prNumber: 7, prURL: "https://x/pull/7", draft: false),
             .summary,
         ])
-        #expect(runner.lastArgs == ["sync", "--jsonl", "--no-rebase-check"])
+        #expect(runner.lastArgs == ["sync", "--jsonl"])
         #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
     }
 
@@ -66,7 +66,7 @@ struct GGServiceActionsTests {
         }
 
         #expect(events == [.summary])
-        #expect(runner.calls == [["sync", "--help"], ["sync", "--json", "--no-rebase-check"]])
+        #expect(runner.calls == [["sync", "--help"], ["sync", "--json"]])
     }
 
     @Test func syncFallbackSurfacesJSONSummaryErrors() async throws {

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -11,7 +11,7 @@ private final class RecordingGGRunner: GGCommandRunning, @unchecked Sendable {
     private(set) var lastCwd: URL?
     private(set) var calls: [[String]] = []
 
-    init(stdout: String = "", exitCode: Int32 = 0, stderr: String = "", syncHelpStdout: String = "--jsonl") {
+    init(stdout: String = "", exitCode: Int32 = 0, stderr: String = "", syncHelpStdout: String = "--json --stream") {
         self.stdout = stdout
         self.exitCode = exitCode
         self.stderr = stderr
@@ -52,7 +52,7 @@ struct GGServiceActionsTests {
             .prCreated(position: 1, prNumber: 7, prURL: "https://x/pull/7", draft: false),
             .summary,
         ])
-        #expect(runner.lastArgs == ["sync", "--jsonl"])
+        #expect(runner.lastArgs == ["sync", "--json", "--stream"])
         #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
     }
 

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -11,7 +11,7 @@ private final class RecordingGGRunner: GGCommandRunning, @unchecked Sendable {
     private(set) var lastCwd: URL?
     private(set) var calls: [[String]] = []
 
-    init(stdout: String = "", exitCode: Int32 = 0, stderr: String = "", syncHelpStdout: String = "--json --stream") {
+    init(stdout: String = "", exitCode: Int32 = 0, stderr: String = "", syncHelpStdout: String = "--jsonl") {
         self.stdout = stdout
         self.exitCode = exitCode
         self.stderr = stderr
@@ -52,7 +52,7 @@ struct GGServiceActionsTests {
             .prCreated(position: 1, prNumber: 7, prURL: "https://x/pull/7", draft: false),
             .summary,
         ])
-        #expect(runner.lastArgs == ["sync", "--json", "--stream"])
+        #expect(runner.lastArgs == ["sync", "--jsonl"])
         #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
     }
 

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import Alas
+
+private final class RecordingGGRunner: GGCommandRunning, @unchecked Sendable {
+    var stdout: String
+    var exitCode: Int32
+    var stderr: String
+    private(set) var lastArgs: [String] = []
+    private(set) var lastCwd: URL?
+
+    init(stdout: String = "", exitCode: Int32 = 0, stderr: String = "") {
+        self.stdout = stdout
+        self.exitCode = exitCode
+        self.stderr = stderr
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        lastArgs = args
+        lastCwd = cwd
+        return ProcessResult(exitCode: exitCode, stdout: stdout, stderr: stderr)
+    }
+}
+
+struct GGServiceActionsTests {
+    @Test func syncStreamsParsedEventsFromDefaultRunner() async throws {
+        // The default runStreaming splits buffered stdout into lines, so a
+        // fake that only implements run() still drives the streaming API.
+        let ndjson = [
+            #"{"event":"start","total_entries":1}"#,
+            #"{"event":"push_started","position":1}"#,
+            #"{"event":"pr_created","position":1,"pr_number":7,"pr_url":"https://x/pull/7","draft":false}"#,
+            #"{"event":"summary"}"#,
+        ].joined(separator: "\n")
+        let runner = RecordingGGRunner(stdout: ndjson)
+        let service = GGService(runner: runner)
+
+        var events: [GGSyncEvent] = []
+        for try await event in service.sync(worktreePath: "/tmp/wt") {
+            events.append(event)
+        }
+        #expect(events == [
+            .start(totalEntries: 1),
+            .pushStarted(position: 1),
+            .prCreated(position: 1, prNumber: 7, prURL: "https://x/pull/7", draft: false),
+            .summary,
+        ])
+        #expect(runner.lastArgs == ["sync", "--jsonl"])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
+    }
+
+    @Test func landAllSendsAllFlagAndDecodes() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"land":{"stack":"s","base":"main","landed":[{"position":1,"pr_number":9}]}}"#
+        )
+        let result = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: nil)
+        #expect(result.landed == [GGLandedEntry(position: 1, prNumber: 9)])
+        #expect(runner.lastArgs == ["land", "--all", "--json"])
+    }
+
+    @Test func landUntilSendsUntilTarget() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"land":{"stack":"s","base":"main","landed":[]}}"#
+        )
+        _ = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: "c-abc")
+        #expect(runner.lastArgs == ["land", "--until", "c-abc", "--json"])
+    }
+
+    @Test func landMapsExit127ToCliMissing() async {
+        let runner = RecordingGGRunner(exitCode: 127, stderr: "not found")
+        await #expect(throws: GGServiceError.cliMissing) {
+            _ = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: nil)
+        }
+    }
+
+    @Test func landMapsNonzeroToCommandFailed() async {
+        let runner = RecordingGGRunner(exitCode: 1, stderr: "boom")
+        await #expect(throws: GGServiceError.commandFailed(stderr: "boom")) {
+            _ = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: nil)
+        }
+    }
+
+    @Test func cleanContinueAbortCheckoutSendExpectedArgs() async throws {
+        let runner = RecordingGGRunner(stdout: "ok")
+        let service = GGService(runner: runner)
+        try await service.clean(worktreePath: "/tmp/wt")
+        #expect(runner.lastArgs == ["clean"])
+        try await service.continueOp(worktreePath: "/tmp/wt")
+        #expect(runner.lastArgs == ["continue"])
+        try await service.abortOp(worktreePath: "/tmp/wt")
+        #expect(runner.lastArgs == ["abort"])
+        try await service.checkout(worktreePath: "/tmp/wt", target: "2")
+        #expect(runner.lastArgs == ["mv", "2"])
+    }
+
+    @Test func cleanMapsNonzeroToCommandFailed() async {
+        let runner = RecordingGGRunner(exitCode: 1, stderr: "dirty")
+        await #expect(throws: GGServiceError.commandFailed(stderr: "dirty")) {
+            try await GGService(runner: runner).clean(worktreePath: "/tmp/wt")
+        }
+    }
+}

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -45,7 +45,7 @@ struct GGServiceActionsTests {
             .prCreated(position: 1, prNumber: 7, prURL: "https://x/pull/7", draft: false),
             .summary,
         ])
-        #expect(runner.lastArgs == ["sync", "--jsonl"])
+        #expect(runner.lastArgs == ["sync", "--jsonl", "--no-rebase-check"])
         #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
     }
 
@@ -84,7 +84,7 @@ struct GGServiceActionsTests {
         let runner = RecordingGGRunner(stdout: "ok")
         let service = GGService(runner: runner)
         try await service.clean(worktreePath: "/tmp/wt")
-        #expect(runner.lastArgs == ["clean"])
+        #expect(runner.lastArgs == ["clean", "--all"])
         try await service.continueOp(worktreePath: "/tmp/wt")
         #expect(runner.lastArgs == ["continue"])
         try await service.abortOp(worktreePath: "/tmp/wt")

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -115,6 +115,29 @@ struct GGServiceActionsTests {
         }
     }
 
+    @Test func landMapsNonzeroJSONStdoutToCommandFailed() async {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"land":{"landed":[],"error":{"message":"not approved"}}}"#,
+            exitCode: 1
+        )
+        await #expect(throws: GGServiceError.commandFailed(stderr: "not approved")) {
+            _ = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: nil)
+        }
+    }
+
+    @Test func syncFallbackMapsNonzeroJSONStdoutToCommandFailed() async {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"sync":{"entries":[{"position":2,"error":{"message":"push rejected"}}]}}"#,
+            exitCode: 1,
+            syncHelpStdout: "--json"
+        )
+        let service = GGService(runner: runner)
+
+        await #expect(throws: GGServiceError.commandFailed(stderr: "[2] push rejected")) {
+            for try await _ in service.sync(worktreePath: "/tmp/wt") {}
+        }
+    }
+
     @Test func cleanContinueAbortCheckoutSendExpectedArgs() async throws {
         let runner = RecordingGGRunner(stdout: "ok")
         let service = GGService(runner: runner)

--- a/AlasTests/Integrations/GGStackActionStateTests.swift
+++ b/AlasTests/Integrations/GGStackActionStateTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct GGStackActionStateTests {
+    @Test func beginActionGuardsAgainstConcurrentActions() {
+        let state = GGStackActionState()
+        #expect(state.beginAction(.sync))
+        #expect(state.inFlightAction == .sync)
+        // A second action while one is in flight is rejected.
+        #expect(!state.beginAction(.land))
+        #expect(state.inFlightAction == .sync)
+        state.endAction(.sync)
+        #expect(state.inFlightAction == nil)
+        #expect(state.beginAction(.land))
+    }
+
+    @Test func endActionOnlyClearsMatchingAction() {
+        let state = GGStackActionState()
+        _ = state.beginAction(.sync)
+        state.endAction(.land) // non-matching: no-op
+        #expect(state.inFlightAction == .sync)
+        state.endAction(.sync)
+        #expect(state.inFlightAction == nil)
+    }
+
+    @Test func syncProgressAccumulatesAndClears() {
+        let state = GGStackActionState()
+        state.appendSyncEvent(.start(totalEntries: 2))
+        state.appendSyncEvent(.pushStarted(position: 1))
+        #expect(state.syncProgress.count == 2)
+        state.clearSyncProgress()
+        #expect(state.syncProgress.isEmpty)
+    }
+
+    @Test func errorAndPausedRoundTrip() {
+        let state = GGStackActionState()
+        state.setError("boom")
+        #expect(state.lastError == "boom")
+        state.clearError()
+        #expect(state.lastError == nil)
+        state.setPaused(GGPausedOperation(pausedBy: .land))
+        #expect(state.pausedOperation == GGPausedOperation(pausedBy: .land))
+        state.clearPaused()
+        #expect(state.pausedOperation == nil)
+    }
+}

--- a/AlasTests/Integrations/GGStackGateTests.swift
+++ b/AlasTests/Integrations/GGStackGateTests.swift
@@ -100,4 +100,27 @@ struct GGStackGateTests {
         #expect(!GGStackGate.isStackShaped(commits: [plain]))
         #expect(!GGStackGate.isStackShaped(commits: []))
     }
+
+    private func makeRepo(rebaseInProgress: Bool) throws -> String {
+        let dir = NSTemporaryDirectory() + "gg-op-" + UUID().uuidString
+        let gitDir = dir + "/.git"
+        try FileManager.default.createDirectory(atPath: gitDir, withIntermediateDirectories: true)
+        if rebaseInProgress {
+            try FileManager.default.createDirectory(atPath: gitDir + "/rebase-merge", withIntermediateDirectories: true)
+        }
+        return dir
+    }
+
+    @Test func detectsRebaseInProgress() throws {
+        #expect(GGStackGate.operationInProgress(repoPath: try makeRepo(rebaseInProgress: true)))
+        #expect(!GGStackGate.operationInProgress(repoPath: try makeRepo(rebaseInProgress: false)))
+    }
+
+    @Test func detectsMergeInProgressViaHeadFile() throws {
+        let dir = NSTemporaryDirectory() + "gg-op-merge-" + UUID().uuidString
+        let gitDir = dir + "/.git"
+        try FileManager.default.createDirectory(atPath: gitDir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: gitDir + "/MERGE_HEAD", contents: Data("sha\n".utf8))
+        #expect(GGStackGate.operationInProgress(repoPath: dir))
+    }
 }

--- a/AlasTests/Integrations/GGStackGateTests.swift
+++ b/AlasTests/Integrations/GGStackGateTests.swift
@@ -123,4 +123,23 @@ struct GGStackGateTests {
         FileManager.default.createFile(atPath: gitDir + "/MERGE_HEAD", contents: Data("sha\n".utf8))
         #expect(GGStackGate.operationInProgress(repoPath: dir))
     }
+
+    /// The paused-operation markers live in the *private* per-worktree git
+    /// dir, not the dir shared across worktrees. Drop a `rebase-merge`
+    /// marker only under the linked worktree's private dir
+    /// (`main/.git/worktrees/feature/rebase-merge`) and confirm the linked
+    /// worktree reports mid-rebase while the primary checkout — whose own
+    /// `.git` never held the marker — does not. A regression that swapped
+    /// in `commonGitDir` (which resolves the linked worktree through to
+    /// `main/.git`) would make `operationInProgress(linked)` wrongly return
+    /// `false` here.
+    @Test func detectsRebaseInProgressOnlyInLinkedWorktreePrivateDir() throws {
+        let (main, linked) = try makeRepoWithLinkedWorktree(withGGConfig: false)
+        let privateGitDir = main + "/.git/worktrees/feature"
+        try FileManager.default.createDirectory(
+            atPath: privateGitDir + "/rebase-merge", withIntermediateDirectories: true
+        )
+        #expect(GGStackGate.operationInProgress(repoPath: linked))
+        #expect(!GGStackGate.operationInProgress(repoPath: main))
+    }
 }

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -70,6 +70,15 @@ struct GGStackReadinessModelTests {
         #expect(model.actions.map(\.kind) == [.continueOp, .abortOp])
     }
 
+    @Test func pausedFallbackOffersContinueAbortWithoutStack() {
+        let action = GGStackActionState()
+        action.setPaused(GGPausedOperation(pausedBy: .sync))
+        let model = GGStackReadinessModel.makePausedFallback(action: action)
+        #expect(model?.isPaused == true)
+        #expect(model?.summaryChip == "paused")
+        #expect(model?.actions.map(\.kind) == [.continueOp, .abortOp])
+    }
+
     @Test func inFlightActionMarksButtonAndDisablesOthers() {
         let action = GGStackActionState()
         _ = action.beginAction(.sync)

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -1,0 +1,121 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct GGStackReadinessModelTests {
+    private func entry(
+        position: Int, prState: GGPRState?, approved: Bool = false, ci: GGCIStatus? = nil
+    ) -> GGStackEntry {
+        GGStackEntry(
+            position: position, sha: "sha\(position)", title: "t\(position)",
+            ggId: "id\(position)", prNumber: prState == nil ? nil : 100 + position,
+            prState: prState, approved: approved, ciStatus: ci
+        )
+    }
+
+    private func stack(_ entries: [GGStackEntry], total: Int? = nil, synced: Int = 0, behind: Int? = nil) -> GGStack {
+        GGStack(
+            name: "feat", base: "main", totalCommits: total ?? entries.count,
+            syncedCommits: synced, currentPosition: nil, behindBase: behind, entries: entries
+        )
+    }
+
+    @Test func titleAndFacts() {
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .merged), entry(position: 2, prState: .open)], synced: 2),
+            action: GGStackActionState()
+        )
+        #expect(model.title == "Stack · feat")
+        #expect(model.facts.contains { $0.label == "Entries" && $0.value == "2" })
+        #expect(model.facts.contains { $0.label == "Merged" && $0.value == "1" })
+    }
+
+    @Test func syncAlwaysEnabled() {
+        let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: nil)]), action: GGStackActionState())
+        let sync = model.actions.first { $0.kind == .sync }
+        #expect(sync?.isEnabled == true)
+    }
+
+    @Test func landReadyEnabledOnlyWithOpenApprovedGreenEntry() {
+        let notReady = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open, approved: false, ci: .success)]),
+            action: GGStackActionState()
+        )
+        #expect(notReady.actions.first { $0.kind == .land }?.isEnabled == false)
+
+        let ready = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open, approved: true, ci: .success)]),
+            action: GGStackActionState()
+        )
+        #expect(ready.actions.first { $0.kind == .land }?.isEnabled == true)
+    }
+
+    @Test func cleanEnabledOnlyWithMergedEntry() {
+        let noMerged = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open)]), action: GGStackActionState()
+        )
+        #expect(noMerged.actions.first { $0.kind == .clean }?.isEnabled == false)
+
+        let merged = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .merged)]), action: GGStackActionState()
+        )
+        #expect(merged.actions.first { $0.kind == .clean }?.isEnabled == true)
+    }
+
+    @Test func pausedSwapsToContinueAbort() {
+        let action = GGStackActionState()
+        action.setPaused(GGPausedOperation(pausedBy: .land))
+        let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: .open)]), action: action)
+        #expect(model.isPaused)
+        #expect(model.actions.map(\.kind) == [.continueOp, .abortOp])
+    }
+
+    @Test func inFlightActionMarksButtonAndDisablesOthers() {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open, approved: true, ci: .success)]), action: action
+        )
+        let sync = model.actions.first { $0.kind == .sync }
+        #expect(sync?.isInFlight == true)
+        // Other actions disabled while one is in flight.
+        #expect(model.actions.first { $0.kind == .land }?.isEnabled == false)
+    }
+
+    @Test func summaryChipPriorityPausedThenUnsyncedThenBehindThenMerged() {
+        let paused = GGStackActionState()
+        paused.setPaused(GGPausedOperation(pausedBy: .sync))
+        #expect(GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: .open)]), action: paused)
+            .summaryChip.lowercased().contains("paused"))
+
+        // 1 of 2 synced → 1 unsynced.
+        let unsynced = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open), entry(position: 2, prState: nil)], total: 2, synced: 1),
+            action: GGStackActionState()
+        )
+        #expect(unsynced.summaryChip.contains("unsynced"))
+
+        let behind = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open)], total: 1, synced: 1, behind: 3),
+            action: GGStackActionState()
+        )
+        #expect(behind.summaryChip.contains("3"))
+
+        let merged = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .merged)], total: 1, synced: 1),
+            action: GGStackActionState()
+        )
+        #expect(merged.summaryChip == "1/1 merged")
+    }
+
+    @Test func progressRowsRenderDuringSync() {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.appendSyncEvent(.start(totalEntries: 1))
+        action.appendSyncEvent(.pushStarted(position: 1))
+        action.appendSyncEvent(.prCreated(position: 1, prNumber: 7, prURL: nil, draft: false))
+        let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: .open)]), action: action)
+        #expect(!model.progressRows.isEmpty)
+        #expect(model.progressRows.contains { $0.contains("7") })
+    }
+}

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -75,6 +75,33 @@ struct GGStackReadinessModelTests {
         ) == nil)
     }
 
+    @Test func blockingGitOperationDisablesStackMutations() {
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open, approved: true, ci: .success)]),
+            action: GGStackActionState(),
+            hasBlockingGitOperation: true
+        )
+
+        #expect(model.actions.allSatisfy { !$0.isEnabled })
+    }
+
+    @Test func drawerTreatsPlainGitOperationAsBlockingOnlyWhenGGIsNotPaused() {
+        let operation = MergeOperation.merge(sourceBranch: "main")
+
+        #expect(GGStackDrawer.hasBlockingGitOperation(
+            mergeOperation: operation,
+            pausedGGOperation: nil
+        ))
+        #expect(!GGStackDrawer.hasBlockingGitOperation(
+            mergeOperation: operation,
+            pausedGGOperation: GGPausedOperation(pausedBy: .sync)
+        ))
+        #expect(!GGStackDrawer.hasBlockingGitOperation(
+            mergeOperation: nil,
+            pausedGGOperation: nil
+        ))
+    }
+
     @Test func landReadyEnabledWithOpenEntryForFreshVerification() {
         let staleProviderState = GGStackReadinessModel.make(
             stack: stack([entry(position: 1, prState: .open, approved: false, ci: .success)]),

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -119,6 +119,23 @@ struct GGStackReadinessModelTests {
         #expect(model.progressRows.contains { $0.contains("7") })
     }
 
+    @Test func pausedOnSyncKeepsProgressRowsAndOffersContinueAbort() {
+        // Reproduces the exact state a rebase conflict during `gg sync` leaves
+        // behind: syncProgress is non-empty AND the operation is paused. The
+        // model must report both facts simultaneously so the drawer can show
+        // the progress list *and* still surface Continue/Abort.
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.appendSyncEvent(.start(totalEntries: 1))
+        action.appendSyncEvent(.pushStarted(position: 1))
+        action.endAction(.sync) // sync's gg process exits when it hits the conflict
+        action.setPaused(GGPausedOperation(pausedBy: .sync)) // watcher-driven filesystem probe picks up the pause
+        let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: .open)]), action: action)
+        #expect(model.isPaused)
+        #expect(model.actions.map(\.kind) == [.continueOp, .abortOp])
+        #expect(!model.progressRows.isEmpty)
+    }
+
     @Test func progressRowsClearedWhenDifferentActionSucceedsSync() {
         let action = GGStackActionState()
         _ = action.beginAction(.sync)

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -118,4 +118,19 @@ struct GGStackReadinessModelTests {
         #expect(!model.progressRows.isEmpty)
         #expect(model.progressRows.contains { $0.contains("7") })
     }
+
+    @Test func progressRowsClearedWhenDifferentActionSucceedsSync() {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.appendSyncEvent(.start(totalEntries: 1))
+        action.appendSyncEvent(.pushStarted(position: 1))
+        action.appendSyncEvent(.prCreated(position: 1, prNumber: 7, prURL: nil, draft: false))
+        action.endAction(.sync)
+        // Simulates the leak scenario: sync finished without clearSyncProgress()
+        // being called, then an unrelated action starts.
+        _ = action.beginAction(.land)
+        let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: .open)]), action: action)
+        #expect(!action.syncProgress.isEmpty)
+        #expect(model.progressRows.isEmpty)
+    }
 }

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -30,10 +30,19 @@ struct GGStackReadinessModelTests {
         #expect(model.facts.contains { $0.label == "Merged" && $0.value == "1" })
     }
 
-    @Test func syncAlwaysEnabled() {
+    @Test func syncEnabledWhenBaseIsCurrent() {
         let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: nil)]), action: GGStackActionState())
         let sync = model.actions.first { $0.kind == .sync }
         #expect(sync?.isEnabled == true)
+    }
+
+    @Test func syncDisabledWhenBaseIsBehind() {
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: nil)], behind: 1),
+            action: GGStackActionState()
+        )
+        let sync = model.actions.first { $0.kind == .sync }
+        #expect(sync?.isEnabled == false)
     }
 
     @Test func landReadyEnabledWithOpenEntryForFreshVerification() {

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -56,6 +57,22 @@ struct GGStackReadinessModelTests {
         #expect(model.actions.first { $0.kind == .sync }?.isEnabled == false)
         #expect(model.facts.contains { $0.label == "Behind base" && $0.value == "2" })
         #expect(model.summaryChip.contains("2"))
+    }
+
+    @Test func drawerUsesLiveBehindBaseOnlyForMatchingStackBase() {
+        let stack = stack([entry(position: 1, prState: nil)], synced: 1, behind: 0)
+        let behind = GitService.BehindStatus(ref: "origin/main", sha: "abc", count: 2, probedAt: Date())
+
+        #expect(GGStackDrawer.liveBehindBaseOverride(
+            stack: stack,
+            selectedBaseBranch: "main",
+            behindBase: behind
+        ) == 2)
+        #expect(GGStackDrawer.liveBehindBaseOverride(
+            stack: stack,
+            selectedBaseBranch: "release",
+            behindBase: behind
+        ) == nil)
     }
 
     @Test func landReadyEnabledWithOpenEntryForFreshVerification() {

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -36,18 +36,18 @@ struct GGStackReadinessModelTests {
         #expect(sync?.isEnabled == true)
     }
 
-    @Test func landReadyEnabledOnlyWithOpenApprovedGreenEntry() {
-        let notReady = GGStackReadinessModel.make(
+    @Test func landReadyEnabledWithOpenEntryForFreshVerification() {
+        let staleProviderState = GGStackReadinessModel.make(
             stack: stack([entry(position: 1, prState: .open, approved: false, ci: .success)]),
             action: GGStackActionState()
         )
-        #expect(notReady.actions.first { $0.kind == .land }?.isEnabled == false)
+        #expect(staleProviderState.actions.first { $0.kind == .land }?.isEnabled == true)
 
-        let ready = GGStackReadinessModel.make(
-            stack: stack([entry(position: 1, prState: .open, approved: true, ci: .success)]),
+        let noOpenEntries = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .merged)]),
             action: GGStackActionState()
         )
-        #expect(ready.actions.first { $0.kind == .land }?.isEnabled == true)
+        #expect(noOpenEntries.actions.first { $0.kind == .land }?.isEnabled == false)
     }
 
     @Test func cleanEnabledOnlyWithMergedEntry() {

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -45,6 +45,19 @@ struct GGStackReadinessModelTests {
         #expect(sync?.isEnabled == false)
     }
 
+    @Test func syncUsesLiveBehindBaseOverride() {
+        let staleStack = stack([entry(position: 1, prState: nil)], synced: 1, behind: 0)
+        let model = GGStackReadinessModel.make(
+            stack: staleStack,
+            action: GGStackActionState(),
+            liveBehindBase: 2
+        )
+
+        #expect(model.actions.first { $0.kind == .sync }?.isEnabled == false)
+        #expect(model.facts.contains { $0.label == "Behind base" && $0.value == "2" })
+        #expect(model.summaryChip.contains("2"))
+    }
+
     @Test func landReadyEnabledWithOpenEntryForFreshVerification() {
         let staleProviderState = GGStackReadinessModel.make(
             stack: stack([entry(position: 1, prState: .open, approved: false, ci: .success)]),

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -97,6 +97,25 @@ struct RightPaneGGLandTests {
         #expect(message == "Merge 2 approved, passing PRs from the bottom of the stack.")
     }
 
+    @Test func readyLandUsesLastVerifiedPrefixEntryAsUntilTarget() {
+        let s = stack([
+            entry(id: "a", position: 1, prState: .open, approved: true, ci: .success),
+            entry(id: "b", position: 2, prState: .open, approved: true, ci: nil),
+            entry(id: "c", position: 3, prState: .open, approved: false, ci: .success),
+        ])
+
+        #expect(RightPaneState.ggLandUntilTarget(for: .ready, in: s) == "b")
+    }
+
+    @Test func untilLandUsesRequestedEntryAsUntilTarget() {
+        let s = stack([
+            entry(id: "a", position: 1, prState: .open, approved: true, ci: .success),
+            entry(id: "b", position: 2, prState: .open, approved: true, ci: .success),
+        ])
+
+        #expect(RightPaneState.ggLandUntilTarget(for: .until(entryId: "b", title: "t2"), in: s) == "b")
+    }
+
     @Test func landStackFingerprintTracksConfirmedStackIdentity() {
         let original = stack([
             GGStackEntry(position: 1, sha: "s1", title: "t1", ggId: "a", prNumber: 6,

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct RightPaneGGLandTests {
+    private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus) -> GGStackEntry {
+        GGStackEntry(position: 1, sha: "s", title: "t", ggId: id, prNumber: 5,
+                     prState: prState, approved: approved, ciStatus: ci)
+    }
+
+    private func stack(_ entries: [GGStackEntry]) -> GGStack {
+        GGStack(name: "feat", base: "main", totalCommits: entries.count, syncedCommits: entries.count,
+                currentPosition: nil, behindBase: nil, entries: entries)
+    }
+
+    @Test func readyLandableWhenAnyEntryOpenApprovedGreen() {
+        let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
+                          path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let landable = stack([entry(id: "a", prState: .open, approved: true, ci: .success)])
+        #expect(state.ggLandTargetStillLandable(.ready, in: landable))
+        let notLandable = stack([entry(id: "a", prState: .open, approved: false, ci: .success)])
+        #expect(!state.ggLandTargetStillLandable(.ready, in: notLandable))
+    }
+
+    @Test func untilLandableWhenTargetEntryPresent() {
+        let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
+                          path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let s = stack([entry(id: "a", prState: .open, approved: true, ci: .success)])
+        #expect(state.ggLandTargetStillLandable(.until(entryId: "a", title: "t"), in: s))
+        #expect(!state.ggLandTargetStillLandable(.until(entryId: "missing", title: "t"), in: s))
+    }
+
+    @Test func requestAndCancelSetAndClearPending() {
+        let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
+                          path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.requestGGLand(.ready)
+        #expect(state.pendingGGLand == .ready)
+        state.cancelGGLand()
+        #expect(state.pendingGGLand == nil)
+    }
+}

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -9,6 +9,17 @@ struct RightPaneGGLandTests {
                      prState: prState, approved: approved, ciStatus: ci)
     }
 
+    private func entry(
+        id: String,
+        position: Int,
+        prState: GGPRState,
+        approved: Bool,
+        ci: GGCIStatus?
+    ) -> GGStackEntry {
+        GGStackEntry(position: position, sha: "s\(position)", title: "t\(position)", ggId: id, prNumber: 5 + position,
+                     prState: prState, approved: approved, ciStatus: ci)
+    }
+
     private func stack(_ entries: [GGStackEntry]) -> GGStack {
         GGStack(name: "feat", base: "main", totalCommits: entries.count, syncedCommits: entries.count,
                 currentPosition: nil, behindBase: nil, entries: entries)
@@ -28,13 +39,58 @@ struct RightPaneGGLandTests {
         #expect(!state.ggLandTargetStillLandable(.ready, in: notLandable))
     }
 
+    @Test func readyRequiresContiguousBottomPrefix() {
+        let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
+                          path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        func positionedEntry(
+            id: String,
+            position: Int,
+            prState: GGPRState,
+            approved: Bool,
+            ci: GGCIStatus?
+        ) -> GGStackEntry {
+            GGStackEntry(position: position, sha: "s\(position)", title: "t\(position)", ggId: id, prNumber: 5 + position,
+                         prState: prState, approved: approved, ciStatus: ci)
+        }
+
+        let blockedBottom = stack([
+            positionedEntry(id: "a", position: 1, prState: .open, approved: false, ci: .success),
+            positionedEntry(id: "b", position: 2, prState: .open, approved: true, ci: .success),
+        ])
+        #expect(!state.ggLandTargetStillLandable(.ready, in: blockedBottom))
+
+        let readyAfterMergedBottom = stack([
+            positionedEntry(id: "a", position: 1, prState: .merged, approved: false, ci: .failed),
+            positionedEntry(id: "b", position: 2, prState: .open, approved: true, ci: .success),
+        ])
+        #expect(state.ggLandTargetStillLandable(.ready, in: readyAfterMergedBottom))
+        #expect(RightPaneState.ggLandReadyPrefix(in: readyAfterMergedBottom).map(\.id) == ["b"])
+    }
+
+    @Test func readyConfirmationCountsContiguousBottomPrefixOnly() {
+        let message = RightPaneState.ggLandConfirmationMessage(
+            for: .ready,
+            stack: stack([
+                GGStackEntry(position: 1, sha: "s1", title: "t1", ggId: "a", prNumber: 6,
+                             prState: .open, approved: true, ciStatus: .success),
+                GGStackEntry(position: 2, sha: "s2", title: "t2", ggId: "b", prNumber: 7,
+                             prState: .open, approved: false, ciStatus: .success),
+                GGStackEntry(position: 3, sha: "s3", title: "t3", ggId: "c", prNumber: 8,
+                             prState: .open, approved: true, ciStatus: .success),
+            ])
+        )
+
+        #expect(message == "Merge 1 approved, passing PR from the bottom of the stack.")
+    }
+
     @Test func readyConfirmationCountsApprovedOpenEntriesWithNoCI() {
         let message = RightPaneState.ggLandConfirmationMessage(
             for: .ready,
             stack: stack([
-                entry(id: "a", prState: .open, approved: true, ci: .success),
-                entry(id: "b", prState: .open, approved: true, ci: nil),
-                entry(id: "c", prState: .open, approved: true, ci: .pending),
+                entry(id: "a", position: 1, prState: .open, approved: true, ci: .success),
+                entry(id: "b", position: 2, prState: .open, approved: true, ci: nil),
+                entry(id: "c", position: 3, prState: .open, approved: true, ci: .pending),
             ])
         )
 

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -50,6 +50,29 @@ struct RightPaneGGLandTests {
         #expect(!state.ggLandTargetStillLandable(.until(entryId: "missing", title: "t"), in: s))
     }
 
+    @Test func untilRequiresReadyTargetEntry() {
+        let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
+                          path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+
+        #expect(!state.ggLandTargetStillLandable(
+            .until(entryId: "a", title: "t"),
+            in: stack([entry(id: "a", prState: .open, approved: false, ci: .success)])
+        ))
+        #expect(!state.ggLandTargetStillLandable(
+            .until(entryId: "a", title: "t"),
+            in: stack([entry(id: "a", prState: .draft, approved: true, ci: .success)])
+        ))
+        #expect(!state.ggLandTargetStillLandable(
+            .until(entryId: "a", title: "t"),
+            in: stack([entry(id: "a", prState: .open, approved: true, ci: .failed)])
+        ))
+        #expect(state.ggLandTargetStillLandable(
+            .until(entryId: "a", title: "t"),
+            in: stack([entry(id: "a", prState: .open, approved: true, ci: nil)])
+        ))
+    }
+
     @Test func requestAndCancelSetAndClearPending() {
         let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
                           path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -73,6 +73,44 @@ struct RightPaneGGLandTests {
         ))
     }
 
+    @Test func untilRequiresReadyLowerEntries() {
+        let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
+                          path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        func positionedEntry(
+            id: String,
+            position: Int,
+            prState: GGPRState,
+            approved: Bool,
+            ci: GGCIStatus?
+        ) -> GGStackEntry {
+            GGStackEntry(position: position, sha: "s\(position)", title: "t\(position)", ggId: id, prNumber: 5 + position,
+                         prState: prState, approved: approved, ciStatus: ci)
+        }
+
+        #expect(state.ggLandTargetStillLandable(
+            .until(entryId: "b", title: "t2"),
+            in: stack([
+                positionedEntry(id: "a", position: 1, prState: .open, approved: true, ci: .success),
+                positionedEntry(id: "b", position: 2, prState: .open, approved: true, ci: .success),
+            ])
+        ))
+        #expect(state.ggLandTargetStillLandable(
+            .until(entryId: "b", title: "t2"),
+            in: stack([
+                positionedEntry(id: "a", position: 1, prState: .merged, approved: false, ci: .failed),
+                positionedEntry(id: "b", position: 2, prState: .open, approved: true, ci: .success),
+            ])
+        ))
+        #expect(!state.ggLandTargetStillLandable(
+            .until(entryId: "b", title: "t2"),
+            in: stack([
+                positionedEntry(id: "a", position: 1, prState: .open, approved: false, ci: .success),
+                positionedEntry(id: "b", position: 2, prState: .open, approved: true, ci: .success),
+            ])
+        ))
+    }
+
     @Test func requestAndCancelSetAndClearPending() {
         let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
                           path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -97,6 +97,26 @@ struct RightPaneGGLandTests {
         #expect(message == "Merge 2 approved, passing PRs from the bottom of the stack.")
     }
 
+    @Test func landStackFingerprintTracksConfirmedStackIdentity() {
+        let original = stack([
+            GGStackEntry(position: 1, sha: "s1", title: "t1", ggId: "a", prNumber: 6,
+                         prState: .open, approved: true, ciStatus: .success),
+            GGStackEntry(position: 2, sha: "s2", title: "t2", ggId: "b", prNumber: 7,
+                         prState: .open, approved: true, ciStatus: .success),
+        ])
+        let rebased = stack([
+            GGStackEntry(position: 1, sha: "s1-rebased", title: "t1", ggId: "a", prNumber: 6,
+                         prState: .open, approved: true, ciStatus: .success),
+            GGStackEntry(position: 2, sha: "s2", title: "t2", ggId: "b", prNumber: 7,
+                         prState: .open, approved: true, ciStatus: .success),
+        ])
+        let fingerprint = RightPaneState.ggLandStackFingerprint(original)
+
+        #expect(RightPaneState.ggLandStackMatchesPendingConfirmation(original, fingerprint: fingerprint))
+        #expect(!RightPaneState.ggLandStackMatchesPendingConfirmation(rebased, fingerprint: fingerprint))
+        #expect(!RightPaneState.ggLandStackMatchesPendingConfirmation(original, fingerprint: nil))
+    }
+
     @Test func untilLandableWhenTargetEntryPresent() {
         let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
                           path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -42,4 +42,14 @@ struct RightPaneGGLandTests {
         state.cancelGGLand()
         #expect(state.pendingGGLand == nil)
     }
+
+    @Test func requestAndCancelCleanAllSetAndClearPending() {
+        let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
+                          path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.requestGGCleanAll()
+        #expect(state.pendingGGCleanAll)
+        state.cancelGGCleanAll()
+        #expect(!state.pendingGGCleanAll)
+    }
 }

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @MainActor
 struct RightPaneGGLandTests {
-    private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus) -> GGStackEntry {
+    private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus?) -> GGStackEntry {
         GGStackEntry(position: 1, sha: "s", title: "t", ggId: id, prNumber: 5,
                      prState: prState, approved: approved, ciStatus: ci)
     }
@@ -20,8 +20,25 @@ struct RightPaneGGLandTests {
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         let landable = stack([entry(id: "a", prState: .open, approved: true, ci: .success)])
         #expect(state.ggLandTargetStillLandable(.ready, in: landable))
+        let landableWithoutCI = stack([entry(id: "a", prState: .open, approved: true, ci: nil)])
+        #expect(state.ggLandTargetStillLandable(.ready, in: landableWithoutCI))
+        let failingCI = stack([entry(id: "a", prState: .open, approved: true, ci: .failed)])
+        #expect(!state.ggLandTargetStillLandable(.ready, in: failingCI))
         let notLandable = stack([entry(id: "a", prState: .open, approved: false, ci: .success)])
         #expect(!state.ggLandTargetStillLandable(.ready, in: notLandable))
+    }
+
+    @Test func readyConfirmationCountsApprovedOpenEntriesWithNoCI() {
+        let message = RightPaneState.ggLandConfirmationMessage(
+            for: .ready,
+            stack: stack([
+                entry(id: "a", prState: .open, approved: true, ci: .success),
+                entry(id: "b", prState: .open, approved: true, ci: nil),
+                entry(id: "c", prState: .open, approved: true, ci: .pending),
+            ])
+        )
+
+        #expect(message == "Merge 2 approved, passing PRs from the bottom of the stack.")
     }
 
     @Test func untilLandableWhenTargetEntryPresent() {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -33,9 +33,9 @@ private final class ThrowingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
 private final class ConflictAfterSyncRunner: GGCommandRunning, @unchecked Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         if args == ["sync", "--help"] {
-            return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
+            return ProcessResult(exitCode: 0, stdout: "--json --stream", stderr: "")
         }
-        if args == ["sync", "--jsonl"], let cwd {
+        if args == ["sync", "--json", "--stream"], let cwd {
             try FileManager.default.createDirectory(
                 at: cwd.appendingPathComponent(".git/rebase-merge"),
                 withIntermediateDirectories: true

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -347,4 +347,34 @@ struct RightPaneGGStackTests {
         #expect(state.ggStackCommitsKey == nil)
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
     }
+
+    /// `gg ls --json` can't report a paused rebase, so `refreshGGStack()`
+    /// reconciles `ggActionState.pausedOperation` from a git-level probe
+    /// (`GGStackGate.operationInProgress`) independent of the gg query.
+    @Test func refreshReconcilesPausedFromGitProbe() async throws {
+        // Real temp repo with a rebase-merge dir → operationInProgress true.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-paused-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git/rebase-merge"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = Worktree(
+            id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
+            branch: "feature", path: dir, status: .clean, lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(state.ggActionState.pausedOperation != nil)
+
+        // Remove the marker → next refresh clears paused.
+        try FileManager.default.removeItem(at: dir.appendingPathComponent(".git/rebase-merge"))
+        state.ggStackCommitsKey = nil // force a re-query past the unchanged-key guard
+        await state.refreshGGStack()
+        #expect(state.ggActionState.pausedOperation == nil)
+    }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -380,11 +380,9 @@ struct RightPaneGGStackTests {
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
     }
 
-    /// `gg ls --json` can't report a paused rebase, so `refreshGGStack()`
-    /// reconciles `ggActionState.pausedOperation` from a git-level probe
-    /// (`GGStackGate.operationInProgress`) independent of the gg query.
-    @Test func refreshReconcilesPausedFromGitProbe() async throws {
-        // Real temp repo with a rebase-merge dir → operationInProgress true.
+    /// Plain git actions use the same marker files as paused gg actions, so
+    /// stack refresh must not infer a gg pause from filesystem state alone.
+    @Test func refreshDoesNotInferPausedFromPlainGitProbe() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-gg-paused-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git/rebase-merge"), withIntermediateDirectories: true)
@@ -401,7 +399,13 @@ struct RightPaneGGStackTests {
         state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
+        #expect(state.ggActionState.pausedOperation == nil)
+
+        _ = state.ggActionState.beginAction(.sync)
+        state.ggStackCommitsKey = nil
+        await state.refreshGGStack()
         #expect(state.ggActionState.pausedOperation != nil)
+        state.ggActionState.endAction(.sync)
 
         // Remove the marker → next refresh clears paused.
         try FileManager.default.removeItem(at: dir.appendingPathComponent(".git/rebase-merge"))
@@ -423,6 +427,7 @@ struct RightPaneGGStackTests {
         state.ggService = GGService(runner: ThrowingFakeGGRunner())
         state.ggGateProvider = { true }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "m", count: 40), stackShaped: true)]
+        state.ggActionState.setPaused(GGPausedOperation(pausedBy: .sync))
 
         await state.refreshGGStack()
 

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -377,4 +377,24 @@ struct RightPaneGGStackTests {
         await state.refreshGGStack()
         #expect(state.ggActionState.pausedOperation == nil)
     }
+
+    @Test func thrownRefreshKeepsPausedOperationWhenGitProbeIsPaused() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-paused-throw-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git/rebase-merge"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = Worktree(
+            id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
+            branch: "feature", path: dir, status: .clean, lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: ThrowingFakeGGRunner())
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "m", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+
+        #expect(state.ggStack == nil)
+        #expect(state.ggActionState.pausedOperation != nil)
+    }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -35,7 +35,7 @@ private final class ConflictAfterSyncRunner: GGCommandRunning, @unchecked Sendab
         if args == ["sync", "--help"] {
             return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
         }
-        if args == ["sync", "--jsonl", "--no-rebase-check"], let cwd {
+        if args == ["sync", "--jsonl"], let cwd {
             try FileManager.default.createDirectory(
                 at: cwd.appendingPathComponent(".git/rebase-merge"),
                 withIntermediateDirectories: true
@@ -423,6 +423,7 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.pausedOperation == nil)
 
         _ = state.ggActionState.beginAction(.sync)
+        GGStackGate.markAlasGGOperationInProgress(repoPath: dir.path)
         state.ggStackCommitsKey = nil
         await state.refreshGGStack()
         #expect(state.ggActionState.pausedOperation != nil)
@@ -433,6 +434,28 @@ struct RightPaneGGStackTests {
         state.ggStackCommitsKey = nil // force a re-query past the unchanged-key guard
         await state.refreshGGStack()
         #expect(state.ggActionState.pausedOperation == nil)
+    }
+
+    @Test func refreshRestoresPausedGGOperationFromAlasMarker() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-paused-reload-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git/rebase-merge"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        GGStackGate.markAlasGGOperationInProgress(repoPath: dir.path)
+        let wt = Worktree(
+            id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
+            branch: "feature", path: dir, status: .clean, lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "r", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+
+        #expect(state.ggActionState.pausedOperation == GGPausedOperation(pausedBy: .sync))
     }
 
     @Test func thrownRefreshKeepsPausedOperationWhenGitProbeIsPaused() async throws {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -131,6 +131,18 @@ struct RightPaneGGStackTests {
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
     }
 
+    @Test func gateClosedClearsPausedOperation() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggGateProvider = { false }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
+        state.ggActionState.setPaused(GGPausedOperation(pausedBy: .sync))
+
+        await state.refreshGGStack()
+
+        #expect(state.ggActionState.pausedOperation == nil)
+    }
+
     @Test func notStackShapedSkipsCLIAndClearsStack() async throws {
         let wt = makeWorktree()
         let state = RightPaneState(worktree: wt, baseBranch: "main")

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -30,8 +30,29 @@ private final class ThrowingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
     }
 }
 
+private final class ConflictAfterSyncRunner: GGCommandRunning, @unchecked Sendable {
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["sync", "--help"] {
+            return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
+        }
+        if args == ["sync", "--jsonl", "--no-rebase-check"], let cwd {
+            try FileManager.default.createDirectory(
+                at: cwd.appendingPathComponent(".git/rebase-merge"),
+                withIntermediateDirectories: true
+            )
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "conflict")
+        }
+        return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+    }
+}
+
 @MainActor
 struct RightPaneGGStackTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
     private func makeWorktree() -> Worktree {
         let path = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-gg-stack-\(UUID().uuidString)")
@@ -433,5 +454,27 @@ struct RightPaneGGStackTests {
 
         #expect(state.ggStack == nil)
         #expect(state.ggActionState.pausedOperation != nil)
+    }
+
+    @Test func syncConflictPreservesPausedBeforeClearingInFlight() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-sync-conflict-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = Worktree(
+            id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
+            branch: "feature", path: dir, status: .clean, lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: ConflictAfterSyncRunner())
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
+
+        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        while state.ggActionState.inFlightAction != nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(state.ggActionState.pausedOperation == GGPausedOperation(pausedBy: .sync))
     }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -143,6 +143,26 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.pausedOperation == nil)
     }
 
+    @Test func activeGGOperationPreservesPausedWhenStackShapeDisappears() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-paused-unshaped-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git/rebase-merge"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = Worktree(
+            id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
+            branch: "feature", path: dir, status: .clean, lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "o", count: 40), stackShaped: false)]
+        _ = state.ggActionState.beginAction(.sync)
+
+        await state.refreshGGStack()
+
+        #expect(state.ggActionState.pausedOperation != nil)
+        state.ggActionState.endAction(.sync)
+    }
+
     @Test func notStackShapedSkipsCLIAndClearsStack() async throws {
         let wt = makeWorktree()
         let state = RightPaneState(worktree: wt, baseBranch: "main")

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -458,6 +458,29 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.pausedOperation == GGPausedOperation(pausedBy: .sync))
     }
 
+    @Test func refreshClearsStaleAlasMarkerWhenNoGitOperationIsInProgress() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-stale-marker-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        GGStackGate.markAlasGGOperationInProgress(repoPath: dir.path)
+        let wt = Worktree(
+            id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
+            branch: "feature", path: dir, status: .clean, lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "t", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+
+        #expect(state.ggActionState.pausedOperation == nil)
+        #expect(GGStackGate.alasGGOperationInProgress(repoPath: dir.path) == false)
+    }
+
     @Test func thrownRefreshKeepsPausedOperationWhenGitProbeIsPaused() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-gg-paused-throw-\(UUID().uuidString)")

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -33,9 +33,9 @@ private final class ThrowingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
 private final class ConflictAfterSyncRunner: GGCommandRunning, @unchecked Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         if args == ["sync", "--help"] {
-            return ProcessResult(exitCode: 0, stdout: "--json --stream", stderr: "")
+            return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
         }
-        if args == ["sync", "--json", "--stream"], let cwd {
+        if args == ["sync", "--jsonl"], let cwd {
             try FileManager.default.createDirectory(
                 at: cwd.appendingPathComponent(".git/rebase-merge"),
                 withIntermediateDirectories: true


### PR DESCRIPTION
## Summary
- add GG stack action models and service operations for sync, land, clean, continue, abort, and checkout
- add stack drawer UI with action state, progress rows, land confirmation, and paused-operation controls
- add tests for GG action events, streaming command behavior, stack readiness, gate behavior, and right pane stack interactions

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build\n- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test (interrupted after the process stayed silent and idle for several minutes)