### PR TITLE
feat(gg): add native stack lifecycle workflows

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -786,6 +786,7 @@
 		9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */; };
 		965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B133843C0559BBD6E769ABB8 /* ACPManagerAccessorsTests.swift */; };
 		9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */; };
+		969E735EC4826E875A0862D5 /* GGRestackSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152EB5D0C23CAEB13283C634 /* GGRestackSheet.swift */; };
 		96BE44DEEDA6FDF72BD51173 /* ACPReconnectPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D020BC9CC6586ECAB8A38042 /* ACPReconnectPolicy.swift */; };
 		9707DC02317F0E92AB06196B /* ImageDiffModeApplicabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */; };
 		970B6BCA824C6AF4DA812946 /* ProcessMemoryProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AA350F5909E28954C623B7 /* ProcessMemoryProbe.swift */; };
@@ -1286,6 +1287,7 @@
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		EF276F4856AA2E82C2ECDC7E /* CodeHostModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C5E43E973803E6FD1528C /* CodeHostModels.swift */; };
+		F0440F0D4E6B9BD0ACD7B0C9 /* GGReorderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111B9EB86E55850C982CEEFA /* GGReorderSheet.swift */; };
 		F04E4353813EB99D4459750F /* ReviewRequestDiffLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0A56D300AE7380A16F1D42 /* ReviewRequestDiffLoader.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F098EBE9088B2EE1DAAF1BFD /* WorktreePathTemplateRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */; };
@@ -1465,6 +1467,7 @@
 		107D334C822CF40697E7F15B /* AlasCLIEnvInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIEnvInjection.swift; sourceTree = "<group>"; };
 		10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostCapabilities.swift; sourceTree = "<group>"; };
 		10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalMessages.swift; sourceTree = "<group>"; };
+		111B9EB86E55850C982CEEFA /* GGReorderSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGReorderSheet.swift; sourceTree = "<group>"; };
 		11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClientTests.swift; sourceTree = "<group>"; };
 		11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTerminalLaunchTests.swift; sourceTree = "<group>"; };
 		11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateFocusMainWorktreeTests.swift; sourceTree = "<group>"; };
@@ -1486,6 +1489,7 @@
 		14CEB6C5C076B4147D587909 /* ReviewThreadMutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewThreadMutations.swift; sourceTree = "<group>"; };
 		14D1ECA099BBDCB5BB2EEC67 /* DiffReviewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewModels.swift; sourceTree = "<group>"; };
 		1513AFD842F4CF16F8DEEA31 /* ChangesPreparationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationCard.swift; sourceTree = "<group>"; };
+		152EB5D0C23CAEB13283C634 /* GGRestackSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGRestackSheet.swift; sourceTree = "<group>"; };
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionChecker.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
@@ -4939,6 +4943,8 @@
 				CCB8945B6B3ECFCD8BA28B82 /* GGMutationCoordinator.swift */,
 				993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */,
 				1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */,
+				111B9EB86E55850C982CEEFA /* GGReorderSheet.swift */,
+				152EB5D0C23CAEB13283C634 /* GGRestackSheet.swift */,
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */,
 				43E189D66411992DFC659CBF /* GGSplitCommitTabView.swift */,
@@ -5664,6 +5670,8 @@
 				99B188A81AF135564ED9EE17 /* GGMutationCoordinator.swift in Sources */,
 				04D55B4985BDF4CEF0BA3C0E /* GGMutationModels.swift in Sources */,
 				A95EC5D1544C32B61DE0B2C9 /* GGProjectMode.swift in Sources */,
+				F0440F0D4E6B9BD0ACD7B0C9 /* GGReorderSheet.swift in Sources */,
+				969E735EC4826E875A0862D5 /* GGRestackSheet.swift in Sources */,
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				B7F9949C9F8915C07A80F7C4 /* GGSplitCommitModel.swift in Sources */,
 				084E0061691FD9F495E8209B /* GGSplitCommitTabView.swift in Sources */,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -543,6 +543,46 @@ private struct RootGGPresentationHandlers: ViewModifier {
                 }
                 .environment(\.theme, state.themeStore.current)
             }
