### PR TITLE
feat(gg): add commit workflow menu

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		2659BA65A6CABBE800A06AB3 /* tool-call-content-diff.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */; };
 		2661C51A093174D940CB5733 /* ProviderReviewActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9F77CC231E1131962F5A43 /* ProviderReviewActions.swift */; };
 		26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */; };
+		270146424B271EBDB8886DD2 /* GGUnstackSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02E6B12C5EC8FAA50202EEA /* GGUnstackSheet.swift */; };
 		272EE1BE3B1A4A3BFA7B2703 /* ACPManagedAdapterDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA89D4C70102BCF7B6B2450B /* ACPManagedAdapterDescriptor.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
 		2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */; };
@@ -881,6 +882,7 @@
 		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
 		A8D21135BA6C2542E3820E19 /* TreeSitterHTML in Frameworks */ = {isa = PBXBuildFile; productRef = E1F30BF52DCE8CD60F19C921 /* TreeSitterHTML */; };
 		A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */; };
+		A955D8E9871CA023ED98A095 /* GGCommitMenuModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EE59978053FA18629BC280 /* GGCommitMenuModelTests.swift */; };
 		A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */; };
 		A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */; };
 		A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF32A1544E13321E9E223AFF /* DiffPaneView.swift */; };
@@ -1335,6 +1337,7 @@
 		FB9BAF6C82A1750E41594DB7 /* SelfUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CF2E2BF116094A9FEE3F8D /* SelfUpdater.swift */; };
 		FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */; };
 		FBEC59B1FD0C1DDDB6CE3100 /* RemoteNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8084388AF564A1907548C /* RemoteNetworkTests.swift */; };
+		FBFAB8DAB738CC7A21076D22 /* GGCommitMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7C5CADC042EF509370EB87 /* GGCommitMenuModel.swift */; };
 		FC9BC95960AE236F82D69E0B /* ACPQuestionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */; };
 		FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */; };
 		FCC6BC72DF062AA572F5535F /* RemoteZmxInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */; };
@@ -2163,6 +2166,7 @@
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipTests.swift; sourceTree = "<group>"; };
 		98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxStoreTests.swift; sourceTree = "<group>"; };
+		98EE59978053FA18629BC280 /* GGCommitMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGCommitMenuModelTests.swift; sourceTree = "<group>"; };
 		993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationModels.swift; sourceTree = "<group>"; };
 		99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPServer.swift; sourceTree = "<group>"; };
 		99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffLoaderTests.swift; sourceTree = "<group>"; };
@@ -2194,6 +2198,7 @@
 		9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilter.swift; sourceTree = "<group>"; };
 		9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseChecker.swift; sourceTree = "<group>"; };
 		A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParserTests.swift; sourceTree = "<group>"; };
+		A02E6B12C5EC8FAA50202EEA /* GGUnstackSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGUnstackSheet.swift; sourceTree = "<group>"; };
 		A1503D1CB549B39E499EFAB8 /* DiffInlineAnnotationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineAnnotationCard.swift; sourceTree = "<group>"; };
 		A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewModelsTests.swift; sourceTree = "<group>"; };
 		A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateStoreTests.swift; sourceTree = "<group>"; };
@@ -2408,6 +2413,7 @@
 		CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPVisibleRowsCacheTests.swift; sourceTree = "<group>"; };
 		CA43AA9C8462D579E733B46C /* AppIntents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
 		CA554728676F9D3B5E2C05FA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		CA7C5CADC042EF509370EB87 /* GGCommitMenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGCommitMenuModel.swift; sourceTree = "<group>"; };
 		CAB5BDBCB990CC0452BF9164 /* ReviewRequestDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDraft.swift; sourceTree = "<group>"; };
 		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
 		CB020862232495EC1C5ECBEA /* WindowAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearance.swift; sourceTree = "<group>"; };
@@ -4648,6 +4654,7 @@
 				1A25C83033616FE27526C945 /* GGActionEventsTests.swift */,
 				EF9480C66C4CDDB090A5F4FB /* GGAvailabilityTests.swift */,
 				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
+				98EE59978053FA18629BC280 /* GGCommitMenuModelTests.swift */,
 				B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */,
 				4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */,
 				52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */,
@@ -4912,6 +4919,7 @@
 			isa = PBXGroup;
 			children = (
 				F1F0EED235328724082B570B /* GGActionEvents.swift */,
+				CA7C5CADC042EF509370EB87 /* GGCommitMenuModel.swift */,
 				56A2D492EE89A160CD404985 /* GGConfigReader.swift */,
 				9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */,
 				8C511B229168DDEA87173A41 /* GGInboxStore.swift */,
@@ -4931,6 +4939,7 @@
 				4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */,
 				B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */,
 				724A473AB9439DAA535B33F8 /* GGUndoMarkerStore.swift */,
+				A02E6B12C5EC8FAA50202EEA /* GGUnstackSheet.swift */,
 			);
 			path = GG;
 			sourceTree = "<group>";
@@ -5633,6 +5642,7 @@
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */,
+				FBFAB8DAB738CC7A21076D22 /* GGCommitMenuModel.swift in Sources */,
 				31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */,
 				188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */,
 				E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */,
@@ -5652,6 +5662,7 @@
 				8ADC05EBB9FE7D278508A941 /* GGStackReadinessModel.swift in Sources */,
 				DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */,
 				318F74C3CB02BFF1D06DF7DA /* GGUndoMarkerStore.swift in Sources */,
+				270146424B271EBDB8886DD2 /* GGUnstackSheet.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
 				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,
@@ -6304,6 +6315,7 @@
 				0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */,
 				192F93BD900B2DC13205E96E /* GGAvailabilityTests.swift in Sources */,
 				A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */,
