### PR TITLE
fix(gg): Refresh clean topology from a surviving worktree

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1186,10 +1186,10 @@ final class AppState {
                         path: newWorktree.path,
                         hidden: false
                     )
-                    let gcDropped = try await projectsManager.refreshWorktrees(projectId: project.id)
+                    _ = try await refreshProjectWorktrees(projectId: project.id)
                     guard projects.contains(where: { $0.id == projectId }) else { return }
                     projectsManager.setOperationState(id: optimistic.id, state: nil)
-                    if wasHidden || gcDropped {
+                    if wasHidden {
                         saveProjects()
                     }
 
@@ -1778,7 +1778,7 @@ final class AppState {
         var staleProjectIds: [String] = []
         for project in projects {
             do {
-                try await projectsManager.refreshWorktrees(projectId: project.id)
+                try await refreshProjectWorktrees(projectId: project.id)
             } catch {
                 guard project.host == nil else { continue }
                 guard !FileManager.default.fileExists(atPath: project.path) else { continue }
@@ -1856,13 +1856,20 @@ final class AppState {
         }
     }
 
-    func refreshProjectTopology(projectId: String) async {
-        let beforeIds = allWorktreeIds()
+    @discardableResult
+    private func refreshProjectWorktrees(projectId: String) async throws -> Bool {
         let previousPaths = Dictionary(uniqueKeysWithValues: projectsManager.projects
             .filter { $0.id == projectId }
             .map { ($0.id, $0.path) })
-        if (try? await projectsManager.refreshWorktrees(projectId: projectId)) == true { saveProjects() }
+        let changed = try await projectsManager.refreshWorktrees(projectId: projectId)
+        if changed { saveProjects() }
         restartProjectGitWatchers(previousPaths: previousPaths)
+        return changed
+    }
+
+    func refreshProjectTopology(projectId: String) async {
+        let beforeIds = allWorktreeIds()
+        _ = try? await refreshProjectWorktrees(projectId: projectId)
         let afterIds = allWorktreeIds()
         let addedIds = afterIds.subtracting(beforeIds)
         if !addedIds.isEmpty {
@@ -4382,9 +4389,7 @@ final class AppState {
         // Always clear the deleting state after a successful remove,
         // even if the subsequent refresh fails.
         projectsManager.setOperationState(id: worktree.id, state: nil)
-        if (try? await projectsManager.refreshWorktrees(projectId: worktree.projectId)) == true {
-            saveProjects()
-        }
+        _ = try? await refreshProjectWorktrees(projectId: worktree.projectId)
         if selectedWorktreeId == worktree.id {
             selectWorktree(id: selectionAfterRemoval(
                 removedFromProjectId: worktree.projectId,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -460,12 +460,15 @@ final class AppState {
     private var projectGitWatchers: [String: ProjectGitWatcher] = [:]
     @ObservationIgnored
     private var remoteProjectWatchers: [String: RemoteProjectGitWatcher] = [:]
+    @ObservationIgnored
+    private let projectGitWatcherFactory: (URL) -> ProjectGitWatcher
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
         persistenceErrorHandler: ((String, String) -> Void)? = nil,
         fileActionErrorHandler: ((String, String) -> Void)? = nil,
-        terminalSessionOpener: TerminalSessionOpener? = nil
+        terminalSessionOpener: TerminalSessionOpener? = nil,
+        projectGitWatcherFactory: @escaping (URL) -> ProjectGitWatcher = { ProjectGitWatcher(repoPath: $0) }
     ) {
         self.store = store
         self.persistenceErrorHandler = persistenceErrorHandler ?? { title, message in
@@ -475,6 +478,7 @@ final class AppState {
             AppState.showWarningAlert(title: title, message: message)
         }
         self.terminalSessionOpener = terminalSessionOpener
+        self.projectGitWatcherFactory = projectGitWatcherFactory
         let config = (try? store.readIfExists(AppConfig.self, from: Paths.appConfigFile)) ?? AppConfig.defaults
         let projectsFile = (try? store.readIfExists(ProjectsFile.self, from: Paths.projectsFile)) ?? ProjectsFile(projects: [])
         let spacesFile = try? store.readIfExists(SpacesFile.self, from: Paths.spacesFile)
@@ -1817,7 +1821,7 @@ final class AppState {
             watcher.start()
             return
         }
-        let watcher = ProjectGitWatcher(repoPath: URL(fileURLWithPath: project.path))
+        let watcher = projectGitWatcherFactory(URL(fileURLWithPath: project.path))
         let projectId = project.id
         watcher.onHeadChanged = { [weak self] map in self?.handleProjectHeadUpdates(projectId: projectId, branchByWorktreePath: map) }
         watcher.onTopologyChanged = { [weak self] in self?.handleProjectTopologyChange(projectId: projectId) }
@@ -1855,7 +1859,12 @@ final class AppState {
 
     func refreshProjectTopology(projectId: String) async {
         let beforeIds = allWorktreeIds()
+        let previousProjectPath = projectsManager.projects.first { $0.id == projectId }?.path
         if (try? await projectsManager.refreshWorktrees(projectId: projectId)) == true { saveProjects() }
+        if let project = projectsManager.projects.first(where: { $0.id == projectId }),
+           project.path != previousProjectPath {
+            startProjectGitWatcher(for: project)
+        }
         let afterIds = allWorktreeIds()
         let addedIds = afterIds.subtracting(beforeIds)
         if !addedIds.isEmpty {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1633,10 +1633,9 @@ final class AppState {
         spacesManager.addProject(project.id, toSpace: spacesManager.activeSpaceId)
         saveProjects()
         saveSpaces()
-        if await projectsManager.refreshAll() {
-            saveProjects()
-        }
-        startProjectGitWatcher(for: project)
+        _ = await refreshAllProjectTopologies()
+        let refreshedProject = projectsManager.projects.first { $0.id == project.id } ?? project
+        startProjectGitWatcher(for: refreshedProject)
     }
 
     func addProject(
@@ -1859,18 +1858,36 @@ final class AppState {
 
     func refreshProjectTopology(projectId: String) async {
         let beforeIds = allWorktreeIds()
-        let previousProjectPath = projectsManager.projects.first { $0.id == projectId }?.path
+        let previousPaths = Dictionary(uniqueKeysWithValues: projectsManager.projects
+            .filter { $0.id == projectId }
+            .map { ($0.id, $0.path) })
         if (try? await projectsManager.refreshWorktrees(projectId: projectId)) == true { saveProjects() }
-        if let project = projectsManager.projects.first(where: { $0.id == projectId }),
-           project.path != previousProjectPath {
-            startProjectGitWatcher(for: project)
-        }
+        restartProjectGitWatchers(previousPaths: previousPaths)
         let afterIds = allWorktreeIds()
         let addedIds = afterIds.subtracting(beforeIds)
         if !addedIds.isEmpty {
             tabs.loadAll(worktreeIds: Array(addedIds))
         }
         cleanupMissingWorktrees(beforeIds: beforeIds)
+    }
+
+    /// Refresh every project, persist any reconciled configuration, and move
+    /// existing watchers when a deleted linked-worktree anchor is replaced.
+    @discardableResult
+    func refreshAllProjectTopologies() async -> Bool {
+        let previousPaths = Dictionary(uniqueKeysWithValues: projectsManager.projects.map { ($0.id, $0.path) })
+        let changed = await projectsManager.refreshAll()
+        if changed { saveProjects() }
+        restartProjectGitWatchers(previousPaths: previousPaths)
+        return changed
+    }
+
+    private func restartProjectGitWatchers(previousPaths: [String: String]) {
+        for project in projectsManager.projects {
+            guard let previousPath = previousPaths[project.id], previousPath != project.path else { continue }
+            guard projectGitWatchers[project.id] != nil || remoteProjectWatchers[project.id] != nil else { continue }
+            startProjectGitWatcher(for: project)
+        }
     }
 
     func updateProject(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -461,14 +461,14 @@ final class AppState {
     @ObservationIgnored
     private var remoteProjectWatchers: [String: RemoteProjectGitWatcher] = [:]
     @ObservationIgnored
-    private let projectGitWatcherFactory: (URL) -> ProjectGitWatcher
+    private let projectGitWatcherFactory: @MainActor (URL) -> ProjectGitWatcher
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
         persistenceErrorHandler: ((String, String) -> Void)? = nil,
         fileActionErrorHandler: ((String, String) -> Void)? = nil,
         terminalSessionOpener: TerminalSessionOpener? = nil,
-        projectGitWatcherFactory: @escaping (URL) -> ProjectGitWatcher = { ProjectGitWatcher(repoPath: $0) }
+        projectGitWatcherFactory: @escaping @MainActor (URL) -> ProjectGitWatcher = { ProjectGitWatcher(repoPath: $0) }
     ) {
         self.store = store
         self.persistenceErrorHandler = persistenceErrorHandler ?? { title, message in

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -327,7 +327,17 @@ final class ProjectsManager {
     @discardableResult
     func refreshWorktrees(projectId: String) async throws -> Bool {
         guard let project = projects.first(where: { $0.id == projectId }) else { return false }
-        let url = URL(fileURLWithPath: project.path)
+        let configuredURL = URL(fileURLWithPath: project.path)
+        let url: URL
+        if project.host == nil,
+           !FileManager.default.fileExists(atPath: configuredURL.path),
+           let survivingWorktree = worktreesByProject[projectId, default: []].first(where: {
+               FileManager.default.fileExists(atPath: $0.path.path)
+           }) {
+            url = survivingWorktree.path
+        } else {
+            url = configuredURL
+        }
         let trees = try await worktreeSvc.list(repoPath: url, projectId: projectId)
 
         // Reconcile optimistic rows: preserve creating rows until the owner

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -329,6 +329,8 @@ final class ProjectsManager {
         guard let project = projects.first(where: { $0.id == projectId }) else { return false }
         let configuredURL = URL(fileURLWithPath: project.path)
         let url: URL
+        // gg clean can remove the linked worktree stored as the project path.
+        // Query from another cached checkout so the deleted row can be reconciled.
         if project.host == nil,
            !FileManager.default.fileExists(atPath: configuredURL.path),
            let survivingWorktree = worktreesByProject[projectId, default: []].first(where: {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -341,6 +341,7 @@ final class ProjectsManager {
             url = configuredURL
         }
         let trees = try await worktreeSvc.list(repoPath: url, projectId: projectId)
+        let anchorChanged = url.standardizedFileURL != configuredURL.standardizedFileURL
 
         // Reconcile optimistic rows: preserve creating rows until the owner
         // task completes, while still replacing them with real rows when
@@ -390,10 +391,13 @@ final class ProjectsManager {
         let orderChanged = applyWorktreeOrdering(projectId: projectId)
 
         guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return false }
+        if anchorChanged {
+            projects[idx].path = url.path
+        }
         let live = Set(trees.map { canonical($0.path) })
         let before = projects[idx].hiddenWorktreePaths.count
         projects[idx].hiddenWorktreePaths.removeAll { !live.contains($0) }
-        return orderChanged || projects[idx].hiddenWorktreePaths.count != before
+        return anchorChanged || orderChanged || projects[idx].hiddenWorktreePaths.count != before
     }
 
     func reconcileRemoteHostRegistrations(project: ProjectConfig, previous: [Worktree], reconciled: [Worktree]) {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -64,9 +64,7 @@ struct RootView: View {
             }
             .task {
                 state.startHarness()
-                if await state.projectsManager.refreshAll() {
-                    state.saveProjects()
-                }
+                _ = await state.refreshAllProjectTopologies()
                 // Worktrees now exist — load any persisted tab files for them. Init
                 // can't do this because refreshAll runs async after init.
                 state.reloadTabs()
@@ -662,10 +660,7 @@ private struct RootBaseHandlers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .alasRefreshWorktrees)) { _ in
                 let beforeIds = state.allWorktreeIds()
                 Task {
-                    let changed = await state.projectsManager.refreshAll()
-                    if changed {
-                        state.saveProjects()
-                    }
+                    _ = await state.refreshAllProjectTopologies()
                     state.cleanupMissingWorktrees(beforeIds: beforeIds)
                 }
             }

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -5,6 +5,11 @@ import Foundation
 @Suite(.serialized)
 @MainActor
 struct AppStateCleanupTests {
+    enum AnchorRefreshPath {
+        case refreshAll
+        case clearProjectsWithoutWorktrees
+    }
+
     private struct MemoryStore: PersistenceStoreProtocol {
         var config: AppConfig? = nil
         var projectsFile: ProjectsFile? = nil
@@ -200,7 +205,8 @@ struct AppStateCleanupTests {
         #expect(state.tabs.tabs(forWorktree: linkedId).map(\.title) == ["persisted"])
     }
 
-    @Test func refreshAllRestartsWatcherWhenProjectAnchorChanges() async throws {
+    @Test(arguments: [AnchorRefreshPath.refreshAll, .clearProjectsWithoutWorktrees])
+    func refreshRestartsWatcherWhenProjectAnchorChanges(_ refreshPath: AnchorRefreshPath) async throws {
         let repo = try await makeRepo(name: "topology-anchor-watcher")
         let linked = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleanup-linked-\(UUID().uuidString)")
@@ -251,7 +257,13 @@ struct AppStateCleanupTests {
             deleteBranchIfMerged: false,
             force: false
         )
-        await state.refreshAllProjectTopologies()
+        switch refreshPath {
+        case .refreshAll:
+            await state.refreshAllProjectTopologies()
+        case .clearProjectsWithoutWorktrees:
+            let removed = await state.clearProjectsWithoutWorktrees()
+            #expect(removed == 0)
+        }
 
         #expect(watchedPaths.map(\.path) == [linked.standardizedFileURL.path, repo.standardizedFileURL.path])
     }

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -200,6 +200,62 @@ struct AppStateCleanupTests {
         #expect(state.tabs.tabs(forWorktree: linkedId).map(\.title) == ["persisted"])
     }
 
+    @Test func topologyRefreshRestartsWatcherWhenProjectAnchorChanges() async throws {
+        let repo = try await makeRepo(name: "topology-anchor-watcher")
+        let linked = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleanup-linked-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: linked)
+            try? FileManager.default.removeItem(at: repo)
+        }
+
+        let projectId = "topology-anchor-watcher"
+        let worktreeService = WorktreeService()
+        let linkedWorktree = try await worktreeService.add(
+            repoPath: repo,
+            base: "main",
+            branch: "linked-anchor",
+            destination: linked,
+            projectId: projectId
+        )
+        let project = ProjectConfig(
+            id: projectId,
+            name: "topology-anchor-watcher",
+            path: linked.path,
+            color: "#5fb7c4",
+            addedAt: Date()
+        )
+        var watchedPaths: [URL] = []
+        let state = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [project])),
+            projectGitWatcherFactory: { path in
+                watchedPaths.append(path.standardizedFileURL)
+                return ProjectGitWatcher(
+                    repoPath: path,
+                    resolvedGitDir: repo.appendingPathComponent(".git"),
+                    resolvedWorktreeRoot: path,
+                    headDebounceInterval: 0.01,
+                    headDebounceMaxWait: 0.02,
+                    topologyDebounceInterval: 0.01,
+                    topologyDebounceMaxWait: 0.02,
+                    startStreamOverride: { _, _ in }
+                )
+            }
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: projectId)
+        state.startProjectGitWatcher(for: project)
+
+        try await worktreeService.remove(
+            repoPath: repo,
+            worktree: linkedWorktree,
+            deleteBranchIfMerged: false,
+            force: false
+        )
+        await state.refreshProjectTopology(projectId: projectId)
+
+        #expect(watchedPaths.map(\.path) == [linked.standardizedFileURL.path, repo.standardizedFileURL.path])
+    }
+
     @Test func createWorktreeInsertsOptimisticRowImmediately() async throws {
         let repo = try await makeRepo(name: "create-opt")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -200,7 +200,7 @@ struct AppStateCleanupTests {
         #expect(state.tabs.tabs(forWorktree: linkedId).map(\.title) == ["persisted"])
     }
 
-    @Test func topologyRefreshRestartsWatcherWhenProjectAnchorChanges() async throws {
+    @Test func refreshAllRestartsWatcherWhenProjectAnchorChanges() async throws {
         let repo = try await makeRepo(name: "topology-anchor-watcher")
         let linked = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleanup-linked-\(UUID().uuidString)")
@@ -251,7 +251,7 @@ struct AppStateCleanupTests {
             deleteBranchIfMerged: false,
             force: false
         )
-        await state.refreshProjectTopology(projectId: projectId)
+        await state.refreshAllProjectTopologies()
 
         #expect(watchedPaths.map(\.path) == [linked.standardizedFileURL.path, repo.standardizedFileURL.path])
     }

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -95,11 +95,20 @@ struct ProjectsManagerTests {
             deleteBranchIfMerged: false,
             force: false
         )
-        try await manager.refreshWorktrees(projectId: projectId)
+        let projectChanged = try await manager.refreshWorktrees(projectId: projectId)
 
         let remaining = manager.worktrees(projectId: projectId)
+        #expect(projectChanged)
         #expect(remaining.count == 1)
         #expect(remaining.first?.path.standardizedFileURL == repo.standardizedFileURL)
+        let persistedPath = manager.projects.first.map { URL(fileURLWithPath: $0.path).standardizedFileURL }
+        #expect(persistedPath == repo.standardizedFileURL)
+
+        let restartedManager = ProjectsManager(persistedProjects: manager.projects)
+        try await restartedManager.refreshWorktrees(projectId: projectId)
+        let restartedWorktrees = restartedManager.worktrees(projectId: projectId)
+        #expect(restartedWorktrees.count == 1)
+        #expect(restartedWorktrees.first?.path.standardizedFileURL == repo.standardizedFileURL)
     }
 
     @Test func remoteRegistrationReconcileUnregistersRemovedWorktreeRoots() {

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -65,6 +65,43 @@ struct ProjectsManagerTests {
         #expect(trees.first?.branch == "main")
     }
 
+    @Test func refreshWorktreesFallsBackWhenConfiguredLinkedWorktreeDisappears() async throws {
+        let repo = try await makeRepo(name: "linked-anchor")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let service = WorktreeService()
+        let linkedPath = repo.appendingPathComponent("linked-anchor")
+        let projectId = "linked-anchor-project"
+        let linkedWorktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "linked-anchor-branch",
+            destination: linkedPath,
+            projectId: projectId
+        )
+        let project = ProjectConfig(
+            id: projectId,
+            name: "linked-anchor",
+            path: linkedPath.path,
+            color: "#5fb7c4",
+            addedAt: Date()
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+        try await manager.refreshWorktrees(projectId: projectId)
+        #expect(manager.worktrees(projectId: projectId).count == 2)
+
+        try await service.remove(
+            repoPath: repo,
+            worktree: linkedWorktree,
+            deleteBranchIfMerged: false,
+            force: false
+        )
+        try await manager.refreshWorktrees(projectId: projectId)
+
+        let remaining = manager.worktrees(projectId: projectId)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.path.standardizedFileURL == repo.standardizedFileURL)
+    }
+
     @Test func remoteRegistrationReconcileUnregistersRemovedWorktreeRoots() {
         let project = ProjectConfig(
             id: "remote-project",


### PR DESCRIPTION
## What changed

- fall back to a cached surviving local worktree when the configured project path has disappeared
- keep remote-project refresh behavior unchanged
- add an integration regression test for removing the linked worktree used as the project path

## Why

Follow-up to the Codex review on #855. A removed linked worktree could remain the unusable topology refresh anchor and leave stale worktree rows and tabs.

## Validation

- xcodegen
- SwiftFormat lint
- clean macOS build
- ProjectsManagerTests
- identical commit passed GitHub Actions on #856