+            .sheet(
+                item: Binding(
+                    get: { state.rightPaneStore.stateWithPendingGGReorder()?.pendingGGReorder },
+                    set: { if $0 == nil { state.rightPaneStore.stateWithPendingGGReorder()?.cancelGGReorder() } }
+                )
+            ) { presentation in
+                GGReorderSheet(
+                    presentation: presentation,
+                    onApply: { model in
+                        guard let owner = state.rightPaneStore.stateWithPendingGGReorder() else {
+                            throw GGMutationError.staleConfirmation
+                        }
+                        try await owner.submitGGReorder(model)
+                    },
+                    onCancel: {
+                        state.rightPaneStore.stateWithPendingGGReorder()?.cancelGGReorder()
+                    }
+                )
+                .environment(\.theme, state.themeStore.current)
+            }
+            .sheet(
+                item: Binding(
+                    get: { state.rightPaneStore.stateWithPendingGGRestack()?.pendingGGRestack },
+                    set: { if $0 == nil { state.rightPaneStore.stateWithPendingGGRestack()?.cancelGGRestack() } }
+                )
+            ) { presentation in
+                GGRestackSheet(
+                    presentation: presentation,
+                    onApply: {
+                        guard let currentOwner = state.rightPaneStore.stateWithPendingGGRestack() else {
+                            throw GGMutationError.staleConfirmation
+                        }
+                        try await currentOwner.submitGGRestack()
+                    },
+                    onCancel: {
+                        state.rightPaneStore.stateWithPendingGGRestack()?.cancelGGRestack()
+                    }
+                )
+                .environment(\.theme, state.themeStore.current)
+            }
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 
 @MainActor
 struct GGMutationContext {
@@ -10,6 +11,8 @@ struct GGMutationContext {
     var worktreeExists: () -> Bool
     var invalidateInbox: () -> Void
     var selectWorktreeAtPath: (String) async -> Void
+    /// The worktree's current branch, used to scope final-drop undo recovery.
+    var currentBranch: () -> String?
 }
 
 enum GGMutationExecutionResult {
@@ -20,31 +23,36 @@ enum GGMutationExecutionResult {
     case split(GGSplitApplyResult)
 }
 
-private enum GGUndoBaseline {
-    case unavailable
-    case operationID(String?)
-}
-
 @MainActor
 protocol GGMutationExecuting {
     func execute(
         _ request: GGMutationRequest,
         worktreePath: String,
+        clientOperationID: String?,
         onSyncEvent: (GGSyncEvent) -> Void
     ) async throws -> GGMutationExecutionResult
     func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary]
+    func previewRestack(worktreePath: String) async throws -> GGRestackResult
 }
 
 @MainActor
+@Observable
 final class GGMutationCoordinator {
     private let worktreeId: String
     private let worktreePath: String
     private let service: any GGMutationExecuting
     private let actionState: GGStackActionState
     private let undoMarkerStore: any GGUndoMarkerStoring
+    private let clientOperationIDCapability: () -> Bool
+    private let clientOperationIDGenerator: () -> String
     private let context: GGMutationContext
 
     private(set) var activeRequest: GGMutationRequest?
+    private(set) var undoCandidate: GGUndoCandidate?
+
+    var hasUndoStateToReconcile: Bool {
+        undoCandidate != nil || undoMarkerStore.marker(worktreeId: worktreeId) != nil
+    }
 
     init(
         worktreeId: String,
@@ -52,6 +60,12 @@ final class GGMutationCoordinator {
         service: any GGMutationExecuting,
         actionState: GGStackActionState,
         undoMarkerStore: any GGUndoMarkerStoring = GGUndoMarkerStore(),
+        clientOperationIDCapability: @escaping () -> Bool = {
+            GGAvailability.shared.capabilities.clientOperationID
+        },
+        clientOperationIDGenerator: @escaping () -> String = {
+            "alas:\(UUID().uuidString)"
+        },
         context: GGMutationContext
     ) {
         self.worktreeId = worktreeId
@@ -59,6 +73,8 @@ final class GGMutationCoordinator {
         self.service = service
         self.actionState = actionState
         self.undoMarkerStore = undoMarkerStore
+        self.clientOperationIDCapability = clientOperationIDCapability
+        self.clientOperationIDGenerator = clientOperationIDGenerator
         self.context = context
     }
 
@@ -69,6 +85,80 @@ final class GGMutationCoordinator {
 
         let snapshot = try await context.loadFreshStack()
         return try preflight(request, snapshot: snapshot)
+    }
+
+    func prepareRestackPreview() async throws -> GGPreparedRestack {
+        guard activeRequest == nil else { throw GGMutationError.operationInFlight }
+        activeRequest = .restack
+        defer { activeRequest = nil }
+
+        let before = try await context.loadFreshStack()
+        let prepared = try preflight(.restack, snapshot: before)
+        let plan = try await service.previewRestack(worktreePath: worktreePath)
+        guard plan.dryRun, plan.stackName == prepared.snapshot.stackName else {
+            throw GGServiceError.malformedOutput("gg returned a restack plan for a different stack.")
+        }
+        let after = try await context.loadFreshStack()
+        guard after.identity == prepared.snapshot else {
+            throw GGMutationError.staleConfirmation
+        }
+        return GGPreparedRestack(plan: plan, snapshot: prepared.snapshot)
+    }
+
+    func restoreUndoCandidate(currentStackName: String?) async {
+        guard let marker = undoMarkerStore.marker(worktreeId: worktreeId) else {
+            undoCandidate = nil
+            return
+        }
+        guard currentStackName != nil || marker.removedFinalStackCommit else {
+            undoCandidate = nil
+            undoMarkerStore.clear(worktreeId: worktreeId)
+            return
+        }
+        guard isRecoveryInScope(currentStackName: currentStackName, marker: marker) else {
+            undoCandidate = nil
+            undoMarkerStore.clear(worktreeId: worktreeId)
+            return
+        }
+        do {
+            let newest = try await service.listUndoOperations(worktreePath: worktreePath, limit: 1).first
+            guard let newest,
+                  newest.id == marker.operationID,
+                  newest.matchesUndoScope(currentStackName: currentStackName, marker: marker),
+                  newest.status == .completed,
+                  newest.isUndoable,
+                  !newest.touchedRemote,
+                  !newest.isUndo,
+                  newest.isSafeLocalRewrite,
+                  newest.hasAlasClientOperationID
+            else {
+                undoCandidate = nil
+                undoMarkerStore.clear(worktreeId: worktreeId)
+                return
+            }
+            undoCandidate = GGUndoCandidate(operation: newest)
+        } catch {
+            undoCandidate = nil
+        }
+    }
+
+    /// A final-drop recovery leaves the stack empty, so `currentStackName` is
+    /// nil both on the branch where the drop happened and on any other branch
+    /// the user later checks out. Scope it to the recorded branch so the
+    /// recovery isn't offered (or run) against an unrelated branch. Markers
+    /// without a recorded branch (legacy) keep the prior behavior.
+    private func isRecoveryInScope(currentStackName: String?, marker: GGUndoMarker) -> Bool {
+        guard currentStackName == nil, let markerBranch = marker.branch else { return true }
+        return markerBranch == context.currentBranch()
+    }
+
+    func clearUndoCandidate() {
+        undoCandidate = nil
+        undoMarkerStore.clear(worktreeId: worktreeId)
+    }
+
+    func suspendUndoCandidate() {
+        undoCandidate = nil
     }
 
     func apply(_ request: GGMutationRequest, confirmedAgainst identity: GGStackIdentity?) async throws {
@@ -133,38 +223,63 @@ final class GGMutationCoordinator {
             guard isRecoveryRequest else { throw error }
             snapshot = nil
         }
-
-        if isRecoveryRequest {
+        let continuedOperationID: String?
+        switch request {
+        case .continueOperation, .abortOperation:
             if let identity, snapshot?.identity != identity {
                 throw GGMutationError.staleConfirmation
             }
-        } else {
+            continuedOperationID = snapshot?.operationID
+        case .undo:
+            if let identity, snapshot?.identity != identity {
+                throw GGMutationError.staleConfirmation
+            }
+            continuedOperationID = nil
+        default:
             guard let snapshot else { throw GGMutationError.staleConfirmation }
             let prepared = try preflight(request, snapshot: snapshot)
             if let identity, prepared.snapshot != identity {
                 throw GGMutationError.staleConfirmation
             }
+            if let confirmation, prepared.confirmation != confirmation {
+                throw GGMutationError.staleConfirmation
+            }
+            continuedOperationID = prepared.snapshot.operationID
+        }
+        try await validateUndoRequest(request, currentStackName: snapshot?.stack?.name)
+        if !request.isUndo {
+            undoCandidate = nil
+            undoMarkerStore.clear(worktreeId: worktreeId)
         }
 
-        let undoBaseline = isRecoveryRequest
-            ? GGUndoBaseline.unavailable
-            : await captureUndoBaseline(for: request)
-        undoMarkerStore.clear(worktreeId: worktreeId)
+        let clientOperationID = request.generatesClientOperationID && clientOperationIDCapability()
+            ? clientOperationIDGenerator()
+            : nil
         GGStackGate.markAlasGGOperationInProgress(repoPath: worktreePath)
 
         do {
             let result = try await service.execute(
                 request,
                 worktreePath: worktreePath,
+                clientOperationID: clientOperationID,
                 onSyncEvent: { [actionState] event in
                     actionState.appendSyncEvent(event)
                     if case .error(let message) = event { actionState.setError(message) }
                 }
             )
+            await recordUndoMarker(
+                after: request,
+                result: result,
+                clientOperationID: clientOperationID,
+                continuedOperationID: continuedOperationID
+            )
             recordSummary(for: request, result: result)
             reconcilePausedState(after: request, error: nil)
             await refresh(after: request, result: result)
-            await recordUndoMarker(after: request, baseline: undoBaseline)
+            if request.isUndo {
+                undoCandidate = nil
+                undoMarkerStore.clear(worktreeId: worktreeId)
+            }
         } catch let error as GGServiceError {
             reconcilePausedState(after: request, error: error)
             await refresh(after: request, result: .none)
@@ -234,8 +349,79 @@ final class GGMutationCoordinator {
         case .applySplit(_, let identity, _):
             let target = stack.splitTarget(matching: identity)
             guard target != nil else { throw GGMutationError.staleConfirmation }
+        case .reorder(let order):
+            let orderedEntries = stack.entries.sorted(by: { $0.position < $1.position })
+            let exactIDs = orderedEntries.compactMap(\.ggId)
+            guard exactIDs.count == stack.entries.count,
+                  order.count == exactIDs.count,
+                  Set(order).count == order.count,
+                  Set(order) == Set(exactIDs)
+            else { throw GGMutationError.staleConfirmation }
+            for (index, id) in exactIDs.enumerated()
+            where orderedEntries[index].prState == .merged && order[index] != id {
+                throw GGMutationError.immutableTarget(
+                    reason: "Merged commits must remain fixed while reordering."
+                )
+            }
+            try validateReorderRegionMembership(
+                originalIDs: exactIDs,
+                submittedIDs: order,
+                entries: orderedEntries
+            )
         default:
             break
+        }
+    }
+
+    private func validateReorderRegionMembership(
+        originalIDs: [String],
+        submittedIDs: [String],
+        entries: [GGStackEntry]
+    ) throws {
+        var regionStart = 0
+        for index in 0...entries.count {
+            let isBoundary = index == entries.count || entries[index].prState == .merged
+            guard isBoundary else { continue }
+            if regionStart < index,
+               Set(originalIDs[regionStart..<index]) != Set(submittedIDs[regionStart..<index]) {
+                throw GGMutationError.immutableTarget(
+                    reason: "Commits cannot move across an immutable boundary."
+                )
+            }
+            regionStart = index + 1
+        }
+    }
+
+    private func validateUndoRequest(
+        _ request: GGMutationRequest,
+        currentStackName: String?
+    ) async throws {
+        guard case .undo(let operationID) = request else { return }
+        guard let marker = undoMarkerStore.marker(worktreeId: worktreeId),
+              marker.operationID == operationID
+        else {
+            undoCandidate = nil
+            undoMarkerStore.clear(worktreeId: worktreeId)
+            throw GGMutationError.staleConfirmation
+        }
+        guard isRecoveryInScope(currentStackName: currentStackName, marker: marker) else {
+            undoCandidate = nil
+            undoMarkerStore.clear(worktreeId: worktreeId)
+            throw GGMutationError.staleConfirmation
+        }
+        let newest = try await service.listUndoOperations(worktreePath: worktreePath, limit: 1).first
+        guard let newest,
+              newest.id == operationID,
+              newest.matchesUndoScope(currentStackName: currentStackName, marker: marker),
+              newest.status == .completed,
+              newest.isUndoable,
+              !newest.touchedRemote,
+              !newest.isUndo,
+              newest.isSafeLocalRewrite
+        else {
+            undoCandidate = nil
+            undoMarkerStore.clear(worktreeId: worktreeId)
+            throw GGMutationError.staleConfirmation
         }
     }
 
@@ -365,26 +551,52 @@ final class GGMutationCoordinator {
         }
     }
 
-    private func captureUndoBaseline(for request: GGMutationRequest) async -> GGUndoBaseline {
-        guard !request.touchesRemote else { return .unavailable }
-        do {
-            let operationID = try await service.listUndoOperations(worktreePath: worktreePath, limit: 1).first?.id
-            return .operationID(operationID)
-        } catch {
-            return .unavailable
-        }
-    }
+    private func recordUndoMarker(
+        after request: GGMutationRequest,
+        result: GGMutationExecutionResult,
+        clientOperationID: String?,
+        continuedOperationID: String?
+    ) async {
+        guard request.recordsUndoCandidate else { return }
 
-    private func recordUndoMarker(after request: GGMutationRequest, baseline: GGUndoBaseline) async {
-        guard !request.touchesRemote,
-              case .operationID(let previousOperationID) = baseline,
-              let newest = (try? await service.listUndoOperations(worktreePath: worktreePath, limit: 1))?.first,
-              newest.id != previousOperationID,
+        let matchesRequest: (GGOperationSummary) -> Bool
+        if request == .continueOperation {
+            guard let continuedOperationID else { return }
+            matchesRequest = {
+                $0.id == continuedOperationID && $0.hasAlasClientOperationID
+            }
+        } else {
+            guard let clientOperationID else { return }
+            matchesRequest = { $0.hasClientOperationID(clientOperationID) }
+        }
+
+        guard let newest = (try? await service.listUndoOperations(
+                  worktreePath: worktreePath,
+                  limit: 1
+              ))?.first,
+              newest.stackName != nil,
               newest.status == .completed,
               newest.isUndoable,
-              !newest.touchedRemote
+              !newest.touchedRemote,
+              !newest.isUndo,
+              newest.isSafeLocalRewrite
         else { return }
-        undoMarkerStore.set(operationID: newest.id, worktreeId: worktreeId)
+        guard matchesRequest(newest) else { return }
+
+        let removedFinalStackCommit = if case .drop(let drop) = result {
+            drop.remaining == 0
+        } else {
+            false
+        }
+        undoMarkerStore.set(
+            GGUndoMarker(
+                operationID: newest.id,
+                removedFinalStackCommit: removedFinalStackCommit,
+                branch: context.currentBranch()
+            ),
+            worktreeId: worktreeId
+        )
+        undoCandidate = GGUndoCandidate(operation: newest)
     }
 }
 
@@ -415,6 +627,26 @@ private extension GGMutationRequest {
         default: false
         }
     }
+
+    var recordsUndoCandidate: Bool {
+        switch self {
+        case .amendCurrent, .absorbStaged, .drop, .reorder, .restack,
+             .rebase, .continueOperation, .applySplit:
+            true
+        default:
+            false
+        }
+    }
+
+    var generatesClientOperationID: Bool {
+        switch self {
+        case .amendCurrent, .absorbStaged, .drop, .reorder, .restack,
+             .rebase, .applySplit:
+            true
+        default:
+            false
+        }
+    }
 }
 
 private extension GGStack {
@@ -434,45 +666,104 @@ extension GGService: GGMutationExecuting {
     func execute(
         _ request: GGMutationRequest,
         worktreePath: String,
+        clientOperationID: String?,
         onSyncEvent: (GGSyncEvent) -> Void
     ) async throws -> GGMutationExecutionResult {
+        let service = clientOperationID.map {
+            GGService(runner: GGClientOperationRunner(base: runner, clientOperationID: $0))
+        } ?? self
         switch request {
         case .amendCurrent:
-            try await amendCurrent(worktreePath: worktreePath)
+            try await service.amendCurrent(worktreePath: worktreePath)
         case .absorbStaged:
-            try await absorbStaged(worktreePath: worktreePath)
+            try await service.absorbStaged(worktreePath: worktreePath)
         case .checkout(let target):
-            try await checkout(worktreePath: worktreePath, target: target)
+            try await service.checkout(worktreePath: worktreePath, target: target)
         case .drop(let target):
-            _ = try await drop(worktreePath: worktreePath, target: target)
+            return .drop(try await service.drop(worktreePath: worktreePath, target: target))
         case .unstack(let target, let name, let createWorktree):
-            return .unstack(try await unstack(
+            return .unstack(try await service.unstack(
                 worktreePath: worktreePath,
                 target: target,
                 name: name,
                 createWorktree: createWorktree
             ))
         case .reorder(let order):
-            try await reorder(worktreePath: worktreePath, order: order)
+            try await service.reorder(worktreePath: worktreePath, order: order)
         case .restack:
-            _ = try await restack(worktreePath: worktreePath, dryRun: false)
+            _ = try await service.restack(worktreePath: worktreePath, dryRun: false)
         case .rebase(let target):
-            try await rebase(worktreePath: worktreePath, target: target)
+            try await service.rebase(worktreePath: worktreePath, target: target)
         case .sync:
-            for try await event in sync(worktreePath: worktreePath) { onSyncEvent(event) }
+            for try await event in service.sync(worktreePath: worktreePath) { onSyncEvent(event) }
         case .land(let target):
-            return .land(try await land(worktreePath: worktreePath, until: target))
+            return .land(try await service.land(worktreePath: worktreePath, until: target))
         case .clean:
-            try await clean(worktreePath: worktreePath)
+            try await service.clean(worktreePath: worktreePath)
         case .continueOperation:
-            try await continueOp(worktreePath: worktreePath)
+            try await service.continueOp(worktreePath: worktreePath)
         case .abortOperation:
-            try await abortOp(worktreePath: worktreePath)
+            try await service.abortOp(worktreePath: worktreePath)
         case .undo(let operationID):
-            _ = try await undo(worktreePath: worktreePath, operationID: operationID)
+            _ = try await service.undo(worktreePath: worktreePath, operationID: operationID)
         case .applySplit(let planURL, _, _):
-            return .split(try await applySplit(worktreePath: worktreePath, planURL: planURL))
+            return .split(try await service.applySplit(worktreePath: worktreePath, planURL: planURL))
         }
         return .none
+    }
+
+    func previewRestack(worktreePath: String) async throws -> GGRestackResult {
+        try await restack(worktreePath: worktreePath, dryRun: true)
+    }
+}
+
+private struct GGClientOperationRunner: GGCommandRunning {
+    let base: any GGCommandRunning
+    let clientOperationID: String
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        try await base.run(
+            args: ["--client-operation-id", clientOperationID] + args,
+            cwd: cwd
+        )
+    }
+
+    func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
+        base.runStreaming(
+            args: ["--client-operation-id", clientOperationID] + args,
+            cwd: cwd
+        )
+    }
+}
+
+private extension GGOperationSummary {
+    func matchesUndoScope(currentStackName: String?, marker: GGUndoMarker) -> Bool {
+        if let currentStackName {
+            return stackName == currentStackName
+        }
+        return marker.removedFinalStackCommit && kind == "drop" && stackName != nil
+    }
+
+    var isSafeLocalRewrite: Bool {
+        switch kind {
+        case "squash", "absorb", "drop", "reorder", "restack", "rebase", "split":
+            true
+        default:
+            false
+        }
+    }
+
+    func hasClientOperationID(_ clientOperationID: String) -> Bool {
+        guard args.count >= 2 else { return false }
+        return args.indices.dropLast().contains { index in
+            args[index] == "--client-operation-id" && args[index + 1] == clientOperationID
+        }
+    }
+
+    var hasAlasClientOperationID: Bool {
+        guard args.count >= 2 else { return false }
+        return args.indices.dropLast().contains { index in
+            args[index] == "--client-operation-id" && args[index + 1].hasPrefix("alas:")
+        }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -14,6 +14,15 @@ struct GGCapabilities: Equatable, Sendable {
     var stagedOnlyAmend: Bool = false
 }
 
+struct GGLocalChangeStatistics: Equatable, Sendable {
+    var staged: Int
+    var unstaged: Int
+
+    static let zero = GGLocalChangeStatistics(staged: 0, unstaged: 0)
+
+    var hasChanges: Bool { staged > 0 || unstaged > 0 }
+}
+
 enum GGMutationRequest: Equatable, Sendable {
     case amendCurrent
     case absorbStaged
@@ -65,6 +74,11 @@ struct GGPreparedMutation: Equatable, Sendable {
     var confirmation: GGMutationConfirmation?
 }
 
+struct GGPreparedRestack: Equatable, Sendable {
+    var plan: GGRestackResult
+    var snapshot: GGStackIdentity
+}
+
 enum GGMutationConfirmation: Equatable, Sendable {
     case drop(target: String, rewrittenDescendants: Int, hasOpenReview: Bool)
     case unstack(
@@ -103,6 +117,7 @@ enum GGMutationError: Error, Equatable {
     case staleConfirmation
     case immutableTarget(reason: String)
     case pausedOperation
+    case blockingGitOperation
 }
 
 extension GGMutationError: LocalizedError {
@@ -112,6 +127,7 @@ extension GGMutationError: LocalizedError {
         case .staleConfirmation: "The stack changed. Review the updated state and try again."
         case .immutableTarget(let reason): reason
         case .pausedOperation: "Continue or abort the paused gg operation first."
+        case .blockingGitOperation: "Finish the current Git operation first."
         }
     }
 }
@@ -260,6 +276,22 @@ struct GGOperationSummary: Codable, Equatable, Sendable {
 
 struct GGUndoResult: Codable, Equatable, Sendable {
     let undone: GGOperationSummary
+}
+
+struct GGUndoCandidate: Equatable, Sendable {
+    let operationID: String
+    let kind: String
+    let status: GGOperationStatus
+    let touchedRemote: Bool
+    let isUndoable: Bool
+
+    init(operation: GGOperationSummary) {
+        operationID = operation.id
+        kind = operation.kind
+        status = operation.status
+        touchedRemote = operation.touchedRemote
+        isUndoable = operation.isUndoable
+    }
 }
 
 struct GGSplitTargetIdentity: Codable, Equatable, Sendable {

--- a/Alas/Sources/Integrations/GG/GGReorderSheet.swift
+++ b/Alas/Sources/Integrations/GG/GGReorderSheet.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+enum GGReorderMoveResult: Equatable {
+    case moved
+    case immutableBoundary
+}
+
+enum GGReorderSheetAction: Equatable {
+    case apply
+    case cancel
+}
+
+struct GGReorderEntry: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let isMutable: Bool
+
+    static func mutable(id: String, title: String) -> GGReorderEntry {
+        GGReorderEntry(id: id, title: title, isMutable: true)
+    }
+
+    static func immutable(id: String, title: String) -> GGReorderEntry {
+        GGReorderEntry(id: id, title: title, isMutable: false)
+    }
+}
+
+struct GGReorderModel: Equatable {
+    private(set) var entries: [GGReorderEntry]
+    private let originalIDs: [String]
+
+    init(entries: [GGReorderEntry]) {
+        self.entries = entries
+        originalIDs = entries.map(\.id)
+    }
+
+    var orderedIDs: [String] { entries.map(\.id) }
+    var hasChanges: Bool { orderedIDs != originalIDs }
+    var availableActions: [GGReorderSheetAction] { [.apply, .cancel] }
+
+    mutating func move(from source: Int, to destination: Int) -> GGReorderMoveResult {
+        guard entries.indices.contains(source),
+              entries.startIndex...entries.endIndex ~= destination,
+              entries[source].isMutable
+        else { return .immutableBoundary }
+        let region = mutableRegion(containing: source)
+        let target = destination == region.upperBound + 1 ? region.upperBound : destination
+        guard region.contains(target) else { return .immutableBoundary }
+        guard source != destination else { return .moved }
+        let entry = entries.remove(at: source)
+        entries.insert(entry, at: target)
+        return .moved
+    }
+
+    private func mutableRegion(containing index: Int) -> ClosedRange<Int> {
+        var lower = index
+        var upper = index
+        while lower > entries.startIndex, entries[lower - 1].isMutable { lower -= 1 }
+        while upper + 1 < entries.endIndex, entries[upper + 1].isMutable { upper += 1 }
+        return lower...upper
+    }
+}
+
+struct GGReorderPresentation: Equatable, Identifiable {
+    let snapshot: GGStackIdentity
+    var model: GGReorderModel
+
+    var id: String { "\(snapshot.stackName):\(snapshot.headSHA)" }
+}
+
+struct GGReorderSheet: View {
+    let presentation: GGReorderPresentation
+    let onApply: (GGReorderModel) async throws -> Void
+    let onCancel: () -> Void
+
+    @Environment(\.theme) private var theme
+    @Environment(\.dismiss) private var dismiss
+    @State private var model: GGReorderModel
+    @State private var isApplying = false
+    @State private var errorMessage: String?
+
+    init(
+        presentation: GGReorderPresentation,
+        onApply: @escaping (GGReorderModel) async throws -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.presentation = presentation
+        self.onApply = onApply
+        self.onCancel = onCancel
+        _model = State(initialValue: presentation.model)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Reorder Stack")
+                .font(.system(size: 16, weight: .semibold))
+            Text("Drag commits within each mutable section.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(theme.color("fg-dim"))
+
+            List {
+                ForEach(model.entries) { entry in
+                    HStack(spacing: 10) {
+                        Image(systemName: entry.isMutable ? "line.3.horizontal" : "lock.fill")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(theme.color("fg-faint"))
+                            .frame(width: 16, height: 16)
+                        Text(entry.title)
+                            .font(.system(size: 12.5))
+                            .lineLimit(1)
+                        Spacer(minLength: 8)
+                        Text(entry.id)
+                            .font(.system(size: 10.5, design: .monospaced))
+                            .foregroundStyle(theme.color("fg-faint"))
+                            .lineLimit(1)
+                    }
+                    .frame(height: 30)
+                    .moveDisabled(!entry.isMutable)
+                }
+                .onMove { offsets, destination in
+                    guard let source = offsets.first else { return }
+                    let target = min(
+                        max(0, destination > source ? destination - 1 : destination),
+                        model.entries.count - 1
+                    )
+                    _ = model.move(from: source, to: target)
+                }
+            }
+            .listStyle(.bordered(alternatesRowBackgrounds: true))
+            .frame(minWidth: 500, minHeight: 260)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("warn"))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Cancel") {
+                    onCancel()
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                .disabled(isApplying)
+                Button("Apply") { apply() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!model.hasChanges || isApplying)
+            }
+        }
+        .padding(18)
+        .interactiveDismissDisabled(isApplying)
+    }
+
+    private func apply() {
+        guard model.hasChanges, !isApplying else { return }
+        isApplying = true
+        errorMessage = nil
+        Task { @MainActor in
+            do {
+                try await onApply(model)
+                dismiss()
+            } catch {
+                errorMessage = GGErrorPresentation.message(for: error)
+                isApplying = false
+            }
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGRestackSheet.swift
+++ b/Alas/Sources/Integrations/GG/GGRestackSheet.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct GGRestackPresentation: Equatable, Identifiable {
+    let prepared: GGPreparedRestack
+
+    var id: String {
+        "\(prepared.snapshot.stackName):\(prepared.snapshot.headSHA)"
+    }
+
+    var hasWork: Bool {
+        prepared.plan.entriesRestacked > 0 || prepared.plan.steps.contains { $0.action != "ok" }
+    }
+}
+
+struct GGRestackSheet: View {
+    let presentation: GGRestackPresentation
+    let onApply: () async throws -> Void
+    let onCancel: () -> Void
+
+    @Environment(\.theme) private var theme
+    @Environment(\.dismiss) private var dismiss
+    @State private var isApplying = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Restack")
+                .font(.system(size: 16, weight: .semibold))
+            Text(presentation.hasWork
+                 ? "Review the rewrite plan before applying it."
+                 : "This stack is already correctly based.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(theme.color("fg-dim"))
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(presentation.prepared.plan.steps, id: \.ggID) { step in
+                        HStack(spacing: 10) {
+                            Text("\(step.position)")
+                                .font(.system(size: 10.5, design: .monospaced))
+                                .foregroundStyle(theme.color("fg-faint"))
+                                .frame(width: 24, alignment: .trailing)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(step.title)
+                                    .font(.system(size: 12.5, weight: .medium))
+                                    .lineLimit(1)
+                                Text(stepDetail(step))
+                                    .font(.system(size: 10.5, design: .monospaced))
+                                    .foregroundStyle(theme.color("fg-faint"))
+                                    .lineLimit(1)
+                            }
+                            Spacer(minLength: 8)
+                            Text(step.action)
+                                .font(.system(size: 10.5, weight: .semibold))
+                                .foregroundStyle(step.action == "ok" ? theme.color("add") : theme.color("warn"))
+                        }
+                        .frame(minHeight: 44)
+                        .padding(.horizontal, 10)
+                        .background(theme.color("bg-2").opacity(0.45))
+                        if step.ggID != presentation.prepared.plan.steps.last?.ggID {
+                            Divider()
+                        }
+                    }
+                }
+            }
+            .frame(minWidth: 540, minHeight: 230)
+            .clipShape(.rect(cornerRadius: 6))
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("warn"))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Cancel") {
+                    onCancel()
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                .disabled(isApplying)
+                Button("Apply Restack") { apply() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!presentation.hasWork || isApplying)
+            }
+        }
+        .padding(18)
+        .interactiveDismissDisabled(isApplying)
+    }
+
+    private func stepDetail(_ step: GGRestackStep) -> String {
+        switch (step.currentParent, step.expectedParent) {
+        case let (current?, expected?): "\(current) → \(expected)"
+        case let (current?, nil): current
+        case let (nil, expected?): expected
+        case (nil, nil): step.ggID
+        }
+    }
+
+    private func apply() {
+        guard presentation.hasWork, !isApplying else { return }
+        isApplying = true
+        errorMessage = nil
+        Task { @MainActor in
+            do {
+                try await onApply()
+                dismiss()
+            } catch {
+                errorMessage = GGErrorPresentation.message(for: error)
+                isApplying = false
+            }
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -21,7 +21,31 @@ struct GGStackDrawer: View {
                 hasBlockingGitOperation: Self.hasBlockingGitOperation(
                     mergeOperation: rps.mergeOp.current,
                     pausedGGOperation: rps.ggActionState.pausedOperation
-                )
+                ),
+                effectiveConfig: rps.ggEffectiveConfig,
+                localChanges: rps.ggLocalChangeStatistics,
+                undoCandidate: rps.ggUndoCandidate
+            )
+        }
+        if rps.ggActionState.pausedOperation == nil, rps.ggUndoCandidate != nil {
+            let inFlight = rps.ggActionState.inFlightAction
+            return GGStackReadinessModel(
+                title: "Stack recovery",
+                summaryChip: "undo available",
+                facts: [],
+                primaryActions: [GGStackReadinessModel.Action(
+                    kind: .undo,
+                    title: "Undo Last GG Operation",
+                    detail: nil,
+                    isEnabled: inFlight == nil,
+                    isInFlight: inFlight == .undo,
+                    emphasis: .primary
+                )],
+                overflowActions: [],
+                progressRows: [],
+                isPaused: false,
+                actionSummary: rps.ggActionState.lastActionSummary,
+                localChangesNote: nil
             )
         }
         return GGStackReadinessModel.makePausedFallback(action: rps.ggActionState)
@@ -126,6 +150,7 @@ struct GGStackDrawer: View {
                     Text(err).font(.system(size: 11)).foregroundColor(theme.color("warn")).lineLimit(3)
                 }
                 actionRow(model)
+                actionDetails(model)
                 factsView(model)
             } else if !model.progressRows.isEmpty {
                 progressList(model)
@@ -137,6 +162,7 @@ struct GGStackDrawer: View {
                     Text(err).font(.system(size: 11)).foregroundColor(theme.color("warn")).lineLimit(3)
                 }
                 actionRow(model)
+                actionDetails(model)
                 factsView(model)
             }
         }
@@ -154,10 +180,9 @@ struct GGStackDrawer: View {
     private func actionRow(_ model: GGStackReadinessModel) -> some View {
         ScrollView(.horizontal) {
             HStack(spacing: 8) {
-                ForEach(model.actions) { action in
+                ForEach(model.primaryActions) { action in
                     Button {
-                        if action.kind == .land { rps.requestGGLand(.ready) }
-                        else { rps.onGGStackAction(action.kind, appState: appState) }
+                        perform(action)
                     } label: {
                         HStack(spacing: 6) {
                             if action.isInFlight { Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10) }
@@ -174,9 +199,50 @@ struct GGStackDrawer: View {
                     .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
                     .help(action.title)
                 }
+                if !model.overflowActions.isEmpty {
+                    Menu {
+                        ForEach(model.overflowActions) { action in
+                            Button(action.title) { perform(action) }
+                                .disabled(!action.isEnabled)
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(theme.color("fg-muted"))
+                            .frame(width: 26, height: 26)
+                            .background(theme.color("bg-3").opacity(0.72))
+                            .clipShape(.rect(cornerRadius: 6))
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .frame(width: 26, height: 26)
+                    .help("Stack actions")
+                }
             }
         }
         .scrollIndicators(.hidden)
+    }
+
+    @ViewBuilder
+    private func actionDetails(_ model: GGStackReadinessModel) -> some View {
+        if let detail = model.primaryActions.first?.detail {
+            Text(detail)
+                .font(.system(size: 10.5))
+                .foregroundStyle(theme.color("fg-dim"))
+        }
+        if let note = model.localChangesNote {
+            Text(note)
+                .font(.system(size: 10.5))
+                .foregroundStyle(theme.color("warn"))
+        }
+    }
+
+    private func perform(_ action: GGStackReadinessModel.Action) {
+        if action.kind == .land {
+            rps.requestGGLand(.ready)
+        } else {
+            rps.onGGStackAction(action.kind, appState: appState)
+        }
     }
 
     private func factsView(_ model: GGStackReadinessModel) -> some View {

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Pure presentation model for the stack-mode drawer. Computes the title,
-/// summary chip, fact rows, action buttons (+ enablement), and live sync
-/// progress rows from the stack and its action state. No I/O — unit-tested.
+/// Pure presentation policy for the stack drawer. GG remains authoritative
+/// at execution time; this model only selects the action the current snapshot
+/// calls for and describes its effect.
 struct GGStackReadinessModel: Equatable {
     struct Fact: Equatable, Identifiable {
         let label: String
@@ -14,6 +14,7 @@ struct GGStackReadinessModel: Equatable {
         enum Emphasis: Equatable { case primary, normal }
         let kind: GGStackActionKind
         let title: String
+        let detail: String?
         let isEnabled: Bool
         let isInFlight: Bool
         let emphasis: Emphasis
@@ -23,17 +24,25 @@ struct GGStackReadinessModel: Equatable {
     let title: String
     let summaryChip: String
     let facts: [Fact]
-    let actions: [Action]
+    let primaryActions: [Action]
+    let overflowActions: [Action]
     let progressRows: [String]
     let isPaused: Bool
     let actionSummary: String?
+    let localChangesNote: String?
+
+    /// Compatibility for callers that need to reason about every action.
+    var actions: [Action] { primaryActions + overflowActions }
 
     @MainActor
     static func make(
         stack: GGStack,
         action: GGStackActionState,
         liveBehindBase: Int? = nil,
-        hasBlockingGitOperation: Bool = false
+        hasBlockingGitOperation: Bool = false,
+        effectiveConfig: GGEffectiveConfig = .defaults,
+        localChanges: GGLocalChangeStatistics = .zero,
+        undoCandidate: GGUndoCandidate? = nil
     ) -> GGStackReadinessModel {
         let merged = stack.entries.filter { $0.prState == .merged }.count
         let unsynced = max(0, stack.totalCommits - stack.syncedCommits)
@@ -41,6 +50,7 @@ struct GGStackReadinessModel: Equatable {
         let isPaused = action.pausedOperation != nil
         let inFlight = action.inFlightAction
         let busy = inFlight != nil || hasBlockingGitOperation
+        let rebaseThreshold = effectiveConfig.syncBehindThreshold
 
         let summaryChip: String = {
             if isPaused { return "paused" }
@@ -49,45 +59,93 @@ struct GGStackReadinessModel: Equatable {
             return "\(merged)/\(stack.totalCommits) merged"
         }()
 
-        let facts: [Fact] = [
+        let facts = [
             Fact(label: "Commits", value: "\(stack.totalCommits)"),
             Fact(label: "Merged", value: "\(merged)"),
             Fact(label: "Unsynced", value: "\(unsynced)"),
             Fact(label: "Behind base", value: "\(behind)"),
         ]
 
-        let actions: [Action]
+        let primaryActions: [Action]
         if isPaused {
-            actions = [
-                Action(kind: .continueOp, title: "Continue", isEnabled: !busy,
-                       isInFlight: inFlight == .continueOp, emphasis: .primary),
-                Action(kind: .abortOp, title: "Abort", isEnabled: !busy,
-                       isInFlight: inFlight == .abortOp, emphasis: .normal),
+            primaryActions = [
+                makeAction(.continueOp, title: "Continue", enabled: !busy, inFlight: inFlight, emphasis: .primary),
+                makeAction(.abortOp, title: "Abort", enabled: !busy, inFlight: inFlight),
+            ]
+        } else if behind > 0,
+                  rebaseThreshold > 0,
+                  !effectiveConfig.syncAutoRebase,
+                  behind >= rebaseThreshold {
+            primaryActions = [
+                makeAction(
+                    .rebase,
+                    title: "Rebase onto \(stack.base)",
+                    enabled: !busy,
+                    inFlight: inFlight,
+                    emphasis: .primary
+                ),
+            ]
+        } else if unsynced > 0 || behind > 0 || stack.entries.contains(where: { $0.prState == nil }) {
+            primaryActions = [
+                makeAction(
+                    .sync,
+                    title: "Sync stack",
+                    detail: rebaseThreshold > 0
+                        && effectiveConfig.syncAutoRebase
+                        && behind >= rebaseThreshold
+                        ? "Includes rebase onto \(stack.base)"
+                        : nil,
+                    enabled: !busy,
+                    inFlight: inFlight,
+                    emphasis: .primary
+                ),
+            ]
+        } else if hasLandablePrefix(stack) {
+            primaryActions = [
+                makeAction(.land, title: "Land ready", enabled: !busy, inFlight: inFlight, emphasis: .primary),
             ]
         } else {
-            let canSync = behind == 0
-            let canCheckLandReadiness = stack.entries.contains { $0.prState == .open }
-            let hasMerged = merged > 0
-            actions = [
-                Action(kind: .sync, title: "Sync stack", isEnabled: !busy && canSync,
-                       isInFlight: inFlight == .sync, emphasis: .primary),
-                Action(kind: .land, title: "Land ready", isEnabled: !busy && canCheckLandReadiness,
-                       isInFlight: inFlight == .land, emphasis: .normal),
-                Action(kind: .clean, title: "Clean all", isEnabled: !busy && hasMerged,
-                       isInFlight: inFlight == .clean, emphasis: .normal),
-            ]
+            primaryActions = []
         }
 
+        let mutableRegionCanReorder = stack.entries
+            .split(whereSeparator: { $0.prState == .merged })
+            .contains { $0.count > 1 }
+        let overflowActions: [Action] = isPaused ? [] : [
+            makeAction(
+                .reorder,
+                title: "Reorder Stack…",
+                enabled: !busy && mutableRegionCanReorder && stack.entries.allSatisfy { $0.ggId != nil },
+                inFlight: inFlight
+            ),
+            makeAction(.restack, title: "Restack…", enabled: !busy, inFlight: inFlight),
+            makeAction(
+                .undo,
+                title: "Undo Last GG Operation",
+                enabled: !busy && undoCandidate != nil,
+                inFlight: inFlight
+            ),
+            makeAction(
+                .clean,
+                title: "Clean Merged Commits…",
+                enabled: !busy && merged > 0,
+                inFlight: inFlight
+            ),
+        ]
+
         let syncIsRelevant = inFlight == .sync || action.pausedOperation?.pausedBy == .sync
-        let actionSummary = (inFlight == .sync) ? nil : action.lastActionSummary
         return GGStackReadinessModel(
             title: "Stack · \(stack.name)",
             summaryChip: summaryChip,
             facts: facts,
-            actions: actions,
+            primaryActions: primaryActions,
+            overflowActions: overflowActions,
             progressRows: syncIsRelevant ? progressRows(from: action.syncProgress) : [],
             isPaused: isPaused,
-            actionSummary: actionSummary
+            actionSummary: inFlight == .sync ? nil : action.lastActionSummary,
+            localChangesNote: primaryActions.contains(where: { $0.kind == .sync }) && localChanges.hasChanges
+                ? "Local changes are not included"
+                : nil
         )
     }
 
@@ -101,16 +159,44 @@ struct GGStackReadinessModel: Equatable {
             title: "Stack operation",
             summaryChip: "paused",
             facts: [],
-            actions: [
-                Action(kind: .continueOp, title: "Continue", isEnabled: !busy,
-                       isInFlight: inFlight == .continueOp, emphasis: .primary),
-                Action(kind: .abortOp, title: "Abort", isEnabled: !busy,
-                       isInFlight: inFlight == .abortOp, emphasis: .normal),
+            primaryActions: [
+                makeAction(.continueOp, title: "Continue", enabled: !busy, inFlight: inFlight, emphasis: .primary),
+                makeAction(.abortOp, title: "Abort", enabled: !busy, inFlight: inFlight),
             ],
+            overflowActions: [],
             progressRows: syncIsRelevant ? progressRows(from: action.syncProgress) : [],
             isPaused: true,
-            actionSummary: nil
+            actionSummary: nil,
+            localChangesNote: nil
         )
+    }
+
+    private static func makeAction(
+        _ kind: GGStackActionKind,
+        title: String,
+        detail: String? = nil,
+        enabled: Bool,
+        inFlight: GGStackActionKind?,
+        emphasis: Action.Emphasis = .normal
+    ) -> Action {
+        Action(
+            kind: kind,
+            title: title,
+            detail: detail,
+            isEnabled: enabled,
+            isInFlight: inFlight == kind,
+            emphasis: emphasis
+        )
+    }
+
+    private static func hasLandablePrefix(_ stack: GGStack) -> Bool {
+        for entry in stack.entries.sorted(by: { $0.position < $1.position }) {
+            if entry.prState == .merged { continue }
+            return entry.prState == .open
+                && entry.approved
+                && (entry.ciStatus == nil || entry.ciStatus == .success)
+        }
+        return false
     }
 
     private static func progressRows(from events: [GGSyncEvent]) -> [String] {

--- a/Alas/Sources/Integrations/GG/GGUndoMarkerStore.swift
+++ b/Alas/Sources/Integrations/GG/GGUndoMarkerStore.swift
@@ -3,10 +3,16 @@ import Foundation
 struct GGUndoMarker: Codable, Equatable, Sendable {
     let operationID: String
     let removedFinalStackCommit: Bool
+    /// Branch the recovery was recorded on. Used to scope a final-drop
+    /// recovery (where the stack becomes empty, so `currentStackName` is nil)
+    /// to the branch where the drop happened. Optional for backward
+    /// compatibility with markers persisted before this field existed.
+    let branch: String?
 
-    init(operationID: String, removedFinalStackCommit: Bool = false) {
+    init(operationID: String, removedFinalStackCommit: Bool = false, branch: String? = nil) {
         self.operationID = operationID
         self.removedFinalStackCommit = removedFinalStackCommit
+        self.branch = branch
     }
 }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -64,7 +64,11 @@ struct ChangesTabView: View {
     }
 
     private var isGGDrawerActive: Bool {
-        Self.shouldShowGGDrawer(stack: rps.ggStack, pausedGGOperation: rps.ggActionState.pausedOperation)
+        Self.shouldShowGGDrawer(
+            stack: rps.ggStack,
+            pausedGGOperation: rps.ggActionState.pausedOperation,
+            hasUndoCandidate: rps.ggUndoCandidate != nil
+        )
     }
 
     private var ggPreparationMutationDisabledReason: String? {
@@ -287,8 +291,12 @@ struct ChangesTabView: View {
         mergeOperation != nil && pausedGGOperation == nil
     }
 
-    static func shouldShowGGDrawer(stack: GGStack?, pausedGGOperation: GGPausedOperation?) -> Bool {
-        stack != nil || pausedGGOperation != nil
+    static func shouldShowGGDrawer(
+        stack: GGStack?,
+        pausedGGOperation: GGPausedOperation?,
+        hasUndoCandidate: Bool
+    ) -> Bool {
+        stack != nil || pausedGGOperation != nil || hasUndoCandidate
     }
 
     static func shouldShowChangesPreparationCard(

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -103,6 +103,7 @@ final class RightPaneState: GGSplitCommitServicing {
     /// Current gg stack for this worktree's branch; nil when gating fails
     /// or the branch is not a stack. Loaded during performRefresh.
     var ggStack: GGStack? = nil
+    var ggEffectiveConfig: GGEffectiveConfig = .defaults
     /// Injected by RightPaneStore — resolves gates 1–3 (master toggle,
     /// gg installed, per-project mode) against app-level state.
     var ggGateProvider: (@MainActor () -> Bool)? = nil
@@ -113,10 +114,14 @@ final class RightPaneState: GGSplitCommitServicing {
     @ObservationIgnored
     var selectWorktreeAtPathAfterGGMutation: (@MainActor (String) async -> Void)? = nil
     var ggService = GGService() {
-        didSet { ggMutationCoordinatorStorage = nil }
+        didSet {
+            ggMutationCoordinatorStorage = nil
+            didAttemptGGUndoRestore = false
+        }
     }
     @ObservationIgnored
     private var ggMutationCoordinatorStorage: GGMutationCoordinator? = nil
+    @ObservationIgnored private var didAttemptGGUndoRestore = false
     /// Backing store for the stack drawer's mutation UI (in-flight action,
     /// sync progress, paused/error state). Not snapshot-derived, so
     /// `markSnapshotUnknown()` does not reset it.
@@ -143,6 +148,10 @@ final class RightPaneState: GGSplitCommitServicing {
     /// Off-critical-path gg stack load. Cancelled+restarted per refresh so a
     /// slow `gg ls --json` never blocks the Changes-pane snapshot.
     @ObservationIgnored private var ggStackRefreshTask: Task<Void, Never>? = nil
+    /// A refresh result may still arrive after its task was cancelled. Only
+    /// the most recently started GG refresh may publish snapshot-derived
+    /// stack state.
+    @ObservationIgnored private var ggStackRefreshGeneration: UInt = 0
 
     var currentGGStackCommitsKey: String {
         "\(currentBranch)|" + ggStackSourceCommits.map(\.sha).joined(separator: "|")
@@ -237,6 +246,19 @@ final class RightPaneState: GGSplitCommitServicing {
     @ObservationIgnored var pendingGGUnstackPrepared: GGPreparedMutation? = nil
     var pendingGGCleanAll: Bool = false
     @ObservationIgnored private var pendingGGCleanPrepared: GGPreparedMutation? = nil
+    var pendingGGReorder: GGReorderPresentation? = nil
+    var pendingGGRestack: GGRestackPresentation? = nil
+
+    var ggLocalChangeStatistics: GGLocalChangeStatistics {
+        GGLocalChangeStatistics(
+            staged: changes.filter { $0.stage == .staged }.count,
+            unstaged: changes.filter { $0.stage == .unstaged }.count
+        )
+    }
+
+    var ggUndoCandidate: GGUndoCandidate? {
+        ggMutationCoordinator.undoCandidate
+    }
 
     /// The split target of an in-flight `.applySplit`, if any, so a split tab
     /// can tell whether the running split is its own apply or another tab's.
@@ -390,7 +412,8 @@ final class RightPaneState: GGSplitCommitServicing {
                     guard let self else { return }
                     GGInboxStore.shared.invalidate(projectId: self.worktree.projectId)
                 },
-                selectWorktreeAtPath: { [weak self] path in await self?.selectWorktreeAtPathAfterGGMutation?(path) }
+                selectWorktreeAtPath: { [weak self] path in await self?.selectWorktreeAtPathAfterGGMutation?(path) },
+                currentBranch: { [weak self] in self?.currentBranch }
             )
         )
         ggMutationCoordinatorStorage = coordinator
@@ -868,6 +891,8 @@ final class RightPaneState: GGSplitCommitServicing {
     @MainActor
     func refreshGGStack() async {
         let snapshotGeneration = snapshotInvalidationGeneration
+        ggStackRefreshGeneration &+= 1
+        let refreshGeneration = ggStackRefreshGeneration
         let gated = ggGateProvider?() ?? false
         guard gated, GGStackGate.isStackShaped(commits: ggStackSourceCommits) else {
             ggStackCommitsKey = nil
@@ -880,9 +905,20 @@ final class RightPaneState: GGSplitCommitServicing {
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
             }
+            if gated {
+                await reconcileGGUndoCandidateIfNeeded()
+            } else {
+                // The gg gate can read false transiently before the startup
+                // `GGAvailability` probe resolves. Only hide the candidate;
+                // keep the persisted marker so a valid recovery Undo survives
+                // until the gate is known to be intentionally disabled and the
+                // later re-check can restore or reject it.
+                ggMutationCoordinator.suspendUndoCandidate()
+            }
             return
         }
         reconcilePausedOperation()
+        ggEffectiveConfig = GGConfigReader.effectiveConfig(repoPath: worktree.path.path)
         // `gg ls --json` reaches out to gh/glab for PR state — skip when
         // the branch and commit set are unchanged since the last query. PR-
         // state churn from the outside world refreshes on the next commits
@@ -892,7 +928,10 @@ final class RightPaneState: GGSplitCommitServicing {
         // to share the same commits (e.g. right after `git checkout -b`)
         // must not reuse the old branch's cached stack.
         let key = currentGGStackCommitsKey
-        guard key != ggStackCommitsKey else { return }
+        guard key != ggStackCommitsKey else {
+            await reconcileGGUndoCandidateIfNeeded()
+            return
+        }
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
             // A newer refresh, or a `markSnapshotUnknown()` invalidation,
@@ -900,13 +939,16 @@ final class RightPaneState: GGSplitCommitServicing {
             // invalidation's own reset) will write the current state;
             // writing here would race it with a stale result.
             if Task.isCancelled { return }
-            guard snapshotGeneration == snapshotInvalidationGeneration else { return }
+            guard snapshotGeneration == snapshotInvalidationGeneration,
+                  refreshGeneration == ggStackRefreshGeneration
+            else { return }
             ggStackCommitsKey = key
             if ggStack != stack { ggStack = stack }
             let summary = stack?.summary
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
             }
+            await reconcileGGUndoCandidateIfNeeded()
         } catch {
             // A transient gg/provider failure (gh/glab auth hiccup, network
             // blip, etc.) must not cache the *failed* key `key` — it stays
@@ -925,13 +967,35 @@ final class RightPaneState: GGSplitCommitServicing {
             // later return to that same branch/commit set as "already
             // cached" and skip re-fetching the now-cleared stack.
             if Task.isCancelled { return }
-            guard snapshotGeneration == snapshotInvalidationGeneration else { return }
+            guard snapshotGeneration == snapshotInvalidationGeneration,
+                  refreshGeneration == ggStackRefreshGeneration
+            else { return }
             ggStackCommitsKey = nil
             if ggStack != nil { ggStack = nil }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
             }
+            // The cached stack we just dropped belonged to a different key, so
+            // the current stack identity is unknown until a refresh succeeds.
+            // Hide any recovery candidate (keeping its marker) so the drawer
+            // does not offer an Undo scoped to the previous stack; it is
+            // rebuilt once a later reconcile validates against the new stack.
+            ggMutationCoordinator.suspendUndoCandidate()
         }
+    }
+
+    private func reconcileGGUndoCandidateIfNeeded() async {
+        let coordinator = ggMutationCoordinator
+        guard !didAttemptGGUndoRestore || coordinator.hasUndoStateToReconcile else { return }
+        if Self.ggUndoRecoveryIsBlockedByGenericGitOperation(
+            operationInProgress: GGStackGate.operationInProgress(repoPath: worktree.path.path),
+            alasGGOperationInProgress: GGStackGate.alasGGOperationInProgress(repoPath: worktree.path.path)
+        ) {
+            coordinator.suspendUndoCandidate()
+            return
+        }
+        didAttemptGGUndoRestore = true
+        await coordinator.restoreUndoCandidate(currentStackName: ggStack?.name)
     }
 
     /// Re-run the gg gate immediately (e.g. after a Settings toggle) rather
@@ -1007,12 +1071,98 @@ final class RightPaneState: GGSplitCommitServicing {
         case .absorbStaged:
             runGGMutation(.absorbStaged)
         case .restack:
-            runGGMutation(.restack)
+            requestGGRestack()
         case .rebase:
-            runGGMutation(.rebase(target: nil))
-        case .drop, .unstack, .reorder, .undo, .split:
+            guard let stackBase = ggStack?.base else {
+                ggActionState.setError("The stack base is no longer available. Refresh and try again.")
+                return
+            }
+            runGGMutation(.rebase(target: Self.ggManualRebaseTarget(
+                stackBase: stackBase,
+                behindBase: behindBase
+            )))
+        case .reorder:
+            requestGGReorder()
+        case .undo:
+            guard let candidate = ggUndoCandidate else { return }
+            runGGMutation(.undo(operationID: candidate.operationID))
+        case .drop, .unstack, .split:
             break
         }
+    }
+
+    func requestGGReorder() {
+        guard let stack = ggStack,
+              stack.entries.allSatisfy({ $0.ggId != nil })
+        else {
+            ggActionState.setError("Every stack commit needs a GG ID before it can be reordered.")
+            return
+        }
+        let entries = stack.entries.sorted(by: { $0.position < $1.position }).map { entry in
+            let id = entry.ggId!
+            return entry.prState == .merged
+                ? GGReorderEntry.immutable(id: id, title: entry.title)
+                : GGReorderEntry.mutable(id: id, title: entry.title)
+        }
+        let model = GGReorderModel(entries: entries)
+        Task { @MainActor in
+            do {
+                let prepared = try await ggMutationCoordinator.prepare(.reorder(order: model.orderedIDs))
+                pendingGGReorder = GGReorderPresentation(snapshot: prepared.snapshot, model: model)
+            } catch {
+                ggActionState.setError(GGErrorPresentation.message(for: error))
+            }
+        }
+    }
+
+    func cancelGGReorder() {
+        pendingGGReorder = nil
+    }
+
+    func submitGGReorder(_ model: GGReorderModel) async throws {
+        guard let pending = pendingGGReorder,
+              model.hasChanges
+        else { throw GGMutationError.staleConfirmation }
+        guard mergeOp.current == nil else { throw GGMutationError.blockingGitOperation }
+        try await ggMutationCoordinator.apply(
+            .reorder(order: model.orderedIDs),
+            confirmedAgainst: pending.snapshot
+        )
+        pendingGGReorder = nil
+    }
+
+    func requestGGRestack() {
+        Task { @MainActor in
+            do {
+                pendingGGRestack = GGRestackPresentation(
+                    prepared: try await ggMutationCoordinator.prepareRestackPreview()
+                )
+            } catch {
+                ggActionState.setError(GGErrorPresentation.message(for: error))
+            }
+        }
+    }
+
+    func cancelGGRestack() {
+        pendingGGRestack = nil
+    }
+
+    func submitGGRestack() async throws {
+        guard let pending = pendingGGRestack, pending.hasWork else {
+            throw GGMutationError.staleConfirmation
+        }
+        guard mergeOp.current == nil else { throw GGMutationError.blockingGitOperation }
+        // The stack identity only carries the base name + head SHA, so a base
+        // ref that advanced since the preview was built would still match.
+        // Re-run the dry-run plan and require it to equal the reviewed one, so
+        // Apply can't rewrite against a different parent than the user saw.
+        let revalidated = try await ggMutationCoordinator.prepareRestackPreview()
+        guard revalidated.plan == pending.prepared.plan else {
+            pendingGGRestack = GGRestackPresentation(prepared: revalidated)
+            throw GGMutationError.staleConfirmation
+        }
+        try await ggMutationCoordinator.apply(.restack, confirmedAgainst: revalidated.snapshot)
+        pendingGGRestack = nil
     }
 
     func requestGGLand(_ request: GGLandRequest) {

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -358,6 +358,14 @@ final class RightPaneStore {
         states.values.first { $0.pendingGGUnstack != nil }
     }
 
+    func stateWithPendingGGReorder() -> RightPaneState? {
+        states.values.first { $0.pendingGGReorder != nil }
+    }
+
+    func stateWithPendingGGRestack() -> RightPaneState? {
+        states.values.first { $0.pendingGGRestack != nil }
+    }
+
     /// The first cached state with a pending gg clean-all confirmation.
     /// Mirrors the other cross-worktree confirmations so changing selection
     /// while the dialog is open resolves the state that requested it.

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -65,7 +65,9 @@ struct ChangesTabViewTests {
     }
 
     @Test func ggDrawerActiveForStackOrPausedOperation() {
-        #expect(!ChangesTabView.shouldShowGGDrawer(stack: nil, pausedGGOperation: nil))
+        #expect(!ChangesTabView.shouldShowGGDrawer(
+            stack: nil, pausedGGOperation: nil, hasUndoCandidate: false
+        ))
         #expect(ChangesTabView.shouldShowGGDrawer(
             stack: GGStack(
                 name: "feat",
@@ -76,11 +78,16 @@ struct ChangesTabViewTests {
                 behindBase: nil,
                 entries: []
             ),
-            pausedGGOperation: nil
+            pausedGGOperation: nil,
+            hasUndoCandidate: false
         ))
         #expect(ChangesTabView.shouldShowGGDrawer(
             stack: nil,
-            pausedGGOperation: GGPausedOperation(pausedBy: .sync)
+            pausedGGOperation: GGPausedOperation(pausedBy: .sync),
+            hasUndoCandidate: false
+        ))
+        #expect(ChangesTabView.shouldShowGGDrawer(
+            stack: nil, pausedGGOperation: nil, hasUndoCandidate: true
         ))
     }
 

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -21,11 +21,21 @@ private func waitUntil(
 @MainActor
 private final class RecordingGGMutationExecutor: GGMutationExecuting {
     var requests: [GGMutationRequest] = []
+    var clientOperationIDs: [String?] = []
     var result: GGMutationExecutionResult = .none
     var error: Error?
     var newestOperation: GGOperationSummary?
     var operationLists: [[GGOperationSummary]] = []
     var operationListCallCount = 0
+    var restackPreview = GGRestackResult(
+        stackName: "feature", totalEntries: 2, entriesRestacked: 1, entriesOK: 1,
+        dryRun: true,
+        steps: [GGRestackStep(
+            position: 2, ggID: "change-2", title: "Head", action: "restack",
+            currentParent: "old", expectedParent: "base"
+        )]
+    )
+    var restackPreviewCallCount = 0
     var blockExecution = false
     var syncEvents: [GGSyncEvent] = [.start(totalEntries: 1), .summary]
     private var executionContinuation: CheckedContinuation<Void, Never>?
@@ -33,9 +43,11 @@ private final class RecordingGGMutationExecutor: GGMutationExecuting {
     func execute(
         _ request: GGMutationRequest,
         worktreePath: String,
+        clientOperationID: String?,
         onSyncEvent: (GGSyncEvent) -> Void
     ) async throws -> GGMutationExecutionResult {
         requests.append(request)
+        clientOperationIDs.append(clientOperationID)
         if request == .sync {
             for event in syncEvents { onSyncEvent(event) }
         }
@@ -54,9 +66,31 @@ private final class RecordingGGMutationExecutor: GGMutationExecuting {
         return newestOperation.map { [$0] } ?? []
     }
 
+    func previewRestack(worktreePath: String) async throws -> GGRestackResult {
+        restackPreviewCallCount += 1
+        if let error { throw error }
+        return restackPreview
+    }
+
     func resumeExecution() {
         executionContinuation?.resume()
         executionContinuation = nil
+    }
+}
+
+@MainActor
+private final class GGClientOperationCapabilityBox {
+    var isSupported: Bool
+    init(_ isSupported: Bool) { self.isSupported = isSupported }
+}
+
+@MainActor
+private final class GGClientOperationTokenGenerator {
+    private var count = 0
+
+    func next() -> String {
+        count += 1
+        return "alas:test-\(count)"
     }
 }
 
@@ -96,23 +130,32 @@ private final class GGMutationHarness {
     let service = RecordingGGMutationExecutor()
     let markers = RecordingUndoMarkerStore()
     let actionState = GGStackActionState()
+    let clientOperationCapability: GGClientOperationCapabilityBox
+    let tokenGenerator: GGClientOperationTokenGenerator
     var stacks: [GGStackSnapshot]
     var loadError: Error?
     var loadCount = 0
     var refreshes: [Refresh] = []
     var selectedPaths: [String] = []
     var worktreeExists = true
+    var currentBranch: String? = "feature"
     var onRefreshStack: (() async -> Void)?
     private(set) var coordinator: GGMutationCoordinator!
 
-    init(stacks: [GGStackSnapshot]) {
+    init(stacks: [GGStackSnapshot], supportsClientOperationID: Bool = false) {
         self.stacks = stacks
+        let capability = GGClientOperationCapabilityBox(supportsClientOperationID)
+        clientOperationCapability = capability
+        let generator = GGClientOperationTokenGenerator()
+        tokenGenerator = generator
         coordinator = GGMutationCoordinator(
             worktreeId: "wt",
             worktreePath: "/repo/wt",
             service: service,
             actionState: actionState,
             undoMarkerStore: markers,
+            clientOperationIDCapability: { capability.isSupported },
+            clientOperationIDGenerator: { generator.next() },
             context: GGMutationContext(
                 loadFreshStack: { [unowned self] in
                     if let loadError { throw loadError }
@@ -131,7 +174,8 @@ private final class GGMutationHarness {
                     return worktreeExists
                 },
                 invalidateInbox: { [unowned self] in refreshes.append(.inbox) },
-                selectWorktreeAtPath: { [unowned self] path in selectedPaths.append(path) }
+                selectWorktreeAtPath: { [unowned self] path in selectedPaths.append(path) },
+                currentBranch: { [unowned self] in currentBranch }
             )
         )
     }
@@ -279,6 +323,131 @@ struct GGMutationCoordinatorTests {
 
         #expect(harness.service.requests.isEmpty)
         #expect(harness.refreshes.isEmpty)
+    }
+
+    @Test func splitPreflightMatchesAnAbbreviatedSHAWhenNoGGIDIsAvailable() async throws {
+        let entries = [
+            GGStackEntry(position: 1, sha: "base", title: "Base", ggId: "change-1"),
+            GGStackEntry(
+                position: 2,
+                sha: "abcdef1",
+                title: "Target",
+                isCurrent: true
+            ),
+        ]
+        let harness = GGMutationHarness(stacks: [stack(head: "abcdef1", entries: entries)])
+        let request = GGMutationRequest.applySplit(
+            planURL: URL(fileURLWithPath: "/tmp/plan.json"),
+            target: GGSplitTargetIdentity(
+                ggID: nil,
+                sha: "abcdef1234567890",
+                tree: "tree"
+            ),
+            planToken: "token"
+        )
+
+        let prepared = try await harness.coordinator.prepare(request)
+
+        #expect(prepared.request == request)
+    }
+
+    @Test func splitPreflightDoesNotFallBackToSHAWhenAGGIDIsPresent() async {
+        let entries = [
+            GGStackEntry(position: 1, sha: "base", title: "Base", ggId: "change-1"),
+            GGStackEntry(
+                position: 2,
+                sha: "abcdef1",
+                title: "Target",
+                ggId: "change-2",
+                isCurrent: true
+            ),
+        ]
+        let harness = GGMutationHarness(stacks: [stack(head: "abcdef1", entries: entries)])
+        let request = GGMutationRequest.applySplit(
+            planURL: URL(fileURLWithPath: "/tmp/plan.json"),
+            target: GGSplitTargetIdentity(
+                ggID: "changed-id",
+                sha: "abcdef1234567890",
+                tree: "tree"
+            ),
+            planToken: "token"
+        )
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            _ = try await harness.coordinator.prepare(request)
+        }
+    }
+
+    @Test func preflightFailurePreservesExistingUndoState() async {
+        let candidate = GGOperationSummary(
+            id: "op_existing", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:existing", "reorder"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: candidate.id, worktreeId: "wt")
+        harness.service.newestOperation = candidate
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(.drop(target: "missing"), confirmedAgainst: nil)
+        }
+
+        #expect(harness.coordinator.undoCandidate?.operationID == candidate.id)
+        #expect(harness.markers.operationID(worktreeId: "wt") == candidate.id)
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func reorderRequiresCompleteGGIDOrderAndKeepsImmutableRowsFixed() async throws {
+        let entries = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Merged", ggId: "change-1",
+                prNumber: 1, prState: .merged
+            ),
+            GGStackEntry(position: 2, sha: "b", title: "Two", ggId: "change-2"),
+            GGStackEntry(position: 3, sha: "c", title: "Three", ggId: "change-3", isCurrent: true),
+        ]
+        let harness = GGMutationHarness(stacks: [stack(head: "c", entries: entries)])
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            _ = try await harness.coordinator.prepare(.reorder(order: ["change-2", "change-3"]))
+        }
+        await #expect(throws: GGMutationError.immutableTarget(
+            reason: "Merged commits must remain fixed while reordering."
+        )) {
+            _ = try await harness.coordinator.prepare(
+                .reorder(order: ["change-2", "change-1", "change-3"])
+            )
+        }
+
+        let prepared = try await harness.coordinator.prepare(
+            .reorder(order: ["change-1", "change-3", "change-2"])
+        )
+        #expect(prepared.request == .reorder(order: ["change-1", "change-3", "change-2"]))
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func reorderRejectsForgedOrderThatCrossesAnImmutableBoundary() async {
+        let entries = [
+            GGStackEntry(position: 1, sha: "a", title: "Lower", ggId: "change-1"),
+            GGStackEntry(
+                position: 2, sha: "b", title: "Merged", ggId: "change-2",
+                prNumber: 2, prState: .merged
+            ),
+            GGStackEntry(position: 3, sha: "c", title: "Upper", ggId: "change-3", isCurrent: true),
+        ]
+        let harness = GGMutationHarness(stacks: [stack(head: "c", entries: entries)])
+
+        await #expect(throws: GGMutationError.immutableTarget(
+            reason: "Commits cannot move across an immutable boundary."
+        )) {
+            _ = try await harness.coordinator.prepare(
+                .reorder(order: ["change-3", "change-2", "change-1"])
+            )
+        }
+
+        #expect(harness.service.requests.isEmpty)
     }
 
     @Test func applyRechecksLandReadinessWhenProviderStateChanges() async throws {
@@ -448,21 +617,736 @@ struct GGMutationCoordinatorTests {
         #expect(harness.actionState.inFlightAction == nil)
     }
 
-    @Test func localSuccessPersistsNewestUndoableOperationAndLaterMutationClearsIt() async throws {
-        let harness = GGMutationHarness(stacks: [stack(head: "a"), stack(head: "a")])
-        let operation = GGOperationSummary(
-            id: "op_1", kind: "sc", status: .completed, createdAtMs: 1,
-            args: ["sc"], touchedRemote: false, isUndoable: true
+    @Test func continueConflictPreservesTheOriginalPausedAction() async {
+        let harness = GGMutationHarness(stacks: [stack(head: "a", operationID: "op_paused")])
+        harness.actionState.setPaused(GGPausedOperation(pausedBy: .restack))
+        harness.service.error = GGServiceError.pausedConflict(message: "Resolve conflicts")
+
+        await #expect(throws: GGServiceError.pausedConflict(message: "Resolve conflicts")) {
+            try await harness.coordinator.apply(.continueOperation, confirmedAgainst: nil)
+        }
+
+        #expect(harness.actionState.pausedOperation == GGPausedOperation(pausedBy: .restack))
+    }
+
+    @Test func abortFailurePreservesTheOriginalPausedAction() async {
+        let harness = GGMutationHarness(stacks: [stack(head: "a", operationID: "op_paused")])
+        harness.actionState.setPaused(GGPausedOperation(pausedBy: .sync))
+        harness.service.error = GGServiceError.commandFailed(stderr: "abort failed")
+
+        await #expect(throws: GGServiceError.commandFailed(stderr: "abort failed")) {
+            try await harness.coordinator.apply(.abortOperation, confirmedAgainst: nil)
+        }
+
+        #expect(harness.actionState.pausedOperation == GGPausedOperation(pausedBy: .sync))
+    }
+
+    @Test func restackAlwaysPreviewsBeforeApplyAndUsesTheSameStackIdentity() async throws {
+        let harness = GGMutationHarness(stacks: [
+            stack(head: "a"),
+            stack(head: "a"),
+            stack(head: "a"),
+        ])
+
+        let prepared = try await harness.coordinator.prepareRestackPreview()
+        #expect(harness.service.restackPreviewCallCount == 1)
+        #expect(prepared.plan.dryRun)
+        #expect(prepared.snapshot.headSHA == "a")
+        #expect(harness.service.requests.isEmpty)
+
+        try await harness.coordinator.apply(.restack, confirmedAgainst: prepared.snapshot)
+        #expect(harness.service.requests == [.restack])
+    }
+
+    @Test func restackRejectsAPreviewWhenTheStackChangesDuringTheDryRun() async {
+        let harness = GGMutationHarness(stacks: [
+            stack(head: "a"),
+            stack(head: "b"),
+        ])
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            _ = try await harness.coordinator.prepareRestackPreview()
+        }
+
+        #expect(harness.service.restackPreviewCallCount == 1)
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func restackRejectsApplyWhenStackChangedAfterPreview() async throws {
+        let harness = GGMutationHarness(stacks: [
+            stack(head: "a"),
+            stack(head: "a"),
+            stack(head: "b"),
+        ])
+
+        let prepared = try await harness.coordinator.prepareRestackPreview()
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(.restack, confirmedAgainst: prepared.snapshot)
+        }
+
+        #expect(harness.service.restackPreviewCallCount == 1)
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func restackRejectsNonDryRunOrWrongStackPreviewPayload() async {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.service.restackPreview = GGRestackResult(
+            stackName: "other", totalEntries: 1, entriesRestacked: 1, entriesOK: 0,
+            dryRun: false, steps: []
         )
-        harness.service.operationLists = [[], [operation]]
+
+        await #expect(throws: GGServiceError.malformedOutput(
+            "gg returned a restack plan for a different stack."
+        )) {
+            _ = try await harness.coordinator.prepareRestackPreview()
+        }
+
+        #expect(harness.service.restackPreviewCallCount == 1)
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func localSuccessPersistsNewestUndoableOperationAndLaterMutationClearsIt() async throws {
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a"), stack(head: "a")],
+            supportsClientOperationID: true
+        )
+        let operation = GGOperationSummary(
+            id: "op_1", kind: "squash", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:test-1", "sc"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        harness.service.operationLists = [[operation]]
         try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
         #expect(harness.markers.operationID(worktreeId: "wt") == "op_1")
+        #expect(harness.coordinator.undoCandidate?.operationID == "op_1")
+        #expect(harness.service.clientOperationIDs == ["alas:test-1"])
 
         harness.service.operationLists = []
         harness.service.error = GGServiceError.commandFailed(stderr: "failed")
         await #expect(throws: GGServiceError.commandFailed(stderr: "failed")) {
             try await harness.coordinator.apply(.checkout(target: "change-1"), confirmedAgainst: nil)
         }
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+        #expect(harness.coordinator.undoCandidate == nil)
+    }
+
+    @Test func decodedSquashOperationExposesUndoAfterAmend() async throws {
+        let payload = Data(#"{"id":"op_1","kind":"squash","status":"committed","created_at_ms":1,"args":["--client-operation-id","alas:test-1","sc","--staged-only"],"stack_name":"feature","touched_remote":false,"is_undoable":true}"#.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let operation = try decoder.decode(GGOperationSummary.self, from: payload)
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+        harness.service.newestOperation = operation
+
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: operation))
+        #expect(harness.markers.operationID(worktreeId: "wt") == operation.id)
+    }
+
+    @Test func localOperationWithoutStackNameDoesNotExposeUnusableUndo() async throws {
+        let operation = GGOperationSummary(
+            id: "op_1", kind: "squash", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:test-1", "sc"],
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+        harness.service.newestOperation = operation
+
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func suspendingUndoCandidateKeepsItAvailableAfterGitRecovery() async {
+        let operation = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "reorder"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: operation.id, worktreeId: "wt")
+        harness.service.newestOperation = operation
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        harness.coordinator.suspendUndoCandidate()
+
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == operation.id)
+    }
+
+    @Test func finalDropRecoveryRestoresOnRecordedBranch() async {
+        let operation = GGOperationSummary(
+            id: "op_drop", kind: "drop", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "drop", "change-1"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.currentBranch = "feature"
+        harness.markers.set(
+            GGUndoMarker(operationID: operation.id, removedFinalStackCommit: true, branch: "feature"),
+            worktreeId: "wt"
+        )
+        harness.service.newestOperation = operation
+
+        // Empty stack after the final drop → currentStackName is nil.
+        await harness.coordinator.restoreUndoCandidate(currentStackName: nil)
+
+        #expect(harness.coordinator.undoCandidate?.operationID == "op_drop")
+        #expect(harness.markers.operationID(worktreeId: "wt") == "op_drop")
+    }
+
+    @Test func finalDropRecoveryClearedAfterCheckoutToAnotherBranch() async {
+        let operation = GGOperationSummary(
+            id: "op_drop", kind: "drop", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "drop", "change-1"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.currentBranch = "unrelated-branch"
+        harness.markers.set(
+            GGUndoMarker(operationID: operation.id, removedFinalStackCommit: true, branch: "feature"),
+            worktreeId: "wt"
+        )
+        harness.service.newestOperation = operation
+
+        await harness.coordinator.restoreUndoCandidate(currentStackName: nil)
+
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func unsupportedGGMutatesNormallyWithoutUndoCorrelation() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.service.newestOperation = GGOperationSummary(
+            id: "op_external", kind: "squash", status: .completed, createdAtMs: 1,
+            args: ["sc"], touchedRemote: false, isUndoable: true
+        )
+
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+
+        #expect(harness.service.requests == [.amendCurrent])
+        #expect(harness.service.clientOperationIDs == [nil])
+        #expect(harness.service.operationListCallCount == 0)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+        #expect(harness.coordinator.undoCandidate == nil)
+    }
+
+    @Test func unrelatedNewestOperationCannotClaimGeneratedClientToken() async throws {
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+        harness.service.newestOperation = GGOperationSummary(
+            id: "op_external", kind: "reorder", status: .completed, createdAtMs: 2,
+            args: ["--client-operation-id", "alas:other", "alas:test-1"],
+            touchedRemote: false, isUndoable: true
+        )
+
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+
+        #expect(harness.service.clientOperationIDs == ["alas:test-1"])
+        #expect(harness.service.operationListCallCount == 1)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+        #expect(harness.coordinator.undoCandidate == nil)
+    }
+
+    @Test func dynamicCapabilityCanEnableCorrelationWithoutRecreatingCoordinator() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+        #expect(harness.service.clientOperationIDs == [nil])
+        #expect(harness.service.operationListCallCount == 0)
+
+        harness.clientOperationCapability.isSupported = true
+        let matching = GGOperationSummary(
+            id: "op_1", kind: "squash", status: .completed, createdAtMs: 2,
+            args: ["--client-operation-id", "alas:test-1", "sc"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        harness.service.newestOperation = matching
+
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+
+        #expect(harness.service.clientOperationIDs == [nil, "alas:test-1"])
+        #expect(harness.service.operationListCallCount == 1)
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: matching))
+    }
+
+    @Test func continueCorrelatesTheCompletedPausedOperationWithoutSendingANewToken() async throws {
+        let completed = GGOperationSummary(
+            id: "op_paused", kind: "restack", status: .completed, createdAtMs: 2,
+            args: ["--client-operation-id", "alas:original", "restack"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a", operationID: "op_paused")],
+            supportsClientOperationID: true
+        )
+        harness.service.newestOperation = completed
+
+        try await harness.coordinator.apply(.continueOperation, confirmedAgainst: nil)
+
+        #expect(harness.service.clientOperationIDs == [nil])
+        #expect(harness.service.operationListCallCount == 1)
+        #expect(harness.markers.operationID(worktreeId: "wt") == completed.id)
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: completed))
+    }
+
+    @Test func continueRejectsANewerOperationThanThePausedOperation() async throws {
+        let newer = GGOperationSummary(
+            id: "op_external", kind: "reorder", status: .completed, createdAtMs: 3,
+            args: ["--client-operation-id", "alas:external", "reorder"],
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a", operationID: "op_paused")],
+            supportsClientOperationID: true
+        )
+        harness.service.newestOperation = newer
+
+        try await harness.coordinator.apply(.continueOperation, confirmedAgainst: nil)
+
+        #expect(harness.service.clientOperationIDs == [nil])
+        #expect(harness.service.operationListCallCount == 1)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+        #expect(harness.coordinator.undoCandidate == nil)
+    }
+
+    @Test func continueRejectsThePausedOperationWithoutAnAlasClientToken() async throws {
+        let legacy = GGOperationSummary(
+            id: "op_paused", kind: "restack", status: .completed, createdAtMs: 2,
+            args: ["restack"], touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a", operationID: "op_paused")],
+            supportsClientOperationID: true
+        )
+        harness.service.newestOperation = legacy
+
+        try await harness.coordinator.apply(.continueOperation, confirmedAgainst: nil)
+
+        #expect(harness.service.clientOperationIDs == [nil])
+        #expect(harness.service.operationListCallCount == 1)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+        #expect(harness.coordinator.undoCandidate == nil)
+    }
+
+    @Test func abortNeverSendsATokenOrQueriesForUndo() async throws {
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a", operationID: "op_paused")],
+            supportsClientOperationID: true
+        )
+        harness.service.newestOperation = GGOperationSummary(
+            id: "op_paused", kind: "restack", status: .completed, createdAtMs: 2,
+            args: ["--client-operation-id", "alas:original", "restack"],
+            touchedRemote: false, isUndoable: true
+        )
+
+        try await harness.coordinator.apply(.abortOperation, confirmedAgainst: nil)
+
+        #expect(harness.service.clientOperationIDs == [nil])
+        #expect(harness.service.operationListCallCount == 0)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+        #expect(harness.coordinator.undoCandidate == nil)
+    }
+
+    @Test func relaunchRestoresOnlyMatchingPersistedLocalUndoableOperation() async {
+        let matching = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "reorder"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: "op_1", worktreeId: "wt")
+        harness.service.newestOperation = matching
+
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: matching))
+        #expect(harness.service.operationListCallCount == 1)
+    }
+
+    @Test func relaunchClearsMarkerWhenNewestOperationDoesNotMatch() async {
+        let newest = GGOperationSummary(
+            id: "op_2", kind: "reorder", status: .completed, createdAtMs: 2,
+            args: ["reorder"], touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: "op_1", worktreeId: "wt")
+        harness.service.newestOperation = newest
+
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func relaunchRejectsLegacyMarkerWithoutAlasClientCorrelation() async {
+        let legacy = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["reorder"], touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: legacy.id, worktreeId: "wt")
+        harness.service.newestOperation = legacy
+
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func relaunchRejectsUndoOperationFromAnotherStack() async {
+        let otherStack = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "reorder"],
+            stackName: "other",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: otherStack.id, worktreeId: "wt")
+        harness.service.newestOperation = otherStack
+
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func relaunchClearsOrdinaryUndoWhenThereIsNoCurrentStack() async {
+        let operation = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "reorder"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: operation.id, worktreeId: "wt")
+        harness.service.newestOperation = operation
+
+        await harness.coordinator.restoreUndoCandidate(currentStackName: nil)
+
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+        #expect(harness.service.operationListCallCount == 0)
+    }
+
+    @Test func remoteTouchedAndRemoteMutationsNeverExposeUndo() async throws {
+        let remoteTouched = GGOperationSummary(
+            id: "op_1", kind: "drop", status: .completed, createdAtMs: 1,
+            args: ["drop"], touchedRemote: true, isUndoable: true
+        )
+        let local = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+        local.service.operationLists = [[GGOperationSummary(
+            id: remoteTouched.id, kind: remoteTouched.kind, status: remoteTouched.status,
+            createdAtMs: remoteTouched.createdAtMs,
+            args: ["--client-operation-id", "alas:test-1", "drop"],
+            touchedRemote: true, isUndoable: true
+        )]]
+        try await local.coordinator.apply(.drop(target: "change-2"), confirmedAgainst: nil)
+        #expect(local.coordinator.undoCandidate == nil)
+        #expect(local.markers.operationID(worktreeId: "wt") == nil)
+        #expect(local.service.operationListCallCount == 1)
+
+        let sync = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+        sync.service.operationLists = [[GGOperationSummary(
+            id: "op_sync", kind: "sync", status: .completed, createdAtMs: 1,
+            args: ["sync"], touchedRemote: false, isUndoable: true
+        )]]
+        try await sync.coordinator.apply(.sync, confirmedAgainst: nil)
+        #expect(sync.service.clientOperationIDs == [nil])
+        #expect(sync.service.operationListCallCount == 0)
+        #expect(sync.coordinator.undoCandidate == nil)
+
+        let landEntries = [
+            GGStackEntry(
+                position: 1, sha: "a", title: "Ready", ggId: "change-1",
+                prNumber: 7, prState: .open, approved: true, ciStatus: .success,
+                isCurrent: true
+            ),
+        ]
+        let land = GGMutationHarness(
+            stacks: [stack(head: "a", entries: landEntries)],
+            supportsClientOperationID: true
+        )
+        try await land.coordinator.apply(.land(target: "change-1"), confirmedAgainst: nil)
+        #expect(land.service.clientOperationIDs == [nil])
+        #expect(land.service.operationListCallCount == 0)
+        #expect(land.coordinator.undoCandidate == nil)
+    }
+
+    @Test func nonRewriteLocalMutationsNeverReceiveTokensOrExposeUndo() async throws {
+        let requests: [GGMutationRequest] = [
+            .checkout(target: "change-1"),
+            .unstack(target: "change-2", name: "upper", createWorktree: false),
+            .clean,
+        ]
+        for request in requests {
+            let harness = GGMutationHarness(
+                stacks: [stack(head: "a")], supportsClientOperationID: true
+            )
+            if case .unstack = request {
+                harness.service.result = .unstack(.init(
+                    originalStack: "feature", newStack: "upper", movedCommits: [],
+                    worktreePath: nil, currentStack: "feature"
+                ))
+            }
+            harness.service.newestOperation = GGOperationSummary(
+                id: "op_1", kind: "checkout", status: .completed, createdAtMs: 1,
+                args: ["--client-operation-id", "alas:test-1", "checkout"],
+                touchedRemote: false, isUndoable: true
+            )
+
+            try await harness.coordinator.apply(request, confirmedAgainst: nil)
+
+            #expect(harness.service.clientOperationIDs == [nil])
+            #expect(harness.service.operationListCallCount == 0)
+            #expect(harness.coordinator.undoCandidate == nil)
+        }
+    }
+
+    @Test func cleanRefreshesPerWorktreeSurfacesAfterTopologyWhenWorktreeStillExists() async throws {
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+
+        try await harness.coordinator.apply(.clean, confirmedAgainst: nil)
+
+        #expect(harness.refreshes == [
+            .topology, .worktreeExistenceCheck, .stack, .gitChanges, .providerReviews, .inbox,
+        ])
+        #expect(harness.service.clientOperationIDs == [nil])
+        #expect(harness.service.operationListCallCount == 0)
+    }
+
+    @Test func cleanSkipsPerWorktreeRefreshesWhenTopologyRemovedTheWorktree() async throws {
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+        harness.worktreeExists = false
+
+        try await harness.coordinator.apply(.clean, confirmedAgainst: nil)
+
+        #expect(harness.refreshes == [.topology, .worktreeExistenceCheck, .inbox])
+    }
+
+    @Test func restoreRejectsAlasTaggedNonRewriteOperation() async {
+        let checkout = GGOperationSummary(
+            id: "op_checkout", kind: "checkout", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "mv"],
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: checkout.id, worktreeId: "wt")
+        harness.service.newestOperation = checkout
+
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func continueRejectsPausedNonRewriteOperation() async throws {
+        let unstack = GGOperationSummary(
+            id: "op_paused", kind: "unstack", status: .completed, createdAtMs: 2,
+            args: ["--client-operation-id", "alas:original", "unstack"],
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a", operationID: "op_paused")],
+            supportsClientOperationID: true
+        )
+        harness.service.newestOperation = unstack
+
+        try await harness.coordinator.apply(.continueOperation, confirmedAgainst: nil)
+
+        #expect(harness.service.operationListCallCount == 1)
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func streamedSyncErrorIsNotOverwrittenByGenericProcessFailure() async {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.service.syncEvents = [.error(message: "push rejected by protected branch")]
+        harness.service.error = GGServiceError.commandFailed(stderr: "")
+
+        await #expect(throws: GGServiceError.commandFailed(stderr: "")) {
+            try await harness.coordinator.apply(.sync, confirmedAgainst: nil)
+        }
+
+        #expect(harness.actionState.lastError == "push rejected by protected branch")
+    }
+
+    @Test func undoRechecksNewestOperationImmediatelyBeforeLaunch() async {
+        let candidate = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "reorder"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let later = GGOperationSummary(
+            id: "op_2", kind: "restack", status: .completed, createdAtMs: 2,
+            args: ["restack"], touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: candidate.id, worktreeId: "wt")
+        harness.service.operationLists = [[candidate], [later]]
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(.undo(operationID: candidate.id), confirmedAgainst: nil)
+        }
+
+        #expect(harness.service.requests.isEmpty)
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func undoRefusalSurfacesGGRecoveryHintWithoutFallbackRollback() async {
+        let candidate = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "reorder"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.markers.set(operationID: candidate.id, worktreeId: "wt")
+        harness.service.operationLists = [[candidate], [candidate], [candidate]]
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+        harness.service.error = GGServiceError.undoRefused(
+            message: "This operation touched remote state.",
+            hint: "Restore the affected branch manually."
+        )
+
+        await #expect(throws: GGServiceError.undoRefused(
+            message: "This operation touched remote state.",
+            hint: "Restore the affected branch manually."
+        )) {
+            try await harness.coordinator.apply(.undo(operationID: candidate.id), confirmedAgainst: nil)
+        }
+
+        #expect(harness.service.requests == [.undo(operationID: candidate.id)])
+        #expect(harness.actionState.lastError == "This operation touched remote state.\nRestore the affected branch manually.")
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: candidate))
+        #expect(harness.markers.operationID(worktreeId: "wt") == candidate.id)
+    }
+
+    @Test func undoOfLastDroppedStackCommitRunsFromTheUndoLogWithoutACurrentStack() async throws {
+        let candidate = GGOperationSummary(
+            id: "op_drop", kind: "drop", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "drop", "change-1"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let noCurrentStack = GGStackSnapshot(version: 1, stack: nil)
+        let harness = GGMutationHarness(stacks: [noCurrentStack])
+        harness.markers.set(
+            GGUndoMarker(operationID: candidate.id, removedFinalStackCommit: true),
+            worktreeId: "wt"
+        )
+        harness.service.operationLists = [[candidate], [candidate]]
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        try await harness.coordinator.apply(.undo(operationID: candidate.id), confirmedAgainst: nil)
+
+        #expect(harness.service.requests == [.undo(operationID: candidate.id)])
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func lastDropPersistsNoStackEvidenceBeforeRefreshReconcilesUndo() async throws {
+        let candidate = GGOperationSummary(
+            id: "op_drop", kind: "drop", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:test-1", "drop", "change-1"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "only")], supportsClientOperationID: true
+        )
+        harness.service.result = .drop(GGDropResult(
+            dropped: [GGDropCommit(position: 1, sha: "only", title: "Only")],
+            remaining: 0
+        ))
+        harness.service.operationLists = [[candidate], [candidate]]
+        harness.onRefreshStack = {
+            await harness.coordinator.restoreUndoCandidate(currentStackName: nil)
+        }
+
+        try await harness.coordinator.apply(.drop(target: "change-2"), confirmedAgainst: nil)
+
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: candidate))
+        #expect(harness.markers.marker(worktreeId: "wt") == GGUndoMarker(
+            operationID: candidate.id, removedFinalStackCommit: true, branch: "feature"
+        ))
+        #expect(harness.service.requests == [.drop(target: "change-2")])
+    }
+
+    @Test func undoRejectsNewestOperationFromAnotherCurrentStack() async {
+        let candidate = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "reorder"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let otherStack = GGStackSnapshot(
+            version: 1,
+            stack: GGStack(
+                name: "other", base: "main", totalCommits: 1, syncedCommits: 0,
+                currentPosition: 1, behindBase: 0,
+                entries: [GGStackEntry(
+                    position: 1, sha: "other-head", title: "Other",
+                    ggId: "other-change", isCurrent: true
+                )]
+            )
+        )
+        let harness = GGMutationHarness(stacks: [otherStack])
+        harness.markers.set(operationID: candidate.id, worktreeId: "wt")
+        harness.service.operationLists = [[candidate], [candidate]]
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(.undo(operationID: candidate.id), confirmedAgainst: nil)
+        }
+
+        #expect(harness.service.requests.isEmpty)
+        #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func undoWithoutACurrentStackRejectsOrdinaryDropWithoutFinalCommitEvidence() async {
+        let candidate = GGOperationSummary(
+            id: "op_1", kind: "drop", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:persisted", "drop", "change-1"],
+            stackName: "feature",
+            touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(stacks: [GGStackSnapshot(version: 1, stack: nil)])
+        harness.markers.set(operationID: candidate.id, worktreeId: "wt")
+        harness.service.operationLists = [[candidate], [candidate]]
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await harness.coordinator.apply(.undo(operationID: candidate.id), confirmedAgainst: nil)
+        }
+
+        #expect(harness.service.requests.isEmpty)
+        #expect(harness.coordinator.undoCandidate == nil)
         #expect(harness.markers.operationID(worktreeId: "wt") == nil)
     }
 

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -196,6 +196,35 @@ struct GGServiceActionsTests {
         #expect(!runner.lastArgs.contains("--force"))
     }
 
+    @MainActor
+    @Test func mutationExecutionPrefixesExactClientOperationID() async throws {
+        let runner = RecordingGGRunner()
+
+        _ = try await GGService(runner: runner).execute(
+            .amendCurrent,
+            worktreePath: "/repo",
+            clientOperationID: "alas:1234",
+            onSyncEvent: { _ in }
+        )
+
+        #expect(runner.calls == [["--client-operation-id", "alas:1234", "sc", "--staged-only"]])
+        #expect(runner.lastCwd == URL(fileURLWithPath: "/repo"))
+    }
+
+    @MainActor
+    @Test func mutationExecutionWithoutClientOperationIDPreservesLegacyArguments() async throws {
+        let runner = RecordingGGRunner()
+
+        _ = try await GGService(runner: runner).execute(
+            .amendCurrent,
+            worktreePath: "/repo",
+            clientOperationID: nil,
+            onSyncEvent: { _ in }
+        )
+
+        #expect(runner.calls == [["sc", "--staged-only"]])
+    }
+
     @Test func absorbStagedUsesStagedOnlyCommandInWorktree() async throws {
         let runner = RecordingGGRunner()
 

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -31,19 +31,89 @@ struct GGStackReadinessModelTests {
         #expect(model.facts.contains { $0.label == "Merged" && $0.value == "1" })
     }
 
-    @Test func syncEnabledWhenBaseIsCurrent() {
+    @Test func unsyncedStackSelectsSyncPrimary() {
         let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: nil)]), action: GGStackActionState())
-        let sync = model.actions.first { $0.kind == .sync }
-        #expect(sync?.isEnabled == true)
+        #expect(model.primaryActions.map(\.kind) == [.sync])
     }
 
-    @Test func syncDisabledWhenBaseIsBehind() {
+    @Test func autoRebaseKeepsSyncPrimaryWhileBehind() {
         let model = GGStackReadinessModel.make(
             stack: stack([entry(position: 1, prState: nil)], behind: 1),
-            action: GGStackActionState()
+            action: GGStackActionState(),
+            effectiveConfig: .init(syncAutoRebase: true, syncBehindThreshold: 1),
+            localChanges: .zero
         )
-        let sync = model.actions.first { $0.kind == .sync }
-        #expect(sync?.isEnabled == false)
+        #expect(model.primaryActions.map(\.kind) == [.sync])
+        #expect(model.primaryActions[0].detail == "Includes rebase onto main")
+    }
+
+    @Test func autoRebaseBelowThresholdKeepsSyncDetailPlain() {
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: nil)], behind: 1),
+            action: GGStackActionState(),
+            effectiveConfig: .init(syncAutoRebase: true, syncBehindThreshold: 3),
+            localChanges: .zero
+        )
+        #expect(model.primaryActions.map(\.kind) == [.sync])
+        #expect(model.primaryActions[0].detail == nil)
+    }
+
+    @Test func thresholdSelectsManualRebase() {
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: nil)], behind: 2),
+            action: GGStackActionState(),
+            effectiveConfig: .init(syncAutoRebase: false, syncBehindThreshold: 2),
+            localChanges: .zero
+        )
+        #expect(model.primaryActions.map(\.kind) == [.rebase])
+        #expect(model.primaryActions[0].title == "Rebase onto main")
+    }
+
+    @Test func belowThresholdKeepsSyncPrimary() {
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: nil)], behind: 1),
+            action: GGStackActionState(),
+            effectiveConfig: .init(syncAutoRebase: false, syncBehindThreshold: 2),
+            localChanges: .zero
+        )
+        #expect(model.primaryActions.map(\.kind) == [.sync])
+    }
+
+    @Test func zeroThresholdAlwaysUsesPlainSyncRegardlessOfAutoRebase() {
+        for autoRebase in [false, true] {
+            let model = GGStackReadinessModel.make(
+                stack: stack([entry(position: 1, prState: nil)], behind: 3),
+                action: GGStackActionState(),
+                effectiveConfig: .init(
+                    syncAutoRebase: autoRebase,
+                    syncBehindThreshold: 0
+                )
+            )
+
+            #expect(model.primaryActions.map(\.kind) == [.sync])
+            #expect(model.primaryActions[0].detail == nil)
+        }
+    }
+
+    @Test func syncWithLocalChangesStatesTheyAreExcluded() {
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: nil)]),
+            action: GGStackActionState(),
+            effectiveConfig: .defaults,
+            localChanges: .init(staged: 1, unstaged: 2)
+        )
+        #expect(model.primaryActions.map(\.kind) == [.sync])
+        #expect(model.localChangesNote == "Local changes are not included")
+    }
+
+    @Test func publishableCommitSelectsSyncEvenWhenCommitCountIsSynced() {
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: nil)], synced: 1),
+            action: GGStackActionState(),
+            effectiveConfig: .defaults,
+            localChanges: .zero
+        )
+        #expect(model.primaryActions.map(\.kind) == [.sync])
     }
 
     @Test func syncUsesLiveBehindBaseOverride() {
@@ -54,7 +124,7 @@ struct GGStackReadinessModelTests {
             liveBehindBase: 2
         )
 
-        #expect(model.actions.first { $0.kind == .sync }?.isEnabled == false)
+        #expect(model.primaryActions.map(\.kind) == [.rebase])
         #expect(model.facts.contains { $0.label == "Behind base" && $0.value == "2" })
         #expect(model.summaryChip.contains("2"))
     }
