### PR TITLE
feat(gg): stacked-diffs phase 4 — inbox triage tab and hardening

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -618,6 +618,7 @@
 		763947308C99E2D3CB565889 /* AgentKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C792D59DBFFF6C28F2D426 /* AgentKind.swift */; };
 		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
 		77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */; };
+		77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D5CB480CE056B1C4457D6 /* GGInboxTabsTests.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
 		78D49DF401553D2A9BCE1EE5 /* RemoteTerminalScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E14E781F0E1127387A06907 /* RemoteTerminalScriptTests.swift */; };
 		78D7FFD42803C098160BADC6 /* ProjectMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */; };
@@ -1875,6 +1876,7 @@
 		63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionDiscovery.swift; sourceTree = "<group>"; };
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
 		639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryTests.swift; sourceTree = "<group>"; };
+		649D5CB480CE056B1C4457D6 /* GGInboxTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxTabsTests.swift; sourceTree = "<group>"; };
 		64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabView.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
@@ -3004,6 +3006,7 @@
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */,
 				4836677A0E66A8ADD2D9E89A /* GGConfigCodableTests.swift */,
+				649D5CB480CE056B1C4457D6 /* GGInboxTabsTests.swift */,
 				70BDCB22C2FDC36F6022ADB3 /* GGStackCreateModeTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
@@ -6259,6 +6262,7 @@
 				362A966BA9FED1E92B8410CC /* GGInboxHelpersTests.swift in Sources */,
 				490CB816CBED69EC7C886497 /* GGInboxModelsTests.swift in Sources */,
 				16B6CE9E05F7E9B72D191F0C /* GGInboxStoreTests.swift in Sources */,
+				77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 		67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */; };
 		6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4A215AF2876091E31F6F8A /* LineEnding.swift */; };
 		68D58F9361C2C31EE200479A /* ACPBrokerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A27D9BBDE49BF3A41FAFB7 /* ACPBrokerClient.swift */; };
+		69C592752249412BC8A6EF3C /* GGInboxHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB6D67179D2557D3A255AA3 /* GGInboxHostTests.swift */; };
 		6A10E9DF8A052DBDFF477863 /* OpenCodeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */; };
 		6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */; };
 		6A5B87FF631136E5246D0F38 /* AgentLauncherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */; };
@@ -1850,6 +1851,7 @@
 		5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchBackend.swift; sourceTree = "<group>"; };
 		5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabView.swift; sourceTree = "<group>"; };
 		5DABE7D3F41C67D28CA2C2F9 /* RemoteImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageCache.swift; sourceTree = "<group>"; };
+		5DB6D67179D2557D3A255AA3 /* GGInboxHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxHostTests.swift; sourceTree = "<group>"; };
 		5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypography.swift; sourceTree = "<group>"; };
 		5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolver.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
@@ -3006,6 +3008,7 @@
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */,
 				4836677A0E66A8ADD2D9E89A /* GGConfigCodableTests.swift */,
+				5DB6D67179D2557D3A255AA3 /* GGInboxHostTests.swift */,
 				649D5CB480CE056B1C4457D6 /* GGInboxTabsTests.swift */,
 				70BDCB22C2FDC36F6022ADB3 /* GGStackCreateModeTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
@@ -6260,6 +6263,7 @@
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,
 				362A966BA9FED1E92B8410CC /* GGInboxHelpersTests.swift in Sources */,
+				69C592752249412BC8A6EF3C /* GGInboxHostTests.swift in Sources */,
 				490CB816CBED69EC7C886497 /* GGInboxModelsTests.swift in Sources */,
 				16B6CE9E05F7E9B72D191F0C /* GGInboxStoreTests.swift in Sources */,
 				77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */; };
 		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
+		16B6CE9E05F7E9B72D191F0C /* GGInboxStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */; };
 		16EFA072E6C91CF41269482C /* ACPElicitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4F66F89778A1995407BB50 /* ACPElicitation.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */; };
@@ -1176,6 +1177,7 @@
 		DF2960A73C07F97DA0A615D4 /* ReviewDraftSummaryRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */; };
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
+		E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C511B229168DDEA87173A41 /* GGInboxStore.swift */; };
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
 		E0F4EFE612252BDD7F999A70 /* ReviewFeedbackAgentSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
@@ -2065,6 +2067,7 @@
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
 		8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProviderTests.swift; sourceTree = "<group>"; };
+		8C511B229168DDEA87173A41 /* GGInboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxStore.swift; sourceTree = "<group>"; };
 		8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMCPInjectionTests.swift; sourceTree = "<group>"; };
 		8CA0EE530F852A921942B04C /* ACPRemoteLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteLaunchTests.swift; sourceTree = "<group>"; };
 		8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictColumnView.swift; sourceTree = "<group>"; };
@@ -2133,6 +2136,7 @@
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipTests.swift; sourceTree = "<group>"; };
+		98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxStoreTests.swift; sourceTree = "<group>"; };
 		99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPServer.swift; sourceTree = "<group>"; };
 		99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffLoaderTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
@@ -4606,6 +4610,7 @@
 				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
 				B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */,
 				52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */,
+				98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
@@ -4865,6 +4870,7 @@
 				F1F0EED235328724082B570B /* GGActionEvents.swift */,
 				56A2D492EE89A160CD404985 /* GGConfigReader.swift */,
 				9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */,
+				8C511B229168DDEA87173A41 /* GGInboxStore.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
@@ -5577,6 +5583,7 @@
 				1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */,
 				31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */,
 				188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */,
+				E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
@@ -6243,6 +6250,7 @@
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,
 				490CB816CBED69EC7C886497 /* GGInboxModelsTests.swift in Sources */,
+				16B6CE9E05F7E9B72D191F0C /* GGInboxStoreTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		106120CBE8107E0AC4EA353A /* ProcessKiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */; };
 		1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8B52175A7F6144B4C52010 /* EditorTabView.swift */; };
 		10C27B7147AF2D41AD109E9A /* session-update-session-info-goal.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D751485790AD46EBC15A979 /* session-update-session-info-goal.json */; };
+		10D0D26BCE0EF4D8677CEA79 /* GGServiceInboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF688C3B9D43B4F5FF48F7D3 /* GGServiceInboxTests.swift */; };
 		10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */; };
 		111516874CEE27D789DF61E9 /* ReviewChangesFileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41995BCAEF1E2B356E499333 /* ReviewChangesFileSection.swift */; };
 		11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCEFADD952DB870B8BAB890 /* CommitRow.swift */; };
@@ -2486,6 +2487,7 @@
 		DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessionsTests.swift; sourceTree = "<group>"; };
 		DF0CB94DB8949712B0274413 /* RemoteStatusFingerprintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteStatusFingerprintTests.swift; sourceTree = "<group>"; };
 		DF32A1544E13321E9E223AFF /* DiffPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneView.swift; sourceTree = "<group>"; };
+		DF688C3B9D43B4F5FF48F7D3 /* GGServiceInboxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGServiceInboxTests.swift; sourceTree = "<group>"; };
 		DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrameTests.swift; sourceTree = "<group>"; };
 		DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipState.swift; sourceTree = "<group>"; };
 		DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnectingPlaceholder.swift; sourceTree = "<group>"; };
@@ -4607,6 +4609,7 @@
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
+				DF688C3B9D43B4F5FF48F7D3 /* GGServiceInboxTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
 				7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */,
 				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
@@ -6243,6 +6246,7 @@
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,
+				10D0D26BCE0EF4D8677CEA79 /* GGServiceInboxTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
 				EE4A552DB5EF6559CA1A5AE0 /* GGStackActionStateTests.swift in Sources */,
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		3537561BEB5D7D8666C7DFFD /* ACPStreamingText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033CEEE92FCAFF8A177428E4 /* ACPStreamingText.swift */; };
 		35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */; };
 		35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */; };
+		362A966BA9FED1E92B8410CC /* GGInboxHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */; };
 		363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */; };
 		370EA3E196540ACC6174D5CC /* GitLabCLIProviderVerdictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D95FBEE2C9BF1AD1A602C28 /* GitLabCLIProviderVerdictTests.swift */; };
 		3739AAA93F150060DDAADACA /* SSHCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8351793355009D8A73AA91A2 /* SSHCommand.swift */; };
@@ -461,6 +462,7 @@
 		55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */; };
 		55C7881F382ACCEBCDB7D157 /* AgentsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */; };
 		55F30DD1D8943C46FD4D1608 /* session-update-tool-call-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 3E3ADEB5299C3FFB091D55EE /* session-update-tool-call-meta.json */; };
+		56286C44BC30C1716CD44363 /* GGInboxTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32762D888121D56722E03F5 /* GGInboxTabView.swift */; };
 		5632CE3BB7220370D87A987B /* AgentLauncherModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		56891962450BF0BF596A428A /* TreeSitterKotlin in Frameworks */ = {isa = PBXBuildFile; productRef = 69B81D6B7546F6A8AF3207E9 /* TreeSitterKotlin */; };
