### PR TITLE
fix(gitlab): send Content-Type header on glab api --input requests

### DIFF
--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -880,6 +880,9 @@ struct GitLabCLIProvider: CodeHostProvider {
                 Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "discussions"),
                 "--method", "POST",
                 "--hostname", remote.host,
+                // glab omits the Content-Type header when the body comes from
+                // --input, which makes GitLab reject the request with HTTP 415.
+                "-H", "Content-Type: application/json",
                 "--input", "-",
             ],
             cwd: cwd,
@@ -903,6 +906,9 @@ struct GitLabCLIProvider: CodeHostProvider {
                 Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "approve"),
                 "--method", "POST",
                 "--hostname", remote.host,
+                // glab omits the Content-Type header when the body comes from
+                // --input, which makes GitLab reject the request with HTTP 415.
+                "-H", "Content-Type: application/json",
                 "--input", "-",
             ],
             cwd: cwd,
@@ -929,6 +935,9 @@ struct GitLabCLIProvider: CodeHostProvider {
                 Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "notes"),
                 "--method", "POST",
                 "--hostname", remote.host,
+                // glab omits the Content-Type header when the body comes from
+                // --input, which makes GitLab reject the request with HTTP 415.
+                "-H", "Content-Type: application/json",
                 "--input", "-",
             ],
             cwd: cwd,
@@ -954,6 +963,9 @@ struct GitLabCLIProvider: CodeHostProvider {
                 Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "discussions/\(discussionID)/notes"),
                 "--method", "POST",
                 "--hostname", remote.host,
+                // glab omits the Content-Type header when the body comes from
+                // --input, which makes GitLab reject the request with HTTP 415.
+                "-H", "Content-Type: application/json",
                 "--input", "-",
             ],
             cwd: cwd,
@@ -979,6 +991,9 @@ struct GitLabCLIProvider: CodeHostProvider {
                 Self.mergeRequestAPIPath(remote: remote, request: request, suffix: "discussions/\(discussionID)"),
                 "--method", "PUT",
                 "--hostname", remote.host,
+                // glab omits the Content-Type header when the body comes from
+                // --input, which makes GitLab reject the request with HTTP 415.
+                "-H", "Content-Type: application/json",
                 "--input", "-",
             ],
             cwd: cwd,

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -872,6 +872,12 @@ struct GitLabCLIProviderTests {
         ])
         let discussionPayload = try Self.jsonObject(from: commands[1].stdin)
         #expect(discussionPayload["body"] as? String == "Please fix this.")
+        // glab does not set Content-Type when the body is read from --input, so
+        // GitLab rejects the request with HTTP 415 unless we send it explicitly.
+        let discussionSetsJSONContentType = Self.sendsJSONContentType(commands[1].args)
+        let approveSetsJSONContentType = Self.sendsJSONContentType(commands[2].args)
+        #expect(discussionSetsJSONContentType)
+        #expect(approveSetsJSONContentType)
         #expect(commands[2].args.suffix(2) == ["--input", "-"])
         let approvePayload = try Self.jsonObject(from: commands[2].stdin)
         #expect(approvePayload["sha"] as? String == "head123")
@@ -1286,6 +1292,7 @@ struct GitLabCLIProviderTests {
             "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions/discussion-1/notes",
             "--method", "POST",
             "--hostname", "gitlab.example.com",
+            "-H", "Content-Type: application/json",
             "--input", "-",
         ])
         #expect(commands[5].args == [
@@ -1293,6 +1300,7 @@ struct GitLabCLIProviderTests {
             "projects/platform%2Fmobile%2Falas/merge_requests/42/discussions/discussion-1",
             "--method", "PUT",
             "--hostname", "gitlab.example.com",
+            "-H", "Content-Type: application/json",
             "--input", "-",
         ])
         #expect(try Self.jsonObject(from: commands[5].stdin)["resolved"] as? Bool == true)
@@ -2458,6 +2466,16 @@ struct GitLabCLIProviderTests {
             updatedAt: Date(timeIntervalSince1970: 11)
         )
         return try #require(ProviderReviewDraftComment(localDraft: draft))
+    }
+
+    /// True when the argument list passes an explicit `-H Content-Type: application/json` header.
+    private static func sendsJSONContentType(_ args: [String]) -> Bool {
+        for index in args.indices.dropLast() where args[index] == "-H" {
+            if args[index + 1] == "Content-Type: application/json" {
+                return true
+            }
+        }
+        return false
     }
 
     private static func jsonObject(from stdin: String?) throws -> [String: Any] {


### PR DESCRIPTION
## Summary

Publishing a review from the PR/MR review pane to GitLab failed on every draft comment with `glab api merge request discussions failed: glab: HTTP 415`.

Root cause: `glab api` does **not** set a `Content-Type` header when the request body is read from `--input` (verified with `GLAB_DEBUG_HTTP=1`), so GitLab rejects the JSON body with HTTP 415 Unsupported Media Type. The older `-f` form-field path sets the header automatically, which is why other calls worked.

Fix: pass an explicit `-H "Content-Type: application/json"` on all five `--input -` call sites in `GitLabCLIProvider` (create discussion, approve, MR note, discussion note, resolve).

## Testing

- `GitLabCLIProviderTests` (88) and `GitLabCLIProviderVerdictTests` (5) pass.
- Updated exact-arg assertions in `threadMutationsUseDiscussionEndpointsAndRefreshMR` and added a `sendsJSONContentType` assertion to the publish-review test to lock in the header.