@@ -102,30 +172,49 @@ struct GGStackReadinessModelTests {
         ))
     }
 
-    @Test func landReadyEnabledWithOpenEntryForFreshVerification() {
+    @Test func freshLandableStackSelectsLandPrimary() {
+        let ready = GGStackReadinessModel.make(
+            stack: stack(
+                [entry(position: 1, prState: .open, approved: true, ci: .success)],
+                synced: 1
+            ),
+            action: GGStackActionState()
+        )
+        #expect(ready.primaryActions.map(\.kind) == [.land])
+
         let staleProviderState = GGStackReadinessModel.make(
             stack: stack([entry(position: 1, prState: .open, approved: false, ci: .success)]),
             action: GGStackActionState()
         )
-        #expect(staleProviderState.actions.first { $0.kind == .land }?.isEnabled == true)
+        #expect(staleProviderState.primaryActions.map(\.kind) == [.sync])
 
         let noOpenEntries = GGStackReadinessModel.make(
-            stack: stack([entry(position: 1, prState: .merged)]),
+            stack: stack([entry(position: 1, prState: .merged)], synced: 1),
             action: GGStackActionState()
         )
-        #expect(noOpenEntries.actions.first { $0.kind == .land }?.isEnabled == false)
+        #expect(noOpenEntries.primaryActions.isEmpty)
     }
 
-    @Test func cleanEnabledOnlyWithMergedEntry() {
-        let noMerged = GGStackReadinessModel.make(
-            stack: stack([entry(position: 1, prState: .open)]), action: GGStackActionState()
-        )
-        #expect(noMerged.actions.first { $0.kind == .clean }?.isEnabled == false)
-
+    @Test func overflowOrderKeepsLifecycleActionsSeparateFromPrimary() {
         let merged = GGStackReadinessModel.make(
-            stack: stack([entry(position: 1, prState: .merged)]), action: GGStackActionState()
+            stack: stack([entry(position: 1, prState: .merged)], synced: 1), action: GGStackActionState()
         )
-        #expect(merged.actions.first { $0.kind == .clean }?.isEnabled == true)
+        #expect(merged.overflowActions.map(\.kind) == [.reorder, .restack, .undo, .clean])
+        #expect(merged.overflowActions.first { $0.kind == .clean }?.isEnabled == true)
+    }
+
+    @Test func undoOverflowIsEnabledOnlyForCoordinatorCandidate() {
+        let operation = GGOperationSummary(
+            id: "op_1", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["reorder"], touchedRemote: false, isUndoable: true
+        )
+        let model = GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .merged)], synced: 1),
+            action: GGStackActionState(),
+            undoCandidate: GGUndoCandidate(operation: operation)
+        )
+
+        #expect(model.overflowActions.first { $0.kind == .undo }?.isEnabled == true)
     }
 
     @Test func pausedSwapsToContinueAbort() {
@@ -133,7 +222,7 @@ struct GGStackReadinessModelTests {
         action.setPaused(GGPausedOperation(pausedBy: .land))
         let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: .open)]), action: action)
         #expect(model.isPaused)
