### PR TITLE
feat(gg): stacked-diffs phase 3 — agent integration and hardening

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		1901EE20123215C998400B25 /* ACPAdapterInstallCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2F61CCAFB23F6C394ACD8D /* ACPAdapterInstallCoordinatorTests.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
+		192F93BD900B2DC13205E96E /* GGAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9480C66C4CDDB090A5F4FB /* GGAvailabilityTests.swift */; };
 		195102F7D680452476D70329 /* GitLabCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */; };
 		1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
@@ -2566,6 +2567,7 @@
 		EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAgentProposalView.swift; sourceTree = "<group>"; };
 		EF5F20AB3B3F7BCEAA56B143 /* SQLiteDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabase.swift; sourceTree = "<group>"; };
 		EF69D638124D1B4D1C04BD31 /* ProviderReviewPublishConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewPublishConfirmationView.swift; sourceTree = "<group>"; };
+		EF9480C66C4CDDB090A5F4FB /* GGAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGAvailabilityTests.swift; sourceTree = "<group>"; };
 		EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateSpacesTests.swift; sourceTree = "<group>"; };
 		F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTopPaginationIndicator.swift; sourceTree = "<group>"; };
 		F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCFramerTests.swift; sourceTree = "<group>"; };
@@ -4583,6 +4585,7 @@
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				1A25C83033616FE27526C945 /* GGActionEventsTests.swift */,
+				EF9480C66C4CDDB090A5F4FB /* GGAvailabilityTests.swift */,
 				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
 				B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
@@ -6208,6 +6211,7 @@
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */,
+				192F93BD900B2DC13205E96E /* GGAvailabilityTests.swift in Sources */,
 				A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -757,6 +757,7 @@
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
 		9547580C9DFECD838C120B90 /* DiffReviewRenderEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */; };
 		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
+		95DAB9F9E361DFD0395CC4C2 /* GGStackSummaryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4FE9500B277A3921C8AB2 /* GGStackSummaryStoreTests.swift */; };
 		960593EAB0380436038D1400 /* ACPSessionToolCallTruncationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */; };
 		962361DC40B0707AB7CA6E75 /* session-update-tool-call-update-no-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 30BAC172C16C360F917B6EED /* session-update-tool-call-update-no-meta.json */; };
 		9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */; };
@@ -1674,6 +1675,7 @@
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
 		3E3ADEB5299C3FFB091D55EE /* session-update-tool-call-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-tool-call-meta.json"; sourceTree = "<group>"; };
 		3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupChecker.swift; sourceTree = "<group>"; };
+		3EC4FE9500B277A3921C8AB2 /* GGStackSummaryStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackSummaryStoreTests.swift; sourceTree = "<group>"; };
 		3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeatureRenderingTests.swift; sourceTree = "<group>"; };
 		3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdapterUpdateState.swift; sourceTree = "<group>"; };
 		3F3914A1820E1098DA558CD0 /* ACPTerminalHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHostTests.swift; sourceTree = "<group>"; };
@@ -4606,6 +4608,7 @@
 				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
 				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
 				F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */,
+				3EC4FE9500B277A3921C8AB2 /* GGStackSummaryStoreTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
@@ -6239,6 +6242,7 @@
 				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
 				CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */,
+				95DAB9F9E361DFD0395CC4C2 /* GGStackSummaryStoreTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,
 				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -346,6 +346,7 @@
 		40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */; };
 		40C56ABCF57F6F3F7D40E020 /* RemoteHelperInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */; };
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
+		40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */; };
 		4107D595F9EBF8A1FC69E101 /* EditorFindRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB950CFAAADD11E84E783E1F /* EditorFindRequestTests.swift */; };
 		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
 		4135B5BC24856ED442E39069 /* GitServiceStashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */; };
@@ -1208,6 +1209,7 @@
 		E541E14A713FB78AF4595FEB /* ReviewRequestContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */; };
 		E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */; };
 		E5D32C15B08F30DF3B46CA74 /* DiffReviewScrollSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */; };
+		E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */; };
 		E6426E94A57602E76D401D21 /* AlasActionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005F92E45C7D391D8BD5A3FD /* AlasActionService.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */; };
@@ -2054,6 +2056,7 @@
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
 		8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProviderTests.swift; sourceTree = "<group>"; };
+		8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMCPInjectionTests.swift; sourceTree = "<group>"; };
 		8CA0EE530F852A921942B04C /* ACPRemoteLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteLaunchTests.swift; sourceTree = "<group>"; };
 		8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictColumnView.swift; sourceTree = "<group>"; };
 		8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulse.swift; sourceTree = "<group>"; };
@@ -2128,6 +2131,7 @@
 		9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTerminalRoutingTests.swift; sourceTree = "<group>"; };
 		9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSunPathBudget.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
+		9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMCPInjection.swift; sourceTree = "<group>"; };
 		9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffSelectionBridgingTests.swift; sourceTree = "<group>"; };
 		9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileOps.swift; sourceTree = "<group>"; };
 		9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTransitionalView.swift; sourceTree = "<group>"; };
@@ -4589,6 +4593,7 @@
 				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
 				B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
+				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
 				7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */,
@@ -4844,6 +4849,7 @@
 				F1F0EED235328724082B570B /* GGActionEvents.swift */,
 				56A2D492EE89A160CD404985 /* GGConfigReader.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
+				9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */,
@@ -5553,6 +5559,7 @@
 				1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */,
 				31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
+				E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */,
@@ -6216,6 +6223,7 @@
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
+				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
 				EE4A552DB5EF6559CA1A5AE0 /* GGStackActionStateTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		0E892EAAAC4EBA733BC441F2 /* MergeRegionVisualLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */; };
 		0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */; };
 		0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */; };
+		0F118A7F54315A836A169B89 /* GGStackCreateModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BDCB22C2FDC36F6022ADB3 /* GGStackCreateModeTests.swift */; };
 		0F556F82FA5BF1E8D50096E2 /* RemoteConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3066B2C18213B0105D32213F /* RemoteConfigTests.swift */; };
 		0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */; };
 		0FA612529F7E2BC05E577420 /* RemoteAccessPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DAD29A75E3651CA720017D /* RemoteAccessPolicy.swift */; };
@@ -1208,6 +1209,7 @@
 		E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */; };
 		E541E14A713FB78AF4595FEB /* ReviewRequestContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */; };
 		E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */; };
+		E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */; };
 		E5D32C15B08F30DF3B46CA74 /* DiffReviewScrollSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */; };
 		E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */; };
 		E6426E94A57602E76D401D21 /* AlasActionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005F92E45C7D391D8BD5A3FD /* AlasActionService.swift */; };
@@ -1933,6 +1935,7 @@
 		708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottleTests.swift; sourceTree = "<group>"; };
 		7094534860369BA79FC5A877 /* session-update-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-plan.json"; sourceTree = "<group>"; };
 		7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinator.swift; sourceTree = "<group>"; };
+		70BDCB22C2FDC36F6022ADB3 /* GGStackCreateModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackCreateModeTests.swift; sourceTree = "<group>"; };
 		71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRendererTests.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
 		71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionStateResolverTests.swift; sourceTree = "<group>"; };
@@ -2252,6 +2255,7 @@
 		B5E898E9F7E2680132FF54D4 /* ACPSelectChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChip.swift; sourceTree = "<group>"; };
 		B65018D176CD2E52A3999CF0 /* AlasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackSummaryStore.swift; sourceTree = "<group>"; };
+		B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackCreateMode.swift; sourceTree = "<group>"; };
 		B6F6E707551671670D8CBA38 /* AgentLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLogoView.swift; sourceTree = "<group>"; };
 		B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSidebarContrastTests.swift; sourceTree = "<group>"; };
 		B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGenerator.swift; sourceTree = "<group>"; };
@@ -2984,6 +2988,7 @@
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */,
 				4836677A0E66A8ADD2D9E89A /* GGConfigCodableTests.swift */,
+				70BDCB22C2FDC36F6022ADB3 /* GGStackCreateModeTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
 				6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */,
@@ -4854,6 +4859,7 @@
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */,
 				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
+				B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */,
 				D7860DF249939BC7FC1EBD76 /* GGStackDrawer.swift */,
 				ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
@@ -5564,6 +5570,7 @@
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */,
 				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
+				E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */,
 				3AFEB19356A2BC5E7B6E1E4A /* GGStackDrawer.swift in Sources */,
 				4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
@@ -6228,6 +6235,7 @@
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
 				EE4A552DB5EF6559CA1A5AE0 /* GGStackActionStateTests.swift in Sources */,
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,
+				0F118A7F54315A836A169B89 /* GGStackCreateModeTests.swift in Sources */,
 				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
 				CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
 		316A645ECCB46A0F74915EA4 /* RemoteProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */; };
 		316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */; };
+		31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2D492EE89A160CD404985 /* GGConfigReader.swift */; };
 		31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */; };
 		32324CCE247B8B4784674453 /* RemoteContentSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
@@ -1088,6 +1089,7 @@
 		D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */; };
 		D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */; };
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
+		D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */; };
 		D1826BD546F4C8D2755D8F56 /* ReviewDraftCommentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */; };
 		D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
@@ -1793,6 +1795,7 @@
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeActionGutter.swift; sourceTree = "<group>"; };
 		567E1895FBD42067D10C8C5E /* ACPRemoteNodeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteNodeEnvironment.swift; sourceTree = "<group>"; };
+		56A2D492EE89A160CD404985 /* GGConfigReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGConfigReader.swift; sourceTree = "<group>"; };
 		56BF141F589820AA91674BD0 /* TreeSitterJavaScript */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterJavaScript; path = ThirdParty/TreeSitterJavaScript; sourceTree = SOURCE_ROOT; };
 		56C7878101DA7532B9850D13 /* ProjectIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconView.swift; sourceTree = "<group>"; };
 		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
@@ -2234,6 +2237,7 @@
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
 		B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInstaller.swift; sourceTree = "<group>"; };
+		B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGConfigReaderTests.swift; sourceTree = "<group>"; };
 		B586C7A794B846F3AD9228BD /* RemoteWeb */ = {isa = PBXFileReference; lastKnownFileType = folder; name = RemoteWeb; path = Alas/Resources/RemoteWeb; sourceTree = SOURCE_ROOT; };
 		B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneLSP.swift; sourceTree = "<group>"; };
 		B58DD85A6E01972B39F2D8AD /* AgentPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPath.swift; sourceTree = "<group>"; };
@@ -4580,6 +4584,7 @@
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				1A25C83033616FE27526C945 /* GGActionEventsTests.swift */,
 				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
