### PR TITLE
fix(gg): Refresh clean topology from a surviving worktree

### DIFF
--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -327,7 +327,17 @@ final class ProjectsManager {
     @discardableResult
     func refreshWorktrees(projectId: String) async throws -> Bool {
         guard let project = projects.first(where: { $0.id == projectId }) else { return false }
-        let url = URL(fileURLWithPath: project.path)
+        let configuredURL = URL(fileURLWithPath: project.path)
+        let url: URL
+        if project.host == nil,
+           !FileManager.default.fileExists(atPath: configuredURL.path),
+           let survivingWorktree = worktreesByProject[projectId, default: []].first(where: {
+               FileManager.default.fileExists(atPath: $0.path.path)
+           }) {
+            url = survivingWorktree.path
+        } else {
+            url = configuredURL
+        }
         let trees = try await worktreeSvc.list(repoPath: url, projectId: projectId)
 
         // Reconcile optimistic rows: preserve creating rows until the owner

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -65,6 +65,43 @@ struct ProjectsManagerTests {
         #expect(trees.first?.branch == "main")
     }
 
+    @Test func refreshWorktreesFallsBackWhenConfiguredLinkedWorktreeDisappears() async throws {
+        let repo = try await makeRepo(name: "linked-anchor")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let service = WorktreeService()
+        let linkedPath = repo.appendingPathComponent("linked-anchor")
+        let projectId = "linked-anchor-project"
+        let linkedWorktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "linked-anchor-branch",
+            destination: linkedPath,
+            projectId: projectId
+        )
+        let project = ProjectConfig(
+            id: projectId,
+            name: "linked-anchor",
+            path: linkedPath.path,
+            color: "#5fb7c4",
+            addedAt: Date()
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+        try await manager.refreshWorktrees(projectId: projectId)
+        #expect(manager.worktrees(projectId: projectId).count == 2)
+
+        try await service.remove(
+            repoPath: repo,
+            worktree: linkedWorktree,
+            deleteBranchIfMerged: false,
+            force: false
+        )
+        try await manager.refreshWorktrees(projectId: projectId)
+
+        let remaining = manager.worktrees(projectId: projectId)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.path.standardizedFileURL == repo.standardizedFileURL)
+    }
+
     @Test func remoteRegistrationReconcileUnregistersRemovedWorktreeRoots() {
         let project = ProjectConfig(
             id: "remote-project",


### PR DESCRIPTION
## What changed

- fall back to a cached surviving local worktree when the configured project path has disappeared
- keep remote-project refresh behavior unchanged
- add an integration regression test for removing the linked worktree used as the project path

## Why

Follow-up to the Codex review on #855. When gg clean removed the linked worktree used as the persisted project path, topology refresh anchored git worktree list at a missing directory and left deleted worktree rows and tabs stale.

## Validation

- xcodegen
- SwiftFormat lint
- clean macOS build
- ProjectsManagerTests