-        #expect(model.actions.map(\.kind) == [.continueOp, .abortOp])
+        #expect(model.primaryActions.map(\.kind) == [.continueOp, .abortOp])
     }
 
     @Test func pausedFallbackOffersContinueAbortWithoutStack() {
@@ -142,7 +231,7 @@ struct GGStackReadinessModelTests {
         let model = GGStackReadinessModel.makePausedFallback(action: action)
         #expect(model?.isPaused == true)
         #expect(model?.summaryChip == "paused")
-        #expect(model?.actions.map(\.kind) == [.continueOp, .abortOp])
+        #expect(model?.primaryActions.map(\.kind) == [.continueOp, .abortOp])
     }
 
     @Test func inFlightActionMarksButtonAndDisablesOthers() {
@@ -151,10 +240,9 @@ struct GGStackReadinessModelTests {
         let model = GGStackReadinessModel.make(
             stack: stack([entry(position: 1, prState: .open, approved: true, ci: .success)]), action: action
         )
-        let sync = model.actions.first { $0.kind == .sync }
+        let sync = model.primaryActions.first { $0.kind == .sync }
         #expect(sync?.isInFlight == true)
-        // Other actions disabled while one is in flight.
-        #expect(model.actions.first { $0.kind == .land }?.isEnabled == false)
+        #expect(model.overflowActions.allSatisfy { !$0.isEnabled })
     }
 
     @Test func summaryChipPriorityPausedThenUnsyncedThenBehindThenMerged() {
@@ -207,7 +295,7 @@ struct GGStackReadinessModelTests {
         action.setPaused(GGPausedOperation(pausedBy: .sync)) // watcher-driven filesystem probe picks up the pause
         let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: .open)]), action: action)
         #expect(model.isPaused)
