### PR TITLE
fix(acp): memoize markdown row measurement to end transcript scroll beachball

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		2843F603A4D71AEEA4C09317 /* CloseTabConfirmationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */; };
 		28710B18EF9FAE100B99E0A7 /* ACPThumbnailImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
+		28D8C1BBA0B577679782AA68 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D73156DBE6DB95469D4D80 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift */; };
 		28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
 		292E443F13B06303EAF8E24B /* CreatingWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3AC3A1F7C5649E75015293 /* CreatingWorktreeView.swift */; };
@@ -2178,6 +2179,7 @@
 		97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroupViewTests.swift; sourceTree = "<group>"; };
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
 		9797C4D8F5DCCC9563D79007 /* ACPProcessLivenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPProcessLivenessTests.swift; sourceTree = "<group>"; };
+		97D73156DBE6DB95469D4D80 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextViewMeasurementCacheTests.swift; sourceTree = "<group>"; };
 		97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-options.json"; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOptionTests.swift; sourceTree = "<group>"; };
@@ -3698,6 +3700,7 @@
 				A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
 				50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */,
+				97D73156DBE6DB95469D4D80 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift */,
 				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
 				8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */,
 				E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */,
@@ -6122,6 +6125,7 @@
 				965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				BDA40E9BFA15217CDED5B2F0 /* ACPMarkdownInlineRendererTests.swift in Sources */,
+				28D8C1BBA0B577679782AA68 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift in Sources */,
 				6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */,
 				162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */,
 				26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
