### PR TITLE
feat(gg): detect workflow configuration and capabilities

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C506EF972D34E2F937D4FEEC /* InstallerHost.swift */; };
 		043D6A4860C1336134311DD3 /* tool-call-content-terminal.json in Resources */ = {isa = PBXBuildFile; fileRef = D60051A6C7BEE35773F3FBB9 /* tool-call-content-terminal.json */; };
 		04C778DB96502CD36E4C031B /* MergeConflictTabModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */; };
+		04D55B4985BDF4CEF0BA3C0E /* GGMutationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */; };
 		04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */; };
 		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
 		0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */; };
@@ -2144,6 +2145,7 @@
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipTests.swift; sourceTree = "<group>"; };
 		98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxStoreTests.swift; sourceTree = "<group>"; };
+		993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationModels.swift; sourceTree = "<group>"; };
 		99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPServer.swift; sourceTree = "<group>"; };
 		99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffLoaderTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
@@ -4885,6 +4887,7 @@
 				B32762D888121D56722E03F5 /* GGInboxTabView.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */,
+				993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */,
@@ -5599,6 +5602,7 @@
 				56286C44BC30C1716CD44363 /* GGInboxTabView.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */,
+				04D55B4985BDF4CEF0BA3C0E /* GGMutationModels.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */,

--- a/Alas/Sources/Integrations/GG/GGConfigReader.swift
+++ b/Alas/Sources/Integrations/GG/GGConfigReader.swift
@@ -44,6 +44,23 @@ enum GGConfigReader {
         return nil
     }
 
+    static func effectiveConfig(
+        repoPath: String,
+        globalConfigPath: String? = GGConfigReader.defaultGlobalConfigPath
+    ) -> GGEffectiveConfig {
+        let localPath = GGStackGate.ggConfigPath(repoPath: repoPath)
+        let hasLocalConfig = localPath.map(FileManager.default.fileExists(atPath:)) ?? false
+        let effectiveDefaults = hasLocalConfig
+            ? localPath.flatMap(readDefaults(at:))
+            : globalConfigPath.flatMap(readDefaults(at:))
+        return GGEffectiveConfig(
+            syncAutoRebase: effectiveDefaults?.syncAutoRebase
+                ?? GGEffectiveConfig.defaults.syncAutoRebase,
+            syncBehindThreshold: effectiveDefaults?.syncBehindThreshold.flatMap { $0 >= 0 ? $0 : nil }
+                ?? GGEffectiveConfig.defaults.syncBehindThreshold
+        )
+    }
+
     /// gg's stack-branch naming convention.
     static func composeStackBranch(username: String, stackName: String) -> String {
         "\(username)/\(stackName)"
@@ -57,5 +74,32 @@ enum GGConfigReader {
               !value.isEmpty
         else { return nil }
         return value
+    }
+
+    private static func readDefaults(at path: String) -> EffectiveDefaults? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let config = try? JSONDecoder().decode(EffectiveConfig.self, from: data)
+        else { return nil }
+        return config.defaults
+    }
+
+    private struct EffectiveConfig: Decodable {
+        var defaults: EffectiveDefaults?
+    }
+
+    private struct EffectiveDefaults: Decodable {
+        var syncAutoRebase: Bool?
+        var syncBehindThreshold: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case syncAutoRebase = "sync_auto_rebase"
+            case syncBehindThreshold = "sync_behind_threshold"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            syncAutoRebase = try? container.decode(Bool.self, forKey: .syncAutoRebase)
+            syncBehindThreshold = try? container.decode(Int.self, forKey: .syncBehindThreshold)
+        }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -1,0 +1,13 @@
+struct GGEffectiveConfig: Equatable, Sendable {
+    var syncAutoRebase: Bool
+    var syncBehindThreshold: Int
+
+    static let defaults = GGEffectiveConfig(syncAutoRebase: false, syncBehindThreshold: 1)
+}
+
+struct GGCapabilities: Equatable, Sendable {
+    var structuredSplit: Bool
+    var keepCurrentUnstack: Bool
+    var clientOperationID: Bool = false
+    var stagedOnlyAmend: Bool = false
+}

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -287,6 +287,24 @@ struct GGService {
         return output.split(separator: " ").last.map(String.init)
     }
 