-        #expect(model.actions.map(\.kind) == [.continueOp, .abortOp])
+        #expect(model.primaryActions.map(\.kind) == [.continueOp, .abortOp])
         #expect(!model.progressRows.isEmpty)
     }
 

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -2,6 +2,47 @@ import Foundation
 import Testing
 @testable import Alas
 
+struct GGReorderModelTests {
+    @Test func moveIsLimitedToContiguousMutableRegion() {
+        var model = GGReorderModel(entries: [
+            .mutable(id: "a", title: "A"),
+            .mutable(id: "b", title: "B"),
+            .immutable(id: "c", title: "C"),
+            .mutable(id: "d", title: "D"),
+        ])
+
+        #expect(model.move(from: 0, to: 1) == .moved)
+        #expect(model.orderedIDs == ["b", "a", "c", "d"])
+        #expect(model.move(from: 1, to: 3) == .immutableBoundary)
+        #expect(model.orderedIDs == ["b", "a", "c", "d"])
+        #expect(model.move(from: 2, to: 1) == .immutableBoundary)
+    }
+
+    @Test func moveAllowsTheEndInsertionOffsetOfAMutableRegion() {
+        var model = GGReorderModel(entries: [
+            .mutable(id: "a", title: "A"),
+            .mutable(id: "b", title: "B"),
+            .immutable(id: "merged", title: "Merged"),
+            .mutable(id: "c", title: "C"),
+        ])
+
+        #expect(model.move(from: 0, to: 2) == .moved)
+        #expect(model.orderedIDs == ["b", "a", "merged", "c"])
+    }
+
+    @Test func reorderAlwaysSubmitsCompleteExactIdentifierOrderAndHasNoDropAction() {
+        var model = GGReorderModel(entries: [
+            .immutable(id: "merged", title: "Merged"),
+            .mutable(id: "one", title: "One"),
+            .mutable(id: "two", title: "Two"),
+        ])
+
+        #expect(model.move(from: 2, to: 1) == .moved)
+        #expect(model.orderedIDs == ["merged", "two", "one"])
+        #expect(model.availableActions == [.apply, .cancel])
+    }
+}
+
 /// Counts `run(...)` calls so tests can assert `refreshGGStack()` skips the
 /// gg CLI when gated closed / not stack-shaped, and dedupes when the commit
 /// set is unchanged since the last query.
