### PR TITLE
fix(diff): new diff comment composers

### DIFF
--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -118,6 +118,7 @@ struct DiffReviewFileSection: View {
     @StateObject private var renderContextCache = DiffReviewRenderContextCache()
     @State private var pendingDraftAnchor: DiffReviewLineAnchor?
     @State private var pendingDraftBody = ""
+    @State private var draftComposerFocusRequestGeneration = 0
     @State private var expandedCollapsedRowIDs: Set<String> = []
     @State private var contextSnapshot: DiffReviewFileContextSnapshot?
     @State private var contextExpansion = DiffContextExpansionState()
@@ -186,12 +187,6 @@ struct DiffReviewFileSection: View {
         }
         .onChange(of: contextStateSignature) { _, _ in
             resetContextState()
-        }
-        .onChange(of: pendingDraftAnchor) { _, anchor in
-            guard allowsDraftCommentCreation, anchor != nil else { return }
-            Task { @MainActor in
-                draftComposerFocused = true
-            }
         }
     }
 
@@ -704,10 +699,7 @@ struct DiffReviewFileSection: View {
                                     lspContext: lspContext,
                                     activeCommentHighlight: activeHighlight(for: rowSeg.rows),
                                     allowsReviewLineSelection: allowsDraftCommentCreation,
-                                    onReviewLineSelected: { anchor in
-                                        pendingDraftAnchor = anchor
-                                        pendingDraftBody = ""
-                                    },
+                                    onReviewLineSelected: beginPendingDraft,
                                     onContextExpansion: loadContextAndExpand
                                 )
                                 .fixedSize(horizontal: false, vertical: true)