+    func probeCapabilities() async -> GGCapabilities {
+        let root = try? await runner.run(args: ["--help"], cwd: nil)
+        let split = try? await runner.run(args: ["split", "--help"], cwd: nil)
+        let unstack = try? await runner.run(args: ["unstack", "--help"], cwd: nil)
+        let sc = try? await runner.run(args: ["sc", "--help"], cwd: nil)
+        return GGCapabilities(
+            structuredSplit: split?.exitCode == 0
+                && split?.stdout.contains("--describe") == true
+                && split?.stdout.contains("--plan-json") == true,
+            keepCurrentUnstack: unstack?.exitCode == 0
+                && unstack?.stdout.contains("--keep-current") == true,
+            clientOperationID: root?.exitCode == 0
+                && root?.stdout.contains("--client-operation-id") == true,
+            stagedOnlyAmend: sc?.exitCode == 0
+                && sc?.stdout.contains("--staged-only") == true
+        )
+    }
+
     /// Loads the current branch's stack via `gg ls --json`. Returns nil
     /// when the branch is not a gg stack (gg emits the all-stacks shape).
     func currentStack(worktreePath: String) async throws -> GGStack? {
@@ -419,6 +437,10 @@ final class GGAvailability {
     private(set) var version: String?
     private(set) var hasProbed = false
     private(set) var ggMCPBinaryPath: String?
+    private(set) var capabilities = GGCapabilities(
+        structuredSplit: false,
+        keepCurrentUnstack: false
+    )
 
     var isInstalled: Bool { version != nil }
 
@@ -439,8 +461,15 @@ final class GGAvailability {
         force: Bool = false
     ) async {
         if hasProbed && !force { return }
-        version = await service.probeVersion()
-        ggMCPBinaryPath = version != nil ? await which("gg-mcp") : nil
-        hasProbed = true
+        let detectedVersion = await service.probeVersion()
+        let detectedMCPBinaryPath = detectedVersion != nil ? await which("gg-mcp") : nil
+        let detectedCapabilities = detectedVersion != nil
+            ? await service.probeCapabilities()
+            : GGCapabilities(structuredSplit: false, keepCurrentUnstack: false)
+
+        if version != detectedVersion { version = detectedVersion }
+        if ggMCPBinaryPath != detectedMCPBinaryPath { ggMCPBinaryPath = detectedMCPBinaryPath }
+        if capabilities != detectedCapabilities { capabilities = detectedCapabilities }
+        if !hasProbed { hasProbed = true }
     }
 }

--- a/AlasTests/Integrations/GGAvailabilityTests.swift
+++ b/AlasTests/Integrations/GGAvailabilityTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import Testing
 @testable import Alas
 
@@ -12,8 +13,115 @@ private struct FixedVersionGGRunner: GGCommandRunning {
     }
 }
 
