### PR TITLE
feat(gg): add worktree-level mode controls

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1080,6 +1080,7 @@
 		C8BF4593D35403A93FC05D50 /* ACPAdapterInstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C99F8D1A0A37DC4A6DBAEE /* ACPAdapterInstallCoordinator.swift */; };
 		C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
+		C964306024B5EF69D7D4ED6D /* GGWorktreeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C7BDB3BEEB5B23DCE7F2C0 /* GGWorktreeContext.swift */; };
 		C968F976028C3D9C6E17EC44 /* GGUndoMarkerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246A2AF26902AB36730A4F44 /* GGUndoMarkerStoreTests.swift */; };
 		C97F67F96D887D0A417F9FD3 /* BinaryPreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E678D9C5E3D9D39BDD2AA51 /* BinaryPreviewTabView.swift */; };
 		C99FAC8BF1908B490E058FDA /* RemoteAccessPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EEBEEB1AC6532031BDE17F /* RemoteAccessPolicyTests.swift */; };
@@ -1281,6 +1282,7 @@
 		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
 		EBED65EE62760994B7C6010F /* SSHHostSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */; };
 		EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79485A502B7856609349A138 /* GGInstallController.swift */; };
+		EC066EB4CAFEDB2A0694DCF7 /* GGWorktreeContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1B5714AB51C0D1E7B6DB66 /* GGWorktreeContextTests.swift */; };
 		EC2C564EBA85B494489DF323 /* CursorModelVariantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */; };
 		EC3209AD2538061259084545 /* ACPTerminalMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */; };
 		EC9A9B3211CFE0B652F5CA83 /* MemoryDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */; };
@@ -1464,6 +1466,7 @@
 		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
 		0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationStateTests.swift; sourceTree = "<group>"; };
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
+		0E1B5714AB51C0D1E7B6DB66 /* GGWorktreeContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGWorktreeContextTests.swift; sourceTree = "<group>"; };
 		0E6600436B01C75D85C01FFA /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
 		0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperInstaller.swift; sourceTree = "<group>"; };
@@ -1867,6 +1870,7 @@
 		57E1A9B42D47CC0244C24F7B /* ACPElicitationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitationTests.swift; sourceTree = "<group>"; };
 		58B78EE378B0A076C904E2E4 /* TreeSitterLua */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterLua; path = ThirdParty/TreeSitterLua; sourceTree = SOURCE_ROOT; };
 		58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentController.swift; sourceTree = "<group>"; };
+		59C7BDB3BEEB5B23DCE7F2C0 /* GGWorktreeContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGWorktreeContext.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
 		59F17DE68E81565014FC9454 /* RemoteHelperWatchSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperWatchSession.swift; sourceTree = "<group>"; };
 		59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackChipModelTests.swift; sourceTree = "<group>"; };
@@ -4719,6 +4723,7 @@
 				F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */,
 				3EC4FE9500B277A3921C8AB2 /* GGStackSummaryStoreTests.swift */,
 				246A2AF26902AB36730A4F44 /* GGUndoMarkerStoreTests.swift */,
+				0E1B5714AB51C0D1E7B6DB66 /* GGWorktreeContextTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
 				48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
@@ -4991,6 +4996,7 @@
 				B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */,
 				724A473AB9439DAA535B33F8 /* GGUndoMarkerStore.swift */,
 				A02E6B12C5EC8FAA50202EEA /* GGUnstackSheet.swift */,
+				59C7BDB3BEEB5B23DCE7F2C0 /* GGWorktreeContext.swift */,
 			);
 			path = GG;
 			sourceTree = "<group>";
@@ -5720,6 +5726,7 @@
 				DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */,
 				318F74C3CB02BFF1D06DF7DA /* GGUndoMarkerStore.swift in Sources */,
 				270146424B271EBDB8886DD2 /* GGUnstackSheet.swift in Sources */,
+				C964306024B5EF69D7D4ED6D /* GGWorktreeContext.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
 				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,
@@ -6403,6 +6410,7 @@
 				CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */,
 				95DAB9F9E361DFD0395CC4C2 /* GGStackSummaryStoreTests.swift in Sources */,
 				C968F976028C3D9C6E17EC44 /* GGUndoMarkerStoreTests.swift in Sources */,
+				EC066EB4CAFEDB2A0694DCF7 /* GGWorktreeContextTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,
 				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -754,6 +754,7 @@
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8E8ABE6BBA778EEA4170423C /* MergeScrollCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */; };
 		8E988C41547B229AF19CBE31 /* ACPSessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A590E6B7A73546D38D4F95 /* ACPSessionPersistence.swift */; };
+		8ED9196CA54498198826E799 /* GGWorktreeMenuModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792D7045679FE1E12AAFA04 /* GGWorktreeMenuModelTests.swift */; };
 		8EEB68F55286EF9DADAA710A /* ACPSessionManagerPlanSidebarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCFA45F98F080043C4D664A /* ACPSessionManagerPlanSidebarLayoutTests.swift */; };
 		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
@@ -2104,6 +2105,7 @@
 		86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStreamTests.swift; sourceTree = "<group>"; };
 		86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackModels.swift; sourceTree = "<group>"; };
 		8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownTextBareURLTests.swift; sourceTree = "<group>"; };
+		8792D7045679FE1E12AAFA04 /* GGWorktreeMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGWorktreeMenuModelTests.swift; sourceTree = "<group>"; };
 		87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariants.swift; sourceTree = "<group>"; };
 		881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputer.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
@@ -3080,6 +3082,7 @@
 				5DB6D67179D2557D3A255AA3 /* GGInboxHostTests.swift */,
 				649D5CB480CE056B1C4457D6 /* GGInboxTabsTests.swift */,
 				70BDCB22C2FDC36F6022ADB3 /* GGStackCreateModeTests.swift */,
+				8792D7045679FE1E12AAFA04 /* GGWorktreeMenuModelTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
 				6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */,
@@ -6411,6 +6414,7 @@
 				95DAB9F9E361DFD0395CC4C2 /* GGStackSummaryStoreTests.swift in Sources */,
 				C968F976028C3D9C6E17EC44 /* GGUndoMarkerStoreTests.swift in Sources */,
 				EC066EB4CAFEDB2A0694DCF7 /* GGWorktreeContextTests.swift in Sources */,
