### PR TITLE
feat(gg): add stack-aware change preparation

### DIFF
--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -229,7 +229,7 @@ struct CenterPaneView: View {
                             tabState: draftState,
                             appState: state
                         )
-                        .id(draftState.id)
+                        .id(draftState.presentationID)
                         .task(id: rightPaneActivationKey) {
                             activateRightPaneStateForCenterTab()
                         }

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -245,6 +245,11 @@ struct DraftCommitTabState: Codable, Equatable, Identifiable {
     var bodyText: String
     var amend: Bool
     var selectedPath: String?
+    private var presentationRevision: Int?
+
+    var presentationID: String {
+        "\(id):presentation:\(presentationRevision ?? 0)"
+    }
 
     init(
         worktreeId: String,
@@ -259,6 +264,12 @@ struct DraftCommitTabState: Codable, Equatable, Identifiable {
         self.bodyText = bodyText
         self.amend = amend
         self.selectedPath = selectedPath
+        self.presentationRevision = nil
+    }
+
+    mutating func prepareForNewCommit() {
+        amend = false
+        presentationRevision = (presentationRevision ?? 0) + 1
     }
 }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -815,18 +815,30 @@ final class TabsManager {
     }
 
     @discardableResult
-    func openOrFocusDraftCommit(worktreeId: String) -> Tab {
+    func openOrFocusDraftCommit(worktreeId: String, resetAmend: Bool = false) -> Tab {
         let baseState = DraftCommitTabState(worktreeId: worktreeId)
         if var file = byWorktree[worktreeId],
            let idx = file.tabs.firstIndex(where: { $0.id == baseState.id }),
-           case .draftCommit(let existing) = file.tabs[idx] {
+           case .draftCommit(var existing) = file.tabs[idx] {
+            if resetAmend {
+                existing.prepareForNewCommit()
+                file.tabs[idx] = .draftCommit(existing)
+            }
             file.activeTabId = existing.id
             byWorktree[worktreeId] = file
             persist(worktreeId)
             return file.tabs[idx]
         }
         // No live tab — restore from the stash if present, otherwise start fresh.
-        let state = byWorktree[worktreeId]?.stashedDraft ?? baseState
+        var state = byWorktree[worktreeId]?.stashedDraft ?? baseState
+        if resetAmend {
+            state.prepareForNewCommit()
+            if var file = byWorktree[worktreeId], file.stashedDraft != nil {
+                file.stashedDraft = state
+                byWorktree[worktreeId] = file
+                persist(worktreeId)
+            }
+        }
         let tab = Tab.draftCommit(state)
         append(tab, to: worktreeId)
         return tab

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -99,6 +99,10 @@ struct GGInboxTabView: View {
         }
     }
 
+    static func commitCountLabel(_ count: Int) -> String {
+        "\(count) commit\(count == 1 ? "" : "s")"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
@@ -115,7 +119,7 @@ struct GGInboxTabView: View {
             Text(tabState.title).font(.system(size: 13, weight: .semibold))
                 .foregroundColor(theme.color("fg"))
             if let snapshot = inboxState.snapshot {
-                Text("\(snapshot.totalItems)")
+                Text(Self.commitCountLabel(snapshot.totalItems))
                     .font(.system(size: 11, weight: .medium)).monospacedDigit()
                     .foregroundColor(theme.color("fg-dim"))
             }
@@ -202,7 +206,7 @@ struct GGInboxTabView: View {
                 Text(bucket.title.uppercased())
                     .font(.system(size: 10.5, weight: .semibold)).tracking(0.5)
                     .foregroundColor(theme.color("fg-muted"))
-                Text("\(entries.count)")
+                Text(Self.commitCountLabel(entries.count))
                     .font(.system(size: 10.5, weight: .semibold)).monospacedDigit()
                     .foregroundColor(theme.color(bucket.themeToken))
             }

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -70,6 +70,26 @@ enum GGMutationConfirmation: Equatable, Sendable {
     case unstack(target: String, movedCommits: Int, lowerStack: String, newStack: String)
     case land(target: String, readyCommits: Int)
     case clean(mergedCommits: Int)
+
+    var message: String {
+        switch self {
+        case .drop(let target, let rewrittenDescendants, let hasOpenReview):
+            let descendants = Self.commitCount(rewrittenDescendants, qualifier: "descendant")
+            let reviewWarning = hasOpenReview ? " The selected commit has an open review." : ""
+            return "Drop \(target) and rewrite \(descendants).\(reviewWarning)"
+        case .unstack(_, let movedCommits, let lowerStack, let newStack):
+            return "Move \(Self.commitCount(movedCommits)) from \(lowerStack) to \(newStack)."
+        case .land(let target, let readyCommits):
+            return "Land \(Self.commitCount(readyCommits, qualifier: "ready")) through \(target)."
+        case .clean(let mergedCommits):
+            return "Clean \(Self.commitCount(mergedCommits, qualifier: "merged"))."
+        }
+    }
+
+    private static func commitCount(_ count: Int, qualifier: String? = nil) -> String {
+        let prefix = qualifier.map { "\($0) " } ?? ""
+        return "\(count) \(prefix)commit\(count == 1 ? "" : "s")"
+    }
 }
 
 enum GGMutationError: Error, Equatable {

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -50,7 +50,7 @@ struct GGStackReadinessModel: Equatable {
         }()
 
         let facts: [Fact] = [
-            Fact(label: "Entries", value: "\(stack.totalCommits)"),
+            Fact(label: "Commits", value: "\(stack.totalCommits)"),
             Fact(label: "Merged", value: "\(merged)"),
             Fact(label: "Unsynced", value: "\(unsynced)"),
             Fact(label: "Behind base", value: "\(behind)"),
@@ -116,7 +116,7 @@ struct GGStackReadinessModel: Equatable {
     private static func progressRows(from events: [GGSyncEvent]) -> [String] {
         events.compactMap { event in
             switch event {
-            case .start(let total): return "Syncing \(total) entr\(total == 1 ? "y" : "ies")…"
+            case .start(let total): return "Syncing \(total) commit\(total == 1 ? "" : "s")…"
             case .entryStarted(let pos, let title): return "[\(pos)] \(title)"
             case .pushStarted(let pos): return "[\(pos)] pushing…"
             case .pushDone(let pos, _): return "[\(pos)] pushed"

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -18,6 +18,7 @@ struct ChangesPreparationCard: View {
     let model: ChangesPreparationModel
     let onReviewChanges: () -> Void
     let onDraftCommit: () -> Void
+    let onGGAction: (GGChangesPreparationAction) -> Void
     let onReviewRequestAction: (ReviewReadinessActionKind) -> Void
 
     @Environment(\.theme) private var theme
@@ -28,7 +29,13 @@ struct ChangesPreparationCard: View {
             if let reviewAction = model.reviewAction {
                 primaryReviewButton(reviewAction)
             }
-            if model.draftAction != nil || !model.reviewRequestActions.isEmpty {
+            if !model.ggActions.isEmpty {
+                HStack(spacing: 6) {
+                    ForEach(model.ggActions, id: \.kind) { action in
+                        ggDestinationButton(action)
+                    }
+                }
+            } else if model.draftAction != nil || !model.reviewRequestActions.isEmpty {
                 ViewThatFits(in: .horizontal) {
                     secondaryActionsHorizontal
                     secondaryActionsVertical
@@ -150,6 +157,75 @@ struct ChangesPreparationCard: View {
             action: { onReviewRequestAction(action.kind) }
         )
         .accessibilityIdentifier("changes-preparation-review-request")
+    }
+
+    private func ggDestinationButton(_ action: ChangesPreparationModel.GGAction) -> some View {
+        Button {
+            onGGAction(action.kind)
+        } label: {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    Icon(name: ggIconName(for: action.kind), size: 10, color: theme.color("fg-dim"))
+                    Text(action.title)
+                        .font(.system(size: 10.5, weight: .semibold))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.85)
+                    Spacer(minLength: 0)
+                }
+                Text(ggSubtitle(for: action))
+                    .font(.system(size: 9.5, design: .monospaced))
+                    .foregroundColor(theme.color("fg-faint"))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .padding(.horizontal, 7)
+            .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(!action.isEnabled)
+        .opacity(action.isEnabled ? 1 : 0.5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(theme.color("bg-2").opacity(0.72))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line").opacity(0.65), lineWidth: 0.75)
+        )
+        .help(action.disabledReason ?? action.title)
+        .accessibilityIdentifier("changes-preparation-gg-\(ggIdentifier(for: action.kind))")
+    }
+
+    private func ggSubtitle(for action: ChangesPreparationModel.GGAction) -> String {
+        if let disabledReason = action.disabledReason {
+            return disabledReason
+        }
+        if action.kind == .newStackCommit, action.hasNonEmptyDraft, !action.stats.hasChanges {
+            return "Draft ready"
+        }
+        return ChangesPreparationCardText.draftStats(
+            stagedCount: action.stats.files,
+            additions: action.stats.insertions,
+            deletions: action.stats.deletions
+        )
+    }
+
+    private func ggIconName(for action: GGChangesPreparationAction) -> String {
+        switch action {
+        case .newStackCommit: "commit"
+        case .amendCurrent: "arrow.uturn.backward.circle"
+        case .absorbIntoStack: "arrow.down.to.line.compact"
+        }
+    }
+
+    private func ggIdentifier(for action: GGChangesPreparationAction) -> String {
+        switch action {
+        case .newStackCommit: "new"
+        case .amendCurrent: "amend"
+        case .absorbIntoStack: "absorb"
+        }
     }
 
     private func secondaryButton(

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -1,6 +1,22 @@
 import Foundation
 
+enum GGChangesPreparationAction: Equatable, Sendable {
+    case newStackCommit
+    case amendCurrent
+    case absorbIntoStack
+}
+
 struct ChangesPreparationModel: Equatable {
+    struct StagedStats: Equatable, Sendable {
+        let files: Int
+        let insertions: Int
+        let deletions: Int
+
+        static let zero = StagedStats(files: 0, insertions: 0, deletions: 0)
+
+        var hasChanges: Bool { files > 0 }
+    }
+
     struct ReviewAction: Equatable {
         let title: String
         let fileCount: Int
@@ -25,12 +41,28 @@ struct ChangesPreparationModel: Equatable {
         let emphasis: ReviewReadinessModel.Action.Emphasis
     }
 
+    struct GGAction: Equatable {
+        let kind: GGChangesPreparationAction
+        let title: String
+        let stats: StagedStats
+        let hasNonEmptyDraft: Bool
+        let disabledReason: String?
+
+        var isEnabled: Bool { disabledReason == nil }
+    }
+
     let reviewAction: ReviewAction?
     let draftAction: DraftAction?
     let reviewRequestActions: [ReviewRequestAction]
+    let ggActions: [GGAction]
+
+    var primaryAction: ReviewAction? { reviewAction }
 
     var isVisible: Bool {
-        reviewAction != nil || draftAction != nil || !reviewRequestActions.isEmpty
+        if !ggActions.isEmpty {
+            return reviewAction != nil || ggAction(.newStackCommit)?.isEnabled == true
+        }
+        return reviewAction != nil || draftAction != nil || !reviewRequestActions.isEmpty
     }
 
     init(
@@ -69,6 +101,7 @@ struct ChangesPreparationModel: Equatable {
 
         reviewAction = builtReviewAction
         draftAction = builtDraftAction
+        ggActions = []
         let builtActions = Self.compactReviewRequestActions(from: readinessActions)
         let effectiveAheadCommitCount = local?.aheadCommitCount ?? aheadCommitCount
         reviewRequestActions = Self.applyingHideRules(
@@ -78,6 +111,119 @@ struct ChangesPreparationModel: Equatable {
             local: local,
             aheadCommitCount: effectiveAheadCommitCount
         )
+    }
+
+    static func makeGG(
+        changes: [ChangedFile],
+        hasDraft: Bool,
+        capabilities: GGCapabilities,
+        mutationDisabledReason: String? = nil,
+        newCommitDisabledReason: String? = nil
+    ) -> ChangesPreparationModel {
+        let summary = ReviewChangesTriggerSummary.summary(for: changes)
+        let stagedChanges = changes.filter { $0.stage == .staged }
+        let staged = StagedStats(
+            files: stagedChanges.count,
+            insertions: stagedChanges.reduce(0) { $0 + $1.add },
+            deletions: stagedChanges.reduce(0) { $0 + $1.del }
+        )
+        return makeGG(
+            staged: staged,
+            hasDraft: hasDraft,
+            capabilities: capabilities,
+            mutationDisabledReason: mutationDisabledReason,
+            newCommitDisabledReason: newCommitDisabledReason,
+            reviewSummary: summary
+        )
+    }
+
+    static func makeGG(
+        staged: StagedStats,
+        hasDraft: Bool,
+        capabilities: GGCapabilities,
+        mutationDisabledReason: String? = nil,
+        newCommitDisabledReason: String? = nil
+    ) -> ChangesPreparationModel {
+        let summary = staged.hasChanges
+            ? ReviewChangesTriggerSummary(
+                fileCount: staged.files,
+                additions: staged.insertions,
+                deletions: staged.deletions
+            )
+            : nil
+        return makeGG(
+            staged: staged,
+            hasDraft: hasDraft,
+            capabilities: capabilities,
+            mutationDisabledReason: mutationDisabledReason,
+            newCommitDisabledReason: newCommitDisabledReason,
+            reviewSummary: summary
+        )
+    }
+
+    func ggAction(_ kind: GGChangesPreparationAction) -> GGAction? {
+        ggActions.first { $0.kind == kind }
+    }
+
+    private static func makeGG(
+        staged: StagedStats,
+        hasDraft: Bool,
+        capabilities: GGCapabilities,
+        mutationDisabledReason: String?,
+        newCommitDisabledReason: String?,
+        reviewSummary: ReviewChangesTriggerSummary?
+    ) -> ChangesPreparationModel {
+        let reviewAction = reviewSummary.map {
+            ReviewAction(
+                title: "Review current changes",
+                fileCount: $0.fileCount,
+                additions: $0.additions,
+                deletions: $0.deletions
+            )
+        }
+        let effectiveNewCommitDisabledReason = mutationDisabledReason
+            ?? newCommitDisabledReason
+            ?? (staged.hasChanges || hasDraft ? nil : "Stage changes first")
+        let rewriteDisabledReason = mutationDisabledReason
+            ?? (staged.hasChanges ? nil : "Stage changes first")
+        let amendDisabledReason = mutationDisabledReason ?? (
+            capabilities.stagedOnlyAmend
+                ? rewriteDisabledReason
+                : "Update GG to amend staged changes safely"
+        )
+        return ChangesPreparationModel(
+            reviewAction: reviewAction,
+            ggActions: [
+                GGAction(
+                    kind: .newStackCommit,
+                    title: "New stack commit",
+                    stats: staged,
+                    hasNonEmptyDraft: hasDraft,
+                    disabledReason: effectiveNewCommitDisabledReason
+                ),
+                GGAction(
+                    kind: .amendCurrent,
+                    title: "Amend current",
+                    stats: staged,
+                    hasNonEmptyDraft: false,
+                    disabledReason: amendDisabledReason
+                ),
+                GGAction(
+                    kind: .absorbIntoStack,
+                    title: "Absorb into stack",
+                    stats: staged,
+                    hasNonEmptyDraft: false,
+                    disabledReason: rewriteDisabledReason
+                ),
+            ]
+        )
+    }
+
+    private init(reviewAction: ReviewAction?, ggActions: [GGAction]) {
+        self.reviewAction = reviewAction
+        draftAction = nil
+        reviewRequestActions = []
+        self.ggActions = ggActions
     }
 
     private static func compactReviewRequestActions(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -18,6 +18,18 @@ struct ChangesTabView: View {
     }
 
     private var preparationModel: ChangesPreparationModel {
+        if isGGDrawerActive {
+            return ChangesPreparationModel.makeGG(
+                changes: rps.changes,
+                hasDraft: draftNonEmpty,
+                capabilities: GGAvailability.shared.capabilities,
+                mutationDisabledReason: ggPreparationMutationDisabledReason,
+                newCommitDisabledReason: Self.ggNewStackCommitDisabledReason(
+                    stack: rps.ggStack,
+                    currentHeadSHA: rps.currentHeadSHA
+                )
+            )
+        }
         let readiness = ReviewReadinessModel(
             snapshot: rps.reviewLoop.snapshot,
             lastError: rps.reviewLoop.lastError,
@@ -53,6 +65,47 @@ struct ChangesTabView: View {
 
     private var isGGDrawerActive: Bool {
         Self.shouldShowGGDrawer(stack: rps.ggStack, pausedGGOperation: rps.ggActionState.pausedOperation)
+    }
+
+    private var ggPreparationMutationDisabledReason: String? {
+        Self.ggPreparationMutationDisabledReason(
+            hasStack: rps.ggStack != nil,
+            pausedOperation: rps.ggActionState.pausedOperation,
+            inFlightAction: rps.ggActionState.inFlightAction,
+            mergeOperation: rps.mergeOp.current
+        )
+    }
+
+    static func ggPreparationMutationDisabledReason(
+        hasStack: Bool,
+        pausedOperation: GGPausedOperation?,
+        inFlightAction: GGStackActionKind?,
+        mergeOperation: MergeOperation?
+    ) -> String? {
+        if !hasStack || pausedOperation != nil {
+            return "Continue or abort the paused GG operation first."
+        }
+        if inFlightAction != nil {
+            return "Another GG operation is running."
+        }
+        if mergeOperation != nil {
+            return "Finish the current Git operation first."
+        }
+        return nil
+    }
+
+    static func ggNewStackCommitDisabledReason(
+        stack: GGStack?,
+        currentHeadSHA: String
+    ) -> String? {
+        guard !currentHeadSHA.isEmpty,
+              let head = stack?.entries.max(by: { $0.position < $1.position }),
+              !head.sha.isEmpty,
+              currentHeadSHA.hasPrefix(head.sha) || head.sha.hasPrefix(currentHeadSHA)
+        else {
+            return "Checkout the stack head to create a new stack commit."
+        }
+        return nil
     }
 
     private var scrollContent: some View {
@@ -100,13 +153,13 @@ struct ChangesTabView: View {
             )
 
             if Self.shouldShowChangesPreparationCard(
-                preparationIsVisible: preparationModel.isVisible,
-                ggDrawerIsActive: isGGDrawerActive
+                preparationIsVisible: preparationModel.isVisible
             ) {
                 ChangesPreparationCard(
                     model: preparationModel,
                     onReviewChanges: openReviewChangesTab,
                     onDraftCommit: openDraftTab,
+                    onGGAction: handleGGPreparationAction,
                     onReviewRequestAction: { action in
                         rps.handleReviewReadinessAction(action, appState: appState)
                     }
@@ -244,10 +297,17 @@ struct ChangesTabView: View {
     }
 
     static func shouldShowChangesPreparationCard(
-        preparationIsVisible: Bool,
-        ggDrawerIsActive: Bool
+        preparationIsVisible: Bool
     ) -> Bool {
-        preparationIsVisible && !ggDrawerIsActive
+        preparationIsVisible
+    }
+
+    static func stackAction(for action: GGChangesPreparationAction) -> GGStackActionKind? {
+        switch action {
+        case .newStackCommit: nil
+        case .amendCurrent: .amendCurrent
+        case .absorbIntoStack: .absorbStaged
+        }
     }
 
     private var hasDraftTab: Bool {
@@ -273,6 +333,18 @@ struct ChangesTabView: View {
 
     private func openDraftTab() {
         _ = appState.tabs.openOrFocusDraftCommit(worktreeId: rps.worktree.id)
+    }
+
+    private func handleGGPreparationAction(_ action: GGChangesPreparationAction) {
+        if action == .newStackCommit {
+            _ = appState.tabs.openOrFocusDraftCommit(
+                worktreeId: rps.worktree.id,
+                resetAmend: true
+            )
+            return
+        }
+        guard let stackAction = Self.stackAction(for: action) else { return }
+        rps.onGGStackAction(stackAction, appState: appState)
     }
 
     private func openReviewChangesTab() {

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct CommitRow: View {
+    static let ggCheckoutTitle = "Checkout Commit"
+
     enum ContextMenuAction: Hashable {
         case edit
         case review
@@ -77,7 +79,7 @@ struct CommitRow: View {
                     Button("Open \(codeHostKind?.reviewRequestLabel ?? "PR")") { onGGOpenPR() }
                 }
                 if let onGGCheckout {
-                    Button("Checkout Entry") { onGGCheckout() }
+                    Button(Self.ggCheckoutTitle) { onGGCheckout() }
                 }
                 if let onGGLandUntil {
                     Button("Land Until Here…") { onGGLandUntil() }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 
 struct WorktreeRowView: View {
+    static func stackSummaryTooltip(merged: Int, total: Int) -> String {
+        "gg stack · \(merged) of \(total) commit\(total == 1 ? "" : "s") merged"
+    }
+
     let worktree: Worktree
     let isSelected: Bool
     let isMain: Bool
@@ -101,7 +105,7 @@ struct WorktreeRowView: View {
                             Text("▲ \(stack.merged)/\(stack.total)")
                                 .font(.system(size: 10.5, design: .monospaced))
                                 .foregroundColor(theme.color("accent"))
-                                .help("gg stack · \(stack.merged) of \(stack.total) entries merged")
+                                .help(Self.stackSummaryTooltip(merged: stack.merged, total: stack.total))
                         }
                         if let summary = harnessSummary {
                             Spacer()

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -20,19 +20,48 @@ struct ChangesTabViewTests {
         ))
     }
 
-    @Test func changesPreparationCardHiddenWhenGGDrawerIsActive() {
+    @Test func changesPreparationCardVisibilityDoesNotDependOnGGDrawer() {
         #expect(ChangesTabView.shouldShowChangesPreparationCard(
-            preparationIsVisible: true,
-            ggDrawerIsActive: false
+            preparationIsVisible: true
         ))
         #expect(!ChangesTabView.shouldShowChangesPreparationCard(
-            preparationIsVisible: true,
-            ggDrawerIsActive: true
+            preparationIsVisible: false
         ))
-        #expect(!ChangesTabView.shouldShowChangesPreparationCard(
-            preparationIsVisible: false,
-            ggDrawerIsActive: false
-        ))
+    }
+
+    @Test func regularGitOperationDisablesGGPreparationMutations() {
+        let reason = ChangesTabView.ggPreparationMutationDisabledReason(
+            hasStack: true,
+            pausedOperation: nil,
+            inFlightAction: nil,
+            mergeOperation: .merge(sourceBranch: "main")
+        )
+
+        #expect(reason == "Finish the current Git operation first.")
+    }
+
+    @Test func newStackCommitRequiresActualStackHeadCheckout() {
+        let stack = stack(currentPosition: 1)
+
+        #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            stack: stack,
+            currentHeadSHA: "1111111111111111111111111111111111111111"
+        ) == "Checkout the stack head to create a new stack commit.")
+        #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            stack: stack,
+            currentHeadSHA: "2222222222222222222222222222222222222222"
+        ) == nil)
+    }
+
+    @Test func newStackCommitIsConservativelyDisabledWithoutVerifiableHead() {
+        #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            stack: stack(currentPosition: nil, entries: []),
+            currentHeadSHA: "1111111111111111111111111111111111111111"
+        ) == "Checkout the stack head to create a new stack commit.")
+        #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            stack: stack(currentPosition: 2),
+            currentHeadSHA: ""
+        ) == "Checkout the stack head to create a new stack commit.")
     }
 
     @Test func ggDrawerActiveForStackOrPausedOperation() {
@@ -53,5 +82,32 @@ struct ChangesTabViewTests {
             stack: nil,
             pausedGGOperation: GGPausedOperation(pausedBy: .sync)
         ))
+    }
+
+    private func stack(
+        currentPosition: Int?,
+        entries: [GGStackEntry] = [
+            GGStackEntry(
+                position: 1,
+                sha: "1111111",
+                title: "First",
+                isCurrent: true
+            ),
+            GGStackEntry(
+                position: 2,
+                sha: "2222222",
+                title: "Second"
+            ),
+        ]
+    ) -> GGStack {
+        GGStack(
+            name: "feat",
+            base: "main",
+            totalCommits: entries.count,
+            syncedCommits: 0,
+            currentPosition: currentPosition,
+            behindBase: nil,
+            entries: entries
+        )
     }
 }

--- a/AlasTests/DraftCommitTabsManagerTests.swift
+++ b/AlasTests/DraftCommitTabsManagerTests.swift
@@ -32,6 +32,79 @@ struct DraftCommitTabsManagerTests {
         #expect(mgr.activeTabId(forWorktree: worktreeId) == first.id)
     }
 
+    @Test func openOrFocusDraftCommitForNewCommit_resetsLiveAmendBeforeFocusing() {
+        let worktreeId = "draft-commit-tabs-mgr-new-live"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let first = mgr.openOrFocusDraftCommit(worktreeId: worktreeId)
+        mgr.updateDraftCommit(worktreeId: worktreeId, tabId: first.id) { state in
+            state.subject = "Keep this message"
+            state.bodyText = "Keep this body"
+            state.amend = true
+        }
+        guard case .draftCommit(let mountedState) = mgr.tabs(forWorktree: worktreeId).first else {
+            Issue.record("expected mounted draftCommit tab")
+            return
+        }
+
+        let reopened = mgr.openOrFocusDraftCommit(worktreeId: worktreeId, resetAmend: true)
+
+        guard case .draftCommit(let state) = reopened else {
+            Issue.record("expected draftCommit tab")
+            return
+        }
+        #expect(state.subject == "Keep this message")
+        #expect(state.bodyText == "Keep this body")
+        #expect(state.amend == false)
+        #expect(state.presentationID != mountedState.presentationID)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == first.id)
+    }
+
+    @Test func openOrFocusDraftCommitForGenericDraft_preservesLiveAmend() {
+        let worktreeId = "draft-commit-tabs-mgr-generic-live"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let first = mgr.openOrFocusDraftCommit(worktreeId: worktreeId)
+        mgr.updateDraftCommit(worktreeId: worktreeId, tabId: first.id) { state in
+            state.amend = true
+        }
+        guard case .draftCommit(let mountedState) = mgr.tabs(forWorktree: worktreeId).first else {
+            Issue.record("expected mounted draftCommit tab")
+            return
+        }
+
+        let reopened = mgr.openOrFocusDraftCommit(worktreeId: worktreeId)
+
+        guard case .draftCommit(let state) = reopened else {
+            Issue.record("expected draftCommit tab")
+            return
+        }
+        #expect(state.amend == true)
+        #expect(state.presentationID == mountedState.presentationID)
+    }
+
+    @Test func openOrFocusDraftCommitForNewCommit_resetsStashedAmendBeforeOpening() {
+        let worktreeId = "draft-commit-tabs-mgr-new-stashed"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let first = mgr.openOrFocusDraftCommit(worktreeId: worktreeId)
+        mgr.updateDraftCommit(worktreeId: worktreeId, tabId: first.id) { state in
+            state.subject = "Keep this stashed message"
+            state.amend = true
+        }
+        mgr.close(worktreeId: worktreeId, tabId: first.id)
+
+        let reopened = mgr.openOrFocusDraftCommit(worktreeId: worktreeId, resetAmend: true)
+
+        guard case .draftCommit(let state) = reopened else {
+            Issue.record("expected draftCommit tab")
+            return
+        }
+        #expect(state.subject == "Keep this stashed message")
+        #expect(state.amend == false)
+        #expect(mgr.stashedDraft(worktreeId: worktreeId)?.amend == false)
+    }
+
     @Test func updateDraftCommit_persistsSubjectAndBody() {
         let worktreeId = "draft-commit-tabs-mgr-update"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -27,7 +27,7 @@ struct GGStackReadinessModelTests {
             action: GGStackActionState()
         )
         #expect(model.title == "Stack · feat")
-        #expect(model.facts.contains { $0.label == "Entries" && $0.value == "2" })
+        #expect(model.facts.contains { $0.label == "Commits" && $0.value == "2" })
         #expect(model.facts.contains { $0.label == "Merged" && $0.value == "1" })
     }
 

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -4,6 +4,11 @@ import Testing
 
 struct ChangesPreparationModelTests {
     private typealias Action = ReviewReadinessModel.Action
+    private let stagedOnlyCapabilities = GGCapabilities(
+        structuredSplit: false,
+        keepCurrentUnstack: false,
+        stagedOnlyAmend: true
+    )
 
     private func makeModel(actions: [Action], aheadCommitCount: Int = 1) -> ChangesPreparationModel {
         ChangesPreparationModel(
@@ -48,4 +53,136 @@ struct ChangesPreparationModelTests {
         #expect(model.reviewRequestActions.isEmpty)
         #expect(!model.isVisible)
     }
+
+    @Test func nonGGPreparationKeepsExistingActions() {
+        let model = ChangesPreparationModel(
+            changes: [changedFile("Sources/App.swift", stage: .staged, add: 3, del: 1)],
+            hasDraft: false,
+            draftNonEmpty: false,
+            readinessActions: []
+        )
+
+        #expect(model.reviewAction?.title == "Review current changes")
+        #expect(model.draftAction?.title == "Draft commit")
+        #expect(model.ggActions.isEmpty)
+    }
+
+    @Test func ggPreparationShowsReviewAndThreeDestinations() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .init(files: 2, insertions: 8, deletions: 3),
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities
+        )
+
+        #expect(model.primaryAction?.title == "Review current changes")
+        #expect(model.ggActions.map(\.kind) == [.newStackCommit, .amendCurrent, .absorbIntoStack])
+        #expect(model.ggActions.map(\.title) == ["New stack commit", "Amend current", "Absorb into stack"])
+        #expect(model.ggActions.allSatisfy { $0.isEnabled })
+    }
+
+    @Test func ggRewriteDestinationsRequireStagedChanges() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: true,
+            capabilities: stagedOnlyCapabilities
+        )
+
+        #expect(model.ggAction(.newStackCommit)?.isEnabled == true)
+        #expect(model.ggAction(.amendCurrent)?.disabledReason == "Stage changes first")
+        #expect(model.ggAction(.absorbIntoStack)?.disabledReason == "Stage changes first")
+    }
+
+    @Test func ggRewriteDestinationsShowStagedStatistics() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .init(files: 2, insertions: 8, deletions: 3),
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities
+        )
+
+        #expect(model.ggAction(.amendCurrent)?.stats == .init(files: 2, insertions: 8, deletions: 3))
+        #expect(model.ggAction(.absorbIntoStack)?.stats == .init(files: 2, insertions: 8, deletions: 3))
+    }
+
+    @Test func emptyGGPreparationIsHiddenButKeepsStableDestinations() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities
+        )
+
+        #expect(model.ggActions.map(\.kind) == [.newStackCommit, .amendCurrent, .absorbIntoStack])
+        #expect(!model.ggActions.contains { $0.isEnabled })
+        #expect(!model.isVisible)
+    }
+
+    @Test func oldGGDisablesOnlyUnsafeAmendWithUpdateReason() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .init(files: 1, insertions: 2, deletions: 1),
+            hasDraft: false,
+            capabilities: GGCapabilities(structuredSplit: false, keepCurrentUnstack: false)
+        )
+
+        #expect(model.ggAction(.newStackCommit)?.isEnabled == true)
+        #expect(model.ggAction(.absorbIntoStack)?.isEnabled == true)
+        #expect(model.ggAction(.amendCurrent)?.disabledReason == "Update GG to amend staged changes safely")
+    }
+
+    @Test func pausedGGOperationDisablesEveryMutationDestination() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .init(files: 1, insertions: 2, deletions: 1),
+            hasDraft: true,
+            capabilities: stagedOnlyCapabilities,
+            mutationDisabledReason: "Continue or abort the paused GG operation first."
+        )
+
+        #expect(model.ggActions.allSatisfy { !$0.isEnabled })
+        #expect(model.ggActions.allSatisfy {
+            $0.disabledReason == "Continue or abort the paused GG operation first."
+        })
+    }
+
+    @Test func nonHeadCheckoutDisablesOnlyNewStackCommit() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .init(files: 1, insertions: 2, deletions: 1),
+            hasDraft: true,
+            capabilities: stagedOnlyCapabilities,
+            newCommitDisabledReason: "Checkout the stack head to create a new stack commit."
+        )
+
+        #expect(model.ggAction(.newStackCommit)?.disabledReason ==
+            "Checkout the stack head to create a new stack commit.")
+        #expect(model.ggAction(.amendCurrent)?.isEnabled == true)
+        #expect(model.ggAction(.absorbIntoStack)?.isEnabled == true)
+    }
+
+    @Test func globalMutationGateTakesPriorityOverNewCommitGate() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .init(files: 1, insertions: 2, deletions: 1),
+            hasDraft: true,
+            capabilities: stagedOnlyCapabilities,
+            mutationDisabledReason: "Another GG operation is running.",
+            newCommitDisabledReason: "Checkout the stack head to create a new stack commit."
+        )
+
+        #expect(model.ggActions.allSatisfy {
+            $0.disabledReason == "Another GG operation is running."
+        })
+    }
+}
+
+private func changedFile(
+    _ path: String,
+    stage: ChangeStage,
+    add: Int,
+    del: Int
+) -> ChangedFile {
+    ChangedFile(
+        path: path,
+        status: "M",
+        stage: stage,
+        add: add,
+        del: del,
+        renameFrom: nil,
+        conflict: nil
+    )
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -134,6 +134,52 @@ struct RightPaneGGStackTests {
         )
     }
 