+				B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
@@ -4834,6 +4839,7 @@
 			isa = PBXGroup;
 			children = (
 				F1F0EED235328724082B570B /* GGActionEvents.swift */,
+				56A2D492EE89A160CD404985 /* GGConfigReader.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
@@ -5542,6 +5548,7 @@
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */,
+				31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
@@ -6203,6 +6210,7 @@
 				0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */,
 				A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
+				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
@@ -81,12 +81,16 @@ enum ACPMCPPromptPreamble {
     ) -> String {
         var lines: [String] = []
         lines.append("<alas-workspace-context>")
-        lines.append(
-            "This session runs inside Alas, the user's macOS workspace app. "
-            + "MCP servers are attached to this session. Some agent harnesses "
-            + "defer MCP tools behind tool search, so they may not appear in "
-            + "your direct tool inventory — they ARE available; use your tool "
-            + "discovery/search mechanism to load them.")
+        if builtInInjected || !userServerNames.isEmpty {
+            lines.append(
+                "This session runs inside Alas, the user's macOS workspace app. "
+                + "MCP servers are attached to this session. Some agent harnesses "
+                + "defer MCP tools behind tool search, so they may not appear in "
+                + "your direct tool inventory — they ARE available; use your tool "
+                + "discovery/search mechanism to load them.")
+        } else {
+            lines.append("This session runs inside Alas, the user's macOS workspace app.")
+        }
         if builtInInjected {
             let sessionTools = isDelegated
                 ? "session_list/session_send"

--- a/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
@@ -13,6 +13,16 @@ enum ACPMCPPreambleMode: Equatable {
     case cli(serverAvailability: ACPMCPExternalStatus.AdapterServerAvailability)
 }
 
+/// gg stacked-diffs context for the session's worktree, rendered as one
+/// extra paragraph of the preamble. `stackName == nil` renders the generic
+/// "this is a gg-enabled worktree" form (repo has gg config but the stack
+/// state wasn't loaded at session start).
+struct GGPreambleStackContext: Equatable {
+    let stackName: String?
+    let entryCount: Int?
+    let ggMCPAttached: Bool
+}
+
 /// Builds the one-time, wire-only context preamble injected into the first
 /// prompt of a freshly created ACP session. Modern agent harnesses defer MCP
 /// tools behind tool search, so the model never sees the attached tools
@@ -35,28 +45,32 @@ enum ACPMCPPromptPreamble {
         builtInInjected: Bool,
         isDelegated: Bool,
         userServerNames: [String],
-        mode: ACPMCPPreambleMode = .mcp
+        mode: ACPMCPPreambleMode = .mcp,
+        ggStack: GGPreambleStackContext? = nil
     ) -> String? {
-        guard builtInInjected || !userServerNames.isEmpty else { return nil }
+        guard builtInInjected || !userServerNames.isEmpty || ggStack != nil else { return nil }
         switch mode {
         case .mcp:
             return mcpText(
                 builtInInjected: builtInInjected,
                 isDelegated: isDelegated,
-                userServerNames: userServerNames)
+                userServerNames: userServerNames,
+                ggStack: ggStack)
         case .cli(let serverAvailability):
             return cliText(
                 builtInInjected: builtInInjected,
                 isDelegated: isDelegated,
                 userServerNames: userServerNames,
-                serverAvailability: serverAvailability)
+                serverAvailability: serverAvailability,
+                ggStack: ggStack)
         }
     }
 
     private static func mcpText(
         builtInInjected: Bool,
         isDelegated: Bool,
-        userServerNames: [String]
+        userServerNames: [String],
+        ggStack: GGPreambleStackContext?
     ) -> String {
         var lines: [String] = []
         lines.append("<alas-workspace-context>")
@@ -88,6 +102,9 @@ enum ACPMCPPromptPreamble {
             lines.append("Additional MCP servers attached: "
                 + userServerNames.joined(separator: ", ") + ".")
         }
+        if let ggStack {
+            lines.append(ggStackLine(ggStack, cliMode: false))
+        }
         lines.append("</alas-workspace-context>")
         return lines.joined(separator: "\n")
     }
@@ -96,7 +113,8 @@ enum ACPMCPPromptPreamble {
         builtInInjected: Bool,
         isDelegated: Bool,
         userServerNames: [String],
-        serverAvailability: ACPMCPExternalStatus.AdapterServerAvailability
+        serverAvailability: ACPMCPExternalStatus.AdapterServerAvailability,
+        ggStack: GGPreambleStackContext?
     ) -> String {
         var lines: [String] = []
         lines.append("<alas-workspace-context>")
@@ -147,7 +165,31 @@ enum ACPMCPPromptPreamble {
                 break
             }
         }
+        if let ggStack {
+            lines.append(ggStackLine(ggStack, cliMode: true))
+        }
         lines.append("</alas-workspace-context>")
         return lines.joined(separator: "\n")
+    }
+
+    private static func ggStackLine(_ context: GGPreambleStackContext, cliMode: Bool) -> String {
+        var line: String
+        if let name = context.stackName {
+            let entries = context.entryCount.map { " (\($0) entr\($0 == 1 ? "y" : "ies"))" } ?? ""
+            line = "This worktree is the gg stacked-diffs stack \"\(name)\"\(entries)."
+        } else {
+            line = "This worktree belongs to a gg stacked-diffs repo."
+        }
+        line += " Keep one logical change per commit; prefer `gg absorb` or "
+            + "`gg amend` to fold changes into existing stack entries; run "
+            + "`gg sync` to push the stack and create/update its PR chain; "
+            + "never push stack branches directly with `git push`. If a gg "
+            + "operation pauses on conflicts, resolve them, then `gg continue` "
+            + "— or `gg abort` to roll back."
+        if context.ggMCPAttached, !cliMode {
+            line += " The MCP server \"git-gud\" exposes stack tools "
+                + "(list/log/sync/land); prefer them over parsing CLI output."
+        }
+        return line
     }
 }

--- a/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
+++ b/Alas/Sources/ACP/Session/ACPMCPPromptPreamble.swift
@@ -23,6 +23,13 @@ struct GGPreambleStackContext: Equatable {
     let ggMCPAttached: Bool
 }
 
+/// What the session's worktree looks like to gg at session-creation time.
+enum GGPreambleSignal: Equatable {
+    case none
+    case generic // gg-enabled repo, stack not loaded
+    case stack(name: String, entryCount: Int) // loaded stack state
+}
+
 /// Builds the one-time, wire-only context preamble injected into the first
 /// prompt of a freshly created ACP session. Modern agent harnesses defer MCP
 /// tools behind tool search, so the model never sees the attached tools

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -33,6 +33,14 @@ final class ACPSessionManager: ObservableObject {
         _ worktreePath: String,
         _ sessionId: ACPSession.ID
     ) async -> BuiltInAlasMCP.Injection?
