### PR TITLE
feat(gg): add native split commit editor

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		074B2BB17D428AE20AB482AA /* ACPThumbnailImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45952C734DFE7E7F02B047E7 /* ACPThumbnailImageCache.swift */; };
 		07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */; };
 		082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */; };
+		084E0061691FD9F495E8209B /* GGSplitCommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E189D66411992DFC659CBF /* GGSplitCommitTabView.swift */; };
 		08681BEDBD6D7232CC937704 /* HoverFeatureBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */; };
 		086C7DE57FBE661C6E3C718F /* GitInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83370751580C42D5DE93F80 /* GitInvocation.swift */; };
 		0871949C8A9030B15FA56FFF /* JSONRPCNewlineFramer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06375E561569DA36EC289C6F /* JSONRPCNewlineFramer.swift */; };
@@ -395,6 +396,7 @@
 		466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240C5961343C3042D865570 /* GeneralPane.swift */; };
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
 		46A9AFFA9A459522F71E073E /* DiffTabRenderContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F14E32DEBE042825BCA44A /* DiffTabRenderContext.swift */; };
+		46D0693DB76BC258780CE113 /* GGSplitCommitModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8257A2ECCB938BA608A972A /* GGSplitCommitModelTests.swift */; };
 		46E3CCB2AC426BD5F8CB55DC /* ACPImageBlocksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */; };
 		472B73818FD74F0A4D40DA59 /* RemoteExecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */; };
 		474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */; };
@@ -621,6 +623,7 @@
 		74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 77EF95AD63DDA8DB0504087B /* TreeSitterSwift */; };
 		74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A34259DE8E978943E8BE16 /* OKLCH.swift */; };
 		74F193BC4B2A1BD5AD58C6DA /* GitService+Pull.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */; };
+		7528D9FD7DCE1D6F7CF70C3F /* GGSplitTabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */; };
 		7556121D51C54458FCAFED2A /* ACPProtocolVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBCF3820A017BBF33B0AB07 /* ACPProtocolVersion.swift */; };
 		75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */; };
 		7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3855FBA3E4444960418639E9 /* FileIndexTests.swift */; };
@@ -969,6 +972,7 @@
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
 		B7F21BA3E994F3A0990D4C06 /* ACPOrchestrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
+		B7F9949C9F8915C07A80F7C4 /* GGSplitCommitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */; };
 		B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */; };
 		B834ADF0BB988121361AF334 /* tool-call-content-blocks.json in Resources */ = {isa = PBXBuildFile; fileRef = F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */; };
 		B83DBBA1D5090E5E757B01F5 /* CloseTabConfirmationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */; };
@@ -1731,6 +1735,7 @@
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteContentSearch.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
+		43E189D66411992DFC659CBF /* GGSplitCommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitCommitTabView.swift; sourceTree = "<group>"; };
 		442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProjectCollisionTests.swift; sourceTree = "<group>"; };
 		4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionScope.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
@@ -2220,6 +2225,7 @@
 		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
 		A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdateTests.swift; sourceTree = "<group>"; };
 		A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageThumbnail.swift; sourceTree = "<group>"; };
+		A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitTabsManagerTests.swift; sourceTree = "<group>"; };
 		A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerImageExtractTests.swift; sourceTree = "<group>"; };
 		A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntent.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -2323,6 +2329,7 @@
 		B96B454EC8216FFF50B92C1D /* SSHHostSuggestionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostSuggestionsTests.swift; sourceTree = "<group>"; };
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
 		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
+		B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitCommitModel.swift; sourceTree = "<group>"; };
 		B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileAccessTests.swift; sourceTree = "<group>"; };
 		BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneGGStackTests.swift; sourceTree = "<group>"; };
 		BA59378FB8733DBAC67592A3 /* RemotePairingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingServiceTests.swift; sourceTree = "<group>"; };
@@ -2401,6 +2408,7 @@
 		C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulseTests.swift; sourceTree = "<group>"; };
 		C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spinner.swift; sourceTree = "<group>"; };
 		C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Surface.swift; sourceTree = "<group>"; };
+		C8257A2ECCB938BA608A972A /* GGSplitCommitModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitCommitModelTests.swift; sourceTree = "<group>"; };
 		C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageTests.swift; sourceTree = "<group>"; };
 		C8A5CD97B6A04929595B0A9D /* CommitReviewLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitReviewLoaderTests.swift; sourceTree = "<group>"; };
 		C9042DA34C7025958BCFEE08 /* RemoteHelperHandshake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperHandshake.swift; sourceTree = "<group>"; };
@@ -4666,6 +4674,7 @@
 				7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */,
 				DF688C3B9D43B4F5FF48F7D3 /* GGServiceInboxTests.swift */,
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
+				C8257A2ECCB938BA608A972A /* GGSplitCommitModelTests.swift */,
 				7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */,
 				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
 				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
@@ -4793,6 +4802,7 @@
 		E53B7655C8A8FB0CEC069C7B /* Center */ = {
 			isa = PBXGroup;
 			children = (
+				A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */,
 				A43DE0BBE093A618267071AD /* Review */,
 			);
 			path = Center;
@@ -4930,6 +4940,8 @@
 				993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
+				B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */,
+				43E189D66411992DFC659CBF /* GGSplitCommitTabView.swift */,
 				2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */,
 				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
 				B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */,
@@ -5653,6 +5665,8 @@
 				04D55B4985BDF4CEF0BA3C0E /* GGMutationModels.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
+				B7F9949C9F8915C07A80F7C4 /* GGSplitCommitModel.swift in Sources */,
+				084E0061691FD9F495E8209B /* GGSplitCommitTabView.swift in Sources */,
 				F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */,
 				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
 				E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */,
@@ -6330,6 +6344,8 @@
 				AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */,
 				10D0D26BCE0EF4D8677CEA79 /* GGServiceInboxTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
+				46D0693DB76BC258780CE113 /* GGSplitCommitModelTests.swift in Sources */,
+				7528D9FD7DCE1D6F7CF70C3F /* GGSplitTabsManagerTests.swift in Sources */,
 				EE4A552DB5EF6559CA1A5AE0 /* GGStackActionStateTests.swift in Sources */,
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,
 				0F118A7F54315A836A169B89 /* GGStackCreateModeTests.swift in Sources */,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -331,6 +331,58 @@ struct CenterPaneView: View {
                     case .ggInbox(let s):
                         GGInboxTabView(state: state, tabState: s)
                             .id(s.id)
+                    case .ggSplitCommit(let s):
+                        let capabilities = GGAvailability.shared.capabilities
+                        if let rightPaneState = state.rightPaneStore.activeState(worktreeId: worktree.id) {
+                            let hasBlockingGitOperation = rightPaneState.mergeOp.current != nil
+                            let ggActionState = rightPaneState.ggActionState
+                            let targetEntry = s.targetEntry(in: rightPaneState.ggStack)
+                            // A `.split` in flight for *this tab's own target* is its
+                            // own Apply; it stays "available" (the view manages it via
+                            // `isApplying`) so the workflowAvailable-keyed `.id` below
+                            // doesn't recreate the editor mid-apply and discard its
+                            // inline error. Any other in-flight mutation — including a
+                            // split started from a different tab — still gates it off.
+                            let ownSplitApplying = ggActionState.inFlightAction == .split
+                                && (rightPaneState.activeSplitTargetIdentity
+                                    .map { s.matches(splitTarget: $0) } ?? false)
+                            let otherActionInFlight = ggActionState.inFlightAction != nil
+                                && !ownSplitApplying
+                            let workflowAvailable = rightPaneState.ggGateProvider?() == true
+                                && targetEntry != nil
+                                && targetEntry?.prState != .merged
+                                && !otherActionInFlight
+                                && ggActionState.pausedOperation == nil
+                            GGSplitCommitTabView(
+                                tabState: s,
+                                rightPaneState: rightPaneState,
+                                capabilities: capabilities,
+                                workflowAvailable: workflowAvailable,
+                                hasBlockingGitOperation: hasBlockingGitOperation,
+                                initialDraft: state.tabs.ggSplitCommitDraft(worktreeId: worktree.id, tabId: s.id),
+                                codeFontFamily: state.config.code.fontFamily,
+                                codeFontSize: CGFloat(state.config.code.fontSize),
+                                onCancel: {
+                                    state.tabs.close(worktreeId: worktree.id, tabId: s.id)
+                                },
+                                onDraftChange: { draft in
+                                    state.tabs.updateGGSplitCommitDraft(
+                                        worktreeId: worktree.id,
+                                        tabId: s.id,
+                                        draft: draft
+                                    )
+                                }
+                            )
+                            .id("\(s.id):\(capabilities.structuredSplit):\(workflowAvailable):\(hasBlockingGitOperation)")
+                            .task(id: rightPaneActivationKey) {
+                                activateRightPaneStateForCenterTab()
+                            }
+                        } else {
+                            ProgressView()
+                                .task(id: rightPaneActivationKey) {
+                                    activateRightPaneStateForCenterTab()
+                                }
+                        }
                     }
                 }
             }

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -21,6 +21,7 @@ enum Tab: Codable, Equatable, Identifiable {
     case fileSnapshot(FileSnapshotTabState)
     case fileHistory(FileHistoryTabState)
     case ggInbox(GGInboxTabState)
+    case ggSplitCommit(GGSplitCommitTabState)
 
     var id: TabID {
         switch self {
@@ -42,6 +43,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .fileSnapshot(let s): return s.id
         case .fileHistory(let s):  return s.id
         case .ggInbox(let s):      return s.id
+        case .ggSplitCommit(let s): return s.id
         }
     }
 
@@ -65,6 +67,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .fileSnapshot(let s): return s.title
         case .fileHistory(let s):  return s.title
         case .ggInbox(let s):      return s.title
+        case .ggSplitCommit:       return "Split Commit"
         }
     }
 