@@ -27,6 +68,28 @@ private final class ThrowingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         callCount += 1
         throw GGServiceError.commandFailed(stderr: "boom")
+    }
+}
+
+/// Delays the first stack read so a later refresh can publish a newer stack
+/// before the stale watcher result returns.
+private final class DelayedStackGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var callCount = 0
+    private let staleResult: ProcessResult
+    private let freshResult: ProcessResult
+
+    init(staleResult: ProcessResult, freshResult: ProcessResult) {
+        self.staleResult = staleResult
+        self.freshResult = freshResult
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        callCount += 1
+        if callCount == 1 {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            return staleResult
+        }
+        return freshResult
     }
 }
 
@@ -102,6 +165,129 @@ private final class CleanMutationFakeGGRunner: GGCommandRunning, @unchecked Send
     }
 }
 
+private final class RecordingLifecycleGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var arguments: [[String]] = []
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        arguments.append(args)
+        if args == ["undo", "--list", "--json", "--limit", "1"] {
+            return ProcessResult(
+                exitCode: 0,
+                stdout: #"{"version":1,"operations":[]}"#,
+                stderr: ""
+            )
+        }
+        return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+    }
+}
+
+private final class AdvancingUndoGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var lsCallCount = 0
+    private(set) var undoListCallCount = 0
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["ls", "--json"] {
+            lsCallCount += 1
+            return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        }
+        if args == ["undo", "--list", "--json", "--limit", "1"] {
+            undoListCallCount += 1
+            let id = undoListCallCount == 1 ? "op_1" : "op_2"
+            return ProcessResult(
+                exitCode: 0,
+                stdout: """
+                {"version":1,"operations":[{"id":"\(id)","kind":"reorder","status":"committed","created_at_ms":1,"args":["--client-operation-id","alas:persisted","reorder"],"stack_name":"agent-inbox","touched_remote":false,"is_undoable":true}]}
+                """,
+                stderr: ""
+            )
+        }
+        return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected args: \(args)")
+    }
+}
+
+/// Serves a valid stack + undo candidate on the first `ls`, then throws on the
+/// next `ls` to simulate a stale-key refresh failure after switching branches.
+private final class FailSecondLsUndoGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var lsCallCount = 0
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["ls", "--json"] {
+            lsCallCount += 1
+            if lsCallCount >= 2 {
+                throw GGServiceError.commandFailed(stderr: "boom")
+            }
+            return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        }
+        if args == ["undo", "--list", "--json", "--limit", "1"] {
+            return ProcessResult(
+                exitCode: 0,
+                stdout: """
+                {"version":1,"operations":[{"id":"op_1","kind":"reorder","status":"committed","created_at_ms":1,"args":["--client-operation-id","alas:persisted","reorder"],"stack_name":"agent-inbox","touched_remote":false,"is_undoable":true}]}
+                """,
+                stderr: ""
+            )
+        }
+        return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected args: \(args)")
+    }
+}
+
+private final class NoCurrentStackUndoGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var undoListCallCount = 0
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["ls", "--json"] {
+            return ProcessResult(exitCode: 0, stdout: #"{"version":1,"stacks":[]}"#, stderr: "")
+        }
+        if args == ["undo", "--list", "--json", "--limit", "1"] {
+            undoListCallCount += 1
+            return ProcessResult(
+                exitCode: 0,
+                stdout: #"{"version":1,"operations":[{"id":"op_drop","kind":"drop","status":"committed","created_at_ms":1,"args":["--client-operation-id","alas:persisted","drop","change-1"],"stack_name":"agent-inbox","touched_remote":false,"is_undoable":true}]}"#,
+                stderr: ""
+            )
+        }
+        return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected args: \(args)")
+    }
+}
+
+private final class PausedContinueGGRunner: GGCommandRunning, @unchecked Sendable {
+    let snapshotOperationID: String?
+    let listedOperationID: String
+    private(set) var continueCallCount = 0
+    private(set) var undoListCallCount = 0
+
+    init(snapshotOperationID: String?, listedOperationID: String) {
+        self.snapshotOperationID = snapshotOperationID
+        self.listedOperationID = listedOperationID
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["ls", "--json"] {
+            let operationField = snapshotOperationID.map { #", "operation_id": "\#($0)""# } ?? ""
+            let payload = GGStackModelsTests.fixture.replacingOccurrences(
+                of: #""version": 1"#,
+                with: #""version": 1\#(operationField)"#
+            )
+            return ProcessResult(exitCode: 0, stdout: payload, stderr: "")
+        }
+        if args == ["continue"] {
+            continueCallCount += 1
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+        }
+        if args == ["undo", "--list", "--json", "--limit", "1"] {
+            undoListCallCount += 1
+            return ProcessResult(
+                exitCode: 0,
+                stdout: """
+                {"version":1,"operations":[{"id":"\(listedOperationID)","kind":"restack","status":"committed","created_at_ms":1,"args":["--client-operation-id","alas:original","restack"],"stack_name":"agent-inbox","touched_remote":false,"is_undoable":true}]}
+                """,
+                stderr: ""
+            )
+        }
+        return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+    }
+}
+
 @MainActor
 struct RightPaneGGStackTests {
     private struct MemoryStore: PersistenceStoreProtocol {
@@ -147,6 +333,285 @@ struct RightPaneGGStackTests {
         #expect(ChangesTabView.stackAction(for: .newStackCommit) == nil)
         #expect(ChangesTabView.stackAction(for: .amendCurrent) == .amendCurrent)
         #expect(ChangesTabView.stackAction(for: .absorbIntoStack) == .absorbStaged)
+    }
+
+    @Test func manualRebaseActionTargetsTheProbedBehindBaseRef() async throws {
+        let wt = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: wt.path.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: wt.path) }
+        let runner = RecordingLifecycleGGRunner()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggStack = try GGStackSnapshot.decode(
+            fromJSON: Data(GGStackModelsTests.fixture.utf8)
+        ).stack
+        state.behindBase = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "base-sha",
+            count: 2,
+            probedAt: Date()
+        )
+
+        state.onGGStackAction(.rebase, appState: AppState(store: MemoryStore()))
+        for _ in 0..<500 where !runner.arguments.contains(["rebase", "origin/main"]) {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(runner.arguments.contains(["rebase", "origin/main"]))
+        #expect(!runner.arguments.contains(["rebase", "main"]))
+    }
+
+    @Test func manualRebaseIgnoresBehindRefForADifferentStackBase() async throws {
+        let wt = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: wt.path.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: wt.path) }
+        let runner = RecordingLifecycleGGRunner()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        let releaseFixture = GGStackModelsTests.fixture.replacingOccurrences(
+            of: #""base": "main""#,
+            with: #""base": "release""#
+        )
+        state.ggStack = try GGStackSnapshot.decode(fromJSON: Data(releaseFixture.utf8)).stack
+        state.behindBase = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "base-sha",
+            count: 2,
+            probedAt: Date()
+        )
+
+        state.onGGStackAction(.rebase, appState: AppState(store: MemoryStore()))
+        for _ in 0..<500 where !runner.arguments.contains(["rebase", "release"]) {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(runner.arguments.contains(["rebase", "release"]))
+        #expect(!runner.arguments.contains(["rebase", "origin/main"]))
+    }
+
+    @Test func manualRebaseUsesRemoteQualifiedRefOnlyForTheExactStackBase() {
+        let qualifiedRelease = GitService.BehindStatus(
+            ref: "origin/release",
+            sha: "base-sha",
+            count: 2,
+            probedAt: Date()
+        )
+        let nestedRelease = GitService.BehindStatus(
+            ref: "origin/team/release",
+            sha: "base-sha",
+            count: 2,
+            probedAt: Date()
+        )
+
+        #expect(RightPaneState.ggManualRebaseTarget(
+            stackBase: "release",
+            behindBase: qualifiedRelease
+        ) == "origin/release")
+        #expect(RightPaneState.ggManualRebaseTarget(
+            stackBase: "release",
+            behindBase: nestedRelease
+        ) == "release")
+        #expect(RightPaneState.ggManualRebaseTarget(
+            stackBase: "team/release",
+            behindBase: nestedRelease
+        ) == "origin/team/release")
+    }
+
+    @Test func genericGitRecoveryBlocksOnlyTheGGUndoPresentation() {
+        #expect(RightPaneState.ggUndoRecoveryIsBlockedByGenericGitOperation(
+            operationInProgress: true,
+            alasGGOperationInProgress: false
+        ))
+        #expect(!RightPaneState.ggUndoRecoveryIsBlockedByGenericGitOperation(
+            operationInProgress: false,
+            alasGGOperationInProgress: false
+        ))
+        #expect(!RightPaneState.ggUndoRecoveryIsBlockedByGenericGitOperation(
+            operationInProgress: true,
+            alasGGOperationInProgress: true
+        ))
+    }
+
+    @Test func prepareFailurePresentsGGServiceUserMessage() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: ThrowingFakeGGRunner())
+        let entry = try #require(try GGStackSnapshot.decode(
+            fromJSON: Data(GGStackModelsTests.fixture.utf8)
+        ).stack?.entries.first)
+
+        state.requestGGDrop(entry)
+        for _ in 0..<500 where state.ggActionState.lastError == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(state.ggActionState.lastError == "boom")
+    }
+
+    @Test func applyPreflightFailurePresentsGGServiceUserMessage() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: ThrowingFakeGGRunner())
+
+        state.requestGGCheckout(target: "change-1")
+        for _ in 0..<500 where state.ggActionState.lastError == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(state.ggActionState.lastError == "boom")
+    }
+
+    @Test func unchangedStackKeyStillReloadsEffectiveConfig() async throws {
+        let wt = makeWorktree()
+        let configURL = wt.path.appendingPathComponent(".git/gg/config.json")
+        try FileManager.default.createDirectory(
+            at: configURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: wt.path) }
+        try #"{"defaults":{"sync_auto_rebase":false,"sync_behind_threshold":2}}"#
+            .write(to: configURL, atomically: true, encoding: .utf8)
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "q", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(state.ggEffectiveConfig == .init(syncAutoRebase: false, syncBehindThreshold: 2))
+        try #"{"defaults":{"sync_auto_rebase":true,"sync_behind_threshold":7}}"#
+            .write(to: configURL, atomically: true, encoding: .utf8)
+
+        await state.refreshGGStack()
+
+        #expect(state.ggEffectiveConfig == .init(syncAutoRebase: true, syncBehindThreshold: 7))
+        #expect(runner.callCount == 1)
+    }
+
+    @Test func unchangedStackKeyReconcilesUndoAgainstExternalLaterOperation() async throws {
+        let wt = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: wt.path.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        defer {
+            GGUndoMarkerStore().clear(worktreeId: wt.id)
+            try? FileManager.default.removeItem(at: wt.path)
+        }
+        let markerStore = GGUndoMarkerStore()
+        markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
+        let runner = AdvancingUndoGGRunner()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "u", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(state.ggUndoCandidate?.operationID == "op_1")
+        #expect(markerStore.marker(worktreeId: wt.id)?.operationID == "op_1")
+
+        await state.refreshGGStack()
+
+        #expect(state.ggUndoCandidate == nil)
+        #expect(markerStore.marker(worktreeId: wt.id) == nil)
+        #expect(runner.lsCallCount == 1)
+        #expect(runner.undoListCallCount == 2)
+    }
+
+    @Test func relaunchRestoresFinalDropUndoWhenCurrentBranchHasNoStack() async throws {
+        let wt = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: wt.path.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        defer {
+            GGUndoMarkerStore().clear(worktreeId: wt.id)
+            try? FileManager.default.removeItem(at: wt.path)
+        }
+        GGUndoMarkerStore().set(
+            GGUndoMarker(operationID: "op_drop", removedFinalStackCommit: true),
+            worktreeId: wt.id
+        )
+        let runner = NoCurrentStackUndoGGRunner()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [
+            commit(sha: String(repeating: "u", count: 40), stackShaped: true),
+        ]
+
+        await state.refreshGGStack()
+
+        #expect(state.ggStack == nil)
+        #expect(state.ggUndoCandidate?.operationID == "op_drop")
+        #expect(runner.undoListCallCount == 1)
+    }
+
+    @Test func continueUsesExactPausedOperationIDFromProductionSnapshotPath() async throws {
+        let wt = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: wt.path.appendingPathComponent(".git/rebase-merge"),
+            withIntermediateDirectories: true
+        )
+        defer {
+            GGUndoMarkerStore().clear(worktreeId: wt.id)
+            try? FileManager.default.removeItem(at: wt.path)
+        }
+        let runner = PausedContinueGGRunner(
+            snapshotOperationID: "op_paused",
+            listedOperationID: "op_paused"
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        // Seed the gg gate and a stack-shaped commit set so the post-continue
+        // refresh loads the `agent-inbox` stack and reconciles the undo
+        // candidate against a matching scope, rather than treating the gate as
+        // closed and suspending it.
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "c", count: 40), stackShaped: true)]
+        state.ggActionState.setPaused(GGPausedOperation(pausedBy: .restack))
+
+        state.onGGStackAction(.continueOp, appState: AppState(store: MemoryStore()))
+        for _ in 0..<500 where runner.continueCallCount == 0 || state.ggUndoCandidate == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(runner.continueCallCount == 1)
+        #expect(state.ggUndoCandidate?.operationID == "op_paused")
+    }
+
+    @Test func continueNeverSynthesizesMissingPausedOperationID() async throws {
+        let wt = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: wt.path.appendingPathComponent(".git/rebase-merge"),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: wt.path) }
+        let runner = PausedContinueGGRunner(
+            snapshotOperationID: nil,
+            listedOperationID: "in-progress"
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggActionState.setPaused(GGPausedOperation(pausedBy: .restack))
+
+        state.onGGStackAction(.continueOp, appState: AppState(store: MemoryStore()))
+        for _ in 0..<500 where runner.continueCallCount == 0 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(runner.continueCallCount == 1)
+        #expect(runner.undoListCallCount == 0)
+        #expect(state.ggUndoCandidate == nil)
     }
 
     @Test func ggOwnedPresentationUsesCommitTerminology() {
@@ -266,6 +731,64 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.pausedOperation == nil)
     }
 