+				A955D8E9871CA023ED98A095 /* GGCommitMenuModelTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,
 				362A966BA9FED1E92B8410CC /* GGInboxHelpersTests.swift in Sources */,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -496,6 +496,23 @@ private struct RootGGPresentationHandlers: ViewModifier {
                 Text(state.rightPaneStore.stateWithPendingGGLand()?.pendingGGLandConfirmationMessage ?? "")
             }
             .confirmationDialog(
+                "Drop commit?",
+                isPresented: Binding(
+                    get: { state.rightPaneStore.stateWithPendingGGDrop() != nil },
+                    set: { if !$0 { state.rightPaneStore.stateWithPendingGGDrop()?.cancelGGDrop() } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button("Drop Commit", role: .destructive) {
+                    state.rightPaneStore.stateWithPendingGGDrop()?.performGGDrop()
+                }
+                Button("Cancel", role: .cancel) {
+                    state.rightPaneStore.stateWithPendingGGDrop()?.cancelGGDrop()
+                }
+            } message: {
+                Text(state.rightPaneStore.stateWithPendingGGDrop()?.pendingGGDrop?.message ?? "")
+            }
+            .confirmationDialog(
                 "Clean all merged stacks?",
                 isPresented: Binding(
                     get: { state.rightPaneStore.stateWithPendingGGCleanAll() != nil },
@@ -511,6 +528,20 @@ private struct RootGGPresentationHandlers: ViewModifier {
                 }
             } message: {
                 Text("Remove every merged gg stack and associated worktree in this repository.")
+            }
+            .sheet(
+                item: Binding(
+                    get: { state.rightPaneStore.stateWithPendingGGUnstack()?.pendingGGUnstack },
+                    set: { if $0 == nil { state.rightPaneStore.stateWithPendingGGUnstack()?.cancelGGUnstack() } }
+                )
+            ) { model in
+                GGUnstackSheet(model: model) { editedModel in
+                    guard let owner = state.rightPaneStore.stateWithPendingGGUnstack() else {
+                        throw GGMutationError.staleConfirmation
+                    }
+                    return try await owner.submitGGUnstack(editedModel)
+                }
+                .environment(\.theme, state.themeStore.current)
             }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGCommitMenuModel.swift
+++ b/Alas/Sources/Integrations/GG/GGCommitMenuModel.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+enum GGCommitAction: Hashable, Sendable {
+    case reviewProviderRequest(number: Int, url: URL)
+    case openProviderRequest(number: Int)
+    case checkout
+    case splitCommit
+    case dropCommit
+    case unstackHere
+    case landThrough
+}
+
+struct GGCommitMenuContext: Equatable {
+    let entry: GGStackEntry
+    let stack: GGStack
+    let provider: CodeHostKind?
+    let capabilities: GGCapabilities
+    let inFlightAction: GGStackActionKind?
+    let pausedOperation: GGPausedOperation?
+    let hasBlockingGitOperation: Bool
+    let selectionIsStale: Bool
+    var canOpenSplitCommit: Bool = false
+    var providerReviewURL: URL?
+}
+
+struct GGCommitMenuItem: Identifiable, Equatable {
+    enum ID: Hashable {
+        case reviewProviderRequest
+        case openProviderRequest
+        case remoteSeparator
+        case checkout
+        case splitCommit
+        case lifecycleSeparator
+        case dropCommit
+        case unstackHere
+        case landThrough
+    }
+
+    let id: ID
+    let title: String?
+    let systemImage: String?
+    let action: GGCommitAction?
+    let isVisible: Bool
+    let isEnabled: Bool
+    let disabledReason: String?
+
+    var isSeparator: Bool { action == nil }
+}
+
+struct GGCommitMenuModel: Equatable {
+    let items: [GGCommitMenuItem]
+
+    var visibleItems: [GGCommitMenuItem] {
+        items.filter(\.isVisible)
+    }
+
+    func item(for action: GGCommitAction) -> GGCommitMenuItem? {
+        items.first { $0.action == action }
+    }
+
+    static func make(context: GGCommitMenuContext) -> GGCommitMenuModel {
+        let reviewNumber = context.entry.prNumber
+        let reviewLabel = context.provider?.reviewRequestLabel ?? "PR"
+        let reviewURL = context.providerReviewURL
+        let hasProviderReview = context.provider != nil && reviewNumber != nil && reviewURL != nil
+        let mutationReason = mutationDisabledReason(context: context)
+        let immutableReason = context.entry.prState == .merged
+            ? "Merged commits cannot be rewritten."
+            : nil
+
+        func actionItem(
+            id: GGCommitMenuItem.ID,
+            title: String,
+            systemImage: String,
+            action: GGCommitAction?,
+            isVisible: Bool = true,
+            disabledReason: String? = nil
+        ) -> GGCommitMenuItem {
+            GGCommitMenuItem(
+                id: id,
+                title: title,
+                systemImage: systemImage,
+                action: action,
+                isVisible: isVisible,
+                isEnabled: disabledReason == nil,
+                disabledReason: disabledReason
+            )
+        }
+
+        func separator(_ id: GGCommitMenuItem.ID, isVisible: Bool = true) -> GGCommitMenuItem {
+            GGCommitMenuItem(
+                id: id,
+                title: nil,
+                systemImage: nil,
+                action: nil,
+                isVisible: isVisible,
+                isEnabled: false,
+                disabledReason: nil
+            )
+        }
+
+        let reviewAction = reviewNumber.flatMap { number in
+            reviewURL.map { GGCommitAction.reviewProviderRequest(number: number, url: $0) }
+        }
+        let openAction = GGCommitAction.openProviderRequest(number: reviewNumber ?? 0)
+        let splitReason = mutationReason
+            ?? (context.capabilities.structuredSplit ? nil : "Update GG to split commits in Alas.")
+            ?? immutableReason
+        let rewriteReason = mutationReason ?? immutableReason
+        let unstackReason = rewriteReason ?? (
+            context.entry.position == context.stack.entries.map(\.position).min()
+                ? "Select a commit above the bottom of the stack."
+                : nil
+        )
+        let landReason = mutationReason ?? landDisabledReason(context: context)
+
+        return GGCommitMenuModel(items: [
+            actionItem(
+                id: .reviewProviderRequest,
+                title: "Review \(reviewLabel) in Alas...",
+                systemImage: "text.bubble",
+                action: reviewAction,
+                isVisible: hasProviderReview
+            ),
+            actionItem(
+                id: .openProviderRequest,
+                title: "Open \(reviewLabel) in Browser",
+                systemImage: "safari",
+                action: openAction,
+                isVisible: hasProviderReview
+            ),
+            separator(.remoteSeparator, isVisible: hasProviderReview),
+            actionItem(
+                id: .checkout,
+                title: "Checkout Commit",
+                systemImage: "arrow.triangle.branch",
+                action: .checkout,
+                isVisible: !context.entry.isCurrent,
+                disabledReason: mutationReason
+            ),
+            actionItem(
+                id: .splitCommit,
+                title: "Split Commit...",
+                systemImage: "square.split.2x1",
+                action: .splitCommit,
+                disabledReason: splitReason
+            ),
+            separator(.lifecycleSeparator),
+            actionItem(
+                id: .dropCommit,
+                title: "Drop Commit...",
+                systemImage: "trash",
+                action: .dropCommit,
+                disabledReason: rewriteReason
+            ),
+            actionItem(
+                id: .unstackHere,
+                title: "Split Stack Here...",
+                systemImage: "arrow.trianglehead.branch",
+                action: .unstackHere,
+                disabledReason: unstackReason
+            ),
+            actionItem(
+                id: .landThrough,
+                title: "Land Through Here...",
+                systemImage: "arrow.down.to.line",
+                action: .landThrough,
+                disabledReason: landReason
+            ),
+        ])
+    }
+
+    private static func mutationDisabledReason(context: GGCommitMenuContext) -> String? {
+        if context.selectionIsStale {
+            return "The stack changed. Refresh and try again."
+        }
+        if context.pausedOperation != nil {
+            return "Continue or abort the paused GG operation first."
+        }
+        if context.inFlightAction != nil {
+            return "Another GG operation is running."
+        }
+        if context.hasBlockingGitOperation {
+            return "Finish the current Git operation first."
+        }
+        return nil
+    }
+
+    private static func landDisabledReason(context: GGCommitMenuContext) -> String? {
+        guard context.entry.prState == .open,
+              context.entry.approved,
+              context.entry.ciStatus == nil || context.entry.ciStatus == .success
+        else { return "This commit is not ready to land." }
+
+        let lowerEntriesAreReady = context.stack.entries
+            .filter { $0.position < context.entry.position }
+            .allSatisfy { entry in
+                entry.prState == .merged
+                    || (entry.prState == .open
+                        && entry.approved
+                        && (entry.ciStatus == nil || entry.ciStatus == .success))
+            }
+        return lowerEntriesAreReady ? nil : "A lower commit is not ready to land."
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -73,7 +73,16 @@ final class GGMutationCoordinator {
 
     func apply(_ request: GGMutationRequest, confirmedAgainst identity: GGStackIdentity?) async throws {
         guard reserve(request) else { throw GGMutationError.operationInFlight }
-        try await applyReserved(request, confirmedAgainst: identity)
+        try await applyReserved(request, confirmedAgainst: identity, confirmedWith: nil)
+    }
+
+    func apply(_ prepared: GGPreparedMutation) async throws {
+        guard reserve(prepared.request) else { throw GGMutationError.operationInFlight }
+        try await applyReserved(
+            prepared.request,
+            confirmedAgainst: prepared.snapshot,
+            confirmedWith: prepared.confirmation
+        )
     }
 
     func startApplying(
@@ -81,7 +90,18 @@ final class GGMutationCoordinator {
         confirmedAgainst identity: GGStackIdentity?
     ) -> Task<Void, Error>? {
         guard reserve(request) else { return nil }
-        return Task { try await self.applyReserved(request, confirmedAgainst: identity) }
+        return Task { try await self.applyReserved(request, confirmedAgainst: identity, confirmedWith: nil) }
+    }
+
+    func startApplying(_ prepared: GGPreparedMutation) -> Task<Void, Error>? {
+        guard reserve(prepared.request) else { return nil }
+        return Task {
+            try await self.applyReserved(
+                prepared.request,
+                confirmedAgainst: prepared.snapshot,
+                confirmedWith: prepared.confirmation
+            )
+        }
     }
 
     private func reserve(_ request: GGMutationRequest) -> Bool {
@@ -94,7 +114,8 @@ final class GGMutationCoordinator {
 
     private func applyReserved(
         _ request: GGMutationRequest,
-        confirmedAgainst identity: GGStackIdentity?
+        confirmedAgainst identity: GGStackIdentity?,
+        confirmedWith confirmation: GGMutationConfirmation?
     ) async throws {
         defer {
             activeRequest = nil
@@ -211,8 +232,7 @@ final class GGMutationCoordinator {
                 }
             guard lowerEntriesAreReady else { throw GGMutationError.staleConfirmation }
         case .applySplit(_, let identity, _):
-            let target = identity.ggID.flatMap { stack.entry(matchingStableID: $0) }
-                ?? stack.entry(matchingStableID: identity.sha)
+            let target = stack.splitTarget(matching: identity)
             guard target != nil else { throw GGMutationError.staleConfirmation }
         default:
             break
@@ -227,8 +247,7 @@ final class GGMutationCoordinator {
         case .drop(let id), .unstack(let id, _, _):
             target = stack.entry(matchingStableID: id)
         case .applySplit(_, let identity, _):
-            target = identity.ggID.flatMap { stack.entry(matchingStableID: $0) }
-                ?? stack.entry(matchingStableID: identity.sha)
+            target = stack.splitTarget(matching: identity)
         default:
             target = nil
         }
@@ -250,6 +269,7 @@ final class GGMutationCoordinator {
             guard let entry = stack.entry(matchingStableID: target) else { return nil }
             return .unstack(
                 target: target,
+                targetTitle: entry.title,
                 movedCommits: stack.entries.filter { $0.position >= entry.position }.count,
                 lowerStack: stack.name,
                 newStack: name
@@ -329,6 +349,12 @@ final class GGMutationCoordinator {
             if let summary = GGStackActionState.landSummaryLine(from: result.landed) {
                 actionState.setActionSummary(summary)
             }
+        case .unstack(let result) where result.worktreePath == nil:
+            precondition(
+                result.currentStack == result.originalStack,
+                "Unstack without a worktree must keep the current lower stack checked out."
+            )
+            actionState.setActionSummary("New stack created without a worktree")
         default:
             if request == .sync,
                actionState.lastError == nil,
@@ -394,6 +420,13 @@ private extension GGMutationRequest {
 private extension GGStack {
     func entry(matchingStableID target: String) -> GGStackEntry? {
         entries.first { $0.id == target || $0.sha == target }
+    }
+
+    func splitTarget(matching identity: GGSplitTargetIdentity) -> GGStackEntry? {
+        if let ggID = identity.ggID {
+            return entry(matchingStableID: ggID)
+        }
+        return entry(matchingCommitSHA: identity.sha)
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -67,7 +67,13 @@ struct GGPreparedMutation: Equatable, Sendable {
 
 enum GGMutationConfirmation: Equatable, Sendable {
     case drop(target: String, rewrittenDescendants: Int, hasOpenReview: Bool)
-    case unstack(target: String, movedCommits: Int, lowerStack: String, newStack: String)
+    case unstack(
+        target: String,
+        targetTitle: String,
+        movedCommits: Int,
+        lowerStack: String,
+        newStack: String
+    )
     case land(target: String, readyCommits: Int)
     case clean(mergedCommits: Int)
 
@@ -77,8 +83,8 @@ enum GGMutationConfirmation: Equatable, Sendable {
             let descendants = Self.commitCount(rewrittenDescendants, qualifier: "descendant")
             let reviewWarning = hasOpenReview ? " The selected commit has an open review." : ""
             return "Drop \(target) and rewrite \(descendants).\(reviewWarning)"
-        case .unstack(_, let movedCommits, let lowerStack, let newStack):
-            return "Move \(Self.commitCount(movedCommits)) from \(lowerStack) to \(newStack)."
+        case .unstack(_, let targetTitle, let movedCommits, let lowerStack, let newStack):
+            return "Split at \u{201C}\(targetTitle)\u{201D}. Move \(Self.commitCount(movedCommits)) from \(lowerStack) to \(newStack)."
         case .land(let target, let readyCommits):
             return "Land \(Self.commitCount(readyCommits, qualifier: "ready")) through \(target)."
         case .clean(let mergedCommits):

--- a/Alas/Sources/Integrations/GG/GGUnstackSheet.swift
+++ b/Alas/Sources/Integrations/GG/GGUnstackSheet.swift
@@ -1,0 +1,214 @@
+import SwiftUI
+
+struct GGUnstackModel: Identifiable, Equatable {
+    let targetID: String
+    let targetTitle: String
+    let lowerStackName: String
+    let movedCommitCount: Int
+    let supportsKeepCurrent: Bool
+    let confirmedStackName: String
+    let confirmedCreateWorktree: Bool
+    private(set) var stackName: String
+    private(set) var createWorktree: Bool
+
+    var id: String { targetID }
+
+    init(prepared: GGPreparedMutation, supportsKeepCurrent: Bool) throws {
+        guard case .unstack(
+            let target,
+            let targetTitle,
+            let movedCommits,
+            let lowerStack,
+            let newStack
+        ) = prepared.confirmation,
+        case .unstack(let requestTarget, _, let createWorktree) = prepared.request,
+        requestTarget == target
+        else { throw GGMutationError.staleConfirmation }
+
+        self.targetID = target
+        self.targetTitle = targetTitle
+        self.lowerStackName = lowerStack
+        self.movedCommitCount = movedCommits
+        self.supportsKeepCurrent = supportsKeepCurrent
+        self.confirmedStackName = newStack
+        self.confirmedCreateWorktree = createWorktree
+        self.stackName = newStack
+        self.createWorktree = createWorktree
+    }
+
+    var isCreateWorktreeToggleEnabled: Bool { supportsKeepCurrent }
+
+    var createWorktreeDisabledReason: String? {
+        supportsKeepCurrent ? nil : "Update GG to create a stack without a worktree"
+    }
+
+    var validatedStackName: String? {
+        validationMessage == nil ? stackName : nil
+    }
+
+    var validationMessage: String? {
+        if stackName.contains("/") { return "Stack name cannot contain '/'." }
+        if stackName.contains("--") { return "Stack name cannot contain '--'." }
+        for character in ["~", "^", ":", "?", "*", "[", "\\", "@"] where stackName.contains(character) {
+            return "Stack name cannot contain '\(character)'."
+        }
+        if stackName.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains) {
+            return "Stack name cannot contain control characters."
+        }
+        if stackName.contains("..") { return "Stack name cannot contain '..'." }
+        if stackName.hasPrefix(".") || stackName.hasSuffix(".") {
+            return "Stack name cannot start or end with '.'."
+        }
+        if stackName.hasSuffix(".lock") { return "Stack name cannot end with '.lock'." }
+        if stackName.isEmpty || stackName.allSatisfy({ $0 == "-" }) {
+            return "Stack name cannot be empty."
+        }
+        if stackName == lowerStackName { return "New stack name must differ from the current stack." }
+        return nil
+    }
+
+    var confirmationMessage: String {
+        let count = "\(movedCommitCount) commit\(movedCommitCount == 1 ? "" : "s")"
+        return "Split at \u{201C}\(targetTitle)\u{201D}. Move \(count) from \(lowerStackName) to \(confirmedStackName)."
+    }
+
+    var requiresReconfirmation: Bool {
+        stackName != confirmedStackName || createWorktree != confirmedCreateWorktree
+    }
+
+    mutating func setStackName(_ value: String) {
+        stackName = value.replacingOccurrences(of: " ", with: "-")
+    }
+
+    mutating func setCreateWorktree(_ value: Bool) {
+        createWorktree = supportsKeepCurrent ? value : true
+    }
+
+    static func derivedStackName(from title: String) -> String {
+        let withoutConventionalPrefix = title.replacingOccurrences(
+            of: #"^[A-Za-z]+(?:\([^)]*\))?!?:\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        let folded = withoutConventionalPrefix
+            .folding(options: [.diacriticInsensitive, .widthInsensitive], locale: .current)
+            .lowercased()
+        let components = folded.components(separatedBy: CharacterSet.alphanumerics.inverted)
+        let normalized = components.filter { !$0.isEmpty }.joined(separator: "-")
+        return normalized.isEmpty ? "new-stack" : normalized
+    }
+}
+
+enum GGUnstackSubmissionResult: Equatable {
+    case reconfirm(GGUnstackModel)
+    case applied
+}
+
+struct GGUnstackSheetPresentationState: Equatable {
+    let isSubmitting: Bool
+
+    var canCancel: Bool { !isSubmitting }
+    var preventsInteractiveDismissal: Bool { isSubmitting }
+
+    func canSubmit(isValid: Bool) -> Bool {
+        isValid && !isSubmitting
+    }
+}
+
+struct GGUnstackSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var model: GGUnstackModel
+    @State private var submissionError: String?
+    @State private var isSubmitting = false
+    let onConfirm: @MainActor (GGUnstackModel) async throws -> GGUnstackSubmissionResult
+
+    init(
+        model: GGUnstackModel,
+        onConfirm: @escaping @MainActor (GGUnstackModel) async throws -> GGUnstackSubmissionResult
+    ) {
+        _model = State(initialValue: model)
+        self.onConfirm = onConfirm
+    }
+
+    private var presentationState: GGUnstackSheetPresentationState {
+        GGUnstackSheetPresentationState(isSubmitting: isSubmitting)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Split Stack")
+                .font(.title2.weight(.semibold))
+
+            Form {
+                TextField(
+                    "New stack name",
+                    text: Binding(
+                        get: { model.stackName },
+                        set: {
+                            model.setStackName($0)
+                            submissionError = nil
+                        }
+                    )
+                )
+                Toggle(
+                    "Create a new worktree",
+                    isOn: Binding(
+                        get: { model.createWorktree },
+                        set: { model.setCreateWorktree($0) }
+                    )
+                )
+                .toggleStyle(.checkbox)
+                .disabled(!model.isCreateWorktreeToggleEnabled)
+            }
+            .formStyle(.grouped)
+
+            if let reason = model.createWorktreeDisabledReason {
+                Label(reason, systemImage: "info.circle")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let reason = model.validationMessage ?? submissionError {
+                Label(reason, systemImage: "exclamationmark.triangle")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+            }
+
+            Text(model.confirmationMessage)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) { dismiss() }
+                    .disabled(!presentationState.canCancel)
+                Button(
+                    model.requiresReconfirmation ? "Review Changes" : "Split Stack",
+                    systemImage: "arrow.trianglehead.branch"
+                ) {
+                    isSubmitting = true
+                    submissionError = nil
+                    Task { @MainActor in
+                        defer { isSubmitting = false }
+                        do {
+                            switch try await onConfirm(model) {
+                            case .reconfirm(let freshModel):
+                                model = freshModel
+                            case .applied:
+                                dismiss()
+                            }
+                        } catch {
+                            submissionError = GGErrorPresentation.message(for: error)
+                        }
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!presentationState.canSubmit(isValid: model.validatedStackName != nil))
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+        .interactiveDismissDisabled(presentationState.preventsInteractiveDismissal)
+    }
+}

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -273,14 +273,9 @@ struct ChangesTabView: View {
                 rps: rps,
                 ggStack: rps.ggStack,
                 stackCodeHostKind: rps.commitRemote?.kind,
-                onGGOpenPR: rps.commitRemote.map { remote in
-                    { entry in
-                        guard let number = entry.prNumber else { return }
-                        NSWorkspace.shared.open(remote.reviewRequestURL(number: number))
-                    }
-                },
-                onGGLandUntil: { entry in rps.requestGGLand(.until(entryId: entry.id, title: entry.title)) },
-                onGGCheckout: { entry in rps.requestGGCheckout(target: entry.id) }
+                onGGAction: { action, commit in
+                    rps.handleGGCommitAction(action, commit: commit, appState: appState)
+                }
             )
         }
     }

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CommitRow: View {
     static let ggCheckoutTitle = "Checkout Commit"
+    static let ggContextMenuTitle = "GG"
 
     enum ContextMenuAction: Hashable {
         case edit
@@ -19,9 +20,9 @@ struct CommitRow: View {
     var onReview: (() -> Void)? = nil
     var onCherryPick: (() -> Void)? = nil
     var onRevert: (() -> Void)? = nil
+    var ggMenu: GGCommitMenuModel? = nil
+    var onGGAction: ((GGCommitAction) -> Void)? = nil
     var onGGOpenPR: (() -> Void)? = nil
-    var onGGLandUntil: (() -> Void)? = nil
-    var onGGCheckout: (() -> Void)? = nil
     /// Stack entry for this commit when the branch is a gg stack.
     var stackEntry: GGStackEntry? = nil
     var codeHostKind: CodeHostKind? = nil
@@ -73,16 +74,32 @@ struct CommitRow: View {
             if let onOpenRemote {
                 Button("Open Commit on Remote") { onOpenRemote() }
             }
-            if stackEntry != nil {
+            if let ggMenu {
                 Divider()
-                if let onGGOpenPR, stackEntry?.prNumber != nil {
-                    Button("Open \(codeHostKind?.reviewRequestLabel ?? "PR")") { onGGOpenPR() }
-                }
-                if let onGGCheckout {
-                    Button(Self.ggCheckoutTitle) { onGGCheckout() }
-                }
-                if let onGGLandUntil {
-                    Button("Land Until Here…") { onGGLandUntil() }
+                Menu(Self.ggContextMenuTitle, systemImage: "square.stack.3d.up") {
+                    ForEach(ggMenu.visibleItems) { item in
+                        if item.isSeparator {
+                            Divider()
+                        } else if let title = item.title, let action = item.action {
+                            Button {
+                                onGGAction?(action)
+                            } label: {
+                                if let systemImage = item.systemImage {
+                                    Label(title, systemImage: systemImage)
+                                } else {
+                                    Text(title)
+                                }
+                            }
+                            .disabled(!item.isEnabled)
+                            .help(item.disabledReason ?? "")
+
+                            if !item.isEnabled, let reason = item.disabledReason {
+                                Text(reason)
+                                    .foregroundStyle(.secondary)
+                                    .disabled(true)
+                            }
+                        }
+                    }
                 }
             }
             if onCherryPick != nil {

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -101,9 +101,7 @@ struct CommitsSectionView: View {
     let rps: RightPaneState
     let ggStack: GGStack?
     let stackCodeHostKind: CodeHostKind?
-    let onGGOpenPR: ((GGStackEntry) -> Void)?
-    let onGGLandUntil: (GGStackEntry) -> Void
-    let onGGCheckout: (GGStackEntry) -> Void
+    let onGGAction: (GGCommitAction, CommitInfo) -> Void
 
     @Environment(\.theme) private var theme
 
@@ -179,6 +177,10 @@ struct CommitsSectionView: View {
             )
     }
 
+    static func ggSelectionIsStale(rps: RightPaneState) -> Bool {
+        rps.ggCommitSelectionIsStale
+    }
+
     @ViewBuilder
     private var expandedBody: some View {
         // 1. Worktree commits ("your work") OR today's empty placeholder.
@@ -195,9 +197,8 @@ struct CommitsSectionView: View {
                     onReview: { onReview(commit) },
                     onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
                     onRevert: { rps.runRevert(sha: commit.sha) },
-                    onGGOpenPR: ggStack?.entry(matchingCommitSHA: commit.sha).flatMap { e in onGGOpenPR.map { openPR in { openPR(e) } } },
-                    onGGLandUntil: ggLandUntilAction(for: commit),
-                    onGGCheckout: ggCheckoutAction(for: commit),
+                    ggMenu: ggMenu(for: commit),
+                    onGGAction: { action in onGGAction(action, commit) },
                     stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),
                     codeHostKind: stackCodeHostKind
                 )
@@ -260,22 +261,26 @@ struct CommitsSectionView: View {
         .padding(.vertical, 6)
     }
 
-    private var ggRowMutationsEnabled: Bool {
-        Self.ggRowMutationsEnabled(
+    private func ggMenu(for commit: CommitInfo) -> GGCommitMenuModel? {
+        guard let stack = ggStack,
+              let entry = stack.entry(matchingCommitSHA: commit.sha)
+        else { return nil }
+        let providerReviewURL = entry.prNumber.flatMap { rps.commitRemote?.reviewRequestURL(number: $0) }
+        return GGCommitMenuModel.make(context: GGCommitMenuContext(
+            entry: entry,
+            stack: stack,
+            provider: stackCodeHostKind,
+            capabilities: GGAvailability.shared.capabilities,
             inFlightAction: rps.ggActionState.inFlightAction,
-            mergeOperation: rps.mergeOp.current,
-            pausedGGOperation: rps.ggActionState.pausedOperation
-        )
-    }
-
-    private func ggLandUntilAction(for commit: CommitInfo) -> (() -> Void)? {
-        guard ggRowMutationsEnabled, let entry = ggStack?.entry(matchingCommitSHA: commit.sha) else { return nil }
-        return { onGGLandUntil(entry) }
-    }
-
-    private func ggCheckoutAction(for commit: CommitInfo) -> (() -> Void)? {
-        guard ggRowMutationsEnabled, let entry = ggStack?.entry(matchingCommitSHA: commit.sha) else { return nil }
-        return { onGGCheckout(entry) }
+            pausedOperation: rps.ggActionState.pausedOperation,
+            hasBlockingGitOperation: GGStackDrawer.hasBlockingGitOperation(
+                mergeOperation: rps.mergeOp.current,
+                pausedGGOperation: rps.ggActionState.pausedOperation
+            ),
+            selectionIsStale: Self.ggSelectionIsStale(rps: rps),
+            canOpenSplitCommit: rps.requestGGSplitCommit != nil && rps.mergeOp.current == nil,
+            providerReviewURL: providerReviewURL
+        ))
     }
 
     private func openRemoteAction(for commit: CommitInfo, remote: CodeHostRemote?) -> (() -> Void)? {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -139,10 +139,18 @@ final class RightPaneState {
     // import` without a real git repo driving `refresh()`. Bookkeeping only,
     // never read by a view — kept out of observation to avoid invalidation
     // churn on the hot refresh path.
-    @ObservationIgnored var ggStackCommitsKey: String? = nil
+    var ggStackCommitsKey: String? = nil
     /// Off-critical-path gg stack load. Cancelled+restarted per refresh so a
     /// slow `gg ls --json` never blocks the Changes-pane snapshot.
     @ObservationIgnored private var ggStackRefreshTask: Task<Void, Never>? = nil
+
+    var currentGGStackCommitsKey: String {
+        "\(currentBranch)|" + ggStackSourceCommits.map(\.sha).joined(separator: "|")
+    }
+
+    var ggCommitSelectionIsStale: Bool {
+        ggStack != nil && ggStackCommitsKey != currentGGStackCommitsKey
+    }
 
     // Sync-nudge state. All fields are in-memory only; nothing is
     // persisted to AppConfig. Two independent conditions:
@@ -223,6 +231,10 @@ final class RightPaneState {
     var mergeQueuedMessage: String? = nil
     var pendingGGLand: GGLandRequest? = nil
     @ObservationIgnored private var pendingGGLandPrepared: GGPreparedMutation? = nil
+    var pendingGGDrop: GGDropPresentation? = nil
+    @ObservationIgnored private var pendingGGDropPrepared: GGPreparedMutation? = nil
+    var pendingGGUnstack: GGUnstackModel? = nil
+    @ObservationIgnored var pendingGGUnstackPrepared: GGPreparedMutation? = nil
     var pendingGGCleanAll: Bool = false
     @ObservationIgnored private var pendingGGCleanPrepared: GGPreparedMutation? = nil
 
@@ -870,7 +882,7 @@ final class RightPaneState {
         // *current* branch — a checkout to a different branch that happens
         // to share the same commits (e.g. right after `git checkout -b`)
         // must not reuse the old branch's cached stack.
-        let key = "\(currentBranch)|" + ggStackSourceCommits.map(\.sha).joined(separator: "|")
+        let key = currentGGStackCommitsKey
         guard key != ggStackCommitsKey else { return }
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
@@ -1016,6 +1028,155 @@ final class RightPaneState {
         }
     }
 
+    func handleGGCommitAction(_ action: GGCommitAction, commit: CommitInfo, appState: AppState) {
+        guard let entry = ggStack?.entry(matchingCommitSHA: commit.sha) else {
+            ggActionState.setError("The stack changed. Refresh and try again.")
+            return
+        }
+
+        switch action {
+        case .reviewProviderRequest(let number, let url):
+            guard entry.prNumber == number,
+                  commitRemote?.reviewRequestURL(number: number) == url
+            else {
+                ggActionState.setError("The provider review changed. Refresh and try again.")
+                return
+            }
+            Task { @MainActor in
+                let response = await appState.cliOpenProviderReview(
+                    worktree: worktree,
+                    target: url.absoluteString
+                )
+                if let message = Self.ggProviderReviewError(response) {
+                    ggActionState.setError(message)
+                }
+            }
+        case .openProviderRequest(let number):
+            guard entry.prNumber == number, let remote = commitRemote else {
+                ggActionState.setError("The provider review is no longer available.")
+                return
+            }
+            NSWorkspace.shared.open(remote.reviewRequestURL(number: number))
+        case .checkout:
+            requestGGCheckout(target: entry.id)
+        case .splitCommit:
+            guard mergeOp.current == nil else {
+                ggActionState.setError("Finish the current Git operation before splitting a commit.")
+                return
+            }
+            requestGGSplitCommit?(entry)
+        case .dropCommit:
+            requestGGDrop(entry)
+        case .unstackHere:
+            requestGGUnstack(entry)
+        case .landThrough:
+            requestGGLand(.until(entryId: entry.id, title: entry.title))
+        }
+    }
+
+    static func ggProviderReviewError(_ response: AlasCLIResponse) -> String? {
+        guard case .error(let message) = response else { return nil }
+        return message
+    }
+
+    @ObservationIgnored var requestGGSplitCommit: ((GGStackEntry) -> Void)? = nil
+
+    func requestGGDrop(_ entry: GGStackEntry) {
+        Task { @MainActor in
+            do {
+                let prepared = try await ggMutationCoordinator.prepare(.drop(target: entry.id))
+                guard case .drop(_, let descendants, let hasOpenReview) = prepared.confirmation else {
+                    throw GGMutationError.staleConfirmation
+                }
+                pendingGGDropPrepared = prepared
+                pendingGGDrop = GGDropPresentation(
+                    target: entry.id,
+                    title: entry.title,
+                    rewrittenDescendants: descendants,
+                    openReviewLabel: hasOpenReview
+                        ? (commitRemote?.kind.reviewRequestLabel ?? "review")
+                        : nil
+                )
+            } catch {
+                ggActionState.setError(GGErrorPresentation.message(for: error))
+            }
+        }
+    }
+
+    func cancelGGDrop() {
+        pendingGGDrop = nil
+        pendingGGDropPrepared = nil
+    }
+
+    func performGGDrop() {
+        guard let prepared = pendingGGDropPrepared else { return }
+        pendingGGDrop = nil
+        pendingGGDropPrepared = nil
+        runGGMutation(prepared)
+    }
+
+    func requestGGUnstack(_ entry: GGStackEntry) {
+        let name = GGUnstackModel.derivedStackName(from: entry.title)
+        let request = GGMutationRequest.unstack(
+            target: entry.id,
+            name: name,
+            createWorktree: true
+        )
+        Task { @MainActor in
+            do {
+                let prepared = try await ggMutationCoordinator.prepare(request)
+                let model = try GGUnstackModel(
+                    prepared: prepared,
+                    supportsKeepCurrent: GGAvailability.shared.capabilities.keepCurrentUnstack
+                )
+                pendingGGUnstackPrepared = prepared
+                pendingGGUnstack = model
+            } catch {
+                ggActionState.setError(GGErrorPresentation.message(for: error))
+            }
+        }
+    }
+
+    func cancelGGUnstack() {
+        pendingGGUnstack = nil
+        pendingGGUnstackPrepared = nil
+    }
+
+    func submitGGUnstack(_ model: GGUnstackModel) async throws -> GGUnstackSubmissionResult {
+        guard let pending = pendingGGUnstack,
+              let prepared = pendingGGUnstackPrepared,
+              pending.id == model.id,
+              let name = model.validatedStackName
+        else {
+            throw GGMutationError.staleConfirmation
+        }
+        let request = GGMutationRequest.unstack(
+            target: model.targetID,
+            name: name,
+            createWorktree: model.createWorktree
+        )
+
+        let freshPrepared = try await ggMutationCoordinator.prepare(request)
+        if request != prepared.request
+            || freshPrepared.snapshot != prepared.snapshot
+            || freshPrepared.confirmation != prepared.confirmation
+        {
+            let freshModel = try GGUnstackModel(
+                prepared: freshPrepared,
+                supportsKeepCurrent: GGAvailability.shared.capabilities.keepCurrentUnstack
+            )
+            pendingGGUnstackPrepared = freshPrepared
+            pendingGGUnstack = freshModel
+            return .reconfirm(freshModel)
+        }
+
+        pendingGGUnstackPrepared = freshPrepared
+        try await ggMutationCoordinator.apply(freshPrepared)
+        pendingGGUnstack = nil
+        pendingGGUnstackPrepared = nil
+        return .applied
+    }
+
     func cancelGGLand() {
         pendingGGLand = nil
         pendingGGLandPrepared = nil
@@ -1118,10 +1279,18 @@ final class RightPaneState {
         stackBase: String,
         behindBase: GitService.BehindStatus?
     ) -> String {
-        guard let ref = behindBase?.ref,
-              ref == stackBase || ref.hasSuffix("/\(stackBase)")
-        else { return stackBase }
+        guard let ref = behindBase?.ref else { return stackBase }
+        if ref == stackBase { return ref }
+        let components = ref.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+        guard components.count == 2, components[1] == stackBase else { return stackBase }
         return ref
+    }
+
+    static func ggUndoRecoveryIsBlockedByGenericGitOperation(
+        operationInProgress: Bool,
+        alasGGOperationInProgress: Bool
+    ) -> Bool {
+        operationInProgress && !alasGGOperationInProgress
     }
 
     var pendingGGLandConfirmationMessage: String? {
@@ -1150,6 +1319,19 @@ final class RightPaneState {
             request,
             confirmedAgainst: identity
         ) else { return }
+        Task { @MainActor in
+            do {
+                try await operation.value
+            } catch {
+                if ggActionState.lastError == nil {
+                    ggActionState.setError(GGErrorPresentation.message(for: error))
+                }
+            }
+        }
+    }
+
+    private func runGGMutation(_ prepared: GGPreparedMutation) {
+        guard let operation = ggMutationCoordinator.startApplying(prepared) else { return }
         Task { @MainActor in
             do {
                 try await operation.value
@@ -2658,5 +2840,18 @@ final class RightPaneState {
         case .error(let message):
             logger.error("operation returned error: \(message, privacy: .public)")
         }
+    }
+}
+
+struct GGDropPresentation: Equatable {
+    let target: String
+    let title: String
+    let rewrittenDescendants: Int
+    let openReviewLabel: String?
+
+    var message: String {
+        let descendants = "\(rewrittenDescendants) descendant commit\(rewrittenDescendants == 1 ? "" : "s")"
+        let reviewWarning = openReviewLabel.map { " The selected commit has an open \($0)." } ?? ""
+        return "Drop \u{201C}\(title)\u{201D}. GG will rewrite and retain \(descendants).\(reviewWarning)"
     }
 }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -342,6 +342,14 @@ final class RightPaneStore {
         states.values.first { $0.pendingGGLand != nil }
     }
 
+    func stateWithPendingGGDrop() -> RightPaneState? {
+        states.values.first { $0.pendingGGDrop != nil }
+    }
+
+    func stateWithPendingGGUnstack() -> RightPaneState? {
+        states.values.first { $0.pendingGGUnstack != nil }
+    }
+
     /// The first cached state with a pending gg clean-all confirmation.
     /// Mirrors the other cross-worktree confirmations so changing selection
     /// while the dialog is open resolves the state that requested it.

--- a/AlasTests/CommitRowTests.swift
+++ b/AlasTests/CommitRowTests.swift
@@ -67,6 +67,11 @@ struct CommitRowTests {
         #expect(CommitRow.leadingContextMenuActions(canEdit: true, canReview: false) == [.edit])
     }
 
+    @Test func ggContextMenuUsesOneTypedActionSurface() {
+        #expect(CommitRow.ggContextMenuTitle == "GG")
+        #expect(GGCommitAction.checkout != .dropCommit)
+    }
+
     @MainActor
     @Test func copyFeedbackShowsThenDismisses() async throws {
         let feedback = CopyFeedbackState(displayNanoseconds: 10_000_000)

--- a/AlasTests/Integrations/GGCommitMenuModelTests.swift
+++ b/AlasTests/Integrations/GGCommitMenuModelTests.swift
@@ -1,0 +1,360 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGCommitMenuModelTests {
+    @Test func unstackSubmissionUsesGGServiceUserMessage() {
+        let error = GGServiceError.commandFailed(stderr: "Resolve the paused operation first.")
+
+        #expect(GGErrorPresentation.message(for: error) == "Resolve the paused operation first.")
+    }
+
+    @Test func unstackSheetLocksDismissalAndRepeatSubmissionWhileSubmitting() {
+        let idle = GGUnstackSheetPresentationState(isSubmitting: false)
+        #expect(idle.canCancel)
+        #expect(!idle.preventsInteractiveDismissal)
+        #expect(idle.canSubmit(isValid: true))
+        #expect(!idle.canSubmit(isValid: false))
+
+        let submitting = GGUnstackSheetPresentationState(isSubmitting: true)
+        #expect(!submitting.canCancel)
+        #expect(submitting.preventsInteractiveDismissal)
+        #expect(!submitting.canSubmit(isValid: true))
+    }
+
+    private func entry(
+        position: Int = 2,
+        title: String = "Add provider review routing",
+        prNumber: Int? = 42,
+        prState: GGPRState? = .open,
+        approved: Bool = true,
+        ciStatus: GGCIStatus? = .success,
+        isCurrent: Bool = false
+    ) -> GGStackEntry {
+        GGStackEntry(
+            position: position,
+            sha: "sha-\(position)",
+            title: title,
+            ggId: "change-\(position)",
+            prNumber: prNumber,
+            prState: prState,
+            approved: approved,
+            ciStatus: ciStatus,
+            isCurrent: isCurrent
+        )
+    }
+
+    private func stack(target: GGStackEntry, count: Int = 4) -> GGStack {
+        let entries = (1...count).map { position in
+            position == target.position
+                ? target
+                : entry(position: position, prNumber: nil, prState: nil, approved: false, ciStatus: nil)
+        }
+        return GGStack(
+            name: "feature",
+            base: "main",
+            totalCommits: entries.count,
+            syncedCommits: 0,
+            currentPosition: entries.last?.position,
+            behindBase: 0,
+            entries: entries
+        )
+    }
+
+    private func context(
+        target: GGStackEntry? = nil,
+        provider: CodeHostKind? = .github,
+        capabilities: GGCapabilities = .init(structuredSplit: true, keepCurrentUnstack: true),
+        inFlightAction: GGStackActionKind? = nil,
+        pausedOperation: GGPausedOperation? = nil,
+        hasBlockingGitOperation: Bool = false,
+        selectionIsStale: Bool = false,
+        canOpenSplitCommit: Bool = true,
+        reviewURL: URL? = URL(string: "https://github.com/owner/repository/pull/42")!
+    ) -> GGCommitMenuContext {
+        let target = target ?? entry()
+        return GGCommitMenuContext(
+            entry: target,
+            stack: stack(target: target),
+            provider: provider,
+            capabilities: capabilities,
+            inFlightAction: inFlightAction,
+            pausedOperation: pausedOperation,
+            hasBlockingGitOperation: hasBlockingGitOperation,
+            selectionIsStale: selectionIsStale,
+            canOpenSplitCommit: canOpenSplitCommit,
+            providerReviewURL: reviewURL
+        )
+    }
+
+    private func unstackModel(
+        target: GGStackEntry,
+        stack: GGStack,
+        supportsKeepCurrent: Bool
+    ) -> GGUnstackModel {
+        let name = GGUnstackModel.derivedStackName(from: target.title)
+        let prepared = GGPreparedMutation(
+            request: .unstack(target: target.id, name: name, createWorktree: true),
+            snapshot: GGStackIdentity(
+                stackName: stack.name,
+                base: stack.base,
+                headSHA: stack.entries.last?.sha ?? target.sha,
+                operationID: nil
+            ),
+            confirmation: .unstack(
+                target: target.id,
+                targetTitle: target.title,
+                movedCommits: stack.entries.filter { $0.position >= target.position }.count,
+                lowerStack: stack.name,
+                newStack: name
+            )
+        )
+        return try! GGUnstackModel(
+            prepared: prepared,
+            supportsKeepCurrent: supportsKeepCurrent
+        )
+    }
+
+    @Test func mappedPullRequestCommitGetsStrictGGSubmenuOrder() {
+        let model = GGCommitMenuModel.make(context: context())
+
+        #expect(model.items.map(\.action) == [
+            .reviewProviderRequest(
+                number: 42,
+                url: URL(string: "https://github.com/owner/repository/pull/42")!
+            ),
+            .openProviderRequest(number: 42),
+            nil,
+            .checkout,
+            .splitCommit,
+            nil,
+            .dropCommit,
+            .unstackHere,
+            .landThrough,
+        ])
+        #expect(model.items.map(\.title) == [
+            "Review PR in Alas...",
+            "Open PR in Browser",
+            nil,
+            "Checkout Commit",
+            "Split Commit...",
+            nil,
+            "Drop Commit...",
+            "Split Stack Here...",
+            "Land Through Here...",
+        ])
+        #expect(model.visibleItems.count == model.items.count)
+    }
+
+    @Test func reviewActionCarriesTheSelectedRemoteReviewURL() {
+        let reviewURL = URL(string: "https://github.example/acme/alas/pull/42")!
+        let model = GGCommitMenuModel.make(context: context(reviewURL: reviewURL))
+
+        #expect(model.item(for: .reviewProviderRequest(number: 42, url: reviewURL))?.isEnabled == true)
+    }
+
+    @Test func mergeRequestCommitUsesMRLabels() {
+        let model = GGCommitMenuModel.make(context: context(provider: .gitlab))
+
+        #expect(model.items[0].title == "Review MR in Alas...")
+        #expect(model.items[1].title == "Open MR in Browser")
+    }
+
+    @Test func remoteItemsAndTheirSeparatorAreHiddenWithoutMappedProviderReview() {
+        let target = entry(prNumber: nil)
+        let model = GGCommitMenuModel.make(context: context(target: target, provider: nil))
+
+        #expect(!model.items[0].isVisible)
+        #expect(!model.items[1].isVisible)
+        #expect(!model.items[2].isVisible)
+        #expect(model.visibleItems.first?.action == .checkout)
+    }
+
+    @Test func checkoutIsHiddenForCurrentCommit() {
+        let model = GGCommitMenuModel.make(context: context(target: entry(isCurrent: true)))
+
+        let checkout = try? #require(model.item(for: .checkout))
+        #expect(checkout?.isVisible == false)
+    }
+
+    @Test func immutableCommitDisablesRewriteActionsWithReason() {
+        let model = GGCommitMenuModel.make(context: context(target: entry(prState: .merged)))
+
+        for action in [GGCommitAction.splitCommit, .dropCommit, .unstackHere] {
+            let item = try? #require(model.item(for: action))
+            #expect(item?.isEnabled == false)
+            #expect(item?.disabledReason == "Merged commits cannot be rewritten.")
+        }
+        #expect(model.item(for: .checkout)?.isEnabled == true)
+    }
+
+    @Test func inFlightMutationDisablesLocalActionsWithConciseReason() {
+        let model = GGCommitMenuModel.make(context: context(inFlightAction: .sync))
+
+        for action in [
+            GGCommitAction.checkout, .splitCommit, .dropCommit, .unstackHere, .landThrough,
+        ] {
+            let item = try? #require(model.item(for: action))
+            #expect(item?.isEnabled == false)
+            #expect(item?.disabledReason == "Another GG operation is running.")
+        }
+        #expect(model.item(for: .reviewProviderRequest(
+            number: 42,
+            url: URL(string: "https://github.com/owner/repository/pull/42")!
+        ))?.isEnabled == true)
+        #expect(model.item(for: .openProviderRequest(number: 42))?.isEnabled == true)
+    }
+
+    @Test func staleSelectionDisablesLocalActionsWithRefreshReason() {
+        let model = GGCommitMenuModel.make(context: context(selectionIsStale: true))
+
+        #expect(model.item(for: .checkout)?.disabledReason == "The stack changed. Refresh and try again.")
+        #expect(model.item(for: .landThrough)?.isEnabled == false)
+    }
+
+    @Test func pausedOperationDisablesLocalActionsWithRecoveryReason() {
+        let model = GGCommitMenuModel.make(context: context(
+            pausedOperation: GGPausedOperation(pausedBy: .restack)
+        ))
+
+        #expect(model.item(for: .checkout)?.disabledReason == "Continue or abort the paused GG operation first.")
+        #expect(model.item(for: .dropCommit)?.isEnabled == false)
+    }
+
+    @Test func landReadinessExplainsTargetAndLowerCommitFailures() {
+        let blockedTarget = GGCommitMenuModel.make(context: context(
+            target: entry(approved: false)
+        ))
+        #expect(blockedTarget.item(for: .landThrough)?.disabledReason == "This commit is not ready to land.")
+
+        let target = entry(position: 2)
+        let blockedLower = GGStackEntry(
+            position: 1,
+            sha: "sha-1",
+            title: "Blocked lower",
+            ggId: "change-1",
+            prNumber: 41,
+            prState: .open,
+            approved: false,
+            ciStatus: .success
+        )
+        let stack = GGStack(
+            name: "feature",
+            base: "main",
+            totalCommits: 2,
+            syncedCommits: 0,
+            currentPosition: 2,
+            behindBase: 0,
+            entries: [blockedLower, target]
+        )
+        let model = GGCommitMenuModel.make(context: GGCommitMenuContext(
+            entry: target,
+            stack: stack,
+            provider: .github,
+            capabilities: .init(structuredSplit: true, keepCurrentUnstack: true),
+            inFlightAction: nil,
+            pausedOperation: nil,
+            hasBlockingGitOperation: false,
+            selectionIsStale: false
+        ))
+        #expect(model.item(for: .landThrough)?.disabledReason == "A lower commit is not ready to land.")
+    }
+
+    @Test func unavailableStructuredSplitHasUpdateReason() {
+        let capabilities = GGCapabilities(structuredSplit: false, keepCurrentUnstack: true)
+        let model = GGCommitMenuModel.make(context: context(capabilities: capabilities))
+
+        #expect(model.item(for: .splitCommit)?.isEnabled == false)
+        #expect(model.item(for: .splitCommit)?.disabledReason == "Update GG to split commits in Alas.")
+    }
+
+    @Test func splitCommitStaysDisabledUntilItsEditorHandlerIsWired() {
+        let model = GGCommitMenuModel.make(context: context(canOpenSplitCommit: false))
+
+        #expect(model.item(for: .splitCommit)?.isEnabled == false)
+        #expect(model.item(for: .splitCommit)?.disabledReason == "Native Split Commit is unavailable.")
+    }
+
+    @Test func blockingGitOperationKeepsLocalGGActionsDisabled() {
+        let model = GGCommitMenuModel.make(context: context(hasBlockingGitOperation: true))
+
+        #expect(model.item(for: .checkout)?.disabledReason == "Finish the current Git operation first.")
+        #expect(model.item(for: .dropCommit)?.isEnabled == false)
+    }
+
+    @Test func unstackDerivesNormalizedNameAndExactMovedCount() {
+        let target = entry(position: 3, title: "feat(auth): Add OAuth 2.0 callbacks!")
+        let model = unstackModel(
+            target: target,
+            stack: stack(target: target, count: 5),
+            supportsKeepCurrent: true
+        )
+
+        #expect(model.stackName == "add-oauth-2-0-callbacks")
+        #expect(model.movedCommitCount == 3)
+        #expect(model.lowerStackName == "feature")
+        #expect(model.createWorktree)
+        #expect(model.confirmationMessage == "Split at \u{201C}feat(auth): Add OAuth 2.0 callbacks!\u{201D}. Move 3 commits from feature to add-oauth-2-0-callbacks.")
+    }
+
+    @Test func oldGGKeepsDefaultWorktreeToggleOnAndLocked() {
+        var model = unstackModel(
+            target: entry(position: 3),
+            stack: stack(target: entry(position: 3), count: 5),
+            supportsKeepCurrent: false
+        )
+
+        model.setCreateWorktree(false)
+
+        #expect(model.createWorktree)
+        #expect(!model.isCreateWorktreeToggleEnabled)
+        #expect(model.createWorktreeDisabledReason == "Update GG to create a stack without a worktree")
+    }
+
+    @Test func editedStackNameNormalizesSpacesInDisplayedAndSubmittedValue() {
+        var model = unstackModel(
+            target: entry(position: 3),
+            stack: stack(target: entry(position: 3), count: 5),
+            supportsKeepCurrent: true
+        )
+
+        model.setStackName("oauth callbacks v2")
+
+        #expect(model.stackName == "oauth-callbacks-v2")
+        #expect(model.validatedStackName == "oauth-callbacks-v2")
+        #expect(model.validationMessage == nil)
+    }
+
+    @Test func editedStackNameRejectsGGInvalidNames() {
+        let cases = [
+            ("auth/api", "Stack name cannot contain '/'."),
+            ("auth--api", "Stack name cannot contain '--'."),
+            ("auth~api", "Stack name cannot contain '~'."),
+            ("auth^api", "Stack name cannot contain '^'."),
+            ("auth:api", "Stack name cannot contain ':'."),
+            ("auth?api", "Stack name cannot contain '?'."),
+            ("auth*api", "Stack name cannot contain '*'."),
+            ("auth[api", "Stack name cannot contain '['."),
+            (#"auth\api"#, "Stack name cannot contain '\\'."),
+            ("auth@api", "Stack name cannot contain '@'."),
+            ("auth\napi", "Stack name cannot contain control characters."),
+            ("auth..api", "Stack name cannot contain '..'."),
+            (".auth", "Stack name cannot start or end with '.'."),
+            ("auth.", "Stack name cannot start or end with '.'."),
+            ("auth.lock", "Stack name cannot end with '.lock'."),
+            ("", "Stack name cannot be empty."),
+            ("---", "Stack name cannot contain '--'."),
+        ]
+
+        for (name, reason) in cases {
+            var model = unstackModel(
+                target: entry(position: 3),
+                stack: stack(target: entry(position: 3), count: 5),
+                supportsKeepCurrent: true
+            )
+            model.setStackName(name)
+            #expect(model.validationMessage == reason, "\(name) should use GG's validation reason")
+            #expect(model.validatedStackName == nil)
+        }
+    }
+}

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -217,6 +217,59 @@ struct GGMutationCoordinatorTests {
         #expect(harness.service.requests.isEmpty)
     }
 
+    @Test func dropRejectsConfirmationWhenItsReviewWarningChanges() async throws {
+        let open = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Drop", ggId: "change-1",
+                prNumber: 7, prState: .open, isCurrent: true
+            ),
+        ]
+        let closed = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Drop", ggId: "change-1",
+                prNumber: 7, prState: .closed, isCurrent: true
+            ),
+        ]
+        let harness = GGMutationHarness(stacks: [
+            stack(head: "a", entries: open),
+            stack(head: "a", entries: closed),
+        ])
+        let prepared = try await harness.coordinator.prepare(.drop(target: "change-1"))
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(prepared)
+        }
+
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func startApplyingRejectsConfirmationWhenItsReviewWarningChanges() async throws {
+        let open = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Drop", ggId: "change-1",
+                prNumber: 7, prState: .open, isCurrent: true
+            ),
+        ]
+        let closed = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Drop", ggId: "change-1",
+                prNumber: 7, prState: .closed, isCurrent: true
+            ),
+        ]
+        let harness = GGMutationHarness(stacks: [
+            stack(head: "a", entries: open),
+            stack(head: "a", entries: closed),
+        ])
+        let prepared = try await harness.coordinator.prepare(.drop(target: "change-1"))
+        let task = try #require(harness.coordinator.startApplying(prepared))
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await task.value
+        }
+
+        #expect(harness.service.requests.isEmpty)
+    }
+
     @Test func missingTargetIsRejectedBeforeProcessLaunch() async {
         let harness = GGMutationHarness(stacks: [stack(head: "a")])
 
@@ -362,6 +415,7 @@ struct GGMutationCoordinatorTests {
             confirmedAgainst: nil
         )
         #expect(!withoutWorktree.refreshes.contains(.topology))
+        #expect(withoutWorktree.actionState.lastActionSummary == "New stack created without a worktree")
 
         let withWorktree = GGMutationHarness(stacks: [stack(head: "a")])
         withWorktree.service.result = .unstack(.init(

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -2,6 +2,77 @@ import Foundation
 import Testing
 @testable import Alas
 
+private final class FreshUnstackGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var calls: [[String]] = []
+    private let stackResponses: [String]
+    private let unstackError: String?
+
+    init(
+        stackResponses: [String] = [FreshUnstackGGRunner.freshStackJSON],
+        unstackError: String? = nil
+    ) {
+        self.stackResponses = stackResponses
+        self.unstackError = unstackError
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        calls.append(args)
+        if args.first == "undo" {
+            return ProcessResult(
+                exitCode: 0,
+                stdout: #"{"version":1,"operations":[]}"#,
+                stderr: ""
+            )
+        }
+        if args.first == "unstack", let unstackError {
+            return ProcessResult(exitCode: 1, stdout: "", stderr: unstackError)
+        }
+        let index = min(calls.filter { $0 == ["ls", "--json"] }.count - 1, stackResponses.count - 1)
+        return ProcessResult(exitCode: 0, stdout: stackResponses[max(0, index)], stderr: "")
+    }
+
+    static let freshStackJSON = #"""
+    {
+      "version": 1,
+      "stack": {
+        "name": "fresh-lower",
+        "base": "main",
+        "total_commits": 5,
+        "synced_commits": 0,
+        "current_position": 5,
+        "behind_base": 0,
+        "entries": [
+          {"position":1,"sha":"s1","title":"One","gg_id":"change-1","approved":false,"is_current":false},
+          {"position":2,"sha":"s2","title":"Two","gg_id":"change-2","approved":false,"is_current":false},
+          {"position":3,"sha":"s3","title":"Fresh target","gg_id":"change-3","approved":false,"is_current":false},
+          {"position":4,"sha":"s4","title":"Four","gg_id":"change-4","approved":false,"is_current":false},
+          {"position":5,"sha":"s5","title":"Five","gg_id":"change-5","approved":false,"is_current":true}
+        ]
+      }
+    }
+    """#
+
+    static let changedStackJSON = #"""
+    {
+      "version": 1,
+      "stack": {
+        "name": "fresh-lower",
+        "base": "main",
+        "total_commits": 4,
+        "synced_commits": 0,
+        "current_position": 4,
+        "behind_base": 0,
+        "entries": [
+          {"position":1,"sha":"s1","title":"One","gg_id":"change-1","approved":false,"is_current":false},
+          {"position":2,"sha":"s2","title":"Two","gg_id":"change-2","approved":false,"is_current":false},
+          {"position":3,"sha":"s3","title":"Fresh target","gg_id":"change-3","approved":false,"is_current":false},
+          {"position":4,"sha":"s4","title":"Four","gg_id":"change-4","approved":false,"is_current":true}
+        ]
+      }
+    }
+    """#
+}
+
 @MainActor
 struct RightPaneGGLandTests {
     private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus?) -> GGStackEntry {
@@ -23,6 +94,14 @@ struct RightPaneGGLandTests {
     private func stack(_ entries: [GGStackEntry]) -> GGStack {
         GGStack(name: "feat", base: "main", totalCommits: entries.count, syncedCommits: entries.count,
                 currentPosition: nil, behindBase: nil, entries: entries)
+    }
+
+    private func waitForUnstackPresentation(_ state: RightPaneState) async throws {
+        for _ in 0..<100 {
+            if state.pendingGGUnstack != nil { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("Timed out waiting for Unstack preparation")
     }
 
     @Test func readyLandableWhenAnyEntryOpenApprovedGreen() {
@@ -225,5 +304,209 @@ struct RightPaneGGLandTests {
         }
         #expect(!state.pendingGGCleanAll)
         #expect(state.ggActionState.lastError != nil)
+    }
+
+    @Test func dropConfirmationNamesCommitDescendantsAndOpenReviewWarning() {
+        let confirmation = GGMutationConfirmation.drop(
+            target: "change-2",
+            rewrittenDescendants: 2,
+            hasOpenReview: true
+        )
+
+        #expect(confirmation.message == "Drop change-2 and rewrite 2 descendant commits. The selected commit has an open review.")
+    }
+
+    @Test func unstackConfirmationNamesTargetStacksAndExactMovedCount() {
+        let confirmation = GGMutationConfirmation.unstack(
+            target: "change-3",
+            targetTitle: "Add OAuth callbacks",
+            movedCommits: 3,
+            lowerStack: "feature",
+            newStack: "oauth-callbacks"
+        )
+
+        #expect(confirmation.message == "Split at \u{201C}Add OAuth callbacks\u{201D}. Move 3 commits from feature to oauth-callbacks.")
+    }
+
+    @Test func dropPresentationNamesCommitAndProviderWarning() {
+        let presentation = GGDropPresentation(
+            target: "change-2",
+            title: "Add OAuth callbacks",
+            rewrittenDescendants: 2,
+            openReviewLabel: "PR"
+        )
+
+        #expect(presentation.message == "Drop \u{201C}Add OAuth callbacks\u{201D}. GG will rewrite and retain 2 descendant commits. The selected commit has an open PR.")
+    }
+
+    @Test func unstackPreparesFreshConfirmationBeforePresenting() async throws {
+        let target = GGStackEntry(
+            position: 2,
+            sha: "cached",
+            title: "Cached target",
+            ggId: "change-3"
+        )
+        let wt = Worktree(
+            id: "i",
+            projectId: "p",
+            name: "f",
+            branch: "f",
+            path: URL(fileURLWithPath: "/tmp/x"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggStack = GGStack(
+            name: "cached-lower",
+            base: "main",
+            totalCommits: 2,
+            syncedCommits: 0,
+            currentPosition: 2,
+            behindBase: 0,
+            entries: [
+                GGStackEntry(position: 1, sha: "cached-1", title: "Cached one", ggId: "change-1"),
+                target,
+            ]
+        )
+        let runner = FreshUnstackGGRunner()
+        state.ggService = GGService(runner: runner)
+
+        state.requestGGUnstack(target)
+        try await waitForUnstackPresentation(state)
+
+        #expect(runner.calls == [["ls", "--json"]])
+        #expect(state.pendingGGUnstack?.targetTitle == "Fresh target")
+        #expect(state.pendingGGUnstack?.lowerStackName == "fresh-lower")
+        #expect(state.pendingGGUnstack?.movedCommitCount == 3)
+        #expect(state.pendingGGUnstackPrepared?.snapshot.stackName == "fresh-lower")
+    }
+
+    @Test func editedUnstackNameRepreparesAndRequiresFreshConfirmation() async throws {
+        let target = GGStackEntry(position: 3, sha: "s3", title: "Fresh target", ggId: "change-3")
+        let wt = Worktree(
+            id: "i",
+            projectId: "p",
+            name: "f",
+            branch: "f",
+            path: URL(fileURLWithPath: "/tmp/x"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggStack = stack([target])
+        let runner = FreshUnstackGGRunner()
+        state.ggService = GGService(runner: runner)
+        state.requestGGUnstack(target)
+        try await waitForUnstackPresentation(state)
+        var edited = try #require(state.pendingGGUnstack)
+        edited.setStackName("edited destination")
+
+        let result = try await state.submitGGUnstack(edited)
+
+        guard case .reconfirm(let reconfirmed) = result else {
+            Issue.record("Edited request should require a fresh confirmation")
+            return
+        }
+        #expect(runner.calls == [["ls", "--json"], ["ls", "--json"]])
+        #expect(reconfirmed.confirmedStackName == "edited-destination")
+        #expect(state.pendingGGUnstack?.stackName == "edited-destination")
+        #expect(state.pendingGGUnstack?.confirmedStackName == "edited-destination")
+        #expect(state.pendingGGUnstack != nil)
+    }
+
+    @Test func unchangedUnstackRequestReconfirmsWhenFreshFactsChange() async throws {
+        let target = GGStackEntry(position: 3, sha: "s3", title: "Fresh target", ggId: "change-3")
+        let wt = Worktree(
+            id: "i",
+            projectId: "p",
+            name: "f",
+            branch: "f",
+            path: URL(fileURLWithPath: "/tmp/x"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggStack = stack([target])
+        let runner = FreshUnstackGGRunner(stackResponses: [
+            FreshUnstackGGRunner.freshStackJSON,
+            FreshUnstackGGRunner.changedStackJSON,
+        ])
+        state.ggService = GGService(runner: runner)
+        state.requestGGUnstack(target)
+        try await waitForUnstackPresentation(state)
+        let confirmed = try #require(state.pendingGGUnstack)
+        #expect(confirmed.movedCommitCount == 3)
+
+        let result = try await state.submitGGUnstack(confirmed)
+
+        guard case .reconfirm(let fresh) = result else {
+            Issue.record("Changed moved count should require a fresh confirmation")
+            return
+        }
+        #expect(fresh.movedCommitCount == 2)
+        #expect(runner.calls == [["ls", "--json"], ["ls", "--json"]])
+    }
+
+    @Test func unchangedUnstackRequestReconfirmsWhenOnlyTheSnapshotChanges() async throws {
+        let target = GGStackEntry(position: 3, sha: "s3", title: "Fresh target", ggId: "change-3")
+        let wt = Worktree(
+            id: "i", projectId: "p", name: "f", branch: "f",
+            path: URL(fileURLWithPath: "/tmp/x"), status: .clean, lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggStack = stack([target])
+        let rewrittenHead = FreshUnstackGGRunner.freshStackJSON.replacingOccurrences(
+            of: #""sha":"s5""#,
+            with: #""sha":"rewritten-s5""#
+        )
+        let runner = FreshUnstackGGRunner(stackResponses: [
+            FreshUnstackGGRunner.freshStackJSON,
+            rewrittenHead,
+        ])
+        state.ggService = GGService(runner: runner)
+        state.requestGGUnstack(target)
+        try await waitForUnstackPresentation(state)
+        let confirmed = try #require(state.pendingGGUnstack)
+
+        let result = try await state.submitGGUnstack(confirmed)
+
+        guard case .reconfirm = result else {
+            Issue.record("A rewritten stack must require fresh unstack confirmation")
+            return
+        }
+        #expect(runner.calls == [["ls", "--json"], ["ls", "--json"]])
+    }
+
+    @Test func contextualUnstackExecutionErrorKeepsPreparedSheetOpen() async throws {
+        let target = GGStackEntry(position: 3, sha: "s3", title: "Fresh target", ggId: "change-3")
+        let wt = Worktree(
+            id: "i",
+            projectId: "p",
+            name: "f",
+            branch: "f",
+            path: URL(fileURLWithPath: "/tmp/x"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggStack = stack([target])
+        let runner = FreshUnstackGGRunner(
+            unstackError: "Stack 'fresh-target' already exists."
+        )
+        state.ggService = GGService(runner: runner)
+        state.requestGGUnstack(target)
+        try await waitForUnstackPresentation(state)
+        let confirmed = try #require(state.pendingGGUnstack)
+        let prepared = try #require(state.pendingGGUnstackPrepared)
+
+        await #expect(throws: GGServiceError.self) {
+            try await state.submitGGUnstack(confirmed)
+        }
+
+        #expect(state.pendingGGUnstack == confirmed)
+        #expect(state.pendingGGUnstackPrepared?.request == prepared.request)
+        #expect(state.pendingGGUnstackPrepared?.snapshot == prepared.snapshot)
+        #expect(state.ggActionState.lastError == "Stack 'fresh-target' already exists.")
+        #expect(runner.calls.contains { $0.first == "unstack" })
     }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -729,4 +729,33 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.lastError != nil)
         #expect(state.ggActionState.lastActionSummary == nil)
     }
+
+    @Test func commitMenuSelectionStalenessTracksStackSnapshotSourceKey() {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let source = commit(sha: String(repeating: "a", count: 40), stackShaped: true)
+        state.ggStackSourceCommits = [source]
+        state.ggStack = GGStack(
+            name: "feature",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: [
+                GGStackEntry(position: 1, sha: source.sha, title: source.subject, ggId: "change-1")
+            ]
+        )
+
+        #expect(CommitsSectionView.ggSelectionIsStale(rps: state))
+
+        state.ggStackCommitsKey = state.currentGGStackCommitsKey
+        #expect(!CommitsSectionView.ggSelectionIsStale(rps: state))
+    }
+
+    @Test func providerReviewResponseSurfacesOnlyErrors() {
+        #expect(RightPaneState.ggProviderReviewError(.ok) == nil)
+        #expect(RightPaneState.ggProviderReviewError(.text(["opened"])) == nil)
+        #expect(RightPaneState.ggProviderReviewError(.error("Review could not be opened")) == "Review could not be opened")
+    }
 }


### PR DESCRIPTION
## What

- Adds a GG-prefixed commit contextual menu with stack-aware verbs.
- Explains why native operations are unavailable instead of exposing inert actions.

## Validation

- `GGCommitMenuModelTests`
- Commit-row coverage.

## Stack

- Builds on #873.

<!-- gg:managed:start -->
Part of stack `prepare-gg`

Commit: 8b2d45c
<!-- gg:managed:end -->