+    /// Builds the gg-mcp server entry for a worktree path, or nil when gg
+    /// integration is disabled/unavailable for that worktree. Mirrors
+    /// `BuiltInMCPProvider` but is synchronous — gg gating needs no async work.
+    typealias GGMCPProvider = @MainActor (_ worktreePath: String) -> GGMCPInjection.Injection?
+    /// Reports the gg stack state (or lack thereof) for the preamble. Mirrors
+    /// `GGMCPProvider`'s gating so the preamble stays consistent with whether
+    /// gg-mcp was actually attached.
+    typealias GGPreambleProvider = @MainActor (_ worktreePath: String) -> GGPreambleSignal
     /// Extra process env for locally spawned adapters so any agent's shell
     /// can drive the `alas` CLI. Nil (or a nil return) skips injection.
     typealias AlasCLIEnvProvider = @MainActor (
@@ -75,6 +83,13 @@ final class ACPSessionManager: ObservableObject {
     /// or nil when injection is disabled/unavailable. Fetched per attach so
     /// the settings toggle applies to the next (re)connect.
     private let builtInMCPProvider: BuiltInMCPProvider?
+    /// Builds the gg-mcp server entry for a worktree path, or nil when gg
+    /// integration is disabled/unavailable. Fetched per attach, mirroring
+    /// `builtInMCPProvider`.
+    private let ggMCPProvider: GGMCPProvider?
+    /// Reports gg stack state for the first-prompt preamble. Fetched per
+    /// attach, mirroring `builtInMCPProvider`.
+    private let ggPreambleProvider: GGPreambleProvider?
     /// Builds extra env for locally spawned adapter processes so the agent's
     /// shell can drive the `alas` CLI. Set post-init (unlike
     /// `builtInMCPProvider`) so AppState can wire it without threading it
@@ -344,7 +359,9 @@ final class ACPSessionManager: ObservableObject {
          connectionFactory: ACPConnectionFactory? = nil,
          brokerServiceFactory: ACPBrokerServiceFactory? = nil,
          mcpProjectContextProvider: MCPProjectContextProvider? = nil,
-         builtInMCPProvider: BuiltInMCPProvider? = nil)
+         builtInMCPProvider: BuiltInMCPProvider? = nil,
+         ggMCPProvider: GGMCPProvider? = nil,
+         ggPreambleProvider: GGPreambleProvider? = nil)
     {
         precondition(store != nil || persistence != nil, "ACPSessionManager requires persistence")
         let resolvedPersistence = persistence ?? ACPSessionPersistence(path: store!.path)
@@ -360,6 +377,8 @@ final class ACPSessionManager: ObservableObject {
         self.onDelegatedMessageAvailable = onDelegatedMessageAvailable
         self.mcpProjectContextProvider = mcpProjectContextProvider
         self.builtInMCPProvider = builtInMCPProvider
+        self.ggMCPProvider = ggMCPProvider
+        self.ggPreambleProvider = ggPreambleProvider
         self.changeNotifier = changeNotifier ?? DarwinChangeNotifier(worktreeId: worktreeId)
         self.delegatedMessageNotifier = delegatedMessageNotifier
             ?? DarwinChangeNotifier(worktreeId: worktreeId, channel: "delegated-inbox")
@@ -2522,6 +2541,14 @@ extension ACPSessionManager {
                 plannedWireServers.append(builtInMCP.server)
                 plannedStatuses.append(builtInMCP.status)
             }
+            // gg-mcp composes the same way as the alas built-in: after
+            // planning, local-only, suppressed by a user-configured server
+            // of the same name (checked inside the injection).
+            let ggMCP = remoteHost == nil ? ggMCPProvider?(worktreePath) : nil
+            if let ggMCP {
+                plannedWireServers.append(ggMCP.server)
+                plannedStatuses.append(ggMCP.status)
+            }
             session.mcpAttachmentSummary = .init(
                 statuses: plannedStatuses,
                 configurationFingerprint: mcpPlan.configurationFingerprint
@@ -2869,15 +2896,27 @@ extension ACPSessionManager {
                 } else {
                     userServerNames = wireMCPServers.map(\.name)
                         .filter { !(builtInMCP != nil && $0 == BuiltInAlasMCP.serverName) }
+                        .filter { !(ggMCP != nil && $0 == GGMCPInjection.serverName) }
                     preambleMode = .mcp
                 }
+                let ggSignal = ggPreambleProvider?(worktreePath) ?? GGPreambleSignal.none
+                let ggStackContext: GGPreambleStackContext? = {
+                    switch ggSignal {
+                    case .none: return nil
+                    case .generic:
+                        return .init(stackName: nil, entryCount: nil, ggMCPAttached: ggMCP != nil)
+                    case let .stack(name, entryCount):
+                        return .init(stackName: name, entryCount: entryCount, ggMCPAttached: ggMCP != nil)
+                    }
+                }()
                 let preamble = ACPMCPPromptPreamble.text(
                     builtInInjected: preambleMode == .mcp ? (builtInMCP != nil) : cliEnvActive,
                     isDelegated: preambleMode == .mcp
                         ? (builtInMCP?.isDelegated == true)
                         : (cliParentSessionId != nil),
                     userServerNames: userServerNames,
-                    mode: preambleMode
+                    mode: preambleMode,
+                    ggStack: ggStackContext
                 )
                 if isWriter(for: sessionId) {
                     session.pendingMCPPreamble = preamble

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -736,6 +736,13 @@ final class AppState {
         for id in disappeared {
             cleanupWorktreeState(worktreeId: id)
         }
+        // Stack badges are keyed by worktree path; drop entries for
+        // worktrees that no longer exist so deleted stacks don't keep a
+        // stale ▲ badge forever.
+        let livePaths = Set(projectsManager.projects.flatMap { project in
+            projectsManager.worktrees(projectId: project.id).map(\.path.path)
+        })
+        GGStackSummaryStore.shared.prune(keepingPaths: livePaths)
         if reconcileMissingSpaceProjects() {
             saveSpaces()
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4792,6 +4792,41 @@ final class AppState {
                     sessionId: sessionId,
                     parentSessionId: parentSessionId
                 )
+            },
+            ggMCPProvider: { [weak self] worktreePath in
+                guard let self,
+                      let project = self.projects.first(where: { $0.id == worktree.projectId }),
+                      self.config.changes.stackedDiffsEnabled,
+                      GGAvailability.shared.isInstalled,
+                      GGStackGate.projectEnabled(
+                          masterEnabled: true, ggInstalled: true,
+                          mode: project.ggMode, repoPath: project.path,
+                          isRemoteProject: project.host != nil
+                      ),
+                      GGStackGate.repoHasGGConfig(repoPath: worktreePath)
+                else { return nil }
+                return GGMCPInjection.injection(
+                    gatePassed: true,
+                    binaryPath: GGAvailability.shared.ggMCPBinaryPath,
+                    configuredServers: project.mcpServers,
+                    worktreePath: worktreePath
+                )
+            },
+            ggPreambleProvider: { [weak self] worktreePath in
+                guard let self,
+                      let project = self.projects.first(where: { $0.id == worktree.projectId }),
+                      self.config.changes.stackedDiffsEnabled,
+                      GGAvailability.shared.isInstalled,
+                      GGStackGate.projectEnabled(
+                          masterEnabled: true, ggInstalled: true,
+                          mode: project.ggMode, repoPath: project.path,
+                          isRemoteProject: project.host != nil
+                      )
+                else { return .none }
+                if let stack = self.rightPaneStore.stackForWorktreePath(worktreePath) {
+                    return .stack(name: stack.name, entryCount: stack.totalCommits)
+                }
+                return GGStackGate.repoHasGGConfig(repoPath: worktreePath) ? .generic : .none
             }
         )
         mgr.alasCLIEnvProvider = { [weak self] worktreePath, sessionId in

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -58,6 +58,11 @@ struct NewWorktreeDialog: View {
                         isLoading: isLoadingBranches,
                         errorMessage: branchLoadError
                     )
+                    .disabled(stackPinnedBase != nil)
+                }
+                if stackPinnedBase != nil {
+                    Text("Pinned to gg's stack base").font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim"))
                 }
                 DialogField(label: createAsGGStack ? "Stack name" : "Branch name") {
                     AlasField(
@@ -136,13 +141,15 @@ struct NewWorktreeDialog: View {
         .onChange(of: projectId) { _, _ in
             applyLaunchDefaults(for: projectId)
             loadBranchesForSelectedProject()
+            if let pinned = stackPinnedBase { base = pinned }
         }
         .onChange(of: branch) { _, _ in
             createErrorMessage = nil
         }
         .onChange(of: createAsGGStack) { _, isOn in
-            if isOn, branch == state.config.worktrees.branchPrefix {
-                branch = ""
+            if isOn {
+                if branch == state.config.worktrees.branchPrefix { branch = "" }
+                if let pinned = stackPinnedBase { base = pinned }
             }
         }
     }
@@ -190,6 +197,18 @@ struct NewWorktreeDialog: View {
             return GGConfigReader.composeStackBranch(username: username, stackName: branch)
         }
         return branch
+    }
+
+    /// When creating a gg stack, the worktree base is pinned to gg's
+    /// `defaults.base` so the branch is cut from the commit gg will treat as
+    /// the stack base — otherwise a non-default pick would leave gg
+    /// syncing/PR-ing against the repo default. Nil when create-as-stack is
+    /// off/unavailable or gg config records no base (then the picker stays free).
+    private var stackPinnedBase: String? {
+        guard createAsGGStack, case .enabled = ggStackAvailability,
+              let project = state.projects.first(where: { $0.id == projectId })
+        else { return nil }
+        return GGConfigReader.defaultBase(repoPath: project.path)
     }
 
     private var subtitleText: String {
@@ -244,7 +263,7 @@ struct NewWorktreeDialog: View {
                     availableBranches: discovered,
                     configuredDefault: state.config.worktrees.baseBranch
                 )
-                if base == baseBeforeLoad {
+                if base == baseBeforeLoad, stackPinnedBase == nil {
                     base = preferred
                 }
             } catch {

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -18,6 +18,7 @@ struct NewWorktreeDialog: View {
     @State private var base: String = ""
     @State private var branch: String = ""
     @State private var runStartup: Bool = true
+    @State private var createAsGGStack: Bool = false
     @State private var openAfterCreate: Bool = true
     @State private var launchMode: AppConfig.LauncherMode = .terminal
     /// The launcher mode to persist — preserves the user's intent even when
@@ -58,7 +59,7 @@ struct NewWorktreeDialog: View {
                         errorMessage: branchLoadError
                     )
                 }
-                DialogField(label: "Branch name") {
+                DialogField(label: createAsGGStack ? "Stack name" : "Branch name") {
                     AlasField(
                         text: $branch,
                         monospaced: true,
@@ -71,6 +72,21 @@ struct NewWorktreeDialog: View {
                     AlasToggle(on: $runStartup)
                     Text("Run startup script after create").font(.system(size: 12))
                         .foregroundColor(theme.color("fg"))
+                }
+                if ggStackAvailability != .hidden {
+                    HStack(spacing: 10) {
+                        AlasToggle(on: $createAsGGStack)
+                            .disabled({ if case .disabled = ggStackAvailability { return true } else { return false } }())
+                        Text("Create as gg stack").font(.system(size: 12))
+                            .foregroundColor(theme.color("fg"))
+                    }
+                    if case .disabled(let hint) = ggStackAvailability {
+                        Text(hint).font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+                    } else if createAsGGStack, case .enabled(let username) = ggStackAvailability, !branch.isEmpty {
+                        Text("Branch: \(GGConfigReader.composeStackBranch(username: username, stackName: branch))")
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(theme.color("fg-dim"))
+                    }
                 }
                 if let validationMessage = branchValidationMessage, branch != state.config.worktrees.branchPrefix {
                     Text(validationMessage).font(.system(size: 11)).foregroundColor(.red)
@@ -124,6 +140,11 @@ struct NewWorktreeDialog: View {
         .onChange(of: branch) { _, _ in
             createErrorMessage = nil
         }
+        .onChange(of: createAsGGStack) { _, isOn in
+            if isOn, branch == state.config.worktrees.branchPrefix {
+                branch = ""
+            }
+        }
     }
 
     private var presetProject: ProjectConfig? {
@@ -142,6 +163,33 @@ struct NewWorktreeDialog: View {
         case .invalid(let message):
             return message
         }
+    }
+
+    private var ggStackAvailability: GGStackCreateMode.Availability {
+        guard let project = state.projects.first(where: { $0.id == projectId }) else { return .hidden }
+        let gatePassed = state.config.changes.stackedDiffsEnabled
+            && GGAvailability.shared.isInstalled
+            && GGStackGate.projectEnabled(
+                masterEnabled: true, ggInstalled: true,
+                mode: project.ggMode, repoPath: project.path,
+                isRemoteProject: project.host != nil
+            )
+        guard gatePassed else { return .hidden }
+        return GGStackCreateMode.availability(
+            gatePassed: true,
+            username: GGConfigReader.branchUsername(repoPath: project.path)
+        )
+    }
+
+    /// The branch actually created. In stack mode `branch` holds the stack
+    /// name and the real branch is gg's `<username>/<name>` convention;
+    /// otherwise it's the field verbatim (existing behavior, incl. the
+    /// global branchPrefix default the field is seeded with).
+    private var effectiveBranch: String {
+        if createAsGGStack, case .enabled(let username) = ggStackAvailability {
+            return GGConfigReader.composeStackBranch(username: username, stackName: branch)
+        }
+        return branch
     }
 
     private var subtitleText: String {
@@ -170,7 +218,7 @@ struct NewWorktreeDialog: View {
             template: state.config.worktrees.pathTemplate,
             worktreeRoot: state.config.worktrees.rootPath,
             repoName: project.name,
-            branch: branch
+            branch: effectiveBranch
         ).path
     }
 
@@ -254,7 +302,7 @@ struct NewWorktreeDialog: View {
             let id = await state.createWorktree(
                 projectId: project.id,
                 base: base,
-                branch: branch,
+                branch: effectiveBranch,
                 destination: dest,
                 runStartup: runStartup,
                 launchSurface: surface

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -141,6 +141,7 @@ struct NewWorktreeDialog: View {
         .onChange(of: projectId) { _, _ in
             applyLaunchDefaults(for: projectId)
             loadBranchesForSelectedProject()
+            createAsGGStack = Self.stackModeSurvives(createAsGGStack, availability: ggStackAvailability)
             if let pinned = stackPinnedBase { base = pinned }
         }
         .onChange(of: branch) { _, _ in
@@ -361,6 +362,21 @@ struct NewWorktreeDialog: View {
         guard !projectsEmpty, !branchEmpty, branchValidation == nil else { return false }
         if requiresAcpAgent, !hasAcpAgent { return false }
         return true
+    }
+
+    /// Stack mode only survives while the selected project still offers it.
+    /// Switching to a repo where gg stacks aren't enabled (or `branch_username`
+    /// is unresolved, so availability is `.disabled`/`.hidden` rather than
+    /// `.enabled`) clears the toggle — otherwise Create would silently produce a
+    /// plain branch named after the intended stack, since `effectiveBranch`
+    /// falls back to the raw field when availability isn't `.enabled`.
+    nonisolated static func stackModeSurvives(
+        _ on: Bool,
+        availability: GGStackCreateMode.Availability
+    ) -> Bool {
+        guard on else { return false }
+        if case .enabled = availability { return true }
+        return false
     }
 
     nonisolated static func resolvedPresetProject(

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -147,4 +147,5 @@ struct GGLandResult: Equatable {
 struct GGLandedEntry: Equatable, Decodable {
     let position: Int
     let prNumber: Int?
+    var action: String? = nil
 }

--- a/Alas/Sources/Integrations/GG/GGConfigReader.swift
+++ b/Alas/Sources/Integrations/GG/GGConfigReader.swift
@@ -17,11 +17,29 @@ enum GGConfigReader {
         globalConfigPath: String? = GGConfigReader.defaultGlobalConfigPath
     ) -> String? {
         if let repoConfig = GGStackGate.ggConfigPath(repoPath: repoPath),
-           let username = readBranchUsername(atPath: repoConfig) {
+           let username = readDefault(key: "branch_username", atPath: repoConfig) {
             return username
         }
-        if let globalConfigPath, let username = readBranchUsername(atPath: globalConfigPath) {
+        if let globalConfigPath, let username = readDefault(key: "branch_username", atPath: globalConfigPath) {
             return username
+        }
+        return nil
+    }
+
+    /// `defaults.base` from the repo's gg config, falling back to the global
+    /// config. Nil when neither sets it (or files are unreadable). gg records
+    /// this on init; when present it is the commit new stacks are expected to
+    /// track, so create-as-stack pins the worktree base to it.
+    static func defaultBase(
+        repoPath: String,
+        globalConfigPath: String? = GGConfigReader.defaultGlobalConfigPath
+    ) -> String? {
+        if let repoConfig = GGStackGate.ggConfigPath(repoPath: repoPath),
+           let base = readDefault(key: "base", atPath: repoConfig) {
+            return base
+        }
+        if let globalConfigPath, let base = readDefault(key: "base", atPath: globalConfigPath) {
+            return base
         }
         return nil
     }
@@ -31,13 +49,13 @@ enum GGConfigReader {
         "\(username)/\(stackName)"
     }
 
-    private static func readBranchUsername(atPath path: String) -> String? {
+    private static func readDefault(key: String, atPath path: String) -> String? {
         guard let data = FileManager.default.contents(atPath: path),
               let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
               let defaults = object["defaults"] as? [String: Any],
-              let username = defaults["branch_username"] as? String,
-              !username.isEmpty
+              let value = defaults[key] as? String,
+              !value.isEmpty
         else { return nil }
-        return username
+        return value
     }
 }

--- a/Alas/Sources/Integrations/GG/GGConfigReader.swift
+++ b/Alas/Sources/Integrations/GG/GGConfigReader.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Tolerant reads of gg's JSON config. gg persists `defaults.branch_username`
+/// on first `gg co` (or the user sets it), so config is a reliable source for
+/// any repo where gg has been used; when absent we fail closed (callers
+/// disable the dependent feature with a hint) rather than re-implementing
+/// gg's gh/glab whoami resolution.
+enum GGConfigReader {
+    static var defaultGlobalConfigPath: String {
+        (NSHomeDirectory() as NSString).appendingPathComponent(".config/gg/config.json")
+    }
+
+    /// `defaults.branch_username` from the repo's gg config, falling back to
+    /// the global config. Nil when neither sets it (or files are unreadable).
+    static func branchUsername(
+        repoPath: String,
+        globalConfigPath: String? = GGConfigReader.defaultGlobalConfigPath
+    ) -> String? {
+        if let repoConfig = GGStackGate.ggConfigPath(repoPath: repoPath),
+           let username = readBranchUsername(atPath: repoConfig) {
+            return username
+        }
+        if let globalConfigPath, let username = readBranchUsername(atPath: globalConfigPath) {
+            return username
+        }
+        return nil
+    }
+
+    /// gg's stack-branch naming convention.
+    static func composeStackBranch(username: String, stackName: String) -> String {
+        "\(username)/\(stackName)"
+    }
+
+    private static func readBranchUsername(atPath path: String) -> String? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let defaults = object["defaults"] as? [String: Any],
+              let username = defaults["branch_username"] as? String,
+              !username.isEmpty
+        else { return nil }
+        return username
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGMCPInjection.swift
+++ b/Alas/Sources/Integrations/GG/GGMCPInjection.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Auto-attached gg MCP server for ACP sessions in gg-gated worktrees.
+/// Mirrors `BuiltInAlasMCP`: composed alongside — never inside —
+/// `MCPAttachmentPlanner`, so the planner stays a pure function of user
+/// configuration. A project-configured server named "git-gud" is an
+/// intentional user override and suppresses the auto-attach.
+enum GGMCPInjection {
+    static let serverName = "git-gud"
+    static let statusId = "builtin-gg-mcp"
+
+    struct Injection: Equatable {
+        let server: ACPMCPServer
+        let status: MCPAttachmentServerStatus
+    }
+
+    /// The wire entry + status row for the built-in gg-mcp server, or nil
+    /// when it must not be injected: the gg gate did not pass, the gg-mcp
+    /// binary is unavailable, or the project already configures a server
+    /// named "git-gud" (an intentional user override).
+    static func injection(
+        gatePassed: Bool,
+        binaryPath: String?,
+        configuredServers: [ProjectMCPServer],
+        worktreePath: String
+    ) -> Injection? {
+        guard gatePassed, let binaryPath else { return nil }
+        let userOverride = configuredServers.contains {
+            $0.name.trimmingCharacters(in: .whitespacesAndNewlines) == serverName
+        }
+        guard !userOverride else { return nil }
+        return Injection(
+            server: .stdio(
+                name: serverName,
+                command: binaryPath,
+                args: [],
+                env: [.init(name: "GG_REPO_PATH", value: worktreePath)]
+            ),
+            status: .init(
+                id: statusId,
+                name: serverName,
+                transport: .stdio,
+                disposition: .requested
+            )
+        )
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -25,12 +25,8 @@ extension GGCommandRunning {
                     }
                     if result.exitCode == 0 {
                         continuation.finish()
-                    } else if result.exitCode == 127 {
-                        continuation.finish(throwing: GGServiceError.cliMissing)
                     } else {
-                        continuation.finish(throwing: GGServiceError.commandFailed(
-                            stderr: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-                        ))
+                        continuation.finish(throwing: GGServiceError.map(exitCode: result.exitCode, stderr: result.stderr))
                     }
                 } catch {
                     continuation.finish(throwing: error)
@@ -131,12 +127,8 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                         continuation.finish(throwing: ProcessError.timedOut(executable: executable, args: args, seconds: timeout))
                     } else if status == 0 {
                         continuation.finish()
-                    } else if status == 127 {
-                        continuation.finish(throwing: GGServiceError.cliMissing)
                     } else {
-                        continuation.finish(throwing: GGServiceError.commandFailed(
-                            stderr: stderrAccum.text().trimmingCharacters(in: .whitespacesAndNewlines)
-                        ))
+                        continuation.finish(throwing: GGServiceError.map(exitCode: status, stderr: stderrAccum.text()))
                     }
                 }
             }
@@ -310,13 +302,11 @@ struct GGService {
             throw GGServiceError.commandFailed(stderr: String(describing: error))
         }
         guard result.exitCode == 0 else {
-            if result.exitCode == 127 { throw GGServiceError.cliMissing }
+            if result.exitCode == 127 { throw GGServiceError.map(exitCode: result.exitCode, stderr: result.stderr) }
             if let message = GGActionErrorMessage.parse(fromJSON: Data(result.stdout.utf8)) {
                 throw GGServiceError.commandFailed(stderr: message)
             }
-            throw GGServiceError.commandFailed(
-                stderr: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            )
+            throw GGServiceError.map(exitCode: result.exitCode, stderr: result.stderr)
         }
         return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8)).stack
     }
@@ -393,13 +383,11 @@ struct GGService {
             throw GGServiceError.commandFailed(stderr: String(describing: error))
         }
         guard result.exitCode == 0 else {
-            if result.exitCode == 127 { throw GGServiceError.cliMissing }
+            if result.exitCode == 127 { throw GGServiceError.map(exitCode: result.exitCode, stderr: result.stderr) }
             if let message = GGActionErrorMessage.parse(fromJSON: Data(result.stdout.utf8)) {
                 throw GGServiceError.commandFailed(stderr: message)
             }
-            throw GGServiceError.commandFailed(
-                stderr: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            )
+            throw GGServiceError.map(exitCode: result.exitCode, stderr: result.stderr)
         }
         return result
     }

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -347,11 +347,13 @@ struct GGService {
         let result = try await runChecked(args: args, worktreePath: worktreePath)
         do {
             return try GGLandResult.decode(fromJSON: Data(result.stdout.utf8))
-        } catch {
-            // Exit 0 means the land completed; output-shape drift must not
+        } catch GGServiceError.malformedOutput {
+            // Exit 0 means the land completed; JSON-shape drift must not
             // surface as a failure after the PRs were already merged.
             return GGLandResult(landed: [])
         }
+        // A real in-band error (GGServiceError.commandFailed thrown by
+        // decode) and anything else still propagate.
     }
 
     func clean(worktreePath: String) async throws {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -410,12 +410,29 @@ final class GGAvailability {
 
     private(set) var version: String?
     private(set) var hasProbed = false
+    private(set) var ggMCPBinaryPath: String?
 
     var isInstalled: Bool { version != nil }
 
-    func probe(service: GGService = GGService(), force: Bool = false) async {
+    /// Resolves an executable path via `which` on the login-shell PATH.
+    /// Never executes the target binary (gg-mcp is a stdio server that
+    /// would block if run); `which` only resolves.
+    static let defaultWhich: @Sendable (String) async -> String? = { name in
+        guard let result = try? await Process.run(
+            "/usr/bin/env", args: ["which", name], env: Process.gitEnv()
+        ), result.exitCode == 0 else { return nil }
+        let path = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return path.isEmpty ? nil : path
+    }
+
+    func probe(
+        service: GGService = GGService(),
+        which: @Sendable (String) async -> String? = GGAvailability.defaultWhich,
+        force: Bool = false
+    ) async {
         if hasProbed && !force { return }
         version = await service.probeVersion()
+        ggMCPBinaryPath = version != nil ? await which("gg-mcp") : nil
         hasProbed = true
     }
 }

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -345,7 +345,13 @@ struct GGService {
     func land(worktreePath: String, until: String?) async throws -> GGLandResult {
         let args: [String] = until.map { ["land", "--until", $0, "--json", "--no-clean"] } ?? ["land", "--all", "--json", "--no-clean"]
         let result = try await runChecked(args: args, worktreePath: worktreePath)
-        return try GGLandResult.decode(fromJSON: Data(result.stdout.utf8))
+        do {
+            return try GGLandResult.decode(fromJSON: Data(result.stdout.utf8))
+        } catch {
+            // Exit 0 means the land completed; output-shape drift must not
+            // surface as a failure after the PRs were already merged.
+            return GGLandResult(landed: [])
+        }
     }
 
     func clean(worktreePath: String) async throws {

--- a/Alas/Sources/Integrations/GG/GGStackActionState.swift
+++ b/Alas/Sources/Integrations/GG/GGStackActionState.swift
@@ -64,8 +64,17 @@ final class GGStackActionState {
         return parts.joined(separator: " · ")
     }
 
-    static func landSummaryLine(landedCount: Int) -> String? {
-        guard landedCount > 0 else { return nil }
-        return "Landed \(landedCount) PR\(landedCount == 1 ? "" : "s")"
+    /// One-line result for a completed land. Distinguishes merged PRs from
+    /// entries only queued into a merge train (GitLab auto-merge: gg reports
+    /// `queued`/`already_queued`), so the drawer never claims a queued MR was
+    /// landed. Nil when nothing landed.
+    static func landSummaryLine(from landed: [GGLandedEntry]) -> String? {
+        guard !landed.isEmpty else { return nil }
+        let queued = landed.filter { $0.action == "queued" || $0.action == "already_queued" }.count
+        let merged = landed.count - queued
+        var parts: [String] = []
+        if merged > 0 { parts.append("Landed \(merged) PR\(merged == 1 ? "" : "s")") }
+        if queued > 0 { parts.append("Queued \(queued) PR\(queued == 1 ? "" : "s")") }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 }

--- a/Alas/Sources/Integrations/GG/GGStackActionState.swift
+++ b/Alas/Sources/Integrations/GG/GGStackActionState.swift
@@ -28,11 +28,13 @@ final class GGStackActionState {
     private(set) var syncProgress: [GGSyncEvent] = []
     private(set) var lastError: String?
     private(set) var pausedOperation: GGPausedOperation?
+    private(set) var lastActionSummary: String?
 
     /// Returns false when another action is already running (one at a time).
     func beginAction(_ action: GGStackActionKind) -> Bool {
         guard inFlightAction == nil else { return false }
         inFlightAction = action
+        if lastActionSummary != nil { lastActionSummary = nil }
         return true
     }
 
@@ -47,4 +49,23 @@ final class GGStackActionState {
     func clearError() { if lastError != nil { lastError = nil } }
     func setPaused(_ paused: GGPausedOperation) { if pausedOperation != paused { pausedOperation = paused } }
     func clearPaused() { if pausedOperation != nil { pausedOperation = nil } }
+    func setActionSummary(_ message: String) { lastActionSummary = message }
+
+    /// One-line result for a completed sync, from the accumulated stream
+    /// events. Nil unless the terminal `.summary` event arrived (an errored
+    /// or cancelled sync produces no summary line).
+    static func syncSummaryLine(from events: [GGSyncEvent]) -> String? {
+        guard events.contains(.summary) else { return nil }
+        let pushed = events.filter { if case .pushDone = $0 { return true } else { return false } }.count
+        let created = events.filter { if case .prCreated = $0 { return true } else { return false } }.count
+        var parts = ["Synced"]
+        if pushed > 0 { parts.append("\(pushed) pushed") }
+        if created > 0 { parts.append("\(created) PR\(created == 1 ? "" : "s") created") }
+        return parts.joined(separator: " · ")
+    }
+
+    static func landSummaryLine(landedCount: Int) -> String? {
+        guard landedCount > 0 else { return nil }
+        return "Landed \(landedCount) PR\(landedCount == 1 ? "" : "s")"
+    }
 }

--- a/Alas/Sources/Integrations/GG/GGStackCreateMode.swift
+++ b/Alas/Sources/Integrations/GG/GGStackCreateMode.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Availability of the "Create as gg stack" mode in the new-worktree
+/// dialog. Hidden when the project isn't gg-gated; disabled (with a hint)
+/// when gg's branch_username can't be resolved from config — we fail
+/// closed rather than re-implementing gg's whoami resolution.
+enum GGStackCreateMode {
+    enum Availability: Equatable {
+        case hidden
+        case disabled(hint: String)
+        case enabled(username: String)
+    }
+
+    static func availability(gatePassed: Bool, username: String?) -> Availability {
+        guard gatePassed else { return .hidden }
+        guard let username else {
+            return .disabled(
+                hint: "Set branch_username in gg config or run `gg co` once in this repo."
+            )
+        }
+        return .enabled(username: username)
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -6,6 +6,7 @@ struct GGStackDrawer: View {
 
     @Environment(\.theme) private var theme
     @State private var expanded = false
+    @State private var isRefreshing = false
 
     private var model: GGStackReadinessModel? {
         if let stack = rps.ggStack {
@@ -63,11 +64,46 @@ struct GGStackDrawer: View {
             Spacer(minLength: 6)
             Text(model.summaryChip)
                 .font(.system(size: 10.5, weight: .medium)).foregroundColor(theme.color("fg-dim"))
+            if isRefreshing {
+                Spinner(lineWidth: 1.4, duration: 0.8).frame(width: 11, height: 11)
+            } else {
+                Button {
+                    isRefreshing = true
+                    let task = rps.reevaluateGGGate()
+                    Task { @MainActor in
+                        await task.value
+                        isRefreshing = false
+                    }
+                } label: {
+                    Icon(name: "arrow.clockwise", size: 10, color: theme.color("fg-faint"))
+                }
+                .buttonStyle(.plain)
+                .focusEffectDisabled()
+                .disabled(rps.ggActionState.inFlightAction != nil)
+                .help("Refresh stack and PR status")
+            }
             Icon(name: expanded ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
         }
         .padding(.horizontal, 10).padding(.vertical, 7)
         .contentShape(Rectangle())
         .onTapGesture { expanded.toggle() }
+        .focusable()
+        .focusEffectDisabled()
+        .onKeyPress(.return) {
+            expanded.toggle()
+            return .handled
+        }
+        .onKeyPress(.space) {
+            expanded.toggle()
+            return .handled
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(model.title)
+        .accessibilityHint(expanded ? "Collapse stack status" : "Expand stack status")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction {
+            expanded.toggle()
+        }
     }
 
     @ViewBuilder
@@ -86,6 +122,9 @@ struct GGStackDrawer: View {
             } else if !model.progressRows.isEmpty {
                 progressList(model)
             } else {
+                if let summary = model.actionSummary {
+                    Text(summary).font(.system(size: 11)).foregroundColor(theme.color("add"))
+                }
                 if let err = rps.ggActionState.lastError {
                     Text(err).font(.system(size: 11)).foregroundColor(theme.color("warn")).lineLimit(3)
                 }
@@ -122,8 +161,10 @@ struct GGStackDrawer: View {
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                     }
                     .buttonStyle(.plain)
+                    .focusEffectDisabled()
                     .disabled(!action.isEnabled)
                     .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
+                    .help(action.title)
                 }
             }
         }

--- a/Alas/Sources/Integrations/GG/GGStackGate.swift
+++ b/Alas/Sources/Integrations/GG/GGStackGate.swift
@@ -14,9 +14,15 @@ enum GGStackGate {
     /// `repo.commondir()` in gg's own source), so resolve the same way
     /// instead of assuming `<repoPath>/.git` is the config's home.
     static func repoHasGGConfig(repoPath: String) -> Bool {
-        guard let commonGitDir = commonGitDir(repoPath: repoPath) else { return false }
-        let path = (commonGitDir as NSString).appendingPathComponent("gg/config.json")
+        guard let path = ggConfigPath(repoPath: repoPath) else { return false }
         return FileManager.default.fileExists(atPath: path)
+    }
+
+    /// Path to the repo's gg config file (`<commondir>/gg/config.json`),
+    /// or nil when the repo path doesn't resolve to a git checkout.
+    static func ggConfigPath(repoPath: String) -> String? {
+        guard let commonGitDir = commonGitDir(repoPath: repoPath) else { return nil }
+        return (commonGitDir as NSString).appendingPathComponent("gg/config.json")
     }
 
     /// True when a git rebase/merge/cherry-pick/revert is in progress in the

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -19,6 +19,13 @@ extension GGServiceError {
         case .unsupportedSchema(let version): return "Unsupported gg output (schema \(version))."
         }
     }
+
+    /// Canonical exit-code mapping shared by every gg invocation path.
+    /// Callers only invoke this for non-zero exits.
+    static func map(exitCode: Int32, stderr: String) -> GGServiceError {
+        if exitCode == 127 { return .cliMissing }
+        return .commandFailed(stderr: stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
 }
 
 /// Decoded envelope of `gg ls --json` / `gg log --json`. When the current

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -26,6 +26,7 @@ struct GGStackReadinessModel: Equatable {
     let actions: [Action]
     let progressRows: [String]
     let isPaused: Bool
+    let actionSummary: String?
 
     @MainActor
     static func make(
@@ -78,13 +79,15 @@ struct GGStackReadinessModel: Equatable {
         }
 
         let syncIsRelevant = inFlight == .sync || action.pausedOperation?.pausedBy == .sync
+        let actionSummary = (inFlight == .sync) ? nil : action.lastActionSummary
         return GGStackReadinessModel(
             title: "Stack · \(stack.name)",
             summaryChip: summaryChip,
             facts: facts,
             actions: actions,
             progressRows: syncIsRelevant ? progressRows(from: action.syncProgress) : [],
-            isPaused: isPaused
+            isPaused: isPaused,
+            actionSummary: actionSummary
         )
     }
 
@@ -105,7 +108,8 @@ struct GGStackReadinessModel: Equatable {
                        isInFlight: inFlight == .abortOp, emphasis: .normal),
             ],
             progressRows: syncIsRelevant ? progressRows(from: action.syncProgress) : [],
-            isPaused: true
+            isPaused: true,
+            actionSummary: nil
         )
     }
 

--- a/Alas/Sources/Integrations/GG/GGStackSummaryStore.swift
+++ b/Alas/Sources/Integrations/GG/GGStackSummaryStore.swift
@@ -9,4 +9,12 @@ import Observation
 final class GGStackSummaryStore {
     static let shared = GGStackSummaryStore()
     var summaries: [String: GGStackSummary] = [:]
+
+    /// Drops summaries for worktrees that no longer exist. Called after the
+    /// app's worktree cleanup pass; value-diffed to avoid invalidating
+    /// observers when nothing was pruned.
+    func prune(keepingPaths: Set<String>) {
+        let pruned = summaries.filter { keepingPaths.contains($0.key) }
+        if pruned.count != summaries.count { summaries = pruned }
+    }
 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1068,7 +1068,10 @@ final class RightPaneState {
                     ggActionState.setError("This stack is no longer ready to land.")
                     return
                 }
-                _ = try await ggService.land(worktreePath: worktree.path.path, until: until)
+                let result = try await ggService.land(worktreePath: worktree.path.path, until: until)
+                if let summary = GGStackActionState.landSummaryLine(landedCount: result.landed.count) {
+                    ggActionState.setActionSummary(summary)
+                }
             } catch let error as GGServiceError {
                 ggActionState.setError(error.userMessage)
             } catch {
@@ -1096,6 +1099,10 @@ final class RightPaneState {
                 for try await event in ggService.sync(worktreePath: worktree.path.path) {
                     ggActionState.appendSyncEvent(event)
                     if case .error(let message) = event { ggActionState.setError(message) }
+                }
+                if let summary = GGStackActionState.syncSummaryLine(from: ggActionState.syncProgress) {
+                    ggActionState.setActionSummary(summary)
+                    ggActionState.clearSyncProgress()
                 }
             } catch let error as GGServiceError {
                 if ggActionState.lastError == nil { ggActionState.setError(error.userMessage) }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1069,7 +1069,7 @@ final class RightPaneState {
                     return
                 }
                 let result = try await ggService.land(worktreePath: worktree.path.path, until: until)
-                if let summary = GGStackActionState.landSummaryLine(landedCount: result.landed.count) {
+                if let summary = GGStackActionState.landSummaryLine(from: result.landed) {
                     ggActionState.setActionSummary(summary)
                 }
             } catch let error as GGServiceError {

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -320,6 +320,12 @@ final class RightPaneStore {
         states.values.first { $0.pendingMerge != nil }
     }
 
+    /// Loaded stack state for a worktree path, if its pane has been
+    /// activated. Used by the ACP preamble at session creation.
+    func stackForWorktreePath(_ path: String) -> GGStack? {
+        states.values.first { $0.worktree.path.path == path }?.ggStack
+    }
+
     /// The first cached state with a pending gg-land confirmation, if any.
     /// Mirrors `stateWithPendingMerge` for the same reason: the confirmation
     /// dialog (see RootView) must resolve its owning state through this

--- a/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
+++ b/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
@@ -129,4 +129,41 @@ struct ACPMCPPromptPreambleTests {
             builtInInjected: true, isDelegated: false, userServerNames: []))
         #expect(text.contains("MCP server \"alas\""))
     }
+
+    @Test func ggStackContextRendersNamedForm() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: false, userServerNames: [], mode: .mcp,
+            ggStack: .init(stackName: "auth-flow", entryCount: 3, ggMCPAttached: true)
+        ))
+        #expect(text.contains("gg stacked-diffs stack \"auth-flow\" (3 entries)"))
+        #expect(text.contains("gg absorb"))
+        #expect(text.contains("gg sync"))
+        #expect(text.contains("never push stack branches directly with `git push`"))
+        #expect(text.contains("git-gud")) // MCP mention when attached
+    }
+
+    @Test func ggStackContextGenericFormAndNoMCPMention() throws {
+        let text = try #require(ACPMCPPromptPreamble.text(
+            builtInInjected: true, isDelegated: false, userServerNames: [], mode: .cli(serverAvailability: .available),
+            ggStack: .init(stackName: nil, entryCount: nil, ggMCPAttached: false)
+        ))
+        #expect(text.contains("gg stacked-diffs"))
+        #expect(!text.contains("\"auth-flow\""))
+        #expect(!text.contains("git-gud"))
+    }
+
+    @Test func stackOnlyPreambleIsEmitted() {
+        // No built-in, no user servers — but a stack context alone still
+        // produces a preamble.
+        #expect(ACPMCPPromptPreamble.text(
+            builtInInjected: false, isDelegated: false, userServerNames: [], mode: .mcp,
+            ggStack: .init(stackName: "s", entryCount: 1, ggMCPAttached: false)
+        ) != nil)
+    }
+
+    @Test func nilGGStackKeepsExistingBehavior() {
+        #expect(ACPMCPPromptPreamble.text(
+            builtInInjected: false, isDelegated: false, userServerNames: [], mode: .mcp
+        ) == nil)
+    }
 }

--- a/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
+++ b/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
@@ -152,13 +152,15 @@ struct ACPMCPPromptPreambleTests {
         #expect(!text.contains("git-gud"))
     }
 
-    @Test func stackOnlyPreambleIsEmitted() {
+    @Test func stackOnlyPreambleIsEmitted() throws {
         // No built-in, no user servers — but a stack context alone still
-        // produces a preamble.
-        #expect(ACPMCPPromptPreamble.text(
+        // produces a preamble. It must not claim MCP tools are attached.
+        let text = try #require(ACPMCPPromptPreamble.text(
             builtInInjected: false, isDelegated: false, userServerNames: [], mode: .mcp,
             ggStack: .init(stackName: "s", entryCount: 1, ggMCPAttached: false)
-        ) != nil)
+        ))
+        #expect(!text.contains("MCP servers are attached"))
+        #expect(text.contains("gg stacked-diffs"))
     }
 
     @Test func nilGGStackKeepsExistingBehavior() {

--- a/AlasTests/GGStackCreateModeTests.swift
+++ b/AlasTests/GGStackCreateModeTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import Alas
+
+struct GGStackCreateModeTests {
+    @Test func hiddenWhenGateFails() {
+        #expect(GGStackCreateMode.availability(gatePassed: false, username: "nacho") == .hidden)
+    }
+
+    @Test func disabledWithHintWhenUsernameMissing() {
+        let availability = GGStackCreateMode.availability(gatePassed: true, username: nil)
+        guard case .disabled(let hint) = availability else {
+            Issue.record("expected disabled")
+            return
+        }
+        #expect(hint.contains("branch_username"))
+    }
+
+    @Test func enabledCarriesUsername() {
+        #expect(GGStackCreateMode.availability(gatePassed: true, username: "nacho") == .enabled(username: "nacho"))
+    }
+}

--- a/AlasTests/Integrations/GGActionEventsTests.swift
+++ b/AlasTests/Integrations/GGActionEventsTests.swift
@@ -43,6 +43,12 @@ struct GGActionEventsTests {
         ])
     }
 
+    @Test func decodesLandResultActions() throws {
+        let json = #"{"version":1,"land":{"stack":"s","base":"main","landed":[{"position":1,"pr_number":42,"action":"merged"},{"position":2,"pr_number":43,"action":"queued"}]}}"#
+        let result = try GGLandResult.decode(fromJSON: Data(json.utf8))
+        #expect(result.landed.map(\.action) == ["merged", "queued"])
+    }
+
     @Test func decodesLandResultWithEmptyLanded() throws {
         let json = #"{"version":1,"land":{"stack":"s","base":"main","landed":[]}}"#
         #expect(try GGLandResult.decode(fromJSON: Data(json.utf8)).landed.isEmpty)

--- a/AlasTests/Integrations/GGAvailabilityTests.swift
+++ b/AlasTests/Integrations/GGAvailabilityTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import Alas
+
+private struct FixedVersionGGRunner: GGCommandRunning {
+    let version: String?
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        guard args == ["--version"], let version else {
+            return ProcessResult(exitCode: 127, stdout: "", stderr: "not found")
+        }
+        return ProcessResult(exitCode: 0, stdout: "gg \(version)\n", stderr: "")
+    }
+}
+
+@MainActor
+struct GGAvailabilityTests {
+    @Test func probePopulatesVersionAndMCPPath() async {
+        let availability = GGAvailability()
+        await availability.probe(
+            service: GGService(runner: FixedVersionGGRunner(version: "0.9.9")),
+            which: { name in name == "gg-mcp" ? "/opt/homebrew/bin/gg-mcp" : nil },
+            force: true
+        )
+        #expect(availability.version == "0.9.9")
+        #expect(availability.isInstalled)
+        #expect(availability.ggMCPBinaryPath == "/opt/homebrew/bin/gg-mcp")
+    }
+
+    @Test func missingMCPBinaryYieldsNilWithoutAffectingGG() async {
+        let availability = GGAvailability()
+        await availability.probe(
+            service: GGService(runner: FixedVersionGGRunner(version: "0.9.9")),
+            which: { _ in nil },
+            force: true
+        )
+        #expect(availability.isInstalled)
+        #expect(availability.ggMCPBinaryPath == nil)
+    }
+
+    @Test func nonForceProbeIsCachedAfterFirstRun() async {
+        let availability = GGAvailability()
+        await availability.probe(
+            service: GGService(runner: FixedVersionGGRunner(version: "1.0.0")),
+            which: { _ in "/first/gg-mcp" },
+            force: true
+        )
+        // Second, non-force probe must not overwrite cached results.
+        await availability.probe(
+            service: GGService(runner: FixedVersionGGRunner(version: "9.9.9")),
+            which: { _ in "/second/gg-mcp" },
+            force: false
+        )
+        #expect(availability.version == "1.0.0")
+        #expect(availability.ggMCPBinaryPath == "/first/gg-mcp")
+    }
+}

--- a/AlasTests/Integrations/GGConfigReaderTests.swift
+++ b/AlasTests/Integrations/GGConfigReaderTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGConfigReaderTests {
+    private func makeRepo(configJSON: String?) throws -> String {
+        let dir = NSTemporaryDirectory() + "gg-cfg-" + UUID().uuidString
+        try FileManager.default.createDirectory(atPath: dir + "/.git/gg", withIntermediateDirectories: true)
+        if let configJSON {
+            try configJSON.write(toFile: dir + "/.git/gg/config.json", atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    private func makeGlobal(configJSON: String) throws -> String {
+        let path = NSTemporaryDirectory() + "gg-global-" + UUID().uuidString + ".json"
+        try configJSON.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    @Test func readsRepoUsername() throws {
+        let repo = try makeRepo(configJSON: #"{"defaults":{"branch_username":"nacho"}}"#)
+        #expect(GGConfigReader.branchUsername(repoPath: repo, globalConfigPath: nil) == "nacho")
+    }
+
+    @Test func fallsBackToGlobalWhenRepoLacksIt() throws {
+        let repo = try makeRepo(configJSON: #"{"defaults":{}}"#)
+        let global = try makeGlobal(configJSON: #"{"defaults":{"branch_username":"globaluser"}}"#)
+        #expect(GGConfigReader.branchUsername(repoPath: repo, globalConfigPath: global) == "globaluser")
+    }
+
+    @Test func nilWhenNeitherSetsItOrGarbage() throws {
+        let noKey = try makeRepo(configJSON: #"{"defaults":{}}"#)
+        #expect(GGConfigReader.branchUsername(repoPath: noKey, globalConfigPath: nil) == nil)
+        let garbage = try makeRepo(configJSON: "not json")
+        #expect(GGConfigReader.branchUsername(repoPath: garbage, globalConfigPath: nil) == nil)
+        let missing = try makeRepo(configJSON: nil)
+        #expect(GGConfigReader.branchUsername(repoPath: missing, globalConfigPath: nil) == nil)
+    }
+
+    @Test func composesStackBranch() {
+        #expect(GGConfigReader.composeStackBranch(username: "nacho", stackName: "auth-flow") == "nacho/auth-flow")
+    }
+}

--- a/AlasTests/Integrations/GGConfigReaderTests.swift
+++ b/AlasTests/Integrations/GGConfigReaderTests.swift
@@ -41,4 +41,22 @@ struct GGConfigReaderTests {
     @Test func composesStackBranch() {
         #expect(GGConfigReader.composeStackBranch(username: "nacho", stackName: "auth-flow") == "nacho/auth-flow")
     }
+
+    @Test func readsRepoBase() throws {
+        let repo = try makeRepo(configJSON: #"{"defaults":{"base":"release/1.2"}}"#)
+        #expect(GGConfigReader.defaultBase(repoPath: repo, globalConfigPath: nil) == "release/1.2")
+    }
+
+    @Test func baseFallsBackToGlobal() throws {
+        let repo = try makeRepo(configJSON: #"{"defaults":{}}"#)
+        let global = try makeGlobal(configJSON: #"{"defaults":{"base":"develop"}}"#)
+        #expect(GGConfigReader.defaultBase(repoPath: repo, globalConfigPath: global) == "develop")
+    }
+
+    @Test func baseNilWhenAbsentOrGarbage() throws {
+        let noKey = try makeRepo(configJSON: #"{"defaults":{}}"#)
+        #expect(GGConfigReader.defaultBase(repoPath: noKey, globalConfigPath: nil) == nil)
+        let garbage = try makeRepo(configJSON: "not json")
+        #expect(GGConfigReader.defaultBase(repoPath: garbage, globalConfigPath: nil) == nil)
+    }
 }

--- a/AlasTests/Integrations/GGMCPInjectionTests.swift
+++ b/AlasTests/Integrations/GGMCPInjectionTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import Alas
+
+struct GGMCPInjectionTests {
+    @Test func happyPathBuildsStdioServerWithRepoPath() throws {
+        let injection = try #require(GGMCPInjection.injection(
+            gatePassed: true,
+            binaryPath: "/opt/homebrew/bin/gg-mcp",
+            configuredServers: [],
+            worktreePath: "/tmp/wt"
+        ))
+        guard case let .stdio(name, command, args, env) = injection.server else {
+            Issue.record("expected stdio server")
+            return
+        }
+        #expect(name == "git-gud")
+        #expect(command == "/opt/homebrew/bin/gg-mcp")
+        #expect(args.isEmpty)
+        #expect(env.contains { $0.name == "GG_REPO_PATH" && $0.value == "/tmp/wt" })
+        #expect(injection.status.name == "git-gud")
+    }
+
+    @Test func nilWhenGateFailsOrBinaryMissing() {
+        #expect(GGMCPInjection.injection(
+            gatePassed: false, binaryPath: "/x/gg-mcp", configuredServers: [], worktreePath: "/tmp/wt"
+        ) == nil)
+        #expect(GGMCPInjection.injection(
+            gatePassed: true, binaryPath: nil, configuredServers: [], worktreePath: "/tmp/wt"
+        ) == nil)
+    }
+
+    @Test func userConfiguredServerNamedGitGudWins() {
+        let override = ProjectMCPServer.stdio(name: " git-gud ", command: "/custom/gg-mcp")
+        #expect(GGMCPInjection.injection(
+            gatePassed: true, binaryPath: "/x/gg-mcp", configuredServers: [override], worktreePath: "/tmp/wt"
+        ) == nil)
+    }
+}

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -163,4 +163,17 @@ struct GGServiceActionsTests {
         let result = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: "c-abc")
         #expect(result.landed.isEmpty)
     }
+
+    @Test func landDoesNotTolerateInBandErrorOnSuccessfulExit() async {
+        // Exit 0 with a well-formed JSON body that itself reports an
+        // in-band error must still surface as a failure: only JSON-shape
+        // drift is tolerated, not a genuine reported error.
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"land":{"landed":[],"error":{"message":"not approved"}}}"#,
+            exitCode: 0
+        )
+        await #expect(throws: GGServiceError.commandFailed(stderr: "not approved")) {
+            _ = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: nil)
+        }
+    }
 }

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -157,4 +157,10 @@ struct GGServiceActionsTests {
             try await GGService(runner: runner).clean(worktreePath: "/tmp/wt")
         }
     }
+
+    @Test func landToleratesUndecodableOutputAfterSuccessfulExit() async throws {
+        let runner = RecordingGGRunner(stdout: "not json at all", exitCode: 0)
+        let result = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: "c-abc")
+        #expect(result.landed.isEmpty)
+    }
 }

--- a/AlasTests/Integrations/GGServiceTests.swift
+++ b/AlasTests/Integrations/GGServiceTests.swift
@@ -83,4 +83,10 @@ struct GGServiceTests {
             _ = try await GGService(runner: runner).currentStack(worktreePath: "/tmp/wt")
         }
     }
+
+    @Test func mapConvertsExitCodesToErrors() {
+        #expect(GGServiceError.map(exitCode: 127, stderr: "anything") == .cliMissing)
+        #expect(GGServiceError.map(exitCode: 1, stderr: "  boom \n") == .commandFailed(stderr: "boom"))
+        #expect(GGServiceError.map(exitCode: 2, stderr: "") == .commandFailed(stderr: ""))
+    }
 }

--- a/AlasTests/Integrations/GGStackActionStateTests.swift
+++ b/AlasTests/Integrations/GGStackActionStateTests.swift
@@ -44,4 +44,34 @@ struct GGStackActionStateTests {
         state.clearPaused()
         #expect(state.pausedOperation == nil)
     }
+
+    @Test func actionSummaryLifecycle() {
+        let state = GGStackActionState()
+        state.setActionSummary("Synced · 2 pushed")
+        #expect(state.lastActionSummary == "Synced · 2 pushed")
+        // Starting any new action clears the previous summary.
+        _ = state.beginAction(.clean)
+        #expect(state.lastActionSummary == nil)
+    }
+
+    @Test func syncSummaryLineCountsEvents() {
+        let events: [GGSyncEvent] = [
+            .start(totalEntries: 3),
+            .pushDone(position: 1, forced: false),
+            .pushDone(position: 2, forced: false),
+            .prCreated(position: 2, prNumber: 42, prURL: nil, draft: false),
+            .summary,
+        ]
+        #expect(GGStackActionState.syncSummaryLine(from: events) == "Synced · 2 pushed · 1 PR created")
+        // No .summary event (errored/cancelled sync) → no summary line.
+        #expect(GGStackActionState.syncSummaryLine(from: [.pushDone(position: 1, forced: false)]) == nil)
+        // Summary with nothing pushed/created → plain "Synced".
+        #expect(GGStackActionState.syncSummaryLine(from: [.summary]) == "Synced")
+    }
+
+    @Test func landSummaryLine() {
+        #expect(GGStackActionState.landSummaryLine(landedCount: 0) == nil)
+        #expect(GGStackActionState.landSummaryLine(landedCount: 1) == "Landed 1 PR")
+        #expect(GGStackActionState.landSummaryLine(landedCount: 3) == "Landed 3 PRs")
+    }
 }

--- a/AlasTests/Integrations/GGStackActionStateTests.swift
+++ b/AlasTests/Integrations/GGStackActionStateTests.swift
@@ -70,8 +70,23 @@ struct GGStackActionStateTests {
     }
 
     @Test func landSummaryLine() {
-        #expect(GGStackActionState.landSummaryLine(landedCount: 0) == nil)
-        #expect(GGStackActionState.landSummaryLine(landedCount: 1) == "Landed 1 PR")
-        #expect(GGStackActionState.landSummaryLine(landedCount: 3) == "Landed 3 PRs")
+        #expect(GGStackActionState.landSummaryLine(from: []) == nil)
+        #expect(GGStackActionState.landSummaryLine(from: [
+            GGLandedEntry(position: 1, prNumber: 1),
+        ]) == "Landed 1 PR")
+        #expect(GGStackActionState.landSummaryLine(from: [
+            GGLandedEntry(position: 1, prNumber: 1),
+            GGLandedEntry(position: 2, prNumber: 2),
+            GGLandedEntry(position: 3, prNumber: 3),
+        ]) == "Landed 3 PRs")
+        // Queued (GitLab merge-train) entries are reported separately, not as landed.
+        #expect(GGStackActionState.landSummaryLine(from: [
+            GGLandedEntry(position: 1, prNumber: 1, action: "merged"),
+            GGLandedEntry(position: 2, prNumber: 2, action: "queued"),
+            GGLandedEntry(position: 3, prNumber: 3, action: "already_queued"),
+        ]) == "Landed 1 PR · Queued 2 PRs")
+        #expect(GGStackActionState.landSummaryLine(from: [
+            GGLandedEntry(position: 1, prNumber: 1, action: "queued"),
+        ]) == "Queued 1 PR")
     }
 }

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -225,4 +225,19 @@ struct GGStackReadinessModelTests {
         #expect(!action.syncProgress.isEmpty)
         #expect(model.progressRows.isEmpty)
     }