+private struct HelpGGRunner: GGCommandRunning {
+    let version: String?
+    let root: String?
+    let split: String?
+    let unstack: String?
+    let sc: String?
+
+    init(
+        version: String? = "1.0.0",
+        root: String? = nil,
+        split: String?,
+        unstack: String?,
+        sc: String? = nil
+    ) {
+        self.version = version
+        self.root = root
+        self.split = split
+        self.unstack = unstack
+        self.sc = sc
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        switch args {
+        case ["--version"]:
+            guard let version else { break }
+            return ProcessResult(exitCode: 0, stdout: "gg \(version)\n", stderr: "")
+        case ["--help"]:
+            guard let root else { break }
+            return ProcessResult(exitCode: 0, stdout: root, stderr: "")
+        case ["split", "--help"]:
+            guard let split else { break }
+            return ProcessResult(exitCode: 0, stdout: split, stderr: "")
+        case ["unstack", "--help"]:
+            guard let unstack else { break }
+            return ProcessResult(exitCode: 0, stdout: unstack, stderr: "")
+        case ["sc", "--help"]:
+            guard let sc else { break }
+            return ProcessResult(exitCode: 0, stdout: sc, stderr: "")
+        default:
+            break
+        }
+        return ProcessResult(exitCode: 127, stdout: "", stderr: "not found")
+    }
+}
+
+private final class InvalidationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 @MainActor
 struct GGAvailabilityTests {
+    @Test func splitCapabilityRequiresBothFlags() async {
+        let service = GGService(
+            runner: HelpGGRunner(split: "--describe --plan-json", unstack: "--keep-current")
+        )
+        #expect(
+            await service.probeCapabilities()
+                == GGCapabilities(structuredSplit: true, keepCurrentUnstack: true)
+        )
+
+        let oldService = GGService(runner: HelpGGRunner(split: "--describe", unstack: ""))
+        #expect(
+            await oldService.probeCapabilities()
+                == GGCapabilities(structuredSplit: false, keepCurrentUnstack: false)
+        )
+    }
+
+    @Test func capabilityProbeReturnsFalseWhenHelpCommandsFail() async {
+        let service = GGService(runner: HelpGGRunner(split: nil, unstack: nil))
+
+        #expect(
+            await service.probeCapabilities()
+                == GGCapabilities(structuredSplit: false, keepCurrentUnstack: false)
+        )
+    }
+
+    @Test func clientOperationCapabilityUsesRootHelpAndDefaultsOff() async {
+        let current = GGService(runner: HelpGGRunner(
+            root: "--client-operation-id <ID>", split: "", unstack: ""
+        ))
+        #expect((await current.probeCapabilities()).clientOperationID)
+
+        let old = GGService(runner: HelpGGRunner(root: "--verbose", split: "", unstack: ""))
+        #expect(!(await old.probeCapabilities()).clientOperationID)
+    }
+
+    @Test func stagedOnlyAmendCapabilityUsesScHelpAndDefaultsOff() async {
+        let current = GGService(runner: HelpGGRunner(
+            split: "", unstack: "", sc: "--staged-only"
+        ))
+        #expect((await current.probeCapabilities()).stagedOnlyAmend)
+
+        let old = GGService(runner: HelpGGRunner(split: "", unstack: "", sc: "--message"))
+        #expect(!(await old.probeCapabilities()).stagedOnlyAmend)
+    }
+
     @Test func probePopulatesVersionAndMCPPath() async {
         let availability = GGAvailability()
         await availability.probe(
@@ -52,5 +160,55 @@ struct GGAvailabilityTests {
         )
         #expect(availability.version == "1.0.0")
         #expect(availability.ggMCPBinaryPath == "/first/gg-mcp")
+    }
+
+    @Test func forcedProbeUpdatesCapabilitiesWithDetectedVersion() async {
+        let availability = GGAvailability()
+        await availability.probe(
+            service: GGService(
+                runner: HelpGGRunner(
+                    version: "1.0.0",
+                    split: "--describe --plan-json",
+                    unstack: "--keep-current"
+                )
+            ),
+            which: { _ in nil },
+            force: true
+        )
+        #expect(
+            availability.capabilities
+                == GGCapabilities(structuredSplit: true, keepCurrentUnstack: true)
+        )
+
+        await availability.probe(
+            service: GGService(
+                runner: HelpGGRunner(version: "2.0.0", split: "--describe", unstack: "")
+            ),
+            which: { _ in nil },
+            force: true
+        )
+        #expect(availability.version == "2.0.0")
+        #expect(
+            availability.capabilities
+                == GGCapabilities(structuredSplit: false, keepCurrentUnstack: false)
+        )
+    }
+
+    @Test func unchangedCapabilityProbeDoesNotInvalidateObservers() async {
+        let availability = GGAvailability()
+        let service = GGService(
+            runner: HelpGGRunner(split: "--describe --plan-json", unstack: "--keep-current")
+        )
+        await availability.probe(service: service, which: { _ in nil }, force: true)
+
+        let invalidations = InvalidationCounter()
+        withObservationTracking {
+            _ = availability.capabilities
+        } onChange: {
+            invalidations.increment()
+        }
+
+        await availability.probe(service: service, which: { _ in nil }, force: true)
+        #expect(invalidations.count == 0)
     }
 }