+				8ED9196CA54498198826E799 /* GGWorktreeMenuModelTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,
 				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -538,7 +538,7 @@ final class AppState {
         ShellEnvResolver.shared.resolve()
 
         // Probe gg CLI availability once at startup so the stacked-diffs
-        // gate (RightPaneStore.ggGateProvider) has an answer by the time
+        // context provider (RightPaneStore.ggContextProvider) has an answer by the time
         // the first right pane activates. Wait for the login-shell PATH
         // resolution kicked off above first — otherwise a gg installed only
         // via Homebrew (not on the process's own PATH, e.g. launched from
@@ -5477,6 +5477,27 @@ final class AppState {
                 mode: project.ggMode, repoPath: project.path,
                 isRemoteProject: project.host != nil
             )
+    }
+
+    func ggWorktreeContext(
+        project: ProjectConfig,
+        worktree: Worktree,
+        branch: String
+    ) -> GGWorktreeContext {
+        GGWorktreeContextResolver.resolve(
+            masterEnabled: config.changes.stackedDiffsEnabled,
+            ggInstalled: GGAvailability.shared.isInstalled,
+            isRemoteProject: project.host != nil,
+            projectMode: project.ggMode,
+            worktreeOverride: projectsManager.ggWorktreeMode(
+                projectId: project.id,
+                worktreeId: worktree.id
+            ),
+            isMainWorktree: projectsManager.isMain(worktree, in: project),
+            repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path),
+            branchUsername: GGConfigReader.branchUsername(repoPath: project.path),
+            branch: branch
+        )
     }
 
     /// Chooses which of the target project's worktrees hosts its inbox tab:

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1879,7 +1879,18 @@ final class AppState {
         let previousPaths = Dictionary(uniqueKeysWithValues: projectsManager.projects
             .filter { $0.id == projectId }
             .map { ($0.id, $0.path) })
+        let previousBranches = Dictionary(uniqueKeysWithValues: projectsManager
+            .worktrees(projectId: projectId)
+            .map { (Self.canonicalWorktreePath($0.path.path), (path: $0.path.path, branch: $0.branch)) })
         let changed = try await projectsManager.refreshWorktrees(projectId: projectId)
+        for worktree in projectsManager.worktrees(projectId: projectId) {
+            let canonicalPath = Self.canonicalWorktreePath(worktree.path.path)
+            guard let previous = previousBranches[canonicalPath], previous.branch != worktree.branch else {
+                continue
+            }
+            GGStackSummaryStore.shared.summaries[previous.path] = nil
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+        }
         if changed { saveProjects() }
         restartProjectGitWatchers(previousPaths: previousPaths)
         return changed

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1858,8 +1858,14 @@ final class AppState {
         remoteProjectWatchers.removeAll()
     }
 
-    private func handleProjectHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) {
-        projectsManager.applyHeadUpdates(projectId: projectId, branchByWorktreePath: branchByWorktreePath)
+    func handleProjectHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) {
+        let changedPaths = projectsManager.applyHeadUpdates(
+            projectId: projectId,
+            branchByWorktreePath: branchByWorktreePath
+        )
+        for path in changedPaths {
+            GGStackSummaryStore.shared.summaries[path] = nil
+        }
     }
 
     private func handleProjectTopologyChange(projectId: String) {
@@ -4429,6 +4435,10 @@ final class AppState {
         // Always clear the deleting state after a successful remove,
         // even if the subsequent refresh fails.
         projectsManager.setOperationState(id: worktree.id, state: nil)
+        removePersistedGGWorktreeMode(
+            projectId: worktree.projectId,
+            worktreeId: worktree.id
+        )
         _ = try? await refreshProjectWorktrees(projectId: worktree.projectId)
         if selectedWorktreeId == worktree.id {
             selectWorktree(id: selectionAfterRemoval(
@@ -5538,6 +5548,15 @@ final class AppState {
         )
         saveProjects()
         rightPaneStore.reevaluateGGGate(worktreeId: worktreeId)
+    }
+
+    func removePersistedGGWorktreeMode(projectId: String, worktreeId: String) {
+        guard projectsManager.ggWorktreeMode(
+            projectId: projectId,
+            worktreeId: worktreeId
+        ) != .inherit else { return }
+        projectsManager.removeGGWorktreeMode(projectId: projectId, worktreeId: worktreeId)
+        saveProjects()
     }
 
     nonisolated static func resolveGGWorktreeContext(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5488,11 +5488,12 @@ final class AppState {
     func ggWorktreeContext(
         project: ProjectConfig,
         worktree: Worktree,
-        branch: String
+        branch: String,
+        ggInstalled: Bool = GGAvailability.shared.isInstalled
     ) -> GGWorktreeContext {
         Self.resolveGGWorktreeContext(
             masterEnabled: config.changes.stackedDiffsEnabled,
-            ggInstalled: GGAvailability.shared.isInstalled,
+            ggInstalled: ggInstalled,
             project: project,
             worktreeOverride: projectsManager.ggWorktreeMode(
                 projectId: project.id,
@@ -5578,18 +5579,26 @@ final class AppState {
         return .stack(name: stack.name, entryCount: stack.totalCommits)
     }
 
-    private func ggACPWorktreeIntegration(
-        worktreePath: String
+    func ggACPWorktreeIntegration(
+        worktreePath: String,
+        ggInstalled: Bool = GGAvailability.shared.isInstalled
     ) -> (project: ProjectConfig, worktree: Worktree, context: GGWorktreeContext)? {
         let requestedPath = Self.canonicalWorktreePath(worktreePath)
         for project in projects {
             guard let worktree = projectsManager.worktrees(projectId: project.id).first(where: {
                 Self.canonicalWorktreePath($0.path.path) == requestedPath
             }) else { continue }
+            let branch = rightPaneStore.currentBranchForWorktreePath(worktree.path.path)
+                ?? worktree.branch
             return (
                 project,
                 worktree,
-                ggWorktreeContext(project: project, worktree: worktree, branch: worktree.branch)
+                ggWorktreeContext(
+                    project: project,
+                    worktree: worktree,
+                    branch: branch,
+                    ggInstalled: ggInstalled
+                )
             )
         }
         return nil

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5530,7 +5530,7 @@ final class AppState {
             mode: mode
         )
         saveProjects()
-        rightPaneStore.reevaluateGGGates()
+        rightPaneStore.reevaluateGGGate(worktreeId: worktreeId)
     }
 
     nonisolated static func resolveGGWorktreeContext(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4928,8 +4928,9 @@ final class AppState {
                 else { return .none }
                 return Self.ggPreambleSignal(
                     context: integration.context,
-                    loadedStack: self.rightPaneStore.stackForWorktreePath(
-                        integration.worktree.path.path
+                    snapshot: self.rightPaneStore.ggStackSnapshotForWorktreePath(
+                        integration.worktree.path.path,
+                        effectiveContext: integration.context
                     )
                 )
             }
@@ -5567,11 +5568,14 @@ final class AppState {
 
     nonisolated static func ggPreambleSignal(
         context: GGWorktreeContext,
-        loadedStack: GGStack?
+        snapshot: RightPaneGGStackSnapshot?
     ) -> GGPreambleSignal {
         guard context.isActive else { return .none }
-        guard let loadedStack else { return .generic }
-        return .stack(name: loadedStack.name, entryCount: loadedStack.totalCommits)
+        guard let snapshot,
+              snapshot.loadState == .loaded,
+              let stack = snapshot.stack
+        else { return .generic }
+        return .stack(name: stack.name, entryCount: stack.totalCommits)
     }
 
     private func ggACPWorktreeIntegration(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5499,6 +5499,40 @@ final class AppState {
         )
     }
 
+    func ggWorktreeMenuModel(
+        project: ProjectConfig,
+        worktree: Worktree
+    ) -> GGWorktreeMenuModel {
+        let selectedMode = projectsManager.ggWorktreeMode(
+            projectId: project.id,
+            worktreeId: worktree.id
+        )
+        return GGWorktreeMenuModel(
+            selectedMode: selectedMode,
+            context: ggWorktreeContext(
+                project: project,
+                worktree: worktree,
+                branch: worktree.branch
+            ),
+            hasStackSummary: GGStackSummaryStore.shared.summaries[worktree.path.path] != nil,
+            isRemoteWorktree: project.host != nil || worktree.path.isRemoteAlasPath
+        )
+    }
+
+    func setGGWorktreeMode(
+        projectId: String,
+        worktreeId: String,
+        mode: GGWorktreeMode
+    ) {
+        projectsManager.setGGWorktreeMode(
+            projectId: projectId,
+            worktreeId: worktreeId,
+            mode: mode
+        )
+        saveProjects()
+        rightPaneStore.reevaluateGGGates()
+    }
+
     nonisolated static func resolveGGWorktreeContext(
         masterEnabled: Bool,
         ggInstalled: Bool,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5484,11 +5484,10 @@ final class AppState {
         worktree: Worktree,
         branch: String
     ) -> GGWorktreeContext {
-        GGWorktreeContextResolver.resolve(
+        Self.resolveGGWorktreeContext(
             masterEnabled: config.changes.stackedDiffsEnabled,
             ggInstalled: GGAvailability.shared.isInstalled,
-            isRemoteProject: project.host != nil,
-            projectMode: project.ggMode,
+            project: project,
             worktreeOverride: projectsManager.ggWorktreeMode(
                 projectId: project.id,
                 worktreeId: worktree.id
@@ -5496,6 +5495,29 @@ final class AppState {
             isMainWorktree: projectsManager.isMain(worktree, in: project),
             repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path),
             branchUsername: GGConfigReader.branchUsername(repoPath: project.path),
+            branch: branch
+        )
+    }
+
+    nonisolated static func resolveGGWorktreeContext(
+        masterEnabled: Bool,
+        ggInstalled: Bool,
+        project: ProjectConfig,
+        worktreeOverride: GGWorktreeMode,
+        isMainWorktree: Bool,
+        repoHasGGConfig: Bool,
+        branchUsername: String?,
+        branch: String
+    ) -> GGWorktreeContext {
+        GGWorktreeContextResolver.resolve(
+            masterEnabled: masterEnabled,
+            ggInstalled: ggInstalled,
+            isRemoteProject: project.host != nil,
+            projectMode: project.ggMode,
+            worktreeOverride: worktreeOverride,
+            isMainWorktree: isMainWorktree,
+            repoHasGGConfig: repoHasGGConfig,
+            branchUsername: branchUsername,
             branch: branch
         )
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1620,7 +1620,9 @@ final class AppState {
 
     func removeFailedOptimisticWorktree(id: String, projectId: String) {
         cleanupWorktreeState(worktreeId: id)
+        projectsManager.removeGGWorktreeMode(projectId: projectId, worktreeId: id)
         projectsManager.removeOptimisticWorktree(id: id, projectId: projectId)
+        saveProjects()
         if selectedWorktreeId == id {
             selectWorktree(id: resolvedSelectionForActiveSpace())
         }
@@ -4910,38 +4912,26 @@ final class AppState {
             },
             ggMCPProvider: { [weak self] worktreePath in
                 guard let self,
-                      let project = self.projects.first(where: { $0.id == worktree.projectId }),
-                      self.config.changes.stackedDiffsEnabled,
-                      GGAvailability.shared.isInstalled,
-                      GGStackGate.projectEnabled(
-                          masterEnabled: true, ggInstalled: true,
-                          mode: project.ggMode, repoPath: project.path,
-                          isRemoteProject: project.host != nil
-                      ),
-                      GGStackGate.repoHasGGConfig(repoPath: worktreePath)
+                      let integration = self.ggACPWorktreeIntegration(worktreePath: worktreePath),
+                      Self.shouldAttachGGMCP(context: integration.context)
                 else { return nil }
                 return GGMCPInjection.injection(
                     gatePassed: true,
                     binaryPath: GGAvailability.shared.ggMCPBinaryPath,
-                    configuredServers: project.mcpServers,
+                    configuredServers: integration.project.mcpServers,
                     worktreePath: worktreePath
                 )
             },
             ggPreambleProvider: { [weak self] worktreePath in
                 guard let self,
-                      let project = self.projects.first(where: { $0.id == worktree.projectId }),
-                      self.config.changes.stackedDiffsEnabled,
-                      GGAvailability.shared.isInstalled,
-                      GGStackGate.projectEnabled(
-                          masterEnabled: true, ggInstalled: true,
-                          mode: project.ggMode, repoPath: project.path,
-                          isRemoteProject: project.host != nil
-                      )
+                      let integration = self.ggACPWorktreeIntegration(worktreePath: worktreePath)
                 else { return .none }
-                if let stack = self.rightPaneStore.stackForWorktreePath(worktreePath) {
-                    return .stack(name: stack.name, entryCount: stack.totalCommits)
-                }
-                return GGStackGate.repoHasGGConfig(repoPath: worktreePath) ? .generic : .none
+                return Self.ggPreambleSignal(
+                    context: integration.context,
+                    loadedStack: self.rightPaneStore.stackForWorktreePath(
+                        integration.worktree.path.path
+                    )
+                )
             }
         )
         mgr.alasCLIEnvProvider = { [weak self] worktreePath, sessionId in
@@ -5466,17 +5456,32 @@ final class AppState {
         tabs.activate(worktreeId: worktree.id, tabId: tab.id)
     }
 
-    /// The phase-3 gg gate for a project: gg feature on, CLI installed, and
-    /// the project (local, not remote) has gg enabled.
+    /// Project-scoped gg inbox capability. This intentionally does not use a
+    /// hosting worktree's effective context because the inbox spans the repo.
     func ggInboxAvailable(projectId: String) -> Bool {
         guard let project = projects.first(where: { $0.id == projectId }) else { return false }
-        return config.changes.stackedDiffsEnabled
-            && GGAvailability.shared.isInstalled
-            && GGStackGate.projectEnabled(
-                masterEnabled: true, ggInstalled: true,
-                mode: project.ggMode, repoPath: project.path,
-                isRemoteProject: project.host != nil
-            )
+        return Self.resolveGGInboxAvailable(
+            masterEnabled: config.changes.stackedDiffsEnabled,
+            ggInstalled: GGAvailability.shared.isInstalled,
+            isRemoteProject: project.host != nil,
+            projectMode: project.ggMode,
+            repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path),
+            worktreeOverrides: Array(project.ggWorktreeModes.values)
+        )
+    }
+
+    nonisolated static func resolveGGInboxAvailable(
+        masterEnabled: Bool,
+        ggInstalled: Bool,
+        isRemoteProject: Bool,
+        projectMode: GGProjectMode,
+        repoHasGGConfig: Bool,
+        worktreeOverrides: [GGWorktreeMode]
+    ) -> Bool {
+        guard masterEnabled, ggInstalled, !isRemoteProject else { return false }
+        return repoHasGGConfig
+            || projectMode == .on
+            || worktreeOverrides.contains(.on)
     }
 
     func ggWorktreeContext(
@@ -5554,6 +5559,43 @@ final class AppState {
             branchUsername: branchUsername,
             branch: branch
         )
+    }
+
+    nonisolated static func shouldAttachGGMCP(context: GGWorktreeContext) -> Bool {
+        context.isActive
+    }
+
+    nonisolated static func ggPreambleSignal(
+        context: GGWorktreeContext,
+        loadedStack: GGStack?
+    ) -> GGPreambleSignal {
+        guard context.isActive else { return .none }
+        guard let loadedStack else { return .generic }
+        return .stack(name: loadedStack.name, entryCount: loadedStack.totalCommits)
+    }
+
+    private func ggACPWorktreeIntegration(
+        worktreePath: String
+    ) -> (project: ProjectConfig, worktree: Worktree, context: GGWorktreeContext)? {
+        let requestedPath = Self.canonicalWorktreePath(worktreePath)
+        for project in projects {
+            guard let worktree = projectsManager.worktrees(projectId: project.id).first(where: {
+                Self.canonicalWorktreePath($0.path.path) == requestedPath
+            }) else { continue }
+            return (
+                project,
+                worktree,
+                ggWorktreeContext(project: project, worktree: worktree, branch: worktree.branch)
+            )
+        }
+        return nil
+    }
+
+    nonisolated private static func canonicalWorktreePath(_ path: String) -> String {
+        URL(fileURLWithPath: path)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
     }
 
     /// Chooses which of the target project's worktrees hosts its inbox tab:

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -165,6 +165,24 @@ final class ProjectsManager {
         projects[idx].ggMode = mode
     }
 
+    func ggWorktreeMode(projectId: String, worktreeId: String) -> GGWorktreeMode {
+        projects.first(where: { $0.id == projectId })?.ggWorktreeModes[worktreeId] ?? .inherit
+    }
+
+    func setGGWorktreeMode(projectId: String, worktreeId: String, mode: GGWorktreeMode) {
+        guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return }
+        if mode == .inherit {
+            projects[idx].ggWorktreeModes.removeValue(forKey: worktreeId)
+        } else {
+            projects[idx].ggWorktreeModes[worktreeId] = mode
+        }
+    }
+
+    func removeGGWorktreeMode(projectId: String, worktreeId: String) {
+        guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return }
+        projects[idx].ggWorktreeModes.removeValue(forKey: worktreeId)
+    }
+
     func reorderProject(fromIndex: Int, toIndex: Int) {
         guard projects.indices.contains(fromIndex),
               projects.indices.contains(toIndex),

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -635,6 +635,7 @@ final class ProjectsManager {
     }
 
     private func isMainWorktree(_ worktree: Worktree, project: ProjectConfig) -> Bool {
-        canonical(worktree.path) == canonical(URL(fileURLWithPath: project.path))
+        worktree.isMainWorktree
+            ?? (canonical(worktree.path) == canonical(URL(fileURLWithPath: project.path)))
     }
 }

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -487,12 +487,14 @@ final class ProjectsManager {
     /// has on disk yet. `.deleting` and `.deleteFailed` rows are still
     /// updated — they correspond to real git worktrees with a pending UI
     /// operation, so git's branch is still the truth.
-    func applyHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) {
-        guard var rows = worktreesByProject[projectId], !rows.isEmpty else { return }
+    @discardableResult
+    func applyHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) -> Set<String> {
+        guard var rows = worktreesByProject[projectId], !rows.isEmpty else { return [] }
         let lookup: [String: String] = Dictionary(uniqueKeysWithValues:
             branchByWorktreePath.map { (canonical($0.key), $0.value) }
         )
         var changed = false
+        var changedPaths: Set<String> = []
         for i in rows.indices {
             let key = canonical(rows[i].path)
             guard let newBranch = lookup[key] else { continue }
@@ -506,12 +508,14 @@ final class ProjectsManager {
                 rows[i].branch = newBranch
                 rows[i].name = newBranch
                 changed = true
+                changedPaths.insert(rows[i].path.path)
             }
         }
         if changed {
             worktreesByProject[projectId] = rows
             applyWorktreeOrdering(projectId: projectId)
         }
+        return changedPaths
     }
 
     private func hiddenSet(projectId: String) -> Set<String> {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -339,9 +339,8 @@ final class ProjectsManager {
         projects[idx].hiddenWorktreePaths = paths
     }
 
-    /// Refresh the live worktree list for a project and GC orphan hidden
-    /// paths. Returns `true` when the GC dropped at least one entry, so the
-    /// caller can persist the change to disk; `false` otherwise.
+    /// Refresh the live worktree list and reconcile per-worktree persisted
+    /// configuration. Returns `true` when the caller should persist changes.
     @discardableResult
     func refreshWorktrees(projectId: String) async throws -> Bool {
         guard let project = projects.first(where: { $0.id == projectId }) else { return false }
@@ -415,7 +414,15 @@ final class ProjectsManager {
         let live = Set(trees.map { canonical($0.path) })
         let before = projects[idx].hiddenWorktreePaths.count
         projects[idx].hiddenWorktreePaths.removeAll { !live.contains($0) }
-        return anchorChanged || orderChanged || projects[idx].hiddenWorktreePaths.count != before
+        let reconciledIds = Set(reconciled.map(\.id))
+        let previousGGWorktreeModes = projects[idx].ggWorktreeModes
+        projects[idx].ggWorktreeModes = previousGGWorktreeModes.filter {
+            reconciledIds.contains($0.key)
+        }
+        return anchorChanged
+            || orderChanged
+            || projects[idx].hiddenWorktreePaths.count != before
+            || projects[idx].ggWorktreeModes != previousGGWorktreeModes
     }
 
     func reconcileRemoteHostRegistrations(project: ProjectConfig, previous: [Worktree], reconciled: [Worktree]) {
@@ -458,7 +465,7 @@ final class ProjectsManager {
     }
 
     /// Refresh every project. Returns `true` when at least one project's
-    /// hidden-path GC dropped an entry, so the caller can persist the change.
+    /// persisted configuration changed, so the caller can save it.
     @discardableResult
     func refreshAll() async -> Bool {
         var changed = false

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -348,7 +348,7 @@ struct CenterPaneView: View {
                                     .map { s.matches(splitTarget: $0) } ?? false)
                             let otherActionInFlight = ggActionState.inFlightAction != nil
                                 && !ownSplitApplying
-                            let workflowAvailable = rightPaneState.ggGateProvider?() == true
+                            let workflowAvailable = rightPaneState.ggContext.isActive
                                 && targetEntry != nil
                                 && targetEntry?.prState != .merged
                                 && !otherActionInFlight

--- a/Alas/Sources/Git/GitTypes.swift
+++ b/Alas/Sources/Git/GitTypes.swift
@@ -10,6 +10,8 @@ struct Worktree: Identifiable, Equatable, Codable {
     var name: String         // display name (usually the branch)
     var branch: String
     var path: URL
+    /// Nil for legacy or synthetic rows whose identity has not been read from Git.
+    var isMainWorktree: Bool?
     var status: WorktreeStatus
     var lastActivity: Date
     var createdAt: Date
@@ -17,7 +19,7 @@ struct Worktree: Identifiable, Equatable, Codable {
     var deletedLines: Int = 0
 
     enum CodingKeys: String, CodingKey {
-        case id, projectId, name, branch, path, status,
+        case id, projectId, name, branch, path, isMainWorktree, status,
              lastActivity, createdAt, addedLines, deletedLines
     }
 
@@ -27,6 +29,7 @@ struct Worktree: Identifiable, Equatable, Codable {
         name: String,
         branch: String,
         path: URL,
+        isMainWorktree: Bool? = nil,
         status: WorktreeStatus,
         lastActivity: Date,
         createdAt: Date? = nil,
@@ -38,6 +41,7 @@ struct Worktree: Identifiable, Equatable, Codable {
         self.name = name
         self.branch = branch
         self.path = path
+        self.isMainWorktree = isMainWorktree
         self.status = status
         self.lastActivity = lastActivity
         self.createdAt = createdAt ?? lastActivity
@@ -52,6 +56,7 @@ struct Worktree: Identifiable, Equatable, Codable {
         name = try c.decode(String.self, forKey: .name)
         branch = try c.decode(String.self, forKey: .branch)
         path = try c.decode(URL.self, forKey: .path)
+        isMainWorktree = try c.decodeIfPresent(Bool.self, forKey: .isMainWorktree)
         status = try c.decode(WorktreeStatus.self, forKey: .status)
         lastActivity = try c.decode(Date.self, forKey: .lastActivity)
         createdAt = (try? c.decode(Date.self, forKey: .createdAt)) ?? lastActivity

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -164,6 +164,7 @@ struct WorktreeService {
                     name: branch,
                     branch: branch,
                     path: path,
+                    isMainWorktree: result.isEmpty,
                     status: .clean,
                     lastActivity: lastActivity,
                     createdAt: ctime
@@ -613,6 +614,7 @@ struct WorktreeService {
             name: branch,
             branch: branch,
             path: destination,
+            isMainWorktree: false,
             status: .clean,
             lastActivity: now,
             createdAt: now

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -1,5 +1,49 @@
 import SwiftUI
 
+struct GGStackPlaceholderModel: Equatable {
+    let title: String
+    let summaryChip: String
+    let detail: String?
+    let canRetry: Bool
+    let isLoading: Bool
+
+    static func make(
+        context: GGWorktreeContext,
+        loadState: GGStackLoadState
+    ) -> GGStackPlaceholderModel? {
+        guard case .active(let stackName) = context else { return nil }
+
+        switch loadState {
+        case .loading:
+            return GGStackPlaceholderModel(
+                title: stackName,
+                summaryChip: "Loading",
+                detail: nil,
+                canRetry: false,
+                isLoading: true
+            )
+        case .empty:
+            return GGStackPlaceholderModel(
+                title: stackName,
+                summaryChip: "0 commits",
+                detail: nil,
+                canRetry: false,
+                isLoading: false
+            )
+        case .failed(let message):
+            return GGStackPlaceholderModel(
+                title: stackName,
+                summaryChip: "Unavailable",
+                detail: message,
+                canRetry: true,
+                isLoading: false
+            )
+        case .inactive, .loaded:
+            return nil
+        }
+    }
+}
+
 struct GGStackDrawer: View {
     @Bindable var rps: RightPaneState
     let appState: AppState
@@ -9,7 +53,7 @@ struct GGStackDrawer: View {
     @State private var isRefreshing = false
 
     private var model: GGStackReadinessModel? {
-        if let stack = rps.ggStack {
+        if rps.ggStackLoadState == .loaded, let stack = rps.ggStack {
             return GGStackReadinessModel.make(
                 stack: stack,
                 action: rps.ggActionState,
@@ -51,6 +95,13 @@ struct GGStackDrawer: View {
         return GGStackReadinessModel.makePausedFallback(action: rps.ggActionState)
     }
 
+    private var placeholderModel: GGStackPlaceholderModel? {
+        GGStackPlaceholderModel.make(
+            context: rps.ggContext,
+            loadState: rps.ggStackLoadState
+        )
+    }
+
     static func liveBehindBaseOverride(
         stack: GGStack,
         selectedBaseBranch: String,
@@ -75,18 +126,48 @@ struct GGStackDrawer: View {
                 if expanded { expandedBody(model) }
             }
             .background(theme.color("bg-1").opacity(0.97))
+        } else if let placeholderModel {
+            VStack(spacing: 0) {
+                Rectangle().fill(theme.color("accent").opacity(0.24)).frame(height: 1)
+                collapsedRow(placeholderModel)
+                if expanded { expandedBody(placeholderModel) }
+            }
+            .background(theme.color("bg-1").opacity(0.97))
         }
     }
 
     private func collapsedRow(_ model: GGStackReadinessModel) -> some View {
+        collapsedRow(
+            title: model.title,
+            summaryChip: model.summaryChip,
+            isPaused: model.isPaused,
+            showsLoading: false
+        )
+    }
+
+    private func collapsedRow(_ model: GGStackPlaceholderModel) -> some View {
+        collapsedRow(
+            title: model.title,
+            summaryChip: model.summaryChip,
+            isPaused: false,
+            showsLoading: model.isLoading
+        )
+    }
+
+    private func collapsedRow(
+        title: String,
+        summaryChip: String,
+        isPaused: Bool,
+        showsLoading: Bool
+    ) -> some View {
         HStack(spacing: 7) {
-            Circle().fill(theme.color(model.isPaused ? "warn" : "accent")).frame(width: 6, height: 6)
+            Circle().fill(theme.color(isPaused ? "warn" : "accent")).frame(width: 6, height: 6)
             Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
-            Text(model.title.uppercased())
+            Text(title.uppercased())
                 .font(.system(size: 10.5, weight: .semibold)).tracking(0.5)
                 .foregroundColor(theme.color("fg-muted")).lineLimit(1).truncationMode(.middle)
             Spacer(minLength: 6)
-            Text(model.summaryChip)
+            Text(summaryChip)
                 .font(.system(size: 10.5, weight: .medium)).foregroundColor(theme.color("fg-dim"))
             Button {
                 appState.openGGInbox(projectId: rps.worktree.projectId)
@@ -96,24 +177,7 @@ struct GGStackDrawer: View {
             .buttonStyle(.plain)
             .focusEffectDisabled()
             .help("Open gg inbox")
-            if isRefreshing {
-                Spinner(lineWidth: 1.4, duration: 0.8).frame(width: 11, height: 11)
-            } else {
-                Button {
-                    isRefreshing = true
-                    let task = rps.reevaluateGGGate()
-                    Task { @MainActor in
-                        await task.value
-                        isRefreshing = false
-                    }
-                } label: {
-                    Icon(name: "arrow.clockwise", size: 10, color: theme.color("fg-faint"))
-                }
-                .buttonStyle(.plain)
-                .focusEffectDisabled()
-                .disabled(rps.ggActionState.inFlightAction != nil)
-                .help("Refresh stack and PR status")
-            }
+            refreshControl(showsLoading: showsLoading)
             Icon(name: expanded ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
         }
         .padding(.horizontal, 10).padding(.vertical, 7)
@@ -130,11 +194,47 @@ struct GGStackDrawer: View {
             return .handled
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(model.title)
+        .accessibilityLabel(title)
         .accessibilityHint(expanded ? "Collapse stack status" : "Expand stack status")
         .accessibilityAddTraits(.isButton)
         .accessibilityAction {
             expanded.toggle()
+        }
+    }
+
+    @ViewBuilder
+    private func refreshControl(showsLoading: Bool) -> some View {
+        if showsLoading || isRefreshing {
+            Spinner(lineWidth: 1.4, duration: 0.8).frame(width: 11, height: 11)
+        } else {
+            Button(action: refresh) {
+                Icon(name: "arrow.clockwise", size: 10, color: theme.color("fg-faint"))
+            }
+            .buttonStyle(.plain)
+            .focusEffectDisabled()
+            .disabled(rps.ggActionState.inFlightAction != nil)
+            .help("Refresh stack and PR status")
+        }
+    }
+
+    @ViewBuilder
+    private func expandedBody(_ model: GGStackPlaceholderModel) -> some View {
+        if model.detail != nil || model.canRetry {
+            VStack(alignment: .leading, spacing: 8) {
+                if let detail = model.detail {
+                    Text(detail)
+                        .font(.system(size: 11))
+                        .foregroundStyle(theme.color("warn"))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if model.canRetry {
+                    Button("Retry", action: refresh)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(isRefreshing)
+                }
+            }
+            .padding(.horizontal, 10).padding(.bottom, 10)
         }
     }
 
@@ -242,6 +342,15 @@ struct GGStackDrawer: View {
             rps.requestGGLand(.ready)
         } else {
             rps.onGGStackAction(action.kind, appState: appState)
+        }
+    }
+
+    private func refresh() {
+        isRefreshing = true
+        let task = rps.reevaluateGGGate()
+        Task { @MainActor in
+            await task.value
+            isRefreshing = false
         }
     }
 

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -7,6 +7,8 @@ struct GGStackPlaceholderModel: Equatable {
     let canRetry: Bool
     let isLoading: Bool
 
+    var isExpandable: Bool { detail != nil || canRetry }
+
     static func make(
         context: GGWorktreeContext,
         loadState: GGStackLoadState
@@ -137,7 +139,7 @@ struct GGStackDrawer: View {
     }
 
     private func collapsedRow(_ model: GGStackReadinessModel) -> some View {
-        collapsedRow(
+        expandableCollapsedRow(
             title: model.title,
             summaryChip: model.summaryChip,
             isPaused: model.isPaused,
@@ -145,42 +147,37 @@ struct GGStackDrawer: View {
         )
     }
 
+    @ViewBuilder
     private func collapsedRow(_ model: GGStackPlaceholderModel) -> some View {
-        collapsedRow(
-            title: model.title,
-            summaryChip: model.summaryChip,
-            isPaused: false,
-            showsLoading: model.isLoading
-        )
+        if model.isExpandable {
+            expandableCollapsedRow(
+                title: model.title,
+                summaryChip: model.summaryChip,
+                isPaused: false,
+                showsLoading: model.isLoading
+            )
+        } else {
+            staticCollapsedRow(
+                title: model.title,
+                summaryChip: model.summaryChip,
+                showsLoading: model.isLoading
+            )
+        }
     }
 
-    private func collapsedRow(
+    private func expandableCollapsedRow(
         title: String,
         summaryChip: String,
         isPaused: Bool,
         showsLoading: Bool
     ) -> some View {
-        HStack(spacing: 7) {
-            Circle().fill(theme.color(isPaused ? "warn" : "accent")).frame(width: 6, height: 6)
-            Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
-            Text(title.uppercased())
-                .font(.system(size: 10.5, weight: .semibold)).tracking(0.5)
-                .foregroundColor(theme.color("fg-muted")).lineLimit(1).truncationMode(.middle)
-            Spacer(minLength: 6)
-            Text(summaryChip)
-                .font(.system(size: 10.5, weight: .medium)).foregroundColor(theme.color("fg-dim"))
-            Button {
-                appState.openGGInbox(projectId: rps.worktree.projectId)
-            } label: {
-                Icon(name: "tray.full", size: 10, color: theme.color("fg-faint"))
-            }
-            .buttonStyle(.plain)
-            .focusEffectDisabled()
-            .help("Open gg inbox")
-            refreshControl(showsLoading: showsLoading)
-            Icon(name: expanded ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
-        }
-        .padding(.horizontal, 10).padding(.vertical, 7)
+        collapsedRowContent(
+            title: title,
+            summaryChip: summaryChip,
+            isPaused: isPaused,
+            showsLoading: showsLoading,
+            showsChevron: true
+        )
         .contentShape(Rectangle())
         .onTapGesture { expanded.toggle() }
         .focusable()
@@ -200,6 +197,54 @@ struct GGStackDrawer: View {
         .accessibilityAction {
             expanded.toggle()
         }
+    }
+
+    private func staticCollapsedRow(
+        title: String,
+        summaryChip: String,
+        showsLoading: Bool
+    ) -> some View {
+        collapsedRowContent(
+            title: title,
+            summaryChip: summaryChip,
+            isPaused: false,
+            showsLoading: showsLoading,
+            showsChevron: false
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(title)
+    }
+
+    private func collapsedRowContent(
+        title: String,
+        summaryChip: String,
+        isPaused: Bool,
+        showsLoading: Bool,
+        showsChevron: Bool
+    ) -> some View {
+        HStack(spacing: 7) {
+            Circle().fill(theme.color(isPaused ? "warn" : "accent")).frame(width: 6, height: 6)
+            Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
+            Text(title.uppercased())
+                .font(.system(size: 10.5, weight: .semibold)).tracking(0.5)
+                .foregroundColor(theme.color("fg-muted")).lineLimit(1).truncationMode(.middle)
+            Spacer(minLength: 6)
+            Text(summaryChip)
+                .font(.system(size: 10.5, weight: .medium)).foregroundColor(theme.color("fg-dim"))
+            Button {
+                appState.openGGInbox(projectId: rps.worktree.projectId)
+            } label: {
+                Icon(name: "tray.full", size: 10, color: theme.color("fg-faint"))
+            }
+            .buttonStyle(.plain)
+            .focusEffectDisabled()
+            .help("Open gg inbox")
+            refreshControl(showsLoading: showsLoading)
+            if showsChevron {
+                Icon(name: expanded ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+            }
+        }
+        .padding(.horizontal, 10).padding(.vertical, 7)
     }
 
     @ViewBuilder

--- a/Alas/Sources/Integrations/GG/GGWorktreeContext.swift
+++ b/Alas/Sources/Integrations/GG/GGWorktreeContext.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+enum GGWorktreeMode: String, Codable, Equatable, CaseIterable {
+    case inherit
+    case on
+    case off
+}
+
+enum GGWorktreeInactiveReason: Equatable {
+    case masterDisabled
+    case cliMissing
+    case remoteProject
+    case policyOff
+    case branchUsernameMissing
+    case branchPrefixMismatch(expectedPrefix: String)
+}
+
+enum GGWorktreeContext: Equatable {
+    case active(stackName: String)
+    case inactive(reason: GGWorktreeInactiveReason)
+
+    var isActive: Bool {
+        if case .active = self { return true }
+        return false
+    }
+}
+
+enum GGWorktreeContextResolver {
+    static func stackName(branch: String, username: String) -> String? {
+        let prefix = "\(username)/"
+        guard branch.hasPrefix(prefix) else { return nil }
+        let name = String(branch.dropFirst(prefix.count))
+        return name.isEmpty ? nil : name
+    }
+
+    static func resolve(
+        masterEnabled: Bool,
+        ggInstalled: Bool,
+        isRemoteProject: Bool,
+        projectMode: GGProjectMode,
+        worktreeOverride: GGWorktreeMode,
+        isMainWorktree: Bool,
+        repoHasGGConfig: Bool,
+        branchUsername: String?,
+        branch: String
+    ) -> GGWorktreeContext {
+        guard masterEnabled else { return .inactive(reason: .masterDisabled) }
+        guard ggInstalled else { return .inactive(reason: .cliMissing) }
+        guard !isRemoteProject else { return .inactive(reason: .remoteProject) }
+
+        let policyEnabled: Bool
+        switch worktreeOverride {
+        case .on:
+            policyEnabled = true
+        case .off:
+            policyEnabled = false
+        case .inherit:
+            if isMainWorktree {
+                policyEnabled = false
+            } else {
+                switch projectMode {
+                case .off: policyEnabled = false
+                case .auto: policyEnabled = repoHasGGConfig
+                case .on: policyEnabled = true
+                }
+            }
+        }
+        guard policyEnabled else { return .inactive(reason: .policyOff) }
+
+        guard let branchUsername, !branchUsername.isEmpty else {
+            return .inactive(reason: .branchUsernameMissing)
+        }
+        guard let name = stackName(branch: branch, username: branchUsername) else {
+            return .inactive(reason: .branchPrefixMismatch(expectedPrefix: "\(branchUsername)/"))
+        }
+        return .active(stackName: name)
+    }
+}

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -100,11 +100,14 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var host: String?
     /// Per-project stacked-diffs (gg) mode. Defaults to `.auto`.
     var ggMode: GGProjectMode = .auto
+    /// Sparse per-worktree overrides. Missing entries inherit project policy.
+    var ggWorktreeModes: [String: GGWorktreeMode] = [:]
 
     enum CodingKeys: String, CodingKey {
         case id, name, path, color, icon, addedAt, hiddenWorktreePaths, worktreeOrder,
              worktreeOrderIsManual, startupScripts,
-             mcpServers, worktreeOpenAfterCreate, worktreeDefaultLauncherMode, host, ggMode
+             mcpServers, worktreeOpenAfterCreate, worktreeDefaultLauncherMode, host, ggMode,
+             ggWorktreeModes
     }
 
     init(
@@ -121,7 +124,9 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         mcpServers: [ProjectMCPServer] = [],
         worktreeOpenAfterCreate: Bool? = nil,
         worktreeDefaultLauncherMode: AppConfig.LauncherMode? = nil,
-        host: String? = nil
+        host: String? = nil,
+        ggMode: GGProjectMode = .auto,
+        ggWorktreeModes: [String: GGWorktreeMode] = [:]
     ) {
         self.id = id
         self.name = name
@@ -136,6 +141,8 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.worktreeOpenAfterCreate = worktreeOpenAfterCreate
         self.worktreeDefaultLauncherMode = worktreeDefaultLauncherMode
         self.host = host
+        self.ggMode = ggMode
+        self.ggWorktreeModes = ggWorktreeModes
     }
 
     // Tolerant decode: older projects.json files predate hiddenWorktreePaths
@@ -163,6 +170,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         worktreeDefaultLauncherMode = try? c.decode(AppConfig.LauncherMode.self, forKey: .worktreeDefaultLauncherMode)
         host = try? c.decode(String.self, forKey: .host)
         ggMode = (try? c.decode(GGProjectMode.self, forKey: .ggMode)) ?? .auto
+        ggWorktreeModes = (try? c.decode([String: GGWorktreeMode].self, forKey: .ggWorktreeModes)) ?? [:]
     }
 
     func encode(to encoder: Encoder) throws {
@@ -182,5 +190,9 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         try c.encodeIfPresent(worktreeDefaultLauncherMode, forKey: .worktreeDefaultLauncherMode)
         try c.encodeIfPresent(host, forKey: .host)
         try c.encode(ggMode, forKey: .ggMode)
+        let sparseGGWorktreeModes = ggWorktreeModes.filter { $0.value != .inherit }
+        if !sparseGGWorktreeModes.isEmpty {
+            try c.encode(sparseGGWorktreeModes, forKey: .ggWorktreeModes)
+        }
     }
 }

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -117,6 +117,7 @@ struct ChangesPreparationModel: Equatable {
         changes: [ChangedFile],
         hasDraft: Bool,
         capabilities: GGCapabilities,
+        hasLoadedCommit: Bool = true,
         mutationDisabledReason: String? = nil,
         newCommitDisabledReason: String? = nil
     ) -> ChangesPreparationModel {
@@ -131,6 +132,7 @@ struct ChangesPreparationModel: Equatable {
             staged: staged,
             hasDraft: hasDraft,
             capabilities: capabilities,
+            hasLoadedCommit: hasLoadedCommit,
             mutationDisabledReason: mutationDisabledReason,
             newCommitDisabledReason: newCommitDisabledReason,
             reviewSummary: summary
@@ -141,6 +143,7 @@ struct ChangesPreparationModel: Equatable {
         staged: StagedStats,
         hasDraft: Bool,
         capabilities: GGCapabilities,
+        hasLoadedCommit: Bool = true,
         mutationDisabledReason: String? = nil,
         newCommitDisabledReason: String? = nil
     ) -> ChangesPreparationModel {
@@ -155,6 +158,7 @@ struct ChangesPreparationModel: Equatable {
             staged: staged,
             hasDraft: hasDraft,
             capabilities: capabilities,
+            hasLoadedCommit: hasLoadedCommit,
             mutationDisabledReason: mutationDisabledReason,
             newCommitDisabledReason: newCommitDisabledReason,
             reviewSummary: summary
@@ -169,6 +173,7 @@ struct ChangesPreparationModel: Equatable {
         staged: StagedStats,
         hasDraft: Bool,
         capabilities: GGCapabilities,
+        hasLoadedCommit: Bool,
         mutationDisabledReason: String?,
         newCommitDisabledReason: String?,
         reviewSummary: ReviewChangesTriggerSummary?
@@ -185,12 +190,13 @@ struct ChangesPreparationModel: Equatable {
             ?? newCommitDisabledReason
             ?? (staged.hasChanges || hasDraft ? nil : "Stage changes first")
         let rewriteDisabledReason = mutationDisabledReason
+            ?? (hasLoadedCommit ? nil : "Create the first stack commit.")
             ?? (staged.hasChanges ? nil : "Stage changes first")
-        let amendDisabledReason = mutationDisabledReason ?? (
-            capabilities.stagedOnlyAmend
+        let amendDisabledReason = mutationDisabledReason
+            ?? (hasLoadedCommit ? nil : "Create the first stack commit.")
+            ?? (capabilities.stagedOnlyAmend
                 ? rewriteDisabledReason
-                : "Update GG to amend staged changes safely"
-        )
+                : "Update GG to amend staged changes safely")
         return ChangesPreparationModel(
             reviewAction: reviewAction,
             ggActions: [

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -23,7 +23,7 @@ struct ChangesTabView: View {
                 changes: rps.changes,
                 hasDraft: draftNonEmpty,
                 capabilities: GGAvailability.shared.capabilities,
-                hasLoadedCommit: rps.ggStack?.entries.isEmpty == false,
+                hasLoadedCommit: rps.ggStackLoadState.hasLoadedCommit,
                 mutationDisabledReason: ggPreparationMutationDisabledReason,
                 newCommitDisabledReason: Self.ggNewStackCommitDisabledReason(
                     contextIsActive: rps.ggContext.isActive,

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -23,8 +23,11 @@ struct ChangesTabView: View {
                 changes: rps.changes,
                 hasDraft: draftNonEmpty,
                 capabilities: GGAvailability.shared.capabilities,
+                hasLoadedCommit: rps.ggStack?.entries.isEmpty == false,
                 mutationDisabledReason: ggPreparationMutationDisabledReason,
                 newCommitDisabledReason: Self.ggNewStackCommitDisabledReason(
+                    contextIsActive: rps.ggContext.isActive,
+                    stackLoadState: rps.ggStackLoadState,
                     stack: rps.ggStack,
                     currentHeadSHA: rps.currentHeadSHA
                 )
@@ -65,7 +68,7 @@ struct ChangesTabView: View {
 
     private var isGGDrawerActive: Bool {
         Self.shouldShowGGDrawer(
-            stack: rps.ggStack,
+            contextIsActive: rps.ggContext.isActive,
             pausedGGOperation: rps.ggActionState.pausedOperation,
             hasUndoCandidate: rps.ggUndoCandidate != nil
         )
@@ -73,7 +76,8 @@ struct ChangesTabView: View {
 
     private var ggPreparationMutationDisabledReason: String? {
         Self.ggPreparationMutationDisabledReason(
-            hasStack: rps.ggStack != nil,
+            contextIsActive: rps.ggContext.isActive,
+            stackLoadState: rps.ggStackLoadState,
             pausedOperation: rps.ggActionState.pausedOperation,
             inFlightAction: rps.ggActionState.inFlightAction,
             mergeOperation: rps.mergeOp.current
@@ -81,12 +85,13 @@ struct ChangesTabView: View {
     }
 
     static func ggPreparationMutationDisabledReason(
-        hasStack: Bool,
+        contextIsActive: Bool,
+        stackLoadState: GGStackLoadState,
         pausedOperation: GGPausedOperation?,
         inFlightAction: GGStackActionKind?,
         mergeOperation: MergeOperation?
     ) -> String? {
-        if !hasStack || pausedOperation != nil {
+        if pausedOperation != nil {
             return "Continue or abort the paused GG operation first."
         }
         if inFlightAction != nil {
@@ -95,15 +100,41 @@ struct ChangesTabView: View {
         if mergeOperation != nil {
             return "Finish the current Git operation first."
         }
-        return nil
+        guard contextIsActive else { return "A GG stack is not available." }
+        switch stackLoadState {
+        case .loading:
+            return "Wait for the GG stack to load."
+        case .failed:
+            return "Retry loading the GG stack."
+        case .inactive:
+            return "A GG stack is not available."
+        case .empty, .loaded:
+            return nil
+        }
     }
 
     static func ggNewStackCommitDisabledReason(
+        contextIsActive: Bool,
+        stackLoadState: GGStackLoadState,
         stack: GGStack?,
         currentHeadSHA: String
     ) -> String? {
+        guard contextIsActive else { return "A GG stack is not available." }
+        switch stackLoadState {
+        case .empty:
+            return nil
+        case .loading:
+            return "Wait for the GG stack to load."
+        case .failed:
+            return "Retry loading the GG stack."
+        case .inactive:
+            return "A GG stack is not available."
+        case .loaded:
+            break
+        }
+        guard let stack else { return "A GG stack is not available." }
         guard !currentHeadSHA.isEmpty,
-              let head = stack?.entries.max(by: { $0.position < $1.position }),
+              let head = stack.entries.max(by: { $0.position < $1.position }),
               !head.sha.isEmpty,
               currentHeadSHA.hasPrefix(head.sha) || head.sha.hasPrefix(currentHeadSHA)
         else {
@@ -292,11 +323,11 @@ struct ChangesTabView: View {
     }
 
     static func shouldShowGGDrawer(
-        stack: GGStack?,
+        contextIsActive: Bool,
         pausedGGOperation: GGPausedOperation?,
         hasUndoCandidate: Bool
     ) -> Bool {
-        stack != nil || pausedGGOperation != nil || hasUndoCandidate
+        contextIsActive || pausedGGOperation != nil || hasUndoCandidate
     }
 
     static func shouldShowChangesPreparationCard(

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -942,11 +942,7 @@ final class RightPaneState: GGSplitCommitServicing {
             await reconcileGGUndoCandidateIfNeeded()
             return
         }
-        if ggStack == nil,
-           GGStackSummaryStore.shared.summaries[worktree.path.path] == nil
-        {
-            ggStackLoadState = .loading
-        }
+        ggStackLoadState = .loading
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
             // A newer refresh, or a `markSnapshotUnknown()` invalidation,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -924,10 +924,10 @@ final class RightPaneState: GGSplitCommitServicing {
         let refreshGeneration = ggStackRefreshGeneration
         let context = ggContextProvider?(currentBranch) ?? .inactive(reason: .policyOff)
         if ggContext != context { ggContext = context }
+        reconcilePausedOperation()
         guard context.isActive else {
             ggStackCommitsKey = nil
             ggStackLoadState = .inactive
-            ggActionState.clearPaused()
             if ggStack != nil { ggStack = nil }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
@@ -938,7 +938,6 @@ final class RightPaneState: GGSplitCommitServicing {
             ggMutationCoordinator.suspendUndoCandidate()
             return
         }
-        reconcilePausedOperation()
         ggEffectiveConfig = GGConfigReader.effectiveConfig(repoPath: worktree.path.path)
         // `gg ls --json` reaches out to gh/glab for PR state — skip when
         // the branch and commit set are unchanged since the last query. PR-

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -5,6 +5,14 @@ import os
 
 enum RightPaneTab: String { case changes, files }
 
+enum GGStackLoadState: Equatable {
+    case inactive
+    case loading
+    case empty
+    case loaded
+    case failed(String)
+}
+
 struct ReviewLoopRemoteFingerprint: Equatable, Sendable {
     var branchName: String
     var headSHA: String
@@ -100,13 +108,15 @@ final class RightPaneState: GGSplitCommitServicing {
     var hasMoreOlder: Bool = true
     var isLoadingOlder: Bool = false
 
-    /// Current gg stack for this worktree's branch; nil when gating fails
-    /// or the branch is not a stack. Loaded during performRefresh.
+    /// Current gg stack for this worktree's branch; nil when inactive or when
+    /// gg reports that the active context has no stack metadata.
     var ggStack: GGStack? = nil
     var ggEffectiveConfig: GGEffectiveConfig = .defaults
-    /// Injected by RightPaneStore — resolves gates 1–3 (master toggle,
-    /// gg installed, per-project mode) against app-level state.
-    var ggGateProvider: (@MainActor () -> Bool)? = nil
+    var ggContext: GGWorktreeContext = .inactive(reason: .policyOff)
+    var ggStackLoadState: GGStackLoadState = .inactive
+    /// Injected by RightPaneStore to resolve the current live branch against
+    /// app-, project-, and worktree-level GG policy.
+    var ggContextProvider: (@MainActor (_ branch: String) -> GGWorktreeContext)? = nil
     /// Injected by RightPaneStore so mutations that add or remove worktrees
     /// can reconcile app-level project topology.
     @ObservationIgnored
@@ -893,28 +903,20 @@ final class RightPaneState: GGSplitCommitServicing {
         let snapshotGeneration = snapshotInvalidationGeneration
         ggStackRefreshGeneration &+= 1
         let refreshGeneration = ggStackRefreshGeneration
-        let gated = ggGateProvider?() ?? false
-        guard gated, GGStackGate.isStackShaped(commits: ggStackSourceCommits) else {
+        let context = ggContextProvider?(currentBranch) ?? .inactive(reason: .policyOff)
+        if ggContext != context { ggContext = context }
+        guard context.isActive else {
             ggStackCommitsKey = nil
-            if gated, shouldPreservePausedOperationOutsideStackShape() {
-                reconcilePausedOperation()
-            } else {
-                ggActionState.clearPaused()
-            }
+            ggStackLoadState = .inactive
+            ggActionState.clearPaused()
             if ggStack != nil { ggStack = nil }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
             }
-            if gated {
-                await reconcileGGUndoCandidateIfNeeded()
-            } else {
-                // The gg gate can read false transiently before the startup
-                // `GGAvailability` probe resolves. Only hide the candidate;
-                // keep the persisted marker so a valid recovery Undo survives
-                // until the gate is known to be intentionally disabled and the
-                // later re-check can restore or reject it.
-                ggMutationCoordinator.suspendUndoCandidate()
-            }
+            // Context can be inactive transiently while startup availability
+            // resolves. Hide the candidate but retain its persisted marker for
+            // a later active-context reconciliation.
+            ggMutationCoordinator.suspendUndoCandidate()
             return
         }
         reconcilePausedOperation()
@@ -932,6 +934,11 @@ final class RightPaneState: GGSplitCommitServicing {
             await reconcileGGUndoCandidateIfNeeded()
             return
         }
+        if ggStack == nil,
+           GGStackSummaryStore.shared.summaries[worktree.path.path] == nil
+        {
+            ggStackLoadState = .loading
+        }
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
             // A newer refresh, or a `markSnapshotUnknown()` invalidation,
@@ -944,6 +951,7 @@ final class RightPaneState: GGSplitCommitServicing {
             else { return }
             ggStackCommitsKey = key
             if ggStack != stack { ggStack = stack }
+            ggStackLoadState = stack == nil ? .empty : .loaded
             let summary = stack?.summary
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
@@ -975,6 +983,7 @@ final class RightPaneState: GGSplitCommitServicing {
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
             }
+            ggStackLoadState = .failed(error.localizedDescription)
             // The cached stack we just dropped belonged to a different key, so
             // the current stack identity is unknown until a refresh succeeds.
             // Hide any recovery candidate (keeping its marker) so the drawer
@@ -1037,13 +1046,6 @@ final class RightPaneState: GGSplitCommitServicing {
         } else {
             ggActionState.clearPaused()
         }
-    }
-
-    private func shouldPreservePausedOperationOutsideStackShape() -> Bool {
-        guard GGStackGate.operationInProgress(repoPath: worktree.path.path) else { return false }
-        return ggActionState.inFlightAction != nil
-            || ggActionState.pausedOperation != nil
-            || GGStackGate.alasGGOperationInProgress(repoPath: worktree.path.path)
     }
 
     /// Dispatches a stack-drawer action kind to its gg mutation. `.land`

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -907,6 +907,17 @@ final class RightPaneState: GGSplitCommitServicing {
     // `ggStackSourceCommits` / `ggService` without needing a real git repo +
     // watcher.
     @MainActor
+    func seedGGContext(branch: String) {
+        if currentBranch != branch {
+            currentBranch = branch
+            ggStackCommitsKey = nil
+        }
+        let context = ggContextProvider?(branch) ?? .inactive(reason: .policyOff)
+        if ggContext != context { ggContext = context }
+        ggStackLoadState = context.isActive ? .loading : .inactive
+    }
+
+    @MainActor
     func refreshGGStack() async {
         let snapshotGeneration = snapshotInvalidationGeneration
         ggStackRefreshGeneration &+= 1

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -955,6 +955,12 @@ final class RightPaneState: GGSplitCommitServicing {
             return
         }
         ggStackLoadState = .loading
+        ggStackCommitsKey = nil
+        if ggStack != nil { ggStack = nil }
+        if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+        }
+        ggMutationCoordinator.suspendUndoCandidate()
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
             // A newer refresh, or a `markSnapshotUnknown()` invalidation,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -991,7 +991,9 @@ final class RightPaneState: GGSplitCommitServicing {
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
             }
-            ggStackLoadState = .failed(error.localizedDescription)
+            ggStackLoadState = .failed(
+                (error as? GGServiceError)?.userMessage ?? error.localizedDescription
+            )
             // The cached stack we just dropped belonged to a different key, so
             // the current stack identity is unknown until a refresh succeeds.
             // Hide any recovery candidate (keeping its marker) so the drawer

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -164,7 +164,15 @@ final class RightPaneState: GGSplitCommitServicing {
     @ObservationIgnored private var ggStackRefreshGeneration: UInt = 0
 
     var currentGGStackCommitsKey: String {
-        "\(currentBranch)|" + ggStackSourceCommits.map(\.sha).joined(separator: "|")
+        let contextIdentity: String
+        switch ggContext {
+        case .active(let stackName):
+            contextIdentity = "active:\(stackName)"
+        case .inactive:
+            contextIdentity = "inactive"
+        }
+        return "\(currentBranch)|\(contextIdentity)|"
+            + ggStackSourceCommits.map(\.sha).joined(separator: "|")
     }
 
     var ggCommitSelectionIsStale: Bool {
@@ -1551,6 +1559,7 @@ final class RightPaneState: GGSplitCommitServicing {
         ggStackSourceCommits = []
         ggStackCommitsKey = nil
         if ggStack != nil { ggStack = nil }
+        ggStackLoadState = ggContext.isActive ? .loading : .inactive
         if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
             GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -11,6 +11,8 @@ enum GGStackLoadState: Equatable {
     case empty
     case loaded
     case failed(String)
+
+    var hasLoadedCommit: Bool { self == .loaded }
 }
 
 struct ReviewLoopRemoteFingerprint: Equatable, Sendable {
@@ -965,8 +967,9 @@ final class RightPaneState: GGSplitCommitServicing {
             else { return }
             ggStackCommitsKey = key
             if ggStack != stack { ggStack = stack }
-            ggStackLoadState = stack == nil ? .empty : .loaded
-            let summary = stack?.summary
+            let stackIsEmpty = stack.map { $0.totalCommits == 0 || $0.entries.isEmpty } ?? true
+            ggStackLoadState = stackIsEmpty ? .empty : .loaded
+            let summary = stackIsEmpty ? nil : stack?.summary
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
             }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -2,6 +2,11 @@ import Foundation
 import Observation
 import os
 
+struct RightPaneGGStackSnapshot: Equatable {
+    let stack: GGStack?
+    let loadState: GGStackLoadState
+}
+
 @Observable
 @MainActor
 final class RightPaneStore {
@@ -338,10 +343,29 @@ final class RightPaneStore {
         states.values.first { $0.pendingMerge != nil }
     }
 
-    /// Loaded stack state for a worktree path, if its pane has been
-    /// activated. Used by the ACP preamble at session creation.
-    func stackForWorktreePath(_ path: String) -> GGStack? {
-        states.values.first { $0.worktree.path.path == path }?.ggStack
+    /// Cached stack state for a worktree path, if its pane has been activated.
+    /// A loaded stack whose key no longer matches the live branch/context is
+    /// exposed as loading so non-UI consumers cannot treat it as current.
+    func ggStackSnapshotForWorktreePath(
+        _ path: String,
+        effectiveContext: GGWorktreeContext
+    ) -> RightPaneGGStackSnapshot? {
+        guard let state = states.values.first(where: { $0.worktree.path.path == path }) else {
+            return nil
+        }
+        let loadState: GGStackLoadState
+        if state.ggStackLoadState == .loaded,
+           (state.ggStackCommitsKey != state.currentGGStackCommitsKey
+            || state.ggContext != effectiveContext)
+        {
+            loadState = effectiveContext.isActive ? .loading : .inactive
+        } else {
+            loadState = state.ggStackLoadState
+        }
+        return RightPaneGGStackSnapshot(
+            stack: state.ggStack,
+            loadState: loadState
+        )
     }
 
     /// The first cached state with a pending gg-land confirmation, if any.

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -150,20 +150,16 @@ final class RightPaneStore {
                 )
                 app.tabs.activate(worktreeId: id, tabId: tab.id)
             }
-            new.ggGateProvider = { [weak self] in
-                guard let app = self?.appState else { return false }
-                guard app.config.changes.stackedDiffsEnabled,
-                      GGAvailability.shared.isInstalled,
+            new.ggContextProvider = { [weak self] branch in
+                guard let app = self?.appState,
                       let project = app.projectsManager.projects.first(
                         where: { $0.id == worktree.projectId }
                       )
-                else { return false }
-                return GGStackGate.projectEnabled(
-                    masterEnabled: true,
-                    ggInstalled: true,
-                    mode: project.ggMode,
-                    repoPath: project.path,
-                    isRemoteProject: project.host != nil
+                else { return .inactive(reason: .policyOff) }
+                return app.ggWorktreeContext(
+                    project: project,
+                    worktree: worktree,
+                    branch: branch
                 )
             }
             new.refreshProjectTopologyAfterGGMutation = { [weak self] in

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -283,6 +283,13 @@ final class RightPaneStore {
         for state in states.values { state.reevaluateGGGate() }
     }
 
+    /// Re-evaluate the gg gate for one cached worktree after its override
+    /// changes. Returns nil when that worktree has no cached pane state.
+    @discardableResult
+    func reevaluateGGGate(worktreeId: String) -> Task<Void, Never>? {
+        states[worktreeId]?.reevaluateGGGate()
+    }
+
     func commitEditorComparisonRef(worktreeId: String) -> String? {
         guard let state = states[worktreeId] else { return nil }
         return state.comparisonRef

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -368,10 +368,14 @@ final class RightPaneStore {
         )
     }
 
-    /// Latest branch observed by the cached pane state. Nil when the pane has
-    /// never been created, allowing callers to fall back to topology state.
+    /// Latest branch observed by the active pane state. Quiescent cached panes
+    /// have no watcher and must not override a newer topology snapshot.
     func currentBranchForWorktreePath(_ path: String) -> String? {
-        states.values.first { $0.worktree.path.path == path }?.currentBranch
+        guard let activeId,
+              let state = states[activeId],
+              state.worktree.path.path == path
+        else { return nil }
+        return state.currentBranch
     }
 
     /// The first cached state with a pending gg-land confirmation, if any.

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -368,6 +368,12 @@ final class RightPaneStore {
         )
     }
 
+    /// Latest branch observed by the cached pane state. Nil when the pane has
+    /// never been created, allowing callers to fall back to topology state.
+    func currentBranchForWorktreePath(_ path: String) -> String? {
+        states.values.first { $0.worktree.path.path == path }?.currentBranch
+    }
+
     /// The first cached state with a pending gg-land confirmation, if any.
     /// Mirrors `stateWithPendingMerge` for the same reason: the confirmation
     /// dialog (see RootView) must resolve its owning state through this

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -168,6 +168,7 @@ final class RightPaneStore {
                     branch: branch
                 )
             }
+            new.seedGGContext(branch: worktree.branch)
             new.refreshProjectTopologyAfterGGMutation = { [weak self] in
                 guard let app = self?.appState else { return }
                 await app.refreshProjectTopology(projectId: worktree.projectId)
@@ -227,12 +228,7 @@ final class RightPaneStore {
                 prevState.stop()
             }
             if wasCached, result.currentBranch != worktree.branch {
-                result.currentBranch = worktree.branch
-                result.ggStackCommitsKey = nil
-                let context = result.ggContextProvider?(worktree.branch)
-                    ?? .inactive(reason: .policyOff)
-                result.ggContext = context
-                result.ggStackLoadState = context.isActive ? .loading : .inactive
+                result.seedGGContext(branch: worktree.branch)
             }
             activeId = id
             // Don't start the state's background work here if we deferred it

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -68,6 +68,7 @@ final class RightPaneStore {
 
     func state(for worktree: Worktree, baseBranch: String, comparisonMode: AppConfig.Changes.ChangesComparisonMode) -> RightPaneState {
         let id = worktree.id
+        let wasCached = states[id] != nil
         let result: RightPaneState
         let rawDefault = Self.effectiveBaseBranch(worktree: worktree, baseBranch: baseBranch)
         if let existing = states[id] {
@@ -224,6 +225,14 @@ final class RightPaneStore {
         if activeId != id {
             if let prev = activeId, let prevState = states[prev] {
                 prevState.stop()
+            }
+            if wasCached, result.currentBranch != worktree.branch {
+                result.currentBranch = worktree.branch
+                result.ggStackCommitsKey = nil
+                let context = result.ggContextProvider?(worktree.branch)
+                    ?? .inactive(reason: .policyOff)
+                result.ggContext = context
+                result.ggStackLoadState = context.isActive ? .loading : .inactive
             }
             activeId = id
             // Don't start the state's background work here if we deferred it

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -79,8 +79,8 @@ struct ChangesPane: View {
                             }
                     }
                     SettingsRow(
-                        name: "Per project",
-                        desc: "Auto enables gg UI when the repo's main worktree has .git/gg/config.json."
+                        name: "Default for linked worktrees",
+                        desc: "Main worktrees default Off. Override individual worktrees from their sidebar menu."
                     ) {
                         EmptyView()
                     }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -16,6 +16,7 @@ struct RepoGroupView: View {
     let isMain: (Worktree) -> Bool
     let operationState: (Worktree) -> WorktreeOperationState?
     let harnessSummary: (String) -> HarnessService.WorktreeHarnessSummary?
+    let ggMenuModel: (Worktree) -> GGWorktreeMenuModel
     let onSelect: (Worktree) -> Void
     let onNewWorktree: () -> Void
     let onEditProject: () -> Void
@@ -39,6 +40,7 @@ struct RepoGroupView: View {
     let onCopyError: (String) -> Void
     let onRetryCreate: (Worktree) -> Void
     let onRetryDelete: (Worktree) -> Void
+    let onSetGGWorktreeMode: (Worktree, GGWorktreeMode) -> Void
     let onRemoveFailed: (Worktree) -> Void
     let onDropWorktree: (_ draggedId: String, _ destinationId: String) -> Void
     let onDropProject: (_ draggedId: String, _ destinationId: String) -> Void
@@ -163,6 +165,7 @@ struct RepoGroupView: View {
                             isMain: isMain(wt),
                             operationState: operationState(wt),
                             harnessSummary: harnessSummary(wt.id),
+                            ggMenuModel: ggMenuModel(wt),
                             onTap: { onSelect(wt) },
                             onOpenTerminal: { onOpenTerminal(wt) },
                             onCopyPath: { onCopyPath(wt) },
@@ -176,7 +179,8 @@ struct RepoGroupView: View {
                             onCopyError: onCopyError,
                             onRemoveFailed: { onRemoveFailed(wt) },
                             onRetryCreate: { onRetryCreate(wt) },
-                            onRetryDelete: { onRetryDelete(wt) }
+                            onRetryDelete: { onRetryDelete(wt) },
+                            onSetGGWorktreeMode: { mode in onSetGGWorktreeMode(wt, mode) }
                         )
                         .draggable(wt.id)
                         .dropDestination(for: String.self) { ids, _ in

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -58,6 +58,9 @@ struct SidebarView: View {
                                     }
                                     return state.harness.summary(forSessionIds: ids)
                                 },
+                                ggMenuModel: { wt in
+                                    state.ggWorktreeMenuModel(project: project, worktree: wt)
+                                },
                                 onSelect: { wt in state.selectWorktree(id: wt.id) },
                                 onNewWorktree: { onNewWorktree(project.id) },
                                 onEditProject: { onEditProject(project.id) },
@@ -143,6 +146,13 @@ struct SidebarView: View {
                                     }
                                 },
                                 onRetryDelete: { wt in state.deleteWorktree(wt) },
+                                onSetGGWorktreeMode: { wt, mode in
+                                    state.setGGWorktreeMode(
+                                        projectId: project.id,
+                                        worktreeId: wt.id,
+                                        mode: mode
+                                    )
+                                },
                                 onRemoveFailed: { wt in
                                     state.removeFailedOptimisticWorktree(id: wt.id, projectId: project.id)
                                 },

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -1,5 +1,48 @@
 import SwiftUI
 
+struct GGWorktreeMenuModel: Equatable {
+    let selectedMode: GGWorktreeMode
+    let isEffectiveActive: Bool
+    let inactiveExplanation: String?
+    let showsStatusIndicator: Bool
+    let isVisible: Bool
+
+    init(
+        selectedMode: GGWorktreeMode,
+        context: GGWorktreeContext,
+        hasStackSummary: Bool,
+        isRemoteWorktree: Bool = false
+    ) {
+        self.selectedMode = selectedMode
+        isEffectiveActive = context.isActive
+        showsStatusIndicator = context.isActive && !hasStackSummary
+        let contextIsRemote = context == .inactive(reason: .remoteProject)
+        isVisible = !isRemoteWorktree && !contextIsRemote
+
+        guard !isRemoteWorktree else {
+            inactiveExplanation = nil
+            return
+        }
+
+        switch context {
+        case .active:
+            inactiveExplanation = nil
+        case .inactive(reason: .masterDisabled):
+            inactiveExplanation = "Stacked diffs are disabled in Settings."
+        case .inactive(reason: .cliMissing):
+            inactiveExplanation = "gg is not installed."
+        case .inactive(reason: .remoteProject):
+            inactiveExplanation = nil
+        case .inactive(reason: .policyOff):
+            inactiveExplanation = nil
+        case .inactive(reason: .branchUsernameMissing):
+            inactiveExplanation = "Set branch_username in gg config."
+        case .inactive(reason: .branchPrefixMismatch(let expectedPrefix)):
+            inactiveExplanation = "Branch must start with \(expectedPrefix)"
+        }
+    }
+}
+
 struct WorktreeRowView: View {
     static func stackSummaryTooltip(merged: Int, total: Int) -> String {
         "gg stack · \(merged) of \(total) commit\(total == 1 ? "" : "s") merged"
@@ -10,6 +53,7 @@ struct WorktreeRowView: View {
     let isMain: Bool
     let operationState: WorktreeOperationState?
     let harnessSummary: HarnessService.WorktreeHarnessSummary?
+    let ggMenuModel: GGWorktreeMenuModel
     let onTap: () -> Void
     let onOpenTerminal: () -> Void
     let onCopyPath: () -> Void
@@ -24,6 +68,7 @@ struct WorktreeRowView: View {
     let onRemoveFailed: () -> Void
     let onRetryCreate: () -> Void
     let onRetryDelete: () -> Void
+    let onSetGGWorktreeMode: (GGWorktreeMode) -> Void
     @Environment(\.theme) var theme
 
     private var isPending: Bool {
@@ -106,6 +151,11 @@ struct WorktreeRowView: View {
                                 .font(.system(size: 10.5, design: .monospaced))
                                 .foregroundColor(theme.color("accent"))
                                 .help(Self.stackSummaryTooltip(merged: stack.merged, total: stack.total))
+                        } else if ggMenuModel.showsStatusIndicator {
+                            Text("GG")
+                                .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+                                .foregroundColor(theme.color("accent"))
+                                .help("gg is active for this worktree.")
                         }
                         if let summary = harnessSummary {
                             Spacer()
@@ -161,11 +211,36 @@ struct WorktreeRowView: View {
                     Button("Reveal in Finder", action: onRevealInFinder)
                 }
                 Divider()
+                if ggMenuModel.isVisible {
+                    Menu("GG Mode") {
+                        ggModeButton("Inherit repository default", mode: .inherit)
+                        ggModeButton("On", mode: .on)
+                        ggModeButton("Off", mode: .off)
+                    }
+                    if let explanation = ggMenuModel.inactiveExplanation {
+                        Divider()
+                        Text(explanation)
+                    }
+                    Divider()
+                }
                 Button("Archive", action: onArchive)
                 Button("Delete Worktree…", role: .destructive, action: onDelete)
                 if showKeepBranchOption {
                     Button("Delete Worktree, Keep Branch…", role: .destructive, action: onDeleteKeepBranch)
                 }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func ggModeButton(_ title: String, mode: GGWorktreeMode) -> some View {
+        Button {
+            onSetGGWorktreeMode(mode)
+        } label: {
+            if ggMenuModel.selectedMode == mode {
+                Label(title, systemImage: "checkmark")
+            } else {
+                Text(title)
             }
         }
     }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -212,10 +212,13 @@ struct WorktreeRowView: View {
                 }
                 Divider()
                 if ggMenuModel.isVisible {
-                    Menu("GG Mode") {
-                        ggModeButton("Inherit repository default", mode: .inherit)
-                        ggModeButton("On", mode: .on)
-                        ggModeButton("Off", mode: .off)
+                    Picker("GG Mode", selection: Binding(
+                        get: { ggMenuModel.selectedMode },
+                        set: { mode in onSetGGWorktreeMode(mode) }
+                    )) {
+                        Text("Inherit repository default").tag(GGWorktreeMode.inherit)
+                        Text("On").tag(GGWorktreeMode.on)
+                        Text("Off").tag(GGWorktreeMode.off)
                     }
                     if let explanation = ggMenuModel.inactiveExplanation {
                         Divider()
@@ -228,19 +231,6 @@ struct WorktreeRowView: View {
                 if showKeepBranchOption {
                     Button("Delete Worktree, Keep Branch…", role: .destructive, action: onDeleteKeepBranch)
                 }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func ggModeButton(_ title: String, mode: GGWorktreeMode) -> some View {
-        Button {
-            onSetGGWorktreeMode(mode)
-        } label: {
-            if ggMenuModel.selectedMode == mode {
-                Label(title, systemImage: "checkmark")
-            } else {
-                Text(title)
             }
         }
     }

--- a/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
+++ b/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
@@ -5,25 +5,38 @@ import Testing
 struct ACPMCPPromptPreambleTests {
     @Test("active gg context uses loaded stack details")
     func activeGGContextWithStack() {
+        let context = GGWorktreeContext.active(stackName: "loaded-name")
         #expect(AppState.ggPreambleSignal(
-            context: .active(stackName: "context-name"),
-            loadedStack: GGStack(
-                name: "loaded-name",
-                base: "main",
-                totalCommits: 3,
-                syncedCommits: 2,
-                currentPosition: nil,
-                behindBase: nil,
-                entries: []
+            context: context,
+            snapshot: RightPaneGGStackSnapshot(
+                stack: Self.stack,
+                loadState: .loaded
             )
         ) == .stack(name: "loaded-name", entryCount: 3))
     }
 
-    @Test("active gg context without a loaded stack stays generic")
-    func activeGGContextWithoutStack() {
+    @Test("active gg context without current loaded metadata stays generic")
+    func activeGGContextWithoutCurrentLoadedMetadata() {
+        let context = GGWorktreeContext.active(stackName: "loaded-name")
+        let states: [GGStackLoadState] = [
+            .inactive,
+            .loading,
+            .empty,
+            .failed("boom"),
+        ]
+        for loadState in states {
+            #expect(AppState.ggPreambleSignal(
+                context: context,
+                snapshot: RightPaneGGStackSnapshot(
+                    stack: Self.stack,
+                    loadState: loadState
+                )
+            ) == .generic)
+        }
+        #expect(AppState.ggPreambleSignal(context: context, snapshot: nil) == .generic)
         #expect(AppState.ggPreambleSignal(
-            context: .active(stackName: "feature"),
-            loadedStack: nil
+            context: context,
+            snapshot: RightPaneGGStackSnapshot(stack: nil, loadState: .loaded)
         ) == .generic)
     }
 
@@ -40,9 +53,22 @@ struct ACPMCPPromptPreambleTests {
         )
         #expect(AppState.ggPreambleSignal(
             context: .inactive(reason: .policyOff),
-            loadedStack: stack
+            snapshot: RightPaneGGStackSnapshot(
+                stack: stack,
+                loadState: .loaded
+            )
         ) == .none)
     }
+
+    private static let stack = GGStack(
+        name: "loaded-name",
+        base: "main",
+        totalCommits: 3,
+        syncedCommits: 2,
+        currentPosition: nil,
+        behindBase: nil,
+        entries: []
+    )
 
     @Test("nothing attached produces no preamble")
     func nothingAttached() {

--- a/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
+++ b/AlasTests/ACP/Session/ACPMCPPromptPreambleTests.swift
@@ -3,6 +3,47 @@ import Testing
 
 @Suite("ACPMCPPromptPreamble")
 struct ACPMCPPromptPreambleTests {
+    @Test("active gg context uses loaded stack details")
+    func activeGGContextWithStack() {
+        #expect(AppState.ggPreambleSignal(
+            context: .active(stackName: "context-name"),
+            loadedStack: GGStack(
+                name: "loaded-name",
+                base: "main",
+                totalCommits: 3,
+                syncedCommits: 2,
+                currentPosition: nil,
+                behindBase: nil,
+                entries: []
+            )
+        ) == .stack(name: "loaded-name", entryCount: 3))
+    }
+
+    @Test("active gg context without a loaded stack stays generic")
+    func activeGGContextWithoutStack() {
+        #expect(AppState.ggPreambleSignal(
+            context: .active(stackName: "feature"),
+            loadedStack: nil
+        ) == .generic)
+    }
+
+    @Test("inactive gg context produces no gg preamble")
+    func inactiveGGContext() {
+        let stack = GGStack(
+            name: "stale",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 1,
+            currentPosition: nil,
+            behindBase: nil,
+            entries: []
+        )
+        #expect(AppState.ggPreambleSignal(
+            context: .inactive(reason: .policyOff),
+            loadedStack: stack
+        ) == .none)
+    }
+
     @Test("nothing attached produces no preamble")
     func nothingAttached() {
         #expect(ACPMCPPromptPreamble.text(

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -923,6 +923,7 @@ struct AppStateCleanupTests {
 
         // Simulate a failed delete.
         state.projectsManager.setOperationState(id: wt.id, state: .deleteFailed(message: "permission denied"))
+        state.projectsManager.setGGWorktreeMode(projectId: project.id, worktreeId: wt.id, mode: .on)
         state.selectedWorktreeId = wt.id
 
         // Archive should succeed and hide the worktree.
@@ -931,6 +932,7 @@ struct AppStateCleanupTests {
         #expect(state.projectsManager.isWorktreeHidden(projectId: project.id, path: wt.path))
         #expect(state.projectsManager.archivedWorktrees(projectId: project.id).count == 1)
         #expect(state.projectsManager.visibleWorktrees(projectId: project.id).isEmpty)
+        #expect(state.projectsManager.ggWorktreeMode(projectId: project.id, worktreeId: wt.id) == .on)
         // Operation state should be cleared.
         #expect(state.projectsManager.operationState(for: wt.id) == nil)
         // Selection should move away because the worktree is no longer visible.

--- a/AlasTests/AppStatePersistenceTests.swift
+++ b/AlasTests/AppStatePersistenceTests.swift
@@ -26,6 +26,25 @@ struct AppStatePersistenceTests {
         }
     }
 
+    private final class RecordingStore: PersistenceStoreProtocol, @unchecked Sendable {
+        let initialProjectsFile: ProjectsFile
+        var writtenProjectsFile: ProjectsFile?
+
+        init(initialProjectsFile: ProjectsFile) {
+            self.initialProjectsFile = initialProjectsFile
+        }
+
+        func write<T: Encodable>(_ value: T, to _: URL) throws {
+            if let projectsFile = value as? ProjectsFile {
+                writtenProjectsFile = projectsFile
+            }
+        }
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from _: URL) throws -> T? {
+            type == ProjectsFile.self ? initialProjectsFile as? T : nil
+        }
+    }
+
     @Test func saveConfigReportsWriteFailure() {
         var reports: [(title: String, message: String)] = []
         let state = AppState(store: FailingStore()) { title, message in
@@ -50,6 +69,36 @@ struct AppStatePersistenceTests {
         #expect(saved == false)
         #expect(reports.map(\.title) == ["Projects Save Failed"])
         #expect(reports.first?.message == "write rejected")
+    }
+
+    @Test func deletedWorktreeOverrideIsRemovedAndPersistedBeforeTopologyRefresh() throws {
+        let persistedProject = ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: "/tmp/alas",
+            color: "teal",
+            addedAt: .now
+        )
+        let store = RecordingStore(
+            initialProjectsFile: ProjectsFile(projects: [persistedProject])
+        )
+        let state = AppState(store: store)
+        state.projectsManager.setGGWorktreeMode(
+            projectId: persistedProject.id,
+            worktreeId: "deleted-worktree",
+            mode: .on
+        )
+
+        state.removePersistedGGWorktreeMode(
+            projectId: persistedProject.id,
+            worktreeId: "deleted-worktree"
+        )
+
+        #expect(state.projectsManager.ggWorktreeMode(
+            projectId: persistedProject.id,
+            worktreeId: "deleted-worktree"
+        ) == .inherit)
+        #expect(store.writtenProjectsFile?.projects.first?.ggWorktreeModes.isEmpty == true)
     }
 
     @Test func shortcutOverridesPersistThroughSaveAndReload() throws {

--- a/AlasTests/AppStateSpacesTests.swift
+++ b/AlasTests/AppStateSpacesTests.swift
@@ -490,7 +490,9 @@ struct AppStateSpacesTests {
     }
 
     @Test func removingFailedActiveSpaceWorktreeDoesNotSelectOtherSpaceWorktree() {
-        let p1 = project("p1")
+        var persistedProjects: ProjectsFile?
+        var p1 = project("p1")
+        p1.ggWorktreeModes["wt1"] = .on
         let p2 = project("p2")
         let spaces = SpacesFile(
             version: 1,
@@ -500,7 +502,14 @@ struct AppStateSpacesTests {
                 SpaceConfig(id: "s2", name: "Home", emoji: "🏠", projectIds: ["p2"], lastSelectedWorktreeId: "wt2", createdAt: Date())
             ]
         )
-        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [p1, p2]), spacesFile: spaces))
+        let state = AppState(store: MemoryStore(
+            projectsFile: ProjectsFile(projects: [p1, p2]),
+            spacesFile: spaces,
+            writes: { value, url in
+                guard url == Paths.projectsFile else { return }
+                persistedProjects = value as? ProjectsFile
+            }
+        ))
         state.projectsManager.insertOptimisticWorktree(worktree("wt1", projectId: "p1"))
         state.projectsManager.insertOptimisticWorktree(worktree("wt2", projectId: "p2"))
         state.selectedWorktreeId = "wt1"
@@ -510,6 +519,8 @@ struct AppStateSpacesTests {
         #expect(state.spacesManager.activeSpaceId == "s1")
         #expect(state.selectedWorktreeId == nil)
         #expect(state.spacesManager.activeSpace?.lastSelectedWorktreeId == nil)
+        #expect(state.projectsManager.ggWorktreeMode(projectId: "p1", worktreeId: "wt1") == .inherit)
+        #expect(persistedProjects?.projects.first { $0.id == "p1" }?.ggWorktreeModes["wt1"] == nil)
     }
 
     @Test func focusingGlobalWorktreeSwitchesToContainingSpace() {

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -31,7 +31,8 @@ struct ChangesTabViewTests {
 
     @Test func regularGitOperationDisablesGGPreparationMutations() {
         let reason = ChangesTabView.ggPreparationMutationDisabledReason(
-            hasStack: true,
+            contextIsActive: true,
+            stackLoadState: .loaded,
             pausedOperation: nil,
             inFlightAction: nil,
             mergeOperation: .merge(sourceBranch: "main")
@@ -44,50 +45,83 @@ struct ChangesTabViewTests {
         let stack = stack(currentPosition: 1)
 
         #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            contextIsActive: true,
+            stackLoadState: .loaded,
             stack: stack,
             currentHeadSHA: "1111111111111111111111111111111111111111"
         ) == "Checkout the stack head to create a new stack commit.")
         #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            contextIsActive: true,
+            stackLoadState: .loaded,
             stack: stack,
             currentHeadSHA: "2222222222222222222222222222222222222222"
         ) == nil)
     }
 
-    @Test func newStackCommitIsConservativelyDisabledWithoutVerifiableHead() {
+    @Test func activeEmptyContextAllowsFirstStackCommitButNotRewrites() {
         #expect(ChangesTabView.ggNewStackCommitDisabledReason(
-            stack: stack(currentPosition: nil, entries: []),
+            contextIsActive: true,
+            stackLoadState: .empty,
+            stack: nil,
             currentHeadSHA: "1111111111111111111111111111111111111111"
-        ) == "Checkout the stack head to create a new stack commit.")
+        ) == nil)
+
+        let model = ChangesPreparationModel.makeGG(
+            staged: .init(files: 1, insertions: 1, deletions: 0),
+            hasDraft: false,
+            capabilities: GGCapabilities(
+                structuredSplit: true,
+                keepCurrentUnstack: true,
+                stagedOnlyAmend: true
+            ),
+            hasLoadedCommit: false
+        )
+        #expect(model.ggAction(.newStackCommit)?.isEnabled == true)
+        #expect(model.ggAction(.amendCurrent)?.disabledReason == "Create the first stack commit.")
+        #expect(model.ggAction(.absorbIntoStack)?.disabledReason == "Create the first stack commit.")
+    }
+
+    @Test func unavailableStackStateDisablesPreparationWithAccurateReason() {
+        #expect(ChangesTabView.ggPreparationMutationDisabledReason(
+            contextIsActive: true,
+            stackLoadState: .loading,
+            pausedOperation: nil,
+            inFlightAction: nil,
+            mergeOperation: nil
+        ) == "Wait for the GG stack to load.")
         #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            contextIsActive: true,
+            stackLoadState: .failed("gg unavailable"),
+            stack: nil,
+            currentHeadSHA: "1111111111111111111111111111111111111111"
+        ) == "Retry loading the GG stack.")
+    }
+
+    @Test func loadedStackWithoutVerifiableHeadDisablesNewCommit() {
+        #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            contextIsActive: true,
+            stackLoadState: .loaded,
             stack: stack(currentPosition: 2),
             currentHeadSHA: ""
         ) == "Checkout the stack head to create a new stack commit.")
     }
 
-    @Test func ggDrawerActiveForStackOrPausedOperation() {
+    @Test func ggDrawerActiveForContextOrRecovery() {
         #expect(!ChangesTabView.shouldShowGGDrawer(
-            stack: nil, pausedGGOperation: nil, hasUndoCandidate: false
+            contextIsActive: false, pausedGGOperation: nil, hasUndoCandidate: false
         ))
         #expect(ChangesTabView.shouldShowGGDrawer(
-            stack: GGStack(
-                name: "feat",
-                base: "main",
-                totalCommits: 0,
-                syncedCommits: 0,
-                currentPosition: nil,
-                behindBase: nil,
-                entries: []
-            ),
+            contextIsActive: true,
             pausedGGOperation: nil,
             hasUndoCandidate: false
         ))
         #expect(ChangesTabView.shouldShowGGDrawer(
-            stack: nil,
+            contextIsActive: false,
             pausedGGOperation: GGPausedOperation(pausedBy: .sync),
             hasUndoCandidate: false
         ))
         #expect(ChangesTabView.shouldShowGGDrawer(
-            stack: nil, pausedGGOperation: nil, hasUndoCandidate: true
+            contextIsActive: false, pausedGGOperation: nil, hasUndoCandidate: true
         ))
     }
 

--- a/AlasTests/GGConfigCodableTests.swift
+++ b/AlasTests/GGConfigCodableTests.swift
@@ -24,6 +24,39 @@ struct GGConfigCodableTests {
         #expect(decoded.ggMode == .on)
     }
 
+    @Test func projectConfigGGWorktreeModesDefaultEmptyWhenMissing() throws {
+        let json = """
+        {"id": "p1", "name": "alas", "path": "/tmp/alas", "color": "teal",
+         "addedAt": 700000000}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+
+        let project = try decoder.decode(ProjectConfig.self, from: Data(json.utf8))
+
+        #expect(project.ggWorktreeModes.isEmpty)
+    }
+
+    @Test func projectConfigGGWorktreeModesEncodeSparselyAndRoundTrip() throws {
+        var project = ProjectConfig(
+            id: "p1", name: "alas", path: "/tmp/alas", color: "teal", addedAt: Date(),
+            ggWorktreeModes: ["on-worktree": .on, "off-worktree": .off, "inherited-worktree": .inherit]
+        )
+        let data = try JSONEncoder().encode(project)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let modes = try #require(object["ggWorktreeModes"] as? [String: String])
+
+        #expect(modes == ["on-worktree": "on", "off-worktree": "off"])
+
+        project.ggWorktreeModes = [:]
+        let emptyData = try JSONEncoder().encode(project)
+        let emptyObject = try #require(JSONSerialization.jsonObject(with: emptyData) as? [String: Any])
+        #expect(emptyObject["ggWorktreeModes"] == nil)
+
+        let decoded = try JSONDecoder().decode(ProjectConfig.self, from: data)
+        #expect(decoded.ggWorktreeModes == ["on-worktree": .on, "off-worktree": .off])
+    }
+
     @Test func stackedDiffsEnabledDefaultsTrueOnLegacyConfig() throws {
         // Simulate a config written before `stackedDiffsEnabled` existed by
         // encoding the defaults and stripping the key from the changes

--- a/AlasTests/GGInboxTabsTests.swift
+++ b/AlasTests/GGInboxTabsTests.swift
@@ -4,6 +4,59 @@ import Foundation
 
 @MainActor
 struct GGInboxTabsTests {
+    @Test(arguments: [
+        (GGProjectMode.auto, true, [GGWorktreeMode](), true),
+        (.off, true, [], true),
+        (.on, false, [], true),
+        (.on, false, [.off], true),
+        (.off, false, [.on], true),
+        (.auto, false, [.off, .on], true),
+        (.off, false, [.off, .inherit], false),
+        (.auto, false, [], false),
+    ])
+    func inboxUsesRepositoryCapability(
+        projectMode: GGProjectMode,
+        repoHasGGConfig: Bool,
+        worktreeOverrides: [GGWorktreeMode],
+        expected: Bool
+    ) {
+        #expect(AppState.resolveGGInboxAvailable(
+            masterEnabled: true,
+            ggInstalled: true,
+            isRemoteProject: false,
+            projectMode: projectMode,
+            repoHasGGConfig: repoHasGGConfig,
+            worktreeOverrides: worktreeOverrides
+        ) == expected)
+    }
+
+    @Test func inboxHardStopsDoNotDependOnCapability() {
+        #expect(!AppState.resolveGGInboxAvailable(
+            masterEnabled: false,
+            ggInstalled: true,
+            isRemoteProject: false,
+            projectMode: .on,
+            repoHasGGConfig: true,
+            worktreeOverrides: [.on]
+        ))
+        #expect(!AppState.resolveGGInboxAvailable(
+            masterEnabled: true,
+            ggInstalled: false,
+            isRemoteProject: false,
+            projectMode: .on,
+            repoHasGGConfig: true,
+            worktreeOverrides: [.on]
+        ))
+        #expect(!AppState.resolveGGInboxAvailable(
+            masterEnabled: true,
+            ggInstalled: true,
+            isRemoteProject: true,
+            projectMode: .on,
+            repoHasGGConfig: true,
+            worktreeOverrides: [.on]
+        ))
+    }
+
     @Test func openOrFocusGGInboxDedupesById() {
         let worktreeId = "gg-inbox-tabs-dedupe"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }

--- a/AlasTests/GGWorktreeMenuModelTests.swift
+++ b/AlasTests/GGWorktreeMenuModelTests.swift
@@ -1,0 +1,114 @@
+import Testing
+@testable import Alas
+
+struct GGWorktreeMenuModelTests {
+    @Test func inheritedMainWorktreeWithPolicyOffHasNoMisleadingExplanation() {
+        let model = menuModel(
+            selectedMode: .inherit,
+            context: .inactive(reason: .policyOff)
+        )
+
+        #expect(model.selectedMode == .inherit)
+        #expect(!model.isEffectiveActive)
+        #expect(model.inactiveExplanation == nil)
+        #expect(!model.showsStatusIndicator)
+        #expect(model.isVisible)
+    }
+
+    @Test func explicitOnValidBranchIsActive() {
+        let model = menuModel(
+            selectedMode: .on,
+            context: .active(stackName: "my-stack"),
+            hasStackSummary: true
+        )
+
+        #expect(model.selectedMode == .on)
+        #expect(model.isEffectiveActive)
+        #expect(model.inactiveExplanation == nil)
+        #expect(!model.showsStatusIndicator)
+    }
+
+    @Test func branchMismatchExplainsRequiredPrefix() {
+        let model = menuModel(
+            selectedMode: .on,
+            context: .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/"))
+        )
+
+        #expect(model.inactiveExplanation == "Branch must start with nacho/")
+    }
+
+    @Test func missingUsernameHasUsefulExplanation() {
+        let model = menuModel(
+            selectedMode: .on,
+            context: .inactive(reason: .branchUsernameMissing)
+        )
+
+        #expect(model.inactiveExplanation == "Set branch_username in gg config.")
+    }
+
+    @Test func missingCLIHasUsefulExplanation() {
+        let model = menuModel(
+            selectedMode: .on,
+            context: .inactive(reason: .cliMissing)
+        )
+
+        #expect(model.inactiveExplanation == "gg is not installed.")
+    }
+
+    @Test func globalDisableHasUsefulExplanation() {
+        let model = menuModel(
+            selectedMode: .on,
+            context: .inactive(reason: .masterDisabled)
+        )
+
+        #expect(model.inactiveExplanation == "Stacked diffs are disabled in Settings.")
+    }
+
+    @Test func remoteContextHidesMenuAndExplanation() {
+        let model = menuModel(
+            selectedMode: .on,
+            context: .inactive(reason: .remoteProject)
+        )
+
+        #expect(!model.isVisible)
+        #expect(model.inactiveExplanation == nil)
+        #expect(!model.showsStatusIndicator)
+    }
+
+    @Test func remoteWorktreeFlagHidesMenuWhenEarlierHardStopWins() {
+        let model = menuModel(
+            selectedMode: .on,
+            context: .inactive(reason: .masterDisabled),
+            isRemoteWorktree: true
+        )
+
+        #expect(!model.isVisible)
+        #expect(model.inactiveExplanation == nil)
+        #expect(!model.showsStatusIndicator)
+    }
+
+    @Test func activeEmptyStackShowsStatusIndicator() {
+        let model = menuModel(
+            selectedMode: .inherit,
+            context: .active(stackName: "empty-stack"),
+            hasStackSummary: false
+        )
+
+        #expect(model.isEffectiveActive)
+        #expect(model.showsStatusIndicator)
+    }
+
+    private func menuModel(
+        selectedMode: GGWorktreeMode,
+        context: GGWorktreeContext,
+        hasStackSummary: Bool = false,
+        isRemoteWorktree: Bool = false
+    ) -> GGWorktreeMenuModel {
+        GGWorktreeMenuModel(
+            selectedMode: selectedMode,
+            context: context,
+            hasStackSummary: hasStackSummary,
+            isRemoteWorktree: isRemoteWorktree
+        )
+    }
+}

--- a/AlasTests/Integrations/GGMCPInjectionTests.swift
+++ b/AlasTests/Integrations/GGMCPInjectionTests.swift
@@ -2,6 +2,18 @@ import Testing
 @testable import Alas
 
 struct GGMCPInjectionTests {
+    @Test func providerOnlyAttachesForActiveWorktreeContext() {
+        #expect(AppState.shouldAttachGGMCP(
+            context: .active(stackName: "feature")
+        ))
+        #expect(!AppState.shouldAttachGGMCP(
+            context: .inactive(reason: .policyOff)
+        ))
+        #expect(!AppState.shouldAttachGGMCP(
+            context: .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/"))
+        ))
+    }
+
     @Test func happyPathBuildsStdioServerWithRepoPath() throws {
         let injection = try #require(GGMCPInjection.injection(
             gatePassed: true,

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -4,6 +4,30 @@ import Testing
 
 @MainActor
 struct GGStackReadinessModelTests {
+    @Test func placeholderMapsActiveStackLoadStates() {
+        let context = GGWorktreeContext.active(stackName: "feature")
+
+        #expect(GGStackPlaceholderModel.make(context: context, loadState: .loading) == .init(
+            title: "feature", summaryChip: "Loading", detail: nil, canRetry: false, isLoading: true
+        ))
+        #expect(GGStackPlaceholderModel.make(context: context, loadState: .empty) == .init(
+            title: "feature", summaryChip: "0 commits", detail: nil, canRetry: false, isLoading: false
+        ))
+        #expect(GGStackPlaceholderModel.make(context: context, loadState: .failed("gg unavailable")) == .init(
+            title: "feature", summaryChip: "Unavailable", detail: "gg unavailable", canRetry: true, isLoading: false
+        ))
+        #expect(GGStackPlaceholderModel.make(context: context, loadState: .loaded) == nil)
+    }
+
+    @Test func placeholderIsAbsentForInactiveContext() {
+        let context = GGWorktreeContext.inactive(reason: .policyOff)
+
+        #expect(GGStackPlaceholderModel.make(context: context, loadState: .loading) == nil)
+        #expect(GGStackPlaceholderModel.make(context: context, loadState: .empty) == nil)
+        #expect(GGStackPlaceholderModel.make(context: context, loadState: .failed("nope")) == nil)
+        #expect(GGStackPlaceholderModel.make(context: context, loadState: .inactive) == nil)
+    }
+
     private func entry(
         position: Int, prState: GGPRState?, approved: Bool = false, ci: GGCIStatus? = nil
     ) -> GGStackEntry {

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -7,15 +7,23 @@ struct GGStackReadinessModelTests {
     @Test func placeholderMapsActiveStackLoadStates() {
         let context = GGWorktreeContext.active(stackName: "feature")
 
-        #expect(GGStackPlaceholderModel.make(context: context, loadState: .loading) == .init(
+        let loading = GGStackPlaceholderModel.make(context: context, loadState: .loading)
+        #expect(loading == .init(
             title: "feature", summaryChip: "Loading", detail: nil, canRetry: false, isLoading: true
         ))
-        #expect(GGStackPlaceholderModel.make(context: context, loadState: .empty) == .init(
+        #expect(loading?.isExpandable == false)
+
+        let empty = GGStackPlaceholderModel.make(context: context, loadState: .empty)
+        #expect(empty == .init(
             title: "feature", summaryChip: "0 commits", detail: nil, canRetry: false, isLoading: false
         ))
-        #expect(GGStackPlaceholderModel.make(context: context, loadState: .failed("gg unavailable")) == .init(
+        #expect(empty?.isExpandable == false)
+
+        let failed = GGStackPlaceholderModel.make(context: context, loadState: .failed("gg unavailable"))
+        #expect(failed == .init(
             title: "feature", summaryChip: "Unavailable", detail: "gg unavailable", canRetry: true, isLoading: false
         ))
+        #expect(failed?.isExpandable == true)
         #expect(GGStackPlaceholderModel.make(context: context, loadState: .loaded) == nil)
     }
 

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -276,7 +276,6 @@ struct AppStateGGACPWorktreeContextTests {
             baseBranch: "main",
             comparisonMode: .manual
         )
-        state.rightPaneStore.deactivate()
 
         pane.currentBranch = "main"
         let plain = try #require(state.ggACPWorktreeIntegration(
@@ -299,5 +298,14 @@ struct AppStateGGACPWorktreeContextTests {
         #expect(AppState.shouldAttachGGMCP(context: stacked.context))
         #expect(AppState.ggPreambleSignal(context: stacked.context, snapshot: nil) == .generic)
         #expect(stacked.context == .active(stackName: "new-stack"))
+
+        state.rightPaneStore.deactivate()
+        let quiescent = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: path.path,
+            ggInstalled: true
+        ))
+        #expect(!AppState.shouldAttachGGMCP(context: quiescent.context))
+        #expect(AppState.ggPreambleSignal(context: quiescent.context, snapshot: nil) == .none)
+        #expect(quiescent.context == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
     }
 }

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -2,6 +2,18 @@ import Testing
 @testable import Alas
 
 struct GGWorktreeContextTests {
+    private func project(mode: GGProjectMode, host: String? = nil) -> ProjectConfig {
+        ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: "/tmp/alas",
+            color: "teal",
+            addedAt: .now,
+            host: host,
+            ggMode: mode
+        )
+    }
+
     private func resolve(
         masterEnabled: Bool = true,
         ggInstalled: Bool = true,
@@ -75,6 +87,98 @@ struct GGWorktreeContextTests {
         #expect(resolve(branch: "nacho/") == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
         #expect(resolve(branch: "other/feature") == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
         #expect(!resolve(branch: "other/feature").isActive)
+    }
+
+    @Test func appStateMappingPropagatesProjectModeAndRepoConfig() {
+        #expect(AppState.resolveGGWorktreeContext(
+            masterEnabled: true,
+            ggInstalled: true,
+            project: project(mode: .auto),
+            worktreeOverride: .inherit,
+            isMainWorktree: false,
+            repoHasGGConfig: false,
+            branchUsername: "nacho",
+            branch: "nacho/feature"
+        ) == .inactive(reason: .policyOff))
+        #expect(AppState.resolveGGWorktreeContext(
+            masterEnabled: true,
+            ggInstalled: true,
+            project: project(mode: .auto),
+            worktreeOverride: .inherit,
+            isMainWorktree: false,
+            repoHasGGConfig: true,
+            branchUsername: "nacho",
+            branch: "nacho/feature"
+        ) == .active(stackName: "feature"))
+    }
+
+    @Test func appStateMappingPropagatesMasterAndAvailability() {
+        #expect(AppState.resolveGGWorktreeContext(
+            masterEnabled: false,
+            ggInstalled: true,
+            project: project(mode: .on),
+            worktreeOverride: .on,
+            isMainWorktree: false,
+            repoHasGGConfig: true,
+            branchUsername: "nacho",
+            branch: "nacho/feature"
+        ) == .inactive(reason: .masterDisabled))
+        #expect(AppState.resolveGGWorktreeContext(
+            masterEnabled: true,
+            ggInstalled: false,
+            project: project(mode: .on),
+            worktreeOverride: .on,
+            isMainWorktree: false,
+            repoHasGGConfig: true,
+            branchUsername: "nacho",
+            branch: "nacho/feature"
+        ) == .inactive(reason: .cliMissing))
+    }
+
+    @Test func appStateMappingPropagatesOverrideAndMainIdentity() {
+        #expect(AppState.resolveGGWorktreeContext(
+            masterEnabled: true,
+            ggInstalled: true,
+            project: project(mode: .off),
+            worktreeOverride: .on,
+            isMainWorktree: true,
+            repoHasGGConfig: false,
+            branchUsername: "nacho",
+            branch: "nacho/forced"
+        ) == .active(stackName: "forced"))
+        #expect(AppState.resolveGGWorktreeContext(
+            masterEnabled: true,
+            ggInstalled: true,
+            project: project(mode: .on),
+            worktreeOverride: .inherit,
+            isMainWorktree: true,
+            repoHasGGConfig: true,
+            branchUsername: "nacho",
+            branch: "nacho/main"
+        ) == .inactive(reason: .policyOff))
+    }
+
+    @Test func appStateMappingPropagatesRemoteAndLiveBranch() {
+        #expect(AppState.resolveGGWorktreeContext(
+            masterEnabled: true,
+            ggInstalled: true,
+            project: project(mode: .on, host: "build-host"),
+            worktreeOverride: .on,
+            isMainWorktree: false,
+            repoHasGGConfig: true,
+            branchUsername: "nacho",
+            branch: "nacho/live-branch"
+        ) == .inactive(reason: .remoteProject))
+        #expect(AppState.resolveGGWorktreeContext(
+            masterEnabled: true,
+            ggInstalled: true,
+            project: project(mode: .on),
+            worktreeOverride: .inherit,
+            isMainWorktree: false,
+            repoHasGGConfig: true,
+            branchUsername: "nacho",
+            branch: "other/live-branch"
+        ) == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
     }
 }
 

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -259,6 +259,31 @@ struct AppStateGGACPWorktreeContextTests {
         #expect(GGStackSummaryStore.shared.summaries[path.path] == nil)
     }
 
+    @Test func fullTopologyRefreshClearsCachedSidebarSummaryWhenBranchChanges() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-summary-topology-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [])))
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "topology",
+            color: "teal"
+        )
+        await state.refreshProjectTopology(projectId: project.id)
+        let worktreePath = try #require(state.projectsManager.worktrees(projectId: project.id).first?.path.path)
+        GGStackSummaryStore.shared.summaries[worktreePath] = GGStackSummary(merged: 1, total: 2)
+        defer { GGStackSummaryStore.shared.summaries[worktreePath] = nil }
+        state.stopAllProjectGitWatchers()
+
+        _ = try await Process.git(["checkout", "-q", "-b", "nacho/new-stack"], cwd: repo)
+        await state.refreshProjectTopology(projectId: project.id)
+
+        #expect(GGStackSummaryStore.shared.summaries[worktreePath] == nil)
+    }
+
     @Test func cachedLiveBranchOverridesStaleTopologyForACPDecisions() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-gg-acp-live-branch-\(UUID().uuidString)")

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -1,0 +1,111 @@
+import Testing
+@testable import Alas
+
+struct GGWorktreeContextTests {
+    private func resolve(
+        masterEnabled: Bool = true,
+        ggInstalled: Bool = true,
+        isRemoteProject: Bool = false,
+        projectMode: GGProjectMode = .auto,
+        worktreeOverride: GGWorktreeMode = .inherit,
+        isMainWorktree: Bool = false,
+        repoHasGGConfig: Bool = true,
+        branchUsername: String? = "nacho",
+        branch: String = "nacho/my-stack"
+    ) -> GGWorktreeContext {
+        GGWorktreeContextResolver.resolve(
+            masterEnabled: masterEnabled,
+            ggInstalled: ggInstalled,
+            isRemoteProject: isRemoteProject,
+            projectMode: projectMode,
+            worktreeOverride: worktreeOverride,
+            isMainWorktree: isMainWorktree,
+            repoHasGGConfig: repoHasGGConfig,
+            branchUsername: branchUsername,
+            branch: branch
+        )
+    }
+
+    @Test(arguments: [
+        (GGProjectMode.off, true, GGWorktreeContext.inactive(reason: .policyOff)),
+        (.auto, false, .inactive(reason: .policyOff)),
+        (.auto, true, .active(stackName: "my-stack")),
+        (.on, false, .active(stackName: "my-stack")),
+    ])
+    func linkedWorktreeUsesProjectMode(
+        mode: GGProjectMode,
+        hasConfig: Bool,
+        expected: GGWorktreeContext
+    ) {
+        #expect(resolve(projectMode: mode, repoHasGGConfig: hasConfig) == expected)
+    }
+
+    @Test(arguments: GGProjectMode.allCases)
+    func mainWorktreeInheritedDefaultIsOff(mode: GGProjectMode) {
+        #expect(resolve(projectMode: mode, isMainWorktree: true) == .inactive(reason: .policyOff))
+    }
+
+    @Test func explicitOverridesWinInBothDirections() {
+        #expect(resolve(projectMode: .off, worktreeOverride: .on) == .active(stackName: "my-stack"))
+        #expect(resolve(projectMode: .on, worktreeOverride: .off) == .inactive(reason: .policyOff))
+        #expect(resolve(projectMode: .off, worktreeOverride: .on, isMainWorktree: true) == .active(stackName: "my-stack"))
+    }
+
+    @Test func globalCLIAndRemoteChecksAreHardStops() {
+        #expect(resolve(masterEnabled: false, worktreeOverride: .on) == .inactive(reason: .masterDisabled))
+        #expect(resolve(ggInstalled: false, worktreeOverride: .on) == .inactive(reason: .cliMissing))
+        #expect(resolve(isRemoteProject: true, worktreeOverride: .on) == .inactive(reason: .remoteProject))
+    }
+
+    @Test func missingBranchUsernameIsInactive() {
+        #expect(resolve(branchUsername: nil) == .inactive(reason: .branchUsernameMissing))
+        #expect(resolve(branchUsername: "") == .inactive(reason: .branchUsernameMissing))
+    }
+
+    @Test func stackNameAcceptsSimpleAndNestedNames() {
+        #expect(GGWorktreeContextResolver.stackName(branch: "nacho/feature", username: "nacho") == "feature")
+        #expect(GGWorktreeContextResolver.stackName(branch: "nacho/team/feature", username: "nacho") == "team/feature")
+        #expect(resolve(branch: "nacho/team/feature") == .active(stackName: "team/feature"))
+        #expect(resolve(branch: "nacho/team/feature").isActive)
+    }
+
+    @Test func stackNameRejectsEmptyNameAndWrongPrefix() {
+        #expect(GGWorktreeContextResolver.stackName(branch: "nacho/", username: "nacho") == nil)
+        #expect(GGWorktreeContextResolver.stackName(branch: "other/feature", username: "nacho") == nil)
+        #expect(resolve(branch: "nacho/") == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
+        #expect(resolve(branch: "other/feature") == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
+        #expect(!resolve(branch: "other/feature").isActive)
+    }
+}
+
+@MainActor
+struct ProjectsManagerGGWorktreeModeTests {
+    @Test func managerGetsSetsAndRemovesSparseOverrides() {
+        let project = ProjectConfig(
+            id: "project", name: "Alas", path: "/tmp/alas", color: "teal", addedAt: .now
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+
+        #expect(manager.ggWorktreeMode(projectId: project.id, worktreeId: "worktree") == .inherit)
+
+        manager.setGGWorktreeMode(projectId: project.id, worktreeId: "worktree", mode: .on)
+        #expect(manager.ggWorktreeMode(projectId: project.id, worktreeId: "worktree") == .on)
+        #expect(manager.projects[0].ggWorktreeModes == ["worktree": .on])
+
+        manager.setGGWorktreeMode(projectId: project.id, worktreeId: "worktree", mode: .inherit)
+        #expect(manager.ggWorktreeMode(projectId: project.id, worktreeId: "worktree") == .inherit)
+        #expect(manager.projects[0].ggWorktreeModes.isEmpty)
+
+        manager.setGGWorktreeMode(projectId: project.id, worktreeId: "worktree", mode: .off)
+        manager.removeGGWorktreeMode(projectId: project.id, worktreeId: "worktree")
+        #expect(manager.ggWorktreeMode(projectId: project.id, worktreeId: "worktree") == .inherit)
+    }
+
+    @Test func managerIgnoresUnknownProjects() {
+        let manager = ProjectsManager(persistedProjects: [])
+        manager.setGGWorktreeMode(projectId: "missing", worktreeId: "worktree", mode: .on)
+        manager.removeGGWorktreeMode(projectId: "missing", worktreeId: "worktree")
+        #expect(manager.ggWorktreeMode(projectId: "missing", worktreeId: "worktree") == .inherit)
+        #expect(manager.projects.isEmpty)
+    }
+}

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -278,6 +278,12 @@ struct AppStateGGACPWorktreeContextTests {
         )
 
         pane.currentBranch = "main"
+        _ = state.rightPaneStore.state(
+            for: topologyWorktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        #expect(pane.currentBranch == "main")
         let plain = try #require(state.ggACPWorktreeIntegration(
             worktreePath: path.path,
             ggInstalled: true
@@ -307,5 +313,26 @@ struct AppStateGGACPWorktreeContextTests {
         #expect(!AppState.shouldAttachGGMCP(context: quiescent.context))
         #expect(AppState.ggPreambleSignal(context: quiescent.context, snapshot: nil) == .none)
         #expect(quiescent.context == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
+
+        pane.currentBranch = "main"
+        state.projectsManager.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [path: "nacho/reactivated-stack"]
+        )
+        let reactivatedWorktree = try #require(
+            state.projectsManager.worktrees(projectId: project.id).first
+        )
+        _ = state.rightPaneStore.state(
+            for: reactivatedWorktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        let reactivated = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: path.path,
+            ggInstalled: true
+        ))
+        #expect(AppState.shouldAttachGGMCP(context: reactivated.context))
+        #expect(AppState.ggPreambleSignal(context: reactivated.context, snapshot: nil) == .generic)
+        #expect(reactivated.context == .active(stackName: "reactivated-stack"))
     }
 }

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -211,5 +212,92 @@ struct ProjectsManagerGGWorktreeModeTests {
         manager.removeGGWorktreeMode(projectId: "missing", worktreeId: "worktree")
         #expect(manager.ggWorktreeMode(projectId: "missing", worktreeId: "worktree") == .inherit)
         #expect(manager.projects.isEmpty)
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct AppStateGGACPWorktreeContextTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        let projectsFile: ProjectsFile
+
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from _: URL) throws -> T? {
+            type == ProjectsFile.self ? projectsFile as? T : nil
+        }
+    }
+
+    @Test func cachedLiveBranchOverridesStaleTopologyForACPDecisions() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-acp-live-branch-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(".git/gg"),
+            withIntermediateDirectories: true
+        )
+        try Data(#"{"defaults":{"branch_username":"nacho"}}"#.utf8).write(
+            to: root.appendingPathComponent(".git/gg/config.json")
+        )
+
+        let project = ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: root.path,
+            color: "teal",
+            addedAt: .now,
+            ggMode: .off
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let path = root.appendingPathComponent("linked")
+        let topologyWorktree = Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: project.id,
+            name: "nacho/old-stack",
+            branch: "nacho/old-stack",
+            path: path,
+            status: .clean,
+            lastActivity: .now
+        )
+        state.projectsManager.insertOptimisticWorktree(topologyWorktree)
+        state.projectsManager.setGGWorktreeMode(
+            projectId: project.id,
+            worktreeId: topologyWorktree.id,
+            mode: .on
+        )
+        let fallback = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: path.path,
+            ggInstalled: true
+        ))
+        #expect(fallback.context == .active(stackName: "old-stack"))
+
+        let pane = state.rightPaneStore.state(
+            for: topologyWorktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        state.rightPaneStore.deactivate()
+
+        pane.currentBranch = "main"
+        let plain = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: path.path,
+            ggInstalled: true
+        ))
+        #expect(!AppState.shouldAttachGGMCP(context: plain.context))
+        #expect(AppState.ggPreambleSignal(context: plain.context, snapshot: nil) == .none)
+
+        state.projectsManager.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [path: "main"]
+        )
+        #expect(state.projectsManager.worktrees(projectId: project.id).first?.branch == "main")
+        pane.currentBranch = "nacho/new-stack"
+        let stacked = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: path.path,
+            ggInstalled: true
+        ))
+        #expect(AppState.shouldAttachGGMCP(context: stacked.context))
+        #expect(AppState.ggPreambleSignal(context: stacked.context, snapshot: nil) == .generic)
+        #expect(stacked.context == .active(stackName: "new-stack"))
     }
 }

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -228,6 +228,37 @@ struct AppStateGGACPWorktreeContextTests {
         }
     }
 
+    @Test func topologyBranchChangeClearsCachedSidebarSummary() {
+        let project = ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: "/tmp/alas-summary-project",
+            color: "teal",
+            addedAt: .now
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let path = URL(fileURLWithPath: "/tmp/alas-summary-linked")
+        let worktree = Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: project.id,
+            name: "nacho/old-stack",
+            branch: "nacho/old-stack",
+            path: path,
+            status: .clean,
+            lastActivity: .now
+        )
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        GGStackSummaryStore.shared.summaries[path.path] = GGStackSummary(merged: 1, total: 2)
+        defer { GGStackSummaryStore.shared.summaries[path.path] = nil }
+
+        state.handleProjectHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [path: "nacho/new-stack"]
+        )
+
+        #expect(GGStackSummaryStore.shared.summaries[path.path] == nil)
+    }
+
     @Test func cachedLiveBranchOverridesStaleTopologyForACPDecisions() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-gg-acp-live-branch-\(UUID().uuidString)")

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -111,6 +111,38 @@ struct ProjectsManagerTests {
         #expect(restartedWorktrees.first?.path.standardizedFileURL == repo.standardizedFileURL)
     }
 
+    @Test func linkedWorktreeRegistrationPreservesGitsMainWorktreeIdentity() async throws {
+        let repo = try await makeRepo(name: "linked-registration")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let service = WorktreeService()
+        let linkedPath = repo.appendingPathComponent("linked-registration")
+        let projectId = "linked-registration-project"
+        _ = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "linked-registration-branch",
+            destination: linkedPath,
+            projectId: projectId
+        )
+        let project = ProjectConfig(
+            id: projectId,
+            name: "linked-registration",
+            path: linkedPath.path,
+            color: "#5fb7c4",
+            addedAt: Date()
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+
+        try await manager.refreshWorktrees(projectId: projectId)
+
+        let worktrees = manager.worktrees(projectId: projectId)
+        let main = try #require(worktrees.first { $0.path.standardizedFileURL == repo.standardizedFileURL })
+        let linked = try #require(worktrees.first { $0.path.standardizedFileURL == linkedPath.standardizedFileURL })
+        #expect(manager.isMain(main, in: project))
+        #expect(!manager.isMain(linked, in: project))
+        #expect(worktrees.first?.id == main.id)
+    }
+
     @Test func remoteRegistrationReconcileUnregistersRemovedWorktreeRoots() {
         let project = ProjectConfig(
             id: "remote-project",

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -313,6 +313,38 @@ extension ProjectsManagerTests {
         #expect(!mgr.isWorktreeHidden(projectId: project.id, path: bogus))
     }
 
+    @Test func refreshPrunesOnlyMissingGGWorktreeOverrides() async throws {
+        let repo = try await makeRepo(name: "gg-override-prune")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let projectId = "gg-override-prune-project"
+        let linked = try await WorktreeService().add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/archived",
+            destination: repo.appendingPathComponent("wt-archived"),
+            projectId: projectId
+        )
+        let mainId = Worktree.makeId(path: repo)
+        let staleId = "missing-worktree"
+        let project = ProjectConfig(
+            id: projectId,
+            name: "gg-override-prune",
+            path: repo.path,
+            color: "#5fb7c4",
+            addedAt: Date(),
+            hiddenWorktreePaths: [linked.path.path],
+            ggWorktreeModes: [mainId: .on, linked.id: .off, staleId: .on]
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+
+        let changed = try await manager.refreshWorktrees(projectId: projectId)
+
+        #expect(changed)
+        #expect(manager.projects[0].ggWorktreeModes == [mainId: .on, linked.id: .off])
+        #expect(manager.ggWorktreeMode(projectId: projectId, worktreeId: staleId) == .inherit)
+        #expect(manager.archivedWorktrees(projectId: projectId).map(\.id) == [linked.id])
+    }
+
     @Test func refreshAllPopulatesMultipleProjects() async throws {
         let repoA = try await makeRepo(name: "eta")
         defer { try? FileManager.default.removeItem(at: repoA) }

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -53,6 +53,13 @@ struct RepoGroupViewLayoutTests {
             isMain: { _ in false },
             operationState: { _ in nil },
             harnessSummary: { _ in nil },
+            ggMenuModel: { _ in
+                GGWorktreeMenuModel(
+                    selectedMode: .inherit,
+                    context: .inactive(reason: .policyOff),
+                    hasStackSummary: false
+                )
+            },
             onSelect: { _ in },
             onNewWorktree: {},
             onEditProject: {},
@@ -76,6 +83,7 @@ struct RepoGroupViewLayoutTests {
             onCopyError: { _ in },
             onRetryCreate: { _ in },
             onRetryDelete: { _ in },
+            onSetGGWorktreeMode: { _, _ in },
             onRemoveFailed: { _ in },
             onDropWorktree: { _, _ in },
             onDropProject: { _, _ in }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -289,6 +289,38 @@ private final class PausedContinueGGRunner: GGCommandRunning, @unchecked Sendabl
 }
 
 @MainActor
+struct RightPaneGGStackErrorPresentationTests {
+    @Test func cliErrorReachesRetryableDrawerDetail() async {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-stack-error-\(UUID().uuidString)")
+        let worktree = Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "test-project",
+            name: "feature",
+            branch: "feature",
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        let runner = ThrowingFakeGGRunner()
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 1)
+        #expect(state.ggContext == .active(stackName: "stack"))
+        #expect(state.ggStackLoadState == .failed("boom"))
+        #expect(GGStackPlaceholderModel.make(
+            context: state.ggContext,
+            loadState: state.ggStackLoadState
+        )?.detail == "boom")
+        #expect(state.ggStackCommitsKey == nil)
+    }
+}
+
+@MainActor
 struct RightPaneGGStackTests {
     private struct MemoryStore: PersistenceStoreProtocol {
         func write<T: Encodable>(_: T, to _: URL) throws {}
@@ -756,22 +788,6 @@ struct RightPaneGGStackTests {
         #expect(state.ggStack == nil)
         #expect(state.ggStackLoadState == .inactive)
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
-    }
-
-    @Test func stackLoadErrorLeavesContextActiveAndPublishesRetryableFailure() async {
-        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
-        let runner = ThrowingFakeGGRunner()
-        state.ggService = GGService(runner: runner)
-        state.ggContextProvider = { _ in .active(stackName: "stack") }
-
-        await state.refreshGGStack()
-
-        #expect(runner.callCount == 1)
-        #expect(state.ggContext == .active(stackName: "stack"))
-        #expect(state.ggStackLoadState == .failed(
-            GGServiceError.commandFailed(stderr: "boom").localizedDescription
-        ))
-        #expect(state.ggStackCommitsKey == nil)
     }
 
     @Test func gateClosedSkipsCLIAndClearsStack() async throws {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -965,6 +965,33 @@ struct RightPaneGGStackTests {
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
     }
 
+    @Test func storeReevaluatesGGGateOnlyForRequestedWorktree() async throws {
+        let firstWorktree = makeWorktree()
+        let secondWorktree = makeWorktree()
+        let store = RightPaneStore()
+        let first = store.state(for: firstWorktree, baseBranch: "main", comparisonMode: .manual)
+        let second = store.state(for: secondWorktree, baseBranch: "main", comparisonMode: .manual)
+        store.deactivate()
+
+        var firstEvaluationCount = 0
+        var secondEvaluationCount = 0
+        first.ggContextProvider = { _ in
+            firstEvaluationCount += 1
+            return .inactive(reason: .policyOff)
+        }
+        second.ggContextProvider = { _ in
+            secondEvaluationCount += 1
+            return .inactive(reason: .policyOff)
+        }
+
+        let task = try #require(store.reevaluateGGGate(worktreeId: firstWorktree.id))
+        await task.value
+
+        #expect(firstEvaluationCount == 1)
+        #expect(secondEvaluationCount == 0)
+        #expect(store.reevaluateGGGate(worktreeId: "missing") == nil)
+    }
+
     /// A thrown gg failure must not cache the commits key — otherwise a
     /// transient error (auth hiccup, network blip) permanently skips retries
     /// for that commit set via the unchanged-key guard, even after the

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -482,7 +482,7 @@ struct RightPaneGGStackTests {
         )
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "q", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -511,7 +511,7 @@ struct RightPaneGGStackTests {
         let runner = AdvancingUndoGGRunner()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "u", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -543,7 +543,7 @@ struct RightPaneGGStackTests {
         let runner = NoCurrentStackUndoGGRunner()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [
             commit(sha: String(repeating: "u", count: 40), stackShaped: true),
         ]
@@ -575,7 +575,7 @@ struct RightPaneGGStackTests {
         // refresh loads the `agent-inbox` stack and reconciles the undo
         // candidate against a matching scope, rather than treating the gate as
         // closed and suspending it.
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "c", count: 40), stackShaped: true)]
         state.ggActionState.setPaused(GGPausedOperation(pausedBy: .restack))
 
@@ -702,6 +702,78 @@ struct RightPaneGGStackTests {
         #expect(GGStackGate.isStackShaped(commits: state.ggStackSourceCommits))
     }
 
+    @Test func activeContextLoadsStackWithNoSourceCommits() async {
+        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+        state.ggStackSourceCommits = []
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 1)
+        #expect(state.ggStack != nil)
+        #expect(state.ggStackLoadState == .loaded)
+    }
+
+    @Test func nilStackLeavesContextActiveAndPublishesEmpty() async {
+        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(
+                exitCode: 0,
+                stdout: #"{"version": 1, "current_stack": null, "stacks": []}"#,
+                stderr: ""
+            )
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+
+        await state.refreshGGStack()
+
+        #expect(state.ggContext == .active(stackName: "stack"))
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackLoadState == .empty)
+    }
+
+    @Test func inactiveContextSkipsGGAndClearsPublishedState() async throws {
+        let wt = makeWorktree()
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+        await state.refreshGGStack()
+        #expect(state.ggStack != nil)
+
+        state.ggContextProvider = { _ in .inactive(reason: .policyOff) }
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 1)
+        #expect(state.ggContext == .inactive(reason: .policyOff))
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackLoadState == .inactive)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+    }
+
+    @Test func stackLoadErrorLeavesContextActiveAndPublishesRetryableFailure() async {
+        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let runner = ThrowingFakeGGRunner()
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 1)
+        #expect(state.ggContext == .active(stackName: "stack"))
+        #expect(state.ggStackLoadState == .failed(
+            GGServiceError.commandFailed(stderr: "boom").localizedDescription
+        ))
+        #expect(state.ggStackCommitsKey == nil)
+    }
+
     @Test func gateClosedSkipsCLIAndClearsStack() async throws {
         let wt = makeWorktree()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
@@ -709,7 +781,7 @@ struct RightPaneGGStackTests {
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { false }
+        state.ggContextProvider = { _ in .inactive(reason: .policyOff) }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -722,7 +794,7 @@ struct RightPaneGGStackTests {
     @Test func gateClosedClearsPausedOperation() async throws {
         let wt = makeWorktree()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
-        state.ggGateProvider = { false }
+        state.ggContextProvider = { _ in .inactive(reason: .policyOff) }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
         state.ggActionState.setPaused(GGPausedOperation(pausedBy: .sync))
 
@@ -737,7 +809,7 @@ struct RightPaneGGStackTests {
         let markerStore = GGUndoMarkerStore()
         markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
         let state = RightPaneState(worktree: wt, baseBranch: "main")
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
         state.ggService = GGService(runner: AdvancingUndoGGRunner())
 
@@ -747,7 +819,7 @@ struct RightPaneGGStackTests {
         // The gg gate can read closed transiently before the startup
         // availability probe resolves. Hide the candidate but keep the marker
         // so a valid recovery Undo is not destroyed by that race.
-        state.ggGateProvider = { false }
+        state.ggContextProvider = { _ in .inactive(reason: .policyOff) }
         await state.refreshGGStack()
 
         #expect(state.ggUndoCandidate == nil)
@@ -769,7 +841,7 @@ struct RightPaneGGStackTests {
         let runner = FailSecondLsUndoGGRunner()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -799,7 +871,7 @@ struct RightPaneGGStackTests {
             branch: "feature", path: dir, status: .clean, lastActivity: Date()
         )
         let state = RightPaneState(worktree: wt, baseBranch: "main")
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "o", count: 40), stackShaped: false)]
         _ = state.ggActionState.beginAction(.sync)
 
@@ -809,21 +881,21 @@ struct RightPaneGGStackTests {
         state.ggActionState.endAction(.sync)
     }
 
-    @Test func notStackShapedSkipsCLIAndClearsStack() async throws {
+    @Test func activeContextLoadsStackWithoutStackShapedCommits() async throws {
         let wt = makeWorktree()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "b", count: 40), stackShaped: false)]
 
         await state.refreshGGStack()
 
-        #expect(runner.callCount == 0)
-        #expect(state.ggStack == nil)
-        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+        #expect(runner.callCount == 1)
+        #expect(state.ggStack != nil)
+        #expect(GGStackSummaryStore.shared.summaries[wt.path.path] != nil)
     }
 
     @Test func unchangedCommitSetDoesNotReinvokeCLI() async throws {
@@ -833,7 +905,7 @@ struct RightPaneGGStackTests {
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "c", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -862,7 +934,7 @@ struct RightPaneGGStackTests {
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "e", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -870,7 +942,7 @@ struct RightPaneGGStackTests {
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] != nil)
 
         // Simulate the master toggle going off in Settings.
-        state.ggGateProvider = { false }
+        state.ggContextProvider = { _ in .inactive(reason: .policyOff) }
         await state.reevaluateGGGate().value
 
         #expect(state.ggStack == nil)
@@ -886,7 +958,7 @@ struct RightPaneGGStackTests {
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         let runner = ThrowingFakeGGRunner()
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "f", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -907,7 +979,7 @@ struct RightPaneGGStackTests {
         markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: ThrowingFakeGGRunner())
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "f", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -927,7 +999,7 @@ struct RightPaneGGStackTests {
         let runner = DelayedStackGGRunner(staleResult: stale, freshResult: fresh)
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "z", count: 40), stackShaped: true)]
 
         let staleRefresh = Task { @MainActor in await state.refreshGGStack() }
@@ -955,7 +1027,7 @@ struct RightPaneGGStackTests {
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
         state.ggService = GGService(runner: okRunner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.currentBranch = "nacho/stack-a"
         state.ggStackSourceCommits = [commit(sha: String(repeating: "i", count: 40), stackShaped: true)]
         await state.refreshGGStack()
@@ -994,7 +1066,7 @@ struct RightPaneGGStackTests {
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
         state.ggService = GGService(runner: firstRunner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.currentBranch = "nacho/stack-a"
         state.ggStackSourceCommits = commitsA
         await state.refreshGGStack()
@@ -1032,7 +1104,7 @@ struct RightPaneGGStackTests {
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.currentBranch = "nacho/stack-a"
         state.ggStackSourceCommits = [commit(sha: String(repeating: "h", count: 40), stackShaped: true)]
 
@@ -1056,7 +1128,7 @@ struct RightPaneGGStackTests {
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "g", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -1085,7 +1157,7 @@ struct RightPaneGGStackTests {
         state.ggService = GGService(runner: CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         ))
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -1119,7 +1191,7 @@ struct RightPaneGGStackTests {
         state.ggService = GGService(runner: CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         ))
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "r", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -1141,7 +1213,7 @@ struct RightPaneGGStackTests {
         state.ggService = GGService(runner: CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         ))
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "t", count: 40), stackShaped: true)]
 
         await state.refreshGGStack()
@@ -1161,7 +1233,7 @@ struct RightPaneGGStackTests {
         )
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: ThrowingFakeGGRunner())
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "m", count: 40), stackShaped: true)]
         state.ggActionState.setPaused(GGPausedOperation(pausedBy: .sync))
 
@@ -1182,7 +1254,7 @@ struct RightPaneGGStackTests {
         )
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: ConflictAfterSyncRunner())
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
 
         state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
@@ -1230,7 +1302,7 @@ struct RightPaneGGStackTests {
             #"{"event":"summary"}"#,
         ].joined(separator: "\n")
         state.ggService = GGService(runner: NDJSONSyncFakeGGRunner(ndjson: ndjson))
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
 
         // Drive the same body onGGStackAction(.sync) runs, but awaitably:
@@ -1257,7 +1329,7 @@ struct RightPaneGGStackTests {
         let runner = ReentrantSyncFakeGGRunner()
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         state.ggService = GGService(runner: runner)
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
 
         state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
@@ -1285,7 +1357,7 @@ struct RightPaneGGStackTests {
             #"{"event":"summary"}"#,
         ].joined(separator: "\n")
         state.ggService = GGService(runner: NDJSONSyncFakeGGRunner(ndjson: ndjson))
-        state.ggGateProvider = { true }
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
 
         state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -1116,6 +1116,26 @@ struct RightPaneGGStackTests {
         #expect(runner.callCount == 2)
     }
 
+    @Test func activeContextNameChangeWithSameBranchAndCommitsReinvokesCLI() async {
+        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: runner)
+        var stackName = "stack-a"
+        state.ggContextProvider = { _ in .active(stackName: stackName) }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "h", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(runner.callCount == 1)
+
+        stackName = "stack-b"
+        await state.refreshGGStack()
+
+        #expect(state.ggContext == .active(stackName: "stack-b"))
+        #expect(runner.callCount == 2)
+    }
+
     /// `markSnapshotUnknown()` resets `commits` along with the rest of the
     /// snapshot; gg stack state derives from `commits`, so it must be reset
     /// in lockstep or a delayed/failed refresh after invalidation can leave
@@ -1139,7 +1159,18 @@ struct RightPaneGGStackTests {
 
         #expect(state.ggStack == nil)
         #expect(state.ggStackCommitsKey == nil)
+        #expect(state.ggStackLoadState == .loading)
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
+    }
+
+    @Test func markSnapshotUnknownKeepsInactiveLoadStateInactive() {
+        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        state.ggContext = .inactive(reason: .policyOff)
+        state.ggStackLoadState = .inactive
+
+        state.markSnapshotUnknown()
+
+        #expect(state.ggStackLoadState == .inactive)
     }
 
     /// Plain git actions use the same marker files as paused gg actions, so

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -352,6 +352,19 @@ struct RightPaneGGStackTests {
         )
     }
 
+    @Test func seedingContextMakesEligibleFirstActivationLoadingImmediately() {
+        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        state.ggContextProvider = { branch in
+            .active(stackName: String(branch.dropFirst("nacho/".count)))
+        }
+
+        state.seedGGContext(branch: "nacho/first-stack")
+
+        #expect(state.currentBranch == "nacho/first-stack")
+        #expect(state.ggContext == .active(stackName: "first-stack"))
+        #expect(state.ggStackLoadState == .loading)
+    }
+
     @Test func prepareCardRemainsVisibleAlongsideGGDrawer() {
         #expect(ChangesTabView.shouldShowChangesPreparationCard(
             preparationIsVisible: true

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -1179,6 +1179,76 @@ struct RightPaneGGStackTests {
         #expect(runner.callCount == 2)
     }
 
+    @Test func changedKeyPublishesLoadingWhileRetainingPreviousStack() async throws {
+        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "m", count: 40), stackShaped: true)]
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        await state.refreshGGStack()
+        let previousStack = try #require(state.ggStack)
+
+        let delayed = DelayedStackGGRunner(
+            staleResult: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: ""),
+            freshResult: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        state.ggService = GGService(runner: delayed)
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
+        let refresh = Task { @MainActor in await state.refreshGGStack() }
+        for _ in 0..<500 where delayed.callCount == 0 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        #expect(delayed.callCount == 1)
+        #expect(state.ggStack == previousStack)
+        #expect(state.ggStackLoadState == .loading)
+        await refresh.value
+    }
+
+    @Test func storeSnapshotMarksStaleStackKeyAsLoading() async throws {
+        let worktree = makeWorktree()
+        let store = RightPaneStore()
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+        store.deactivate()
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "o", count: 40), stackShaped: true)]
+        await state.refreshGGStack()
+        #expect(state.ggStackLoadState == .loaded)
+
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "p", count: 40), stackShaped: true)]
+        let snapshot = try #require(store.ggStackSnapshotForWorktreePath(
+            worktree.path.path,
+            effectiveContext: .active(stackName: "stack")
+        ))
+
+        #expect(snapshot.stack != nil)
+        #expect(snapshot.loadState == .loading)
+    }
+
+    @Test func storeSnapshotMarksStaleContextAsLoading() async throws {
+        let worktree = makeWorktree()
+        let store = RightPaneStore()
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+        store.deactivate()
+        state.ggContextProvider = { _ in .active(stackName: "old-stack") }
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        await state.refreshGGStack()
+
+        let snapshot = try #require(store.ggStackSnapshotForWorktreePath(
+            worktree.path.path,
+            effectiveContext: .active(stackName: "new-stack")
+        ))
+
+        #expect(snapshot.stack != nil)
+        #expect(snapshot.loadState == .loading)
+    }
+
     /// `markSnapshotUnknown()` resets `commits` along with the rest of the
     /// snapshot; gg stack state derives from `commits`, so it must be reset
     /// in lockstep or a delayed/failed refresh after invalidation can leave

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -132,6 +132,60 @@ private final class DelayedStackGGRunner: GGCommandRunning, @unchecked Sendable 
     }
 }
 
+private actor ControlledStackGGRunner: GGCommandRunning {
+    private let stackResults: [(name: String, result: ProcessResult)]
+    private let suspendedCalls: Set<Int>
+    private(set) var lsCallCount = 0
+    private var lastStackName: String?
+    private var callWaiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
+    private var completions: [Int: CheckedContinuation<Void, Never>] = [:]
+
+    init(
+        stackResults: [(name: String, result: ProcessResult)],
+        suspendedCalls: Set<Int>
+    ) {
+        self.stackResults = stackResults
+        self.suspendedCalls = suspendedCalls
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["undo", "--list", "--json", "--limit", "1"] {
+            guard let lastStackName else {
+                return ProcessResult(exitCode: 0, stdout: #"{"version":1,"operations":[]}"#, stderr: "")
+            }
+            return ProcessResult(
+                exitCode: 0,
+                stdout: """
+                {"version":1,"operations":[{"id":"op_1","kind":"reorder","status":"committed","created_at_ms":1,"args":["--client-operation-id","alas:persisted","reorder"],"stack_name":"\(lastStackName)","touched_remote":false,"is_undoable":true}]}
+                """,
+                stderr: ""
+            )
+        }
+        guard args == ["ls", "--json"], lsCallCount < stackResults.count else {
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected args: \(args)")
+        }
+        lsCallCount += 1
+        let call = lsCallCount
+        let waiters = callWaiters.removeValue(forKey: call) ?? []
+        for waiter in waiters { waiter.resume() }
+        if suspendedCalls.contains(call) {
+            await withCheckedContinuation { completions[call] = $0 }
+        }
+        let response = stackResults[call - 1]
+        lastStackName = response.name
+        return response.result
+    }
+
+    func waitUntilCall(_ call: Int) async {
+        if lsCallCount >= call { return }
+        await withCheckedContinuation { callWaiters[call, default: []].append($0) }
+    }
+
+    func complete(call: Int) {
+        completions.removeValue(forKey: call)?.resume()
+    }
+}
+
 /// Answers the `sync --help` capability probe with `--jsonl` support, then
 /// streams the given NDJSON body for `sync --jsonl` — needed because
 /// `CountingFakeGGRunner` echoes the same stdout to every call, which would
@@ -1260,31 +1314,97 @@ struct RightPaneGGStackTests {
         #expect(runner.callCount == 2)
     }
 
-    @Test func changedKeyPublishesLoadingWhileRetainingPreviousStack() async throws {
-        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
-        state.ggContextProvider = { _ in .active(stackName: "stack") }
-        state.ggStackSourceCommits = [commit(sha: String(repeating: "m", count: 40), stackShaped: true)]
-        state.ggService = GGService(runner: CountingFakeGGRunner(
-            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
-        ))
-        await state.refreshGGStack()
-        let previousStack = try #require(state.ggStack)
-
-        let delayed = DelayedStackGGRunner(
-            staleResult: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: ""),
-            freshResult: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+    @Test func changedKeyLoadingInvalidatesOldCacheAndSuspendsUndoUntilReconciled() async throws {
+        let worktree = makeWorktree()
+        try FileManager.default.createDirectory(
+            at: worktree.path.appendingPathComponent(".git/rebase-merge"),
+            withIntermediateDirectories: true
         )
-        state.ggService = GGService(runner: delayed)
+        let markerStore = GGUndoMarkerStore()
+        markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: worktree.id)
+        GGStackGate.markAlasGGOperationInProgress(repoPath: worktree.path.path)
+        defer {
+            markerStore.clear(worktreeId: worktree.id)
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+            try? FileManager.default.removeItem(at: worktree.path)
+        }
+        let oldResult = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture,
+            stderr: ""
+        )
+        let newResult = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture.replacingOccurrences(
+                of: "agent-inbox",
+                with: "new-stack"
+            ),
+            stderr: ""
+        )
+        let runner = ControlledStackGGRunner(
+            stackResults: [
+                ("agent-inbox", oldResult),
+                ("new-stack", newResult),
+                ("agent-inbox", oldResult),
+                ("new-stack", newResult),
+            ],
+            suspendedCalls: [2, 4]
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+        state.currentBranch = "nacho/old-stack"
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "m", count: 40), stackShaped: true)]
+        await state.refreshGGStack()
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] != nil)
+        #expect(state.ggUndoCandidate?.operationID == "op_1")
+        #expect(state.ggActionState.pausedOperation != nil)
+        let oldKey = try #require(state.ggStackCommitsKey)
+
+        state.currentBranch = "nacho/new-stack"
         state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
         let refresh = Task { @MainActor in await state.refreshGGStack() }
-        for _ in 0..<500 where delayed.callCount == 0 {
-            try await Task.sleep(nanoseconds: 1_000_000)
-        }
+        await runner.waitUntilCall(2)
 
-        #expect(delayed.callCount == 1)
-        #expect(state.ggStack == previousStack)
+        #expect(await runner.lsCallCount == 2)
         #expect(state.ggStackLoadState == .loading)
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackCommitsKey == nil)
+        #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
+        #expect(state.ggUndoCandidate == nil)
+        #expect(markerStore.marker(worktreeId: worktree.id)?.operationID == "op_1")
+        #expect(state.ggActionState.pausedOperation != nil)
+
+        refresh.cancel()
+        await runner.complete(call: 2)
         await refresh.value
+
+        state.currentBranch = "nacho/old-stack"
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "m", count: 40), stackShaped: true)]
+        await state.refreshGGStack()
+
+        let retryCallCount = await runner.lsCallCount
+        #expect(retryCallCount == 3)
+        guard retryCallCount == 3 else { return }
+        #expect(state.ggStackCommitsKey == oldKey)
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(state.ggUndoCandidate?.operationID == "op_1")
+
+        state.currentBranch = "nacho/new-stack"
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
+        let successfulRefresh = Task { @MainActor in await state.refreshGGStack() }
+        await runner.waitUntilCall(4)
+        #expect(state.ggUndoCandidate == nil)
+        #expect(state.ggActionState.pausedOperation != nil)
+        await runner.complete(call: 4)
+        await successfulRefresh.value
+
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStack?.name == "new-stack")
+        #expect(state.ggUndoCandidate?.operationID == "op_1")
+        #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] != nil)
+        #expect(state.ggActionState.pausedOperation != nil)
     }
 
     @Test func storeSnapshotMarksStaleStackKeyAsLoading() async throws {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -60,6 +60,45 @@ private final class CountingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
     }
 }
 
+enum GGStackClassificationFixture: CaseIterable, Sendable {
+    case nilStack
+    case zeroTotalWithEntry
+    case positiveTotalWithoutEntries
+    case populated
+
+    var isEmpty: Bool { self != .populated }
+    var hasStack: Bool { self != .nilStack }
+
+    var json: String {
+        guard self != .nilStack else {
+            return #"{"version": 1, "stack": null}"#
+        }
+        let totalCommits = self == .zeroTotalWithEntry ? 0 : 1
+        let entries = self == .positiveTotalWithoutEntries ? "[]" : """
+        [
+          {"position": 1, "sha": "aaaaaaa", "title": "feat: first",
+           "gg_id": "id-1", "gg_parent": null, "pr_number": null, "pr_state": null,
+           "approved": false, "ci_status": null, "is_current": true,
+           "in_merge_train": false, "merge_train_position": null}
+        ]
+        """
+        return """
+        {
+          "version": 1,
+          "stack": {
+            "name": "stack",
+            "base": "main",
+            "total_commits": \(totalCommits),
+            "synced_commits": 0,
+            "current_position": 1,
+            "behind_base": 0,
+            "entries": \(entries)
+          }
+        }
+        """
+    }
+}
+
 /// Always throws, simulating a transient gg/provider failure (e.g. a gh/glab
 /// auth hiccup) rather than a real "not a stack" result.
 private final class ThrowingFakeGGRunner: GGCommandRunning, @unchecked Sendable {
@@ -768,23 +807,47 @@ struct RightPaneGGStackTests {
         #expect(state.ggStackLoadState == .loaded)
     }
 
-    @Test func nilStackLeavesContextActiveAndPublishesEmpty() async {
-        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+    @Test(arguments: GGStackClassificationFixture.allCases)
+    func stackClassificationKeepsEmptyUIConsistent(_ fixture: GGStackClassificationFixture) async {
+        let worktree = makeWorktree()
+        defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
         let runner = CountingFakeGGRunner(
             result: ProcessResult(
                 exitCode: 0,
-                stdout: #"{"version": 1, "current_stack": null, "stacks": []}"#,
+                stdout: fixture.json,
                 stderr: ""
             )
         )
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
+        state.currentHeadSHA = String(repeating: "a", count: 40)
 
         await state.refreshGGStack()
 
-        #expect(state.ggContext == .active(stackName: "stack"))
-        #expect(state.ggStack == nil)
-        #expect(state.ggStackLoadState == .empty)
+        #expect((state.ggStack != nil) == fixture.hasStack)
+        #expect((state.ggStackLoadState == .empty) == fixture.isEmpty)
+        #expect((GGStackSummaryStore.shared.summaries[worktree.path.path] == nil) == fixture.isEmpty)
+        #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+            contextIsActive: state.ggContext.isActive,
+            stackLoadState: state.ggStackLoadState,
+            stack: state.ggStack,
+            currentHeadSHA: state.currentHeadSHA
+        ) == nil)
+        let hasLoadedCommit = state.ggStackLoadState.hasLoadedCommit
+        #expect(hasLoadedCommit == !fixture.isEmpty)
+        let preparation = ChangesPreparationModel.makeGG(
+            staged: .init(files: 1, insertions: 1, deletions: 0),
+            hasDraft: false,
+            capabilities: GGCapabilities(
+                structuredSplit: true,
+                keepCurrentUnstack: true,
+                stagedOnlyAmend: true
+            ),
+            hasLoadedCommit: hasLoadedCommit
+        )
+        #expect(preparation.ggAction(.newStackCommit)?.isEnabled == true)
+        #expect(preparation.ggAction(.amendCurrent)?.isEnabled == !fixture.isEmpty)
     }
 
     @Test func inactiveContextSkipsGGAndClearsPublishedState() async throws {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -254,6 +254,7 @@ private final class PausedContinueGGRunner: GGCommandRunning, @unchecked Sendabl
     let snapshotOperationID: String?
     let listedOperationID: String
     private(set) var continueCallCount = 0
+    private(set) var abortCallCount = 0
     private(set) var undoListCallCount = 0
 
     init(snapshotOperationID: String?, listedOperationID: String) {
@@ -272,6 +273,10 @@ private final class PausedContinueGGRunner: GGCommandRunning, @unchecked Sendabl
         }
         if args == ["continue"] {
             continueCallCount += 1
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+        }
+        if args == ["abort"] {
+            abortCallCount += 1
             return ProcessResult(exitCode: 0, stdout: "", stderr: "")
         }
         if args == ["undo", "--list", "--json", "--limit", "1"] {
@@ -1354,6 +1359,46 @@ struct RightPaneGGStackTests {
         await state.refreshGGStack()
 
         #expect(state.ggActionState.pausedOperation == GGPausedOperation(pausedBy: .sync))
+    }
+
+    @Test func inactiveDetachedRefreshRestoresPausedGGOperationAndRoutesRecoveryThroughGG() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-paused-detached-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent(".git/rebase-merge"),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+        GGStackGate.markAlasGGOperationInProgress(repoPath: dir.path)
+        let wt = Worktree(
+            id: Worktree.makeId(path: dir), projectId: "p", name: "detached",
+            branch: "", path: dir, status: .clean, lastActivity: Date()
+        )
+        let runner = PausedContinueGGRunner(
+            snapshotOperationID: nil,
+            listedOperationID: "in-progress"
+        )
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")) }
+        state.currentBranch = ""
+
+        await state.refreshGGStack()
+
+        #expect(state.ggStackLoadState == .inactive)
+        #expect(state.ggActionState.pausedOperation == GGPausedOperation(pausedBy: .sync))
+
+        state.onGGStackAction(.continueOp, appState: AppState(store: MemoryStore()))
+        for _ in 0..<500 where runner.continueCallCount == 0 || state.ggActionState.inFlightAction != nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(runner.continueCallCount == 1)
+
+        state.onGGStackAction(.abortOp, appState: AppState(store: MemoryStore()))
+        for _ in 0..<500 where runner.abortCallCount == 0 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(runner.abortCallCount == 1)
     }
 
     @Test func refreshClearsStaleAlasMarkerWhenNoGitOperationIsInProgress() async throws {

--- a/AlasTests/WorktreeCodableTests.swift
+++ b/AlasTests/WorktreeCodableTests.swift
@@ -10,6 +10,7 @@ import Foundation
             name: "feature/x",
             branch: "feature/x",
             path: URL(fileURLWithPath: "/tmp/foo"),
+            isMainWorktree: true,
             status: .dirty,
             lastActivity: Date(timeIntervalSince1970: 1_700_000_000),
             createdAt: Date(timeIntervalSince1970: 1_600_000_000),
@@ -24,8 +25,8 @@ import Foundation
         let decoded = try decoder.decode(Worktree.self, from: data)
 
         // Worktree.Equatable covers every stored property, so `decoded == original`
-        // is sufficient. createdAt and the diff counters (addedLines/deletedLines)
-        // are the fields this test specifically guards (Task 2 follow-up).
+        // is sufficient. Main-worktree identity, createdAt, and the diff counters
+        // are the fields this test specifically guards.
         #expect(decoded == original)
     }
 }

--- a/AlasTests/WorktreeRowHeightTests.swift
+++ b/AlasTests/WorktreeRowHeightTests.swift
@@ -45,8 +45,27 @@ struct WorktreeRowHeightTests {
         #expect(running == awaiting)
     }
 
+    @Test func rowHeightIsStableWithActiveGGIndicator() throws {
+        let inactive = try renderHeight(harnessSummary: nil)
+        let active = try renderHeight(
+            harnessSummary: nil,
+            ggMenuModel: GGWorktreeMenuModel(
+                selectedMode: .on,
+                context: .active(stackName: "feature"),
+                hasStackSummary: false
+            )
+        )
+
+        #expect(inactive == active)
+    }
+
     private func renderHeight(
-        harnessSummary: HarnessService.WorktreeHarnessSummary?
+        harnessSummary: HarnessService.WorktreeHarnessSummary?,
+        ggMenuModel: GGWorktreeMenuModel = GGWorktreeMenuModel(
+            selectedMode: .inherit,
+            context: .inactive(reason: .policyOff),
+            hasStackSummary: false
+        )
     ) throws -> Int {
         let worktree = Worktree(
             id: "wt-1",
@@ -64,6 +83,7 @@ struct WorktreeRowHeightTests {
             isMain: false,
             operationState: nil,
             harnessSummary: harnessSummary,
+            ggMenuModel: ggMenuModel,
             onTap: {},
             onOpenTerminal: {},
             onCopyPath: {},
@@ -77,7 +97,8 @@ struct WorktreeRowHeightTests {
             onCopyError: { _ in },
             onRemoveFailed: {},
             onRetryCreate: {},
-            onRetryDelete: {}
+            onRetryDelete: {},
+            onSetGGWorktreeMode: { _ in }
         )
         .environment(\.theme, try ThemeStore().current)
 

--- a/AlasTests/WorktreeServiceCreatedAtTests.swift
+++ b/AlasTests/WorktreeServiceCreatedAtTests.swift
@@ -3,6 +3,27 @@ import Foundation
 @testable import Alas
 
 @Suite struct WorktreeServiceCreatedAtTests {
+    @Test func parsePorcelainMarksOnlyGitsFirstWorktreeAsMain() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-main-identity-\(UUID().uuidString)")
+        let main = root.appendingPathComponent("main")
+        let linked = root.appendingPathComponent("linked")
+        try FileManager.default.createDirectory(at: main, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: linked, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let porcelain = """
+        worktree \(main.path)
+        branch refs/heads/main
+
+        worktree \(linked.path)
+        branch refs/heads/feature
+        """
+
+        let parsed = WorktreeService.parsePorcelain(porcelain, projectId: "p1")
+
+        #expect(parsed.map(\.isMainWorktree) == [true, false])
+    }
+
     @Test func parsePorcelainPopulatesCreatedAtFromFilesystem() throws {
         let fm = FileManager.default
         let tmp = fm.temporaryDirectory.appendingPathComponent("alas-ctime-\(UUID().uuidString)")

--- a/docs/superpowers/plans/2026-07-22-worktree-gg-mode-implementation.md
+++ b/docs/superpowers/plans/2026-07-22-worktree-gg-mode-implementation.md
@@ -1,0 +1,319 @@
+# Worktree GG Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make GG mode a stable worktree policy with repository defaults, main-worktree opt-out, branch-prefix eligibility, and consistent UI and agent integration for empty or temporarily unavailable stacks.
+
+**Architecture:** Add a pure `GGWorktreeContextResolver` that separates persisted policy from runtime availability and branch eligibility. Persist sparse `Inherit / On / Off` worktree overrides in `ProjectConfig`, then feed the resolved context into the right pane, sidebar, ACP preamble, and GG MCP injection. Replace commit-trailer presentation gating with explicit stack-load state so empty and failed loads remain in GG mode.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Observation, Swift Testing, XcodeGen, existing GG CLI integration.
+
+---
+
+## File Map
+
+- Create `Alas/Sources/Integrations/GG/GGWorktreeContext.swift` for policy and resolution.
+- Modify `ProjectConfig`, `ProjectsManager`, and `AppState` for persistence and shared context.
+- Modify `RightPaneStore`, `RightPaneState`, `ChangesTabView`, and `GGStackDrawer` for stable presentation.
+- Modify `WorktreeRowView`, `RepoGroupView`, `SidebarView`, and `ChangesPane` for controls and status.
+- Update ACP/MCP providers in `AppState` to use the same effective context.
+- Add focused Swift Testing coverage and regenerate `Alas.xcodeproj/project.pbxproj`.
+
+### Task 1: Persisted Policy And Pure Resolver
+
+**Files:**
+- Create: `Alas/Sources/Integrations/GG/GGWorktreeContext.swift`
+- Modify: `Alas/Sources/Persistence/ProjectConfig.swift`
+- Modify: `Alas/Sources/App/ProjectsManager.swift`
+- Create: `AlasTests/Integrations/GGWorktreeContextTests.swift`
+- Modify: `AlasTests/GGConfigCodableTests.swift`
+
+- [ ] **Step 1: Write failing resolver and Codable tests**
+
+Cover linked `Off / Auto / On`, main inherited Off, explicit overrides both ways, global and remote hard stops, missing username, simple and nested prefixes, invalid `username/`, sparse encoding, and tolerant old-config decoding.
+
+```swift
+@Test func mainInheritsOffButCanBeEnabled() {
+    let inherited = GGWorktreeContextResolver.resolve(
+        masterEnabled: true, ggInstalled: true, isRemoteProject: false,
+        projectMode: .on, worktreeOverride: .inherit, isMainWorktree: true,
+        repoHasGGConfig: true, branchUsername: "nacho", branch: "nacho/stack"
+    )
+    #expect(inherited == .inactive(.policyOff))
+
+    let enabled = GGWorktreeContextResolver.resolve(
+        masterEnabled: true, ggInstalled: true, isRemoteProject: false,
+        projectMode: .off, worktreeOverride: .on, isMainWorktree: true,
+        repoHasGGConfig: true, branchUsername: "nacho", branch: "nacho/stack"
+    )
+    #expect(enabled == .active(stackName: "stack"))
+}
+
+@Test func nestedStackNamesAreEligible() {
+    #expect(GGWorktreeContextResolver.stackName(
+        branch: "nacho/team/feature", username: "nacho"
+    ) == "team/feature")
+    #expect(GGWorktreeContextResolver.stackName(branch: "nacho/", username: "nacho") == nil)
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGWorktreeContextTests \
+  -only-testing:AlasTests/GGConfigCodableTests
+```
+
+Expected: compilation fails because the new policy types and persisted map do not exist.
+
+- [ ] **Step 3: Implement policy types and resolver**
+
+Create this module contract:
+
+```swift
+enum GGWorktreeMode: String, Codable, Equatable, CaseIterable {
+    case inherit, on, off
+}
+
+enum GGWorktreeInactiveReason: Equatable {
+    case masterDisabled, cliMissing, remoteProject, policyOff
+    case branchUsernameMissing
+    case branchPrefixMismatch(expectedPrefix: String)
+}
+
+enum GGWorktreeContext: Equatable {
+    case active(stackName: String)
+    case inactive(GGWorktreeInactiveReason)
+
+    var isActive: Bool {
+        if case .active = self { return true }
+        return false
+    }
+}
+```
+
+`GGWorktreeContextResolver.resolve` must apply hard availability stops, resolve explicit override before the main/linked default, require `branchUsername + "/"`, and return the non-empty suffix as the stack name. Add `ggWorktreeModes: [String: GGWorktreeMode] = [:]` to `ProjectConfig`, with tolerant decoding and normal encoding. Add manager get/set/remove methods; setting `.inherit` removes the key.
+
+- [ ] **Step 4: Run the Task 1 command and verify all selected tests pass**
+
+### Task 2: Shared Context And Right-Pane Loading
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/Right/RightPaneStore.swift`
+- Modify: `Alas/Sources/Right/RightPaneState.swift`
+- Modify: `AlasTests/RightPaneGGStackTests.swift`
+- Create: `AlasTests/GGAppContextTests.swift`
+
+- [ ] **Step 1: Write failing shared-context and empty-stack tests**
+
+Test `AppState` context construction and prove an active context calls `currentStack` with no commits, nil becomes `.empty`, inactive does not call GG, and errors become `.failed` without deactivating context.
+
+```swift
+@Test @MainActor func activeContextQueriesGGWithoutGGIDCommits() async {
+    let service = StubGGService(stack: nil)
+    let state = makeState(ggService: service)
+    state.ggContextProvider = { _ in .active(stackName: "empty-stack") }
+    state.ggStackSourceCommits = []
+
+    await state.refreshGGStack()
+
+    #expect(service.currentStackCalls == 1)
+    #expect(state.ggContext == .active(stackName: "empty-stack"))
+    #expect(state.ggStackLoadState == .empty)
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGAppContextTests \
+  -only-testing:AlasTests/RightPaneGGStackTests
+```
+
+Expected: compilation fails for the context provider and load state.
+
+- [ ] **Step 3: Implement shared context and load lifecycle**
+
+Add `AppState.ggWorktreeContext(project:worktree:branch:)` using app config, `GGAvailability`, main identity, repo config, username, override, and live branch. Replace `ggGateProvider` with `ggContextProvider` and add:
+
+```swift
+enum GGStackLoadState: Equatable {
+    case inactive, loading, empty, loaded
+    case failed(String)
+}
+
+var ggContext: GGWorktreeContext = .inactive(.policyOff)
+var ggStackLoadState: GGStackLoadState = .inactive
+var ggContextProvider: (@MainActor (_ branch: String) -> GGWorktreeContext)?
+```
+
+In `refreshGGStack`, publish current context first. Inactive clears stack, summary, cache, and load state. Active bypasses `isStackShaped`, calls `currentStack`, maps stack to `.loaded`, nil to `.empty`, and errors to `.failed(error.localizedDescription)` with cache key unset. Preserve cancellation, snapshot generation, paused-operation, and undo recovery guards.
+
+- [ ] **Step 4: Run the Task 2 command and verify all selected tests pass**
+
+### Task 3: Stable Changes And Drawer Presentation
+
+**Files:**
+- Modify: `Alas/Sources/Right/ChangesTabView.swift`
+- Modify: `Alas/Sources/Integrations/GG/GGStackDrawer.swift`
+- Modify: `Alas/Sources/Right/ChangesPreparationModel.swift`
+- Modify: `AlasTests/ChangesTabViewTests.swift`
+- Modify: `AlasTests/Integrations/GGStackReadinessModelTests.swift`
+
+- [ ] **Step 1: Write failing presentation tests**
+
+Test active context shows GG drawer for loading, empty, and failed states; inactive without recovery does not. Test an active empty stack permits `New stack commit` while amend/absorb say `Create the first stack commit.` Test the retryable error presentation model.
+
+```swift
+@Test func activeEmptyContextShowsGGDrawer() {
+    #expect(ChangesTabView.shouldShowGGDrawer(
+        ggContextActive: true, stack: nil,
+        pausedGGOperation: nil, hasUndoCandidate: false
+    ))
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/ChangesTabViewTests \
+  -only-testing:AlasTests/GGStackReadinessModelTests
+```
+
+Expected: drawer visibility still requires loaded stack or recovery.
+
+- [ ] **Step 3: Implement stable presentation**
+
+Include `rps.ggContext.isActive` in GG drawer and preparation selection. Add a pure placeholder model with `title`, `summary`, optional `detail`, and `canRetry`. Map loading to `Loading`, empty to `0 commits`, and failed to `Unavailable` plus the error and Retry. Reuse drawer layout and refresh button. Allow first commit for active empty context; keep amend and absorb disabled until a stack commit exists.
+
+- [ ] **Step 4: Run the Task 3 command and verify all selected tests pass**
+
+### Task 4: Sidebar Controls And Settings Copy
+
+**Files:**
+- Modify: `Alas/Sources/Sidebar/WorktreeRowView.swift`
+- Modify: `Alas/Sources/Sidebar/RepoGroupView.swift`
+- Modify: `Alas/Sources/Sidebar/SidebarView.swift`
+- Modify: `Alas/Sources/Settings/ChangesPane.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Create: `AlasTests/GGWorktreeMenuModelTests.swift`
+- Modify: `AlasTests/WorktreeRowHeightTests.swift`
+
+- [ ] **Step 1: Write failing menu-model tests**
+
+Create tests for selected raw mode, main inherited Off, prefix explanation, missing CLI, remote exclusion, and active empty-stack indicator using:
+
+```swift
+struct GGWorktreeMenuModel: Equatable {
+    let selectedMode: GGWorktreeMode
+    let effectiveActive: Bool
+    let inactiveExplanation: String?
+    let showsStatusIndicator: Bool
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGWorktreeMenuModelTests \
+  -only-testing:AlasTests/WorktreeRowHeightTests
+```
+
+Expected: compilation fails because the menu model and row inputs do not exist.
+
+- [ ] **Step 3: Implement menu, status, and settings UI**
+
+Add `AppState.setGGWorktreeMode` to update the manager, save projects, and reevaluate gates. Pass the menu model, raw override, and setter through sidebar views. Add a `GG Mode` submenu with `Inherit repository default`, `On`, and `Off`, checkmark the raw selection, and show one disabled inactive explanation below a divider. Hide the submenu for remote worktrees. Show compact `GG` in the existing metadata row only when active and no loaded summary is present. Rename Settings copy to `Default for linked worktrees` and `Main worktrees default Off. Override individual worktrees from their sidebar menu.`
+
+- [ ] **Step 4: Run the Task 4 command and verify all selected tests pass**
+
+### Task 5: ACP, MCP, Inbox, And Deletion Consistency
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/App/ProjectsManager.swift`
+- Modify: `AlasTests/ACP/ACPMCPPromptPreambleTests.swift`
+- Modify: `AlasTests/Integrations/GGMCPInjectionTests.swift`
+- Modify: `AlasTests/GGInboxTabsTests.swift`
+- Modify: `AlasTests/GGConfigCodableTests.swift`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Test active context attaches GG MCP and returns `.generic` preamble for an empty stack, inactive context attaches neither, loaded context returns `.stack`, Inbox availability ignores its hosting worktree override, deletion removes an override, and archive preserves it.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/ACPMCPPromptPreambleTests \
+  -only-testing:AlasTests/GGMCPInjectionTests \
+  -only-testing:AlasTests/GGInboxTabsTests \
+  -only-testing:AlasTests/GGConfigCodableTests
+```
+
+Expected: override and empty-stack cases fail against project-only gating.
+
+- [ ] **Step 3: Route integrations through effective context**
+
+Replace project-only guards in `ggMCPProvider` and `ggPreambleProvider` with shared worktree context. Return `.generic` for active context without loaded stack. Preserve configured MCP override precedence. Keep Inbox repository-capability driven: require the global switch, installed GG, a local project, and either local GG config, project mode `On`, or an explicit worktree `On`; do not consult the hosting worktree's effective mode. On successful deletion and failed optimistic removal, remove the override and save; preserve it on archive.
+
+- [ ] **Step 4: Run the Task 5 command and verify all selected tests pass**
+
+### Task 6: Full Verification
+
+**Files:**
+- Modify: `Alas.xcodeproj/project.pbxproj` via `xcodegen`
+
+- [ ] **Step 1: Regenerate and check the diff**
+
+```bash
+xcodegen
+git diff --check
+git status --short
+```
+
+Expected: generation succeeds; only approved GG files, tests, project output, and plan are present.
+
+- [ ] **Step 2: Run focused GG regressions**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGWorktreeContextTests \
+  -only-testing:AlasTests/GGAppContextTests \
+  -only-testing:AlasTests/RightPaneGGStackTests \
+  -only-testing:AlasTests/ChangesTabViewTests \
+  -only-testing:AlasTests/GGStackReadinessModelTests \
+  -only-testing:AlasTests/GGWorktreeMenuModelTests \
+  -only-testing:AlasTests/ACPMCPPromptPreambleTests \
+  -only-testing:AlasTests/GGMCPInjectionTests
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Run required repository verification**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: build and full test suite pass with exit code 0.
+
+- [ ] **Step 4: Inspect final scope**
+
+```bash
+git status --short
+git diff --check
+git diff --stat
+git diff
+```
+
+Expected: no unrelated changes and no tracked `.superpowers/brainstorm` files.

--- a/docs/superpowers/specs/2026-07-22-worktree-gg-mode-design.md
+++ b/docs/superpowers/specs/2026-07-22-worktree-gg-mode-design.md
@@ -1,0 +1,245 @@
+# Worktree GG Mode
+
+Date: 2026-07-22
+Status: Approved design
+
+## Context
+
+Alas currently stores `Off`, `Auto`, or `On` for each project. That setting
+only controls the first three GG gates: the app-wide switch, GG installation,
+and repository configuration. The Changes pane additionally requires a commit
+with a `GG-ID:` trailer before it asks `gg ls --json` for the current stack.
+
+This makes GG presentation unstable and incorrectly hides it for a valid empty
+stack created with `gg co`. A transient `gg ls` failure also clears the stack
+and silently restores the ordinary review-loop affordances. The user sees the
+workflow change without a visible policy change or an explanation.
+
+The existing manual project setting is only available in Settings. It cannot
+express the common policy that linked worktrees use GG while the repository's
+main worktree does not.
+
+## Goals
+
+- Make GG mode an explicit worktree policy with a repository-level default.
+- Default GG-capable linked worktrees to GG mode and the main worktree to
+  ordinary mode.
+- Let each worktree explicitly inherit, enable, or disable GG mode.
+- Recognize an eligible, empty GG stack without requiring a `GG-ID` commit.
+- Keep GG presentation stable through empty results and transient refresh
+  failures.
+- Use one effective-mode decision for the Changes pane, sidebar, ACP context,
+  and built-in `gg-mcp` attachment.
+- Keep ordinary changes and review-loop behavior unchanged for worktrees where
+  GG mode is not effective.
+
+## Non-goals
+
+- Changing GG's branch naming convention or stack metadata.
+- Making GG available for registered remote projects; GG execution remains
+  local-only.
+- Replacing the app-wide stacked-diffs switch.
+- Adding a permanent mode picker to the Changes header.
+- Reworking stack actions, mutation coordination, or the GG Inbox workflow.
+
+## Policy Model
+
+The app-wide stacked-diffs switch remains the top-level availability control.
+When it is off, no worktree may enter GG mode or attach GG-specific agent
+context.
+
+The existing project `Off`, `Auto`, and `On` setting becomes the default policy
+for linked worktrees:
+
+- `Off`: a linked worktree with no override resolves to Off.
+- `Auto`: a linked worktree with no override resolves to On when the repository
+  has local GG configuration; otherwise it resolves to Off.
+- `On`: a linked worktree with no override resolves to On whenever the remaining
+  GG prerequisites are available.
+
+The main worktree has an implicit default of Off regardless of the project
+default. This prevents the primary checkout from unexpectedly adopting stack
+workflows. The user may still explicitly enable it.
+
+Each worktree stores one of these overrides:
+
+- `Inherit`: use the implicit main-worktree default or the linked-worktree
+  project default.
+- `On`: resolve the worktree policy to On, even when the project default is Off.
+- `Off`: resolve the worktree policy to Off, even when the project default is
+  Auto or On.
+
+The override is persisted in `ProjectConfig` by the worktree's stable,
+path-derived identity. Missing override data decodes as `Inherit`. Overrides
+are removed when their worktrees are deleted, so recreating a worktree at the
+same path starts from current defaults rather than reviving stale intent.
+
+## Effective GG Context
+
+A single resolver computes a worktree's effective GG context. It receives:
+
+- The app-wide stacked-diffs setting.
+- GG installation and supported capabilities.
+- Whether the project is local or remote.
+- The project default and worktree override.
+- Whether the worktree is the project's main checkout.
+- The live current branch.
+- The effective GG `branch_username` from repository or global config.
+
+The resolver separates policy from runtime status. It reports either an active
+GG context or an inactive reason suitable for presentation and tests.
+
+A worktree enters GG mode only when:
+
+1. The app-wide integration is enabled, GG is installed, and the project is
+   local.
+2. The resolved worktree policy is On.
+3. `branch_username` is available.
+4. The live branch is `<branch_username>/<non-empty stack name>`.
+
+Nested stack names remain valid. For example, username `nacho` accepts both
+`nacho/feature` and `nacho/team/feature`, but rejects `main`, `other/feature`,
+and `nacho/`.
+
+This effective context is the shared source of truth for:
+
+- GG versus ordinary Changes presentation.
+- Sidebar GG status.
+- ACP first-prompt GG context.
+- Built-in `gg-mcp` attachment.
+
+The project-wide GG Inbox remains capability-driven. Its availability does not
+depend on the override of the worktree that happens to host the inbox tab.
+
+## Stack Loading And Presentation
+
+Once the effective context is active, Alas remains in GG mode independently of
+whether stack metadata has loaded. `RightPaneState` calls `gg ls --json`
+without requiring a stack-shaped commit list first.
+
+The presentation state distinguishes:
+
+- Loading stack metadata.
+- An eligible branch with no returned stack metadata or zero commits.
+- A loaded stack.
+- A failed stack refresh.
+
+An empty result renders the GG preparation workflow and a zero-commit stack
+drawer state. This covers the period immediately after `gg co` and before the
+first commit.
+
+A refresh failure clears metadata that belongs to an older branch but retains
+GG presentation. The drawer shows the classified error and a Retry action.
+Authentication, network, command, and unsupported-schema failures therefore do
+not silently swap the user into the ordinary review loop.
+
+Existing async generation and snapshot-invalidation checks continue to reject
+late results from an earlier branch or refresh. `GG-ID` trailers may contribute
+to cache invalidation or stack-data validation, but they are not an eligibility
+or presentation gate.
+
+When the live branch changes, the resolver runs again. A matching branch entered
+through `gg co` activates GG mode immediately. A nonmatching branch uses the
+ordinary Changes workflow even when the worktree override is On, and the UI
+explains that the branch does not meet GG's naming requirement.
+
+## User Interface
+
+### Settings
+
+In **Settings > Changes > Stacked diffs**, keep the per-project segmented
+control but label and describe it as the default for linked worktrees. The copy
+states that main worktrees default Off and that individual overrides are in the
+sidebar.
+
+### Worktree menu
+
+Each local worktree's existing sidebar context menu gains a **GG Mode** submenu:
+
+- `Inherit repository default`
+- `On`
+- `Off`
+
+The current override has a checkmark. For the main worktree, the Inherit item
+still resolves to Off. When GG cannot become active, the menu includes a concise
+disabled explanation such as `Branch must start with nacho/`, `gg is not
+installed`, or `GG is unavailable for remote projects`.
+
+### Status
+
+An effectively active worktree receives the existing GG identity and summary
+treatment in the sidebar. A compact GG indication remains available for an
+empty stack, where there is no commit-derived summary yet.
+
+The Changes pane reuses existing Alas preparation and drawer components rather
+than adding a permanent settings control to its header:
+
+- Empty stack: GG preparation UI and zero-commit drawer state.
+- Loaded stack: existing stack-aware UI.
+- Refresh failure: GG drawer with error details and Retry.
+- Inactive context: existing ordinary Changes and review-loop UI.
+
+Exact spacing, typography, colors, icons, and menu styling follow existing Alas
+components. The brainstorming wireframe established placement only and is not a
+visual specification.
+
+## Configuration Migration
+
+Older project files have no worktree override map and decode every worktree as
+`Inherit`. The existing project `ggMode` value is preserved:
+
+- Linked worktrees resolve through that value.
+- Main worktrees resolve Off until explicitly enabled.
+
+No eager override entries are written during migration. This preserves the
+difference between inherited behavior and a deliberate user choice, including
+when the project default changes later.
+
+## Error Handling
+
+- Global disablement, missing GG, remote projects, missing `branch_username`,
+  and branch-prefix mismatch return explicit inactive reasons.
+- A missing username fails closed because Alas does not reimplement GG's forge
+  identity lookup.
+- `gg ls` returning no current stack on an otherwise eligible branch is an
+  empty GG state, not a reason to enter ordinary mode.
+- A transient or classified `gg ls` error retains GG mode and exposes Retry.
+- Stale stack identity and summary data are cleared before presenting an empty
+  or failed state for a different branch.
+- Changing any relevant setting reevaluates cached right-pane states
+  immediately.
+
+## Testing
+
+Focused Swift Testing coverage includes:
+
+- The policy matrix across the app-wide switch, GG availability, local versus
+  remote projects, project mode, main versus linked worktrees, and every
+  worktree override.
+- Branch eligibility for simple and nested stack names, an empty stack name,
+  the wrong username prefix, a missing username, and live branch switches.
+- An eligible empty stack entering GG mode without any `GG-ID` commit.
+- Empty `gg ls` output and refresh failures retaining GG presentation.
+- Retry, stale-result rejection, and clearing metadata from a previous branch.
+- Tolerant Codable migration and deleted-worktree override cleanup.
+- Sidebar submenu selection, inherited/effective state, inactive explanations,
+  and the zero-commit GG indicator.
+- Updated Settings copy and project-default bindings.
+- Matching decisions across Changes, ACP prompt context, and GG MCP injection.
+- Regression coverage for ordinary review-loop presentation in opted-out or
+  branch-ineligible worktrees.
+
+## Acceptance Criteria
+
+- After `gg co my-new-stack`, an opted-in eligible worktree shows GG Changes UI
+  before the first commit exists.
+- Returning to an eligible GG worktree does not show ordinary affordances merely
+  because stack metadata is loading or refresh failed.
+- GG-capable linked worktrees inherit GG On in project Auto mode, while the main
+  worktree inherits Off.
+- Users can override any worktree On or Off from its sidebar menu, including the
+  main worktree and a worktree in a project whose default is Off.
+- Switching an opted-in worktree to a branch outside the configured username
+  prefix restores ordinary mode and provides a clear inactive reason.
+- UI presentation, ACP context, and `gg-mcp` attachment agree on effective GG
+  mode for the same worktree.


### PR DESCRIPTION
## Summary
- add per-worktree GG mode overrides with inherited project defaults and an opt-out main worktree default
- resolve GG mode from explicit policy, CLI availability, repository configuration, and branch-prefix eligibility
- keep right-pane, sidebar, ACP, MCP, and Inbox behavior consistent for empty, active, unavailable, and paused GG stacks
- persist and clean up worktree policy and actual Git main-worktree identity

## Test plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination "platform=macOS" -quiet build`
- focused affected suites: 257 passed, 0 failed
- full macOS suite: 6,355 passed; 11 verified baseline failures (8 opt-in SSH tests, 2 existing order-dependent GG assertions, 1 Markdown sizing test reproduced on `origin/main`)