### PR TITLE
style(diff): simplify context expansion controls

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -595,8 +595,13 @@ struct DiffPaneTextDocumentBuilder {
         return "Expand \(remainingLineCount) unchanged lines \(boundaryText)"
     }
 
-    static func expandableContextSymbolName(boundary: DiffContextBoundary?) -> String {
-        boundary == .above ? "chevron.up" : "chevron.down"
+    static func expandableContextSymbolName(
+        boundary: DiffContextBoundary?,
+        mode: ContextExpansionActionMode = .chunk
+    ) -> String {
+        let direction = boundary == .above ? "up" : "down"
+        let count = mode == .all ? ".2" : ""
+        return "chevron.\(direction)\(count)"
     }
 
     private static let expandableContextActionSeparator = "      "

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -1210,7 +1210,7 @@ final class DiffPaneCodeTextView: NSTextView {
     nonisolated static func expandPillFillAlpha(hovered: Bool, pressed: Bool) -> CGFloat {
         if pressed { return 0.36 }
         if hovered { return 0.28 }
-        return 0.18
+        return 0
     }
 
     nonisolated static func expandPillRect(
@@ -1973,6 +1973,7 @@ final class DiffPaneCodeTextView: NSTextView {
             guard
                 let chevronImage = Self.expandChevronImage(
                     boundary: action.boundary,
+                    mode: action.mode,
                     font: font,
                     color: tint
                 ),
@@ -1992,6 +1993,7 @@ final class DiffPaneCodeTextView: NSTextView {
         let chevronGap: CGFloat = 5
         let chevronSize = Self.expandChevronImage(
             boundary: action.boundary,
+            mode: action.mode,
             font: font,
             color: .textColor
         )?.size ?? .zero
@@ -2013,6 +2015,7 @@ final class DiffPaneCodeTextView: NSTextView {
         let chevronGap: CGFloat = 5
         let chevronImage = Self.expandChevronImage(
             boundary: action.boundary,
+            mode: action.mode,
             font: font,
             color: .textColor
         )
@@ -2070,10 +2073,14 @@ final class DiffPaneCodeTextView: NSTextView {
 
     private static func expandChevronImage(
         boundary: DiffContextBoundary?,
+        mode: DiffPaneTextDocumentBuilder.ContextExpansionActionMode,
         font: NSFont?,
         color: NSColor
     ) -> NSImage? {
-        let symbol = DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: boundary)
+        let symbol = DiffPaneTextDocumentBuilder.expandableContextSymbolName(
+            boundary: boundary,
+            mode: mode
+        )
         let pointSize = (font?.pointSize ?? 13) - 1
         let config = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
             .applying(NSImage.SymbolConfiguration(paletteColors: [color]))

--- a/AlasTests/DiffPaneTextDocumentBuilderTests.swift
+++ b/AlasTests/DiffPaneTextDocumentBuilderTests.swift
@@ -16,8 +16,19 @@ struct DiffPaneTextDocumentBuilderTests {
         #expect(DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: nil) == "chevron.down")
     }
 
+    @Test func expandAllUsesDoubleChevron() {
+        #expect(
+            DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: .above, mode: .all)
+                == "chevron.up.2"
+        )
+        #expect(
+            DiffPaneTextDocumentBuilder.expandableContextSymbolName(boundary: .below, mode: .all)
+                == "chevron.down.2"
+        )
+    }
+
     @Test func pillFillAlphaByState() {
-        #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: false, pressed: false) == 0.18)
+        #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: false, pressed: false) == 0)
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: true, pressed: false) == 0.28)
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: true, pressed: true) == 0.36)
         #expect(DiffPaneCodeTextView.expandPillFillAlpha(hovered: false, pressed: true) == 0.36)


### PR DESCRIPTION
## Summary

- remove the accent fill from expand-context controls while they are idle
- retain the existing accent feedback on hover and press
- use double directional chevrons for "Expand all context" while keeping the labels and existing hit targets
- select and measure the chevron from the action mode so both single- and double-chevron controls remain aligned

## Testing

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneTextDocumentBuilderTests test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- GitHub Actions `build-test`

<!-- gg:managed:start -->
Part of stack `expand-button-ui`

Commit: aa53da8
<!-- gg:managed:end -->