@@ -1750,6 +1752,7 @@
 		4BECCB29ED6324C55C541D54 /* DiffReviewRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRail.swift; sourceTree = "<group>"; };
 		4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionTests.swift; sourceTree = "<group>"; };
 		4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTargetTests.swift; sourceTree = "<group>"; };
+		4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxHelpersTests.swift; sourceTree = "<group>"; };
 		4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiACPInstallerTests.swift; sourceTree = "<group>"; };
 		4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweep.swift; sourceTree = "<group>"; };
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
@@ -2250,6 +2253,7 @@
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalogTests.swift; sourceTree = "<group>"; };
 		B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifier.swift; sourceTree = "<group>"; };
+		B32762D888121D56722E03F5 /* GGInboxTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxTabView.swift; sourceTree = "<group>"; };
 		B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
 		B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThumbnailImageCacheTests.swift; sourceTree = "<group>"; };
 		B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneVisibilityTests.swift; sourceTree = "<group>"; };
@@ -4609,6 +4613,7 @@
 				EF9480C66C4CDDB090A5F4FB /* GGAvailabilityTests.swift */,
 				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
 				B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */,
+				4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */,
 				52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */,
 				98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
@@ -4871,6 +4876,7 @@
 				56A2D492EE89A160CD404985 /* GGConfigReader.swift */,
 				9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */,
 				8C511B229168DDEA87173A41 /* GGInboxStore.swift */,
+				B32762D888121D56722E03F5 /* GGInboxTabView.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
@@ -5584,6 +5590,7 @@
 				31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */,
 				188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */,
 				E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */,
+				56286C44BC30C1716CD44363 /* GGInboxTabView.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
@@ -6249,6 +6256,7 @@
 				A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,
+				362A966BA9FED1E92B8410CC /* GGInboxHelpersTests.swift in Sources */,
 				490CB816CBED69EC7C886497 /* GGInboxModelsTests.swift in Sources */,
 				16B6CE9E05F7E9B72D191F0C /* GGInboxStoreTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
+		188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */; };
 		188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		1901EE20123215C998400B25 /* ACPAdapterInstallCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2F61CCAFB23F6C394ACD8D /* ACPAdapterInstallCoordinatorTests.swift */; };
@@ -401,6 +402,7 @@
 		48AD9728403D96C9C5958AC6 /* ACPSessionTerminalRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */; };
 		48E0B43B698544C1C4524242 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */; };
 		48EFAD2DE1F112D72B5F9FAC /* AgentPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37987D5884297401F95478D3 /* AgentPathTests.swift */; };
+		490CB816CBED69EC7C886497 /* GGInboxModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */; };
 		4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F1C71C2574B1077964E5E1 /* ACPPermissionDecisionLogTests.swift */; };
 		497D21A67A062CE6282008CD /* PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295319DB8544C170DDD6328D /* PathsTests.swift */; };
 		49A112CA4183D8FAEA84294A /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 0714DCAA9EC181C239773440 /* TreeSitterBash */; };
@@ -1780,6 +1782,7 @@
 		52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionByteAccountingTests.swift; sourceTree = "<group>"; };
 		52C55C85672956E1340B03B1 /* MergeSidePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSidePane.swift; sourceTree = "<group>"; };
 		52E5D3E9FAA7B6B251C3883D /* DiffPaneTextDocumentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentBuilder.swift; sourceTree = "<group>"; };
+		52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxModelsTests.swift; sourceTree = "<group>"; };
 		5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClientTests.swift; sourceTree = "<group>"; };
 		530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighter.swift; sourceTree = "<group>"; };
 		5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolver.swift; sourceTree = "<group>"; };
@@ -2147,6 +2150,7 @@
 		9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunnerInvocationTests.swift; sourceTree = "<group>"; };
 		9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeChangeGroup.swift; sourceTree = "<group>"; };
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
+		9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxModels.swift; sourceTree = "<group>"; };
 		9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffView.swift; sourceTree = "<group>"; };
 		9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeSummaryBuilder.swift; sourceTree = "<group>"; };
 		9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPInitializeTests.swift; sourceTree = "<group>"; };
@@ -4599,6 +4603,7 @@
 				EF9480C66C4CDDB090A5F4FB /* GGAvailabilityTests.swift */,
 				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
 				B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */,
