### PR TITLE
fix(diff): expand row pill layout

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -540,25 +540,28 @@ struct DiffPaneTextDocumentBuilder {
         paragraph.firstLineHeadIndent = headIndent
         paragraph.headIndent = headIndent
         paragraph.lineBreakMode = .byClipping
-        // Size the row from the font (code font is user-configurable up to 64pt),
-        // not a fixed height: natural line height plus symmetric vertical padding,
-        // so the row rect grows with the glyphs and the pill keeps its breathing
-        // room at any size. Baseline-shift the glyphs by the padding so they sit in
-        // the vertical center of the row and the pill can center on the row.
-        let naturalLineHeight = font.ascender - font.descender
-        let rowHeight = naturalLineHeight + expandableContextRowPadding * 2
+        // Size the row from the same metrics the text view uses to draw the
+        // pill: label height + pill inset + row inset. The code font is
+        // user-configurable, so fixed row heights clip at larger sizes.
+        let contentInset = expandableContextPillVerticalInset + expandableContextRowOuterVerticalInset
+        let rowHeight = expandableContextRowHeight(font: font)
         paragraph.minimumLineHeight = rowHeight
         paragraph.maximumLineHeight = rowHeight
         return [
             .font: font,
             .foregroundColor: NSColor(theme.color("seg-pill-active-fg")),
             .paragraphStyle: paragraph,
-            .baselineOffset: expandableContextRowPadding,
+            .baselineOffset: contentInset,
         ]
     }
 
-    /// Symmetric vertical padding between the label and the pill edge.
-    private static let expandableContextRowPadding: CGFloat = 5
+    static let expandableContextPillVerticalInset: CGFloat = 2
+    static let expandableContextRowOuterVerticalInset: CGFloat = 4
+
+    static func expandableContextRowHeight(font: NSFont) -> CGFloat {
+        let naturalLineHeight = font.ascender - font.descender
+        return naturalLineHeight + (expandableContextPillVerticalInset + expandableContextRowOuterVerticalInset) * 2
+    }
 
     /// Left inset of the expand label, leaving room for the separately-drawn
     /// chevron and the pill's left padding. Scales with the font so the chevron

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1173,15 +1173,22 @@ final class DiffPaneCodeTextView: NSTextView {
         chevronSize: NSSize,
         chevronGap: CGFloat = 5,
         horizontalPadding: CGFloat = 12,
-        verticalInset: CGFloat = 2
+        verticalInset: CGFloat = DiffPaneTextDocumentBuilder.expandableContextPillVerticalInset
     ) -> NSRect {
         let anchorRect = textRect.isEmpty ? (firstLineRect.isEmpty ? rowRect : firstLineRect) : textRect
         let pillHeight = max(anchorRect.height + verticalInset * 2, 1)
         let chevronLeftX = textRect.minX - chevronGap - chevronSize.width
         let pillLeft = (chevronSize == .zero ? textRect.minX : chevronLeftX) - horizontalPadding
+        let idealY = anchorRect.midY - pillHeight / 2
+        let pillY: CGFloat
+        if !rowRect.isEmpty, rowRect.height >= pillHeight {
+            pillY = min(max(idealY, rowRect.minY), rowRect.maxY - pillHeight)
+        } else {
+            pillY = idealY
+        }
         return NSRect(
             x: pillLeft,
-            y: anchorRect.midY - pillHeight / 2,
+            y: pillY,
             width: textRect.maxX + horizontalPadding - pillLeft,
             height: pillHeight
         )

--- a/AlasTests/DiffPaneTextDocumentBuilderTests.swift
+++ b/AlasTests/DiffPaneTextDocumentBuilderTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import Testing
 @testable import Alas
@@ -20,6 +21,40 @@ struct DiffPaneTextDocumentBuilderTests {
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: true, pressed: false) == 0.28)
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: true, pressed: true) == 0.36)
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: false, pressed: true) == 0.36)
+    }
+
+    @Test func expandableContextRowContainsPillWithVerticalClearance() throws {
+        let font = CenterTypography.resolveCodeFont(family: "", size: 32)
+        let row = expandableContextRow(remainingLineCount: 46, boundary: .below)
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            rows: [row],
+            fileExtension: "swift",
+            font: font,
+            showWhitespace: false,
+            theme: try ThemeStore().current
+        )
+        let paragraph = try #require(
+            result.oldCode.attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        )
+        let rowHeight = paragraph.minimumLineHeight
+        let labelHeight = font.ascender - font.descender
+        let rowRect = CGRect(x: 0, y: 0, width: 600, height: rowHeight)
+        let textRect = CGRect(
+            x: 120,
+            y: (rowHeight - labelHeight) / 2,
+            width: 260,
+            height: labelHeight
+        )
+
+        let pillRect = DiffPaneCodeTextView.expandPillRect(
+            textRect: textRect,
+            firstLineRect: rowRect,
+            rowRect: rowRect,
+            chevronSize: CGSize(width: 31, height: 31)
+        )
+
+        #expect(pillRect.minY - rowRect.minY >= 4)
+        #expect(rowRect.maxY - pillRect.maxY >= 4)
     }
 
     @Test func expandPillStaysWithFirstTextFragmentInTallRows() {
@@ -47,5 +82,40 @@ struct DiffPaneTextDocumentBuilderTests {
 
         #expect(chevronRect.midY == pillRect.midY)
         #expect(chevronRect.midY != rowRect.midY)
+    }
+
+    @Test func expandPillRectClampsInsideRowWhenTextRectEscapes() {
+        let textRect = CGRect(x: 120, y: -3, width: 230, height: 20)
+        let firstLineRect = CGRect(x: 0, y: 0, width: 700, height: 28)
+        let rowRect = CGRect(x: 0, y: 0, width: 700, height: 28)
+        let chevronSize = CGSize(width: 12, height: 12)
+
+        let pillRect = DiffPaneCodeTextView.expandPillRect(
+            textRect: textRect,
+            firstLineRect: firstLineRect,
+            rowRect: rowRect,
+            chevronSize: chevronSize
+        )
+
+        #expect(pillRect.minY >= rowRect.minY)
+        #expect(pillRect.maxY <= rowRect.maxY)
+    }
+
+    private func expandableContextRow(
+        remainingLineCount: Int,
+        boundary: DiffContextBoundary
+    ) -> DiffDisplayRow {
+        DiffDisplayRow(
+            id: "expand-\(boundary.rawValue)",
+            kind: .expandableContext,
+            old: nil,
+            new: nil,
+            collapsedLineCount: remainingLineCount,
+            contextExpansion: DiffContextExpansionRow(
+                key: DiffContextExpansionKey(groupID: "hunk-0", boundary: boundary),
+                boundary: boundary,
+                remainingLineCount: remainingLineCount
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary
Fixes the diff expandable-context row geometry so the expand pills have enough vertical room and cannot render outside their row when text layout reports an escaping rect.

## Changes
- Sizes expandable context rows from the same pill metrics used by drawing, preserving compact density while adding explicit top/bottom clearance.
- Clamps expand pill rectangles inside their row bounds to handle edge-case text fragment placement.
- Adds regression coverage for row clearance and escaping text rects.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneTextDocumentBuilderTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RightPaneStateBaseBranchTests`

## Notes
Full local test suite had one order-dependent failure in `RightPaneStateBaseBranchTests.storeRefreshesWhenConfigMatchesClearedOverride`; rerunning that suite passed all 13 tests.
