### PR TITLE
fix(gg): right-align stack PR chips and make them clickable

### DIFF
--- a/Alas/Sources/Integrations/GG/GGStackChip.swift
+++ b/Alas/Sources/Integrations/GG/GGStackChip.swift
@@ -5,11 +5,14 @@ import SwiftUI
 struct GGStackChipModel: Equatable {
     let label: String
     let colorToken: String
+    /// Tooltip for the clickable chip, e.g. "Open PR #840" / "Open MR !840".
+    let helpLabel: String
 
     static func model(for entry: GGStackEntry, kind: CodeHostKind?) -> GGStackChipModel? {
         guard let number = entry.prNumber else { return nil }
         let prefix = kind == .gitlab ? "!" : "#"
-        let label = "\(prefix)\(number)" + (entry.approved ? " ✓" : "")
+        let reference = "\(prefix)\(number)"
+        let label = reference + (entry.approved ? " ✓" : "")
         let token: String
         switch entry.prState {
         case .open: token = "add"
@@ -18,23 +21,44 @@ struct GGStackChipModel: Equatable {
         case .closed: token = "del"
         case nil: token = "fg-faint"
         }
-        return GGStackChipModel(label: label, colorToken: token)
+        return GGStackChipModel(
+            label: label,
+            colorToken: token,
+            helpLabel: "Open \(kind?.reviewRequestLabel ?? "PR") \(reference)"
+        )
     }
 }
 
 /// Capsule chip styled after `BehindChip` (CommitsSectionView.swift).
+/// When `onTap` is set, the chip becomes a button with hover highlight.
 struct GGStackChip: View {
     let model: GGStackChipModel
+    var onTap: (() -> Void)? = nil
     @Environment(\.theme) private var theme
+    @State private var hovering = false
 
     var body: some View {
+        if let onTap {
+            Button(action: onTap) {
+                chipBody(backgroundOpacity: hovering ? 0.22 : 0.12)
+            }
+            .buttonStyle(.plain)
+            .pointingHandCursor()
+            .onHover { hovering = $0 }
+            .help(model.helpLabel)
+        } else {
+            chipBody(backgroundOpacity: 0.12)
+        }
+    }
+
+    private func chipBody(backgroundOpacity: Double) -> some View {
         let tint = theme.color(model.colorToken)
-        Text(model.label)
+        return Text(model.label)
             .font(.system(size: 9.5, weight: .semibold))
             .lineLimit(1)
             .foregroundColor(tint)
             .padding(.horizontal, 6).padding(.vertical, 1)
-            .background(tint.opacity(0.12))
+            .background(tint.opacity(backgroundOpacity))
             .clipShape(Capsule())
     }
 }

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -184,10 +184,10 @@ struct CommitRow: View {
                     GGCIDot(status: stackEntry.ciStatus)
                 }
                 if let chip = GGStackChipModel.model(for: stackEntry, kind: codeHostKind) {
-                    GGStackChip(model: chip)
+                    GGStackChip(model: chip, onTap: onGGOpenPR)
+                        .layoutPriority(1)
                 }
             }
-            Spacer(minLength: 0)
         }
     }
 

--- a/AlasTests/Integrations/GGStackChipModelTests.swift
+++ b/AlasTests/Integrations/GGStackChipModelTests.swift
@@ -34,4 +34,14 @@ struct GGStackChipModelTests {
         #expect(GGStackChipModel.model(for: entry(prState: .closed), kind: .github)?.colorToken == "del")
         #expect(GGStackChipModel.model(for: entry(prState: nil), kind: .github)?.colorToken == "fg-faint")
     }
+
+    @Test func helpLabelUsesHostTerminology() {
+        #expect(GGStackChipModel.model(for: entry(), kind: .github)?.helpLabel == "Open PR #840")
+        #expect(GGStackChipModel.model(for: entry(), kind: .gitlab)?.helpLabel == "Open MR !840")
+        #expect(GGStackChipModel.model(for: entry(), kind: nil)?.helpLabel == "Open PR #840")
+    }
+
+    @Test func helpLabelOmitsApprovalCheckmark() {
+        #expect(GGStackChipModel.model(for: entry(approved: true), kind: .github)?.helpLabel == "Open PR #840")
+    }
 }


### PR DESCRIPTION
## What

- Right-aligns the CI dot + PR/MR chip in gg stack commit rows so they form a single column instead of floating mid-row. The subject line had two competing `Spacer`s splitting the leftover width; the trailing one is removed and the chip gets `.layoutPriority(1)` so long subjects truncate before the chip compresses.
- Makes the chip clickable to open its PR/MR in the browser, reusing the existing `onGGOpenPR` action that was previously only reachable via the context menu. Clickable chips get a hover highlight, pointing-hand cursor, and an "Open PR #N" / "Open MR !N" tooltip; the plain nested button swallows the tap so the row's select action does not fire.
- When no action is available (e.g. no remote), the chip renders passively exactly as before.

## Validation

- New `GGStackChipModel` tests cover the tooltip label for GitHub/GitLab/nil host kinds and verify the approval checkmark never leaks into it.
- Manual: chips line up flush right across rows; hover/tooltip/click behave as described without selecting the row.

<!-- gg:managed:start -->
Part of stack `ui-gg-commit`

Commit: 7806885
<!-- gg:managed:end -->