@@ -88,6 +91,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .fileSnapshot: return "doc.text.magnifyingglass"
         case .fileHistory:  return "clock.arrow.circlepath"
         case .ggInbox:      return "branch"
+        case .ggSplitCommit: return "arrow.trianglehead.branch"
         }
     }
 
@@ -131,6 +135,63 @@ enum Tab: Codable, Equatable, Identifiable {
         default:
             return false
         }
+    }
+}
+
+enum GGSplitCommitTabPresentation: Equatable {
+    case available
+    case unavailable(reason: String)
+}
+
+struct GGSplitCommitTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let targetGGID: String?
+    let targetSHA: String
+
+    init(worktreeId: String, targetGGID: String?, targetSHA: String) {
+        self.id = "gg-split:\(worktreeId):\(targetGGID ?? targetSHA)"
+        self.worktreeId = worktreeId
+        self.targetGGID = targetGGID
+        self.targetSHA = targetSHA
+    }
+
+    func presentation(
+        capabilities: GGCapabilities,
+        workflowAvailable: Bool,
+        hasBlockingGitOperation: Bool = false
+    ) -> GGSplitCommitTabPresentation {
+        if !capabilities.structuredSplit {
+            return .unavailable(reason: GGSplitCommitModel.unavailableReason)
+        }
+        if hasBlockingGitOperation {
+            return .unavailable(reason: "Finish the current Git operation before splitting a commit.")
+        }
+        return workflowAvailable
+            ? .available
+            : .unavailable(reason: GGSplitCommitModel.workflowUnavailableReason)
+    }
+
+    func belongs(to stack: GGStack?) -> Bool {
+        targetEntry(in: stack) != nil
+    }
+
+    func targetEntry(in stack: GGStack?) -> GGStackEntry? {
+        guard let stack else { return nil }
+        if let targetGGID {
+            return stack.entries.first { $0.ggId == targetGGID }
+        }
+        return stack.entry(matchingCommitSHA: targetSHA)
+    }
+
+    /// Whether an in-flight split identity refers to this tab's own target,
+    /// so a `.split` action started here can be treated as this tab applying
+    /// rather than as another tab's operation.
+    func matches(splitTarget identity: GGSplitTargetIdentity) -> Bool {
+        if let ggID = identity.ggID, let targetGGID {
+            return ggID == targetGGID
+        }
+        return identity.sha == targetSHA
     }
 }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -60,6 +60,9 @@ final class TabsManager {
         var language: String?
     }
     private var externalLSPInfo: [TabID: ExternalLSPInfo] = [:]
+    /// Session-only split drafts survive view recreation when the user switches
+    /// tabs, but are deliberately not persisted as part of the tab identity.
+    private var ggSplitCommitDrafts: [TabID: GGSplitCommitDraft] = [:]
     /// Tracks which tab IDs have already had `openExternalDocument` fired so
     /// that cache-hit calls to `externalBuffer` don't double-count the ref.
     private var openedExternalDocs: Set<TabID> = []
