### PR TITLE
refactor(gg): centralize mutation lifecycle

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
 		0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */; };
 		0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */; };
+		0E054800F6B09275885CF5B6 /* GGMutationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70E37676F2A14E6C9E84B2D /* GGMutationCoordinatorTests.swift */; };
 		0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */; };
 		0E2F2A2FD567CE04CF549C29 /* ACPSessionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A24F057893BB2179C1900C /* ACPSessionDiscoveryTests.swift */; };
 		0E680F7AAD6CBD2A4A829A52 /* DiffReviewRenderableContentEqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */; };
@@ -260,6 +261,7 @@
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
 		316A645ECCB46A0F74915EA4 /* RemoteProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */; };
 		316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */; };
+		318F74C3CB02BFF1D06DF7DA /* GGUndoMarkerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724A473AB9439DAA535B33F8 /* GGUndoMarkerStore.swift */; };
 		31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2D492EE89A160CD404985 /* GGConfigReader.swift */; };
 		31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */; };
 		32324CCE247B8B4784674453 /* RemoteContentSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */; };
@@ -795,6 +797,7 @@
 		99711AA1B0FB450D32770415 /* ZmxSunPathBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */; };
 		9983414D08DCAB87919FB804 /* ACPTranscriptChangeLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */; };
 		999C8421F3610FF682CE9D0E /* ReviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500B60003934104E2CA5A895 /* ReviewTabView.swift */; };
+		99B188A81AF135564ED9EE17 /* GGMutationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB8945B6B3ECFCD8BA28B82 /* GGMutationCoordinator.swift */; };
 		99CD435501BBBAAD8C4214D8 /* ProjectMCPServerEditorPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */; };
 		99FA2F1F9D41CA81E59B20E5 /* ACPRemoteLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DC5AC55D5FF5BF7FECAD2F /* ACPRemoteLaunch.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
@@ -1057,6 +1060,7 @@
 		C8BF4593D35403A93FC05D50 /* ACPAdapterInstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C99F8D1A0A37DC4A6DBAEE /* ACPAdapterInstallCoordinator.swift */; };
 		C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
+		C968F976028C3D9C6E17EC44 /* GGUndoMarkerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246A2AF26902AB36730A4F44 /* GGUndoMarkerStoreTests.swift */; };
 		C99FAC8BF1908B490E058FDA /* RemoteAccessPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EEBEEB1AC6532031BDE17F /* RemoteAccessPolicyTests.swift */; };
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
 		C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AC3FB0255285382EF24D8D /* RemoteHTTPResponder.swift */; };
@@ -1531,6 +1535,7 @@
 		2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostProviderTests.swift; sourceTree = "<group>"; };
 		2463B784210156F489A13FAC /* initialize-response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "initialize-response.json"; sourceTree = "<group>"; };
 		2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageWireTests.swift; sourceTree = "<group>"; };
+		246A2AF26902AB36730A4F44 /* GGUndoMarkerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGUndoMarkerStoreTests.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
 		256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayoutTests.swift; sourceTree = "<group>"; };
 		25B1ED890A8A45244572D8A3 /* RightPaneStatePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStatePullTests.swift; sourceTree = "<group>"; };
@@ -1961,6 +1966,7 @@
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
 		71E01A18A7215E3FEEB71B07 /* ACPBrokerClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBrokerClientTests.swift; sourceTree = "<group>"; };
 		71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefill.swift; sourceTree = "<group>"; };
+		724A473AB9439DAA535B33F8 /* GGUndoMarkerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGUndoMarkerStore.swift; sourceTree = "<group>"; };
 		728F8E1DBF9DA86092C10AD0 /* ACPSessionOrchestrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinator.swift; sourceTree = "<group>"; };
 		7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateView.swift; sourceTree = "<group>"; };
 		72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiffTests.swift; sourceTree = "<group>"; };
@@ -2371,6 +2377,7 @@
 		C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowHeightTests.swift; sourceTree = "<group>"; };
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
 		C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
+		C70E37676F2A14E6C9E84B2D /* GGMutationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationCoordinatorTests.swift; sourceTree = "<group>"; };
 		C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStrip.swift; sourceTree = "<group>"; };
 		C72B05E51A4C6FAE18666DBC /* ACPSyntaxHighlightedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSyntaxHighlightedText.swift; sourceTree = "<group>"; };
 		C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSteerUndoToast.swift; sourceTree = "<group>"; };
@@ -2403,6 +2410,7 @@
 		CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallCard.swift; sourceTree = "<group>"; };
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CC958412AAB6B8788171F74A /* ReviewChangesLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesLoaderTests.swift; sourceTree = "<group>"; };
+		CCB8945B6B3ECFCD8BA28B82 /* GGMutationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationCoordinator.swift; sourceTree = "<group>"; };
 		CD0A56D300AE7380A16F1D42 /* ReviewRequestDiffLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDiffLoader.swift; sourceTree = "<group>"; };
 		CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewContextProvider.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
@@ -4628,6 +4636,7 @@
 				98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
+				C70E37676F2A14E6C9E84B2D /* GGMutationCoordinatorTests.swift */,
 				1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */,
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
 				DF688C3B9D43B4F5FF48F7D3 /* GGServiceInboxTests.swift */,
@@ -4638,6 +4647,7 @@
 				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
 				F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */,
 				3EC4FE9500B277A3921C8AB2 /* GGStackSummaryStoreTests.swift */,
+				246A2AF26902AB36730A4F44 /* GGUndoMarkerStoreTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
@@ -4890,6 +4900,7 @@
 				B32762D888121D56722E03F5 /* GGInboxTabView.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */,
+				CCB8945B6B3ECFCD8BA28B82 /* GGMutationCoordinator.swift */,
 				993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
@@ -4901,6 +4912,7 @@
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
 				4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */,
 				B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */,
+				724A473AB9439DAA535B33F8 /* GGUndoMarkerStore.swift */,
 			);
 			path = GG;
 			sourceTree = "<group>";
@@ -5605,6 +5617,7 @@
 				56286C44BC30C1716CD44363 /* GGInboxTabView.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */,
+				99B188A81AF135564ED9EE17 /* GGMutationCoordinator.swift in Sources */,
 				04D55B4985BDF4CEF0BA3C0E /* GGMutationModels.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
@@ -5616,6 +5629,7 @@
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
 				8ADC05EBB9FE7D278508A941 /* GGStackReadinessModel.swift in Sources */,
 				DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */,
+				318F74C3CB02BFF1D06DF7DA /* GGUndoMarkerStore.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
 				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,
@@ -6276,6 +6290,7 @@
 				77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
+				0E054800F6B09275885CF5B6 /* GGMutationCoordinatorTests.swift in Sources */,
 				4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */,
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,
 				10D0D26BCE0EF4D8677CEA79 /* GGServiceInboxTests.swift in Sources */,
@@ -6287,6 +6302,7 @@
 				7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */,
 				CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */,
 				95DAB9F9E361DFD0395CC4C2 /* GGStackSummaryStoreTests.swift in Sources */,