--- a/AlasTests/Integrations/GGConfigReaderTests.swift
+++ b/AlasTests/Integrations/GGConfigReaderTests.swift
@@ -59,4 +59,85 @@ struct GGConfigReaderTests {
         let garbage = try makeRepo(configJSON: "not json")
         #expect(GGConfigReader.defaultBase(repoPath: garbage, globalConfigPath: nil) == nil)
     }
+
+    @Test func effectiveConfigUsesTypedDefaultsWhenValuesAreAbsent() throws {
+        let repo = try makeRepo(configJSON: #"{"defaults":{}}"#)
+
+        #expect(
+            GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: nil)
+                == .defaults
+        )
+    }
+
+    @Test func effectiveConfigReadsGlobalValues() throws {
+        let repo = try makeRepo(configJSON: nil)
+        let global = try makeGlobal(
+            configJSON: #"{"defaults":{"sync_auto_rebase":true,"sync_behind_threshold":4}}"#
+        )
+
+        #expect(
+            GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: global)
+                == GGEffectiveConfig(syncAutoRebase: true, syncBehindThreshold: 4)
+        )
+    }
+
+    @Test func effectiveConfigLocalDefaultsReplaceGlobalDefaults() throws {
+        let repo = try makeRepo(configJSON: #"{"defaults":{"sync_auto_rebase":true}}"#)
+        let global = try makeGlobal(
+            configJSON: #"{"defaults":{"sync_auto_rebase":false,"sync_behind_threshold":4}}"#
+        )
+
+        #expect(
+            GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: global)
+                == GGEffectiveConfig(syncAutoRebase: true, syncBehindThreshold: 1)
+        )
+    }
+
+    @Test func effectiveConfigMalformedLocalKeyUsesHardcodedDefault() throws {
+        let repo = try makeRepo(
+            configJSON: #"{"defaults":{"sync_auto_rebase":"yes","sync_behind_threshold":2}}"#
+        )
+        let global = try makeGlobal(
+            configJSON: #"{"defaults":{"sync_auto_rebase":true,"sync_behind_threshold":"four"}}"#
+        )
+
+        #expect(
+            GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: global)
+                == GGEffectiveConfig(syncAutoRebase: false, syncBehindThreshold: 2)
+        )
+    }
+
+    @Test func effectiveConfigRejectsCrossTypeLocalValues() throws {
+        let repo = try makeRepo(
+            configJSON: #"{"defaults":{"sync_auto_rebase":1,"sync_behind_threshold":true}}"#
+        )
+        let global = try makeGlobal(
+            configJSON: #"{"defaults":{"sync_auto_rebase":false,"sync_behind_threshold":4}}"#
+        )
+
+        #expect(
+            GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: global)
+                == GGEffectiveConfig(syncAutoRebase: false, syncBehindThreshold: 1)
+        )
+    }
+
+    @Test func effectiveConfigFallsBackForNegativeBehindThreshold() throws {
+        let repo = try makeRepo(
+            configJSON: #"{"defaults":{"sync_auto_rebase":true,"sync_behind_threshold":-1}}"#
+        )
+
+        #expect(
+            GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: nil)
+                == GGEffectiveConfig(syncAutoRebase: true, syncBehindThreshold: 1)
+        )
+    }
+
+    @Test func effectiveConfigInvalidLocalFileDoesNotExposeGlobalPolicy() throws {
+        let repo = try makeRepo(configJSON: "not json")
+        let global = try makeGlobal(
+            configJSON: #"{"defaults":{"sync_auto_rebase":true,"sync_behind_threshold":4}}"#
+        )
+
+        #expect(GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: global) == .defaults)
+    }
 }


### PR DESCRIPTION
## What

- Reads GG workflow configuration and advertised native capabilities.
- Makes that state available to the UI so unsupported actions remain unavailable.
- Treats malformed negative sync thresholds as GG's default threshold.

## Validation

- `GGAvailabilityTests`
- `GGConfigReaderTests`
- `GGStackReadinessModelTests`

## Stack

- Builds on #869.

<!-- gg:managed:start -->
Part of stack `prepare-gg`

Commit: 0b341a2
<!-- gg:managed:end -->