### PR TITLE
fix(diff): feedback lane layout recursion

### DIFF
--- a/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
+++ b/Alas/Sources/Center/Diff/DiffFeedbackLane.swift
@@ -114,6 +114,10 @@ enum DiffFeedbackLineLabels {
 enum DiffFeedbackLaneGeometry {
     static let dividerWidth = DiffPaneSplitGeometry.dividerWidth
 
+    static func containerWidth(for proposal: ProposedViewSize) -> CGFloat {
+        proposal.width.map { max($0, 0) } ?? 0
+    }
+
     static func contentFrame(
         containerWidth: CGFloat,
         layoutMode: DiffLayoutMode,
@@ -145,21 +149,6 @@ enum DiffFeedbackLaneGeometry {
             height: 0
         )
     }
-
-    static func idealContainerWidth(
-        contentWidth: CGFloat,
-        layoutMode: DiffLayoutMode,
-        gutterWidth: CGFloat
-    ) -> CGFloat {
-        let contentWidth = max(contentWidth, 0)
-        let gutterWidth = max(gutterWidth, 0)
-        switch layoutMode {
-        case .split:
-            return (contentWidth + gutterWidth) * 2 + dividerWidth
-        case .stacked:
-            return contentWidth + gutterWidth
-        }
-    }
 }
 
 private struct DiffFeedbackLaneLayout: Layout {
@@ -175,11 +164,7 @@ private struct DiffFeedbackLaneLayout: Layout {
         guard let subview = subviews.first else {
             return CGSize(width: proposal.width ?? 0, height: proposal.height ?? 0)
         }
-        let width = proposal.width.map { max($0, 0) } ?? DiffFeedbackLaneGeometry.idealContainerWidth(
-            contentWidth: subview.sizeThatFits(.unspecified).width,
-            layoutMode: layoutMode,
-            gutterWidth: gutterWidth
-        )
+        let width = DiffFeedbackLaneGeometry.containerWidth(for: proposal)
         let frame = DiffFeedbackLaneGeometry.contentFrame(
             containerWidth: width,
             layoutMode: layoutMode,
@@ -248,7 +233,6 @@ struct DiffFeedbackLaneView<Content: View>: View {
                 content
             }
         }
-        .frame(maxWidth: .infinity)
         .overlay(alignment: .topLeading) {
             if layoutMode == .split {
                 GeometryReader { geometry in

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -496,7 +496,6 @@ struct DiffPaneView: View {
                                 activeThreadID = active ? t.id : (activeThreadID == t.id ? nil : activeThreadID)
                             }
                         )
-                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 case .annotation(let a):
                     DiffFeedbackLaneView(
@@ -505,7 +504,6 @@ struct DiffPaneView: View {
                         rows: visibleRows
                     ) {
                         DiffInlineAnnotationCard(annotation: a)
-                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
             }

--- a/Alas/Sources/Center/Review/DiffInlineAnnotationCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineAnnotationCard.swift
@@ -11,6 +11,7 @@ struct DiffInlineAnnotationCard: View {
             accentBar
             content
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(cardBackground)
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -2098,6 +2098,35 @@ let second = true
         ) != nil)
     }
 
+    @Test func feedbackLaneDoesNotProbeChildWithUnspecifiedWidth() throws {
+        let rows = try #require(model().groups.first?.rows)
+        let counter = LayoutMeasurementCounter()
+        let controller = NSHostingController(rootView:
+            DiffFeedbackLaneView(lane: .right, layoutMode: .split, rows: rows) {
+                LayoutMeasurementProbe(counter: counter) {
+                    Color.clear
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 20)
+            }
+            .environment(\.theme, theme())
+        )
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 20)
+
+        _ = controller.view.fittingSize
+
+        #expect(
+            counter.widthProposals.allSatisfy { $0 != nil },
+            "Feedback lane should not ask content for an unspecified ideal width; proposals were \(counter.widthProposals)"
+        )
+    }
+
+    @Test func feedbackLaneUnspecifiedProposalHasNoIntrinsicContainerWidth() {
+        #expect(DiffFeedbackLaneGeometry.containerWidth(for: .unspecified) == 0)
+        #expect(DiffFeedbackLaneGeometry.containerWidth(for: .init(width: -12, height: nil)) == 0)
+        #expect(DiffFeedbackLaneGeometry.containerWidth(for: .init(width: 900, height: nil)) == 900)
+    }
+
     @Test func diffPreferenceBindingsPersistLayoutAndWrapButKeepWhitespaceLocal() {
         let appState = AppState()
         appState.config.changes.diffLayoutMode = .split
@@ -4622,6 +4651,32 @@ let second = true
                 constraintInvalidationCount += 1
             }
         }
+    }
+
+    private final class LayoutMeasurementCounter: @unchecked Sendable {
+        var measurementCount = 0
+        var widthProposals: [CGFloat?] = []
+    }
+
+    private struct LayoutMeasurementProbe: Layout {
+        let counter: LayoutMeasurementCounter
+
+        func sizeThatFits(
+            proposal: ProposedViewSize,
+            subviews: Subviews,
+            cache: inout ()
+        ) -> CGSize {
+            counter.measurementCount += 1
+            counter.widthProposals.append(proposal.width)
+            return CGSize(width: proposal.width ?? 100, height: 20)
+        }
+
+        func placeSubviews(
+            in bounds: CGRect,
+            proposal: ProposedViewSize,
+            subviews: Subviews,
+            cache: inout ()
+        ) {}
     }
 
     private struct FrameProbe: NSViewRepresentable {


### PR DESCRIPTION
## Summary

- Fix the diff feedback lane so unconstrained layout proposals no longer ask inline feedback content for ideal width.
- Remove redundant flexible frames around diff inline comment and annotation cards.
- Add regression coverage for feedback lane proposal behavior.

## Root Cause

The feedback lane custom layout used child `.unspecified` sizing to derive its own ideal width. In review diffs with inline feedback cards this put a flexible frame/card subtree inside a fixed-frame/stack/flexible-frame chain, matching the SwiftUI `StackLayout.placeChildren -> sizeThatFits -> _FlexFrameLayout -> _FrameLayout` cascade seen in the live process sample.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test -only-testing:AlasTests/DiffPaneViewTests/feedbackLaneDoesNotProbeChildWithUnspecifiedWidth -only-testing:AlasTests/DiffPaneViewTests/feedbackLaneUnspecifiedProposalHasNoIntrinsicContainerWidth -only-testing:AlasTests/DiffPaneViewTests/feedbackLaneWrapperRetainsFullWidthAndHostsMultipleChildren`
- Sampled launched debug app for 3s: main thread mostly waiting for events; no `DiffPaneView`, `DiffFeedbackLane`, or `DiffInlineCommentCard` symbols in the sample.

## Note

Full local `xcodebuild ... test` currently has unrelated reproducible failures in `RightPaneGGStackTests` around expected `gg rebase` argument matching with `--client-operation-id`; the focused diff feedback lane tests pass.
