### PR TITLE
feat(gg): add typed stack mutation commands

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -411,6 +411,7 @@
 		497D21A67A062CE6282008CD /* PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295319DB8544C170DDD6328D /* PathsTests.swift */; };
 		49A112CA4183D8FAEA84294A /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 0714DCAA9EC181C239773440 /* TreeSitterBash */; };
 		49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */; };
+		4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */; };
 		4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */; };
 		4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */; };
 		4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02E429B37288215EBC89571 /* CommitHeaderView.swift */; };
@@ -1452,6 +1453,7 @@
 		11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateFocusMainWorktreeTests.swift; sourceTree = "<group>"; };
 		120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffViewTests.swift; sourceTree = "<group>"; };
 		1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouter.swift; sourceTree = "<group>"; };
+		1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationModelsTests.swift; sourceTree = "<group>"; };
 		1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTests.swift; sourceTree = "<group>"; };
 		12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewTabView.swift; sourceTree = "<group>"; };
 		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
@@ -4626,6 +4628,7 @@
 				98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
+				1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
 				DF688C3B9D43B4F5FF48F7D3 /* GGServiceInboxTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
@@ -6273,6 +6276,7 @@
 				77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
+				4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,
 				10D0D26BCE0EF4D8677CEA79 /* GGServiceInboxTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -84,6 +84,16 @@ enum GGSyncEvent: Equatable {
 }
 
 enum GGActionErrorMessage {
+    private static let responseEnvelopeKeys = [
+        "land",
+        "sync",
+        "clean",
+        "drop",
+        "unstack",
+        "restack",
+        "split",
+    ]
+
     static func parse(fromJSON data: Data) -> String? {
         guard let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { return nil }
         if let line = String(data: data, encoding: .utf8),
@@ -96,8 +106,11 @@ enum GGActionErrorMessage {
 
     static func parse(from object: [String: Any]) -> String? {
         if let message = message(from: object["error"]) { return message }
-        if let land = object["land"] as? [String: Any], let message = parse(from: land) { return message }
-        if let sync = object["sync"] as? [String: Any], let message = parse(from: sync) { return message }
+        for key in responseEnvelopeKeys {
+            if let envelope = object[key] as? [String: Any], let message = parse(from: envelope) {
+                return message
+            }
+        }
         if let entries = object["entries"] as? [[String: Any]] {
             for entry in entries {
                 if let message = message(from: entry["error"]) {
@@ -117,6 +130,15 @@ enum GGActionErrorMessage {
             if let nested = message(from: object["error"]) { return nested }
         }
         return String(describing: error)
+    }
+}
+
+enum GGErrorPresentation {
+    static func message(for error: Error) -> String {
+        if let serviceError = error as? GGServiceError {
+            return serviceError.userMessage
+        }
+        return error.localizedDescription
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -11,3 +11,212 @@ struct GGCapabilities: Equatable, Sendable {
     var clientOperationID: Bool = false
     var stagedOnlyAmend: Bool = false
 }
+
+struct GGDropResult: Codable, Equatable, Sendable {
+    let dropped: [GGDropCommit]
+    let remaining: Int
+}
+
+struct GGDropCommit: Codable, Equatable, Sendable {
+    let position: Int
+    let sha: String
+    let title: String
+}
+
+struct GGUnstackResult: Equatable, Sendable {
+    var originalStack: String
+    var newStack: String
+    var movedCommits: [GGUnstackCommit]
+    var worktreePath: String?
+    var currentStack: String
+}
+
+struct GGUnstackCommit: Codable, Equatable, Sendable {
+    let position: Int
+    let sha: String
+    let title: String
+    let ggID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case position, sha, title, ggID = "ggId"
+    }
+}
+
+struct GGRestackResult: Codable, Equatable, Sendable {
+    let stackName: String
+    let totalEntries: Int
+    let entriesRestacked: Int
+    let entriesOK: Int
+    let dryRun: Bool
+    let steps: [GGRestackStep]
+
+    enum CodingKeys: String, CodingKey {
+        case stackName, totalEntries, entriesRestacked, entriesOK = "entriesOk", dryRun, steps
+    }
+}
+
+struct GGRestackStep: Codable, Equatable, Sendable {
+    let position: Int
+    let ggID: String
+    let title: String
+    let action: String
+    let currentParent: String?
+    let expectedParent: String?
+
+    enum CodingKeys: String, CodingKey {
+        case position, ggID = "ggId", title, action, currentParent, expectedParent
+    }
+}
+
+enum GGOperationStatus: Equatable, Sendable {
+    case pending
+    case completed
+    case interrupted
+}
+
+extension GGOperationStatus: Codable {
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        switch value {
+        case "pending": self = .pending
+        case "committed": self = .completed
+        case "interrupted": self = .interrupted
+        default:
+            throw DecodingError.dataCorruptedError(
+                in: try decoder.singleValueContainer(),
+                debugDescription: "Unknown gg operation status '\(value)'"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .pending: try container.encode("pending")
+        case .completed: try container.encode("committed")
+        case .interrupted: try container.encode("interrupted")
+        }
+    }
+}
+
+struct GGOperationSummary: Codable, Equatable, Sendable {
+    let id: String
+    let kind: String
+    let status: GGOperationStatus
+    let createdAtMs: UInt64
+    let args: [String]
+    let stackName: String?
+    let touchedRemote: Bool
+    let isUndoable: Bool
+    let isUndo: Bool
+    let undoes: String?
+
+    init(
+        id: String,
+        kind: String,
+        status: GGOperationStatus,
+        createdAtMs: UInt64,
+        args: [String],
+        stackName: String? = nil,
+        touchedRemote: Bool,
+        isUndoable: Bool,
+        isUndo: Bool = false,
+        undoes: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.status = status
+        self.createdAtMs = createdAtMs
+        self.args = args
+        self.stackName = stackName
+        self.touchedRemote = touchedRemote
+        self.isUndoable = isUndoable
+        self.isUndo = isUndo
+        self.undoes = undoes
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, kind, status, createdAtMs, args, stackName, touchedRemote, isUndoable, isUndo, undoes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        kind = try container.decode(String.self, forKey: .kind)
+        status = try container.decode(GGOperationStatus.self, forKey: .status)
+        createdAtMs = try container.decode(UInt64.self, forKey: .createdAtMs)
+        args = try container.decode([String].self, forKey: .args)
+        stackName = try container.decodeIfPresent(String.self, forKey: .stackName)
+        touchedRemote = try container.decode(Bool.self, forKey: .touchedRemote)
+        isUndoable = try container.decode(Bool.self, forKey: .isUndoable)
+        isUndo = try container.decodeIfPresent(Bool.self, forKey: .isUndo) ?? false
+        undoes = try container.decodeIfPresent(String.self, forKey: .undoes)
+    }
+}
+
+struct GGUndoResult: Codable, Equatable, Sendable {
+    let undone: GGOperationSummary
+}
+
+struct GGSplitTargetIdentity: Codable, Equatable, Sendable {
+    let ggID: String?
+    let sha: String
+    let tree: String
+
+    enum CodingKeys: String, CodingKey {
+        case ggID = "ggId", sha, tree
+    }
+}
+
+struct GGSplitHunk: Codable, Equatable, Sendable {
+    let id: String
+    let path: String
+    let header: String
+    let patch: String
+}
+
+struct GGSplitDescription: Codable, Equatable, Sendable {
+    let version: Int
+    let planToken: String
+    let target: GGSplitTargetIdentity
+    let hunks: [GGSplitHunk]
+    let nonTextualFiles: [String]
+    let firstMessage: String
+    let remainderMessage: String
+}
+
+struct GGSplitPlan: Codable, Equatable, Sendable {
+    let version: Int
+    let planToken: String
+    let target: GGSplitTargetIdentity
+    let selectedHunkIDs: [String]
+    let firstMessage: String
+    let remainderMessage: String
+
+    enum CodingKeys: String, CodingKey {
+        case version, planToken, target, selectedHunkIDs = "selectedHunkIds", firstMessage, remainderMessage
+    }
+}
+
+struct GGSplitCommitIdentity: Codable, Equatable, Sendable {
+    let sha: String
+    let ggID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sha, ggID = "ggId"
+    }
+}
+
+struct GGSplitApplyResult: Codable, Equatable, Sendable {
+    let version: Int
+    let operationID: String
+    let originalSHA: String
+    let first: GGSplitCommitIdentity
+    let remainder: GGSplitCommitIdentity
+    let rewrittenDescendants: [GGSplitCommitIdentity]
+
+    enum CodingKeys: String, CodingKey {
+        case version, operationID = "operationId", originalSHA = "originalSha",
+             first, remainder, rewrittenDescendants
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -276,6 +276,8 @@ private final class StderrAccumulator: @unchecked Sendable {
 struct GGService {
     var runner: GGCommandRunning = ProcessGGCommandRunner()
 
+    private static let supportedSchemaVersion = 1
+
     /// Returns the gg version string ("0.9.8") or nil when gg is not
     /// installed / not on the login-shell PATH.
     func probeVersion() async -> String? {
@@ -383,7 +385,146 @@ struct GGService {
     }
 
     func clean(worktreePath: String) async throws {
-        _ = try await runChecked(args: ["clean", "--all"], worktreePath: worktreePath)
+        let result = try await runAction(
+            ["clean", "--all", "--json"],
+            cwd: URL(fileURLWithPath: worktreePath)
+        )
+        do {
+            _ = try decodeVersioned(GGCleanResponse.self, from: result)
+        } catch GGServiceError.malformedOutput {
+            // Exit 0 means clean completed. Older GG builds may not emit JSON.
+        }
+    }
+
+    func amendCurrent(worktreePath: String) async throws {
+        _ = try await runAction(
+            ["sc", "--staged-only"],
+            cwd: URL(fileURLWithPath: worktreePath)
+        )
+    }
+
+    func absorbStaged(worktreePath: String) async throws {
+        _ = try await runAction(["absorb", "-s"], cwd: URL(fileURLWithPath: worktreePath))
+    }
+
+    func drop(worktreePath: String, target: String) async throws -> GGDropResult {
+        let result = try await runAction(
+            ["drop", target, "--yes", "--json"],
+            cwd: URL(fileURLWithPath: worktreePath)
+        )
+        return try decodeVersioned(GGDropResponse.self, from: result).drop
+    }
+
+    func unstack(
+        worktreePath: String,
+        target: String,
+        name: String,
+        createWorktree: Bool
+    ) async throws -> GGUnstackResult {
+        var args = [
+            "unstack", "--target", target, "--name", name, "--no-tui", "--json",
+        ]
+        args.append(createWorktree ? "--worktree" : "--keep-current")
+        let result = try await runAction(args, cwd: URL(fileURLWithPath: worktreePath))
+        let wire = try decodeVersioned(GGUnstackResponse.self, from: result).unstack
+
+        let currentStack: String
+        if createWorktree {
+            currentStack = wire.currentStack ?? wire.originalStack
+        } else {
+            guard let reportedCurrent = wire.currentStack else {
+                throw GGServiceError.malformedOutput(
+                    "gg unstack --keep-current did not report current_stack. Update gg and try again."
+                )
+            }
+            guard reportedCurrent == wire.originalStack else {
+                throw GGServiceError.malformedOutput(
+                    "gg unstack --keep-current changed the current stack unexpectedly."
+                )
+            }
+            currentStack = reportedCurrent
+        }
+
+        return GGUnstackResult(
+            originalStack: wire.originalStack,
+            newStack: wire.newStack,
+            movedCommits: wire.movedEntries,
+            worktreePath: wire.worktreePath,
+            currentStack: currentStack
+        )
+    }
+
+    func reorder(worktreePath: String, order: [String]) async throws {
+        _ = try await runAction(
+            ["reorder", "--order", order.joined(separator: ",")],
+            cwd: URL(fileURLWithPath: worktreePath)
+        )
+    }
+
+    func restack(worktreePath: String, dryRun: Bool) async throws -> GGRestackResult {
+        var args = ["restack", "--json"]
+        if dryRun { args.append("--dry-run") }
+        let result = try await runAction(args, cwd: URL(fileURLWithPath: worktreePath))
+        return try decodeVersioned(GGRestackResponse.self, from: result).restack
+    }
+
+    func rebase(worktreePath: String, target: String?) async throws {
+        let args = ["rebase"] + (target.map { [$0] } ?? [])
+        _ = try await runAction(args, cwd: URL(fileURLWithPath: worktreePath))
+    }
+
+    func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary] {
+        let result = try await runAction(
+            ["undo", "--list", "--json", "--limit", String(limit)],
+            cwd: URL(fileURLWithPath: worktreePath)
+        )
+        return try decodeVersioned(GGUndoListResponse.self, from: result).operations
+    }
+
+    func undo(worktreePath: String, operationID: String) async throws -> GGUndoResult {
+        let args = ["undo", operationID, "--json"]
+        let cwd = URL(fileURLWithPath: worktreePath)
+        let result = try await invoke(args, cwd: cwd)
+        if result.exitCode == 127 {
+            throw GGServiceError.cliMissing
+        }
+        if result.exitCode != 0,
+           let refusal = try decodeUndoRefusal(from: result)
+        {
+            throw GGServiceError.undoRefused(
+                message: refusal.message,
+                hint: refusal.hints.isEmpty ? nil : refusal.hints.joined(separator: "\n")
+            )
+        }
+        guard result.exitCode == 0 else { throw actionError(from: result) }
+
+        let response = try decodeVersioned(GGUndoResponse.self, from: result)
+        if let refusal = response.refusal {
+            throw GGServiceError.undoRefused(
+                message: refusal.message,
+                hint: refusal.hints.isEmpty ? nil : refusal.hints.joined(separator: "\n")
+            )
+        }
+        guard response.status == "succeeded", let undone = response.undone else {
+            throw GGServiceError.malformedOutput("gg undo did not return the required undone operation.")
+        }
+        return GGUndoResult(undone: undone)
+    }
+
+    func describeSplit(worktreePath: String, target: String) async throws -> GGSplitDescription {
+        let result = try await runAction(
+            ["split", "--describe", "--commit", target, "--json"],
+            cwd: URL(fileURLWithPath: worktreePath)
+        )
+        return try decodeVersioned(GGSplitDescription.self, from: result)
+    }
+
+    func applySplit(worktreePath: String, planURL: URL) async throws -> GGSplitApplyResult {
+        let result = try await runAction(
+            ["split", "--plan-json", planURL.path, "--json"],
+            cwd: URL(fileURLWithPath: worktreePath)
+        )
+        return try decodeVersioned(GGSplitApplyResult.self, from: result)
     }
 
     private func syncSupportsJSONL() async -> Bool {
@@ -408,22 +549,149 @@ struct GGService {
     /// Runs a gg command and maps a non-zero exit to `GGServiceError`, the
     /// same way `currentStack` does.
     private func runChecked(args: [String], worktreePath: String) async throws -> ProcessResult {
+        try await runAction(args, cwd: URL(fileURLWithPath: worktreePath))
+    }
+
+    private func invoke(_ args: [String], cwd: URL) async throws -> ProcessResult {
         let result: ProcessResult
         do {
-            result = try await runner.run(args: args, cwd: URL(fileURLWithPath: worktreePath))
+            result = try await runner.run(args: args, cwd: cwd)
         } catch let error as GGServiceError {
             throw error
         } catch {
             throw GGServiceError.commandFailed(stderr: String(describing: error))
         }
-        guard result.exitCode == 0 else {
-            if result.exitCode == 127 { throw GGServiceError.map(exitCode: result.exitCode, stderr: result.stderr) }
-            if let message = GGActionErrorMessage.parse(fromJSON: Data(result.stdout.utf8)) {
-                throw GGServiceError.commandFailed(stderr: message)
-            }
-            throw GGServiceError.map(exitCode: result.exitCode, stderr: result.stderr)
-        }
         return result
+    }
+
+    private func runAction(_ args: [String], cwd: URL) async throws -> ProcessResult {
+        let result = try await invoke(args, cwd: cwd)
+        guard result.exitCode == 0 else { throw actionError(from: result) }
+        return result
+    }
+
+    private func actionError(from result: ProcessResult) -> GGServiceError {
+        if result.exitCode == 127 { return .cliMissing }
+        let parsed = GGActionErrorMessage.parse(fromJSON: Data(result.stdout.utf8))
+        let message = parsed
+            ?? result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = message.lowercased()
+
+        if normalized.contains("immutable commit") || normalized.contains("immutable target") {
+            return .immutableTargets(message: message)
+        }
+        if normalized.contains("dirty working") || normalized.contains("working tree is dirty") {
+            return .dirtyWorkingTree(message: message)
+        }
+        if normalized.contains("stale split plan") {
+            return .staleSplitPlan(message: message)
+        }
+        if normalized.contains("stale target") {
+            return .staleTarget(message: message)
+        }
+        if normalized.contains("conflict")
+            && (normalized.contains("continue") || normalized.contains("abort") || normalized.contains("paused"))
+        {
+            return .pausedConflict(message: message)
+        }
+        if normalized.contains("partial mutation") || normalized.contains("partially mutated") {
+            return .partialMutation(message: message)
+        }
+        return .commandFailed(stderr: message)
+    }
+
+    private func decodeVersioned<T: Decodable>(_ type: T.Type, from result: ProcessResult) throws -> T {
+        let data = Data(result.stdout.utf8)
+        let version: Int
+        do {
+            version = try JSONDecoder().decode(GGSchemaVersion.self, from: data).version
+        } catch {
+            throw GGServiceError.malformedOutput(String(describing: error))
+        }
+        guard version == Self.supportedSchemaVersion else {
+            throw GGServiceError.unsupportedSchema(version)
+        }
+        if let message = GGActionErrorMessage.parse(fromJSON: data) {
+            throw actionError(from: ProcessResult(exitCode: 1, stdout: result.stdout, stderr: message))
+        }
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+            return try decoder.decode(type, from: data)
+        } catch let error as GGServiceError {
+            throw error
+        } catch {
+            throw GGServiceError.malformedOutput(String(describing: error))
+        }
+    }
+
+    private func decodeUndoRefusal(from result: ProcessResult) throws -> GGUndoRefusal? {
+        do {
+            let response = try decodeVersioned(GGUndoResponse.self, from: result)
+            return response.status == "refused" ? response.refusal : nil
+        } catch let error as GGServiceError {
+            if case .unsupportedSchema = error { throw error }
+            return nil
+        }
+    }
+}
+
+private struct GGSchemaVersion: Decodable {
+    let version: Int
+}
+
+private struct GGCleanResponse: Decodable {
+    struct Clean: Decodable {
+        let cleaned: [String]
+        let skipped: [String]
+    }
+
+    let clean: Clean
+}
+
+private struct GGDropResponse: Decodable {
+    let drop: GGDropResult
+}
+
+private struct GGUnstackResponse: Decodable {
+    struct Unstack: Decodable {
+        let originalStack: String
+        let newStack: String
+        let movedEntries: [GGUnstackCommit]
+        let worktreePath: String?
+        let currentStack: String?
+    }
+
+    let unstack: Unstack
+}
+
+private struct GGRestackResponse: Decodable {
+    let restack: GGRestackResult
+}
+
+private struct GGUndoListResponse: Decodable {
+    let operations: [GGOperationSummary]
+}
+
+private struct GGUndoResponse: Decodable {
+    let status: String
+    let undone: GGOperationSummary?
+    let refusal: GGUndoRefusal?
+}
+
+private struct GGUndoRefusal: Decodable {
+    let message: String
+    let hints: [String]
+
+    private enum CodingKeys: String, CodingKey {
+        case message, hints
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        message = try container.decode(String.self, forKey: .message)
+        hints = try container.decodeIfPresent([String].self, forKey: .hints) ?? []
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -7,6 +7,13 @@ enum GGServiceError: Error, Equatable {
     case commandFailed(stderr: String)
     case malformedOutput(String)
     case unsupportedSchema(Int)
+    case immutableTargets(message: String)
+    case dirtyWorkingTree(message: String)
+    case staleTarget(message: String)
+    case staleSplitPlan(message: String)
+    case pausedConflict(message: String)
+    case partialMutation(message: String)
+    case undoRefused(message: String, hint: String?)
 }
 
 extension GGServiceError {
@@ -16,7 +23,18 @@ extension GGServiceError {
         case .cliMissing: return "gg is not installed."
         case .commandFailed(let stderr): return stderr.isEmpty ? "gg command failed." : stderr
         case .malformedOutput(let message): return message
-        case .unsupportedSchema(let version): return "Unsupported gg output (schema \(version))."
+        case .unsupportedSchema(let version):
+            return "Unsupported gg output (schema \(version)). Update gg and try again."
+        case .immutableTargets(let message),
+             .dirtyWorkingTree(let message),
+             .staleTarget(let message),
+             .staleSplitPlan(let message),
+             .pausedConflict(let message),
+             .partialMutation(let message):
+            return message
+        case .undoRefused(let message, let hint):
+            guard let hint, !hint.isEmpty else { return message }
+            return "\(message)\n\(hint)"
         }
     }
 

--- a/AlasTests/Integrations/GGActionEventsTests.swift
+++ b/AlasTests/Integrations/GGActionEventsTests.swift
@@ -67,6 +67,22 @@ struct GGActionEventsTests {
         #expect(GGActionErrorMessage.parse(fromJSON: Data(#"{"sync":{"entries":[{"position":4,"error":{"message":"push blocked"}}]}}"#.utf8)) == "[4] push blocked")
     }
 
+    @Test func extractsErrorsFromMutationResponseEnvelopes() {
+        for command in ["clean", "drop", "unstack", "restack", "split"] {
+            let json = #"{"\#(command)":{"error":{"message":"\#(command) blocked"}}}"#
+            #expect(
+                GGActionErrorMessage.parse(fromJSON: Data(json.utf8)) == "\(command) blocked",
+                "Failed to parse the \(command) error envelope."
+            )
+        }
+
+        #expect(
+            GGActionErrorMessage.parse(
+                fromJSON: Data(#"{"metadata":{"error":{"message":"diagnostic only"}}}"#.utf8)
+            ) == nil
+        )
+    }
+
     @Test func landDecodeThrowsMalformedOnGarbage() {
         #expect(throws: GGServiceError.self) {
             _ = try GGLandResult.decode(fromJSON: Data("nonsense".utf8))

--- a/AlasTests/Integrations/GGMutationModelsTests.swift
+++ b/AlasTests/Integrations/GGMutationModelsTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGMutationModelsTests {
+    @Test func splitPlanEncodesProtocolV1SnakeCasePayload() throws {
+        let plan = GGSplitPlan(
+            version: 1,
+            planToken: "token",
+            target: GGSplitTargetIdentity(ggID: "change-2", sha: "abc", tree: "tree"),
+            selectedHunkIDs: ["h-1"],
+            firstMessage: "First",
+            remainderMessage: "Remainder"
+        )
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+
+        let object = try #require(
+            JSONSerialization.jsonObject(with: encoder.encode(plan)) as? [String: Any]
+        )
+
+        #expect(object["version"] as? Int == 1)
+        #expect(object["plan_token"] as? String == "token")
+        #expect(object["selected_hunk_ids"] as? [String] == ["h-1"])
+        #expect((object["target"] as? [String: Any])?["gg_id"] as? String == "change-2")
+    }
+
+    @Test func operationSummaryNormalizesCommittedWireStatusToCompleted() throws {
+        let data = Data(#"{"id":"op_1","kind":"split","status":"committed","created_at_ms":42,"args":["split"],"touched_remote":false,"is_undoable":true,"is_undo":false}"#.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let summary = try decoder.decode(GGOperationSummary.self, from: data)
+
+        #expect(summary.status == .completed)
+        #expect(summary.kind == "split")
+        #expect(summary.createdAtMs == 42)
+        #expect(summary.undoes == nil)
+    }
+
+    @Test func splitDescriptionRoundTripsAllProtocolFields() throws {
+        let value = GGSplitDescription(
+            version: 1,
+            planToken: "token",
+            target: GGSplitTargetIdentity(ggID: nil, sha: "abc", tree: "tree"),
+            hunks: [GGSplitHunk(id: "h-1", path: "A.swift", header: "@@ -1 +1 @@", patch: "-a\n+b\n")],
+            nonTextualFiles: ["image.png"],
+            firstMessage: "First",
+            remainderMessage: "Remainder"
+        )
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let decoded = try decoder.decode(GGSplitDescription.self, from: encoder.encode(value))
+
+        #expect(decoded == value)
+    }
+}

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -139,10 +139,11 @@ struct GGServiceActionsTests {
     }
 
     @Test func cleanContinueAbortCheckoutSendExpectedArgs() async throws {
-        let runner = RecordingGGRunner(stdout: "ok")
+        let runner = RecordingGGRunner(stdout: #"{"version":1,"clean":{"cleaned":[],"skipped":[]}}"#)
         let service = GGService(runner: runner)
         try await service.clean(worktreePath: "/tmp/wt")
-        #expect(runner.lastArgs == ["clean", "--all"])
+        #expect(runner.lastArgs == ["clean", "--all", "--json"])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
         try await service.continueOp(worktreePath: "/tmp/wt")
         #expect(runner.lastArgs == ["continue"])
         try await service.abortOp(worktreePath: "/tmp/wt")
@@ -156,6 +157,14 @@ struct GGServiceActionsTests {
         await #expect(throws: GGServiceError.commandFailed(stderr: "dirty")) {
             try await GGService(runner: runner).clean(worktreePath: "/tmp/wt")
         }
+    }
+
+    @Test func cleanToleratesEmptyOutputAfterSuccessfulExit() async throws {
+        let runner = RecordingGGRunner(stdout: "", exitCode: 0)
+
+        try await GGService(runner: runner).clean(worktreePath: "/tmp/wt")
+
+        #expect(runner.lastArgs == ["clean", "--all", "--json"])
     }
 
     @Test func landToleratesUndecodableOutputAfterSuccessfulExit() async throws {
@@ -174,6 +183,283 @@ struct GGServiceActionsTests {
         )
         await #expect(throws: GGServiceError.commandFailed(stderr: "not approved")) {
             _ = try await GGService(runner: runner).land(worktreePath: "/tmp/wt", until: nil)
+        }
+    }
+
+    @Test func amendCurrentUsesStagedOnlyCommandInWorktree() async throws {
+        let runner = RecordingGGRunner()
+
+        try await GGService(runner: runner).amendCurrent(worktreePath: "/repo")
+
+        #expect(runner.calls == [["sc", "--staged-only"]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+    }
+
+    @Test func absorbStagedUsesStagedOnlyCommandInWorktree() async throws {
+        let runner = RecordingGGRunner()
+
+        try await GGService(runner: runner).absorbStaged(worktreePath: "/repo")
+
+        #expect(runner.calls == [["absorb", "-s"]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+    }
+
+    @Test func dropUsesNoninteractiveJSONArgumentsAndDecodesRequiredResult() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"drop":{"dropped":[{"position":2,"sha":"abc123","title":"Remove me"}],"remaining":1}}"#
+        )
+
+        let result = try await GGService(runner: runner).drop(worktreePath: "/repo", target: "change-2")
+
+        #expect(result == GGDropResult(
+            dropped: [GGDropCommit(position: 2, sha: "abc123", title: "Remove me")],
+            remaining: 1
+        ))
+        #expect(runner.calls == [["drop", "change-2", "--yes", "--json"]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+    }
+
+    @Test func unstackWithoutWorktreeUsesKeepCurrentAndDecodesCurrentStack() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"unstack":{"original_stack":"feature","new_stack":"api","moved_entries":[{"position":2,"sha":"abc123","title":"API","gg_id":"change-2"}],"worktree_path":null,"current_stack":"feature"}}"#
+        )
+
+        let result = try await GGService(runner: runner).unstack(
+            worktreePath: "/repo",
+            target: "change-2",
+            name: "api",
+            createWorktree: false
+        )
+
+        #expect(result == GGUnstackResult(
+            originalStack: "feature",
+            newStack: "api",
+            movedCommits: [GGUnstackCommit(position: 2, sha: "abc123", title: "API", ggID: "change-2")],
+            worktreePath: nil,
+            currentStack: "feature"
+        ))
+        #expect(runner.calls == [[
+            "unstack", "--target", "change-2", "--name", "api", "--no-tui", "--json", "--keep-current",
+        ]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--worktree"))
+        #expect(!runner.lastArgs.contains("--force"))
+    }
+
+    @Test func unstackWithWorktreeAcceptsOlderResponseWithoutCurrentStack() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"unstack":{"original_stack":"feature","new_stack":"api","moved_entries":[],"worktree_path":"/repo-api"}}"#
+        )
+
+        let result = try await GGService(runner: runner).unstack(
+            worktreePath: "/repo",
+            target: "change-2",
+            name: "api",
+            createWorktree: true
+        )
+
+        #expect(result.currentStack == "feature")
+        #expect(result.worktreePath == "/repo-api")
+        #expect(runner.calls == [[
+            "unstack", "--target", "change-2", "--name", "api", "--no-tui", "--json", "--worktree",
+        ]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+    }
+
+    @Test func unstackWithoutWorktreeRequiresMatchingCurrentStack() async {
+        let missingRunner = RecordingGGRunner(
+            stdout: #"{"version":1,"unstack":{"original_stack":"feature","new_stack":"api","moved_entries":[]}}"#
+        )
+        await #expect(throws: GGServiceError.self) {
+            _ = try await GGService(runner: missingRunner).unstack(
+                worktreePath: "/repo", target: "change-2", name: "api", createWorktree: false
+            )
+        }
+
+        let mismatchRunner = RecordingGGRunner(
+            stdout: #"{"version":1,"unstack":{"original_stack":"feature","new_stack":"api","moved_entries":[],"current_stack":"api"}}"#
+        )
+        await #expect(throws: GGServiceError.self) {
+            _ = try await GGService(runner: mismatchRunner).unstack(
+                worktreePath: "/repo", target: "change-2", name: "api", createWorktree: false
+            )
+        }
+    }
+
+    @Test func reorderUsesCommaSeparatedCompleteOrderInWorktree() async throws {
+        let runner = RecordingGGRunner()
+
+        try await GGService(runner: runner).reorder(worktreePath: "/repo", order: ["a", "b", "c"])
+
+        #expect(runner.calls == [["reorder", "--order", "a,b,c"]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+    }
+
+    @Test func restackUsesJSONAndOptionalDryRunArguments() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"restack":{"stack_name":"feature","total_entries":2,"entries_restacked":1,"entries_ok":1,"dry_run":true,"steps":[{"position":2,"gg_id":"change-2","title":"Second","action":"restack","current_parent":"old","expected_parent":"new"}]}}"#
+        )
+        let service = GGService(runner: runner)
+
+        let preview = try await service.restack(worktreePath: "/repo", dryRun: true)
+
+        #expect(preview.stackName == "feature")
+        #expect(preview.steps == [GGRestackStep(
+            position: 2,
+            ggID: "change-2",
+            title: "Second",
+            action: "restack",
+            currentParent: "old",
+            expectedParent: "new"
+        )])
+        #expect(runner.lastArgs == ["restack", "--json", "--dry-run"])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+
+        runner.stdout = #"{"version":1,"restack":{"stack_name":"feature","total_entries":2,"entries_restacked":0,"entries_ok":2,"dry_run":false,"steps":[]}}"#
+        _ = try await service.restack(worktreePath: "/repo", dryRun: false)
+        #expect(runner.lastArgs == ["restack", "--json"])
+    }
+
+    @Test func rebaseUsesOptionalTargetWithoutForce() async throws {
+        let runner = RecordingGGRunner()
+        let service = GGService(runner: runner)
+
+        try await service.rebase(worktreePath: "/repo", target: nil)
+        #expect(runner.lastArgs == ["rebase"])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+
+        try await service.rebase(worktreePath: "/repo", target: "main")
+        #expect(runner.lastArgs == ["rebase", "main"])
+        #expect(!runner.calls.flatMap { $0 }.contains("--force"))
+    }
+
+    @Test func undoListUsesLimitAndDecodesOperations() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"operations":[{"id":"op_1","kind":"drop","status":"committed","created_at_ms":42,"args":["drop","2"],"stack_name":"feature","touched_remote":false,"is_undoable":true,"is_undo":false}]}"#
+        )
+
+        let operations = try await GGService(runner: runner).listUndoOperations(worktreePath: "/repo", limit: 5)
+
+        #expect(operations.count == 1)
+        #expect(operations[0].id == "op_1")
+        #expect(operations[0].status == .completed)
+        #expect(runner.calls == [["undo", "--list", "--json", "--limit", "5"]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+    }
+
+    @Test func undoApplyUsesOperationIDAndRequiresUndoneResult() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"status":"succeeded","undone":{"id":"op_1","kind":"drop","status":"committed","created_at_ms":42,"args":["drop","2"],"touched_remote":false,"is_undoable":true,"is_undo":false}}"#
+        )
+
+        let result = try await GGService(runner: runner).undo(worktreePath: "/repo", operationID: "op_1")
+
+        #expect(result.undone.id == "op_1")
+        #expect(runner.calls == [["undo", "op_1", "--json"]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+
+        runner.stdout = #"{"version":1,"status":"succeeded"}"#
+        await #expect(throws: GGServiceError.self) {
+            _ = try await GGService(runner: runner).undo(worktreePath: "/repo", operationID: "op_1")
+        }
+    }
+
+    @Test func structuredSplitUsesExactDescribeAndApplyArguments() async throws {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"plan_token":"token","target":{"gg_id":"change-2","sha":"abc123","tree":"tree123"},"hunks":[{"id":"h-1","path":"A.swift","header":"@@ -1 +1 @@","patch":"-a\n+b\n"}],"non_textual_files":["image.png"],"first_message":"First","remainder_message":"Remainder"}"#
+        )
+        let service = GGService(runner: runner)
+
+        let description = try await service.describeSplit(worktreePath: "/repo", target: "change-2")
+
+        #expect(description.planToken == "token")
+        #expect(description.hunks.map(\.id) == ["h-1"])
+        #expect(runner.lastArgs == ["split", "--describe", "--commit", "change-2", "--json"])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+
+        runner.stdout = #"{"version":1,"operation_id":"op_2","original_sha":"abc123","first":{"sha":"first123","gg_id":"change-1"},"remainder":{"sha":"remaining123","gg_id":"change-2"},"rewritten_descendants":[{"sha":"child123","gg_id":"change-3"}]}"#
+        let planURL = URL(fileURLWithPath: "/tmp/split-plan.json")
+        let result = try await service.applySplit(worktreePath: "/repo", planURL: planURL)
+
+        #expect(result.operationID == "op_2")
+        #expect(result.rewrittenDescendants.map(\.sha) == ["child123"])
+        #expect(runner.lastArgs == ["split", "--plan-json", planURL.path, "--json"])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+        #expect(!runner.lastArgs.contains("--force"))
+    }
+
+    @Test func typedResultsRejectUnknownSchemaMalformedJSONAndMissingFields() async {
+        let unsupported = RecordingGGRunner(stdout: #"{"version":2}"#)
+        await #expect(throws: GGServiceError.unsupportedSchema(2)) {
+            _ = try await GGService(runner: unsupported).describeSplit(worktreePath: "/repo", target: "change-2")
+        }
+
+        let malformed = RecordingGGRunner(stdout: "not json")
+        await #expect(throws: GGServiceError.self) {
+            _ = try await GGService(runner: malformed).drop(worktreePath: "/repo", target: "change-2")
+        }
+
+        let missing = RecordingGGRunner(stdout: #"{"version":1,"drop":{"dropped":[]}}"#)
+        await #expect(throws: GGServiceError.self) {
+            _ = try await GGService(runner: missing).drop(worktreePath: "/repo", target: "change-2")
+        }
+    }
+
+    @Test func actionErrorsUseStableCategoriesAndPreserveGGText() async {
+        let cases: [(String, GGServiceError)] = [
+            ("cannot rewrite immutable commits: change-2", .immutableTargets(message: "cannot rewrite immutable commits: change-2")),
+            ("Dirty working directory. Please commit first.", .dirtyWorkingTree(message: "Dirty working directory. Please commit first.")),
+            ("stale target: stack changed", .staleTarget(message: "stale target: stack changed")),
+            ("stale split plan: hunks changed", .staleSplitPlan(message: "stale split plan: hunks changed")),
+            ("Rebase conflict. Resolve conflicts and run gg continue.", .pausedConflict(message: "Rebase conflict. Resolve conflicts and run gg continue.")),
+            ("partial mutation: refs may have changed", .partialMutation(message: "partial mutation: refs may have changed")),
+        ]
+
+        for (message, expected) in cases {
+            let runner = RecordingGGRunner(
+                stdout: #"{"version":1,"error":"\#(message)"}"#,
+                exitCode: 1
+            )
+            await #expect(throws: expected) {
+                _ = try await GGService(runner: runner).drop(worktreePath: "/repo", target: "change-2")
+            }
+        }
+    }
+
+    @Test func undoStructuredRefusalPreservesMessageAndRecoveryHint() async {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"status":"refused","refusal":{"reason":"remote","message":"operation touched a remote","hints":["Close PR #7 manually"]}}"#,
+            exitCode: 1
+        )
+
+        await #expect(throws: GGServiceError.undoRefused(
+            message: "operation touched a remote",
+            hint: "Close PR #7 manually"
+        )) {
+            _ = try await GGService(runner: runner).undo(worktreePath: "/repo", operationID: "op_1")
+        }
+    }
+
+    @Test func undoStructuredRefusalAllowsProtocolOmittedEmptyHints() async {
+        let runner = RecordingGGRunner(
+            stdout: #"{"version":1,"status":"refused","refusal":{"reason":"stale","message":"ref moved since the operation"}}"#,
+            exitCode: 1
+        )
+
+        await #expect(throws: GGServiceError.undoRefused(
+            message: "ref moved since the operation",
+            hint: nil
+        )) {
+            _ = try await GGService(runner: runner).undo(worktreePath: "/repo", operationID: "op_1")
         }
     }
 }


### PR DESCRIPTION
## What

- Adds typed GG mutation requests, confirmation models, and service operations.
- Converts lifecycle actions into testable application-level contracts.
- Uses paired native-client capabilities only after they are advertised by GG.

## Validation

- `GGMutationModelsTests`
- `GGServiceActionsTests`

## Stack

- Builds on #870.

<!-- gg:managed:start -->
Part of stack `prepare-gg`

Commit: fee1c4f
<!-- gg:managed:end -->