@@ -101,6 +104,20 @@ final class TabsManager {
     func activeTab(forWorktree id: String) -> Tab? {
         guard let activeId = activeTabId(forWorktree: id) else { return nil }
         return tabs(forWorktree: id).first(where: { $0.id == activeId })
+    }
+
+    func ggSplitCommitDraft(worktreeId: String, tabId: TabID) -> GGSplitCommitDraft? {
+        guard tabs(forWorktree: worktreeId).contains(where: { $0.id == tabId }) else { return nil }
+        return ggSplitCommitDrafts[tabId]
+    }
+
+    func updateGGSplitCommitDraft(
+        worktreeId: String,
+        tabId: TabID,
+        draft: GGSplitCommitDraft
+    ) {
+        guard tabs(forWorktree: worktreeId).contains(where: { $0.id == tabId }) else { return }
+        ggSplitCommitDrafts[tabId] = draft
     }
 
     func moveTab(worktreeId: String, fromId: TabID, toId: TabID) {
@@ -756,6 +773,25 @@ final class TabsManager {
     }
 
     @discardableResult
+    func openGGSplitCommit(
+        worktreeId: String,
+        targetGGID: String?,
+        targetSHA: String
+    ) -> TabID {
+        let state = GGSplitCommitTabState(
+            worktreeId: worktreeId,
+            targetGGID: targetGGID,
+            targetSHA: targetSHA
+        )
+        if tabs(forWorktree: worktreeId).contains(where: { $0.id == state.id }) {
+            activate(worktreeId: worktreeId, tabId: state.id)
+            return state.id
+        }
+        append(.ggSplitCommit(state), to: worktreeId)
+        return state.id
+    }
+
+    @discardableResult
     func openOrFocusReviewSession(worktreeId: String, record: ReviewSessionRecord) -> Tab {
         let baseState = ReviewSessionTabState(worktreeId: worktreeId, record: record)
         if var file = byWorktree[worktreeId],
@@ -1150,6 +1186,7 @@ final class TabsManager {
         captureDraftIfNeeded(&file, removingTabId: tabId)
         let wasActive = file.activeTabId == tabId
         file.tabs.remove(at: idx)
+        ggSplitCommitDrafts.removeValue(forKey: tabId)
         if case .terminal(let state) = tab {
             for leaf in state.root.leaves() {
                 terminalRuntimeTitles.removeValue(forKey: leaf.id)
@@ -1187,6 +1224,7 @@ final class TabsManager {
         guard let kept = file.tabs.first(where: { $0.id == tabId }) else { return [] }
         for id in closed {
             captureDraftIfNeeded(&file, removingTabId: id)
+            ggSplitCommitDrafts.removeValue(forKey: id)
         }
         file.tabs = [kept]
         file.activeTabId = tabId
@@ -1200,6 +1238,7 @@ final class TabsManager {
         let closed = file.tabs.map(\.id)
         for id in closed {
             captureDraftIfNeeded(&file, removingTabId: id)
+            ggSplitCommitDrafts.removeValue(forKey: id)
         }
         file.tabs = []
         file.activeTabId = nil
@@ -1214,6 +1253,7 @@ final class TabsManager {
         let closed = file.tabs[0..<idx].map(\.id)
         for id in closed {
             captureDraftIfNeeded(&file, removingTabId: id)
+            ggSplitCommitDrafts.removeValue(forKey: id)
         }
         if let active = file.activeTabId, closed.contains(active) {
             file.activeTabId = tabId
@@ -1230,6 +1270,7 @@ final class TabsManager {
         let closed = file.tabs[(idx + 1)...].map(\.id)
         for id in closed {
             captureDraftIfNeeded(&file, removingTabId: id)
+            ggSplitCommitDrafts.removeValue(forKey: id)
         }
         if let active = file.activeTabId, closed.contains(active) {
             file.activeTabId = tabId

--- a/Alas/Sources/Integrations/GG/GGCommitMenuModel.swift
+++ b/Alas/Sources/Integrations/GG/GGCommitMenuModel.swift
@@ -104,7 +104,8 @@ struct GGCommitMenuModel: Equatable {
         }
         let openAction = GGCommitAction.openProviderRequest(number: reviewNumber ?? 0)
         let splitReason = mutationReason
-            ?? (context.capabilities.structuredSplit ? nil : "Update GG to split commits in Alas.")
+            ?? (context.capabilities.structuredSplit ? nil : "Update GG to use native Split Commit")
+            ?? (context.canOpenSplitCommit ? nil : "Native Split Commit is unavailable.")
             ?? immutableReason
         let rewriteReason = mutationReason ?? immutableReason
         let unstackReason = rewriteReason ?? (

--- a/Alas/Sources/Integrations/GG/GGSplitCommitModel.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitModel.swift
@@ -1,0 +1,321 @@
+import Foundation
+import Observation
+
+struct GGSplitCommitTarget: Equatable, Sendable {
+    let worktreeId: String
+    let targetGGID: String?
+    let targetSHA: String
+
+    var commandTarget: String { targetGGID ?? targetSHA }
+}
+
+struct GGSplitLoadedDescription: Equatable, Sendable {
+    let description: GGSplitDescription
+    let stackIdentity: GGStackIdentity
+}
+
+@MainActor
+protocol GGSplitCommitServicing: AnyObject {
+    func loadDescription(target: GGSplitCommitTarget) async throws -> GGSplitLoadedDescription
+    func applySplit(
+        planURL: URL,
+        target: GGSplitTargetIdentity,
+        planToken: String,
+        confirmedAgainst identity: GGStackIdentity
+    ) async throws
+}
+
+enum GGSplitCommitFileGroupKind: Equatable {
+    case selectable
+    case remainderOnly
+
+    var idToken: String {
+        switch self {
+        case .selectable: "selectable"
+        case .remainderOnly: "remainder"
+        }
+    }
+}
+
+struct GGSplitCommitFileGroup: Equatable, Identifiable {
+    // A path can appear as both a selectable group and a remainder-only group
+    // (e.g. text edits plus a metadata/chmod change on the same file), so the
+    // kind is part of the identity to keep ForEach IDs unique.
+    var id: String { "\(kind.idToken):\(path)" }
+    let path: String
+    let hunks: [GGSplitHunk]
+    let kind: GGSplitCommitFileGroupKind
+}
+
+struct GGSplitPreviewFile: Equatable, Identifiable {
+    var id: String { path }
+    let path: String
+    let hunkIDs: [String]
+    let diff: ParsedDiff
+}
+
+struct GGSplitPreview: Equatable {
+    let files: [GGSplitPreviewFile]
+    let nonTextualFiles: [String]
+
+    static let empty = GGSplitPreview(files: [], nonTextualFiles: [])
+}
+
+struct GGSplitCommitDraft: Equatable {
+    var selectedHunkIDs: Set<String>
+    var firstMessage: String
+    var remainderMessage: String
+}
+
+enum GGSplitCommitValidationError: Error, Equatable {
+    case unavailable
+    case notLoaded
+    case emptySelection
+    case allHunksSelected
+    case emptyFirstMessage
+    case emptyRemainderMessage
+}
+
+extension GGSplitCommitValidationError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .unavailable: "Update GG to use native Split Commit"
+        case .notLoaded: "Load the split plan before applying it."
+        case .emptySelection: "Select at least one hunk for the first commit."
+        case .allHunksSelected: "Leave at least one hunk for the remainder commit."
+        case .emptyFirstMessage: "Enter a message for the first commit."
+        case .emptyRemainderMessage: "Enter a message for the remainder commit."
+        }
+    }
+}
+
+struct GGSplitPrivatePlanFile {
+    let url: URL
+    let directoryURL: URL
+
+    func remove() {
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}
+
+struct GGSplitPrivatePlanWriter {
+    private let fileManager: FileManager
+    private let temporaryDirectory: URL
+
+    init(
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory
+    ) {
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory
+    }
+
+    func write(_ plan: GGSplitPlan) throws -> GGSplitPrivatePlanFile {
+        let directoryURL = temporaryDirectory
+            .appendingPathComponent("alas-gg-split-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try fileManager.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+
+            let encoder = JSONEncoder()
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+            let data = try encoder.encode(plan)
+            let stagingURL = directoryURL.appendingPathComponent("plan.json.tmp")
+            guard fileManager.createFile(
+                atPath: stagingURL.path,
+                contents: data,
+                attributes: [.posixPermissions: 0o600]
+            ) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: stagingURL.path)
+
+            let planURL = directoryURL.appendingPathComponent("plan.json")
+            try fileManager.moveItem(at: stagingURL, to: planURL)
+            return GGSplitPrivatePlanFile(url: planURL, directoryURL: directoryURL)
+        } catch {
+            try? fileManager.removeItem(at: directoryURL)
+            throw error
+        }
+    }
+}
+
+@Observable
+@MainActor
+final class GGSplitCommitModel {
+    static let unavailableReason = "Update GG to use native Split Commit"
+    static let workflowUnavailableReason = "Native Split Commit is unavailable."
+
+    private let service: any GGSplitCommitServicing
+    private let target: GGSplitCommitTarget
+    private let capabilities: GGCapabilities
+    private let workflowAvailable: Bool
+    private let planWriter: GGSplitPrivatePlanWriter
+    private let initialDraft: GGSplitCommitDraft?
+    private var stackIdentity: GGStackIdentity?
+
+    private(set) var description: GGSplitDescription!
+    private(set) var fileGroups: [GGSplitCommitFileGroup] = []
+    var selectedHunkIDs: Set<String> = []
+    var firstMessage = ""
+    var remainderMessage = ""
+
+    init(
+        service: any GGSplitCommitServicing,
+        target: GGSplitCommitTarget,
+        capabilities: GGCapabilities,
+        workflowAvailable: Bool,
+        initialDraft: GGSplitCommitDraft? = nil,
+        planWriter: GGSplitPrivatePlanWriter = GGSplitPrivatePlanWriter()
+    ) {
+        self.service = service
+        self.target = target
+        self.capabilities = capabilities
+        self.workflowAvailable = workflowAvailable
+        self.initialDraft = initialDraft
+        self.planWriter = planWriter
+    }
+
+    var isAvailable: Bool { capabilities.structuredSplit && workflowAvailable }
+    var unavailableReason: String? {
+        if !capabilities.structuredSplit { return Self.unavailableReason }
+        if !workflowAvailable { return Self.workflowUnavailableReason }
+        return nil
+    }
+    var targetSHA: String? { description?.target.sha }
+    var targetTree: String? { description?.target.tree }
+    var targetGGID: String? { description?.target.ggID }
+    var planToken: String? { description?.planToken }
+    var draft: GGSplitCommitDraft {
+        GGSplitCommitDraft(
+            selectedHunkIDs: selectedHunkIDs,
+            firstMessage: firstMessage,
+            remainderMessage: remainderMessage
+        )
+    }
+
+    var validationMessage: String? {
+        do {
+            _ = try validatedPlan()
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    var canApply: Bool { validationMessage == nil }
+
+    var firstPreview: GGSplitPreview {
+        preview(selecting: { selectedHunkIDs.contains($0.id) }, includesNonTextual: false)
+    }
+
+    var remainderPreview: GGSplitPreview {
+        preview(selecting: { !selectedHunkIDs.contains($0.id) }, includesNonTextual: true)
+    }
+
+    func load() async throws {
+        guard isAvailable else { throw GGSplitCommitValidationError.unavailable }
+        let draftToRestore = description == nil ? initialDraft : draft
+        let loaded = try await service.loadDescription(target: target)
+        description = loaded.description
+        stackIdentity = loaded.stackIdentity
+        let knownHunkIDs = Set(loaded.description.hunks.map(\.id))
+        selectedHunkIDs = draftToRestore?.selectedHunkIDs.intersection(knownHunkIDs) ?? []
+        firstMessage = draftToRestore?.firstMessage ?? loaded.description.firstMessage
+        remainderMessage = draftToRestore?.remainderMessage ?? loaded.description.remainderMessage
+        fileGroups = Self.makeFileGroups(from: loaded.description)
+    }
+
+    func toggleHunk(_ id: String) {
+        guard description?.hunks.contains(where: { $0.id == id }) == true else { return }
+        if selectedHunkIDs.contains(id) {
+            selectedHunkIDs.remove(id)
+        } else {
+            selectedHunkIDs.insert(id)
+        }
+    }
+
+    func validatedPlan() throws -> GGSplitPlan {
+        guard isAvailable else { throw GGSplitCommitValidationError.unavailable }
+        guard let description else { throw GGSplitCommitValidationError.notLoaded }
+        guard !selectedHunkIDs.isEmpty else { throw GGSplitCommitValidationError.emptySelection }
+        let hasRemainderContent = selectedHunkIDs.count < description.hunks.count
+            || !description.nonTextualFiles.isEmpty
+        guard hasRemainderContent else {
+            throw GGSplitCommitValidationError.allHunksSelected
+        }
+        let knownIDs = Set(description.hunks.map(\.id))
+        guard selectedHunkIDs.isSubset(of: knownIDs) else {
+            throw GGSplitCommitValidationError.emptySelection
+        }
+        let first = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !first.isEmpty else { throw GGSplitCommitValidationError.emptyFirstMessage }
+        let remainder = remainderMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !remainder.isEmpty else { throw GGSplitCommitValidationError.emptyRemainderMessage }
+
+        return GGSplitPlan(
+            version: 1,
+            planToken: description.planToken,
+            target: description.target,
+            selectedHunkIDs: description.hunks.map(\.id).filter(selectedHunkIDs.contains),
+            firstMessage: first,
+            remainderMessage: remainder
+        )
+    }
+
+    func apply() async throws {
+        let plan = try validatedPlan()
+        guard let stackIdentity else { throw GGSplitCommitValidationError.notLoaded }
+        let privateFile = try planWriter.write(plan)
+        defer { privateFile.remove() }
+        try await service.applySplit(
+            planURL: privateFile.url,
+            target: plan.target,
+            planToken: plan.planToken,
+            confirmedAgainst: stackIdentity
+        )
+    }
+
+    private static func makeFileGroups(from description: GGSplitDescription) -> [GGSplitCommitFileGroup] {
+        var paths: [String] = []
+        var hunksByPath: [String: [GGSplitHunk]] = [:]
+        for hunk in description.hunks {
+            if hunksByPath[hunk.path] == nil { paths.append(hunk.path) }
+            hunksByPath[hunk.path, default: []].append(hunk)
+        }
+        var groups = paths.map {
+            GGSplitCommitFileGroup(path: $0, hunks: hunksByPath[$0] ?? [], kind: .selectable)
+        }
+        groups.append(contentsOf: description.nonTextualFiles.map {
+            GGSplitCommitFileGroup(path: $0, hunks: [], kind: .remainderOnly)
+        })
+        return groups
+    }
+
+    private func preview(
+        selecting predicate: (GGSplitHunk) -> Bool,
+        includesNonTextual: Bool
+    ) -> GGSplitPreview {
+        guard let description else { return .empty }
+        let grouped = Self.makeFileGroups(from: description)
+        let files = grouped.compactMap { group -> GGSplitPreviewFile? in
+            let hunks = group.hunks.filter(predicate)
+            guard !hunks.isEmpty else { return nil }
+            let rawDiff = hunks.map { hunk in
+                hunk.patch.hasPrefix("@@") ? hunk.patch : "\(hunk.header)\n\(hunk.patch)"
+            }.joined(separator: "\n")
+            return GGSplitPreviewFile(
+                path: group.path,
+                hunkIDs: hunks.map(\.id),
+                diff: DiffParser.parse(rawDiff)
+            )
+        }
+        return GGSplitPreview(
+            files: files,
+            nonTextualFiles: includesNonTextual ? description.nonTextualFiles : []
+        )
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -1,0 +1,373 @@
+import SwiftUI
+
+struct GGSplitCommitTabView: View {
+    let tabState: GGSplitCommitTabState
+    let capabilities: GGCapabilities
+    let workflowAvailable: Bool
+    let hasBlockingGitOperation: Bool
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let onCancel: () -> Void
+    let onDraftChange: (GGSplitCommitDraft) -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var model: GGSplitCommitModel
+    @State private var isLoading = true
+    @State private var isApplying = false
+    @State private var errorMessage: String?
+    @State private var layoutMode: DiffLayoutMode = .stacked
+    @State private var wrapLines = false
+    @State private var showWhitespace = false
+
+    init(
+        tabState: GGSplitCommitTabState,
+        rightPaneState: RightPaneState,
+        capabilities: GGCapabilities,
+        workflowAvailable: Bool,
+        hasBlockingGitOperation: Bool,
+        initialDraft: GGSplitCommitDraft?,
+        codeFontFamily: String,
+        codeFontSize: CGFloat,
+        onCancel: @escaping () -> Void,
+        onDraftChange: @escaping (GGSplitCommitDraft) -> Void
+    ) {
+        self.tabState = tabState
+        self.capabilities = capabilities
+        self.workflowAvailable = workflowAvailable
+        self.hasBlockingGitOperation = hasBlockingGitOperation
+        self.codeFontFamily = codeFontFamily
+        self.codeFontSize = codeFontSize
+        self.onCancel = onCancel
+        self.onDraftChange = onDraftChange
+        _model = State(initialValue: GGSplitCommitModel(
+            service: rightPaneState,
+            target: GGSplitCommitTarget(
+                worktreeId: tabState.worktreeId,
+                targetGGID: tabState.targetGGID,
+                targetSHA: tabState.targetSHA
+            ),
+            capabilities: capabilities,
+            workflowAvailable: workflowAvailable && !hasBlockingGitOperation,
+            initialDraft: initialDraft
+        ))
+    }
+
+    var body: some View {
+        Group {
+            switch tabState.presentation(
+                capabilities: capabilities,
+                workflowAvailable: workflowAvailable,
+                hasBlockingGitOperation: hasBlockingGitOperation
+            ) {
+            case .unavailable(let reason):
+                unavailableView(reason: reason)
+            case .available:
+                availableContent
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+        .task(id: tabState.id) { await load() }
+    }
+
+    private var availableContent: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if isLoading {
+                Spinner()
+                    .frame(width: 20, height: 20)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if model.description == nil {
+                loadFailure
+            } else {
+                HStack(spacing: 0) {
+                    selectionPane
+                        .frame(minWidth: 240, idealWidth: 300, maxWidth: 380)
+                    Divider()
+                    editorAndPreviews
+                        .frame(minWidth: 440, maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "arrow.trianglehead.branch")
+                .foregroundStyle(theme.color("accent"))
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Split Commit")
+                    .font(.headline)
+                Text(tabState.targetGGID ?? tabState.targetSHA)
+                    .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 2)))
+                    .foregroundStyle(theme.color("fg-dim"))
+                    .lineLimit(1)
+                    .textSelection(.enabled)
+            }
+            Spacer()
+            if !isLoading {
+                Button("Reload", systemImage: "arrow.clockwise") {
+                    Task { await load() }
+                }
+                .disabled(isApplying)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-2"))
+    }
+
+    private var selectionPane: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Hunks")
+                .font(.headline)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+            Divider()
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(model.fileGroups) { group in
+                        splitFileGroup(group)
+                    }
+                }
+            }
+        }
+        .background(theme.color("bg-2"))
+    }
+
+    private func splitFileGroup(_ group: GGSplitCommitFileGroup) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: group.kind == .selectable ? "doc.text" : "doc")
+                    .foregroundStyle(theme.color("fg-dim"))
+                Text(group.path)
+                    .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                    .lineLimit(2)
+                    .textSelection(.enabled)
+                Spacer(minLength: 4)
+                if group.kind == .remainderOnly {
+                    Text("Remainder only")
+                        .font(.caption)
+                        .foregroundStyle(theme.color("fg-dim"))
+                }
+            }
+
+            ForEach(group.hunks, id: \.id) { hunk in
+                Toggle(
+                    isOn: Binding(
+                        get: { model.selectedHunkIDs.contains(hunk.id) },
+                        set: { _ in
+                            model.toggleHunk(hunk.id)
+                            errorMessage = nil
+                            onDraftChange(model.draft)
+                        }
+                    )
+                ) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(hunk.header)
+                            .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                            .foregroundStyle(theme.color("fg"))
+                        Text(hunk.patch)
+                            .font(CenterTypography.codeFont(family: codeFontFamily, size: max(9, codeFontSize - 2)))
+                            .foregroundStyle(theme.color("fg-dim"))
+                            .lineLimit(4)
+                            .textSelection(.enabled)
+                    }
+                }
+                .toggleStyle(.checkbox)
+            }
+        }
+        .padding(12)
+        .overlay(Divider(), alignment: .bottom)
+    }
+
+    private var editorAndPreviews: some View {
+        VStack(spacing: 0) {
+            messageEditor
+            Divider()
+            VSplitView {
+                previewPane(title: "First commit", preview: model.firstPreview)
+                    .frame(minHeight: 180)
+                previewPane(title: "Remainder", preview: model.remainderPreview)
+                    .frame(minHeight: 180)
+            }
+            Divider()
+            actionBar
+        }
+    }
+
+    private var messageEditor: some View {
+        Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
+            GridRow {
+                Text("First commit")
+                    .foregroundStyle(theme.color("fg-dim"))
+                TextField("Commit message", text: $model.firstMessage)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: model.firstMessage) {
+                        errorMessage = nil
+                        onDraftChange(model.draft)
+                    }
+            }
+            GridRow {
+                Text("Remainder")
+                    .foregroundStyle(theme.color("fg-dim"))
+                TextField("Commit message", text: $model.remainderMessage)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: model.remainderMessage) {
+                        errorMessage = nil
+                        onDraftChange(model.draft)
+                    }
+            }
+        }
+        .padding(12)
+        .background(theme.color("bg-2"))
+    }
+
+    private func previewPane(title: String, preview: GGSplitPreview) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(title)
+                    .font(.headline)
+                Spacer()
+                Text("\(preview.files.flatMap(\.hunkIDs).count) hunk\(preview.files.flatMap(\.hunkIDs).count == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(theme.color("fg-dim"))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(theme.color("bg-2"))
+            Divider()
+            if preview.files.isEmpty && preview.nonTextualFiles.isEmpty {
+                Text("No content assigned")
+                    .foregroundStyle(theme.color("fg-dim"))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(preview.files) { file in
+                            splitPreviewFile(file)
+                        }
+                        ForEach(preview.nonTextualFiles, id: \.self) { path in
+                            Label(path, systemImage: "doc")
+                                .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                                .foregroundStyle(theme.color("fg-dim"))
+                                .padding(12)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func splitPreviewFile(_ file: GGSplitPreviewFile) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(file.path)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                .foregroundStyle(theme.color("fg"))
+                .textSelection(.enabled)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(theme.color("bg-2"))
+            DiffPaneView(
+                model: DiffDisplayModelBuilder.build(diff: file.diff, filePath: file.path),
+                fileExtension: LanguageRegistry.highlighterExtension(forPath: file.path),
+                layoutMode: $layoutMode,
+                wrapLines: $wrapLines,
+                showWhitespace: $showWhitespace,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                showsToolbar: false,
+                verticalScrollMode: .staticHeight,
+                lspContext: nil,
+                allowsReviewLineSelection: false,
+                hunkActions: { _ in DiffPaneHunkActions() }
+            )
+        }
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: 10) {
+            if let message = errorMessage ?? model.validationMessage {
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 12)
+            Button("Cancel", role: .cancel, action: onCancel)
+                .frame(width: 84)
+                .disabled(isApplying)
+            Button("Apply Split", systemImage: "arrow.trianglehead.branch") {
+                apply()
+            }
+            .buttonStyle(.borderedProminent)
+            .frame(width: 120)
+            .disabled(!model.canApply || isApplying)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(theme.color("bg-2"))
+    }
+
+    private var loadFailure: some View {
+        VStack(spacing: 12) {
+            Label(errorMessage ?? "Could not load the split plan.", systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.red)
+                .multilineTextAlignment(.center)
+            Button("Retry", systemImage: "arrow.clockwise") {
+                Task { await load() }
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func unavailableView(reason: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "arrow.trianglehead.branch")
+                .font(.title)
+                .foregroundStyle(theme.color("fg-dim"))
+            Text("Split Commit Unavailable")
+                .font(.headline)
+            Text(reason)
+                .foregroundStyle(theme.color("fg-dim"))
+            Button("Close Tab", systemImage: "xmark", action: onCancel)
+        }
+        .padding(24)
+    }
+
+    private func load() async {
+        guard model.isAvailable else {
+            isLoading = false
+            return
+        }
+        isLoading = true
+        errorMessage = nil
+        do {
+            try await model.load()
+            onDraftChange(model.draft)
+        } catch {
+            errorMessage = GGErrorPresentation.message(for: error)
+        }
+        isLoading = false
+    }
+
+    private func apply() {
+        guard !isApplying else { return }
+        isApplying = true
+        errorMessage = nil
+        Task { @MainActor in
+            defer { isApplying = false }
+            do {
+                try await model.apply()
+                onCancel()
+            } catch {
+                errorMessage = GGErrorPresentation.message(for: error)
+            }
+        }
+    }
+}

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -27,7 +27,7 @@ private struct SyncFetchTarget: Hashable {
 
 @Observable
 @MainActor
-final class RightPaneState {
+final class RightPaneState: GGSplitCommitServicing {
     nonisolated static let remoteUntrackedContentFingerprintCommand = "git ls-files --others --exclude-standard -z | xargs -0 sh -c '[ \"$#\" -gt 0 ] || exit 0; git hash-object -- \"$@\"' sh 2>/dev/null"
 
     let worktree: Worktree
@@ -237,6 +237,15 @@ final class RightPaneState {
     @ObservationIgnored var pendingGGUnstackPrepared: GGPreparedMutation? = nil
     var pendingGGCleanAll: Bool = false
     @ObservationIgnored private var pendingGGCleanPrepared: GGPreparedMutation? = nil
+
+    /// The split target of an in-flight `.applySplit`, if any, so a split tab
+    /// can tell whether the running split is its own apply or another tab's.
+    var activeSplitTargetIdentity: GGSplitTargetIdentity? {
+        guard case let .applySplit(_, identity, _)? = ggMutationCoordinatorStorage?.activeRequest else {
+            return nil
+        }
+        return identity
+    }
 
     /// True while the workspace-level agent invocation is running.
     /// Surfaced in the Conflicts section header as a spinner; the
@@ -1080,6 +1089,30 @@ final class RightPaneState {
     }
 
     @ObservationIgnored var requestGGSplitCommit: ((GGStackEntry) -> Void)? = nil
+
+    func loadDescription(target: GGSplitCommitTarget) async throws -> GGSplitLoadedDescription {
+        let before = try await ggService.currentStackSnapshot(worktreePath: worktree.path.path)
+        guard let identity = before.identity else { throw GGMutationError.staleConfirmation }
+        let description = try await ggService.describeSplit(
+            worktreePath: worktree.path.path,
+            target: target.commandTarget
+        )
+        let after = try await ggService.currentStackSnapshot(worktreePath: worktree.path.path)
+        guard after.identity == identity else { throw GGMutationError.staleConfirmation }
+        return GGSplitLoadedDescription(description: description, stackIdentity: identity)
+    }
+
+    func applySplit(
+        planURL: URL,
+        target: GGSplitTargetIdentity,
+        planToken: String,
+        confirmedAgainst identity: GGStackIdentity
+    ) async throws {
+        try await ggMutationCoordinator.apply(
+            .applySplit(planURL: planURL, target: target, planToken: planToken),
+            confirmedAgainst: identity
+        )
+    }
 
     func requestGGDrop(_ entry: GGStackEntry) {
         Task { @MainActor in

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -177,6 +177,14 @@ final class RightPaneStore {
                 else { return }
                 app.focusGlobalWorktree(id: target.id, projectId: worktree.projectId)
             }
+            new.requestGGSplitCommit = { [weak self] entry in
+                guard let app = self?.appState else { return }
+                _ = app.tabs.openGGSplitCommit(
+                    worktreeId: worktree.id,
+                    targetGGID: entry.ggId,
+                    targetSHA: entry.sha
+                )
+            }
 
             if shouldDeferInitialRefresh {
                 new.baseBranchProbeTask = Task { @MainActor [weak self, weak new] in

--- a/AlasTests/Center/GGSplitTabsManagerTests.swift
+++ b/AlasTests/Center/GGSplitTabsManagerTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct GGSplitTabsManagerTests {
+    @Test func openingSplitTargetCreatesAndFocusesStableTab() {
+        let worktreeID = "gg-split-tabs-open"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeID)) }
+        let tabs = TabsManager()
+
+        let id = tabs.openGGSplitCommit(
+            worktreeId: worktreeID,
+            targetGGID: "change-2",
+            targetSHA: "abc"
+        )
+
+        #expect(id == "gg-split:\(worktreeID):change-2")
+        #expect(tabs.activeTabId(forWorktree: worktreeID) == id)
+        #expect(tabs.tabs(forWorktree: worktreeID).map(\.id) == [id])
+    }
+
+    @Test func openingSameSplitTargetFocusesExistingTab() {
+        let worktreeID = "gg-split-tabs-dedupe"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeID)) }
+        let tabs = TabsManager()
+        let first = tabs.openGGSplitCommit(
+            worktreeId: worktreeID,
+            targetGGID: "change-2",
+            targetSHA: "abc"
+        )
+        _ = tabs.appendTerminal(worktreeId: worktreeID, title: "Terminal", sessionId: "session")
+
+        let second = tabs.openGGSplitCommit(
+            worktreeId: worktreeID,
+            targetGGID: "change-2",
+            targetSHA: "rewritten-sha"
+        )
+
+        #expect(first == second)
+        #expect(tabs.tabs(forWorktree: worktreeID).filter { $0.id == first }.count == 1)
+        #expect(tabs.activeTabId(forWorktree: worktreeID) == first)
+    }
+
+    @Test func openingDistinctTargetsCreatesDistinctTabs() {
+        let worktreeID = "gg-split-tabs-distinct"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeID)) }
+        let tabs = TabsManager()
+
+        let first = tabs.openGGSplitCommit(worktreeId: worktreeID, targetGGID: "change-1", targetSHA: "abc")
+        let second = tabs.openGGSplitCommit(worktreeId: worktreeID, targetGGID: "change-2", targetSHA: "def")
+
+        #expect(first != second)
+        #expect(tabs.tabs(forWorktree: worktreeID).count == 2)
+    }
+
+    @Test func splitTabCodableRoundTripCarriesOnlyStableIdentity() throws {
+        let state = GGSplitCommitTabState(
+            worktreeId: "wt",
+            targetGGID: "change-2",
+            targetSHA: "abc"
+        )
+
+        let data = try JSONEncoder().encode(Tab.ggSplitCommit(state))
+        let decoded = try JSONDecoder().decode(Tab.self, from: data)
+
+        guard case .ggSplitCommit(let restored) = decoded else {
+            Issue.record("Expected restored gg Split tab")
+            return
+        }
+        #expect(restored == state)
+        #expect(restored.id == "gg-split:wt:change-2")
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(!String(describing: object).contains("selectedHunk"))
+        #expect(!String(describing: object).contains("firstMessage"))
+        #expect(!String(describing: object).contains("planToken"))
+    }
+
+    @Test func restoredSplitTabRemainsVisibleWhenStructuredSplitIsUnavailable() {
+        let state = GGSplitCommitTabState(worktreeId: "wt", targetGGID: nil, targetSHA: "abc")
+
+        let presentation = state.presentation(
+            capabilities: GGCapabilities(structuredSplit: false, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+
+        #expect(presentation == .unavailable(reason: "Update GG to use native Split Commit"))
+        #expect(state.id == "gg-split:wt:abc")
+    }
+
+    @Test func restoredSplitTabRemainsVisibleWhenGGWorkflowIsUnavailable() {
+        let state = GGSplitCommitTabState(worktreeId: "wt", targetGGID: "change-2", targetSHA: "abc")
+
+        let presentation = state.presentation(
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: false
+        )
+
+        #expect(presentation == .unavailable(reason: "Native Split Commit is unavailable."))
+    }
+
+    @Test func restoredSplitTabIsUnavailableDuringGenericGitOperation() {
+        let state = GGSplitCommitTabState(worktreeId: "wt", targetGGID: "change-2", targetSHA: "abc")
+
+        let presentation = state.presentation(
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true,
+            hasBlockingGitOperation: true
+        )
+
+        #expect(presentation == .unavailable(reason: "Finish the current Git operation before splitting a commit."))
+    }
+
+    @Test func splitDraftSurvivesSwitchingAwayAndBack() {
+        let worktreeID = "gg-split-tabs-draft"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeID)) }
+        let tabs = TabsManager()
+        let id = tabs.openGGSplitCommit(worktreeId: worktreeID, targetGGID: "change-2", targetSHA: "abc")
+        let draft = GGSplitCommitDraft(
+            selectedHunkIDs: ["h-1"],
+            firstMessage: "Extract parser",
+            remainderMessage: "Keep renderer"
+        )
+
+        tabs.updateGGSplitCommitDraft(worktreeId: worktreeID, tabId: id, draft: draft)
+        _ = tabs.appendTerminal(worktreeId: worktreeID, title: "Terminal", sessionId: "session")
+        tabs.activate(worktreeId: worktreeID, tabId: id)
+
+        #expect(tabs.ggSplitCommitDraft(worktreeId: worktreeID, tabId: id) == draft)
+    }
+
+    @Test func restoredSplitTabMatchesStableGGIDAfterTargetSHAIsRewritten() {
+        let state = GGSplitCommitTabState(
+            worktreeId: "wt",
+            targetGGID: "change-2",
+            targetSHA: "abc123"
+        )
+        let matchingStack = GGStack(
+            name: "matching",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: [GGStackEntry(position: 1, sha: "rewritten456", title: "target", ggId: "change-2")]
+        )
+        let otherStack = GGStack(
+            name: "other",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: [GGStackEntry(position: 1, sha: "def456", title: "other")]
+        )
+
+        #expect(state.belongs(to: matchingStack))
+        #expect(!state.belongs(to: otherStack))
+        #expect(!state.belongs(to: nil))
+    }
+
+    @Test func restoredSplitTabWithGGIDRejectsMatchingSHAWithoutThatID() {
+        let state = GGSplitCommitTabState(
+            worktreeId: "wt",
+            targetGGID: "change-2",
+            targetSHA: "abc123"
+        )
+        let stack = GGStack(
+            name: "matching-sha-only",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: [GGStackEntry(position: 1, sha: "abc123def", title: "target")]
+        )
+
+        #expect(!state.belongs(to: stack))
+    }
+
+    @Test func restoredSplitTabWithoutGGIDFallsBackToTargetSHA() {
+        let state = GGSplitCommitTabState(worktreeId: "wt", targetGGID: nil, targetSHA: "abc123")
+        let stack = GGStack(
+            name: "matching-sha",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: [GGStackEntry(position: 1, sha: "abc123def", title: "target")]
+        )
+
+        #expect(state.belongs(to: stack))
+    }
+
+    @Test func targetEntryResolvesMergedStateForRestoredTab() {
+        let state = GGSplitCommitTabState(worktreeId: "wt", targetGGID: "change-2", targetSHA: "abc")
+        let stack = GGStack(
+            name: "merged-target",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 1,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: [GGStackEntry(position: 1, sha: "rewritten456", title: "target", ggId: "change-2", prState: .merged)]
+        )
+
+        #expect(state.targetEntry(in: stack)?.prState == .merged)
+        #expect(state.targetEntry(in: nil) == nil)
+    }
+
+    @Test func matchesSplitTargetByGGIDThenSHA() {
+        let state = GGSplitCommitTabState(worktreeId: "wt", targetGGID: "change-2", targetSHA: "abc")
+
+        // Same GG-ID matches even if the SHA was rewritten.
+        #expect(state.matches(splitTarget: GGSplitTargetIdentity(ggID: "change-2", sha: "rewritten", tree: "t")))
+        // Different GG-ID is another tab's target.
+        #expect(!state.matches(splitTarget: GGSplitTargetIdentity(ggID: "change-9", sha: "abc", tree: "t")))
+
+        // Without a GG-ID on either side, fall back to the SHA.
+        let shaOnly = GGSplitCommitTabState(worktreeId: "wt", targetGGID: nil, targetSHA: "abc")
+        #expect(shaOnly.matches(splitTarget: GGSplitTargetIdentity(ggID: nil, sha: "abc", tree: "t")))
+        #expect(!shaOnly.matches(splitTarget: GGSplitTargetIdentity(ggID: nil, sha: "def", tree: "t")))
+    }
+}

--- a/AlasTests/Integrations/GGCommitMenuModelTests.swift
+++ b/AlasTests/Integrations/GGCommitMenuModelTests.swift
@@ -265,7 +265,7 @@ struct GGCommitMenuModelTests {
         let model = GGCommitMenuModel.make(context: context(capabilities: capabilities))
 
         #expect(model.item(for: .splitCommit)?.isEnabled == false)
-        #expect(model.item(for: .splitCommit)?.disabledReason == "Update GG to split commits in Alas.")
+        #expect(model.item(for: .splitCommit)?.disabledReason == "Update GG to use native Split Commit")
     }
 
     @Test func splitCommitStaysDisabledUntilItsEditorHandlerIsWired() {

--- a/AlasTests/Integrations/GGSplitCommitModelTests.swift
+++ b/AlasTests/Integrations/GGSplitCommitModelTests.swift
@@ -1,0 +1,381 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct GGSplitCommitModelTests {
+    @Test func loadGroupsTextHunksAndKeepsNonTextualFilesInRemainderOnly() async throws {
+        let service = SplitServiceStub(description: .fixture)
+        let model = GGSplitCommitModel(
+            service: service,
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+
+        try await model.load()
+
+        #expect(model.targetSHA == "abc123")
+        #expect(model.targetTree == "tree123")
+        #expect(model.targetGGID == "change-2")
+        #expect(model.planToken == "split-v1-token")
+        #expect(model.fileGroups.map(\.path) == ["Sources/A.swift", "Sources/B.swift", "Assets/logo.png"])
+        #expect(model.fileGroups[0].hunks.map(\.id) == ["h-1", "h-2"])
+        #expect(model.fileGroups[1].hunks.map(\.id) == ["h-3"])
+        #expect(model.fileGroups[2].kind == .remainderOnly)
+        #expect(model.fileGroups[2].hunks.isEmpty)
+        #expect(model.selectedHunkIDs.isEmpty)
+    }
+
+    @Test func fileGroupIDsStayUniqueWhenPathHasTextAndRemainder() async throws {
+        let service = SplitServiceStub(description: .collidingPathFixture)
+        let model = GGSplitCommitModel(
+            service: service,
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+
+        try await model.load()
+
+        let sameA = model.fileGroups.filter { $0.path == "Sources/A.swift" }
+        #expect(sameA.map(\.kind) == [.selectable, .remainderOnly])
+        let ids = model.fileGroups.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test func toggleSelectionAcceptsOnlyDescribedTextHunks() async throws {
+        let model = makeModel()
+        try await model.load()
+
+        model.toggleHunk("h-2")
+        #expect(model.selectedHunkIDs == ["h-2"])
+        model.toggleHunk("h-2")
+        #expect(model.selectedHunkIDs.isEmpty)
+        model.toggleHunk("Assets/logo.png")
+        model.toggleHunk("unknown")
+        #expect(model.selectedHunkIDs.isEmpty)
+    }
+
+    @Test func applyRequiresNonEmptyProperSubset() async throws {
+        let model = GGSplitCommitModel(
+            service: SplitServiceStub(description: .textualOnlyFixture),
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+        try await model.load()
+
+        #expect(throws: GGSplitCommitValidationError.emptySelection) {
+            _ = try model.validatedPlan()
+        }
+
+        model.selectedHunkIDs = Set(model.description.hunks.map(\.id))
+        #expect(throws: GGSplitCommitValidationError.allHunksSelected) {
+            _ = try model.validatedPlan()
+        }
+    }
+
+    @Test func applyAllowsAllTextualHunksWhenNonTextualFilesRemain() async throws {
+        let model = makeModel()
+        try await model.load()
+        model.selectedHunkIDs = Set(model.description.hunks.map(\.id))
+
+        let plan = try model.validatedPlan()
+
+        #expect(plan.selectedHunkIDs == ["h-1", "h-2", "h-3"])
+        #expect(model.remainderPreview.files.isEmpty)
+        #expect(model.remainderPreview.nonTextualFiles == ["Assets/logo.png"])
+    }
+
+    @Test func applyAllowsAllTextualHunksWhenModeOnlyChangeRemains() async throws {
+        let description = GGSplitDescription(
+            version: GGSplitDescription.fixture.version,
+            planToken: GGSplitDescription.fixture.planToken,
+            target: GGSplitDescription.fixture.target,
+            hunks: GGSplitDescription.fixture.hunks,
+            nonTextualFiles: ["Scripts/run.sh"],
+            firstMessage: GGSplitDescription.fixture.firstMessage,
+            remainderMessage: GGSplitDescription.fixture.remainderMessage
+        )
+        let model = GGSplitCommitModel(
+            service: SplitServiceStub(description: description),
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+        try await model.load()
+        model.selectedHunkIDs = Set(model.description.hunks.map(\.id))
+
+        let plan = try model.validatedPlan()
+
+        #expect(plan.selectedHunkIDs == ["h-1", "h-2", "h-3"])
+        #expect(model.remainderPreview.nonTextualFiles == ["Scripts/run.sh"])
+    }
+
+    @Test func loadRestoresSavedSplitDraftForLiveHunks() async throws {
+        let model = GGSplitCommitModel(
+            service: SplitServiceStub(description: .fixture),
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true,
+            initialDraft: GGSplitCommitDraft(
+                selectedHunkIDs: ["h-2", "removed-hunk"],
+                firstMessage: "Extract parser",
+                remainderMessage: "Keep renderer"
+            )
+        )
+
+        try await model.load()
+
+        #expect(model.draft == GGSplitCommitDraft(
+            selectedHunkIDs: ["h-2"],
+            firstMessage: "Extract parser",
+            remainderMessage: "Keep renderer"
+        ))
+    }
+
+    @Test func applyValidatesMessagesIndependentlyAndTrimsThem() async throws {
+        let model = makeModel()
+        try await model.load()
+        model.selectedHunkIDs = ["h-1"]
+
+        model.firstMessage = " \n "
+        model.remainderMessage = "Remainder"
+        #expect(throws: GGSplitCommitValidationError.emptyFirstMessage) {
+            _ = try model.validatedPlan()
+        }
+
+        model.firstMessage = "  First commit  "
+        model.remainderMessage = "\t"
+        #expect(throws: GGSplitCommitValidationError.emptyRemainderMessage) {
+            _ = try model.validatedPlan()
+        }
+
+        model.remainderMessage = "  Remainder commit  "
+        let plan = try model.validatedPlan()
+        #expect(plan.firstMessage == "First commit")
+        #expect(plan.remainderMessage == "Remainder commit")
+    }
+
+    @Test func previewsPartitionTextHunksAndKeepNonTextualFilesInRemainder() async throws {
+        let model = makeModel()
+        try await model.load()
+        model.selectedHunkIDs = ["h-2", "h-3"]
+
+        #expect(model.firstPreview.files.map(\.path) == ["Sources/A.swift", "Sources/B.swift"])
+        #expect(model.firstPreview.files.flatMap(\.hunkIDs) == ["h-2", "h-3"])
+        #expect(model.firstPreview.nonTextualFiles.isEmpty)
+        #expect(model.remainderPreview.files.map(\.path) == ["Sources/A.swift"])
+        #expect(model.remainderPreview.files.flatMap(\.hunkIDs) == ["h-1"])
+        #expect(model.remainderPreview.nonTextualFiles == ["Assets/logo.png"])
+        #expect(model.firstPreview.files[0].diff.hunks.first?.header == "@@ -10 +10 @@")
+    }
+
+    @Test func capabilityDisabledPresentationExplainsRequiredUpdate() {
+        let model = GGSplitCommitModel(
+            service: SplitServiceStub(description: .fixture),
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: false, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+
+        #expect(!model.isAvailable)
+        #expect(model.unavailableReason == "Update GG to use native Split Commit")
+        #expect(!model.canApply)
+    }
+
+    @Test func workflowDisabledPreventsLoadDespiteStructuredSplitCapability() async {
+        let service = SplitServiceStub(description: .fixture)
+        let model = GGSplitCommitModel(
+            service: service,
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: false
+        )
+
+        #expect(!model.isAvailable)
+        #expect(model.unavailableReason == "Native Split Commit is unavailable.")
+        await #expect(throws: GGSplitCommitValidationError.unavailable) {
+            try await model.load()
+        }
+        #expect(service.loadCallCount == 0)
+        #expect(throws: GGSplitCommitValidationError.unavailable) {
+            _ = try model.validatedPlan()
+        }
+    }
+
+    @Test func loadAndApplyErrorPresentationUsesGGServiceUserMessage() {
+        #expect(
+            GGErrorPresentation.message(for: GGServiceError.cliMissing)
+                == "gg is not installed."
+        )
+        #expect(
+            GGErrorPresentation.message(
+                for: GGServiceError.undoRefused(message: "Cannot undo.", hint: "Run gg sync first.")
+            ) == "Cannot undo.\nRun gg sync first."
+        )
+
+        let unrelatedError = CocoaError(.fileReadNoSuchFile)
+        #expect(
+            GGErrorPresentation.message(for: unrelatedError)
+                == unrelatedError.localizedDescription
+        )
+    }
+
+    @Test func applyWritesPrivateAtomicPlanAndDeletesItAfterSuccess() async throws {
+        let service = SplitServiceStub(description: .fixture)
+        let model = GGSplitCommitModel(
+            service: service,
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+        try await model.load()
+        model.selectedHunkIDs = ["h-1"]
+
+        try await model.apply()
+
+        let appliedPlan = try #require(service.appliedPlan)
+        #expect(appliedPlan.selectedHunkIDs == ["h-1"])
+        #expect(service.planExistsDuringApply)
+        #expect(service.planPermissionsDuringApply == 0o600)
+        #expect(service.confirmedIdentity == .fixture)
+        let planURL = try #require(service.planURL)
+        #expect(!FileManager.default.fileExists(atPath: planURL.path))
+        #expect(!FileManager.default.fileExists(atPath: planURL.deletingLastPathComponent().path))
+    }
+
+    @Test func staleApplyPreservesEditablePlanAndDeletesPrivateFile() async throws {
+        let service = SplitServiceStub(
+            description: .fixture,
+            applyError: GGServiceError.staleSplitPlan(message: "stale split plan")
+        )
+        let model = GGSplitCommitModel(
+            service: service,
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+        try await model.load()
+        model.selectedHunkIDs = ["h-1"]
+        model.firstMessage = "Extract parser"
+        model.remainderMessage = "Keep renderer"
+
+        await #expect(throws: GGServiceError.staleSplitPlan(message: "stale split plan")) {
+            try await model.apply()
+        }
+
+        #expect(model.selectedHunkIDs == ["h-1"])
+        #expect(model.firstMessage == "Extract parser")
+        #expect(model.remainderMessage == "Keep renderer")
+        let planURL = try #require(service.planURL)
+        #expect(!FileManager.default.fileExists(atPath: planURL.path))
+        #expect(!FileManager.default.fileExists(atPath: planURL.deletingLastPathComponent().path))
+    }
+
+    private func makeModel() -> GGSplitCommitModel {
+        GGSplitCommitModel(
+            service: SplitServiceStub(description: .fixture),
+            target: .fixture,
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+    }
+}
+
+@MainActor
+private final class SplitServiceStub: GGSplitCommitServicing {
+    let description: GGSplitDescription
+    let applyError: Error?
+    private(set) var planURL: URL?
+    private(set) var appliedPlan: GGSplitPlan?
+    private(set) var planExistsDuringApply = false
+    private(set) var planPermissionsDuringApply: Int?
+    private(set) var confirmedIdentity: GGStackIdentity?
+    private(set) var loadCallCount = 0
+
+    init(description: GGSplitDescription, applyError: Error? = nil) {
+        self.description = description
+        self.applyError = applyError
+    }
+
+    func loadDescription(target: GGSplitCommitTarget) async throws -> GGSplitLoadedDescription {
+        loadCallCount += 1
+        #expect(target == .fixture)
+        return GGSplitLoadedDescription(description: description, stackIdentity: .fixture)
+    }
+
+    func applySplit(
+        planURL: URL,
+        target: GGSplitTargetIdentity,
+        planToken: String,
+        confirmedAgainst identity: GGStackIdentity
+    ) async throws {
+        self.planURL = planURL
+        confirmedIdentity = identity
+        planExistsDuringApply = FileManager.default.fileExists(atPath: planURL.path)
+        planPermissionsDuringApply = (try? FileManager.default.attributesOfItem(atPath: planURL.path)[.posixPermissions]) as? Int
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        appliedPlan = try decoder.decode(GGSplitPlan.self, from: Data(contentsOf: planURL))
+        #expect(target == description.target)
+        #expect(planToken == description.planToken)
+        if let applyError { throw applyError }
+    }
+}
+
+private extension GGSplitCommitTarget {
+    static let fixture = GGSplitCommitTarget(
+        worktreeId: "wt",
+        targetGGID: "change-2",
+        targetSHA: "abc123"
+    )
+}
+
+private extension GGStackIdentity {
+    static let fixture = GGStackIdentity(
+        stackName: "stack",
+        base: "main",
+        headSHA: "head",
+        operationID: nil
+    )
+}
+
+private extension GGSplitDescription {
+    static let fixture = GGSplitDescription(
+        version: 1,
+        planToken: "split-v1-token",
+        target: GGSplitTargetIdentity(ggID: "change-2", sha: "abc123", tree: "tree123"),
+        hunks: [
+            GGSplitHunk(id: "h-1", path: "Sources/A.swift", header: "@@ -1 +1 @@", patch: "-old one\n+new one\n"),
+            GGSplitHunk(id: "h-2", path: "Sources/A.swift", header: "@@ -10 +10 @@", patch: "-old two\n+new two\n"),
+            GGSplitHunk(id: "h-3", path: "Sources/B.swift", header: "@@ -2 +2 @@", patch: "-before\n+after\n"),
+        ],
+        nonTextualFiles: ["Assets/logo.png"],
+        firstMessage: "First commit",
+        remainderMessage: "Remainder commit"
+    )
+
+    static let collidingPathFixture = GGSplitDescription(
+        version: 1,
+        planToken: fixture.planToken,
+        target: fixture.target,
+        hunks: [
+            GGSplitHunk(id: "h-1", path: "Sources/A.swift", header: "@@ -1 +1 @@", patch: "-old\n+new\n"),
+        ],
+        nonTextualFiles: ["Sources/A.swift"],
+        firstMessage: fixture.firstMessage,
+        remainderMessage: fixture.remainderMessage
+    )
+
+    static let textualOnlyFixture = GGSplitDescription(
+        version: fixture.version,
+        planToken: fixture.planToken,
+        target: fixture.target,
+        hunks: fixture.hunks,
+        nonTextualFiles: [],
+        firstMessage: fixture.firstMessage,
+        remainderMessage: fixture.remainderMessage
+    )
+}


### PR DESCRIPTION
## What

- Adds the native Split Commit editor and its tab lifecycle.
- Keeps an open split editor associated with a stack commit by GG ID across SHA rewrites.

## Validation

- `GGSplitCommitModelTests`
- `GGSplitTabsManagerTests`

## Stack

- Builds on #874.

<!-- gg:managed:start -->
Part of stack `prepare-gg`

Commit: 5959280
<!-- gg:managed:end -->