+
+    @Test func actionSummarySurfacesWhenIdleOnly() {
+        let action = GGStackActionState()
+        action.setActionSummary("Synced · 1 pushed")
+        let idle = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open)]), action: action
+        )
+        #expect(idle.actionSummary == "Synced · 1 pushed")
+
+        _ = action.beginAction(.sync) // beginAction clears the summary
+        let syncing = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open)]), action: action
+        )
+        #expect(syncing.actionSummary == nil)
+    }
 }

--- a/AlasTests/Integrations/GGStackSummaryStoreTests.swift
+++ b/AlasTests/Integrations/GGStackSummaryStoreTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct GGStackSummaryStoreTests {
+    @Test func pruneKeepsOnlyLivePaths() {
+        let store = GGStackSummaryStore()
+        store.summaries = [
+            "/a": GGStackSummary(merged: 1, total: 2),
+            "/b": GGStackSummary(merged: 0, total: 1),
+        ]
+        store.prune(keepingPaths: ["/a"])
+        #expect(store.summaries.keys.sorted() == ["/a"])
+        // No-op prune leaves the dictionary identity untouched.
+        store.prune(keepingPaths: ["/a"])
+        #expect(store.summaries.keys.sorted() == ["/a"])
+    }
+}

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -321,4 +321,14 @@ struct NewWorktreeDialogTests {
         #expect(result.launchMode == .terminal)
         #expect(result.persistableLaunchMode == .terminal)
     }