+    @Test func prepareCardRemainsVisibleAlongsideGGDrawer() {
+        #expect(ChangesTabView.shouldShowChangesPreparationCard(
+            preparationIsVisible: true
+        ))
+        #expect(!ChangesTabView.shouldShowChangesPreparationCard(
+            preparationIsVisible: false
+        ))
+    }
+
+    @Test func ggPreparationDestinationsRouteToExistingActions() {
+        #expect(ChangesTabView.stackAction(for: .newStackCommit) == nil)
+        #expect(ChangesTabView.stackAction(for: .amendCurrent) == .amendCurrent)
+        #expect(ChangesTabView.stackAction(for: .absorbIntoStack) == .absorbStaged)
+    }
+
+    @Test func ggOwnedPresentationUsesCommitTerminology() {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.appendSyncEvent(.start(totalEntries: 2))
+        let stack = GGStack(
+            name: "feature",
+            base: "main",
+            totalCommits: 2,
+            syncedCommits: 0,
+            currentPosition: 2,
+            behindBase: 0,
+            entries: []
+        )
+        let drawer = GGStackReadinessModel.make(stack: stack, action: action)
+
+        #expect(drawer.facts.first?.label == "Commits")
+        #expect(drawer.progressRows.first == "Syncing 2 commits…")
+        #expect(GGInboxTabView.commitCountLabel(1) == "1 commit")
+        #expect(GGInboxTabView.commitCountLabel(2) == "2 commits")
+        #expect(CommitRow.ggCheckoutTitle == "Checkout Commit")
+        #expect(GGMutationConfirmation.clean(mergedCommits: 2).message.contains("2 merged commits"))
+
+        let typedStrings = drawer.facts.map(\.label)
+            + drawer.progressRows
+            + [GGInboxTabView.commitCountLabel(2), CommitRow.ggCheckoutTitle]
+            + [GGMutationConfirmation.clean(mergedCommits: 2).message]
+        #expect(typedStrings.allSatisfy {
+            !$0.lowercased().contains("entry") && !$0.lowercased().contains("entries")
+        })
+    }
+
     /// A real repo with `main` pushed to a bare remote, then a `nacho/stack`
     /// branch carrying one GG-ID-trailered commit — also fully pushed, so
     /// `@{u}` == HEAD and the branch has nothing left unpushed.