@@ -256,6 +256,14 @@ final class ACPMarkdownInlineNSTextView: NSTextView {
     func fittingSize(for width: CGFloat) -> CGSize {
         let fittingWidth = max(minimumFittingWidth, width)
         if let cachedHeight = fittingHeightByWidth[fittingWidth] {
+            // `widthTracksTextView` only re-syncs the container off a real
+            // frame change, so a cache hit must still restore the container
+            // to this width itself — otherwise, if the previous call was a
+            // miss at a different width and this width's frame goes
+            // unchanged (e.g. re-probed mid-scroll), drawing/selection would
+            // keep wrapping at that stale width while SwiftUI allocates the
+            // (correct) cached height for this one.
+            textContainer?.containerSize = CGSize(width: fittingWidth, height: .greatestFiniteMagnitude)
             return CGSize(width: fittingWidth, height: cachedHeight)
         }
         guard let textContainer, let layoutManager else {
@@ -277,7 +285,13 @@ final class ACPMarkdownInlineNSTextView: NSTextView {
     }
 
     func naturalFittingSize() -> CGSize {
-        if let cachedNaturalFittingSize { return cachedNaturalFittingSize }
+        if let cachedNaturalFittingSize {
+            // See the matching comment in `fittingSize(for:)`: restore the
+            // container even on a cache hit so a stale width from an
+            // intervening `fittingSize` call can't leak into drawing.
+            textContainer?.containerSize = CGSize(width: maximumNaturalFittingWidth, height: .greatestFiniteMagnitude)
+            return cachedNaturalFittingSize
+        }
         guard let textContainer, let layoutManager else {
             return CGSize(width: minimumFittingWidth, height: 0)
         }

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
@@ -47,6 +47,10 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
             memoizeInlineMarkdown: memoizesInlineMarkdown
         )
         textView.textStorage?.setAttributedString(rendered)
+        // The rendered text changed, so any memoized width→height
+        // measurements are stale; drop them before SwiftUI re-queries
+        // `sizeThatFits`.
+        (textView as? ACPMarkdownInlineNSTextView)?.invalidateFittingCache()
         context.coordinator.loadRemoteImages(in: textView, attributedString: rendered)
     }
 
@@ -142,6 +146,9 @@ struct ACPMarkdownInlineTextView: NSViewRepresentable {
             if let textContainer = textView.textContainer {
                 textView.layoutManager?.ensureLayout(for: textContainer)
             }
+            // A loaded (or failed) remote image resizes the run, so cached
+            // fitting measurements no longer hold.
+            (textView as? ACPMarkdownInlineNSTextView)?.invalidateFittingCache()
             textView.invalidateIntrinsicContentSize()
         }
 
@@ -212,12 +219,45 @@ extension NSAttributedString.Key {
     static let acpMarkdownInlineRemoteImage = NSAttributedString.Key("ACPMarkdownInlineRemoteImage")
 }
 
-private final class ACPMarkdownInlineNSTextView: NSTextView {
+final class ACPMarkdownInlineNSTextView: NSTextView {
     private let minimumFittingWidth: CGFloat = 80
     private let maximumNaturalFittingWidth: CGFloat = 10_000
 
+    #if DEBUG
+    /// Number of times a fitting measurement actually ran TextKit layout
+    /// (i.e. a cache miss). Lets tests assert that repeated `sizeThatFits`
+    /// probes at a known width hit the memo instead of re-laying out.
+    private(set) var fittingComputationCountForTests = 0
+    #endif
+    /// Cap on distinct cached widths. SwiftUI's `StackLayout` probes a small,
+    /// bounded set of widths per placement pass (min / ideal / actual), so a
+    /// handful of entries covers steady scrolling; the cap only guards against
+    /// unbounded growth during a live width drag.
+    private static let fittingCacheLimit = 16
+
+    /// Memoized width→height results. `sizeThatFits` is driven by SwiftUI's
+    /// layout engine, which probes each child multiple times per placement
+    /// pass and re-probes on every scroll frame. Running
+    /// `NSLayoutManager.ensureLayout` + `usedRect` on each probe is the
+    /// `NSAttributedString.MetricsCache.metrics` cost that pins the main
+    /// thread while scrolling a long transcript. The text only changes through
+    /// `updateNSView`/remote-image loads, so measurements stay valid between
+    /// those points — cache them and invalidate via `invalidateFittingCache()`.
+    private var fittingHeightByWidth: [CGFloat: CGFloat] = [:]
+    private var cachedNaturalFittingSize: CGSize?
+
+    /// Discard memoized measurements. Call whenever the text storage (or a
+    /// layout input baked into it) changes.
+    func invalidateFittingCache() {
+        fittingHeightByWidth.removeAll(keepingCapacity: true)
+        cachedNaturalFittingSize = nil
+    }
+
     func fittingSize(for width: CGFloat) -> CGSize {
         let fittingWidth = max(minimumFittingWidth, width)
+        if let cachedHeight = fittingHeightByWidth[fittingWidth] {
+            return CGSize(width: fittingWidth, height: cachedHeight)
+        }
         guard let textContainer, let layoutManager else {
             return CGSize(width: fittingWidth, height: 0)
         }
@@ -225,10 +265,19 @@ private final class ACPMarkdownInlineNSTextView: NSTextView {
         textContainer.containerSize = CGSize(width: fittingWidth, height: .greatestFiniteMagnitude)
         layoutManager.ensureLayout(for: textContainer)
         let used = layoutManager.usedRect(for: textContainer)
-        return CGSize(width: fittingWidth, height: ceil(used.height))
+        let height = ceil(used.height)
+        #if DEBUG
+        fittingComputationCountForTests += 1
+        #endif
+        if fittingHeightByWidth.count >= Self.fittingCacheLimit {
+            fittingHeightByWidth.removeAll(keepingCapacity: true)
+        }
+        fittingHeightByWidth[fittingWidth] = height
+        return CGSize(width: fittingWidth, height: height)
     }
 
     func naturalFittingSize() -> CGSize {
+        if let cachedNaturalFittingSize { return cachedNaturalFittingSize }
         guard let textContainer, let layoutManager else {
             return CGSize(width: minimumFittingWidth, height: 0)
         }
@@ -236,10 +285,15 @@ private final class ACPMarkdownInlineNSTextView: NSTextView {
         textContainer.containerSize = CGSize(width: maximumNaturalFittingWidth, height: .greatestFiniteMagnitude)
         layoutManager.ensureLayout(for: textContainer)
         let used = layoutManager.usedRect(for: textContainer)
-        return CGSize(
+        #if DEBUG
+        fittingComputationCountForTests += 1
+        #endif
+        let size = CGSize(
             width: max(minimumFittingWidth, ceil(used.width)),
             height: ceil(used.height)
         )
+        cachedNaturalFittingSize = size
+        return size
     }
 
     override var intrinsicContentSize: NSSize {

--- a/AlasTests/ACP/UI/ACPMarkdownInlineTextViewMeasurementCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineTextViewMeasurementCacheTests.swift
@@ -93,4 +93,30 @@ struct ACPMarkdownInlineTextViewMeasurementCacheTests {
         _ = textView.fittingSize(for: 100)
         #expect(textView.fittingComputationCountForTests == 18)
     }
+
+    /// `widthTracksTextView` only re-syncs the container off a real frame
+    /// change, so a cache hit must restore `textContainer.containerSize`
+    /// itself. Otherwise probing width A (a miss) and then width B (a stale
+    /// cache hit) would leave the container wrapped at A while the cached,
+    /// correct height for B is what SwiftUI actually allocates.
+    @Test func cacheHitRestoresContainerWidth() {
+        let textView = makeTextView("Some wrapping text for the row.")
+
+        _ = textView.fittingSize(for: 200) // miss — container left at 200
+        _ = textView.fittingSize(for: 350) // miss — container left at 350
+        #expect(textView.textContainer?.containerSize.width == 350)
+
+        _ = textView.fittingSize(for: 200) // hit — must restore container to 200
+        #expect(textView.textContainer?.containerSize.width == 200)
+    }
+
+    @Test func naturalFittingSizeCacheHitRestoresContainerWidth() {
+        let textView = makeTextView("Some wrapping text for the row.")
+
+        _ = textView.naturalFittingSize()
+        _ = textView.fittingSize(for: 200) // interleaved miss at a fixed width
+
+        _ = textView.naturalFittingSize() // hit — must restore the natural-width container
+        #expect(textView.textContainer?.containerSize.width == 10_000)
+    }
 }

--- a/AlasTests/ACP/UI/ACPMarkdownInlineTextViewMeasurementCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineTextViewMeasurementCacheTests.swift
@@ -1,0 +1,96 @@
+import AppKit
+import Testing
+@testable import Alas
+
+/// The transcript scroll beachball came from `ACPMarkdownInlineNSTextView`
+/// re-running full TextKit layout on every `sizeThatFits` probe (SwiftUI's
+/// StackLayout probes each row at several widths per placement pass and
+/// re-probes on every scroll frame). These tests pin the memoization that
+/// fixed it: repeated probes at a known width must hit the cache, and any
+/// content change must invalidate it so heights never go stale.
+@MainActor
+struct ACPMarkdownInlineTextViewMeasurementCacheTests {
+    private func makeTextView(_ text: String) -> ACPMarkdownInlineNSTextView {
+        let textView = ACPMarkdownInlineNSTextView()
+        textView.isEditable = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+        textView.textStorage?.setAttributedString(
+            NSAttributedString(string: text, attributes: [.font: NSFont.systemFont(ofSize: 13)])
+        )
+        return textView
+    }
+
+    @Test func repeatedSameWidthProbesHitTheCache() {
+        let textView = makeTextView("The quick brown fox jumps over the lazy dog, several times, wrapping.")
+
+        let first = textView.fittingSize(for: 200)
+        let second = textView.fittingSize(for: 200)
+        let third = textView.fittingSize(for: 200)
+
+        #expect(first == second)
+        #expect(second == third)
+        #expect(textView.fittingComputationCountForTests == 1)
+    }
+
+    @Test func distinctWidthsEachComputeOnce() {
+        let textView = makeTextView("The quick brown fox jumps over the lazy dog, several times, wrapping.")
+
+        _ = textView.fittingSize(for: 200)
+        _ = textView.fittingSize(for: 350)
+        _ = textView.fittingSize(for: 200) // repeat → cache hit
+        _ = textView.fittingSize(for: 350) // repeat → cache hit
+
+        #expect(textView.fittingComputationCountForTests == 2)
+    }
+
+    @Test func invalidateForcesRecomputation() {
+        let textView = makeTextView("Some wrapping text for the row.")
+
+        _ = textView.fittingSize(for: 200)
+        #expect(textView.fittingComputationCountForTests == 1)
+
+        textView.invalidateFittingCache()
+        _ = textView.fittingSize(for: 200)
+        #expect(textView.fittingComputationCountForTests == 2)
+    }
+
+    @Test func naturalFittingSizeIsCached() {
+        let textView = makeTextView("Some wrapping text for the row.")
+
+        let first = textView.naturalFittingSize()
+        let second = textView.naturalFittingSize()
+
+        #expect(first == second)
+        #expect(textView.fittingComputationCountForTests == 1)
+
+        textView.invalidateFittingCache()
+        _ = textView.naturalFittingSize()
+        #expect(textView.fittingComputationCountForTests == 2)
+    }
+
+    @Test func cacheIsBoundedAndEvictsUnderWidthChurn() {
+        let textView = makeTextView("Some wrapping text for the row.")
+
+        // Fill the cache to its 16-entry limit with distinct widths.
+        for offset in 0..<16 {
+            _ = textView.fittingSize(for: 100 + CGFloat(offset))
+        }
+        #expect(textView.fittingComputationCountForTests == 16)
+
+        // An earlier width is still cached — no recomputation.
+        _ = textView.fittingSize(for: 100)
+        #expect(textView.fittingComputationCountForTests == 16)
+
+        // A 17th distinct width overflows the cap and clears the cache.
+        _ = textView.fittingSize(for: 200)
+        #expect(textView.fittingComputationCountForTests == 17)
+
+        // The earlier width was evicted, so it now recomputes.
+        _ = textView.fittingSize(for: 100)
+        #expect(textView.fittingComputationCountForTests == 18)
+    }
+}


### PR DESCRIPTION
## Problem

Scrolling a long ACP transcript beachballed the app. A `sample` of the hung process showed the main thread stuck 100% inside SwiftUI placement — `LazySubviewPlacements.placeSubviews` → `StackLayout.sizeThatFits` → `NSAttributedString.MetricsCache.metrics` — with no app symbols in the hot path.

## Root cause

ACP markdown rows aren't SwiftUI `Text`; every heading/paragraph/quote/table cell is `ACPMarkdownInlineTextView`, an `NSViewRepresentable` around `NSTextView`. Its `sizeThatFits`/`fittingSize(for:)` ran a full `NSLayoutManager.ensureLayout` + `usedRect` on **every** call with no memoization. SwiftUI's `StackLayout` probes each child at several widths per placement pass and re-probes on every scroll frame, so a long transcript re-ran hundreds of synchronous TextKit layouts per pass — a multi-second layout pass that pins the main thread.

The existing `.equatable()` row gate blocks body re-evaluation but cannot stop SwiftUI from re-measuring the already-materialized tree; only memoizing the measurement helps. Ruled out (unchanged): ForEach identity is stable (cached `stableId`), `contentMaxWidth` derives from the chat column (not scroll), and the scroll-anchor callbacks write non-observed storage — so there was no identity churn or observed-write-during-layout loop.

## Fix

Memoize the width→height measurement inside `ACPMarkdownInlineNSTextView` (a small width-keyed cache, capped to bound growth during live width drags, plus the natural-width result), invalidated whenever the text storage changes (`updateNSView` after `setAttributedString`, and the remote-image apply path). Behavior-preserving: repeated probes at a stable width now return without re-laying out.

## Tests

New `ACPMarkdownInlineTextViewMeasurementCacheTests` cover cache hits, per-width recomputation, invalidation on content change, and cap eviction, using a DEBUG-only computation counter (matching the existing `…ForTests` idiom). Assertions are on cache-hit counts, not font-dependent pixel heights, so they're deterministic.

## Verification

- `xcodegen` + full build succeed.
- New suite green; `ACPMarkdownText*`, `ACPMarkdownBlockCache`, and `ACPMessageListPagination` suites pass.
- Not done here (non-interactive session): the live re-`sample` after scrolling a long transcript — worth a manual confirm before merge.