+
+    @Test func stackModeSurvivesOnlyWhenAvailabilityEnabled() {
+        // Stays on when the new project still offers gg stacks.
+        #expect(NewWorktreeDialog.stackModeSurvives(true, availability: .enabled(username: "nacho")) == true)
+        // Clears when the toggle was on but availability dropped to disabled/hidden.
+        #expect(NewWorktreeDialog.stackModeSurvives(true, availability: .disabled(hint: "Set branch_username")) == false)
+        #expect(NewWorktreeDialog.stackModeSurvives(true, availability: .hidden) == false)
+        // Off stays off regardless of availability.
+        #expect(NewWorktreeDialog.stackModeSurvives(false, availability: .enabled(username: "nacho")) == false)
+    }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -30,6 +30,26 @@ private final class ThrowingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
     }
 }
 
+/// Answers the `sync --help` capability probe with `--jsonl` support, then
+/// streams the given NDJSON body for `sync --jsonl` — needed because
+/// `CountingFakeGGRunner` echoes the same stdout to every call, which would
+/// make the probe see the sync body instead of a help string and fall back
+/// to the non-streaming path.
+private final class NDJSONSyncFakeGGRunner: GGCommandRunning, @unchecked Sendable {
+    private let ndjson: String
+
+    init(ndjson: String) {
+        self.ndjson = ndjson
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["sync", "--help"] {
+            return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
+        }
+        return ProcessResult(exitCode: 0, stdout: ndjson, stderr: "")
+    }
+}
+
 private final class ConflictAfterSyncRunner: GGCommandRunning, @unchecked Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         if args == ["sync", "--help"] {
@@ -549,5 +569,36 @@ struct RightPaneGGStackTests {
 
         #expect(runner.callCount == 1)
         #expect(didRefreshProjectTopology)
+    }
+
+    @Test func syncActionLeavesSummaryAndClearsProgress() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let ndjson = [
+            #"{"event":"start","total_entries":1}"#,
+            #"{"event":"push_done","position":1,"forced":false}"#,
+            #"{"event":"summary"}"#,
+        ].joined(separator: "\n")
+        state.ggService = GGService(runner: NDJSONSyncFakeGGRunner(ndjson: ndjson))
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
+
+        // Drive the same body onGGStackAction(.sync) runs, but awaitably:
+        // consume the service stream and apply the summary exactly as
+        // runGGSync does. If runGGSync is refactored to expose an awaitable
+        // core (e.g. `func runGGSyncBody() async`), call that instead —
+        // implementer's choice; the assertion is what matters:
+        _ = state.ggActionState.beginAction(.sync)
+        for try await event in state.ggService.sync(worktreePath: wt.path.path) {
+            state.ggActionState.appendSyncEvent(event)
+        }
+        if let summary = GGStackActionState.syncSummaryLine(from: state.ggActionState.syncProgress) {
+            state.ggActionState.setActionSummary(summary)
+            state.ggActionState.clearSyncProgress()
+        }
+        state.ggActionState.endAction(.sync)
+
+        #expect(state.ggActionState.lastActionSummary == "Synced · 1 pushed")
+        #expect(state.ggActionState.syncProgress.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary

Phase 3 of the gg (git-gud) stacked-diffs integration: **agent integration** and a **hardening batch**. Builds on phase 1 (detect/visualize, #850) and phase 2 (actions, #854/#855).

### Agent integration
- **Stack context in the ACP preamble** — new sessions get a stack-status section (stack name, entry count) and, when the git-gud MCP is actually attached, a note that gg tools are available. Suppressed in CLI mode and for remote projects.
- **Auto-attach `git-gud` MCP** — when gg is enabled for a local project and the repo has gg config, the `gg-mcp` stdio server (env `GG_REPO_PATH`) is composed alongside the built-in Alas MCP. The binary is resolved via `which` at availability-probe time and started on demand by the ACP layer — it is never executed during session creation.

### Create-as-stack
- The new-worktree dialog gains a **"Create as gg stack"** toggle (shown only when gg is enabled and `defaults.branch_username` is configured). Alas creates the worktree with a gg-convention `<username>/<stack-name>` branch, with a live preview.

### Hardening
- `GGServiceError.map` consolidates exit-code→error mapping across all gg invocations.
- Sync/land **completion summaries** ("Synced · N pushed · M PRs created", "Landed N PRs") surface in the drawer.
- `GGService.land` tolerates post-land JSON envelope drift **without** swallowing in-band command errors.
- Drawer gains a **refresh button**, a completion banner, and full keyboard/accessibility parity with the review-loop drawer.
- Stale stack badges are **pruned** when their worktrees disappear.

## Testing
- 42 gg-focused tests across 6 suites pass locally; full `xcodebuild` build clean.
- Full suite runs on CI.

## Notes
- `gg inbox` triage view is deferred to phase 4.