--- a/AlasTests/WorktreeRowHeightTests.swift
+++ b/AlasTests/WorktreeRowHeightTests.swift
@@ -6,6 +6,13 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct WorktreeRowHeightTests {
+    @Test func ggStackTooltipUsesCommitTerminology() {
+        #expect(WorktreeRowView.stackSummaryTooltip(merged: 1, total: 1)
+            == "gg stack · 1 of 1 commit merged")
+        #expect(WorktreeRowView.stackSummaryTooltip(merged: 2, total: 3)
+            == "gg stack · 2 of 3 commits merged")
+    }
+
     @Test func rowHeightIsStableWithAndWithoutBadge() throws {
         let withoutBadge = try renderHeight(harnessSummary: nil)
         let withBadge = try renderHeight(harnessSummary: .init(


### PR DESCRIPTION
## What

- Adds stack-aware preparation actions for New Stack Commit and Amend.
- Resets an active composer to a new-stack state without losing its draft text.
- Keeps ordinary draft reopening behavior unchanged.

## Validation

- `DraftCommitTabsManagerTests`
- `ChangesPreparationModelTests`

## Stack

- Builds on #872.

<!-- gg:managed:start -->
Part of stack `prepare-gg`

Commit: 7c2bed0
<!-- gg:managed:end -->