### PR TITLE
feat(chat): Add ACP go to newest affordance

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -50,6 +50,8 @@ struct ACPMessageList: View {
     /// bottom we guarantee the streaming caret / last message sits
     /// above the composer instead of behind it.
     private let composerSpacerHeight: CGFloat = 220
+    private let goToNewestButtonSize: CGFloat = 32
+    private let goToNewestButtonComposerGap: CGFloat = 12
     /// Step the visible head back when the "Earlier messages…" marker
     /// crosses this many points from the top edge during scroll.
     private let headStepScrollThreshold: CGFloat = 200
@@ -134,181 +136,214 @@ struct ACPMessageList: View {
     var body: some View {
         ScrollViewReader { proxy in
             GeometryReader { viewport in
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 18) {
-                        switch Self.topPaginationIndicator(
-                            visibleHead: transcript.visibleHead,
-                            isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
-                        ) {
-                        case .hidden:
-                            EmptyView()
-                        case .sentinel:
-                            topPaginationSentinel
-                        case .spinner:
-                            Spinner(lineWidth: 1.5)
-                                .frame(width: 14, height: 14)
-                                .frame(maxWidth: .infinity, alignment: .center)
-                                .padding(.bottom, 4)
-                                .background(topPaginationSentinel)
-                        }
-                        ForEach(visibleRows) { row in
-                            visibleRow(row)
-                        }
-                        if Self.shouldShowBottomPaginationSentinel(
-                            visibleTail: transcript.visibleTailBound,
-                            messageCount: transcript.messages.count
-                        ) {
-                            bottomPaginationSentinel
-                        }
-                        if transcript.pendingPermission != nil, let policy = policy {
-                            ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
-                                .id("__pending_perm__")
-                        }
-                        if let request = transcript.pendingUserInputs.first {
-                            ACPUserInputPrompt(
-                                request: request,
-                                onRespond: onUserInputResponse,
-                                onOpenURL: onOpenElicitationURL
-                            )
-                            .id("__pending_user_input_\(request.id)")
-                        }
-                        ForEach(transcript.urlElicitationWaits) { wait in
-                            ACPURLElicitationWaitView(
-                                wait: wait,
-                                onOpenAgain: { NSWorkspace.shared.open($0) },
-                                onDismiss: onDismissElicitationURLWait
-                            )
-                            .id("__elicitation_wait_\(wait.id)")
-                        }
-                        if transcript.streamingState == .streaming {
-                            StreamingCaret().frame(width: 8, height: 14)
-                                .id("__streaming_caret__")
-                        }
-                        let queueHeaderCount = Self.queueHeaderCount(
-                            statuses: session.queue.map(\.status)
-                        )
-                        if queueHeaderCount > 1 {
-                            ACPQueueHeader(count: queueHeaderCount, onClear: onQueueClearAll)
-                                .id("__queue_header__")
-                        }
-                        ForEach(Array(session.queue.enumerated()), id: \.element.id) { idx, item in
-                            if Self.shouldRenderQueueBubble(status: item.status) {
-                                ACPQueuedBubble(
-                                    item: item,
-                                    contentMaxWidth: contentMaxWidth,
-                                    typography: typography,
-                                    onForceSend: { onQueueForceSend(item.id) },
-                                    onEdit: { onQueueEdit(item) },
-                                    onRemove: { onQueueRemove(item.id) },
-                                    onRetry: { onQueueRetry(item.id) }
-                                )
-                                .dropDestination(for: String.self) { items, _ in
-                                    guard let s = items.first,
-                                          let uuid = UUID(uuidString: s),
-                                          let src = session.queue.firstIndex(where: { $0.id == uuid })
-                                    else { return false }
-                                    guard Self.canDropQueuedItem(
-                                        sourceStatus: session.queue[src].status,
-                                        targetStatus: item.status
-                                    ) else { return false }
-                                    onQueueReorder(src, idx)
-                                    return true
-                                }
-                                .id("__queue_\(item.id)")
+                ZStack(alignment: .bottomTrailing) {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 18) {
+                            switch Self.topPaginationIndicator(
+                                visibleHead: transcript.visibleHead,
+                                isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
+                            ) {
+                            case .hidden:
+                                EmptyView()
+                            case .sentinel:
+                                topPaginationSentinel
+                            case .spinner:
+                                Spinner(lineWidth: 1.5)
+                                    .frame(width: 14, height: 14)
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                                    .padding(.bottom, 4)
+                                    .background(topPaginationSentinel)
                             }
+                            ForEach(visibleRows) { row in
+                                visibleRow(row)
+                            }
+                            if Self.shouldShowBottomPaginationSentinel(
+                                visibleTail: transcript.visibleTailBound,
+                                messageCount: transcript.messages.count
+                            ) {
+                                bottomPaginationSentinel
+                            }
+                            if transcript.pendingPermission != nil, let policy = policy {
+                                ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
+                                    .id("__pending_perm__")
+                            }
+                            if let request = transcript.pendingUserInputs.first {
+                                ACPUserInputPrompt(
+                                    request: request,
+                                    onRespond: onUserInputResponse,
+                                    onOpenURL: onOpenElicitationURL
+                                )
+                                .id("__pending_user_input_\(request.id)")
+                            }
+                            ForEach(transcript.urlElicitationWaits) { wait in
+                                ACPURLElicitationWaitView(
+                                    wait: wait,
+                                    onOpenAgain: { NSWorkspace.shared.open($0) },
+                                    onDismiss: onDismissElicitationURLWait
+                                )
+                                .id("__elicitation_wait_\(wait.id)")
+                            }
+                            if transcript.streamingState == .streaming {
+                                StreamingCaret().frame(width: 8, height: 14)
+                                    .id("__streaming_caret__")
+                            }
+                            let queueHeaderCount = Self.queueHeaderCount(
+                                statuses: session.queue.map(\.status)
+                            )
+                            if queueHeaderCount > 1 {
+                                ACPQueueHeader(count: queueHeaderCount, onClear: onQueueClearAll)
+                                    .id("__queue_header__")
+                            }
+                            ForEach(Array(session.queue.enumerated()), id: \.element.id) { idx, item in
+                                if Self.shouldRenderQueueBubble(status: item.status) {
+                                    ACPQueuedBubble(
+                                        item: item,
+                                        contentMaxWidth: contentMaxWidth,
+                                        typography: typography,
+                                        onForceSend: { onQueueForceSend(item.id) },
+                                        onEdit: { onQueueEdit(item) },
+                                        onRemove: { onQueueRemove(item.id) },
+                                        onRetry: { onQueueRetry(item.id) }
+                                    )
+                                    .dropDestination(for: String.self) { items, _ in
+                                        guard let s = items.first,
+                                              let uuid = UUID(uuidString: s),
+                                              let src = session.queue.firstIndex(where: { $0.id == uuid })
+                                        else { return false }
+                                        guard Self.canDropQueuedItem(
+                                            sourceStatus: session.queue[src].status,
+                                            targetStatus: item.status
+                                        ) else { return false }
+                                        onQueueReorder(src, idx)
+                                        return true
+                                    }
+                                    .id("__queue_\(item.id)")
+                                }
+                            }
+                            if let status = session.contextRecoveryStatus {
+                                contextRecoveryRow(status)
+                                    .id("__context_recovery__")
+                            }
+                            // Invisible tail spacer that the auto-scroll pins to
+                            // the viewport bottom; this guarantees the streaming
+                            // caret / last message sits above the composer pill.
+                            Color.clear
+                                .frame(height: composerSpacerHeight)
+                                .id("__composer_spacer__")
                         }
-                        if let status = session.contextRecoveryStatus {
-                            contextRecoveryRow(status)
-                                .id("__context_recovery__")
+                        .frame(maxWidth: contentMaxWidth, alignment: .leading)
+                        .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
+                        .padding(.top, 24)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .environment(\.openURL, openTranscriptURLAction)
+                    }
+                    .coordinateSpace(.named(Self.scrollSpaceName))
+                    .modifier(ACPTranscriptScrollTracking(
+                        isRestoring: { scrollBook.isRestoringTail },
+                        onResolveScrollView: { scrollViewRef.scrollView = $0 },
+                        onHeadFrame: { handleHeadFramePreference($0, proxy: proxy) },
+                        onPaused: { setFollowsTranscriptTail(false) },
+                        onAtBottom: { shouldPageHiddenTail in
+                            handleAtBottom(proxy: proxy, shouldPageHiddenTail: shouldPageHiddenTail)
+                        },
+                        onGeometry: { old, new in
+                            handleScrollGeometry(
+                                previousMinY: old.minY,
+                                newMinY: new.minY,
+                                viewportHeight: new.viewportHeight,
+                                previousContentHeight: old.contentHeight,
+                                contentHeight: new.contentHeight,
+                                proxy: proxy)
                         }
-                        // Invisible tail spacer that the auto-scroll pins to
-                        // the viewport bottom; this guarantees the streaming
-                        // caret / last message sits above the composer pill.
-                        Color.clear
-                            .frame(height: composerSpacerHeight)
-                            .id("__composer_spacer__")
+                    ))
+                    .onAppear {
+                        restoreTailIfNeeded(proxy: proxy, animated: false)
+                        restoreRememberedAnchorIfNeeded(proxy: proxy)
                     }
-                    .frame(maxWidth: contentMaxWidth, alignment: .leading)
-                    .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
-                    .padding(.top, 24)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .environment(\.openURL, openTranscriptURLAction)
-                }
-                .coordinateSpace(.named(Self.scrollSpaceName))
-                .modifier(ACPTranscriptScrollTracking(
-                    isRestoring: { scrollBook.isRestoringTail },
-                    onResolveScrollView: { scrollViewRef.scrollView = $0 },
-                    onHeadFrame: { handleHeadFramePreference($0, proxy: proxy) },
-                    onPaused: { setFollowsTranscriptTail(false) },
-                    onAtBottom: { shouldPageHiddenTail in
-                        handleAtBottom(proxy: proxy, shouldPageHiddenTail: shouldPageHiddenTail)
-                    },
-                    onGeometry: { old, new in
-                        handleScrollGeometry(
-                            previousMinY: old.minY,
-                            newMinY: new.minY,
-                            viewportHeight: new.viewportHeight,
-                            previousContentHeight: old.contentHeight,
-                            contentHeight: new.contentHeight,
-                            proxy: proxy)
+                    .onDisappear {
+                        scrollBook.pendingTailScrollTask?.cancel()
+                        scrollBook.pendingTailScrollTask = nil
+                        scrollBook.pendingContentGrowthTailRestore = nil
+                        scrollBook.pendingContentShrinkResetTask?.cancel()
+                        scrollBook.pendingContentShrinkResetTask = nil
+                        scrollBook.contentShrinkBookmarkResetState = .none
                     }
-                ))
-                .onAppear {
-                    restoreTailIfNeeded(proxy: proxy, animated: false)
-                    restoreRememberedAnchorIfNeeded(proxy: proxy)
-                }
-                .onDisappear {
-                    scrollBook.pendingTailScrollTask?.cancel()
-                    scrollBook.pendingTailScrollTask = nil
-                    scrollBook.pendingContentGrowthTailRestore = nil
-                    scrollBook.pendingContentShrinkResetTask?.cancel()
-                    scrollBook.pendingContentShrinkResetTask = nil
-                    scrollBook.contentShrinkBookmarkResetState = .none
-                }
-                .onChange(of: viewport.size.height) { _, _ in
-                    restoreTailIfNeeded(proxy: proxy, animated: false)
-                    restoreRememberedAnchorIfNeeded(proxy: proxy)
-                }
-                .onChange(of: viewport.size.width) { oldWidth, newWidth in
-                    if Self.shouldRestoreTailAfterViewportWidthChange(
-                        previousWidth: oldWidth,
-                        newWidth: newWidth,
+                    .onChange(of: viewport.size.height) { _, _ in
+                        restoreTailIfNeeded(proxy: proxy, animated: false)
+                        restoreRememberedAnchorIfNeeded(proxy: proxy)
+                    }
+                    .onChange(of: viewport.size.width) { oldWidth, newWidth in
+                        if Self.shouldRestoreTailAfterViewportWidthChange(
+                            previousWidth: oldWidth,
+                            newWidth: newWidth,
+                            followsTranscriptTail: session.followsTranscriptTail
+                        ) {
+                            restoreTailIfNeeded(proxy: proxy, animated: false)
+                        }
+                        restoreRememberedAnchorIfNeeded(proxy: proxy)
+                    }
+                    .onChange(of: scrollSignature) { _, _ in
+                        if session.followsTranscriptTail {
+                            transcript.resetWindowToTail()
+                            scheduleTailScroll(
+                                proxy: proxy,
+                                animated: Self.shouldAnimateTailScroll(
+                                    trigger: .contentSignature,
+                                    streamingState: transcript.streamingState
+                                )
+                            )
+                        }
+                        restoreRememberedAnchorIfNeeded(proxy: proxy)
+                    }
+                    .onChange(of: transcript.streamingState) { _, new in
+                        if session.followsTranscriptTail && (new == .streaming || new == .sending) {
+                            scheduleTailScroll(
+                                proxy: proxy,
+                                animated: Self.shouldAnimateTailScroll(
+                                    trigger: .streamingState,
+                                    streamingState: new
+                                )
+                            )
+                        }
+                    }
+                    .onChange(of: transcript.visibleHead) { _, _ in
+                        restoreRememberedAnchorIfNeeded(proxy: proxy)
+                    }
+                    .modifier(ACPRowFramePreferenceTracking { frames in
+                        handleRowFramePreference(frames, proxy: proxy)
+                    })
+
+                    if Self.shouldShowGoToNewestAffordance(
                         followsTranscriptTail: session.followsTranscriptTail
                     ) {
-                        restoreTailIfNeeded(proxy: proxy, animated: false)
-                    }
-                    restoreRememberedAnchorIfNeeded(proxy: proxy)
-                }
-                .onChange(of: scrollSignature) { _, _ in
-                    if session.followsTranscriptTail {
-                        transcript.resetWindowToTail()
-                        scheduleTailScroll(
-                            proxy: proxy,
-                            animated: Self.shouldAnimateTailScroll(
-                                trigger: .contentSignature,
-                                streamingState: transcript.streamingState
-                            )
+                        Button {
+                            goToNewestMessage(proxy: proxy)
+                        } label: {
+                            Image(systemName: "arrow.down")
+                                .font(.system(size: 14, weight: .semibold))
+                                .frame(width: goToNewestButtonSize, height: goToNewestButtonSize)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(theme.color("fg"))
+                        .background(
+                            Circle()
+                                .fill(theme.color("bg-1").opacity(0.95))
+                                .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
                         )
-                    }
-                    restoreRememberedAnchorIfNeeded(proxy: proxy)
-                }
-                .onChange(of: transcript.streamingState) { _, new in
-                    if session.followsTranscriptTail && (new == .streaming || new == .sending) {
-                        scheduleTailScroll(
-                            proxy: proxy,
-                            animated: Self.shouldAnimateTailScroll(
-                                trigger: .streamingState,
-                                streamingState: new
-                            )
+                        .overlay(
+                            Circle()
+                                .strokeBorder(theme.color("line").opacity(0.9), lineWidth: 0.5)
                         )
+                        .accessibilityLabel("Go to newest message")
+                        .help("Go to newest message")
+                        .padding(.trailing, 20)
+                        .padding(.bottom, Self.goToNewestAffordanceBottomPadding(
+                            composerSpacerHeight: composerSpacerHeight,
+                            gap: goToNewestButtonComposerGap
+                        ))
+                        .transition(.opacity.combined(with: .scale(scale: 0.94)))
                     }
                 }
-                .onChange(of: transcript.visibleHead) { _, _ in
-                    restoreRememberedAnchorIfNeeded(proxy: proxy)
-                }
-                .modifier(ACPRowFramePreferenceTracking { frames in
-                    handleRowFramePreference(frames, proxy: proxy)
-                })
             }
         }
         .background(
@@ -323,6 +358,16 @@ struct ACPMessageList: View {
         guard session.followsTranscriptTail else { return }
         transcript.resetWindowToTail()
         scrollToTail(proxy: proxy, animated: animated)
+    }
+
+    private func goToNewestMessage(proxy: ScrollViewProxy) {
+        let action = Self.goToNewestAffordanceAction()
+        if action.resumesTailFollow {
+            setFollowsTranscriptTail(true)
+        }
+        if action.schedulesTailScroll {
+            scheduleTailScroll(proxy: proxy, animated: action.animatedTailScroll)
+        }
     }
 
     private func restoreRememberedAnchorIfNeeded(proxy: ScrollViewProxy) {
@@ -928,6 +973,37 @@ struct ACPMessageList: View {
         case .streamingState, .contentGrowth:
             return false
         }
+    }
+
+    nonisolated static func shouldShowGoToNewestAffordance(
+        followsTranscriptTail: Bool
+    ) -> Bool {
+        !followsTranscriptTail
+    }
+
+    nonisolated static func shouldAnimateGoToNewestTailScroll() -> Bool {
+        true
+    }
+
+    struct GoToNewestAffordanceAction: Equatable {
+        let resumesTailFollow: Bool
+        let schedulesTailScroll: Bool
+        let animatedTailScroll: Bool
+    }
+
+    nonisolated static func goToNewestAffordanceAction() -> GoToNewestAffordanceAction {
+        GoToNewestAffordanceAction(
+            resumesTailFollow: true,
+            schedulesTailScroll: true,
+            animatedTailScroll: shouldAnimateGoToNewestTailScroll()
+        )
+    }
+
+    nonisolated static func goToNewestAffordanceBottomPadding(
+        composerSpacerHeight: CGFloat,
+        gap: CGFloat
+    ) -> CGFloat {
+        composerSpacerHeight + gap
     }
 
     nonisolated static func shouldRunScheduledTailScroll(followsTranscriptTail: Bool) -> Bool {

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -396,6 +396,29 @@ struct ACPMessageListPaginationTests {
         ))
     }
 
+    @Test("go-to-newest affordance shows only when tail-follow is paused")
+    func goToNewestAffordanceShowsOnlyWhenTailFollowPaused() {
+        #expect(!ACPMessageList.shouldShowGoToNewestAffordance(followsTranscriptTail: true))
+        #expect(ACPMessageList.shouldShowGoToNewestAffordance(followsTranscriptTail: false))
+    }
+
+    @Test("go-to-newest affordance resumes tail-follow with scheduled animated scroll")
+    func goToNewestAffordanceResumesTailFollowWithScheduledAnimatedScroll() {
+        #expect(ACPMessageList.goToNewestAffordanceAction() == ACPMessageList.GoToNewestAffordanceAction(
+            resumesTailFollow: true,
+            schedulesTailScroll: true,
+            animatedTailScroll: true
+        ))
+    }
+
+    @Test("go-to-newest affordance is positioned above composer-safe space")
+    func goToNewestAffordanceIsPositionedAboveComposerSafeSpace() {
+        #expect(ACPMessageList.goToNewestAffordanceBottomPadding(
+            composerSpacerHeight: 220,
+            gap: 12
+        ) == 232)
+    }
+
     @Test("deferred tail scrolls require active tail-follow")
     func deferredTailScrollsRequireActiveTailFollow() {
         #expect(ACPMessageList.shouldRunScheduledTailScroll(followsTranscriptTail: true))

--- a/docs/superpowers/specs/2026-07-21-acp-go-to-newest-affordance-design.md
+++ b/docs/superpowers/specs/2026-07-21-acp-go-to-newest-affordance-design.md
@@ -1,0 +1,59 @@
+# ACP Go To Newest Affordance Design
+
+## Context
+
+The ACP chat pane already tracks whether the transcript should follow the tail through `ACPSession.followsTranscriptTail`. User-driven upward scrolling pauses tail-follow, stores a remembered anchor, and prevents streaming or layout reflow from pulling the viewport back to the newest message. Returning to the bottom resumes tail-follow and clears that remembered anchor.
+
+Long transcripts currently have no direct affordance for returning to the newest message after the user intentionally scrolls away. The user must manually scroll back to the bottom.
+
+## Goal
+
+Add a compact, conventional control that appears when the user has intentionally scrolled away from the transcript tail and jumps back to the newest message.
+
+## Non-Goals
+
+- Do not add a separate unread/new-message counter.
+- Do not infer visibility from raw distance-from-bottom alone.
+- Do not change transcript pagination, remembered-anchor persistence, or streaming auto-scroll behavior beyond wiring the new control into the existing tail-follow path.
+
+## User Experience
+
+When `session.followsTranscriptTail` is `false`, show a lower-right floating button over the transcript scroll area, positioned just above the composer-safe tail space. The control should be compact and icon-first, using a down-arrow system image and an accessibility label such as "Go to newest message".
+
+Clicking the button resumes tail-follow and scrolls to the newest message. The control disappears after tail-follow resumes. If the user manually scrolls back to the bottom, existing bottom detection should also resume tail-follow and hide the control.
+
+## Architecture
+
+Implement the affordance inside `ACPMessageList`, because that view already owns the `ScrollViewReader`, scroll bookkeeping, tail restoration helpers, and access to `session.followsTranscriptTail`.
+
+The button should be an overlay on the scroll view or its surrounding geometry container so it can float independently of transcript rows. It should not be inserted into the lazy message stack, because it is chrome for navigation rather than transcript content.
+
+The click handler should reuse the existing tail-follow transition:
+
+- Set tail-follow to true through the local `setFollowsTranscriptTail(true)` path.
+- Clear remembered scroll state through `onRememberScrollAnchor(nil, nil, true)`.
+- Reset the transcript window to the tail.
+- Scroll to the existing `__composer_spacer__` tail anchor with the same short animation used for non-streaming tail restores.
+
+## State Rules
+
+The visible state is derived from `!session.followsTranscriptTail`. This intentionally matches user intent instead of raw geometry:
+
+- User-driven upward scroll: pauses tail-follow and shows the button.
+- Layout reflow or streaming height changes: do not show the button unless tail-follow was already paused.
+- Click button: resumes tail-follow, scrolls to tail, clears remembered anchor, hides the button.
+- Manual return to bottom: existing bottom detection resumes tail-follow and hides the button.
+
+## Error Handling
+
+The action should be idempotent. If the transcript is already near the bottom, `scrollToTail` can skip redundant scrolling using existing distance checks. If the tail anchor is temporarily absent during a view update, the next layout or transcript change can run the normal restore path.
+
+## Testing
+
+Add focused Swift Testing coverage for pure policy where practical:
+
+- The affordance should be visible only when tail-follow is paused.
+- Resuming from the affordance should map to the same tail-follow state transition as reaching the bottom.
+- Existing tail-scroll idempotency tests should continue to cover redundant scroll suppression.
+
+Avoid broad UI snapshot tests unless the implementation introduces a separate view with meaningful pure layout policy.


### PR DESCRIPTION
Summary:
- Adds a lower-right floating "Go to newest message" affordance in the ACP transcript when tail-follow is paused.
- Reuses the existing resume-tail-follow and scroll-to-tail path when activated.
- Positions the affordance above the composer-safe space and covers the visibility/action/placement policy with focused tests.

Tests:
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPMessageListPaginationTests`\n\nNote: a local full-suite run reached 6099 tests / 597 suites and failed only on 8 SSHIntegrationTests entries that require `ALAS_SSH_INTEGRATION=1` in this environment.