+				C968F976028C3D9C6E17EC44 /* GGUndoMarkerStoreTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,
 				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -492,11 +492,8 @@ private struct RootGGPresentationHandlers: ViewModifier {
                 Button("Cancel", role: .cancel) {
                     state.rightPaneStore.stateWithPendingGGLand()?.cancelGGLand()
                 }
-            } message: { request in
-                Text(RightPaneState.ggLandConfirmationMessage(
-                    for: request,
-                    stack: state.rightPaneStore.stateWithPendingGGLand()?.ggStack
-                ))
+            } message: { _ in
+                Text(state.rightPaneStore.stateWithPendingGGLand()?.pendingGGLandConfirmationMessage ?? "")
             }
             .confirmationDialog(
                 "Clean all merged stacks?",

--- a/Alas/Sources/Integrations/GG/GGInboxStore.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxStore.swift
@@ -17,6 +17,7 @@ final class GGInboxStore {
     }
 
     var states: [String: State] = [:]
+    @ObservationIgnored private var invalidationGenerations: [String: UInt64] = [:]
 
     /// A snapshot older than `threshold` (or missing) should be refetched
     /// when the tab appears or regains focus.
@@ -32,6 +33,7 @@ final class GGInboxStore {
         now: () -> Date = Date.init
     ) async {
         if states[projectId]?.isRefreshing == true { return }
+        let generation = invalidationGenerations[projectId, default: 0]
         var state = states[projectId] ?? State()
         state.isRefreshing = true
         write(projectId, state)
@@ -45,7 +47,22 @@ final class GGInboxStore {
         } catch {
             state.lastError = error.localizedDescription
         }
+        guard invalidationGenerations[projectId, default: 0] == generation else {
+            var invalidated = states[projectId] ?? State()
+            invalidated.isRefreshing = false
+            invalidated.fetchedAt = nil
+            write(projectId, invalidated)
+            return
+        }
         state.isRefreshing = false
+        write(projectId, state)
+    }
+
+    /// Expires cached freshness while retaining the last visible result.
+    func invalidate(projectId: String) {
+        invalidationGenerations[projectId, default: 0] &+= 1
+        guard var state = states[projectId] else { return }
+        state.fetchedAt = nil
         write(projectId, state)
     }
 

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -1,0 +1,445 @@
+import Foundation
+
+@MainActor
+struct GGMutationContext {
+    var loadFreshStack: () async throws -> GGStackSnapshot
+    var refreshStack: () async -> Void
+    var refreshGitChanges: () async -> Void
+    var refreshProviderReviews: () async -> Void
+    var refreshProjectTopology: () async -> Void
+    var worktreeExists: () -> Bool
+    var invalidateInbox: () -> Void
+    var selectWorktreeAtPath: (String) async -> Void
+}
+
+enum GGMutationExecutionResult {
+    case none
+    case drop(GGDropResult)
+    case land(GGLandResult)
+    case unstack(GGUnstackResult)
+    case split(GGSplitApplyResult)
+}
+
+private enum GGUndoBaseline {
+    case unavailable
+    case operationID(String?)
+}
+
+@MainActor
+protocol GGMutationExecuting {
+    func execute(
+        _ request: GGMutationRequest,
+        worktreePath: String,
+        onSyncEvent: (GGSyncEvent) -> Void
+    ) async throws -> GGMutationExecutionResult
+    func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary]
+}
+
+@MainActor
+final class GGMutationCoordinator {
+    private let worktreeId: String
+    private let worktreePath: String
+    private let service: any GGMutationExecuting
+    private let actionState: GGStackActionState
+    private let undoMarkerStore: any GGUndoMarkerStoring
+    private let context: GGMutationContext
+
+    private(set) var activeRequest: GGMutationRequest?
+
+    init(
+        worktreeId: String,
+        worktreePath: String,
+        service: any GGMutationExecuting,
+        actionState: GGStackActionState,
+        undoMarkerStore: any GGUndoMarkerStoring = GGUndoMarkerStore(),
+        context: GGMutationContext
+    ) {
+        self.worktreeId = worktreeId
+        self.worktreePath = worktreePath
+        self.service = service
+        self.actionState = actionState
+        self.undoMarkerStore = undoMarkerStore
+        self.context = context
+    }
+
+    func prepare(_ request: GGMutationRequest) async throws -> GGPreparedMutation {
+        guard activeRequest == nil else { throw GGMutationError.operationInFlight }
+        activeRequest = request
+        defer { activeRequest = nil }
+
+        let snapshot = try await context.loadFreshStack()
+        return try preflight(request, snapshot: snapshot)
+    }
+
+    func apply(_ request: GGMutationRequest, confirmedAgainst identity: GGStackIdentity?) async throws {
+        guard reserve(request) else { throw GGMutationError.operationInFlight }
+        try await applyReserved(request, confirmedAgainst: identity)
+    }
+
+    func startApplying(
+        _ request: GGMutationRequest,
+        confirmedAgainst identity: GGStackIdentity?
+    ) -> Task<Void, Error>? {
+        guard reserve(request) else { return nil }
+        return Task { try await self.applyReserved(request, confirmedAgainst: identity) }
+    }
+
+    private func reserve(_ request: GGMutationRequest) -> Bool {
+        guard activeRequest == nil,
+              actionState.beginAction(request.actionKind)
+        else { return false }
+        activeRequest = request
+        return true
+    }
+
+    private func applyReserved(
+        _ request: GGMutationRequest,
+        confirmedAgainst identity: GGStackIdentity?
+    ) async throws {
+        defer {
+            activeRequest = nil
+            actionState.endAction(request.actionKind)
+        }
+
+        actionState.clearError()
+        if request == .sync { actionState.clearSyncProgress() }
+
+        let isRecoveryRequest = request == .continueOperation || request == .abortOperation
+        let snapshot: GGStackSnapshot?
+        do {
+            snapshot = try await context.loadFreshStack()
+        } catch {
+            guard isRecoveryRequest else { throw error }
+            snapshot = nil
+        }
+
+        if isRecoveryRequest {
+            if let identity, snapshot?.identity != identity {
+                throw GGMutationError.staleConfirmation
+            }
+        } else {
+            guard let snapshot else { throw GGMutationError.staleConfirmation }
+            let prepared = try preflight(request, snapshot: snapshot)
+            if let identity, prepared.snapshot != identity {
+                throw GGMutationError.staleConfirmation
+            }
+        }
+
+        let undoBaseline = isRecoveryRequest
+            ? GGUndoBaseline.unavailable
+            : await captureUndoBaseline(for: request)
+        undoMarkerStore.clear(worktreeId: worktreeId)
+        GGStackGate.markAlasGGOperationInProgress(repoPath: worktreePath)
+
+        do {
+            let result = try await service.execute(
+                request,
+                worktreePath: worktreePath,
+                onSyncEvent: { [actionState] event in
+                    actionState.appendSyncEvent(event)
+                    if case .error(let message) = event { actionState.setError(message) }
+                }
+            )
+            recordSummary(for: request, result: result)
+            reconcilePausedState(after: request, error: nil)
+            await refresh(after: request, result: result)
+            await recordUndoMarker(after: request, baseline: undoBaseline)
+        } catch let error as GGServiceError {
+            reconcilePausedState(after: request, error: error)
+            await refresh(after: request, result: .none)
+            if request.touchesRemote, case .malformedOutput = error {
+                return
+            }
+            if actionState.lastError == nil { actionState.setError(error.userMessage) }
+            throw error
+        } catch {
+            reconcilePausedState(after: request, error: error)
+            await refresh(after: request, result: .none)
+            actionState.setError(error.localizedDescription)
+            throw error
+        }
+    }
+
+    private func preflight(
+        _ request: GGMutationRequest,
+        snapshot: GGStackSnapshot
+    ) throws -> GGPreparedMutation {
+        guard let stack = snapshot.stack, let identity = snapshot.identity else {
+            throw GGMutationError.staleConfirmation
+        }
+        if snapshot.operationID != nil || actionState.pausedOperation != nil {
+            switch request {
+            case .continueOperation, .abortOperation:
+                break
+            default:
+                throw GGMutationError.pausedOperation
+            }
+        }
+
+        try validateTarget(for: request, stack: stack)
+        try rejectKnownImmutableTarget(for: request, stack: stack)
+        return GGPreparedMutation(
+            request: request,
+            snapshot: identity,
+            confirmation: confirmation(for: request, stack: stack)
+        )
+    }
+
+    private func validateTarget(for request: GGMutationRequest, stack: GGStack) throws {
+        switch request {
+        case .amendCurrent:
+            guard stack.entries.contains(where: \.isCurrent) else {
+                throw GGMutationError.staleConfirmation
+            }
+        case .checkout(let target), .drop(let target), .unstack(let target, _, _):
+            guard stack.entry(matchingStableID: target) != nil else {
+                throw GGMutationError.staleConfirmation
+            }
+        case .land(let target):
+            guard let targetEntry = stack.entry(matchingStableID: target),
+                  targetEntry.prState == .open,
+                  targetEntry.approved,
+                  targetEntry.ciStatus == nil || targetEntry.ciStatus == .success
+            else { throw GGMutationError.staleConfirmation }
+            let lowerEntriesAreReady = stack.entries
+                .filter { $0.position < targetEntry.position }
+                .allSatisfy {
+                    $0.prState == .merged
+                        || ($0.prState == .open
+                            && $0.approved
+                            && ($0.ciStatus == nil || $0.ciStatus == .success))
+                }
+            guard lowerEntriesAreReady else { throw GGMutationError.staleConfirmation }
+        case .applySplit(_, let identity, _):
+            let target = identity.ggID.flatMap { stack.entry(matchingStableID: $0) }
+                ?? stack.entry(matchingStableID: identity.sha)
+            guard target != nil else { throw GGMutationError.staleConfirmation }
+        default:
+            break
+        }
+    }
+
+    private func rejectKnownImmutableTarget(for request: GGMutationRequest, stack: GGStack) throws {
+        let target: GGStackEntry?
+        switch request {
+        case .amendCurrent:
+            target = stack.entries.first(where: \.isCurrent)
+        case .drop(let id), .unstack(let id, _, _):
+            target = stack.entry(matchingStableID: id)
+        case .applySplit(_, let identity, _):
+            target = identity.ggID.flatMap { stack.entry(matchingStableID: $0) }
+                ?? stack.entry(matchingStableID: identity.sha)
+        default:
+            target = nil
+        }
+        if target?.prState == .merged {
+            throw GGMutationError.immutableTarget(reason: "Merged commits cannot be rewritten.")
+        }
+    }
+
+    private func confirmation(for request: GGMutationRequest, stack: GGStack) -> GGMutationConfirmation? {
+        switch request {
+        case .drop(let target):
+            guard let entry = stack.entry(matchingStableID: target) else { return nil }
+            return .drop(
+                target: target,
+                rewrittenDescendants: stack.entries.filter { $0.position > entry.position }.count,
+                hasOpenReview: entry.prState == .open || entry.prState == .draft
+            )
+        case .unstack(let target, let name, _):
+            guard let entry = stack.entry(matchingStableID: target) else { return nil }
+            return .unstack(
+                target: target,
+                movedCommits: stack.entries.filter { $0.position >= entry.position }.count,
+                lowerStack: stack.name,
+                newStack: name
+            )
+        case .land(let target):
+            guard let entry = stack.entry(matchingStableID: target) else { return nil }
+            let count = stack.entries.filter {
+                $0.position <= entry.position
+                    && $0.prState == .open
+                    && $0.approved
+                    && ($0.ciStatus == nil || $0.ciStatus == .success)
+            }.count
+            return .land(target: target, readyCommits: count)
+        case .clean:
+            return .clean(mergedCommits: stack.entries.filter { $0.prState == .merged }.count)
+        default:
+            return nil
+        }
+    }
+
+    private func refresh(after request: GGMutationRequest, result: GGMutationExecutionResult) async {
+        if request == .clean {
+            await context.refreshProjectTopology()
+            if context.worktreeExists() {
+                await context.refreshStack()
+                await context.refreshGitChanges()
+                await context.refreshProviderReviews()
+            }
+            context.invalidateInbox()
+            return
+        }
+
+        await context.refreshStack()
+        await context.refreshGitChanges()
+        if request.touchesRemote {
+            await context.refreshProviderReviews()
+        }
+        if request.changesStack || request.touchesRemote {
+            context.invalidateInbox()
+        }
+        if request.refreshesTopology {
+            await context.refreshProjectTopology()
+            if case .unstack(let unstack) = result, let path = unstack.worktreePath {
+                await context.selectWorktreeAtPath(path)
+            }
+        }
+    }
+
+    private func reconcilePausedState(after request: GGMutationRequest, error: Error?) {
+        let existingRecoveryPause: GGPausedOperation?
+        switch request {
+        case .continueOperation, .abortOperation:
+            existingRecoveryPause = actionState.pausedOperation
+        default:
+            existingRecoveryPause = nil
+        }
+        let pausedByError: Bool
+        if let serviceError = error as? GGServiceError, case .pausedConflict = serviceError {
+            pausedByError = true
+        } else {
+            pausedByError = false
+        }
+        if pausedByError
+            || GGStackGate.operationInProgress(repoPath: worktreePath)
+            || (error != nil && existingRecoveryPause != nil)
+        {
+            actionState.setPaused(existingRecoveryPause ?? GGPausedOperation(pausedBy: request.actionKind))
+        } else {
+            actionState.clearPaused()
+            GGStackGate.clearAlasGGOperationInProgress(repoPath: worktreePath)
+        }
+    }
+
+    private func recordSummary(for request: GGMutationRequest, result: GGMutationExecutionResult) {
+        switch result {
+        case .land(let result):
+            if let summary = GGStackActionState.landSummaryLine(from: result.landed) {
+                actionState.setActionSummary(summary)
+            }
+        default:
+            if request == .sync,
+               actionState.lastError == nil,
+               let summary = GGStackActionState.syncSummaryLine(from: actionState.syncProgress) {
+                actionState.setActionSummary(summary)
+                actionState.clearSyncProgress()
+            }
+        }
+    }
+
+    private func captureUndoBaseline(for request: GGMutationRequest) async -> GGUndoBaseline {
+        guard !request.touchesRemote else { return .unavailable }
+        do {
+            let operationID = try await service.listUndoOperations(worktreePath: worktreePath, limit: 1).first?.id
+            return .operationID(operationID)
+        } catch {
+            return .unavailable
+        }
+    }
+
+    private func recordUndoMarker(after request: GGMutationRequest, baseline: GGUndoBaseline) async {
+        guard !request.touchesRemote,
+              case .operationID(let previousOperationID) = baseline,
+              let newest = (try? await service.listUndoOperations(worktreePath: worktreePath, limit: 1))?.first,
+              newest.id != previousOperationID,
+              newest.status == .completed,
+              newest.isUndoable,
+              !newest.touchedRemote
+        else { return }
+        undoMarkerStore.set(operationID: newest.id, worktreeId: worktreeId)
+    }
+}
+
+private extension GGMutationRequest {
+    var isUndo: Bool {
+        if case .undo = self { return true }
+        return false
+    }
+
+    var touchesRemote: Bool {
+        switch self {
+        case .sync, .land, .clean: true
+        default: false
+        }
+    }
+
+    var changesStack: Bool {
+        switch self {
+        case .checkout: false
+        default: true
+        }
+    }
+
+    var refreshesTopology: Bool {
+        switch self {
+        case .clean: true
+        case .unstack(_, _, let createWorktree): createWorktree
+        default: false
+        }
+    }
+}
+
+private extension GGStack {
+    func entry(matchingStableID target: String) -> GGStackEntry? {
+        entries.first { $0.id == target || $0.sha == target }
+    }
+}
+
+extension GGService: GGMutationExecuting {
+    func execute(
+        _ request: GGMutationRequest,
+        worktreePath: String,
+        onSyncEvent: (GGSyncEvent) -> Void
+    ) async throws -> GGMutationExecutionResult {
+        switch request {
+        case .amendCurrent:
+            try await amendCurrent(worktreePath: worktreePath)
+        case .absorbStaged:
+            try await absorbStaged(worktreePath: worktreePath)
+        case .checkout(let target):
+            try await checkout(worktreePath: worktreePath, target: target)
+        case .drop(let target):
+            _ = try await drop(worktreePath: worktreePath, target: target)
+        case .unstack(let target, let name, let createWorktree):
+            return .unstack(try await unstack(
+                worktreePath: worktreePath,
+                target: target,
+                name: name,
+                createWorktree: createWorktree
+            ))
+        case .reorder(let order):
+            try await reorder(worktreePath: worktreePath, order: order)
+        case .restack:
+            _ = try await restack(worktreePath: worktreePath, dryRun: false)
+        case .rebase(let target):
+            try await rebase(worktreePath: worktreePath, target: target)
+        case .sync:
+            for try await event in sync(worktreePath: worktreePath) { onSyncEvent(event) }
+        case .land(let target):
+            return .land(try await land(worktreePath: worktreePath, until: target))
+        case .clean:
+            try await clean(worktreePath: worktreePath)
+        case .continueOperation:
+            try await continueOp(worktreePath: worktreePath)
+        case .abortOperation:
+            try await abortOp(worktreePath: worktreePath)
+        case .undo(let operationID):
+            _ = try await undo(worktreePath: worktreePath, operationID: operationID)
+        case .applySplit(let planURL, _, _):
+            return .split(try await applySplit(worktreePath: worktreePath, planURL: planURL))
+        }
+        return .none
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 struct GGEffectiveConfig: Equatable, Sendable {
     var syncAutoRebase: Bool
     var syncBehindThreshold: Int
@@ -10,6 +12,82 @@ struct GGCapabilities: Equatable, Sendable {
     var keepCurrentUnstack: Bool
     var clientOperationID: Bool = false
     var stagedOnlyAmend: Bool = false
+}
+
+enum GGMutationRequest: Equatable, Sendable {
+    case amendCurrent
+    case absorbStaged
+    case checkout(target: String)
+    case drop(target: String)
+    case unstack(target: String, name: String, createWorktree: Bool)
+    case reorder(order: [String])
+    case restack
+    case rebase(target: String?)
+    case sync
+    case land(target: String)
+    case clean
+    case continueOperation
+    case abortOperation
+    case undo(operationID: String)
+    case applySplit(planURL: URL, target: GGSplitTargetIdentity, planToken: String)
+
+    var actionKind: GGStackActionKind {
+        switch self {
+        case .amendCurrent: .amendCurrent
+        case .absorbStaged: .absorbStaged
+        case .checkout: .checkout
+        case .drop: .drop
+        case .unstack: .unstack
+        case .reorder: .reorder
+        case .restack: .restack
+        case .rebase: .rebase
+        case .sync: .sync
+        case .land: .land
+        case .clean: .clean
+        case .continueOperation: .continueOp
+        case .abortOperation: .abortOp
+        case .undo: .undo
+        case .applySplit: .split
+        }
+    }
+}
+
+struct GGStackIdentity: Equatable, Sendable {
+    var stackName: String
+    var base: String
+    var headSHA: String
+    var operationID: String?
+}
+
+struct GGPreparedMutation: Equatable, Sendable {
+    var request: GGMutationRequest
+    var snapshot: GGStackIdentity
+    var confirmation: GGMutationConfirmation?
+}
+
+enum GGMutationConfirmation: Equatable, Sendable {
+    case drop(target: String, rewrittenDescendants: Int, hasOpenReview: Bool)
+    case unstack(target: String, movedCommits: Int, lowerStack: String, newStack: String)
+    case land(target: String, readyCommits: Int)
+    case clean(mergedCommits: Int)
+}
+
+enum GGMutationError: Error, Equatable {
+    case operationInFlight
+    case staleConfirmation
+    case immutableTarget(reason: String)
+    case pausedOperation
+}
+
+extension GGMutationError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .operationInFlight: "Another gg operation is already running."
+        case .staleConfirmation: "The stack changed. Review the updated state and try again."
+        case .immutableTarget(let reason): reason
+        case .pausedOperation: "Continue or abort the paused gg operation first."
+        }
+    }
 }
 
 struct GGDropResult: Codable, Equatable, Sendable {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -310,6 +310,10 @@ struct GGService {
     /// Loads the current branch's stack via `gg ls --json`. Returns nil
     /// when the branch is not a gg stack (gg emits the all-stacks shape).
     func currentStack(worktreePath: String) async throws -> GGStack? {
+        try await currentStackSnapshot(worktreePath: worktreePath).stack
+    }
+
+    func currentStackSnapshot(worktreePath: String) async throws -> GGStackSnapshot {
         let result: ProcessResult
         do {
             result = try await runner.run(
@@ -328,7 +332,7 @@ struct GGService {
             }
             throw GGServiceError.map(exitCode: result.exitCode, stderr: result.stderr)
         }
-        return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8)).stack
+        return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8))
     }
 
     /// Cross-stack triage snapshot from `gg inbox --json`. Runs at the

--- a/Alas/Sources/Integrations/GG/GGStackActionState.swift
+++ b/Alas/Sources/Integrations/GG/GGStackActionState.swift
@@ -2,8 +2,9 @@ import Foundation
 import Observation
 
 /// Which gg mutation is running / paused.
-enum GGStackActionKind: Equatable {
-    case sync, land, clean, continueOp, abortOp, checkout
+enum GGStackActionKind: Equatable, Sendable {
+    case amendCurrent, absorbStaged, checkout, drop, unstack, reorder, restack
+    case rebase, sync, land, clean, continueOp, abortOp, undo, split
 }
 
 /// What a confirmed `land` should do: land everything currently landable, or

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -54,6 +54,37 @@ struct GGStackSnapshot: Decodable, Equatable {
     static let supportedSchemaVersion = 1
     let version: Int
     let stack: GGStack?
+    let operationID: String?
+
+    init(version: Int, stack: GGStack?, operationID: String? = nil) {
+        self.version = version
+        self.stack = stack
+        self.operationID = operationID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version, stack
+        case operationID = "operationId"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(Int.self, forKey: .version)
+        stack = try container.decodeIfPresent(GGStack.self, forKey: .stack)
+        operationID = try container.decodeIfPresent(String.self, forKey: .operationID)
+    }
+
+    var identity: GGStackIdentity? {
+        guard let stack,
+              let head = stack.entries.max(by: { $0.position < $1.position })
+        else { return nil }
+        return GGStackIdentity(
+            stackName: stack.name,
+            base: stack.base,
+            headSHA: head.sha,
+            operationID: operationID
+        )
+    }
 
     static func decode(fromJSON data: Data) throws -> GGStackSnapshot {
         let decoder = JSONDecoder()

--- a/Alas/Sources/Integrations/GG/GGUndoMarkerStore.swift
+++ b/Alas/Sources/Integrations/GG/GGUndoMarkerStore.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+struct GGUndoMarker: Codable, Equatable, Sendable {
+    let operationID: String
+    let removedFinalStackCommit: Bool
+
+    init(operationID: String, removedFinalStackCommit: Bool = false) {
+        self.operationID = operationID
+        self.removedFinalStackCommit = removedFinalStackCommit
+    }
+}
+
+protocol GGUndoMarkerStoring: Sendable {
+    func marker(worktreeId: String) -> GGUndoMarker?
+    func set(_ marker: GGUndoMarker, worktreeId: String)
+    func clear(worktreeId: String)
+}
+
+extension GGUndoMarkerStoring {
+    func set(operationID: String, worktreeId: String) {
+        set(GGUndoMarker(operationID: operationID), worktreeId: worktreeId)
+    }
+}
+
+final class GGUndoMarkerStore: GGUndoMarkerStoring, @unchecked Sendable {
+    private static let defaultsKey = "gg.undoMarkersByWorktree"
+    private static let lock = NSLock()
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func marker(worktreeId: String) -> GGUndoMarker? {
+        Self.lock.lock()
+        defer { Self.lock.unlock() }
+        return markers()[worktreeId]
+    }
+
+    func set(_ marker: GGUndoMarker, worktreeId: String) {
+        Self.lock.lock()
+        defer { Self.lock.unlock() }
+        var values = markers()
+        values[worktreeId] = marker
+        persist(values)
+    }
+
+    func clear(worktreeId: String) {
+        Self.lock.lock()
+        defer { Self.lock.unlock() }
+        var values = markers()
+        guard values.removeValue(forKey: worktreeId) != nil else { return }
+        persist(values)
+    }
+
+    private func markers() -> [String: GGUndoMarker] {
+        if let data = defaults.data(forKey: Self.defaultsKey),
+           let markers = try? JSONDecoder().decode([String: GGUndoMarker].self, from: data) {
+            return markers
+        }
+        let legacy = defaults.dictionary(forKey: Self.defaultsKey) as? [String: String] ?? [:]
+        return legacy.mapValues { GGUndoMarker(operationID: $0) }
+    }
+
+    private func persist(_ markers: [String: GGUndoMarker]) {
+        guard let data = try? JSONEncoder().encode(markers) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+}

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -106,11 +106,17 @@ final class RightPaneState {
     /// Injected by RightPaneStore — resolves gates 1–3 (master toggle,
     /// gg installed, per-project mode) against app-level state.
     var ggGateProvider: (@MainActor () -> Bool)? = nil
-    /// Injected by RightPaneStore so a successful clean can reconcile any
-    /// gg-managed worktrees removed from the app-level project topology.
+    /// Injected by RightPaneStore so mutations that add or remove worktrees
+    /// can reconcile app-level project topology.
     @ObservationIgnored
-    var refreshProjectTopologyAfterGGClean: (@MainActor () async -> Void)? = nil
-    var ggService = GGService()
+    var refreshProjectTopologyAfterGGMutation: (@MainActor () async -> Void)? = nil
+    @ObservationIgnored
+    var selectWorktreeAtPathAfterGGMutation: (@MainActor (String) async -> Void)? = nil
+    var ggService = GGService() {
+        didSet { ggMutationCoordinatorStorage = nil }
+    }
+    @ObservationIgnored
+    private var ggMutationCoordinatorStorage: GGMutationCoordinator? = nil
     /// Backing store for the stack drawer's mutation UI (in-flight action,
     /// sync progress, paused/error state). Not snapshot-derived, so
     /// `markSnapshotUnknown()` does not reset it.
@@ -216,8 +222,9 @@ final class RightPaneState {
     var mergeError: String? = nil
     var mergeQueuedMessage: String? = nil
     var pendingGGLand: GGLandRequest? = nil
-    @ObservationIgnored private var pendingGGLandStackFingerprint: String? = nil
+    @ObservationIgnored private var pendingGGLandPrepared: GGPreparedMutation? = nil
     var pendingGGCleanAll: Bool = false
+    @ObservationIgnored private var pendingGGCleanPrepared: GGPreparedMutation? = nil
 
     /// True while the workspace-level agent invocation is running.
     /// Surfaced in the Conflicts section header as a spinner; the
@@ -330,6 +337,43 @@ final class RightPaneState {
         remoteEventDebouncer.onFire = { [weak self] in
             Task { @MainActor in await self?.refresh() }
         }
+    }
+
+    private var ggMutationCoordinator: GGMutationCoordinator {
+        if let coordinator = ggMutationCoordinatorStorage { return coordinator }
+        let coordinator = GGMutationCoordinator(
+            worktreeId: worktree.id,
+            worktreePath: worktree.path.path,
+            service: ggService,
+            actionState: ggActionState,
+            context: GGMutationContext(
+                loadFreshStack: { [weak self] in
+                    guard let self else { throw GGServiceError.commandFailed(stderr: "Worktree is no longer available.") }
+                    return try await self.ggService.currentStackSnapshot(
+                        worktreePath: self.worktree.path.path
+                    )
+                },
+                refreshStack: { [weak self] in
+                    guard let self else { return }
+                    self.ggStackCommitsKey = nil
+                    await self.refreshGGStack()
+                },
+                refreshGitChanges: { [weak self] in await self?.refresh() },
+                refreshProviderReviews: { [weak self] in await self?.refresh(forceReviewLoopRemote: true) },
+                refreshProjectTopology: { [weak self] in await self?.refreshProjectTopologyAfterGGMutation?() },
+                worktreeExists: { [weak self] in
+                    guard let self else { return false }
+                    return FileManager.default.fileExists(atPath: self.worktree.path.path)
+                },
+                invalidateInbox: { [weak self] in
+                    guard let self else { return }
+                    GGInboxStore.shared.invalidate(projectId: self.worktree.projectId)
+                },
+                selectWorktreeAtPath: { [weak self] path in await self?.selectWorktreeAtPathAfterGGMutation?(path) }
+            )
+        )
+        ggMutationCoordinatorStorage = coordinator
+        return coordinator
     }
 
     func start() {
@@ -926,46 +970,82 @@ final class RightPaneState {
     func onGGStackAction(_ kind: GGStackActionKind, appState: AppState) {
         switch kind {
         case .sync:
-            runGGSync()
+            runGGMutation(.sync)
         case .clean:
             requestGGCleanAll()
         case .continueOp:
-            runGGSimpleAction(.continueOp) { try await self.ggService.continueOp(worktreePath: self.worktree.path.path) }
+            runGGMutation(.continueOperation)
         case .abortOp:
-            runGGSimpleAction(.abortOp) { try await self.ggService.abortOp(worktreePath: self.worktree.path.path) }
+            runGGMutation(.abortOperation)
         case .checkout:
             break
         case .land:
             requestGGLand(.ready)
+        case .amendCurrent:
+            runGGMutation(.amendCurrent)
+        case .absorbStaged:
+            runGGMutation(.absorbStaged)
+        case .restack:
+            runGGMutation(.restack)
+        case .rebase:
+            runGGMutation(.rebase(target: nil))
+        case .drop, .unstack, .reorder, .undo, .split:
+            break
         }
     }
 
     func requestGGLand(_ request: GGLandRequest) {
-        pendingGGLand = request
-        pendingGGLandStackFingerprint = ggStack.map(Self.ggLandStackFingerprint)
+        guard let stack = ggStack,
+              let target = Self.ggLandUntilTarget(for: request, in: stack)
+        else {
+            ggActionState.setError("This stack is no longer ready to land.")
+            return
+        }
+        Task { @MainActor in
+            do {
+                let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
+                guard case .land(_, let readyCommits) = prepared.confirmation,
+                      readyCommits > 0 else {
+                    throw GGMutationError.staleConfirmation
+                }
+                pendingGGLandPrepared = prepared
+                pendingGGLand = request
+            } catch {
+                ggActionState.setError(GGErrorPresentation.message(for: error))
+            }
+        }
     }
 
     func cancelGGLand() {
         pendingGGLand = nil
-        pendingGGLandStackFingerprint = nil
+        pendingGGLandPrepared = nil
     }
-    func requestGGCleanAll() { pendingGGCleanAll = true }
-    func cancelGGCleanAll() { pendingGGCleanAll = false }
-    func performGGCleanAll() {
-        guard pendingGGCleanAll else { return }
-        pendingGGCleanAll = false
-        runGGSimpleAction(.clean) {
-            try await self.ggService.clean(worktreePath: self.worktree.path.path)
-            await self.refreshProjectTopologyAfterGGClean?()
+    func requestGGCleanAll() {
+        Task { @MainActor in
+            do {
+                pendingGGCleanPrepared = try await ggMutationCoordinator.prepare(.clean)
+                pendingGGCleanAll = true
+            } catch {
+                ggActionState.setError(GGErrorPresentation.message(for: error))
+            }
         }
     }
+    func cancelGGCleanAll() {
+        pendingGGCleanAll = false
+        pendingGGCleanPrepared = nil
+    }
+    func performGGCleanAll() {
+        guard pendingGGCleanAll, let prepared = pendingGGCleanPrepared else { return }
+        pendingGGCleanAll = false
+        pendingGGCleanPrepared = nil
+        runGGMutation(prepared.request, confirmedAgainst: prepared.snapshot)
+    }
 
-    /// Checks out a stack entry (`gg mv <target>`), routed through
-    /// `runGGSimpleAction` so it gets the same busy-gating, error-surfacing,
-    /// and post-action refresh as every other gg mutation.
+    /// Checks out a stack entry (`gg mv <target>`) through the shared mutation
+    /// lifecycle so it gets the same gating and refresh behavior as other actions.
     @MainActor
     func requestGGCheckout(target: String) {
-        runGGSimpleAction(.checkout) { try await self.ggService.checkout(worktreePath: self.worktree.path.path, target: target) }
+        runGGMutation(.checkout(target: target))
     }
 
     /// Pure landability check used both to stage the confirmation and to
@@ -1034,120 +1114,50 @@ final class RightPaneState {
         }
     }
 
+    static func ggManualRebaseTarget(
+        stackBase: String,
+        behindBase: GitService.BehindStatus?
+    ) -> String {
+        guard let ref = behindBase?.ref,
+              ref == stackBase || ref.hasSuffix("/\(stackBase)")
+        else { return stackBase }
+        return ref
+    }
+
+    var pendingGGLandConfirmationMessage: String? {
+        guard let request = pendingGGLand else { return nil }
+        guard case .land(_, let readyCommits) = pendingGGLandPrepared?.confirmation else {
+            return Self.ggLandConfirmationMessage(for: request, stack: ggStack)
+        }
+        switch request {
+        case .ready:
+            return "Merge \(readyCommits) approved, passing PR\(readyCommits == 1 ? "" : "s") from the bottom of the stack."
+        case .until(_, let title):
+            return "Land the stack up to and including \u{201C}\(title)\u{201D}."
+        }
+    }
+
     @MainActor
     func performGGLand() {
-        guard let request = pendingGGLand else { return }
-        let confirmedStackFingerprint = pendingGGLandStackFingerprint
+        guard pendingGGLand != nil, let prepared = pendingGGLandPrepared else { return }
         pendingGGLand = nil
-        pendingGGLandStackFingerprint = nil
-        guard ggActionState.beginAction(.land) else { return }
-        GGStackGate.markAlasGGOperationInProgress(repoPath: worktree.path.path)
-        ggActionState.clearError()
+        pendingGGLandPrepared = nil
+        runGGMutation(prepared.request, confirmedAgainst: prepared.snapshot)
+    }
+
+    private func runGGMutation(_ request: GGMutationRequest, confirmedAgainst identity: GGStackIdentity? = nil) {
+        guard let operation = ggMutationCoordinator.startApplying(
+            request,
+            confirmedAgainst: identity
+        ) else { return }
         Task { @MainActor in
-            defer {
-                preservePausedGGOperationIfNeeded()
-                clearAlasGGOperationMarkerIfComplete()
-                ggActionState.endAction(.land)
-                Task { @MainActor in
-                    await self.refresh()
-                    _ = self.reevaluateGGGate()
-                }
-            }
             do {
-                // Re-verify against a fresh stack before mutating (defends a
-                // stale dialog), mirroring performMerge.
-                let fresh = try await ggService.currentStack(worktreePath: worktree.path.path)
-                guard let fresh,
-                      Self.ggLandStackMatchesPendingConfirmation(fresh, fingerprint: confirmedStackFingerprint),
-                      ggLandTargetStillLandable(request, in: fresh)
-                else {
-                    ggActionState.setError("This stack is no longer ready to land.")
-                    return
-                }
-                guard let until = Self.ggLandUntilTarget(for: request, in: fresh) else {
-                    ggActionState.setError("This stack is no longer ready to land.")
-                    return
-                }
-                let result = try await ggService.land(worktreePath: worktree.path.path, until: until)
-                if let summary = GGStackActionState.landSummaryLine(from: result.landed) {
-                    ggActionState.setActionSummary(summary)
-                }
-            } catch let error as GGServiceError {
-                ggActionState.setError(error.userMessage)
+                try await operation.value
             } catch {
-                ggActionState.setError(error.localizedDescription)
-            }
-        }
-    }
-
-    private func runGGSync() {
-        guard ggActionState.beginAction(.sync) else { return }
-        GGStackGate.markAlasGGOperationInProgress(repoPath: worktree.path.path)
-        ggActionState.clearError()
-        ggActionState.clearSyncProgress()
-        Task { @MainActor in
-            defer {
-                preservePausedGGOperationIfNeeded()
-                clearAlasGGOperationMarkerIfComplete()
-                ggActionState.endAction(.sync)
-                Task { @MainActor in
-                    await self.refresh()
-                    _ = self.reevaluateGGGate()
+                if ggActionState.lastError == nil {
+                    ggActionState.setError(GGErrorPresentation.message(for: error))
                 }
             }
-            do {
-                for try await event in ggService.sync(worktreePath: worktree.path.path) {
-                    ggActionState.appendSyncEvent(event)
-                    if case .error(let message) = event { ggActionState.setError(message) }
-                }
-                if ggActionState.lastError == nil,
-                   let summary = GGStackActionState.syncSummaryLine(from: ggActionState.syncProgress) {
-                    ggActionState.setActionSummary(summary)
-                    ggActionState.clearSyncProgress()
-                }
-            } catch let error as GGServiceError {
-                if ggActionState.lastError == nil { ggActionState.setError(error.userMessage) }
-            } catch {
-                if ggActionState.lastError == nil { ggActionState.setError(error.localizedDescription) }
-            }
-        }
-    }
-
-    private func runGGSimpleAction(_ kind: GGStackActionKind, _ body: @escaping () async throws -> Void) {
-        guard ggActionState.beginAction(kind) else { return }
-        GGStackGate.markAlasGGOperationInProgress(repoPath: worktree.path.path)
-        ggActionState.clearError()
-        Task { @MainActor in
-            defer {
-                preservePausedGGOperationIfNeeded()
-                clearAlasGGOperationMarkerIfComplete()
-                ggActionState.endAction(kind)
-                Task { @MainActor in
-                    await self.refresh()
-                    _ = self.reevaluateGGGate()
-                }
-            }
-            do {
-                try await body()
-            } catch let error as GGServiceError {
-                ggActionState.setError(error.userMessage)
-            } catch {
-                ggActionState.setError(error.localizedDescription)
-            }
-        }
-    }
-
-    private func preservePausedGGOperationIfNeeded() {
-        guard GGStackGate.operationInProgress(repoPath: worktree.path.path),
-              let action = ggActionState.inFlightAction,
-              ggActionState.pausedOperation == nil
-        else { return }
-        ggActionState.setPaused(GGPausedOperation(pausedBy: action))
-    }
-
-    private func clearAlasGGOperationMarkerIfComplete() {
-        if !GGStackGate.operationInProgress(repoPath: worktree.path.path) {
-            GGStackGate.clearAlasGGOperationInProgress(repoPath: worktree.path.path)
         }
     }
 

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -166,9 +166,16 @@ final class RightPaneStore {
                     isRemoteProject: project.host != nil
                 )
             }
-            new.refreshProjectTopologyAfterGGClean = { [weak self] in
+            new.refreshProjectTopologyAfterGGMutation = { [weak self] in
                 guard let app = self?.appState else { return }
                 await app.refreshProjectTopology(projectId: worktree.projectId)
+            }
+            new.selectWorktreeAtPathAfterGGMutation = { [weak self] path in
+                guard let app = self?.appState,
+                      let target = app.projectsManager.worktrees(projectId: worktree.projectId)
+                          .first(where: { $0.path.path == path })
+                else { return }
+                app.focusGlobalWorktree(id: target.id, projectId: worktree.projectId)
             }
 
             if shouldDeferInitialRefresh {

--- a/AlasTests/Integrations/GGActionEventsTests.swift
+++ b/AlasTests/Integrations/GGActionEventsTests.swift
@@ -3,6 +3,31 @@ import Testing
 @testable import Alas
 
 struct GGActionEventsTests {
+    @Test func everyMutationRequestMapsToItsPresentationAction() {
+        let splitTarget = GGSplitTargetIdentity(ggID: "change-1", sha: "abc", tree: "tree")
+        let requests: [(GGMutationRequest, GGStackActionKind)] = [
+            (.amendCurrent, .amendCurrent),
+            (.absorbStaged, .absorbStaged),
+            (.checkout(target: "change-1"), .checkout),
+            (.drop(target: "change-1"), .drop),
+            (.unstack(target: "change-1", name: "upper", createWorktree: true), .unstack),
+            (.reorder(order: ["change-1"]), .reorder),
+            (.restack, .restack),
+            (.rebase(target: "main"), .rebase),
+            (.sync, .sync),
+            (.land(target: "change-1"), .land),
+            (.clean, .clean),
+            (.continueOperation, .continueOp),
+            (.abortOperation, .abortOp),
+            (.undo(operationID: "op_1"), .undo),
+            (.applySplit(planURL: URL(fileURLWithPath: "/tmp/plan"), target: splitTarget, planToken: "token"), .split),
+        ]
+
+        for (request, action) in requests {
+            #expect(request.actionKind == action)
+        }
+    }
+
     @Test func parsesEachSyncEventVariant() {
         #expect(GGSyncEvent.parse(line: #"{"version":1,"command":"sync","event":"start","total_entries":2}"#)
             == .start(totalEntries: 2))

--- a/AlasTests/Integrations/GGInboxStoreTests.swift
+++ b/AlasTests/Integrations/GGInboxStoreTests.swift
@@ -14,6 +14,39 @@ private final class FakeGGRunner: GGCommandRunning, @unchecked Sendable {
     }
 }
 
+private actor SuspendedInboxRunner: GGCommandRunning {
+    private var started = false
+    private var continuation: CheckedContinuation<ProcessResult, Never>?
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        started = true
+        return await withCheckedContinuation { continuation = $0 }
+    }
+
+    func hasStarted() -> Bool { started }
+
+    func finish(with result: ProcessResult) {
+        continuation?.resume(returning: result)
+        continuation = nil
+    }
+}
+
+private enum GGInboxTestTimeout: Error {
+    case timedOut
+}
+
+@MainActor
+private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: () async -> Bool
+) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !(await condition()) {
+        guard Date() < deadline else { throw GGInboxTestTimeout.timedOut }
+        try await Task.sleep(nanoseconds: 1_000_000)
+    }
+}
+
 @MainActor
 struct GGInboxStoreTests {
     private static let emptyJSON = #"{"version":1,"total_items":0,"buckets":{"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[]}"#
@@ -56,6 +89,76 @@ struct GGInboxStoreTests {
         #expect(GGInboxStore.isStale(fetchedAt: nil, now: now))
         #expect(GGInboxStore.isStale(fetchedAt: now.addingTimeInterval(-120), now: now))
         #expect(!GGInboxStore.isStale(fetchedAt: now.addingTimeInterval(-119), now: now))
+    }
+
+    @Test func invalidateExpiresFreshnessWithoutDiscardingVisibleSnapshot() async throws {
+        let store = GGInboxStore()
+        let runner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        let fetchedAt = Date(timeIntervalSince1970: 1_000)
+        await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner), now: { fetchedAt })
+
+        store.invalidate(projectId: "p1")
+
+        let state = try #require(store.states["p1"])
+        #expect(state.snapshot != nil)
+        #expect(state.fetchedAt == nil)
+        #expect(state.lastError == nil)
+    }
+
+    @Test func invalidateDuringRefreshPreventsOlderCompletionFromPublishing() async throws {
+        let store = GGInboxStore()
+        let runner = SuspendedInboxRunner()
+        let refresh = Task { @MainActor in
+            await store.refresh(
+                projectId: "p1",
+                repoPath: "/repo",
+                service: GGService(runner: runner),
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        }
+        try await waitUntil { await runner.hasStarted() }
+
+        store.invalidate(projectId: "p1")
+        await runner.finish(with: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        await refresh.value
+
+        let state = try #require(store.states["p1"])
+        #expect(state.snapshot == nil)
+        #expect(state.fetchedAt == nil)
+        #expect(state.isRefreshing == false)
+    }
+
+    @Test func invalidateDuringRefreshRetainsPreviouslyVisibleSnapshot() async throws {
+        let store = GGInboxStore()
+        let oldRunner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        await store.refresh(
+            projectId: "p1",
+            repoPath: "/repo",
+            service: GGService(runner: oldRunner),
+            now: { Date(timeIntervalSince1970: 1_000) }
+        )
+        let previousSnapshot = try #require(store.states["p1"]?.snapshot)
+
+        let runner = SuspendedInboxRunner()
+        let refresh = Task { @MainActor in
+            await store.refresh(
+                projectId: "p1",
+                repoPath: "/repo",
+                service: GGService(runner: runner),
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        }
+        try await waitUntil { await runner.hasStarted() }
+
+        store.invalidate(projectId: "p1")
+        let replacementJSON = Self.emptyJSON.replacingOccurrences(of: #""total_items":0"#, with: #""total_items":9"#)
+        await runner.finish(with: ProcessResult(exitCode: 0, stdout: replacementJSON, stderr: ""))
+        await refresh.value
+
+        let state = try #require(store.states["p1"])
+        #expect(state.snapshot == previousSnapshot)
+        #expect(state.fetchedAt == nil)
+        #expect(state.isRefreshing == false)
     }
 
     @Test func pruneDropsRemovedProjectsAndIsValueDiffed() {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -1,0 +1,455 @@
+import Foundation
+import Testing
+@testable import Alas
+
+private enum GGMutationTestTimeout: Error {
+    case timedOut
+}
+
+@MainActor
+private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: () -> Bool
+) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !condition() {
+        guard Date() < deadline else { throw GGMutationTestTimeout.timedOut }
+        try await Task.sleep(nanoseconds: 1_000_000)
+    }
+}
+
+@MainActor
+private final class RecordingGGMutationExecutor: GGMutationExecuting {
+    var requests: [GGMutationRequest] = []
+    var result: GGMutationExecutionResult = .none
+    var error: Error?
+    var newestOperation: GGOperationSummary?
+    var operationLists: [[GGOperationSummary]] = []
+    var operationListCallCount = 0
+    var blockExecution = false
+    var syncEvents: [GGSyncEvent] = [.start(totalEntries: 1), .summary]
+    private var executionContinuation: CheckedContinuation<Void, Never>?
+
+    func execute(
+        _ request: GGMutationRequest,
+        worktreePath: String,
+        onSyncEvent: (GGSyncEvent) -> Void
+    ) async throws -> GGMutationExecutionResult {
+        requests.append(request)
+        if request == .sync {
+            for event in syncEvents { onSyncEvent(event) }
+        }
+        if blockExecution {
+            await withCheckedContinuation { executionContinuation = $0 }
+        }
+        if let error { throw error }
+        return result
+    }
+
+    func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary] {
+        defer { operationListCallCount += 1 }
+        if !operationLists.isEmpty {
+            return operationLists[min(operationListCallCount, operationLists.count - 1)]
+        }
+        return newestOperation.map { [$0] } ?? []
+    }
+
+    func resumeExecution() {
+        executionContinuation?.resume()
+        executionContinuation = nil
+    }
+}
+
+private final class RecordingUndoMarkerStore: GGUndoMarkerStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    var values: [String: GGUndoMarker] = [:]
+
+    func marker(worktreeId: String) -> GGUndoMarker? {
+        lock.lock()
+        defer { lock.unlock() }
+        return values[worktreeId]
+    }
+
+    func set(_ marker: GGUndoMarker, worktreeId: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        values[worktreeId] = marker
+    }
+
+    func clear(worktreeId: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        values[worktreeId] = nil
+    }
+
+    func operationID(worktreeId: String) -> String? {
+        marker(worktreeId: worktreeId)?.operationID
+    }
+}
+
+@MainActor
+private final class GGMutationHarness {
+    enum Refresh: Equatable {
+        case stack, gitChanges, providerReviews, topology, worktreeExistenceCheck, inbox
+    }
+
+    let service = RecordingGGMutationExecutor()
+    let markers = RecordingUndoMarkerStore()
+    let actionState = GGStackActionState()
+    var stacks: [GGStackSnapshot]
+    var loadError: Error?
+    var loadCount = 0
+    var refreshes: [Refresh] = []
+    var selectedPaths: [String] = []
+    var worktreeExists = true
+    var onRefreshStack: (() async -> Void)?
+    private(set) var coordinator: GGMutationCoordinator!
+
+    init(stacks: [GGStackSnapshot]) {
+        self.stacks = stacks
+        coordinator = GGMutationCoordinator(
+            worktreeId: "wt",
+            worktreePath: "/repo/wt",
+            service: service,
+            actionState: actionState,
+            undoMarkerStore: markers,
+            context: GGMutationContext(
+                loadFreshStack: { [unowned self] in
+                    if let loadError { throw loadError }
+                    defer { loadCount += 1 }
+                    return stacks[min(loadCount, stacks.count - 1)]
+                },
+                refreshStack: { [unowned self] in
+                    refreshes.append(.stack)
+                    await onRefreshStack?()
+                },
+                refreshGitChanges: { [unowned self] in refreshes.append(.gitChanges) },
+                refreshProviderReviews: { [unowned self] in refreshes.append(.providerReviews) },
+                refreshProjectTopology: { [unowned self] in refreshes.append(.topology) },
+                worktreeExists: { [unowned self] in
+                    refreshes.append(.worktreeExistenceCheck)
+                    return worktreeExists
+                },
+                invalidateInbox: { [unowned self] in refreshes.append(.inbox) },
+                selectWorktreeAtPath: { [unowned self] path in selectedPaths.append(path) }
+            )
+        )
+    }
+}
+
+@MainActor
+private func stack(
+    head: String,
+    base: String = "main",
+    operationID: String? = nil,
+    entries: [GGStackEntry]? = nil
+) -> GGStackSnapshot {
+    let entries = entries ?? [
+        GGStackEntry(position: 1, sha: "base", title: "Base", ggId: "change-1"),
+        GGStackEntry(position: 2, sha: head, title: "Head", ggId: "change-2", isCurrent: true),
+    ]
+    return GGStackSnapshot(
+        version: 1,
+        stack: GGStack(
+            name: "feature",
+            base: base,
+            totalCommits: entries.count,
+            syncedCommits: 0,
+            currentPosition: entries.last?.position,
+            behindBase: 0,
+            entries: entries
+        ),
+        operationID: operationID
+    )
+}
+
+@MainActor
+struct GGMutationCoordinatorTests {
+    @Test func prepareLoadsFreshStackAndReturnsTypedDropConfirmation() async throws {
+        let entries = [
+            GGStackEntry(position: 1, sha: "a", title: "Drop", ggId: "change-1", prState: .open),
+            GGStackEntry(position: 2, sha: "b", title: "Child", ggId: "change-2"),
+            GGStackEntry(position: 3, sha: "c", title: "Head", ggId: "change-3", isCurrent: true),
+        ]
+        let harness = GGMutationHarness(stacks: [stack(head: "c", entries: entries)])
+
+        let prepared = try await harness.coordinator.prepare(.drop(target: "change-1"))
+
+        #expect(harness.loadCount == 1)
+        #expect(prepared.snapshot == GGStackIdentity(
+            stackName: "feature",
+            base: "main",
+            headSHA: "c",
+            operationID: nil
+        ))
+        #expect(prepared.confirmation == .drop(target: "change-1", rewrittenDescendants: 2, hasOpenReview: true))
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func applyRechecksSnapshotAfterConfirmation() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a"), stack(head: "b")])
+        let prepared = try await harness.coordinator.prepare(.drop(target: "change-2"))
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(.drop(target: "change-2"), confirmedAgainst: prepared.snapshot)
+        }
+
+        #expect(harness.loadCount == 2)
+        #expect(harness.service.requests.isEmpty)
+        #expect(harness.refreshes.isEmpty)
+    }
+
+    @Test func applyRejectsConfirmationWhenOnlyTheStackBaseChanges() async throws {
+        let harness = GGMutationHarness(stacks: [
+            stack(head: "a", base: "main"),
+            stack(head: "a", base: "release"),
+        ])
+        let prepared = try await harness.coordinator.prepare(.drop(target: "change-2"))
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(
+                .drop(target: "change-2"),
+                confirmedAgainst: prepared.snapshot
+            )
+        }
+
+        #expect(harness.loadCount == 2)
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func missingTargetIsRejectedBeforeProcessLaunch() async {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(.drop(target: "missing"), confirmedAgainst: nil)
+        }
+
+        #expect(harness.service.requests.isEmpty)
+        #expect(harness.refreshes.isEmpty)
+    }
+
+    @Test func applyRechecksLandReadinessWhenProviderStateChanges() async throws {
+        let ready = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Ready", ggId: "change-1",
+                prNumber: 7, prState: .open, approved: true, ciStatus: .success,
+                isCurrent: true
+            ),
+        ]
+        let blocked = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Blocked", ggId: "change-1",
+                prNumber: 7, prState: .open, approved: false, ciStatus: .success,
+                isCurrent: true
+            ),
+        ]
+        let harness = GGMutationHarness(stacks: [
+            stack(head: "a", entries: ready),
+            stack(head: "a", entries: blocked),
+        ])
+        let prepared = try await harness.coordinator.prepare(.land(target: "change-1"))
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(.land(target: "change-1"), confirmedAgainst: prepared.snapshot)
+        }
+
+        #expect(harness.service.requests.isEmpty)
+        #expect(harness.refreshes.isEmpty)
+    }
+
+    @Test func secondConcurrentRequestIsRefusedInsteadOfQueued() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.service.blockExecution = true
+        let first = Task { try await harness.coordinator.apply(.checkout(target: "change-1"), confirmedAgainst: nil) }
+        try await waitUntil { !harness.service.requests.isEmpty }
+
+        await #expect(throws: GGMutationError.operationInFlight) {
+            try await harness.coordinator.apply(.checkout(target: "change-2"), confirmedAgainst: nil)
+        }
+        #expect(harness.service.requests == [.checkout(target: "change-1")])
+
+        harness.service.resumeExecution()
+        try await first.value
+    }
+
+    @Test func immutableTargetIsRejectedBeforeProcessLaunch() async {
+        let entries = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Merged", ggId: "change-1",
+                prNumber: 7, prState: .merged
+            ),
+            GGStackEntry(position: 2, sha: "b", title: "Head", ggId: "change-2", isCurrent: true),
+        ]
+        let harness = GGMutationHarness(stacks: [stack(head: "b", entries: entries)])
+
+        await #expect(throws: GGMutationError.immutableTarget(reason: "Merged commits cannot be rewritten.")) {
+            _ = try await harness.coordinator.prepare(.drop(target: "change-1"))
+        }
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func pausedOperationBlocksMutationsButAllowsRecoveryActions() async throws {
+        let harness = GGMutationHarness(stacks: [
+            stack(head: "a", operationID: "op_paused"),
+            stack(head: "a", operationID: "op_paused"),
+        ])
+
+        await #expect(throws: GGMutationError.pausedOperation) {
+            try await harness.coordinator.apply(.sync, confirmedAgainst: nil)
+        }
+        try await harness.coordinator.apply(.continueOperation, confirmedAgainst: nil)
+
+        #expect(harness.service.requests == [.continueOperation])
+    }
+
+    @Test func recoveryActionWorksWhenPausedSnapshotHasNoStackShape() async throws {
+        let harness = GGMutationHarness(stacks: [
+            GGStackSnapshot(version: 1, stack: nil, operationID: "op_paused"),
+        ])
+        harness.actionState.setPaused(GGPausedOperation(pausedBy: .restack))
+
+        try await harness.coordinator.apply(.continueOperation, confirmedAgainst: nil)
+
+        #expect(harness.service.requests == [.continueOperation])
+    }
+
+    @Test func recoveryActionStillRunsWhenFreshStackLoadFails() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.loadError = GGServiceError.commandFailed(stderr: "stack unavailable during rebase")
+        harness.actionState.setPaused(GGPausedOperation(pausedBy: .restack))
+
+        try await harness.coordinator.apply(.abortOperation, confirmedAgainst: nil)
+
+        #expect(harness.service.requests == [.abortOperation])
+    }
+
+    @Test func remoteMutationRefreshesEveryAffectedSurface() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+
+        try await harness.coordinator.apply(.sync, confirmedAgainst: nil)
+
+        #expect(harness.refreshes == [.stack, .gitChanges, .providerReviews, .inbox])
+        #expect(harness.actionState.lastActionSummary == "Synced")
+        #expect(harness.actionState.syncProgress.isEmpty)
+    }
+
+    @Test func localMutationRefreshesStackGitAndInboxAfterError() async {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.service.error = GGServiceError.partialMutation(message: "partially rewritten")
+
+        await #expect(throws: GGServiceError.partialMutation(message: "partially rewritten")) {
+            try await harness.coordinator.apply(.drop(target: "change-2"), confirmedAgainst: nil)
+        }
+
+        #expect(harness.refreshes == [.stack, .gitChanges, .inbox])
+        #expect(harness.actionState.lastError == "partially rewritten")
+    }
+
+    @Test func topologyRefreshRunsOnlyForCleanAndWorktreeCreatingUnstack() async throws {
+        let clean = GGMutationHarness(stacks: [stack(head: "a")])
+        try await clean.coordinator.apply(.clean, confirmedAgainst: nil)
+        #expect(clean.refreshes == [
+            .topology, .worktreeExistenceCheck, .stack, .gitChanges, .providerReviews, .inbox,
+        ])
+
+        let withoutWorktree = GGMutationHarness(stacks: [stack(head: "a")])
+        withoutWorktree.service.result = .unstack(.init(
+            originalStack: "feature", newStack: "upper", movedCommits: [],
+            worktreePath: nil, currentStack: "feature"
+        ))
+        try await withoutWorktree.coordinator.apply(
+            .unstack(target: "change-2", name: "upper", createWorktree: false),
+            confirmedAgainst: nil
+        )
+        #expect(!withoutWorktree.refreshes.contains(.topology))
+
+        let withWorktree = GGMutationHarness(stacks: [stack(head: "a")])
+        withWorktree.service.result = .unstack(.init(
+            originalStack: "feature", newStack: "upper", movedCommits: [],
+            worktreePath: "/repo/upper", currentStack: "feature"
+        ))
+        try await withWorktree.coordinator.apply(
+            .unstack(target: "change-2", name: "upper", createWorktree: true),
+            confirmedAgainst: nil
+        )
+        #expect(withWorktree.refreshes == [.stack, .gitChanges, .inbox, .topology])
+        #expect(withWorktree.selectedPaths == ["/repo/upper"])
+    }
+
+    @Test func checkoutDoesNotInvalidateProjectInbox() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        try await harness.coordinator.apply(.checkout(target: "change-1"), confirmedAgainst: nil)
+        #expect(harness.refreshes == [.stack, .gitChanges])
+    }
+
+    @Test func conflictFailurePreservesPausedAction() async {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.service.error = GGServiceError.pausedConflict(message: "Resolve conflicts")
+
+        await #expect(throws: GGServiceError.pausedConflict(message: "Resolve conflicts")) {
+            try await harness.coordinator.apply(.restack, confirmedAgainst: nil)
+        }
+
+        #expect(harness.actionState.pausedOperation == GGPausedOperation(pausedBy: .restack))
+        #expect(harness.actionState.inFlightAction == nil)
+    }
+
+    @Test func localSuccessPersistsNewestUndoableOperationAndLaterMutationClearsIt() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a"), stack(head: "a")])
+        let operation = GGOperationSummary(
+            id: "op_1", kind: "sc", status: .completed, createdAtMs: 1,
+            args: ["sc"], touchedRemote: false, isUndoable: true
+        )
+        harness.service.operationLists = [[], [operation]]
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == "op_1")
+
+        harness.service.operationLists = []
+        harness.service.error = GGServiceError.commandFailed(stderr: "failed")
+        await #expect(throws: GGServiceError.commandFailed(stderr: "failed")) {
+            try await harness.coordinator.apply(.checkout(target: "change-1"), confirmedAgainst: nil)
+        }
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func successfulMutationDoesNotRestoreAnOlderUndoMarker() async throws {
+        let oldOperation = GGOperationSummary(
+            id: "op_old", kind: "squash", status: .completed, createdAtMs: 1,
+            args: ["sc"], touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: oldOperation.id, worktreeId: "wt")
+        harness.service.operationLists = [[oldOperation], [oldOperation]]
+
+        try await harness.coordinator.apply(.checkout(target: "change-1"), confirmedAgainst: nil)
+
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func stackIdentityIncludesSnakeCaseOperationID() throws {
+        let payload = #"{"version":1,"operation_id":"op_7","stack":{"name":"feature","base":"main","total_commits":1,"synced_commits":0,"current_position":1,"behind_base":0,"entries":[{"position":1,"sha":"abc","title":"Head","gg_id":"change-1","is_current":true}]}}"#
+
+        let snapshot = try GGStackSnapshot.decode(fromJSON: Data(payload.utf8))
+
+        #expect(snapshot.identity == GGStackIdentity(
+            stackName: "feature", base: "main", headSHA: "abc", operationID: "op_7"
+        ))
+    }
+
+    @Test func malformedRemoteOutputUsesObservedRefreshAsSuccess() async throws {
+        let entries = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Ready", ggId: "change-2",
+                prNumber: 7, prState: .open, approved: true, ciStatus: .success,
+                isCurrent: true
+            ),
+        ]
+        let harness = GGMutationHarness(stacks: [stack(head: "a", entries: entries)])
+        harness.service.error = GGServiceError.malformedOutput("newer gg schema")
+
+        try await harness.coordinator.apply(.land(target: "change-2"), confirmedAgainst: nil)
+
+        #expect(harness.refreshes == [.stack, .gitChanges, .providerReviews, .inbox])
+        #expect(harness.actionState.lastError == nil)
+    }
+}

--- a/AlasTests/Integrations/GGUndoMarkerStoreTests.swift
+++ b/AlasTests/Integrations/GGUndoMarkerStoreTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGUndoMarkerStoreTests {
+    @Test func storesMarkersPerWorktreeAndClearsIndependently() throws {
+        let suite = "GGUndoMarkerStoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = GGUndoMarkerStore(defaults: defaults)
+
+        store.set(GGUndoMarker(operationID: "op_1"), worktreeId: "wt-1")
+        store.set(
+            GGUndoMarker(operationID: "op_2", removedFinalStackCommit: true),
+            worktreeId: "wt-2"
+        )
+        #expect(store.marker(worktreeId: "wt-1") == GGUndoMarker(operationID: "op_1"))
+        #expect(store.marker(worktreeId: "wt-2") == GGUndoMarker(
+            operationID: "op_2", removedFinalStackCommit: true
+        ))
+
+        store.clear(worktreeId: "wt-1")
+        #expect(store.marker(worktreeId: "wt-1") == nil)
+        #expect(store.marker(worktreeId: "wt-2")?.operationID == "op_2")
+    }
+
+    @Test func aNewStoreReadsThePersistedMarker() throws {
+        let suite = "GGUndoMarkerStoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        GGUndoMarkerStore(defaults: defaults).set(
+            GGUndoMarker(operationID: "op_1", removedFinalStackCommit: true),
+            worktreeId: "wt"
+        )
+
+        #expect(GGUndoMarkerStore(defaults: defaults).marker(worktreeId: "wt") == GGUndoMarker(
+            operationID: "op_1", removedFinalStackCommit: true
+        ))
+    }
+}

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -206,23 +206,24 @@ struct RightPaneGGLandTests {
         ))
     }
 
-    @Test func requestAndCancelSetAndClearPending() {
+    @Test func requestWithoutCachedStackDoesNotStageLandConfirmation() {
         let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
                           path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.requestGGLand(.ready)
-        #expect(state.pendingGGLand == .ready)
-        state.cancelGGLand()
         #expect(state.pendingGGLand == nil)
+        #expect(state.ggActionState.lastError == "This stack is no longer ready to land.")
     }
 
-    @Test func requestAndCancelCleanAllSetAndClearPending() {
+    @Test func cleanPreflightFailureDoesNotStageConfirmation() async throws {
         let wt = Worktree(id: "i", projectId: "p", name: "f", branch: "f",
                           path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date())
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.requestGGCleanAll()
-        #expect(state.pendingGGCleanAll)
-        state.cancelGGCleanAll()
+        for _ in 0..<100 where state.ggActionState.lastError == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
         #expect(!state.pendingGGCleanAll)
+        #expect(state.ggActionState.lastError != nil)
     }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -50,6 +50,26 @@ private final class NDJSONSyncFakeGGRunner: GGCommandRunning, @unchecked Sendabl
     }
 }
 
+private final class ReentrantSyncFakeGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var syncCallCount = 0
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["sync", "--help"] {
+            return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
+        }
+        if args == ["sync", "--jsonl"] {
+            syncCallCount += 1
+            let ndjson = [
+                #"{"event":"start","total_entries":1}"#,
+                #"{"event":"push_done","position":1,"forced":false}"#,
+                #"{"event":"summary"}"#,
+            ].joined(separator: "\n")
+            return ProcessResult(exitCode: 0, stdout: ndjson, stderr: "")
+        }
+        return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+    }
+}
+
 private final class ConflictAfterSyncRunner: GGCommandRunning, @unchecked Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         if args == ["sync", "--help"] {
@@ -61,6 +81,22 @@ private final class ConflictAfterSyncRunner: GGCommandRunning, @unchecked Sendab
                 withIntermediateDirectories: true
             )
             return ProcessResult(exitCode: 1, stdout: "", stderr: "conflict")
+        }
+        return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+    }
+}
+
+private final class CleanMutationFakeGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var arguments: [[String]] = []
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        arguments.append(args)
+        if args == ["clean", "--all", "--json"] {
+            return ProcessResult(
+                exitCode: 0,
+                stdout: #"{"version":1,"clean":{"cleaned":[],"skipped":[]}}"#,
+                stderr: ""
+            )
         }
         return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
     }
@@ -537,7 +573,7 @@ struct RightPaneGGStackTests {
         state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
 
         state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
-        while state.ggActionState.inFlightAction != nil {
+        for _ in 0..<500 where state.ggActionState.pausedOperation == nil {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
 
@@ -551,23 +587,24 @@ struct RightPaneGGStackTests {
             withIntermediateDirectories: true
         )
         defer { try? FileManager.default.removeItem(at: wt.path) }
-        let runner = CountingFakeGGRunner(
-            result: ProcessResult(exitCode: 0, stdout: "", stderr: "")
-        )
+        let runner = CleanMutationFakeGGRunner()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: runner)
         var didRefreshProjectTopology = false
-        state.refreshProjectTopologyAfterGGClean = {
+        state.refreshProjectTopologyAfterGGMutation = {
             didRefreshProjectTopology = true
         }
 
         state.requestGGCleanAll()
+        for _ in 0..<500 where !state.pendingGGCleanAll && state.ggActionState.lastError == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
         state.performGGCleanAll()
-        while state.ggActionState.inFlightAction != nil {
+        for _ in 0..<500 where !didRefreshProjectTopology && state.ggActionState.lastError == nil {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
 
-        #expect(runner.callCount == 1)
+        #expect(runner.arguments.filter { $0 == ["clean", "--all", "--json"] }.count == 1)
         #expect(didRefreshProjectTopology)
     }
 
@@ -602,6 +639,29 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.syncProgress.isEmpty)
     }
 
+    @Test func repeatedSyncInvocationIsSilentlyIgnoredAtUIBoundary() async throws {
+        let wt = makeWorktree()
+        let runner = ReentrantSyncFakeGGRunner()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
+
+        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+
+        let deadline = Date().addingTimeInterval(2)
+        while state.ggActionState.lastActionSummary == nil,
+              state.ggActionState.lastError == nil,
+              Date() < deadline {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        #expect(runner.syncCallCount == 1)
+        #expect(state.ggActionState.lastError == nil)
+        #expect(state.ggActionState.lastActionSummary == "Synced · 1 pushed")
+    }
+
     @Test func syncErrorSuppressesSuccessSummary() async throws {
         let wt = makeWorktree()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
@@ -616,11 +676,8 @@ struct RightPaneGGStackTests {
         state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
 
         state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
-        var iterations = 0
-        while state.ggActionState.inFlightAction != nil {
+        for _ in 0..<500 where state.ggActionState.lastError == nil {
             try await Task.sleep(nanoseconds: 10_000_000)
-            iterations += 1
-            if iterations > 500 { break }
         }
 
         #expect(state.ggActionState.lastError != nil)


### PR DESCRIPTION
## What

- Centralizes prepare, confirm, apply, and undo handling for GG mutations.
- Verifies the full stack identity, including its base ref.
- Preserves actionable GG service errors and stores typed undo markers.

## Validation

- `GGMutationCoordinatorTests`
- Focused right-pane lifecycle tests.

## Stack

- Builds on #871.

<!-- gg:managed:start -->
Part of stack `prepare-gg`

Commit: 714cede
<!-- gg:managed:end -->