+    @Test func gateClosedHidesUndoRecoveryButPreservesMarker() async throws {
+        let wt = makeWorktree()
+        defer { GGUndoMarkerStore().clear(worktreeId: wt.id) }
+        let markerStore = GGUndoMarkerStore()
+        markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
+        state.ggService = GGService(runner: AdvancingUndoGGRunner())
+
+        await state.refreshGGStack()
+        #expect(state.ggUndoCandidate?.operationID == "op_1")
+
+        // The gg gate can read closed transiently before the startup
+        // availability probe resolves. Hide the candidate but keep the marker
+        // so a valid recovery Undo is not destroyed by that race.
+        state.ggGateProvider = { false }
+        await state.refreshGGStack()
+
+        #expect(state.ggUndoCandidate == nil)
+        #expect(markerStore.marker(worktreeId: wt.id)?.operationID == "op_1")
+    }
+
+    @Test func failedStackRefreshHidesUndoRecoveryButPreservesMarker() async throws {
+        let wt = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: wt.path.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        defer {
+            GGUndoMarkerStore().clear(worktreeId: wt.id)
+            try? FileManager.default.removeItem(at: wt.path)
+        }
+        let markerStore = GGUndoMarkerStore()
+        markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
+        let runner = FailSecondLsUndoGGRunner()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(state.ggUndoCandidate?.operationID == "op_1")
+
+        // Switch to a different stack-shaped branch: the commits key changes and
+        // the `gg ls` refresh for it fails, so the cached stack is dropped and
+        // the current identity is unknown. The candidate must be hidden (not
+        // offered for the previous stack) while the marker survives for a later
+        // reconcile to rebuild.
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "b", count: 40), stackShaped: true)]
+        await state.refreshGGStack()
+
+        #expect(state.ggStack == nil)
+        #expect(state.ggUndoCandidate == nil)
+        #expect(markerStore.marker(worktreeId: wt.id)?.operationID == "op_1")
+        #expect(runner.lsCallCount == 2)
+    }
+
     @Test func activeGGOperationPreservesPausedWhenStackShapeDisappears() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-gg-paused-unshaped-\(UUID().uuidString)")