@@ -775,10 +767,7 @@ struct DiffReviewFileSection: View {
                 lspContext: lspContext,
                 activeCommentHighlight: activeHighlight(for: displayGroup.rows),
                 allowsReviewLineSelection: allowsDraftCommentCreation,
-                onReviewLineSelected: { anchor in
-                    pendingDraftAnchor = anchor
-                    pendingDraftBody = ""
-                },
+                onReviewLineSelected: beginPendingDraft,
                 onContextExpansion: loadContextAndExpand,
                 threads: threads,
                 annotations: annotations,
@@ -916,14 +905,12 @@ struct DiffReviewFileSection: View {
                 text: $pendingDraftBody,
                 theme: theme,
                 isFocused: $draftComposerFocused,
+                focusRequestGeneration: draftComposerFocusRequestGeneration,
                 onSave: savePendingDraft,
                 onCancel: clearPendingDraft
             )
             .frame(minHeight: 76, maxHeight: 104)
             .background(focusedComposerMarker)
-            .onAppear {
-                draftComposerFocused = true
-            }
             .clipShape(RoundedRectangle(cornerRadius: 7))
             .overlay(
                 RoundedRectangle(cornerRadius: 7)
@@ -998,6 +985,12 @@ struct DiffReviewFileSection: View {
 
         onSaveDraftComment(canonicalAnchor, body)
         clearPendingDraft()
+    }
+
+    private func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
+        pendingDraftAnchor = anchor
+        pendingDraftBody = ""
+        draftComposerFocusRequestGeneration &+= 1
     }
 
     private func clearPendingDraft() {

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1326,8 +1326,25 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
     @Binding var text: String
     let theme: Theme
     let isFocused: FocusState<Bool>.Binding
+    let focusRequestGeneration: Int
     let onSave: () -> Void
     let onCancel: () -> Void
+
+    init(
+        text: Binding<String>,
+        theme: Theme,
+        isFocused: FocusState<Bool>.Binding,
+        focusRequestGeneration: Int = 0,
+        onSave: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        _text = text
+        self.theme = theme
+        self.isFocused = isFocused
+        self.focusRequestGeneration = focusRequestGeneration
+        self.onSave = onSave
+        self.onCancel = onCancel
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
@@ -1388,6 +1405,14 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         context.coordinator.requestFocusIfNeeded()
     }
 
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        coordinator.cancelScheduledFocusRequest()
+        guard let textView = scrollView.documentView as? ReviewDraftComposerNSTextView else { return }
+        textView.onKeyboardAction = nil
+        textView.onWindowChanged = nil
+        textView.delegate = nil
+    }
+
     private func applyTheme(to scrollView: NSScrollView, textView: NSTextView) {
         scrollView.wantsLayer = true
         scrollView.layer?.backgroundColor = NSColor(theme.color("bg-2")).cgColor
@@ -1396,12 +1421,20 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         textView.insertionPointColor = NSColor(theme.color("accent"))
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: ReviewDraftComposerTextEditor
         weak var textView: NSTextView?
+        private var latestFulfilledFocusRequestGeneration = 0
+        private var scheduledFocusRequestGeneration: Int?
+        private var scheduledFocusTask: Task<Void, Never>?
 
         init(_ parent: ReviewDraftComposerTextEditor) {
             self.parent = parent
+        }
+
+        deinit {
+            scheduledFocusTask?.cancel()
         }
 
         func textDidChange(_ notification: Notification) {
@@ -1417,17 +1450,53 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
             parent.isFocused.wrappedValue = false
         }
 
-        @MainActor
         func requestFocusIfNeeded() {
-            guard parent.isFocused.wrappedValue,
-                  let textView,
-                  let window = textView.window,
-                  window.firstResponder !== textView
-            else { return }
-            window.makeFirstResponder(textView)
+            let generation = parent.focusRequestGeneration
+            let hasExplicitRequest = generation > latestFulfilledFocusRequestGeneration
+            let hasLegacyRequest = generation == 0 && parent.isFocused.wrappedValue
+            guard hasExplicitRequest || hasLegacyRequest else {
+                cancelScheduledFocusRequest()
+                return
+            }
+            guard scheduledFocusRequestGeneration != generation else { return }
+
+            cancelScheduledFocusRequest()
+            scheduledFocusRequestGeneration = generation
+            scheduledFocusTask = Task { @MainActor [weak self] in
+                await Task.yield()
+                guard !Task.isCancelled, let self else { return }
+                defer {
+                    if self.scheduledFocusRequestGeneration == generation {
+                        self.scheduledFocusRequestGeneration = nil
+                        self.scheduledFocusTask = nil
+                    }
+                }
+
+                guard self.parent.focusRequestGeneration == generation else { return }
+                if generation == 0 {
+                    guard self.parent.isFocused.wrappedValue else { return }
+                } else {
+                    guard generation > self.latestFulfilledFocusRequestGeneration else { return }
+                }
+                guard let textView = self.textView,
+                      let window = textView.window
+                else { return }
+
+                if window.firstResponder !== textView {
+                    guard window.makeFirstResponder(textView) else { return }
+                }
+                if generation > 0 {
+                    self.latestFulfilledFocusRequestGeneration = generation
+                }
+            }
         }
 
-        @MainActor
+        func cancelScheduledFocusRequest() {
+            scheduledFocusTask?.cancel()
+            scheduledFocusTask = nil
+            scheduledFocusRequestGeneration = nil
+        }
+
         func perform(_ action: ReviewDraftComposerKeyboardAction) {
             switch action {
             case .save:

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -44,6 +44,7 @@ struct DiffTabView: View {
     @State private var loadedDraftSessionID: ReviewDraftSessionID?
     @State private var pendingDraftAnchor: DiffReviewLineAnchor?
     @State private var pendingDraftBody = ""
+    @State private var draftComposerFocusRequestGeneration = 0
     @State private var reviewExpandedCollapsedRowIDs: Set<String> = []
     @State private var showWhitespace = false
     @StateObject private var renderContextCache = DiffTabRenderContextCache()
@@ -147,10 +148,6 @@ struct DiffTabView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
         .onChange(of: loadKey, initial: true) { _, _ in loadDraftCommentController() }
-        .onChange(of: pendingDraftAnchor) { _, anchor in
-            guard anchor != nil else { return }
-            Task { @MainActor in draftComposerFocused = true }
-        }
         .task(id: loadKey) { await load() }
         .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
             try? draftCommentController?.load()
@@ -534,6 +531,13 @@ struct DiffTabView: View {
     private func clearPendingDraft() {
         pendingDraftAnchor = nil
         pendingDraftBody = ""
+        draftComposerFocused = false
+    }
+
+    private func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
+        pendingDraftAnchor = anchor
+        pendingDraftBody = ""
+        draftComposerFocusRequestGeneration &+= 1
     }
 
     @ViewBuilder
@@ -691,10 +695,7 @@ struct DiffTabView: View {
                             codeFontSize: codeFontSize,
                             theme: theme,
                             lspContext: lspContext,
-                            onReviewLineSelected: { anchor in
-                                pendingDraftAnchor = anchor
-                                pendingDraftBody = ""
-                            }
+                            onReviewLineSelected: beginPendingDraft
                         )
                         .fixedSize(horizontal: false, vertical: true)
                     }
@@ -724,10 +725,7 @@ struct DiffTabView: View {
                     codeFontSize: codeFontSize,
                     theme: theme,
                     lspContext: lspContext,
-                    onReviewLineSelected: { anchor in
-                        pendingDraftAnchor = anchor
-                        pendingDraftBody = ""
-                    }
+                    onReviewLineSelected: beginPendingDraft
                 )
                 .fixedSize(horizontal: false, vertical: true)
             }
@@ -855,6 +853,7 @@ struct DiffTabView: View {
                 text: $pendingDraftBody,
                 theme: theme,
                 isFocused: $draftComposerFocused,
+                focusRequestGeneration: draftComposerFocusRequestGeneration,
                 onSave: savePendingDraft,
                 onCancel: clearPendingDraft
             )
@@ -862,7 +861,6 @@ struct DiffTabView: View {
             .background(theme.color("bg-2"))
             .clipShape(RoundedRectangle(cornerRadius: 6))
             .overlay(RoundedRectangle(cornerRadius: 6).stroke(theme.color("line"), lineWidth: 0.5))
-            .onAppear { draftComposerFocused = true }
             .accessibilityIdentifier("diff-review-draft-composer")
             HStack(spacing: 6) {
                 Spacer(minLength: 0)

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -567,6 +567,60 @@ struct DiffPaneViewTests {
         #expect(missCount == 1)
     }
 
+    @MainActor
+    @Test func diffTabViewRefocusesDraftComposerAfterSelectingDifferentGutterRows() async throws {
+        let repo = try makeTemporaryDiffRepository()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState(store: MemoryStore())
+        state.config.changes.diffLayoutMode = .stacked
+        state.config.changes.diffWrapLines = false
+        let view = DiffTabView(
+            worktreePath: repo,
+            relativePath: "Sources/App.swift",
+            staged: false,
+            originalPath: nil,
+            compareWithHEAD: false,
+            worktreeId: "worktree",
+            appState: state,
+            onOpenFile: nil,
+            onRequestDiscardFile: nil
+        )
+        .environment(\.theme, theme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 520)
+        let window = NSWindow(
+            contentRect: controller.view.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        defer { DiffTabViewFocusRetainer.retain(window, controller) }
+
+        try await waitForRenderPass(controller: controller) {
+            !visibleReviewRulers(in: controller.view).isEmpty
+        }
+        try selectReviewLine(selectionIndex: 0, in: controller.view)
+        try await waitForRenderPass(controller: controller) {
+            draftComposerTextView(in: controller.view).map { window.firstResponder === $0 } ?? false
+        }
+
+        let firstComposer = try #require(draftComposerTextView(in: controller.view))
+        let sink = DiffTabViewFocusSinkView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+        controller.view.addSubview(sink)
+        #expect(window.makeFirstResponder(sink))
+        #expect(window.firstResponder !== firstComposer)
+
+        try selectReviewLine(selectionIndex: 1, in: controller.view)
+        try await waitForRenderPass(controller: controller) {
+            draftComposerTextView(in: controller.view).map { window.firstResponder === $0 } ?? false
+        }
+
+        let relocatedComposer = try #require(draftComposerTextView(in: controller.view))
+        #expect(window.firstResponder === relocatedComposer)
+    }
+
     @Test func splitModeHostsRendererWithoutCrashing() {
         var layout = DiffLayoutMode.split
         var wrap = false
@@ -4645,6 +4699,34 @@ let second = true
         return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
     }
 
+    private func selectReviewLine(selectionIndex: Int, in view: NSView) throws {
+        let selectableRows = visibleReviewRulers(in: view).flatMap { ruler -> [(ruler: DiffPaneLineNumberRulerView, row: Int)] in
+            guard let textView = ruler.scrollView?.documentView as? DiffPaneCodeTextView else { return [] }
+            return (0..<200).compactMap { row in
+                textView.reviewLineAnchor(atRow: row).map { _ in (ruler, row) }
+            }
+        }
+        let selection = try #require(selectableRows.dropFirst(selectionIndex).first)
+        selection.ruler.invokeReviewLineSelectionForTesting(row: selection.row)
+    }
+
+    private func visibleReviewRulers(in view: NSView) -> [DiffPaneLineNumberRulerView] {
+        allSubviews(of: view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
+            .filter(isEffectivelyVisible)
+            .compactMap { $0.verticalRulerView as? DiffPaneLineNumberRulerView }
+            .filter(\.allowsReviewLineSelection)
+    }
+
+    private func draftComposerTextView(in view: NSView) -> NSTextView? {
+        allSubviews(of: view).compactMap { subview -> NSTextView? in
+            guard let textView = subview as? NSTextView,
+                  !(textView is DiffPaneCodeTextView)
+            else { return nil }
+            return textView
+        }.first
+    }
+
     private func visibleCodeTextViews(in view: NSView) -> [DiffPaneCodeTextView] {
         allSubviews(of: view)
             .compactMap { $0 as? DiffPaneTextScrollView }
@@ -4663,4 +4745,17 @@ let second = true
         }
         return true
     }
+}
+
+@MainActor
+private final class DiffTabViewFocusRetainer {
+    private static var retainedObjects: [AnyObject] = []
+
+    static func retain(_ objects: AnyObject...) {
+        retainedObjects.append(contentsOf: objects)
+    }
+}
+
+private final class DiffTabViewFocusSinkView: NSView {
+    override var acceptsFirstResponder: Bool { true }
 }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -164,6 +164,58 @@ struct DiffReviewSurfaceTests {
         }
     }
 
+    @Test func fileSectionRefocusesDraftComposerAfterSelectingDifferentGutterRows() async throws {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/App/AlphaView.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil
+        )
+        var layout = DiffLayoutMode.stacked
+        var wrap = false
+        var whitespace = false
+        let view = DiffReviewFileSection(
+            file: file,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: view)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 520),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+
+        await drainSwiftUI(controller.view)
+        try selectReviewLine(selectionIndex: 0, in: controller.view)
+        await drainSwiftUI(controller.view)
+
+        let firstComposer = try #require(draftComposerTextView(in: controller.view))
+        #expect(window.firstResponder === firstComposer)
+
+        let sink = FocusSinkView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+        controller.view.addSubview(sink)
+        #expect(window.makeFirstResponder(sink))
+        #expect(window.firstResponder !== firstComposer)
+
+        try selectReviewLine(selectionIndex: 1, in: controller.view)
+        await drainSwiftUI(controller.view)
+
+        let relocatedComposer = try #require(draftComposerTextView(in: controller.view))
+        #expect(window.firstResponder === relocatedComposer)
+    }
+
     @Test func stackedFileSectionBoundsHunkMaterializationToScrollViewport() throws {
         let baseModel = largeDisplayModel(groupCount: 80, filePath: "Sources/App/LargeView.swift")
         let groups = baseModel.groups
@@ -3705,6 +3757,29 @@ struct DiffReviewSurfaceTests {
             }
         }
         return false
+    }
+
+    private func selectReviewLine(selectionIndex: Int, in view: NSView) throws {
+        let selectableRows = allSubviews(of: view)
+            .compactMap { $0 as? DiffPaneLineNumberRulerView }
+            .filter(\.allowsReviewLineSelection)
+            .flatMap { ruler -> [(ruler: DiffPaneLineNumberRulerView, row: Int)] in
+                guard let textView = ruler.scrollView?.documentView as? DiffPaneCodeTextView else { return [] }
+                return (0..<200).compactMap { row in
+                    textView.reviewLineAnchor(atRow: row).map { _ in (ruler, row) }
+                }
+            }
+        let selection = try #require(selectableRows.dropFirst(selectionIndex).first)
+        selection.ruler.invokeReviewLineSelectionForTesting(row: selection.row)
+    }
+
+    private func draftComposerTextView(in view: NSView) -> NSTextView? {
+        allSubviews(of: view).compactMap { subview -> NSTextView? in
+            guard let textView = subview as? NSTextView,
+                  !(textView is DiffPaneCodeTextView)
+            else { return nil }
+            return textView
+        }.first
     }
 
     private func accessibilityLabel(in view: NSView, containing text: String) -> String? {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -8,6 +8,37 @@ import Testing
 struct DiffReviewSurfaceTests {
     private func theme() -> Theme { try! ThemeStore().current }
 
+    @Test func draftComposerRefocusesForEachNewFocusRequestGeneration() async throws {
+        let model = ReviewDraftComposerFocusModel()
+        let controller = NSHostingController(
+            rootView: ReviewDraftComposerFocusHarness(theme: theme(), model: model)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+
+        await drainSwiftUI(controller.view)
+
+        let textView = try #require(allSubviews(of: controller.view).compactMap { $0 as? NSTextView }.first)
+        #expect(window.firstResponder === textView)
+
+        let sibling = try #require(
+            subview(withAccessibilityIdentifier: "draft-composer-focus-sibling", in: controller.view)
+        )
+        #expect(window.makeFirstResponder(sibling))
+        #expect(window.firstResponder !== textView)
+
+        model.focusRequestGeneration += 1
+        await drainSwiftUI(controller.view)
+
+        #expect(window.firstResponder === textView)
+    }
+
     @Test func railRendersUngroupedCommitSessionWithFileRowsAndNoSourceHeader() {
         let files = [
             summary(path: "Sources/App/AlphaView.swift", additions: 4, deletions: 1),
@@ -3640,6 +3671,13 @@ struct DiffReviewSurfaceTests {
         return controller
     }
 
+    private func drainSwiftUI(_ view: NSView) async {
+        for _ in 0..<6 {
+            view.layoutSubtreeIfNeeded()
+            await Task.yield()
+        }
+    }
+
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }
@@ -3675,6 +3713,65 @@ struct DiffReviewSurfaceTests {
         }
         return view.subviews.lazy.compactMap { accessibilityLabel(in: $0, containing: text) }.first
     }
+}
+
+@MainActor
+private final class ReviewDraftComposerFocusRetainer {
+    private static var retainedObjects: [AnyObject] = []
+
+    static func retain(_ objects: AnyObject...) {
+        retainedObjects.append(contentsOf: objects)
+    }
+}
+
+@MainActor
+private final class ReviewDraftComposerFocusModel: ObservableObject {
+    @Published var focusRequestGeneration = 1
+}
+
+@MainActor
+private struct ReviewDraftComposerFocusHarness: View {
+    @State private var text = ""
+    @FocusState private var focused: Bool
+
+    let theme: Theme
+    @ObservedObject var model: ReviewDraftComposerFocusModel
+
+    var body: some View {
+        VStack {
+            ReviewDraftComposerTextEditor(
+                text: $text,
+                theme: theme,
+                isFocused: $focused,
+                focusRequestGeneration: model.focusRequestGeneration,
+                onSave: {},
+                onCancel: {}
+            )
+            .frame(height: 100)
+
+            ReviewDraftComposerFocusSiblingView()
+
+            Button("Request focus") {
+                model.focusRequestGeneration += 1
+            }
+            .accessibilityIdentifier("draft-composer-request-focus")
+        }
+        .padding()
+    }
+}
+
+private struct ReviewDraftComposerFocusSiblingView: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let view = FocusSinkView(frame: NSRect(x: 0, y: 0, width: 40, height: 20))
+        view.setAccessibilityIdentifier("draft-composer-focus-sibling")
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+private final class FocusSinkView: NSView {
+    override var acceptsFirstResponder: Bool { true }
 }
 
 private final class ReviewBundleActionRecorder: @unchecked Sendable {

--- a/docs/superpowers/plans/2026-07-22-diff-comment-composer-focus.md
+++ b/docs/superpowers/plans/2026-07-22-diff-comment-composer-focus.md
@@ -1,0 +1,182 @@
+# Diff Comment Composer Focus Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every gutter-created diff comment composer acquire keyboard focus immediately, including when an existing composer moves to another line.
+
+**Architecture:** Keep `ReviewDraftComposerTextEditor` as the single AppKit focus owner, but trigger focus with an explicit request generation instead of relying only on a persistent `FocusState<Bool>`. Each diff surface increments its generation for every gutter selection, and the shared coordinator fulfills the latest request after the text view is attached on the next main-loop turn.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, AppKit, Swift Testing
+
+---
+
+## File Structure
+
+- `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`: shared composer representable, deferred focus coordinator, and unified review-surface request generation.
+- `Alas/Sources/Center/DiffTabView.swift`: standalone staged/unstaged diff request generation.
+- `AlasTests/DiffReviewSurfaceTests.swift`: AppKit-hosted shared-editor regression tests.
+- `AlasTests/DiffPaneViewTests.swift`: standalone diff gutter integration assertion if its existing harness is the more direct place to exercise `DiffTabView`.
+
+### Task 1: Make Shared Composer Focus Requests Durable
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift:1325-1455`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+
+- [ ] **Step 1: Write the failing AppKit focus regression test**
+
+Add a serialized, main-actor test that hosts the real representable in an `NSWindow`. Use a small test-only SwiftUI harness with `@State var focusRequestGeneration`, `@FocusState var focused`, the real `ReviewDraftComposerTextEditor`, and an accessibility-identified button that increments the generation. Mount the window, issue generation `1`, drain the main actor, and assert that the hosted `NSTextView` is `window.firstResponder`. Then make a sibling `NSTextField` first responder, increment the generation, drain again, and assert that the text view regained first-responder status.
+
+The harness must call the desired API explicitly:
+
+```swift
+ReviewDraftComposerTextEditor(
+    text: $text,
+    theme: theme,
+    isFocused: $focused,
+    focusRequestGeneration: focusRequestGeneration,
+    onSave: {},
+    onCancel: {}
+)
+```
+
+Use a helper that yields at least twice to let both SwiftUI reconciliation and the deferred AppKit request finish. Keep the window alive for the whole assertion and close it with `defer`.
+
+- [ ] **Step 2: Run the focused test to verify red**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  test -only-testing:AlasTests/DiffReviewSurfaceTests -quiet
+```
+
+Expected: the new test fails against the current synchronous focus behavior or fails to compile because the explicit request-generation contract is absent. Confirm the failure is specifically caused by the missing behavior/API before continuing.
+
+- [ ] **Step 3: Add request-driven deferred focus to the shared editor**
+
+Add `let focusRequestGeneration: Int` to `ReviewDraftComposerTextEditor`. In its coordinator, track the last fulfilled generation and a cancellable scheduled `Task<Void, Never>?`. Replace direct synchronous `makeFirstResponder` calls with a method that:
+
+```swift
+@MainActor
+func scheduleFocusRequestIfNeeded() {
+    let generation = parent.focusRequestGeneration
+    guard generation > 0,
+          generation != lastFulfilledFocusRequestGeneration
+    else { return }
+
+    scheduledFocusTask?.cancel()
+    scheduledFocusTask = Task { @MainActor [weak self] in
+        await Task.yield()
+        guard !Task.isCancelled,
+              let self,
+              self.parent.focusRequestGeneration == generation,
+              let textView = self.textView,
+              let window = textView.window
+        else { return }
+
+        guard window.firstResponder === textView || window.makeFirstResponder(textView) else { return }
+        self.lastFulfilledFocusRequestGeneration = generation
+    }
+}
+```
+
+Call this method from `updateNSView` and from the text view's `viewDidMoveToWindow` callback. Preserve `textDidBeginEditing` and `textDidEndEditing` so the existing focus binding still reflects actual focus. Cancel the scheduled task when the representable dismantles or when the coordinator is deinitialized.
+
+All existing non-gutter call sites must pass `focusRequestGeneration: 0`; their current `.onAppear` focus binding behavior stays intact. Preserve that legacy binding-triggered path with a deferred request as needed so editing an existing draft does not regress.
+
+- [ ] **Step 4: Run the focused test to verify green**
+
+Run the Task 1 command again. Expected: the new initial-focus and refocus assertions pass, with no failures in `DiffReviewSurfaceTests`.
+
+- [ ] **Step 5: Review the Task 1 diff**
+
+Run `git diff --check` and inspect the full diff. Confirm there is one focus scheduler, stale generations cannot steal focus, scheduled work is cancelled, and focus reporting remains separate from focus-request intent.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift AlasTests/DiffReviewSurfaceTests.swift
+git commit -m "fix(diff): defer comment composer focus"
+```
+
+### Task 2: Emit a Fresh Request From Every Diff Gutter Surface
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift:115-195,680-790,913-932`
+- Modify: `Alas/Sources/Center/DiffTabView.swift:120-160,680-735,850-870`
+- Test: `AlasTests/DiffReviewSurfaceTests.swift`
+- Test: `AlasTests/DiffPaneViewTests.swift` only if needed for direct standalone diff coverage
+
+- [ ] **Step 1: Add failing surface-level request assertions**
+
+Exercise the existing accessibility-enabled gutter selection path in the unified file-section harness and the standalone diff harness. For each surface, press one gutter comment control, assert the composer text view becomes first responder, move first responder away, press a different gutter comment control, and assert that the relocated composer text view regains focus.
+
+If the standalone view cannot be hosted without unrelated services, extract only the request transition into this internal helper and test it directly from both surface test files:
+
+```swift
+struct DiffCommentComposerFocusRequest: Equatable {
+    private(set) var generation = 0
+
+    mutating func request() {
+        generation &+= 1
+    }
+}
+```
+
+The preferred test remains the real gutter-to-first-responder path; use the helper only where the existing view harness makes that impractical.
+
+- [ ] **Step 2: Run the surface tests to verify red**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  test -only-testing:AlasTests/DiffReviewSurfaceTests \
+  -only-testing:AlasTests/DiffPaneViewTests -quiet
+```
+
+Expected: relocation does not produce a new explicit request in both current surfaces, so the new assertion fails for that reason.
+
+- [ ] **Step 3: Wire the unified review surface**
+
+Add `@State private var draftComposerFocusRequestGeneration = 0` to `DiffReviewFileSection`. Centralize both `onReviewLineSelected` closures through one method:
+
+```swift
+private func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
+    pendingDraftAnchor = anchor
+    pendingDraftBody = ""
+    draftComposerFocusRequestGeneration &+= 1
+}
+```
+
+Pass the generation to `ReviewDraftComposerTextEditor`. Remove the redundant pending-anchor `onChange` and composer `onAppear` assignments that attempted to initiate gutter focus through the Boolean binding. Keep `clearPendingDraft()` resetting actual focus state.
+
+- [ ] **Step 4: Wire the standalone diff surface**
+
+Make the same state, helper, call-site replacement, and editor argument changes in `DiffTabView`. Ensure `clearPendingDraft()` also resets `draftComposerFocused = false`, matching the unified surface.
+
+- [ ] **Step 5: Run focused tests to verify green**
+
+Run the Task 2 command again. Expected: all `DiffReviewSurfaceTests` and `DiffPaneViewTests` pass.
+
+- [ ] **Step 6: Run required project verification**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: project generation succeeds, build exits `0`, and the complete test suite reports no failures.
+
+- [ ] **Step 7: Review and commit Task 2**
+
+Run `git diff --check`, inspect `git diff`, and confirm both gutter paths call the same per-surface helper for every selection. Then commit:
+
+```bash
+git add Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift \
+  Alas/Sources/Center/DiffTabView.swift AlasTests/DiffReviewSurfaceTests.swift \
+  AlasTests/DiffPaneViewTests.swift
+git commit -m "fix(diff): focus gutter comment composers"
+```

--- a/docs/superpowers/specs/2026-07-22-diff-comment-composer-focus-design.md
+++ b/docs/superpowers/specs/2026-07-22-diff-comment-composer-focus-design.md
@@ -1,0 +1,54 @@
+# Diff Comment Composer Focus
+
+## Problem
+
+Pressing a diff gutter comment button creates a draft comment composer but does
+not reliably move keyboard focus into its text editor. The same failure can
+occur when an existing empty composer is relocated by pressing another gutter
+button.
+
+The composer is shared by the unified diff review surfaces and the standalone
+staged/unstaged diff tab. It wraps an `NSTextView` in `NSViewRepresentable`.
+The current coordinator attempts to make the text view first responder
+synchronously during representable creation and updates. Those attempts can run
+before the text view has a window or can be superseded later in the same AppKit
+event cycle.
+
+## Behavior
+
+- Creating a draft composer from any enabled diff gutter immediately focuses
+  its text editor.
+- Moving an existing empty composer to another gutter location immediately
+  restores focus to its text editor.
+- Saving and cancelling retain their existing behavior and shortcuts.
+- Reply and existing-comment edit composers are outside this change.
+
+## Design
+
+Each diff surface will issue an explicit focus request whenever its pending
+draft anchor changes to a non-nil value. The request is represented by a
+monotonically changing generation rather than a persistent Boolean, so moving a
+composer while it is already considered focused still creates a new event.
+
+`ReviewDraftComposerTextEditor` will remain the shared focus owner. Its
+coordinator will observe the request generation and schedule a guarded
+first-responder attempt on the next main-loop turn. It will also retry after the
+underlying text view moves into a window. A scheduled request will verify that
+it is still current and that the text view remains attached before calling
+`makeFirstResponder`.
+
+The existing focus binding continues to report actual editing focus for UI and
+accessibility state. It will not be used as the sole trigger for initial focus.
+
+## Testing
+
+An AppKit-hosted regression test will exercise the real shared representable in
+an `NSWindow`:
+
+1. Mount the editor with an initial focus request and verify its `NSTextView`
+   becomes the window's first responder.
+2. Move first-responder status elsewhere, issue a new request generation, and
+   verify the editor regains focus.
+
+Existing diff surface tests and the full project build/test commands will guard
+rendering and integration behavior.


### PR DESCRIPTION
## Summary

This fixes a regression where clicking the gutter add-comment button could render a new diff draft composer without immediately moving keyboard focus into its text field. The focus request is now tied to the user action that opens or relocates the composer, rather than to SwiftUI appearance timing.

## Changes

### Durable Composer Focus

- Added an explicit `focusRequestGeneration` path to `ReviewDraftComposerTextEditor` so each new comment action can request AppKit focus exactly once after the text view is attached to a window.
- Preserved the legacy `FocusState` behavior for existing callers that do not pass an explicit generation.
- Cancel stale scheduled focus work when the representable is dismantled or superseded.

### Diff Surface Wiring

- Routed gutter comment actions in both `DiffReviewFileSection` and `DiffTabView` through a shared `beginPendingDraft` helper.
- Increment the focus generation whenever a draft is started, including when the composer moves between different selected diff lines.
- Clear composer focus state when the draft is cancelled or saved.

### Regression Coverage

- Added a direct harness test proving the shared AppKit text editor refocuses for each new focus generation.
- Added end-to-end surface tests for the file review surface and diff tab surface that select different gutter rows and assert the new composer owns first responder each time.

## Where to start

- `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift` - shared composer focus behavior and file review wiring
- `Alas/Sources/Center/DiffTabView.swift` - diff tab gutter comment wiring
- `AlasTests/DiffReviewSurfaceTests.swift` - focused regression coverage for the shared editor and review surface

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/DiffPaneViewTests -quiet`

Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` ran 6305 tests and failed with unrelated existing issues: 8 `SSHIntegrationTests` require `ALAS_SSH_INTEGRATION=1`, and 2 `RightPaneGGStackTests` manual rebase expectation failures reproduce when run in isolation.
