### PR TITLE
fix(gg): Address post-merge review feedback

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -411,44 +411,7 @@ private struct RootPresentationHandlers: ViewModifier {
         } message: { snapshot in
             Text(RightPaneState.mergeConfirmationMessage(for: snapshot.reviewRequest))
         }
-        .confirmationDialog(
-            "Land stack?",
-            isPresented: Binding(
-                get: { state.rightPaneStore.stateWithPendingGGLand() != nil },
-                set: { if !$0 { state.rightPaneStore.stateWithPendingGGLand()?.cancelGGLand() } }
-            ),
-            titleVisibility: .visible,
-            presenting: state.rightPaneStore.stateWithPendingGGLand()?.pendingGGLand
-        ) { _ in
-            Button("Land", role: .destructive) {
-                state.rightPaneStore.stateWithPendingGGLand()?.performGGLand()
-            }
-            Button("Cancel", role: .cancel) {
-                state.rightPaneStore.stateWithPendingGGLand()?.cancelGGLand()
-            }
-        } message: { request in
-            Text(RightPaneState.ggLandConfirmationMessage(
-                for: request,
-                stack: state.rightPaneStore.stateWithPendingGGLand()?.ggStack
-            ))
-        }
-        .confirmationDialog(
-            "Clean all merged stacks?",
-            isPresented: Binding(
-                get: { state.rightPaneStore.stateWithPendingGGCleanAll() != nil },
-                set: { if !$0 { state.rightPaneStore.stateWithPendingGGCleanAll()?.cancelGGCleanAll() } }
-            ),
-            titleVisibility: .visible
-        ) {
-            Button("Clean all merged stacks", role: .destructive) {
-                state.rightPaneStore.stateWithPendingGGCleanAll()?.performGGCleanAll()
-            }
-            Button("Cancel", role: .cancel) {
-                state.rightPaneStore.stateWithPendingGGCleanAll()?.cancelGGCleanAll()
-            }
-        } message: {
-            Text("Remove every merged gg stack and associated worktree in this repository.")
-        }
+        .modifier(RootGGPresentationHandlers(state: state))
         .alert(
             "Merge failed",
             isPresented: Binding(
@@ -508,6 +471,52 @@ private struct RootPresentationHandlers: ViewModifier {
             }
             .environment(\.theme, state.themeStore.current)
         }
+    }
+}
+
+private struct RootGGPresentationHandlers: ViewModifier {
+    @Bindable var state: AppState
+
+    func body(content: Content) -> some View {
+        content
+            .confirmationDialog(
+                "Land stack?",
+                isPresented: Binding(
+                    get: { state.rightPaneStore.stateWithPendingGGLand() != nil },
+                    set: { if !$0 { state.rightPaneStore.stateWithPendingGGLand()?.cancelGGLand() } }
+                ),
+                titleVisibility: .visible,
+                presenting: state.rightPaneStore.stateWithPendingGGLand()?.pendingGGLand
+            ) { _ in
+                Button("Land", role: .destructive) {
+                    state.rightPaneStore.stateWithPendingGGLand()?.performGGLand()
+                }
+                Button("Cancel", role: .cancel) {
+                    state.rightPaneStore.stateWithPendingGGLand()?.cancelGGLand()
+                }
+            } message: { request in
+                Text(RightPaneState.ggLandConfirmationMessage(
+                    for: request,
+                    stack: state.rightPaneStore.stateWithPendingGGLand()?.ggStack
+                ))
+            }
+            .confirmationDialog(
+                "Clean all merged stacks?",
+                isPresented: Binding(
+                    get: { state.rightPaneStore.stateWithPendingGGCleanAll() != nil },
+                    set: { if !$0 { state.rightPaneStore.stateWithPendingGGCleanAll()?.cancelGGCleanAll() } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button("Clean all merged stacks", role: .destructive) {
+                    state.rightPaneStore.stateWithPendingGGCleanAll()?.performGGCleanAll()
+                }
+                Button("Cancel", role: .cancel) {
+                    state.rightPaneStore.stateWithPendingGGCleanAll()?.cancelGGCleanAll()
+                }
+            } message: {
+                Text("Remove every merged gg stack and associated worktree in this repository.")
+            }
     }
 }
 

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -172,6 +172,7 @@ struct CommitsSectionView: View {
         pausedGGOperation: GGPausedOperation?
     ) -> Bool {
         inFlightAction == nil
+            && pausedGGOperation == nil
             && !GGStackDrawer.hasBlockingGitOperation(
                 mergeOperation: mergeOperation,
                 pausedGGOperation: pausedGGOperation

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -106,6 +106,10 @@ final class RightPaneState {
     /// Injected by RightPaneStore — resolves gates 1–3 (master toggle,
     /// gg installed, per-project mode) against app-level state.
     var ggGateProvider: (@MainActor () -> Bool)? = nil
+    /// Injected by RightPaneStore so a successful clean can reconcile any
+    /// gg-managed worktrees removed from the app-level project topology.
+    @ObservationIgnored
+    var refreshProjectTopologyAfterGGClean: (@MainActor () async -> Void)? = nil
     var ggService = GGService()
     /// Backing store for the stack drawer's mutation UI (in-flight action,
     /// sync progress, paused/error state). Not snapshot-derived, so
@@ -950,7 +954,10 @@ final class RightPaneState {
     func performGGCleanAll() {
         guard pendingGGCleanAll else { return }
         pendingGGCleanAll = false
-        runGGSimpleAction(.clean) { try await self.ggService.clean(worktreePath: self.worktree.path.path) }
+        runGGSimpleAction(.clean) {
+            try await self.ggService.clean(worktreePath: self.worktree.path.path)
+            await self.refreshProjectTopologyAfterGGClean?()
+        }
     }
 
     /// Checks out a stack entry (`gg mv <target>`), routed through

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -166,6 +166,10 @@ final class RightPaneStore {
                     isRemoteProject: project.host != nil
                 )
             }
+            new.refreshProjectTopologyAfterGGClean = { [weak self] in
+                guard let app = self?.appState else { return }
+                await app.refreshProjectTopology(projectId: worktree.projectId)
+            }
 
             if shouldDeferInitialRefresh {
                 new.baseBranchProbeTask = Task { @MainActor [weak self, weak new] in

--- a/AlasTests/CommitsSectionTitleTests.swift
+++ b/AlasTests/CommitsSectionTitleTests.swift
@@ -45,7 +45,7 @@ struct CommitsSectionTitleTests {
             mergeOperation: .merge(sourceBranch: "main"),
             pausedGGOperation: nil
         ))
-        #expect(CommitsSectionView.ggRowMutationsEnabled(
+        #expect(!CommitsSectionView.ggRowMutationsEnabled(
             inFlightAction: nil,
             mergeOperation: .merge(sourceBranch: "main"),
             pausedGGOperation: GGPausedOperation(pausedBy: .sync)

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -523,4 +523,31 @@ struct RightPaneGGStackTests {
 
         #expect(state.ggActionState.pausedOperation == GGPausedOperation(pausedBy: .sync))
     }
+
+    @Test func successfulCleanRefreshesProjectTopology() async throws {
+        let wt = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: wt.path.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: wt.path) }
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: "", stderr: "")
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        var didRefreshProjectTopology = false
+        state.refreshProjectTopologyAfterGGClean = {
+            didRefreshProjectTopology = true
+        }
+
+        state.requestGGCleanAll()
+        state.performGGCleanAll()
+        while state.ggActionState.inFlightAction != nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(runner.callCount == 1)
+        #expect(didRefreshProjectTopology)
+    }
 }


### PR DESCRIPTION
## What changed

- disable commit-row GG mutations while a GG operation is paused
- refresh the affected project topology after a successful `gg clean --all`, including persistence and missing-worktree cleanup through the existing app-level path
- extract GG confirmation dialogs into a focused view modifier to keep SwiftUI type checking reliable
- add regression coverage for paused row mutations and post-clean topology refresh

## Why

This follows up on the two latest outstanding Codex review comments from #854. Paused operations previously left row context-menu mutations available, and successful clean operations refreshed only the right pane while stale managed worktrees remained in project state.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused `CommitsSectionTitleTests` and `RightPaneGGStackTests`

The full local test command was attempted twice but the macOS test host consistently blocked in the pre-existing `ACPTerminalTests.descendantCleanupRunsOffMainActor` source-file read on `/Volumes/Ambrosio`; samples were captured locally. GitHub CI is expected to provide the authoritative full-suite result.