@@ -375,6 +898,50 @@ struct RightPaneGGStackTests {
         // retry rather than being skipped by the unchanged-key guard.
         await state.refreshGGStack()
         #expect(runner.callCount == 2)
+    }
+
+    @Test func transientStackLoadFailurePreservesUndoRecoveryMarker() async throws {
+        let wt = makeWorktree()
+        defer { GGUndoMarkerStore().clear(worktreeId: wt.id) }
+        let markerStore = GGUndoMarkerStore()
+        markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: ThrowingFakeGGRunner())
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "f", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+
+        #expect(state.ggUndoCandidate == nil)
+        #expect(markerStore.marker(worktreeId: wt.id)?.operationID == "op_1")
+    }
+
+    @Test func staleWatcherStackLoadCannotOverwriteNewerRefresh() async throws {
+        let wt = makeWorktree()
+        let stale = ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        let fresh = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture.replacingOccurrences(of: "agent-inbox", with: "fresh-stack"),
+            stderr: ""
+        )
+        let runner = DelayedStackGGRunner(staleResult: stale, freshResult: fresh)
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggGateProvider = { true }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "z", count: 40), stackShaped: true)]
+
+        let staleRefresh = Task { @MainActor in await state.refreshGGStack() }
+        for _ in 0..<500 where runner.callCount == 0 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(runner.callCount == 1)
+
+        state.ggStackCommitsKey = nil
+        await state.refreshGGStack()
+        #expect(state.ggStack?.name == "fresh-stack")
+
+        await staleRefresh.value
+        #expect(state.ggStack?.name == "fresh-stack")
     }
 
     /// A stack loaded for one branch must not keep rendering after the user


### PR DESCRIPTION
## What

- Adds stack workflows for reorder, restack, rebase, land, and undo.
- Uses the matching fetched base ref for manual rebase and falls back safely when the probe is for another ref.

## Validation

- GG lifecycle and undo-marker tests.
- Focused manual-rebase tests.

## Stack

- Builds on #875.

<!-- gg:managed:start -->
Part of stack `prepare-gg`

Commit: 45b5c24
<!-- gg:managed:end -->