+				52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
@@ -4856,6 +4861,7 @@
 			children = (
 				F1F0EED235328724082B570B /* GGActionEvents.swift */,
 				56A2D492EE89A160CD404985 /* GGConfigReader.swift */,
+				9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
@@ -5567,6 +5573,7 @@
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */,
 				31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */,
+				188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
@@ -6232,6 +6239,7 @@
 				A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,
+				490CB816CBED69EC7C886497 /* GGInboxModelsTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -747,6 +747,7 @@ final class AppState {
             projectsManager.worktrees(projectId: project.id).map(\.path.path)
         })
         GGStackSummaryStore.shared.prune(keepingPaths: livePaths)
+        GGInboxStore.shared.prune(keepingProjectIds: Set(projects.map(\.id)))
         if reconcileMissingSpaceProjects() {
             saveSpaces()
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5389,6 +5389,31 @@ final class AppState {
         let tab = tabs.openOrFocusFileHistory(worktreeId: worktree.id, relativePath: relativePath)
         tabs.activate(worktreeId: worktree.id, tabId: tab.id)
     }
+
+    /// The phase-3 gg gate for a project: gg feature on, CLI installed, and
+    /// the project (local, not remote) has gg enabled.
+    func ggInboxAvailable(projectId: String) -> Bool {
+        guard let project = projects.first(where: { $0.id == projectId }) else { return false }
+        return config.changes.stackedDiffsEnabled
+            && GGAvailability.shared.isInstalled
+            && GGStackGate.projectEnabled(
+                masterEnabled: true, ggInstalled: true,
+                mode: project.ggMode, repoPath: project.path,
+                isRemoteProject: project.host != nil
+            )
+    }
+
+    /// Opens (or focuses) the gg inbox tab for `projectId` in the currently
+    /// selected worktree's tab strip, falling back to the project's first
+    /// worktree when none is selected.
+    func openGGInbox(projectId: String) {
+        guard let project = projects.first(where: { $0.id == projectId }) else { return }
+        let candidateIds = [selectedWorktreeId].compactMap { $0 }
+            + projectsManager.worktrees(projectId: projectId).map(\.id)
+        guard let worktreeId = candidateIds.first else { return }
+        tabs.openOrFocusGGInbox(worktreeId: worktreeId, projectId: projectId, projectName: project.name)
+        selectWorktree(id: worktreeId)
+    }
 }
 
 // MARK: - RemoteSessionsProvider

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5403,14 +5403,29 @@ final class AppState {
             )
     }
 
+    /// Chooses which of the target project's worktrees hosts its inbox tab:
+    /// the currently-selected worktree when it belongs to the project,
+    /// otherwise the project's first worktree. Nil when the project has none.
+    nonisolated static func inboxHostWorktreeId(
+        selectedWorktreeId: String?,
+        projectWorktreeIds: [String]
+    ) -> String? {
+        if let selectedWorktreeId, projectWorktreeIds.contains(selectedWorktreeId) {
+            return selectedWorktreeId
+        }
+        return projectWorktreeIds.first
+    }
+
     /// Opens (or focuses) the gg inbox tab for `projectId` in the currently
     /// selected worktree's tab strip, falling back to the project's first
-    /// worktree when none is selected.
+    /// worktree when the current selection belongs to a different project.
     func openGGInbox(projectId: String) {
         guard let project = projects.first(where: { $0.id == projectId }) else { return }
-        let candidateIds = [selectedWorktreeId].compactMap { $0 }
-            + projectsManager.worktrees(projectId: projectId).map(\.id)
-        guard let worktreeId = candidateIds.first else { return }
+        let projectWorktreeIds = projectsManager.worktrees(projectId: projectId).map(\.id)
+        guard let worktreeId = Self.inboxHostWorktreeId(
+            selectedWorktreeId: selectedWorktreeId,
+            projectWorktreeIds: projectWorktreeIds
+        ) else { return }
         tabs.openOrFocusGGInbox(worktreeId: worktreeId, projectId: projectId, projectName: project.name)
         selectWorktree(id: worktreeId)
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5421,7 +5421,7 @@ final class AppState {
     /// worktree when the current selection belongs to a different project.
     func openGGInbox(projectId: String) {
         guard let project = projects.first(where: { $0.id == projectId }) else { return }
-        let projectWorktreeIds = projectsManager.worktrees(projectId: projectId).map(\.id)
+        let projectWorktreeIds = projectsManager.visibleWorktrees(projectId: projectId).map(\.id)
         guard let worktreeId = Self.inboxHostWorktreeId(
             selectedWorktreeId: selectedWorktreeId,
             projectWorktreeIds: projectWorktreeIds

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -296,6 +296,9 @@ struct CenterPaneView: View {
                     case .acpSession(let s):
                         ACPTabView(sessionId: s.sessionId, state: state, worktree: worktree)
                             .id(s.id)
+                    case .ggInbox(let s):
+                        GGInboxTabView(state: state, tabState: s)
+                            .id(s.id)
                     }
                 }
             }

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -19,6 +19,7 @@ enum Tab: Codable, Equatable, Identifiable {
     case reviewPR(ReviewPRTabState)
     case fileSnapshot(FileSnapshotTabState)
     case fileHistory(FileHistoryTabState)
+    case ggInbox(GGInboxTabState)
 
     var id: TabID {
         switch self {
@@ -38,6 +39,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .reviewPR(let s):     return s.id
         case .fileSnapshot(let s): return s.id
         case .fileHistory(let s):  return s.id
+        case .ggInbox(let s):      return s.id
         }
     }
 
@@ -59,6 +61,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .reviewPR(let s):     return s.displayTitle
         case .fileSnapshot(let s): return s.title
         case .fileHistory(let s):  return s.title
+        case .ggInbox(let s):      return s.title
         }
     }
 
@@ -80,6 +83,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .reviewPR:     return "list.bullet.rectangle.portrait.fill"
         case .fileSnapshot: return "doc.text.magnifyingglass"
         case .fileHistory:  return "clock.arrow.circlepath"
+        case .ggInbox:      return "branch"
         }
     }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -744,6 +744,18 @@ final class TabsManager {
     }
 
     @discardableResult
+    func openOrFocusGGInbox(worktreeId: String, projectId: String, projectName: String) -> Tab {
+        let state = GGInboxTabState(projectId: projectId, projectName: projectName)
+        if tabs(forWorktree: worktreeId).contains(where: { $0.id == state.id }) {
+            activate(worktreeId: worktreeId, tabId: state.id)
+            return tabs(forWorktree: worktreeId).first(where: { $0.id == state.id }) ?? .ggInbox(state)
+        }
+        let tab = Tab.ggInbox(state)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
+    @discardableResult
     func openOrFocusReviewSession(worktreeId: String, record: ReviewSessionRecord) -> Tab {
         let baseState = ReviewSessionTabState(worktreeId: worktreeId, record: record)
         if var file = byWorktree[worktreeId],

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -140,9 +140,12 @@ struct NewWorktreeDialog: View {
         }
         .onChange(of: projectId) { _, _ in
             applyLaunchDefaults(for: projectId)
-            loadBranchesForSelectedProject()
             createAsGGStack = Self.stackModeSurvives(createAsGGStack, availability: ggStackAvailability)
-            if let pinned = stackPinnedBase { base = pinned }
+            // Seed the base for the new project synchronously so the picker
+            // never shows the previous project's value; the async branch load
+            // refines it (guarded: it skips pinned bases and user edits).
+            base = stackPinnedBase ?? state.config.worktrees.baseBranch
+            loadBranchesForSelectedProject()
         }
         .onChange(of: branch) { _, _ in
             createErrorMessage = nil

--- a/Alas/Sources/Integrations/GG/GGInboxModels.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxModels.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Decoded `gg inbox --json` snapshot (gg output version 1). Buckets are in
+/// gg's priority order — most urgent first — which is also display order.
+/// `stack_errors` are in-band per-stack failures (exit 0), not command errors.
+struct GGInboxSnapshot: Equatable, Decodable {
+    let version: Int
+    let totalItems: Int
+    let buckets: GGInboxBuckets
+    let stackErrors: [GGInboxStackError]
+
+    static func decode(fromJSON data: Data) throws -> GGInboxSnapshot {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+            return try decoder.decode(GGInboxSnapshot.self, from: data)
+        } catch {
+            throw GGServiceError.malformedOutput(String(describing: error))
+        }
+    }
+}
+
+struct GGInboxBuckets: Equatable, Decodable {
+    let readyToLand: [GGInboxEntry]
+    let changesRequested: [GGInboxEntry]
+    let blockedOnCi: [GGInboxEntry]
+    let awaitingReview: [GGInboxEntry]
+    let behindBase: [GGInboxEntry]
+    let draft: [GGInboxEntry]
+    /// Only serialized by gg with `--all`; absent in the default invocation.
+    var merged: [GGInboxEntry] = []
+
+    private enum CodingKeys: String, CodingKey {
+        case readyToLand, changesRequested, blockedOnCi, awaitingReview, behindBase, draft, merged
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        readyToLand = try c.decode([GGInboxEntry].self, forKey: .readyToLand)
+        changesRequested = try c.decode([GGInboxEntry].self, forKey: .changesRequested)
+        blockedOnCi = try c.decode([GGInboxEntry].self, forKey: .blockedOnCi)
+        awaitingReview = try c.decode([GGInboxEntry].self, forKey: .awaitingReview)
+        behindBase = try c.decode([GGInboxEntry].self, forKey: .behindBase)
+        draft = try c.decode([GGInboxEntry].self, forKey: .draft)
+        merged = try c.decodeIfPresent([GGInboxEntry].self, forKey: .merged) ?? []
+    }
+}
+
+struct GGInboxEntry: Equatable, Decodable {
+    let stackName: String
+    let position: Int
+    let sha: String
+    let title: String
+    let prNumber: Int
+    let prUrl: String
+    let ciStatus: String?
+    let behindBase: Int?
+}
+
+struct GGInboxStackError: Equatable, Decodable {
+    let stackName: String
+    let error: String
+}
+
+/// Presentation metadata for the six rendered buckets, in gg's priority
+/// order. `merged` is decodable but intentionally not rendered (no --all in v1).
+enum GGInboxBucket: CaseIterable, Equatable {
+    case readyToLand, changesRequested, blockedOnCi, awaitingReview, behindBase, draft
+
+    var title: String {
+        switch self {
+        case .readyToLand:      return "Ready to land"
+        case .changesRequested: return "Changes requested"
+        case .blockedOnCi:      return "Blocked on CI"
+        case .awaitingReview:   return "Awaiting review"
+        case .behindBase:       return "Behind base"
+        case .draft:            return "Draft"
+        }
+    }
+
+    var themeToken: String {
+        switch self {
+        case .readyToLand:                    return "add"
+        case .changesRequested, .blockedOnCi: return "warn"
+        case .awaitingReview, .behindBase, .draft: return "fg-dim"
+        }
+    }
+
+    func entries(in buckets: GGInboxBuckets) -> [GGInboxEntry] {
+        switch self {
+        case .readyToLand:      return buckets.readyToLand
+        case .changesRequested: return buckets.changesRequested
+        case .blockedOnCi:      return buckets.blockedOnCi
+        case .awaitingReview:   return buckets.awaitingReview
+        case .behindBase:       return buckets.behindBase
+        case .draft:            return buckets.draft
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGInboxStore.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxStore.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Observation
+
+/// Project id → gg inbox triage state. One `gg inbox` round-trip per
+/// project. Snapshots are retained across refresh failures so the view can
+/// show stale data alongside the error. All writes are value-diffed.
+@MainActor
+@Observable
+final class GGInboxStore {
+    static let shared = GGInboxStore()
+
+    struct State: Equatable {
+        var snapshot: GGInboxSnapshot? = nil
+        var fetchedAt: Date? = nil
+        var isRefreshing: Bool = false
+        var lastError: String? = nil
+    }
+
+    var states: [String: State] = [:]
+
+    /// A snapshot older than `threshold` (or missing) should be refetched
+    /// when the tab appears or regains focus.
+    static func isStale(fetchedAt: Date?, now: Date, threshold: TimeInterval = 120) -> Bool {
+        guard let fetchedAt else { return true }
+        return now.timeIntervalSince(fetchedAt) >= threshold
+    }
+
+    func refresh(
+        projectId: String,
+        repoPath: String,
+        service: GGService,
+        now: () -> Date = Date.init
+    ) async {
+        if states[projectId]?.isRefreshing == true { return }
+        var state = states[projectId] ?? State()
+        state.isRefreshing = true
+        write(projectId, state)
+        do {
+            let snapshot = try await service.inbox(repoPath: repoPath)
+            state.snapshot = snapshot
+            state.fetchedAt = now()
+            state.lastError = nil
+        } catch let error as GGServiceError {
+            state.lastError = error.userMessage
+        } catch {
+            state.lastError = error.localizedDescription
+        }
+        state.isRefreshing = false
+        write(projectId, state)
+    }
+
+    /// Drops states for projects that no longer exist.
+    func prune(keepingProjectIds: Set<String>) {
+        let pruned = states.filter { keepingProjectIds.contains($0.key) }
+        if pruned.count != states.count { states = pruned }
+    }
+
+    private func write(_ projectId: String, _ new: State) {
+        if states[projectId] != new { states[projectId] = new }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -31,14 +31,23 @@ enum GGInboxWorktreeResolver {
     /// e.g. two locally-inferred usernames both have a same-named stack
     /// checked out. gg's JSON carries only `stack_name` per entry, no owning
     /// username or branch, so a duplicated name can't be safely attributed
-    /// to any one worktree. Rows with an ambiguous name are dimmed rather
-    /// than risk navigating to the wrong person's worktree.
-    static func ambiguousStackNames(in buckets: GGInboxBuckets) -> Set<String> {
+    /// to any one worktree. Counts BOTH successfully-classified bucket
+    /// entries and `stack_errors` (a per-user stack that failed to load is
+    /// still a distinct occurrence of that name). Rows with an ambiguous
+    /// name are dimmed rather than risk navigating to the wrong person's
+    /// worktree.
+    static func ambiguousStackNames(
+        in buckets: GGInboxBuckets,
+        stackErrors: [GGInboxStackError] = []
+    ) -> Set<String> {
         var counts: [String: Int] = [:]
         for bucket in GGInboxBucket.allCases {
             for entry in bucket.entries(in: buckets) {
                 counts[entry.stackName, default: 0] += 1
             }
+        }
+        for error in stackErrors {
+            counts[error.stackName, default: 0] += 1
         }
         return Set(counts.filter { $0.value > 1 }.map(\.key))
     }
@@ -274,7 +283,10 @@ struct GGInboxTabView: View {
     private func resolveWorktreeId(_ entry: GGInboxEntry) -> String? {
         guard let project else { return nil }
         if let snapshot = inboxState.snapshot,
-           GGInboxWorktreeResolver.ambiguousStackNames(in: snapshot.buckets).contains(entry.stackName) {
+           GGInboxWorktreeResolver.ambiguousStackNames(
+               in: snapshot.buckets,
+               stackErrors: snapshot.stackErrors
+           ).contains(entry.stackName) {
             return nil
         }
         let worktrees = state.projectsManager.visibleWorktrees(projectId: project.id)

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -21,9 +21,8 @@ enum GGInboxWorktreeResolver {
         username: String?,
         worktrees: [(id: String, branch: String)]
     ) -> String? {
-        if let username,
-           let hit = worktrees.first(where: { $0.branch == "\(username)/\(stackName)" }) {
-            return hit.id
+        if let username {
+            return worktrees.first(where: { $0.branch == "\(username)/\(stackName)" })?.id
         }
         return worktrees.first(where: { $0.branch.hasSuffix("/\(stackName)") })?.id
     }

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -25,7 +25,7 @@ enum GGInboxWorktreeResolver {
         if let username {
             return worktrees.first(where: { $0.branch == "\(username)/\(stackName)" })?.id
         }
-        return worktrees.first(where: { $0.branch.hasSuffix("/\(stackName)") })?.id
+        return worktrees.first(where: { stackNameComponent(ofBranch: $0.branch) == stackName })?.id
     }
 
     /// True when more than one local worktree branch matches gg's
@@ -41,7 +41,19 @@ enum GGInboxWorktreeResolver {
         stackName: String,
         worktrees: [(id: String, branch: String)]
     ) -> Bool {
-        worktrees.filter { $0.branch.hasSuffix("/\(stackName)") }.count > 1
+        worktrees.filter { stackNameComponent(ofBranch: $0.branch) == stackName }.count > 1
+    }
+
+    /// Everything after the FIRST `/` in a gg-convention branch
+    /// (`<username>/<stackName>`). gg stack names can themselves contain
+    /// slashes (path-style names), so only the first slash separates the
+    /// username — a suffix match on the whole branch string would falsely
+    /// conflate an unrelated nested stack (e.g. `feature/auth`) with a
+    /// top-level stack of a shorter name (`auth`). Nil for a branch with no
+    /// slash at all (not gg-convention shaped).
+    private static func stackNameComponent(ofBranch branch: String) -> String? {
+        guard let slashIndex = branch.firstIndex(of: "/") else { return nil }
+        return String(branch[branch.index(after: slashIndex)...])
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -26,6 +26,22 @@ enum GGInboxWorktreeResolver {
         }
         return worktrees.first(where: { $0.branch.hasSuffix("/\(stackName)") })?.id
     }
+
+    /// Stack names gg reports more than once across the whole snapshot —
+    /// e.g. two locally-inferred usernames both have a same-named stack
+    /// checked out. gg's JSON carries only `stack_name` per entry, no owning
+    /// username or branch, so a duplicated name can't be safely attributed
+    /// to any one worktree. Rows with an ambiguous name are dimmed rather
+    /// than risk navigating to the wrong person's worktree.
+    static func ambiguousStackNames(in buckets: GGInboxBuckets) -> Set<String> {
+        var counts: [String: Int] = [:]
+        for bucket in GGInboxBucket.allCases {
+            for entry in bucket.entries(in: buckets) {
+                counts[entry.stackName, default: 0] += 1
+            }
+        }
+        return Set(counts.filter { $0.value > 1 }.map(\.key))
+    }
 }
 
 /// Project-scoped triage tab over `gg inbox`. Navigation-first: rows focus
@@ -257,6 +273,10 @@ struct GGInboxTabView: View {
 
     private func resolveWorktreeId(_ entry: GGInboxEntry) -> String? {
         guard let project else { return nil }
+        if let snapshot = inboxState.snapshot,
+           GGInboxWorktreeResolver.ambiguousStackNames(in: snapshot.buckets).contains(entry.stackName) {
+            return nil
+        }
         let worktrees = state.projectsManager.visibleWorktrees(projectId: project.id)
             .map { (id: $0.id, branch: $0.branch) }
         return GGInboxWorktreeResolver.worktreeId(

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -53,11 +53,20 @@ struct GGInboxTabView: View {
     }
 
     static func ciIconName(_ status: String?) -> String? {
-        switch status {
-        case "passed":             return "checkmark.circle"
-        case "failed":             return "xmark.circle"
-        case "running", "pending": return "clock"
-        default:                   return nil
+        switch GGCIStatus(rawValue: status ?? "") {
+        case .success:            return "checkmark.circle"
+        case .failed, .canceled:  return "xmark.circle"
+        case .running, .pending:  return "clock"
+        case .unknown, .none:     return nil
+        }
+    }
+
+    static func ciIconColorToken(_ status: String?) -> String {
+        switch GGCIStatus(rawValue: status ?? "") {
+        case .success:            return "add"
+        case .failed, .canceled:  return "del"
+        case .running, .pending:  return "caution"
+        case .unknown, .none:     return "fg-dim"
         }
     }
 
@@ -192,7 +201,7 @@ struct GGInboxTabView: View {
                     .font(.system(size: 10.5)).foregroundColor(theme.color("warn"))
             }
             if let icon = Self.ciIconName(entry.ciStatus) {
-                Icon(name: icon, size: 11, color: theme.color(entry.ciStatus == "failed" ? "warn" : "fg-dim"))
+                Icon(name: icon, size: 11, color: theme.color(Self.ciIconColorToken(entry.ciStatus)))
             }
             Button {
                 if let url = URL(string: entry.prUrl) { NSWorkspace.shared.open(url) }

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -21,35 +21,27 @@ enum GGInboxWorktreeResolver {
         username: String?,
         worktrees: [(id: String, branch: String)]
     ) -> String? {
+        guard !hasAmbiguousLocalOwners(stackName: stackName, worktrees: worktrees) else { return nil }
         if let username {
             return worktrees.first(where: { $0.branch == "\(username)/\(stackName)" })?.id
         }
         return worktrees.first(where: { $0.branch.hasSuffix("/\(stackName)") })?.id
     }
 
-    /// Stack names gg reports more than once across the whole snapshot —
-    /// e.g. two locally-inferred usernames both have a same-named stack
-    /// checked out. gg's JSON carries only `stack_name` per entry, no owning
-    /// username or branch, so a duplicated name can't be safely attributed
-    /// to any one worktree. Counts BOTH successfully-classified bucket
-    /// entries and `stack_errors` (a per-user stack that failed to load is
-    /// still a distinct occurrence of that name). Rows with an ambiguous
-    /// name are dimmed rather than risk navigating to the wrong person's
-    /// worktree.
-    static func ambiguousStackNames(
-        in buckets: GGInboxBuckets,
-        stackErrors: [GGInboxStackError] = []
-    ) -> Set<String> {
-        var counts: [String: Int] = [:]
-        for bucket in GGInboxBucket.allCases {
-            for entry in bucket.entries(in: buckets) {
-                counts[entry.stackName, default: 0] += 1
-            }
-        }
-        for error in stackErrors {
-            counts[error.stackName, default: 0] += 1
-        }
-        return Set(counts.filter { $0.value > 1 }.map(\.key))
+    /// True when more than one local worktree branch matches gg's
+    /// `<username>/<stackName>` convention for this stack name — i.e. more
+    /// than one person's stack shares the name. gg infers per-entry
+    /// ownership from local branches (its `infer_stack_usernames` scans them
+    /// for the naming convention), and its inbox JSON carries only
+    /// `stack_name` with no owner, so a second matching branch means a given
+    /// row can't be safely attributed to either one. This is independent of
+    /// how many inbox rows reference the name — a single stack with several
+    /// positions/PRs is normal and must never be treated as ambiguous.
+    static func hasAmbiguousLocalOwners(
+        stackName: String,
+        worktrees: [(id: String, branch: String)]
+    ) -> Bool {
+        worktrees.filter { $0.branch.hasSuffix("/\(stackName)") }.count > 1
     }
 }
 
@@ -282,13 +274,6 @@ struct GGInboxTabView: View {
 
     private func resolveWorktreeId(_ entry: GGInboxEntry) -> String? {
         guard let project else { return nil }
-        if let snapshot = inboxState.snapshot,
-           GGInboxWorktreeResolver.ambiguousStackNames(
-               in: snapshot.buckets,
-               stackErrors: snapshot.stackErrors
-           ).contains(entry.stackName) {
-            return nil
-        }
         let worktrees = state.projectsManager.visibleWorktrees(projectId: project.id)
             .map { (id: $0.id, branch: $0.branch) }
         return GGInboxWorktreeResolver.worktreeId(
@@ -305,7 +290,7 @@ struct GGInboxTabView: View {
     }
 
     private func refresh() {
-        guard let project else { return }
+        guard let project, state.ggInboxAvailable(projectId: project.id) else { return }
         Task { @MainActor in
             await store.refresh(projectId: project.id, repoPath: project.path, service: service)
         }

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -248,7 +248,7 @@ struct GGInboxTabView: View {
 
     private func resolveWorktreeId(_ entry: GGInboxEntry) -> String? {
         guard let project else { return nil }
-        let worktrees = state.projectsManager.worktrees(projectId: project.id)
+        let worktrees = state.projectsManager.visibleWorktrees(projectId: project.id)
             .map { (id: $0.id, branch: $0.branch) }
         return GGInboxWorktreeResolver.worktreeId(
             stackName: entry.stackName,

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -1,0 +1,273 @@
+import AppKit
+import SwiftUI
+
+struct GGInboxTabState: Codable, Equatable, Identifiable {
+    let id: TabID          // "gg-inbox:<projectId>"
+    let projectId: String
+    var title: String
+
+    init(projectId: String, projectName: String) {
+        self.id = "gg-inbox:\(projectId)"
+        self.projectId = projectId
+        self.title = "Inbox — \(projectName)"
+    }
+}
+
+/// Best-effort stack → live-worktree mapping using gg's
+/// `<username>/<stack-name>` branch convention.
+enum GGInboxWorktreeResolver {
+    static func worktreeId(
+        stackName: String,
+        username: String?,
+        worktrees: [(id: String, branch: String)]
+    ) -> String? {
+        if let username,
+           let hit = worktrees.first(where: { $0.branch == "\(username)/\(stackName)" }) {
+            return hit.id
+        }
+        return worktrees.first(where: { $0.branch.hasSuffix("/\(stackName)") })?.id
+    }
+}
+
+/// Project-scoped triage tab over `gg inbox`. Navigation-first: rows focus
+/// the matching live worktree; landing/syncing stays in the per-worktree
+/// drawer.
+struct GGInboxTabView: View {
+    let state: AppState
+    let tabState: GGInboxTabState
+
+    @Environment(\.theme) private var theme
+    private let store = GGInboxStore.shared
+    private let service = GGService()
+
+    private var inboxState: GGInboxStore.State { store.states[tabState.projectId] ?? .init() }
+    private var project: ProjectConfig? { state.projects.first { $0.id == tabState.projectId } }
+
+    // MARK: pure helpers (tested)
+
+    static func updatedLabel(fetchedAt: Date?, now: Date) -> String? {
+        guard let fetchedAt else { return nil }
+        let seconds = now.timeIntervalSince(fetchedAt)
+        if seconds < 60 { return "Updated just now" }
+        if seconds < 3_600 { return "Updated \(Int(seconds / 60))m ago" }
+        return "Updated \(Int(seconds / 3_600))h ago"
+    }
+
+    static func ciIconName(_ status: String?) -> String? {
+        switch status {
+        case "passed":             return "checkmark.circle"
+        case "failed":             return "xmark.circle"
+        case "running", "pending": return "clock"
+        default:                   return nil
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().overlay(theme.color("line"))
+            content
+        }
+        .background(theme.color("bg-1"))
+        .onAppear { refreshIfStale() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Icon(name: "branch", size: 12, color: theme.color("fg-muted"))
+            Text(tabState.title).font(.system(size: 13, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            if let snapshot = inboxState.snapshot {
+                Text("\(snapshot.totalItems)")
+                    .font(.system(size: 11, weight: .medium)).monospacedDigit()
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            Spacer()
+            if let label = Self.updatedLabel(fetchedAt: inboxState.fetchedAt, now: Date()) {
+                Text(label).font(.system(size: 11)).foregroundColor(theme.color("fg-faint"))
+            }
+            if inboxState.isRefreshing {
+                Spinner(lineWidth: 1.4, duration: 0.8).frame(width: 11, height: 11)
+            } else {
+                Button { refresh() } label: {
+                    Icon(name: "arrow.clockwise", size: 11, color: theme.color("fg-faint"))
+                }
+                .buttonStyle(.plain)
+                .focusEffectDisabled()
+                .help("Refresh inbox")
+            }
+        }
+        .padding(.horizontal, 14).padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let error = inboxState.lastError {
+            errorBanner(error)
+        }
+        if let snapshot = inboxState.snapshot {
+            if snapshot.totalItems == 0 && snapshot.stackErrors.isEmpty && inboxState.lastError == nil {
+                emptyState
+            } else {
+                bucketList(snapshot)
+            }
+        } else if !inboxState.isRefreshing && inboxState.lastError == nil {
+            emptyState
+        } else {
+            Spacer()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Spacer()
+            Text("Inbox is clear.").font(.system(size: 13))
+                .foregroundColor(theme.color("fg-dim"))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Text(message).font(.system(size: 11)).foregroundColor(.red)
+                .lineLimit(2)
+            Spacer()
+            Button("Retry") { refresh() }
+                .buttonStyle(.plain)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.color("accent"))
+        }
+        .padding(.horizontal, 14).padding(.vertical, 8)
+        .background(theme.color("bg-2"))
+    }
+
+    private func bucketList(_ snapshot: GGInboxSnapshot) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(GGInboxBucket.allCases, id: \.self) { bucket in
+                    let entries = bucket.entries(in: snapshot.buckets)
+                    if !entries.isEmpty {
+                        bucketSection(bucket, entries: entries)
+                    }
+                }
+                if !snapshot.stackErrors.isEmpty {
+                    stackErrorsSection(snapshot.stackErrors)
+                }
+            }
+            .padding(.vertical, 6)
+        }
+    }
+
+    private func bucketSection(_ bucket: GGInboxBucket, entries: [GGInboxEntry]) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text(bucket.title.uppercased())
+                    .font(.system(size: 10.5, weight: .semibold)).tracking(0.5)
+                    .foregroundColor(theme.color("fg-muted"))
+                Text("\(entries.count)")
+                    .font(.system(size: 10.5, weight: .semibold)).monospacedDigit()
+                    .foregroundColor(theme.color(bucket.themeToken))
+            }
+            .padding(.horizontal, 14).padding(.top, 10).padding(.bottom, 4)
+            ForEach(entries, id: \.sha) { entry in
+                row(entry)
+            }
+        }
+    }
+
+    private func row(_ entry: GGInboxEntry) -> some View {
+        let targetWorktreeId = resolveWorktreeId(entry)
+        return HStack(spacing: 8) {
+            Text("\(entry.position)")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(theme.color("fg-faint"))
+            Text(entry.stackName)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(theme.color("fg-muted"))
+            Text(entry.title).font(.system(size: 12))
+                .foregroundColor(theme.color("fg")).lineLimit(1).truncationMode(.tail)
+            Spacer(minLength: 8)
+            if let behind = entry.behindBase, behind > 0 {
+                Text("behind \(behind)")
+                    .font(.system(size: 10.5)).foregroundColor(theme.color("warn"))
+            }
+            if let icon = Self.ciIconName(entry.ciStatus) {
+                Icon(name: icon, size: 11, color: theme.color(entry.ciStatus == "failed" ? "warn" : "fg-dim"))
+            }
+            Button {
+                if let url = URL(string: entry.prUrl) { NSWorkspace.shared.open(url) }
+            } label: {
+                Text("#\(entry.prNumber)")
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundColor(theme.color("accent"))
+            }
+            .buttonStyle(.plain)
+            .focusEffectDisabled()
+            .help("Open PR in browser")
+        }
+        .padding(.horizontal, 14).padding(.vertical, 5)
+        .contentShape(Rectangle())
+        .opacity(targetWorktreeId == nil ? 0.55 : 1)
+        .onTapGesture {
+            if let id = targetWorktreeId { state.selectWorktree(id: id) }
+        }
+        .focusable()
+        .focusEffectDisabled()
+        .onKeyPress(.return) {
+            if let id = targetWorktreeId {
+                state.selectWorktree(id: id)
+                return .handled
+            }
+            return .ignored
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(entry.stackName): \(entry.title)")
+        .accessibilityHint(targetWorktreeId == nil ? "No live worktree" : "Focus worktree")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private func stackErrorsSection(_ errors: [GGInboxStackError]) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("STACK ERRORS")
+                .font(.system(size: 10.5, weight: .semibold)).tracking(0.5)
+                .foregroundColor(theme.color("warn"))
+                .padding(.horizontal, 14).padding(.top, 12).padding(.bottom, 4)
+            ForEach(errors, id: \.stackName) { item in
+                HStack(spacing: 8) {
+                    Text(item.stackName).font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.color("fg-muted"))
+                    Text(item.error).font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim")).lineLimit(2)
+                }
+                .padding(.horizontal, 14).padding(.vertical, 3)
+            }
+        }
+    }
+
+    // MARK: actions
+
+    private func resolveWorktreeId(_ entry: GGInboxEntry) -> String? {
+        guard let project else { return nil }
+        let worktrees = state.projectsManager.worktrees(projectId: project.id)
+            .map { (id: $0.id, branch: $0.branch) }
+        return GGInboxWorktreeResolver.worktreeId(
+            stackName: entry.stackName,
+            username: GGConfigReader.branchUsername(repoPath: project.path),
+            worktrees: worktrees
+        )
+    }
+
+    private func refreshIfStale() {
+        guard inboxState.snapshot == nil
+            || GGInboxStore.isStale(fetchedAt: inboxState.fetchedAt, now: Date()) else { return }
+        refresh()
+    }
+
+    private func refresh() {
+        guard let project else { return }
+        Task { @MainActor in
+            await store.refresh(projectId: project.id, repoPath: project.path, service: service)
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -311,6 +311,14 @@ struct GGService {
         return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8)).stack
     }
 
+    /// Cross-stack triage snapshot from `gg inbox --json`. Runs at the
+    /// project root — one forge round-trip per project, never per worktree.
+    /// Per-stack failures arrive in-band as `stackErrors`, not as thrown errors.
+    func inbox(repoPath: String) async throws -> GGInboxSnapshot {
+        let result = try await runChecked(args: ["inbox", "--json"], worktreePath: repoPath)
+        return try GGInboxSnapshot.decode(fromJSON: Data(result.stdout.utf8))
+    }
+
     /// Streams sync events when `gg sync --jsonl` is supported; older gg
     /// builds fall back to `--json` and yield a summary event on success.
     func sync(worktreePath: String) -> AsyncThrowingStream<GGSyncEvent, Error> {

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -64,6 +64,14 @@ struct GGStackDrawer: View {
             Spacer(minLength: 6)
             Text(model.summaryChip)
                 .font(.system(size: 10.5, weight: .medium)).foregroundColor(theme.color("fg-dim"))
+            Button {
+                appState.openGGInbox(projectId: rps.worktree.projectId)
+            } label: {
+                Icon(name: "tray.full", size: 10, color: theme.color("fg-faint"))
+            }
+            .buttonStyle(.plain)
+            .focusEffectDisabled()
+            .help("Open gg inbox")
             if isRefreshing {
                 Spinner(lineWidth: 1.4, duration: 0.8).frame(width: 11, height: 11)
             } else {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1100,7 +1100,8 @@ final class RightPaneState {
                     ggActionState.appendSyncEvent(event)
                     if case .error(let message) = event { ggActionState.setError(message) }
                 }
-                if let summary = GGStackActionState.syncSummaryLine(from: ggActionState.syncProgress) {
+                if ggActionState.lastError == nil,
+                   let summary = GGStackActionState.syncSummaryLine(from: ggActionState.syncProgress) {
                     ggActionState.setActionSummary(summary)
                     ggActionState.clearSyncProgress()
                 }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -20,6 +20,7 @@ struct RepoGroupView: View {
     let onNewWorktree: () -> Void
     let onEditProject: () -> Void
     let onRemoveProject: () -> Void
+    let onOpenGGInbox: (() -> Void)?
     let onResetSort: () -> Void
     let spaces: [SpaceConfig]
     let activeSpaceId: String
@@ -88,6 +89,9 @@ struct RepoGroupView: View {
             .onTapGesture { collapsed.toggle() }
             .contextMenu {
                 Button("Edit Project…", action: onEditProject)
+                if let onOpenGGInbox {
+                    Button("gg Inbox", action: onOpenGGInbox)
+                }
                 Button("Reset Sort to Default", action: onResetSort)
                     .disabled(!project.worktreeOrderIsManual)
                 Menu("Spaces") {

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -62,6 +62,9 @@ struct SidebarView: View {
                                 onNewWorktree: { onNewWorktree(project.id) },
                                 onEditProject: { onEditProject(project.id) },
                                 onRemoveProject: { onRemoveProject(project.id) },
+                                onOpenGGInbox: state.ggInboxAvailable(projectId: project.id)
+                                    ? { state.openGGInbox(projectId: project.id) }
+                                    : nil,
                                 onResetSort: {
                                     state.projectsManager.resetWorktreeOrder(projectId: project.id)
                                     state.saveProjects()

--- a/AlasTests/GGInboxHostTests.swift
+++ b/AlasTests/GGInboxHostTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGInboxHostTests {
+    @Test func prefersSelectedWhenInProject() {
+        #expect(AppState.inboxHostWorktreeId(selectedWorktreeId: "w2", projectWorktreeIds: ["w1", "w2"]) == "w2")
+    }
+    @Test func fallsBackToFirstWhenSelectedIsForeign() {
+        #expect(AppState.inboxHostWorktreeId(selectedWorktreeId: "wOther", projectWorktreeIds: ["w1", "w2"]) == "w1")
+    }
+    @Test func fallsBackToFirstWhenNoneSelected() {
+        #expect(AppState.inboxHostWorktreeId(selectedWorktreeId: nil, projectWorktreeIds: ["w1", "w2"]) == "w1")
+    }
+    @Test func nilWhenProjectHasNoWorktrees() {
+        #expect(AppState.inboxHostWorktreeId(selectedWorktreeId: "w1", projectWorktreeIds: []) == nil)
+    }
+}

--- a/AlasTests/GGInboxTabsTests.swift
+++ b/AlasTests/GGInboxTabsTests.swift
@@ -1,0 +1,24 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct GGInboxTabsTests {
+    @Test func openOrFocusGGInboxDedupesById() {
+        let worktreeId = "gg-inbox-tabs-dedupe"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+
+        let first = mgr.openOrFocusGGInbox(worktreeId: worktreeId, projectId: "proj-1", projectName: "Proj One")
+        #expect(mgr.tabs(forWorktree: worktreeId).count == 1)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == first.id)
+
+        _ = mgr.appendTerminal(worktreeId: worktreeId, title: "main", sessionId: "s")
+        #expect(mgr.tabs(forWorktree: worktreeId).count == 2)
+
+        let second = mgr.openOrFocusGGInbox(worktreeId: worktreeId, projectId: "proj-1", projectName: "Proj One")
+        #expect(mgr.tabs(forWorktree: worktreeId).count == 2)
+        #expect(second.id == first.id)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == first.id)
+    }
+}

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -4,9 +4,14 @@ import Testing
 
 struct GGInboxHelpersTests {
     @Test func resolverPrefersExactUsernameBranch() {
+        // A same-named-stack branch from a different user ("other/auth")
+        // is now a genuine ambiguity case (see worktreeIdReturnsNil... below)
+        // and must not be mixed into this fixture, so the distractor here
+        // is a different stack entirely — this test isolates "picks the
+        // exact <username>/<stackName> match among several worktrees."
         let worktrees = [
             (id: "w1", branch: "nacho/auth"),
-            (id: "w2", branch: "other/auth"),
+            (id: "w2", branch: "nacho/perf"),
         ]
         #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: "nacho", worktrees: worktrees) == "w1")
     }
@@ -32,47 +37,29 @@ struct GGInboxHelpersTests {
         #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: nil, worktrees: worktrees) == nil)
     }
 
-    @Test func ambiguousStackNamesDetectsDuplicatesAcrossBuckets() throws {
-        let json = #"""
-        {"version":1,"total_items":2,
-         "buckets":{
-           "ready_to_land":[{"stack_name":"auth","position":1,"sha":"aaa","title":"Alice's auth","pr_number":1,"pr_url":"https://example.test/1"}],
-           "changes_requested":[],
-           "blocked_on_ci":[],
-           "awaiting_review":[{"stack_name":"auth","position":1,"sha":"bbb","title":"Bob's auth","pr_number":2,"pr_url":"https://example.test/2"}],
-           "behind_base":[],
-           "draft":[{"stack_name":"perf","position":1,"sha":"ccc","title":"Unique stack","pr_number":3,"pr_url":"https://example.test/3"}]},
-         "stack_errors":[]}
-        """#
-        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
-        #expect(GGInboxWorktreeResolver.ambiguousStackNames(in: snapshot.buckets) == ["auth"])
+    @Test func hasAmbiguousLocalOwnersTrueWithTwoMatchingBranches() {
+        let worktrees = [(id: "w1", branch: "alice/auth"), (id: "w2", branch: "bob/auth")]
+        #expect(GGInboxWorktreeResolver.hasAmbiguousLocalOwners(stackName: "auth", worktrees: worktrees))
     }
 
-    @Test func ambiguousStackNamesEmptyWhenAllUnique() throws {
-        let json = #"""
-        {"version":1,"total_items":1,
-         "buckets":{
-           "ready_to_land":[{"stack_name":"auth","position":1,"sha":"aaa","title":"t","pr_number":1,"pr_url":"https://example.test/1"}],
-           "changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},
-         "stack_errors":[]}
-        """#
-        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
-        #expect(GGInboxWorktreeResolver.ambiguousStackNames(in: snapshot.buckets).isEmpty)
+    @Test func hasAmbiguousLocalOwnersFalseWithOneMatch() {
+        let worktrees = [(id: "w1", branch: "bob/auth"), (id: "w2", branch: "bob/perf")]
+        #expect(!GGInboxWorktreeResolver.hasAmbiguousLocalOwners(stackName: "auth", worktrees: worktrees))
     }
 
-    @Test func ambiguousStackNamesCountsStackErrorsToo() throws {
-        let json = #"""
-        {"version":1,"total_items":1,
-         "buckets":{
-           "ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],
-           "awaiting_review":[{"stack_name":"auth","position":1,"sha":"bbb","title":"Bob's auth","pr_number":2,"pr_url":"https://example.test/2"}],
-           "behind_base":[],"draft":[]},
-         "stack_errors":[{"stack_name":"auth","error":"branch missing"}]}
-        """#
-        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
-        #expect(GGInboxWorktreeResolver.ambiguousStackNames(
-            in: snapshot.buckets, stackErrors: snapshot.stackErrors
-        ) == ["auth"])
+    @Test func worktreeIdReturnsNilWhenMultipleLocalBranchesShareStackName() {
+        // Even though "bob/auth" is an exact match for username "bob", a
+        // second local branch for the same stack name ("alice/auth") means
+        // this specific row can't be safely attributed — must dim, not guess.
+        let worktrees = [(id: "w1", branch: "alice/auth"), (id: "w2", branch: "bob/auth")]
+        #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: "bob", worktrees: worktrees) == nil)
+    }
+
+    @Test func worktreeIdResolvesNormallyWhenOnlyOneLocalBranchMatches() {
+        // A stack's multiple positions/PRs never affect this — the check is
+        // purely about distinct local branches, not row count.
+        let worktrees = [(id: "w1", branch: "bob/auth")]
+        #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: "bob", worktrees: worktrees) == "w1")
     }
 
     @Test func updatedLabel() {

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -32,6 +32,34 @@ struct GGInboxHelpersTests {
         #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: nil, worktrees: worktrees) == nil)
     }
 
+    @Test func ambiguousStackNamesDetectsDuplicatesAcrossBuckets() throws {
+        let json = #"""
+        {"version":1,"total_items":2,
+         "buckets":{
+           "ready_to_land":[{"stack_name":"auth","position":1,"sha":"aaa","title":"Alice's auth","pr_number":1,"pr_url":"https://example.test/1"}],
+           "changes_requested":[],
+           "blocked_on_ci":[],
+           "awaiting_review":[{"stack_name":"auth","position":1,"sha":"bbb","title":"Bob's auth","pr_number":2,"pr_url":"https://example.test/2"}],
+           "behind_base":[],
+           "draft":[{"stack_name":"perf","position":1,"sha":"ccc","title":"Unique stack","pr_number":3,"pr_url":"https://example.test/3"}]},
+         "stack_errors":[]}
+        """#
+        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
+        #expect(GGInboxWorktreeResolver.ambiguousStackNames(in: snapshot.buckets) == ["auth"])
+    }
+
+    @Test func ambiguousStackNamesEmptyWhenAllUnique() throws {
+        let json = #"""
+        {"version":1,"total_items":1,
+         "buckets":{
+           "ready_to_land":[{"stack_name":"auth","position":1,"sha":"aaa","title":"t","pr_number":1,"pr_url":"https://example.test/1"}],
+           "changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},
+         "stack_errors":[]}
+        """#
+        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
+        #expect(GGInboxWorktreeResolver.ambiguousStackNames(in: snapshot.buckets).isEmpty)
+    }
+
     @Test func updatedLabel() {
         let now = Date(timeIntervalSince1970: 100_000)
         #expect(GGInboxTabView.updatedLabel(fetchedAt: nil, now: now) == nil)

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -60,6 +60,21 @@ struct GGInboxHelpersTests {
         #expect(GGInboxWorktreeResolver.ambiguousStackNames(in: snapshot.buckets).isEmpty)
     }
 
+    @Test func ambiguousStackNamesCountsStackErrorsToo() throws {
+        let json = #"""
+        {"version":1,"total_items":1,
+         "buckets":{
+           "ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],
+           "awaiting_review":[{"stack_name":"auth","position":1,"sha":"bbb","title":"Bob's auth","pr_number":2,"pr_url":"https://example.test/2"}],
+           "behind_base":[],"draft":[]},
+         "stack_errors":[{"stack_name":"auth","error":"branch missing"}]}
+        """#
+        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
+        #expect(GGInboxWorktreeResolver.ambiguousStackNames(
+            in: snapshot.buckets, stackErrors: snapshot.stackErrors
+        ) == ["auth"])
+    }
+
     @Test func updatedLabel() {
         let now = Date(timeIntervalSince1970: 100_000)
         #expect(GGInboxTabView.updatedLabel(fetchedAt: nil, now: now) == nil)

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -17,6 +17,13 @@ struct GGInboxHelpersTests {
         #expect(GGInboxWorktreeResolver.worktreeId(stackName: "missing", username: nil, worktrees: worktrees) == nil)
     }
 
+    @Test func resolverReturnsNilWhenUsernameKnownButOnlyForeignMatch() {
+        // Known username, no exact <username>/<stack> worktree, only a
+        // different user's same-named stack checked out → no navigation.
+        let worktrees = [(id: "w1", branch: "other/auth")]
+        #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: "nacho", worktrees: worktrees) == nil)
+    }
+
     @Test func resolverDoesNotMatchBareOrPartialNames() {
         let worktrees = [
             (id: "w1", branch: "auth"),            // no slash — not gg convention

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -62,6 +62,15 @@ struct GGInboxHelpersTests {
         #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: "bob", worktrees: worktrees) == "w1")
     }
 
+    @Test func doesNotConflateNestedStackNameWithSuffixMatch() {
+        // "alice/feature/auth" is a DIFFERENT stack ("feature/auth"), not
+        // related to stack "auth" — despite ending in the raw substring
+        // "/auth". Must not be treated as a same-name collision.
+        let worktrees = [(id: "w1", branch: "bob/auth"), (id: "w2", branch: "alice/feature/auth")]
+        #expect(!GGInboxWorktreeResolver.hasAmbiguousLocalOwners(stackName: "auth", worktrees: worktrees))
+        #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: "bob", worktrees: worktrees) == "w1")
+    }
+
     @Test func updatedLabel() {
         let now = Date(timeIntervalSince1970: 100_000)
         #expect(GGInboxTabView.updatedLabel(fetchedAt: nil, now: now) == nil)

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -41,12 +41,24 @@ struct GGInboxHelpersTests {
     }
 
     @Test func ciIconMapping() {
-        #expect(GGInboxTabView.ciIconName("passed") == "checkmark.circle")
+        #expect(GGInboxTabView.ciIconName("success") == "checkmark.circle")
         #expect(GGInboxTabView.ciIconName("failed") == "xmark.circle")
+        #expect(GGInboxTabView.ciIconName("canceled") == "xmark.circle")
         #expect(GGInboxTabView.ciIconName("running") == "clock")
         #expect(GGInboxTabView.ciIconName("pending") == "clock")
+        #expect(GGInboxTabView.ciIconName("unknown") == nil)
         #expect(GGInboxTabView.ciIconName(nil) == nil)
         #expect(GGInboxTabView.ciIconName("weird") == nil)
+    }
+
+    @Test func ciIconColorMapping() {
+        #expect(GGInboxTabView.ciIconColorToken("success") == "add")
+        #expect(GGInboxTabView.ciIconColorToken("failed") == "del")
+        #expect(GGInboxTabView.ciIconColorToken("canceled") == "del")
+        #expect(GGInboxTabView.ciIconColorToken("running") == "caution")
+        #expect(GGInboxTabView.ciIconColorToken("pending") == "caution")
+        #expect(GGInboxTabView.ciIconColorToken("unknown") == "fg-dim")
+        #expect(GGInboxTabView.ciIconColorToken(nil) == "fg-dim")
     }
 
     @Test func tabStateIdentityAndCodableRoundTrip() throws {

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGInboxHelpersTests {
+    @Test func resolverPrefersExactUsernameBranch() {
+        let worktrees = [
+            (id: "w1", branch: "nacho/auth"),
+            (id: "w2", branch: "other/auth"),
+        ]
+        #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: "nacho", worktrees: worktrees) == "w1")
+    }
+
+    @Test func resolverFallsBackToSuffixWhenUsernameUnknown() {
+        let worktrees = [(id: "w1", branch: "someone/perf")]
+        #expect(GGInboxWorktreeResolver.worktreeId(stackName: "perf", username: nil, worktrees: worktrees) == "w1")
+        #expect(GGInboxWorktreeResolver.worktreeId(stackName: "missing", username: nil, worktrees: worktrees) == nil)
+    }
+
+    @Test func resolverDoesNotMatchBareOrPartialNames() {
+        let worktrees = [
+            (id: "w1", branch: "auth"),            // no slash — not gg convention
+            (id: "w2", branch: "nacho/auth-flow"), // different stack
+        ]
+        #expect(GGInboxWorktreeResolver.worktreeId(stackName: "auth", username: nil, worktrees: worktrees) == nil)
+    }
+
+    @Test func updatedLabel() {
+        let now = Date(timeIntervalSince1970: 100_000)
+        #expect(GGInboxTabView.updatedLabel(fetchedAt: nil, now: now) == nil)
+        #expect(GGInboxTabView.updatedLabel(fetchedAt: now.addingTimeInterval(-30), now: now) == "Updated just now")
+        #expect(GGInboxTabView.updatedLabel(fetchedAt: now.addingTimeInterval(-150), now: now) == "Updated 2m ago")
+        #expect(GGInboxTabView.updatedLabel(fetchedAt: now.addingTimeInterval(-7_200), now: now) == "Updated 2h ago")
+    }
+
+    @Test func ciIconMapping() {
+        #expect(GGInboxTabView.ciIconName("passed") == "checkmark.circle")
+        #expect(GGInboxTabView.ciIconName("failed") == "xmark.circle")
+        #expect(GGInboxTabView.ciIconName("running") == "clock")
+        #expect(GGInboxTabView.ciIconName("pending") == "clock")
+        #expect(GGInboxTabView.ciIconName(nil) == nil)
+        #expect(GGInboxTabView.ciIconName("weird") == nil)
+    }
+
+    @Test func tabStateIdentityAndCodableRoundTrip() throws {
+        let state = GGInboxTabState(projectId: "p1", projectName: "alas")
+        #expect(state.id == "gg-inbox:p1")
+        #expect(state.title == "Inbox — alas")
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(GGInboxTabState.self, from: data)
+        #expect(decoded == state)
+    }
+}

--- a/AlasTests/Integrations/GGInboxModelsTests.swift
+++ b/AlasTests/Integrations/GGInboxModelsTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGInboxModelsTests {
+    static let fullSample = #"""
+    {"version":1,"total_items":2,
+     "buckets":{
+       "ready_to_land":[{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login flow","pr_number":42,"pr_url":"https://example.test/42","ci_status":"passed","behind_base":2}],
+       "changes_requested":[],
+       "blocked_on_ci":[],
+       "awaiting_review":[{"stack_name":"perf","position":2,"sha":"def456","title":"Cache layer","pr_number":43,"pr_url":"https://example.test/43"}],
+       "behind_base":[],
+       "draft":[]},
+     "stack_errors":[{"stack_name":"broken","error":"stack branch missing"}]}
+    """#
+
+    @Test func decodesFullSample() throws {
+        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(Self.fullSample.utf8))
+        #expect(snapshot.version == 1)
+        #expect(snapshot.totalItems == 2)
+        let ready = snapshot.buckets.readyToLand
+        #expect(ready.count == 1)
+        #expect(ready[0].stackName == "auth")
+        #expect(ready[0].prNumber == 42)
+        #expect(ready[0].ciStatus == "passed")
+        #expect(ready[0].behindBase == 2)
+        // Optional fields absent → nil.
+        let awaiting = snapshot.buckets.awaitingReview
+        #expect(awaiting[0].ciStatus == nil)
+        #expect(awaiting[0].behindBase == nil)
+        // merged absent (no --all) → empty, not a decode failure.
+        #expect(snapshot.buckets.merged.isEmpty)
+        #expect(snapshot.stackErrors == [GGInboxStackError(stackName: "broken", error: "stack branch missing")])
+    }
+
+    @Test func decodesMergedBucketWhenPresent() throws {
+        let json = #"{"version":1,"total_items":0,"buckets":{"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[],"merged":[{"stack_name":"done","position":1,"sha":"aaa","title":"Shipped","pr_number":7,"pr_url":"https://example.test/7"}]},"stack_errors":[]}"#
+        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
+        #expect(snapshot.buckets.merged.count == 1)
+    }
+
+    @Test func malformedJSONThrowsMalformedOutput() {
+        #expect(throws: GGServiceError.self) {
+            _ = try GGInboxSnapshot.decode(fromJSON: Data("not json".utf8))
+        }
+        #expect(throws: GGServiceError.self) {
+            _ = try GGInboxSnapshot.decode(fromJSON: Data(#"{"version":1}"#.utf8))
+        }
+    }
+
+    @Test func bucketMetadataPriorityOrderAndAccessors() throws {
+        #expect(GGInboxBucket.allCases == [.readyToLand, .changesRequested, .blockedOnCi, .awaitingReview, .behindBase, .draft])
+        #expect(GGInboxBucket.readyToLand.title == "Ready to land")
+        #expect(GGInboxBucket.readyToLand.themeToken == "add")
+        #expect(GGInboxBucket.changesRequested.themeToken == "warn")
+        #expect(GGInboxBucket.blockedOnCi.themeToken == "warn")
+        #expect(GGInboxBucket.draft.themeToken == "fg-dim")
+        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(Self.fullSample.utf8))
+        #expect(GGInboxBucket.readyToLand.entries(in: snapshot.buckets).count == 1)
+        #expect(GGInboxBucket.awaitingReview.entries(in: snapshot.buckets).count == 1)
+        #expect(GGInboxBucket.draft.entries(in: snapshot.buckets).isEmpty)
+    }
+}

--- a/AlasTests/Integrations/GGInboxStoreTests.swift
+++ b/AlasTests/Integrations/GGInboxStoreTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import Alas
+
+private final class FakeGGRunner: GGCommandRunning, @unchecked Sendable {
+    private let result: ProcessResult
+
+    init(result: ProcessResult) {
+        self.result = result
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        result
+    }
+}
+
+@MainActor
+struct GGInboxStoreTests {
+    private static let emptyJSON = #"{"version":1,"total_items":0,"buckets":{"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[]}"#
+
+    @Test func refreshStoresSnapshotAndTimestamp() async throws {
+        let store = GGInboxStore()
+        let runner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        let fixed = Date(timeIntervalSince1970: 1_000)
+        await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner), now: { fixed })
+        let state = try #require(store.states["p1"])
+        #expect(state.snapshot?.totalItems == 0)
+        #expect(state.fetchedAt == fixed)
+        #expect(state.lastError == nil)
+        #expect(state.isRefreshing == false)
+    }
+
+    @Test func refreshFailureKeepsStaleSnapshotAndSetsError() async throws {
+        let store = GGInboxStore()
+        let okRunner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: okRunner))
+        let failRunner = FakeGGRunner(result: ProcessResult(exitCode: 1, stdout: "", stderr: "forge unreachable"))
+        await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: failRunner))
+        let state = try #require(store.states["p1"])
+        #expect(state.snapshot != nil) // stale snapshot retained
+        #expect(state.lastError != nil)
+        #expect(state.isRefreshing == false)
+    }
+
+    @Test func refreshDedupesWhileInFlight() async {
+        let store = GGInboxStore()
+        store.states["p1"] = .init(isRefreshing: true)
+        let runner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        // Guard returned before running: no snapshot was written.
+        #expect(store.states["p1"]?.snapshot == nil)
+    }
+
+    @Test func staleness() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        #expect(GGInboxStore.isStale(fetchedAt: nil, now: now))
+        #expect(GGInboxStore.isStale(fetchedAt: now.addingTimeInterval(-120), now: now))
+        #expect(!GGInboxStore.isStale(fetchedAt: now.addingTimeInterval(-119), now: now))
+    }
+
+    @Test func pruneDropsRemovedProjectsAndIsValueDiffed() {
+        let store = GGInboxStore()
+        store.states = ["keep": .init(), "drop": .init()]
+        store.prune(keepingProjectIds: ["keep"])
+        #expect(Array(store.states.keys) == ["keep"])
+        store.prune(keepingProjectIds: ["keep"]) // no-op prune
+        #expect(Array(store.states.keys) == ["keep"])
+    }
+}

--- a/AlasTests/Integrations/GGServiceInboxTests.swift
+++ b/AlasTests/Integrations/GGServiceInboxTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import Alas
+
+private final class InboxRecordingGGRunner: GGCommandRunning, @unchecked Sendable {
+    private let result: ProcessResult
+    private(set) var lastArgs: [String] = []
+    private(set) var lastCwd: URL?
+
+    init(result: ProcessResult) {
+        self.result = result
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        lastArgs = args
+        lastCwd = cwd
+        return result
+    }
+}
+
+struct GGServiceInboxTests {
+    @Test func inboxRunsAtRepoPathAndDecodes() async throws {
+        let json = #"{"version":1,"total_items":0,"buckets":{"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[]}"#
+        let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 0, stdout: json, stderr: ""))
+        let service = GGService(runner: runner)
+        let snapshot = try await service.inbox(repoPath: "/repo/root")
+        #expect(runner.lastArgs == ["inbox", "--json"])
+        #expect(runner.lastCwd?.path == "/repo/root")
+        #expect(snapshot.totalItems == 0)
+    }
+
+    @Test func inboxMapsExitCode127ToCLIMissing() async {
+        let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 127, stdout: "", stderr: "not found"))
+        let service = GGService(runner: runner)
+        await #expect(throws: GGServiceError.self) {
+            _ = try await service.inbox(repoPath: "/repo/root")
+        }
+    }
+
+    @Test func inboxThrowsOnMalformedStdout() async {
+        let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 0, stdout: "garbage", stderr: ""))
+        let service = GGService(runner: runner)
+        await #expect(throws: GGServiceError.self) {
+            _ = try await service.inbox(repoPath: "/repo/root")
+        }
+    }
+}

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -57,6 +57,7 @@ struct RepoGroupViewLayoutTests {
             onNewWorktree: {},
             onEditProject: {},
             onRemoveProject: {},
+            onOpenGGInbox: nil,
             onResetSort: {},
             spaces: [],
             activeSpaceId: "",

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -601,4 +601,29 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.lastActionSummary == "Synced · 1 pushed")
         #expect(state.ggActionState.syncProgress.isEmpty)
     }
+
+    @Test func syncErrorSuppressesSuccessSummary() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let ndjson = [
+            #"{"event":"start","total_entries":1}"#,
+            #"{"event":"push_done","position":1,"forced":false}"#,
+            #"{"event":"error","message":"push rejected"}"#,
+            #"{"event":"summary"}"#,
+        ].joined(separator: "\n")
+        state.ggService = GGService(runner: NDJSONSyncFakeGGRunner(ndjson: ndjson))
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
+
+        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        var iterations = 0
+        while state.ggActionState.inFlightAction != nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            iterations += 1
+            if iterations > 500 { break }
+        }
+
+        #expect(state.ggActionState.lastError != nil)
+        #expect(state.ggActionState.lastActionSummary == nil)
+    }
 }


### PR DESCRIPTION
## Summary

Phase 4 of the gg (git-gud) stacked-diffs integration: a project-scoped **gg Inbox** triage tab, plus two hardening fixes carried from the phase-3 ledger. Builds on phases 1–3 (#850, #854/#855, #858).

### gg Inbox tab
- A new center-pane **Inbox** tab, opened per project from the sidebar project context menu ("gg Inbox") or the stack drawer, backed by `gg inbox --json`.
- Runs `gg inbox` once per **project** (at the repo root) — one forge round-trip per refresh, never per worktree.
- Renders gg's six priority buckets (Ready to land → Draft) with PR/CI state, plus a `stack_errors` footer. Rows navigate to the matching live worktree (only the current user's `<username>/<stack>` branch) and link to the PR; rows without a live worktree are dimmed but keep the PR link.
- Refresh on open when the snapshot is missing or stale (120s), plus a manual refresh button; stale snapshots are retained across refresh failures alongside the error.

### Hardening
- `runGGSync` no longer surfaces a success summary when the sync stream reported an error.
- The new-worktree dialog seeds the base picker synchronously on project switch, so it never briefly shows the previous project's base.

## Testing
- 81 gg-focused tests across 9 suites pass locally (decode, service, store, resolver/helpers, tab dedupe, host targeting, sync summary, dialog); full `xcodebuild` build clean.
- Full suite runs on CI.

## Notes
- The inbox is navigation-first; landing/syncing stays in the per-worktree drawer.
