### PR TITLE
feat(gg): add mode selection to new worktree creation

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1252,7 +1252,11 @@ final class AppState {
                     )
                     projectsManager.setOperationState(
                         id: optimistic.id,
-                        state: .createFailed(message: error.localizedDescription, base: base)
+                        state: .createFailed(
+                            message: error.localizedDescription,
+                            base: base,
+                            ggWorktreeMode: ggWorktreeMode
+                        )
                     )
                 }
             } catch {
@@ -1262,7 +1266,10 @@ final class AppState {
                     worktreeId: optimistic.id,
                     mode: ggWorktreeMode
                 )
-                projectsManager.setOperationState(id: optimistic.id, state: .createFailed(message: msg, base: base))
+                projectsManager.setOperationState(
+                    id: optimistic.id,
+                    state: .createFailed(message: msg, base: base, ggWorktreeMode: ggWorktreeMode)
+                )
             }
         }
         return optimistic.id
@@ -1361,7 +1368,7 @@ final class AppState {
         guard !id.isEmpty else { return .failure(.init(message: "Could not start worktree creation.")) }
         for _ in 0..<1_200 {
             switch projectsManager.operationState(for: id) {
-            case .createFailed(let message, _):
+            case .createFailed(let message, _, _):
                 return .failure(.init(message: message))
             case .creating:
                 try? await Task.sleep(for: .milliseconds(250))

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1253,6 +1253,7 @@ final class AppState {
                     projectsManager.setOperationState(
                         id: optimistic.id,
                         state: .createFailed(
+                            projectId: projectId,
                             message: error.localizedDescription,
                             base: base,
                             ggWorktreeMode: ggWorktreeMode
@@ -1268,7 +1269,12 @@ final class AppState {
                 )
                 projectsManager.setOperationState(
                     id: optimistic.id,
-                    state: .createFailed(message: msg, base: base, ggWorktreeMode: ggWorktreeMode)
+                    state: .createFailed(
+                        projectId: projectId,
+                        message: msg,
+                        base: base,
+                        ggWorktreeMode: ggWorktreeMode
+                    )
                 )
             }
         }
@@ -1368,7 +1374,7 @@ final class AppState {
         guard !id.isEmpty else { return .failure(.init(message: "Could not start worktree creation.")) }
         for _ in 0..<1_200 {
             switch projectsManager.operationState(for: id) {
-            case .createFailed(let message, _, _):
+            case .createFailed(_, let message, _, _):
                 return .failure(.init(message: message))
             case .creating:
                 try? await Task.sleep(for: .milliseconds(250))
@@ -1928,7 +1934,10 @@ final class AppState {
             GGStackSummaryStore.shared.summaries[previous.path] = nil
             GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
         }
-        if changed { saveProjects() }
+        if changed {
+            saveProjects()
+            rightPaneStore.reevaluateGGGates()
+        }
         restartProjectGitWatchers(previousPaths: previousPaths)
         return changed
     }
@@ -1950,7 +1959,10 @@ final class AppState {
     func refreshAllProjectTopologies() async -> Bool {
         let previousPaths = Dictionary(uniqueKeysWithValues: projectsManager.projects.map { ($0.id, $0.path) })
         let changed = await projectsManager.refreshAll()
-        if changed { saveProjects() }
+        if changed {
+            saveProjects()
+            rightPaneStore.reevaluateGGGates()
+        }
         restartProjectGitWatchers(previousPaths: previousPaths)
         return changed
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -15,6 +15,7 @@ final class AppState {
     var config: AppConfig
     var themeStore: ThemeStore
     var projectsManager: ProjectsManager
+    private var unpersistedGGWorktreeModes: [String: [String: GGWorktreeMode]] = [:]
     var spacesManager: SpacesManager
     var selectedWorktreeId: String?
     var pendingSettingsSection: SettingsSection?
@@ -1088,7 +1089,8 @@ final class AppState {
         branch: String,
         destination: URL,
         runStartup: Bool,
-        launchSurface: WorktreeLaunchSurface
+        launchSurface: WorktreeLaunchSurface,
+        ggWorktreeMode: GGWorktreeMode = .inherit
     ) async -> String {
         guard let project = projects.first(where: { $0.id == projectId }) else {
             // Should not happen if the dialog validated the project; fail silently.
@@ -1142,7 +1144,13 @@ final class AppState {
             _ = switchToSpace(id: containing)
         }
         projectsManager.insertOptimisticWorktree(optimistic)
+        setUnpersistedGGWorktreeMode(
+            projectId: projectId,
+            worktreeId: optimistic.id,
+            mode: ggWorktreeMode
+        )
         projectsManager.setOperationState(id: optimistic.id, state: .creating)
+        rightPaneStore.reevaluateGGGate(worktreeId: optimistic.id)
         if launchSurface != .delegated {
             selectWorktree(id: optimistic.id)
         }
@@ -1198,6 +1206,16 @@ final class AppState {
                     )
                     _ = try await refreshProjectWorktrees(projectId: project.id)
                     guard projects.contains(where: { $0.id == projectId }) else { return }
+                    removeUnpersistedGGWorktreeMode(projectId: project.id, worktreeId: newWorktree.id)
+                    projectsManager.setGGWorktreeMode(
+                        projectId: project.id,
+                        worktreeId: newWorktree.id,
+                        mode: ggWorktreeMode
+                    )
+                    if ggWorktreeMode != .inherit {
+                        saveProjects()
+                    }
+                    rightPaneStore.reevaluateGGGate(worktreeId: newWorktree.id)
                     projectsManager.setOperationState(id: optimistic.id, state: nil)
                     if wasHidden {
                         saveProjects()
@@ -1227,6 +1245,11 @@ final class AppState {
                         break
                     }
                 } catch {
+                    discardUnpersistedGGWorktreeMode(
+                        projectId: projectId,
+                        worktreeId: optimistic.id,
+                        mode: ggWorktreeMode
+                    )
                     projectsManager.setOperationState(
                         id: optimistic.id,
                         state: .createFailed(message: error.localizedDescription, base: base)
@@ -1234,6 +1257,11 @@ final class AppState {
                 }
             } catch {
                 let msg = error.localizedDescription
+                discardUnpersistedGGWorktreeMode(
+                    projectId: projectId,
+                    worktreeId: optimistic.id,
+                    mode: ggWorktreeMode
+                )
                 projectsManager.setOperationState(id: optimistic.id, state: .createFailed(message: msg, base: base))
             }
         }
@@ -1620,6 +1648,7 @@ final class AppState {
 
     func removeFailedOptimisticWorktree(id: String, projectId: String) {
         cleanupWorktreeState(worktreeId: id)
+        removeUnpersistedGGWorktreeMode(projectId: projectId, worktreeId: id)
         projectsManager.removeGGWorktreeMode(projectId: projectId, worktreeId: id)
         projectsManager.removeOptimisticWorktree(id: id, projectId: projectId)
         saveProjects()
@@ -1752,6 +1781,7 @@ final class AppState {
             remoteRootsToUnregister = []
         }
         stopProjectGitWatcher(projectId: id)
+        unpersistedGGWorktreeModes.removeValue(forKey: id)
         projectsManager.removeProject(id: id, unregisterRemoteRoots: remoteRootsToUnregister.isEmpty)
         spacesManager.removeProjectEverywhere(id)
         saveProjects()
@@ -5516,10 +5546,7 @@ final class AppState {
             masterEnabled: config.changes.stackedDiffsEnabled,
             ggInstalled: ggInstalled,
             project: project,
-            worktreeOverride: projectsManager.ggWorktreeMode(
-                projectId: project.id,
-                worktreeId: worktree.id
-            ),
+            worktreeOverride: effectiveGGWorktreeMode(projectId: project.id, worktreeId: worktree.id),
             isMainWorktree: projectsManager.isMain(worktree, in: project),
             repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path),
             branchUsername: GGConfigReader.branchUsername(repoPath: project.path),
@@ -5531,10 +5558,7 @@ final class AppState {
         project: ProjectConfig,
         worktree: Worktree
     ) -> GGWorktreeMenuModel {
-        let selectedMode = projectsManager.ggWorktreeMode(
-            projectId: project.id,
-            worktreeId: worktree.id
-        )
+        let selectedMode = effectiveGGWorktreeMode(projectId: project.id, worktreeId: worktree.id)
         return GGWorktreeMenuModel(
             selectedMode: selectedMode,
             context: ggWorktreeContext(
@@ -5559,6 +5583,42 @@ final class AppState {
         )
         saveProjects()
         rightPaneStore.reevaluateGGGate(worktreeId: worktreeId)
+    }
+
+    private func discardUnpersistedGGWorktreeMode(
+        projectId: String,
+        worktreeId: String,
+        mode: GGWorktreeMode
+    ) {
+        guard mode != .inherit else { return }
+        removeUnpersistedGGWorktreeMode(projectId: projectId, worktreeId: worktreeId)
+        rightPaneStore.reevaluateGGGate(worktreeId: worktreeId)
+    }
+
+    private func setUnpersistedGGWorktreeMode(
+        projectId: String,
+        worktreeId: String,
+        mode: GGWorktreeMode
+    ) {
+        guard mode != .inherit else { return }
+        var modes = unpersistedGGWorktreeModes[projectId] ?? [:]
+        modes[worktreeId] = mode
+        unpersistedGGWorktreeModes[projectId] = modes
+    }
+
+    private func removeUnpersistedGGWorktreeMode(projectId: String, worktreeId: String) {
+        guard var modes = unpersistedGGWorktreeModes[projectId] else { return }
+        modes.removeValue(forKey: worktreeId)
+        if modes.isEmpty {
+            unpersistedGGWorktreeModes.removeValue(forKey: projectId)
+        } else {
+            unpersistedGGWorktreeModes[projectId] = modes
+        }
+    }
+
+    private func effectiveGGWorktreeMode(projectId: String, worktreeId: String) -> GGWorktreeMode {
+        unpersistedGGWorktreeModes[projectId]?[worktreeId]
+            ?? projectsManager.ggWorktreeMode(projectId: projectId, worktreeId: worktreeId)
     }
 
     func removePersistedGGWorktreeMode(projectId: String, worktreeId: String) {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -38,7 +38,9 @@ struct ProjectUpdate: Equatable {
 enum WorktreeOperationState: Equatable {
     case creating
     case deleting
-    case createFailed(message: String, base: String)
+    /// The raw GG policy is retry metadata only; AppState removes its effective
+    /// optimistic overlay before entering this state.
+    case createFailed(message: String, base: String, ggWorktreeMode: GGWorktreeMode)
     case deleteFailed(message: String)
 }
 

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -40,7 +40,12 @@ enum WorktreeOperationState: Equatable {
     case deleting
     /// The raw GG policy is retry metadata only; AppState removes its effective
     /// optimistic overlay before entering this state.
-    case createFailed(message: String, base: String, ggWorktreeMode: GGWorktreeMode)
+    case createFailed(
+        projectId: String,
+        message: String,
+        base: String,
+        ggWorktreeMode: GGWorktreeMode
+    )
     case deleteFailed(message: String)
 }
 
@@ -370,6 +375,7 @@ final class ProjectsManager {
         let liveIds = Set(trees.map(\.id))
         var reconciled = trees
         var clearOperationIds: [String] = []
+        var resolvedCreateModes: [String: GGWorktreeMode] = [:]
         for (id, opState) in Array(worktreeOperationStates) {
             guard previousById[id] != nil || liveIds.contains(id) else { continue }
             switch opState {
@@ -385,10 +391,12 @@ final class ProjectsManager {
                 if !liveIds.contains(id) {
                     clearOperationIds.append(id)
                 }
-            case .createFailed:
+            case .createFailed(let originProjectId, _, _, let ggWorktreeMode):
+                guard originProjectId == projectId else { continue }
                 if liveIds.contains(id) {
                     // Worktree exists in git — transient failure is resolved; clear state.
                     clearOperationIds.append(id)
+                    resolvedCreateModes[id] = ggWorktreeMode
                 } else if let existing = previousById[id] {
                     // Preserve failed rows so they remain visible for retry/removal.
                     reconciled.append(existing)
@@ -418,7 +426,14 @@ final class ProjectsManager {
         projects[idx].hiddenWorktreePaths.removeAll { !live.contains($0) }
         let reconciledIds = Set(reconciled.map(\.id))
         let previousGGWorktreeModes = projects[idx].ggWorktreeModes
-        projects[idx].ggWorktreeModes = previousGGWorktreeModes.filter {
+        for (id, mode) in resolvedCreateModes {
+            if mode == .inherit {
+                projects[idx].ggWorktreeModes.removeValue(forKey: id)
+            } else {
+                projects[idx].ggWorktreeModes[id] = mode
+            }
+        }
+        projects[idx].ggWorktreeModes = projects[idx].ggWorktreeModes.filter {
             reconciledIds.contains($0.key)
         }
         return anchorChanged

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -94,7 +94,10 @@ struct NewWorktreeDialog: View {
                     if createsGGStack, case .disabled(let hint) = ggStackAvailability {
                         Text(hint).font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
                     } else if createsGGStack, case .enabled(let username) = ggStackAvailability, !stackName.isEmpty {
-                        Text("Branch: \(GGConfigReader.composeStackBranch(username: username, stackName: stackName))")
+                        Text(Self.ggBranchPreview(
+                            branch: GGConfigReader.composeStackBranch(username: username, stackName: stackName),
+                            base: stackPinnedBase
+                        ))
                             .font(.system(size: 11, design: .monospaced))
                             .foregroundColor(theme.color("fg-dim"))
                     }
@@ -427,6 +430,11 @@ struct NewWorktreeDialog: View {
 
     nonisolated static func ggModeAfterRepositoryChange(current _: GGWorktreeMode) -> GGWorktreeMode {
         .inherit
+    }
+
+    nonisolated static func ggBranchPreview(branch: String, base: String?) -> String {
+        guard let base else { return "Branch: \(branch)" }
+        return "Branch: \(branch), based on \(base)"
     }
 
     nonisolated static func activeName(

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -19,7 +19,7 @@ struct NewWorktreeDialog: View {
     @State private var branch: String = ""
     @State private var stackName: String = ""
     @State private var runStartup: Bool = true
-    @State private var createAsGGStack: Bool = false
+    @State private var ggMode: GGWorktreeMode = .inherit
     @State private var openAfterCreate: Bool = true
     @State private var launchMode: AppConfig.LauncherMode = .terminal
     /// The launcher mode to persist — preserves the user's intent even when
@@ -65,7 +65,7 @@ struct NewWorktreeDialog: View {
                     Text("Pinned to gg's stack base").font(.system(size: 11))
                         .foregroundColor(theme.color("fg-dim"))
                 }
-                DialogField(label: createAsGGStack ? "Stack name" : "Branch name") {
+                DialogField(label: createsGGStack ? "Stack name" : "Branch name") {
                     AlasField(
                         text: activeNameBinding,
                         monospaced: true,
@@ -80,15 +80,20 @@ struct NewWorktreeDialog: View {
                         .foregroundColor(theme.color("fg"))
                 }
                 if ggStackAvailability != .hidden {
-                    HStack(spacing: 10) {
-                        AlasToggle(on: $createAsGGStack)
-                            .disabled({ if case .disabled = ggStackAvailability { return true } else { return false } }())
-                        Text("Create as gg stack").font(.system(size: 12))
-                            .foregroundColor(theme.color("fg"))
+                    DialogField(label: "GG mode") {
+                        Picker("GG mode", selection: $ggMode) {
+                            Text("Inherit").tag(GGWorktreeMode.inherit)
+                            Text("On").tag(GGWorktreeMode.on)
+                            Text("Off").tag(GGWorktreeMode.off)
+                        }
+                        .pickerStyle(.segmented)
                     }
-                    if case .disabled(let hint) = ggStackAvailability {
+                    Text(Self.ggModeDescription(mode: ggMode, createsGGStack: createsGGStack))
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim"))
+                    if createsGGStack, case .disabled(let hint) = ggStackAvailability {
                         Text(hint).font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
-                    } else if createAsGGStack, case .enabled(let username) = ggStackAvailability, !stackName.isEmpty {
+                    } else if createsGGStack, case .enabled(let username) = ggStackAvailability, !stackName.isEmpty {
                         Text("Branch: \(GGConfigReader.composeStackBranch(username: username, stackName: stackName))")
                             .font(.system(size: 11, design: .monospaced))
                             .foregroundColor(theme.color("fg-dim"))
@@ -118,6 +123,7 @@ struct NewWorktreeDialog: View {
                 projectsEmpty: state.projects.isEmpty,
                 branchEmpty: activeName.isEmpty,
                 branchValidation: branchValidationMessage,
+                ggConfigurationMissing: ggConfigurationMissing,
                 requiresAcpAgent: openAfterCreate && launchMode == .acp,
                 hasAcpAgent: launchAgentId != "none"
             )
@@ -141,7 +147,7 @@ struct NewWorktreeDialog: View {
         }
         .onChange(of: projectId) { _, _ in
             applyLaunchDefaults(for: projectId)
-            createAsGGStack = Self.stackModeSurvives(createAsGGStack, availability: ggStackAvailability)
+            ggMode = Self.ggModeAfterRepositoryChange(current: ggMode)
             // Seed the base for the new project synchronously so the picker
             // never shows the previous project's value; the async branch load
             // refines it (guarded: it skips pinned bases and user edits).
@@ -154,8 +160,8 @@ struct NewWorktreeDialog: View {
         .onChange(of: stackName) { _, _ in
             createErrorMessage = nil
         }
-        .onChange(of: createAsGGStack) { _, isOn in
-            if isOn {
+        .onChange(of: ggMode) { _, _ in
+            if createsGGStack {
                 if let pinned = stackPinnedBase { base = pinned }
             }
         }
@@ -170,14 +176,14 @@ struct NewWorktreeDialog: View {
     }
 
     private var activeName: String {
-        Self.activeName(createAsGGStack: createAsGGStack, branch: branch, stackName: stackName)
+        Self.activeName(createsGGStack: createsGGStack, branch: branch, stackName: stackName)
     }
 
     private var activeNameBinding: Binding<String> {
         Binding(
             get: { activeName },
             set: { newValue in
-                if createAsGGStack {
+                if createsGGStack {
                     stackName = newValue
                 } else {
                     branch = newValue
@@ -200,11 +206,7 @@ struct NewWorktreeDialog: View {
         guard let project = state.projects.first(where: { $0.id == projectId }) else { return .hidden }
         let gatePassed = state.config.changes.stackedDiffsEnabled
             && GGAvailability.shared.isInstalled
-            && GGStackGate.projectEnabled(
-                masterEnabled: true, ggInstalled: true,
-                mode: project.ggMode, repoPath: project.path,
-                isRemoteProject: project.host != nil
-            )
+            && project.host == nil
         guard gatePassed else { return .hidden }
         return GGStackCreateMode.availability(
             gatePassed: true,
@@ -212,11 +214,29 @@ struct NewWorktreeDialog: View {
         )
     }
 
+    private var createsGGStack: Bool {
+        guard let project = state.projects.first(where: { $0.id == projectId }) else { return false }
+        return GGStackCreateMode.createsStack(
+            masterEnabled: state.config.changes.stackedDiffsEnabled,
+            ggInstalled: GGAvailability.shared.isInstalled,
+            isRemoteProject: project.host != nil,
+            projectMode: project.ggMode,
+            worktreeMode: ggMode,
+            repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path)
+        )
+    }
+
+    private var ggConfigurationMissing: Bool {
+        guard createsGGStack else { return false }
+        if case .disabled = ggStackAvailability { return true }
+        return false
+    }
+
     /// The branch actually created. In stack mode the real branch follows
     /// gg's `<username>/<name>` convention; otherwise the plain branch field
     /// is used verbatim (including its seeded global branch prefix).
     private var effectiveBranch: String {
-        if createAsGGStack, case .enabled(let username) = ggStackAvailability {
+        if createsGGStack, case .enabled(let username) = ggStackAvailability {
             return GGConfigReader.composeStackBranch(username: username, stackName: stackName)
         }
         return branch
@@ -228,7 +248,7 @@ struct NewWorktreeDialog: View {
     /// syncing/PR-ing against the repo default. Nil when create-as-stack is
     /// off/unavailable or gg config records no base (then the picker stays free).
     private var stackPinnedBase: String? {
-        guard createAsGGStack, case .enabled = ggStackAvailability,
+        guard createsGGStack, case .enabled = ggStackAvailability,
               let project = state.projects.first(where: { $0.id == projectId })
         else { return nil }
         return GGConfigReader.defaultBase(repoPath: project.path)
@@ -347,7 +367,8 @@ struct NewWorktreeDialog: View {
                 branch: effectiveBranch,
                 destination: dest,
                 runStartup: runStartup,
-                launchSurface: surface
+                launchSurface: surface,
+                ggWorktreeMode: ggMode
             )
             guard !id.isEmpty else {
                 createErrorMessage = "A worktree already exists at this path."
@@ -368,6 +389,7 @@ struct NewWorktreeDialog: View {
             projectsEmpty: state.projects.isEmpty,
             branchEmpty: activeName.isEmpty,
             branchValidation: branchValidationMessage,
+            ggConfigurationMissing: ggConfigurationMissing,
             requiresAcpAgent: openAfterCreate && launchMode == .acp,
             hasAcpAgent: launchAgentId != "none"
         ) else { return }
@@ -378,35 +400,41 @@ struct NewWorktreeDialog: View {
         projectsEmpty: Bool,
         branchEmpty: Bool,
         branchValidation: String? = nil,
+        ggConfigurationMissing: Bool = false,
         requiresAcpAgent: Bool = false,
         hasAcpAgent: Bool = true
     ) -> Bool {
-        guard !projectsEmpty, !branchEmpty, branchValidation == nil else { return false }
+        guard !projectsEmpty, !branchEmpty, branchValidation == nil, !ggConfigurationMissing else { return false }
         if requiresAcpAgent, !hasAcpAgent { return false }
         return true
     }
 
-    /// Stack mode only survives while the selected project still offers it.
-    /// Switching to a repo where gg stacks aren't enabled (or `branch_username`
-    /// is unresolved, so availability is `.disabled`/`.hidden` rather than
-    /// `.enabled`) clears the toggle — otherwise Create would silently produce a
-    /// plain branch named after the intended stack, since `effectiveBranch`
-    /// falls back to the raw field when availability isn't `.enabled`.
-    nonisolated static func stackModeSurvives(
-        _ on: Bool,
-        availability: GGStackCreateMode.Availability
-    ) -> Bool {
-        guard on else { return false }
-        if case .enabled = availability { return true }
-        return false
+    nonisolated static func ggModeDescription(
+        mode: GGWorktreeMode,
+        createsGGStack: Bool
+    ) -> String {
+        switch mode {
+        case .inherit:
+            createsGGStack
+                ? "Uses repository default: On."
+                : "Uses repository default: Off. Creates a regular Git branch."
+        case .on:
+            "GG enabled for this worktree."
+        case .off:
+            "GG disabled for this worktree. Creates a regular Git branch."
+        }
+    }
+
+    nonisolated static func ggModeAfterRepositoryChange(current _: GGWorktreeMode) -> GGWorktreeMode {
+        .inherit
     }
 
     nonisolated static func activeName(
-        createAsGGStack: Bool,
+        createsGGStack: Bool,
         branch: String,
         stackName: String
     ) -> String {
-        createAsGGStack ? stackName : branch
+        createsGGStack ? stackName : branch
     }
 
     nonisolated static func resolvedPresetProject(

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -140,7 +140,10 @@ struct NewWorktreeDialog: View {
                 }
             }
             if base.isEmpty {
-                base = state.config.worktrees.baseBranch
+                base = Self.initialBase(
+                    configuredDefault: state.config.worktrees.baseBranch,
+                    stackPinnedBase: stackPinnedBase
+                )
             }
             if branch.isEmpty {
                 branch = state.config.worktrees.branchPrefix
@@ -430,6 +433,13 @@ struct NewWorktreeDialog: View {
 
     nonisolated static func ggModeAfterRepositoryChange(current _: GGWorktreeMode) -> GGWorktreeMode {
         .inherit
+    }
+
+    nonisolated static func initialBase(
+        configuredDefault: String,
+        stackPinnedBase: String?
+    ) -> String {
+        stackPinnedBase ?? configuredDefault
     }
 
     nonisolated static func ggBranchPreview(branch: String, base: String?) -> String {

--- a/Alas/Sources/Integrations/GG/GGStackCreateMode.swift
+++ b/Alas/Sources/Integrations/GG/GGStackCreateMode.swift
@@ -20,4 +20,21 @@ enum GGStackCreateMode {
         }
         return .enabled(username: username)
     }
+
+    static func createsStack(
+        masterEnabled: Bool,
+        ggInstalled: Bool,
+        isRemoteProject: Bool,
+        projectMode: GGProjectMode,
+        worktreeMode: GGWorktreeMode,
+        repoHasGGConfig: Bool
+    ) -> Bool {
+        guard masterEnabled, ggInstalled, !isRemoteProject else { return false }
+        return GGWorktreeContextResolver.isPolicyEnabled(
+            projectMode: projectMode,
+            worktreeOverride: worktreeMode,
+            isMainWorktree: false,
+            repoHasGGConfig: repoHasGGConfig
+        )
+    }
 }

--- a/Alas/Sources/Integrations/GG/GGStackCreateMode.swift
+++ b/Alas/Sources/Integrations/GG/GGStackCreateMode.swift
@@ -1,9 +1,8 @@
 import Foundation
 
-/// Availability of the "Create as gg stack" mode in the new-worktree
-/// dialog. Hidden when the project isn't gg-gated; disabled (with a hint)
-/// when gg's branch_username can't be resolved from config — we fail
-/// closed rather than re-implementing gg's whoami resolution.
+/// Hard availability of GG creation in the new-worktree dialog. This controls
+/// whether the picker is shown and whether GG branch naming has the required
+/// username; effective On/Off policy is resolved separately by `createsStack`.
 enum GGStackCreateMode {
     enum Availability: Equatable {
         case hidden

--- a/Alas/Sources/Integrations/GG/GGWorktreeContext.swift
+++ b/Alas/Sources/Integrations/GG/GGWorktreeContext.swift
@@ -33,6 +33,27 @@ enum GGWorktreeContextResolver {
         return name.isEmpty ? nil : name
     }
 
+    static func isPolicyEnabled(
+        projectMode: GGProjectMode,
+        worktreeOverride: GGWorktreeMode,
+        isMainWorktree: Bool,
+        repoHasGGConfig: Bool
+    ) -> Bool {
+        switch worktreeOverride {
+        case .on:
+            return true
+        case .off:
+            return false
+        case .inherit:
+            if isMainWorktree { return false }
+            switch projectMode {
+            case .off: return false
+            case .auto: return repoHasGGConfig
+            case .on: return true
+            }
+        }
+    }
+
     static func resolve(
         masterEnabled: Bool,
         ggInstalled: Bool,
@@ -48,24 +69,12 @@ enum GGWorktreeContextResolver {
         guard ggInstalled else { return .inactive(reason: .cliMissing) }
         guard !isRemoteProject else { return .inactive(reason: .remoteProject) }
 
-        let policyEnabled: Bool
-        switch worktreeOverride {
-        case .on:
-            policyEnabled = true
-        case .off:
-            policyEnabled = false
-        case .inherit:
-            if isMainWorktree {
-                policyEnabled = false
-            } else {
-                switch projectMode {
-                case .off: policyEnabled = false
-                case .auto: policyEnabled = repoHasGGConfig
-                case .on: policyEnabled = true
-                }
-            }
-        }
-        guard policyEnabled else { return .inactive(reason: .policyOff) }
+        guard isPolicyEnabled(
+            projectMode: projectMode,
+            worktreeOverride: worktreeOverride,
+            isMainWorktree: isMainWorktree,
+            repoHasGGConfig: repoHasGGConfig
+        ) else { return .inactive(reason: .policyOff) }
 
         guard let branchUsername, !branchUsername.isEmpty else {
             return .inactive(reason: .branchUsernameMissing)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -239,7 +239,7 @@ struct SidebarView: View {
         operationState: WorktreeOperationState?,
         defaultBase: String
     ) -> (base: String, ggWorktreeMode: GGWorktreeMode) {
-        guard case .createFailed(_, let base, let ggWorktreeMode) = operationState else {
+        guard case .createFailed(_, _, let base, let ggWorktreeMode) = operationState else {
             return (defaultBase, .inherit)
         }
         return (base, ggWorktreeMode)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -127,21 +127,19 @@ struct SidebarView: View {
                                     pb.setString(message, forType: .string)
                                 },
                                 onRetryCreate: { wt in
-                                    let retryBase: String
-                                    if let op = state.projectsManager.operationState(for: wt.id),
-                                       case .createFailed(_, let base) = op {
-                                        retryBase = base
-                                    } else {
-                                        retryBase = state.config.worktrees.baseBranch
-                                    }
+                                    let retry = Self.retryCreateParameters(
+                                        operationState: state.projectsManager.operationState(for: wt.id),
+                                        defaultBase: state.config.worktrees.baseBranch
+                                    )
                                     Task { @MainActor in
                                         await state.createWorktree(
                                             projectId: project.id,
-                                            base: retryBase,
+                                            base: retry.base,
                                             branch: wt.branch,
                                             destination: wt.path,
                                             runStartup: false,
-                                            launchSurface: .none
+                                            launchSurface: .none,
+                                            ggWorktreeMode: retry.ggWorktreeMode
                                         )
                                     }
                                 },
@@ -235,6 +233,16 @@ struct SidebarView: View {
                     showTransientSpaceTitle()
                 }
             }
+    }
+
+    nonisolated static func retryCreateParameters(
+        operationState: WorktreeOperationState?,
+        defaultBase: String
+    ) -> (base: String, ggWorktreeMode: GGWorktreeMode) {
+        guard case .createFailed(_, let base, let ggWorktreeMode) = operationState else {
+            return (defaultBase, .inherit)
+        }
+        return (base, ggWorktreeMode)
     }
 
     private func showTransientSpaceTitle() {

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -90,7 +90,7 @@ struct WorktreeRowView: View {
         switch operationState {
         case .creating: return "Creating…"
         case .deleting: return "Deleting…"
-        case .createFailed(let msg, _): return "Create failed: \(msg.trimmedForDisplay)"
+        case .createFailed(let msg, _, _): return "Create failed: \(msg.trimmedForDisplay)"
         case .deleteFailed(let msg): return "Delete failed: \(msg.trimmedForDisplay)"
         case .none: return ""
         }
@@ -98,7 +98,7 @@ struct WorktreeRowView: View {
 
     private var errorMessage: String? {
         switch operationState {
-        case .createFailed(let message, _), .deleteFailed(let message):
+        case .createFailed(let message, _, _), .deleteFailed(let message):
             return message
         case .creating, .deleting, .none:
             return nil

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -90,7 +90,7 @@ struct WorktreeRowView: View {
         switch operationState {
         case .creating: return "Creating…"
         case .deleting: return "Deleting…"
-        case .createFailed(let msg, _, _): return "Create failed: \(msg.trimmedForDisplay)"
+        case .createFailed(_, let msg, _, _): return "Create failed: \(msg.trimmedForDisplay)"
         case .deleteFailed(let msg): return "Delete failed: \(msg.trimmedForDisplay)"
         case .none: return ""
         }
@@ -98,7 +98,7 @@ struct WorktreeRowView: View {
 
     private var errorMessage: String? {
         switch operationState {
-        case .createFailed(let message, _, _), .deleteFailed(let message):
+        case .createFailed(_, let message, _, _), .deleteFailed(let message):
             return message
         case .creating, .deleting, .none:
             return nil

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -474,47 +474,114 @@ struct AppStateCleanupTests {
         }
 
         #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == id })
-        if case .createFailed(let message, _) = state.projectsManager.operationState(for: id) {
+        if case .createFailed(let message, _, _) = state.projectsManager.operationState(for: id) {
             #expect(!message.isEmpty)
         } else {
             Issue.record("Expected createFailed state")
         }
     }
 
-    @Test func createWorktreeRetryAllowsFailedOptimisticDestination() async throws {
-        let repo = try await makeRepo(name: "create-retry")
+    @Test(arguments: [GGWorktreeMode.on, .off])
+    func createWorktreeRetryPreservesExplicitGGMode(mode: GGWorktreeMode) async throws {
+        let modeName = mode == .on ? "on" : "off"
+        let repo = try await makeRepo(name: "create-retry-\(modeName)")
         defer { try? FileManager.default.removeItem(at: repo) }
         let state = AppState()
-        let project = try await state.projectsManager.addProject(path: repo, displayName: "create-retry", color: "#5fb7c4")
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-retry-\(modeName)",
+            color: "#5fb7c4"
+        )
         try await state.projectsManager.refreshWorktrees(projectId: project.id)
 
-        let dest = repo.appendingPathComponent("wt-retry")
+        let retryBase = "retry-base-\(modeName)"
+        let branch = "retry-\(modeName)"
+        let dest = repo.appendingPathComponent("wt-retry-\(modeName)")
         let failedId = await state.createWorktree(
             projectId: project.id,
-            base: "missing-base",
-            branch: "retry-b",
+            base: retryBase,
+            branch: branch,
             destination: dest,
             runStartup: false,
-            launchSurface: .none
+            launchSurface: .none,
+            ggWorktreeMode: mode
         )
         try await waitForOperationStateMatching(state.projectsManager, id: failedId) { state in
             if case .createFailed = state { return true }
             return false
         }
+        let failedWorktree = try #require(
+            state.projectsManager.worktrees(projectId: project.id).first(where: { $0.id == failedId })
+        )
+        #expect(state.ggWorktreeMenuModel(project: project, worktree: failedWorktree).selectedMode == .inherit)
+
+        guard case .createFailed(_, let failedBase, let failedMode) =
+            state.projectsManager.operationState(for: failedId)
+        else {
+            Issue.record("Expected createFailed state")
+            return
+        }
+        #expect(failedBase == retryBase)
+        #expect(failedMode == mode)
+
+        let retryParameters = SidebarView.retryCreateParameters(
+            operationState: state.projectsManager.operationState(for: failedId),
+            defaultBase: state.config.worktrees.baseBranch
+        )
+        #expect(retryParameters.base == retryBase)
+        #expect(retryParameters.ggWorktreeMode == mode)
+
+        _ = try await Process.git(["branch", retryBase, "main"], cwd: repo)
 
         let retryId = await state.createWorktree(
             projectId: project.id,
-            base: "main",
-            branch: "retry-b",
+            base: retryParameters.base,
+            branch: branch,
             destination: dest,
             runStartup: false,
-            launchSurface: .none
+            launchSurface: .none,
+            ggWorktreeMode: retryParameters.ggWorktreeMode
         )
 
         #expect(retryId == failedId)
         #expect(state.projectsManager.operationState(for: retryId) == .creating)
         try await waitForOperationState(state.projectsManager, id: retryId, equals: nil)
         #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == retryId })
+        #expect(state.projectsManager.ggWorktreeMode(projectId: project.id, worktreeId: retryId) == mode)
+        #expect(state.projects.first(where: { $0.id == project.id })?.ggWorktreeModes[retryId] == mode)
+    }
+
+    @Test func successfulInheritCreationKeepsGGWorktreeModesSparse() async throws {
+        let repo = try await makeRepo(name: "create-inherit-sparse")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let store = RecordingStore()
+        let state = AppState(store: store)
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-inherit-sparse",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let id = await state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: "inherit-sparse",
+            destination: repo.appendingPathComponent("wt-inherit-sparse"),
+            runStartup: false,
+            launchSurface: .none,
+            ggWorktreeMode: .inherit
+        )
+
+        try await waitForOperationState(state.projectsManager, id: id, equals: nil)
+        #expect(state.projects.first(where: { $0.id == project.id })?.ggWorktreeModes[id] == nil)
+
+        state.setWorktreeLaunchDefaults(
+            projectId: project.id,
+            openAfterCreate: false,
+            launcherMode: .terminal
+        )
+        #expect(store.writtenProjectsFile?.projects.first(where: { $0.id == project.id })?.ggWorktreeModes[id] == nil)
     }
 
     @Test func deleteWorktreeMarksDeletingImmediately() async throws {

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -27,6 +27,20 @@ struct AppStateCleanupTests {
         }
     }
 
+    private final class RecordingStore: PersistenceStoreProtocol, @unchecked Sendable {
+        var writtenProjectsFile: ProjectsFile?
+
+        func write<T: Encodable>(_ value: T, to _: URL) throws {
+            if let projectsFile = value as? ProjectsFile {
+                writtenProjectsFile = projectsFile
+            }
+        }
+
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? {
+            nil
+        }
+    }
+
     private func makeRepo(name: String) async throws -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleanup-\(name)-\(UUID().uuidString)")
@@ -317,6 +331,98 @@ struct AppStateCleanupTests {
         #expect(state.selectedWorktreeId == id)
 
         try await waitForOperationState(state.projectsManager, id: id, equals: nil)
+    }
+
+    @Test func createWorktreeAppliesAndKeepsExplicitGGMode() async throws {
+        let repo = try await makeRepo(name: "create-gg-off")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-gg-off",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let id = await state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: "regular-branch",
+            destination: repo.appendingPathComponent("wt-gg-off"),
+            runStartup: false,
+            launchSurface: .none,
+            ggWorktreeMode: .off
+        )
+
+        #expect(state.selectedWorktreeId == id)
+        let optimistic = try #require(
+            state.projectsManager.worktrees(projectId: project.id).first(where: { $0.id == id })
+        )
+        #expect(state.ggWorktreeMenuModel(project: project, worktree: optimistic).selectedMode == .off)
+        try await waitForOperationState(state.projectsManager, id: id, equals: nil)
+        #expect(state.projectsManager.ggWorktreeMode(projectId: project.id, worktreeId: id) == .off)
+    }
+
+    @Test func failedCreateRemovesUnpersistedGGMode() async throws {
+        let repo = try await makeRepo(name: "create-gg-fail")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-gg-fail",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let id = await state.createWorktree(
+            projectId: project.id,
+            base: "missing-base",
+            branch: "failed-stack",
+            destination: repo.appendingPathComponent("wt-gg-fail"),
+            runStartup: false,
+            launchSurface: .none,
+            ggWorktreeMode: .on
+        )
+
+        try await waitForOperationStateMatching(state.projectsManager, id: id) {
+            if case .createFailed = $0 { return true }
+            return false
+        }
+        #expect(state.projectsManager.ggWorktreeMode(projectId: project.id, worktreeId: id) == .inherit)
+    }
+
+    @Test func createWorktreeDoesNotPersistGGModeBeforeReconciliation() async throws {
+        let repo = try await makeRepo(name: "create-gg-save")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let store = RecordingStore()
+        let state = AppState(store: store)
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-gg-save",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let id = await state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: "persist-after-reconcile",
+            destination: repo.appendingPathComponent("wt-gg-save"),
+            runStartup: false,
+            launchSurface: .none,
+            ggWorktreeMode: .on
+        )
+        state.setWorktreeLaunchDefaults(
+            projectId: project.id,
+            openAfterCreate: false,
+            launcherMode: .terminal
+        )
+
+        #expect(state.projectsManager.operationState(for: id) == .creating)
+        #expect(store.writtenProjectsFile != nil)
+        #expect(store.writtenProjectsFile?.projects.first(where: { $0.id == project.id })?.ggWorktreeModes[id] == nil)
+        try await waitForOperationState(state.projectsManager, id: id, equals: nil)
+        #expect(store.writtenProjectsFile?.projects.first(where: { $0.id == project.id })?.ggWorktreeModes[id] == .on)
     }
 
     @Test func createWorktreeRejectsExistingDestination() async throws {

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -76,6 +76,59 @@ struct AppStateCleanupTests {
         #expect(ids == Set(trees.map(\.id)))
     }
 
+    @Test func topologyRefreshReevaluatesCachedGGGateAfterPromotingRecoveredMode() async throws {
+        let repo = try await makeRepo(name: "recovered-gg-gate")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState(store: MemoryStore())
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "recovered-gg-gate",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let worktree = try #require(state.projectsManager.worktrees(projectId: project.id).first)
+        let pane = state.rightPaneStore.state(
+            for: worktree,
+            baseBranch: state.config.worktrees.baseBranch,
+            comparisonMode: state.config.changes.comparisonMode
+        )
+        state.rightPaneStore.deactivate()
+        pane.baseBranchProbeTask?.cancel()
+        pane.baseBranchProbeTask = nil
+
+        var gateEvaluationCount = 0
+        pane.ggContextProvider = { _ in
+            gateEvaluationCount += 1
+            return .inactive(reason: .policyOff)
+        }
+        await pane.reevaluateGGGate().value
+        pane.stop()
+        try await Task.sleep(for: .milliseconds(250))
+        pane.stop()
+        gateEvaluationCount = 0
+
+        state.projectsManager.setOperationState(
+            id: worktree.id,
+            state: .createFailed(
+                projectId: project.id,
+                message: "transient",
+                base: "main",
+                ggWorktreeMode: .off
+            )
+        )
+
+        await state.refreshProjectTopology(projectId: project.id)
+        for _ in 0..<20 where gateEvaluationCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(state.projectsManager.ggWorktreeMode(
+            projectId: project.id,
+            worktreeId: worktree.id
+        ) == .off)
+        #expect(gateEvaluationCount == 1)
+    }
+
     @Test func allWorktreeIdsEmptyBeforeRefresh() async throws {
         let repo = try await makeRepo(name: "empty-ids")
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -474,7 +527,7 @@ struct AppStateCleanupTests {
         }
 
         #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == id })
-        if case .createFailed(let message, _, _) = state.projectsManager.operationState(for: id) {
+        if case .createFailed(_, let message, _, _) = state.projectsManager.operationState(for: id) {
             #expect(!message.isEmpty)
         } else {
             Issue.record("Expected createFailed state")
@@ -515,7 +568,7 @@ struct AppStateCleanupTests {
         )
         #expect(state.ggWorktreeMenuModel(project: project, worktree: failedWorktree).selectedMode == .inherit)
 
-        guard case .createFailed(_, let failedBase, let failedMode) =
+        guard case .createFailed(_, _, let failedBase, let failedMode) =
             state.projectsManager.operationState(for: failedId)
         else {
             Issue.record("Expected createFailed state")

--- a/AlasTests/CenterSelectionStateResolverTests.swift
+++ b/AlasTests/CenterSelectionStateResolverTests.swift
@@ -97,7 +97,10 @@ struct CenterSelectionStateResolverTests {
         let wt = Worktree(id: "wt1", projectId: "p1", name: "main", branch: "main", path: URL(fileURLWithPath: "/tmp/a"), status: .clean, lastActivity: Date())
         let mgr = ProjectsManager(persistedProjects: [project])
         mgr.insertOptimisticWorktree(wt)
-        mgr.setOperationState(id: wt.id, state: .createFailed(message: "disk full", base: "main"))
+        mgr.setOperationState(
+            id: wt.id,
+            state: .createFailed(message: "disk full", base: "main", ggWorktreeMode: .inherit)
+        )
         let resolver = CenterSelectionStateResolver(
             selectedWorktreeId: wt.id,
             projects: [project],

--- a/AlasTests/CenterSelectionStateResolverTests.swift
+++ b/AlasTests/CenterSelectionStateResolverTests.swift
@@ -99,7 +99,12 @@ struct CenterSelectionStateResolverTests {
         mgr.insertOptimisticWorktree(wt)
         mgr.setOperationState(
             id: wt.id,
-            state: .createFailed(message: "disk full", base: "main", ggWorktreeMode: .inherit)
+            state: .createFailed(
+                projectId: project.id,
+                message: "disk full",
+                base: "main",
+                ggWorktreeMode: .inherit
+            )
         )
         let resolver = CenterSelectionStateResolver(
             selectedWorktreeId: wt.id,

--- a/AlasTests/GGStackCreateModeTests.swift
+++ b/AlasTests/GGStackCreateModeTests.swift
@@ -2,6 +2,21 @@ import Testing
 @testable import Alas
 
 struct GGStackCreateModeTests {
+    @Test func creationPolicyUsesRawModeAndLinkedRepositoryDefault() {
+        #expect(createsStack(projectMode: .auto, worktreeMode: .inherit, hasConfig: true))
+        #expect(!createsStack(projectMode: .auto, worktreeMode: .inherit, hasConfig: false))
+        #expect(!createsStack(projectMode: .off, worktreeMode: .inherit, hasConfig: true))
+        #expect(createsStack(projectMode: .on, worktreeMode: .inherit, hasConfig: false))
+        #expect(createsStack(projectMode: .off, worktreeMode: .on, hasConfig: false))
+        #expect(!createsStack(projectMode: .on, worktreeMode: .off, hasConfig: true))
+    }
+
+    @Test func creationPolicyHonorsHardStops() {
+        #expect(!createsStack(masterEnabled: false))
+        #expect(!createsStack(ggInstalled: false))
+        #expect(!createsStack(isRemoteProject: true))
+    }
+
     @Test func hiddenWhenGateFails() {
         #expect(GGStackCreateMode.availability(gatePassed: false, username: "nacho") == .hidden)
     }
@@ -17,5 +32,23 @@ struct GGStackCreateModeTests {
 
     @Test func enabledCarriesUsername() {
         #expect(GGStackCreateMode.availability(gatePassed: true, username: "nacho") == .enabled(username: "nacho"))
+    }
+
+    private func createsStack(
+        masterEnabled: Bool = true,
+        ggInstalled: Bool = true,
+        isRemoteProject: Bool = false,
+        projectMode: GGProjectMode = .auto,
+        worktreeMode: GGWorktreeMode = .inherit,
+        hasConfig: Bool = true
+    ) -> Bool {
+        GGStackCreateMode.createsStack(
+            masterEnabled: masterEnabled,
+            ggInstalled: ggInstalled,
+            isRemoteProject: isRemoteProject,
+            projectMode: projectMode,
+            worktreeMode: worktreeMode,
+            repoHasGGConfig: hasConfig
+        )
     }
 }

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -3,6 +3,33 @@ import Testing
 @testable import Alas
 
 struct GGWorktreeContextTests {
+    @Test func policyResolverPreservesWorktreeSemantics() {
+        #expect(GGWorktreeContextResolver.isPolicyEnabled(
+            projectMode: .auto,
+            worktreeOverride: .inherit,
+            isMainWorktree: false,
+            repoHasGGConfig: true
+        ))
+        #expect(!GGWorktreeContextResolver.isPolicyEnabled(
+            projectMode: .on,
+            worktreeOverride: .inherit,
+            isMainWorktree: true,
+            repoHasGGConfig: true
+        ))
+        #expect(GGWorktreeContextResolver.isPolicyEnabled(
+            projectMode: .off,
+            worktreeOverride: .on,
+            isMainWorktree: false,
+            repoHasGGConfig: false
+        ))
+        #expect(!GGWorktreeContextResolver.isPolicyEnabled(
+            projectMode: .on,
+            worktreeOverride: .off,
+            isMainWorktree: false,
+            repoHasGGConfig: true
+        ))
+    }
+
     private func project(mode: GGProjectMode, host: String? = nil) -> ProjectConfig {
         ProjectConfig(
             id: "project",

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -106,6 +106,20 @@ struct NewWorktreeDialogTests {
         #expect(selected == "integration")
     }
 
+    @Test func initialBaseUsesStackPinnedBaseWhenAvailable() {
+        #expect(NewWorktreeDialog.initialBase(
+            configuredDefault: "main",
+            stackPinnedBase: "develop"
+        ) == "develop")
+    }
+
+    @Test func initialBaseUsesConfiguredDefaultWithoutStackPin() {
+        #expect(NewWorktreeDialog.initialBase(
+            configuredDefault: "main",
+            stackPinnedBase: nil
+        ) == "main")
+    }
+
     @Test func canCreateRequiresProjects() {
         #expect(!NewWorktreeDialog.canCreate(projectsEmpty: true, branchEmpty: false))
     }

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -322,24 +322,46 @@ struct NewWorktreeDialogTests {
         #expect(result.persistableLaunchMode == .terminal)
     }
 
-    @Test func stackModeSurvivesOnlyWhenAvailabilityEnabled() {
-        // Stays on when the new project still offers gg stacks.
-        #expect(NewWorktreeDialog.stackModeSurvives(true, availability: .enabled(username: "nacho")) == true)
-        // Clears when the toggle was on but availability dropped to disabled/hidden.
-        #expect(NewWorktreeDialog.stackModeSurvives(true, availability: .disabled(hint: "Set branch_username")) == false)
-        #expect(NewWorktreeDialog.stackModeSurvives(true, availability: .hidden) == false)
-        // Off stays off regardless of availability.
-        #expect(NewWorktreeDialog.stackModeSurvives(false, availability: .enabled(username: "nacho")) == false)
+    @Test func inheritedGGDescriptionReportsEffectiveMode() {
+        #expect(NewWorktreeDialog.ggModeDescription(mode: .inherit, createsGGStack: true) ==
+            "Uses repository default: On.")
+        #expect(NewWorktreeDialog.ggModeDescription(mode: .inherit, createsGGStack: false) ==
+            "Uses repository default: Off. Creates a regular Git branch.")
+    }
+
+    @Test func explicitGGDescriptionsExplainCreation() {
+        #expect(NewWorktreeDialog.ggModeDescription(mode: .on, createsGGStack: true) ==
+            "GG enabled for this worktree.")
+        #expect(NewWorktreeDialog.ggModeDescription(mode: .off, createsGGStack: false) ==
+            "GG disabled for this worktree. Creates a regular Git branch.")
+    }
+
+    @Test func repositoryChangeResetsGGModeToInherit() {
+        #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(current: .on) == .inherit)
+        #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(current: .off) == .inherit)
+    }
+
+    @Test func canCreateBlocksMissingUsernameOnlyForEffectiveGG() {
+        #expect(!NewWorktreeDialog.canCreate(
+            projectsEmpty: false,
+            branchEmpty: false,
+            ggConfigurationMissing: true
+        ))
+        #expect(NewWorktreeDialog.canCreate(
+            projectsEmpty: false,
+            branchEmpty: false,
+            ggConfigurationMissing: false
+        ))
     }
 
     @Test func ggModeUsesIndependentStackNameInsteadOfBranchPrefix() {
         #expect(NewWorktreeDialog.activeName(
-            createAsGGStack: false,
+            createsGGStack: false,
             branch: "nacho/auth-flow",
             stackName: "auth-flow"
         ) == "nacho/auth-flow")
         #expect(NewWorktreeDialog.activeName(
-            createAsGGStack: true,
+            createsGGStack: true,
             branch: "nacho/auth-flow",
             stackName: "auth-flow"
         ) == "auth-flow")
@@ -347,7 +369,7 @@ struct NewWorktreeDialogTests {
 
     @Test func ggModePreservesNestedStackNameVerbatim() {
         #expect(NewWorktreeDialog.activeName(
-            createAsGGStack: true,
+            createsGGStack: true,
             branch: "nacho/other-branch",
             stackName: "nacho/auth-flow"
         ) == "nacho/auth-flow")

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -336,6 +336,16 @@ struct NewWorktreeDialogTests {
             "GG disabled for this worktree. Creates a regular Git branch.")
     }
 
+    @Test func ggBranchPreviewIncludesPinnedBase() {
+        #expect(NewWorktreeDialog.ggBranchPreview(branch: "nacho/feature", base: "main") ==
+            "Branch: nacho/feature, based on main")
+    }
+
+    @Test func ggBranchPreviewOmitsMissingBase() {
+        #expect(NewWorktreeDialog.ggBranchPreview(branch: "nacho/feature", base: nil) ==
+            "Branch: nacho/feature")
+    }
+
     @Test func repositoryChangeResetsGGModeToInherit() {
         #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(current: .on) == .inherit)
         #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(current: .off) == .inherit)

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -92,7 +92,12 @@ struct ProjectsManagerHeadUpdatesTests {
         seed(mgr, projectId: project.id, [row])
         mgr.setOperationState(
             id: row.id,
-            state: .createFailed(message: "x", base: "main", ggWorktreeMode: .inherit)
+            state: .createFailed(
+                projectId: project.id,
+                message: "x",
+                base: "main",
+                ggWorktreeMode: .inherit
+            )
         )
 
         mgr.applyHeadUpdates(

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -90,7 +90,10 @@ struct ProjectsManagerHeadUpdatesTests {
         let (mgr, project) = makeManager()
         let row = wt(path: "/wts/feat", branch: "feat/intent")
         seed(mgr, projectId: project.id, [row])
-        mgr.setOperationState(id: row.id, state: .createFailed(message: "x", base: "main"))
+        mgr.setOperationState(
+            id: row.id,
+            state: .createFailed(message: "x", base: "main", ggWorktreeMode: .inherit)
+        )
 
         mgr.applyHeadUpdates(
             projectId: project.id,

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -554,46 +554,113 @@ extension ProjectsManagerTests {
         mgr.insertOptimisticWorktree(optimistic)
         mgr.setOperationState(
             id: optimistic.id,
-            state: .createFailed(message: "disk full", base: "main", ggWorktreeMode: .inherit)
+            state: .createFailed(
+                projectId: project.id,
+                message: "disk full",
+                base: "main",
+                ggWorktreeMode: .inherit
+            )
         )
 
         try await mgr.refreshWorktrees(projectId: project.id)
         let trees = mgr.worktrees(projectId: project.id)
         #expect(trees.contains { $0.id == optimistic.id })
         #expect(mgr.operationState(for: optimistic.id) == .createFailed(
+            projectId: project.id,
             message: "disk full",
             base: "main",
             ggWorktreeMode: .inherit
         ))
     }
 
-    @Test func refreshClearsCreateFailedWhenWorktreeAppears() async throws {
-        let repo = try await makeRepo(name: "create-failed-live")
+    @Test(arguments: [GGWorktreeMode.on, .off, .inherit])
+    func refreshPromotesCreateFailedGGModeWhenWorktreeAppears(mode: GGWorktreeMode) async throws {
+        let repo = try await makeRepo(name: "create-failed-live-\(mode.rawValue)")
         defer { try? FileManager.default.removeItem(at: repo) }
         let mgr = ProjectsManager(persistedProjects: [])
-        let project = try await mgr.addProject(path: repo, displayName: "create-failed-live", color: "#5fb7c4")
+        let project = try await mgr.addProject(
+            path: repo,
+            displayName: "create-failed-live-\(mode.rawValue)",
+            color: "#5fb7c4"
+        )
         try await mgr.refreshWorktrees(projectId: project.id)
 
         let svc = WorktreeService()
-        let dest = repo.appendingPathComponent("wt-cf-live")
+        let dest = repo.appendingPathComponent("wt-cf-live-\(mode.rawValue)")
         let worktree = try await svc.add(
             repoPath: repo,
             base: "main",
-            branch: "cf-live-b",
+            branch: "cf-live-\(mode.rawValue)",
             destination: dest,
             projectId: project.id
         )
         try await mgr.refreshWorktrees(projectId: project.id)
 
+        if mode == .inherit {
+            mgr.setGGWorktreeMode(projectId: project.id, worktreeId: worktree.id, mode: .on)
+        }
+
         mgr.setOperationState(
             id: worktree.id,
-            state: .createFailed(message: "transient", base: "main", ggWorktreeMode: .inherit)
+            state: .createFailed(
+                projectId: project.id,
+                message: "transient",
+                base: "main",
+                ggWorktreeMode: mode
+            )
         )
-        try await mgr.refreshWorktrees(projectId: project.id)
+        let changed = try await mgr.refreshWorktrees(projectId: project.id)
 
+        #expect(changed)
         #expect(mgr.operationState(for: worktree.id) == nil)
         let trees = mgr.worktrees(projectId: project.id)
         #expect(trees.contains { $0.id == worktree.id })
+        #expect(mgr.ggWorktreeMode(projectId: project.id, worktreeId: worktree.id) == mode)
+        #expect(mgr.projects[0].ggWorktreeModes[worktree.id] == (mode == .inherit ? nil : mode))
+    }
+
+    @Test func refreshDoesNotConsumeCreateFailureFromAnotherProjectWithSameWorktreeId() async throws {
+        let repo = try await makeRepo(name: "create-failed-project-scope")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let origin = ProjectConfig(
+            id: "origin",
+            name: "origin",
+            path: repo.path,
+            color: "#5fb7c4",
+            addedAt: .now
+        )
+        let other = ProjectConfig(
+            id: "other",
+            name: "other",
+            path: repo.path,
+            color: "#c89d6f",
+            addedAt: .now
+        )
+        let manager = ProjectsManager(persistedProjects: [origin, other])
+        try await manager.refreshWorktrees(projectId: origin.id)
+        try await manager.refreshWorktrees(projectId: other.id)
+        let sharedId = try #require(manager.worktrees(projectId: origin.id).first?.id)
+        #expect(manager.worktrees(projectId: other.id).first?.id == sharedId)
+
+        manager.setOperationState(
+            id: sharedId,
+            state: .createFailed(
+                projectId: origin.id,
+                message: "transient",
+                base: "main",
+                ggWorktreeMode: .on
+            )
+        )
+
+        let otherChanged = try await manager.refreshWorktrees(projectId: other.id)
+        #expect(!otherChanged)
+        #expect(manager.operationState(for: sharedId) != nil)
+        #expect(manager.ggWorktreeMode(projectId: other.id, worktreeId: sharedId) == .inherit)
+
+        let originChanged = try await manager.refreshWorktrees(projectId: origin.id)
+        #expect(originChanged)
+        #expect(manager.operationState(for: sharedId) == nil)
+        #expect(manager.ggWorktreeMode(projectId: origin.id, worktreeId: sharedId) == .on)
     }
 
     @Test func refreshClearsDeletingStateWhenWorktreeDisappears() async throws {

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -552,12 +552,19 @@ extension ProjectsManagerTests {
             lastActivity: Date()
         )
         mgr.insertOptimisticWorktree(optimistic)
-        mgr.setOperationState(id: optimistic.id, state: .createFailed(message: "disk full", base: "main"))
+        mgr.setOperationState(
+            id: optimistic.id,
+            state: .createFailed(message: "disk full", base: "main", ggWorktreeMode: .inherit)
+        )
 
         try await mgr.refreshWorktrees(projectId: project.id)
         let trees = mgr.worktrees(projectId: project.id)
         #expect(trees.contains { $0.id == optimistic.id })
-        #expect(mgr.operationState(for: optimistic.id) == .createFailed(message: "disk full", base: "main"))
+        #expect(mgr.operationState(for: optimistic.id) == .createFailed(
+            message: "disk full",
+            base: "main",
+            ggWorktreeMode: .inherit
+        ))
     }
 
     @Test func refreshClearsCreateFailedWhenWorktreeAppears() async throws {
@@ -578,7 +585,10 @@ extension ProjectsManagerTests {
         )
         try await mgr.refreshWorktrees(projectId: project.id)
 
-        mgr.setOperationState(id: worktree.id, state: .createFailed(message: "transient", base: "main"))
+        mgr.setOperationState(
+            id: worktree.id,
+            state: .createFailed(message: "transient", base: "main", ggWorktreeMode: .inherit)
+        )
         try await mgr.refreshWorktrees(projectId: project.id)
 
         #expect(mgr.operationState(for: worktree.id) == nil)

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -459,7 +459,7 @@ struct RemoteAppStateAccessTests {
         state.projectsManager.setOperationState(id: deleting.id, state: .deleting)
         state.projectsManager.setOperationState(
             id: createFailed.id,
-            state: .createFailed(message: "failed", base: "main")
+            state: .createFailed(message: "failed", base: "main", ggWorktreeMode: .inherit)
         )
         state.projectsManager.setOperationState(id: deleteFailed.id, state: .deleteFailed(message: "failed"))
 

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -459,7 +459,12 @@ struct RemoteAppStateAccessTests {
         state.projectsManager.setOperationState(id: deleting.id, state: .deleting)
         state.projectsManager.setOperationState(
             id: createFailed.id,
-            state: .createFailed(message: "failed", base: "main", ggWorktreeMode: .inherit)
+            state: .createFailed(
+                projectId: createFailed.projectId,
+                message: "failed",
+                base: "main",
+                ggWorktreeMode: .inherit
+            )
         )
         state.projectsManager.setOperationState(id: deleteFailed.id, state: .deleteFailed(message: "failed"))
 

--- a/AlasTests/RightPaneSelectionStateResolverTests.swift
+++ b/AlasTests/RightPaneSelectionStateResolverTests.swift
@@ -89,7 +89,10 @@ struct RightPaneSelectionStateResolverTests {
         let wt = Worktree(id: "wt1", projectId: "p1", name: "main", branch: "main", path: URL(fileURLWithPath: "/tmp/a"), status: .clean, lastActivity: Date())
         let mgr = ProjectsManager(persistedProjects: [project])
         mgr.insertOptimisticWorktree(wt)
-        mgr.setOperationState(id: wt.id, state: .createFailed(message: "disk full", base: "main"))
+        mgr.setOperationState(
+            id: wt.id,
+            state: .createFailed(message: "disk full", base: "main", ggWorktreeMode: .inherit)
+        )
         let resolver = RightPaneSelectionStateResolver(
             selectedWorktreeId: wt.id,
             projects: [project],

--- a/AlasTests/RightPaneSelectionStateResolverTests.swift
+++ b/AlasTests/RightPaneSelectionStateResolverTests.swift
@@ -91,7 +91,12 @@ struct RightPaneSelectionStateResolverTests {
         mgr.insertOptimisticWorktree(wt)
         mgr.setOperationState(
             id: wt.id,
-            state: .createFailed(message: "disk full", base: "main", ggWorktreeMode: .inherit)
+            state: .createFailed(
+                projectId: project.id,
+                message: "disk full",
+                base: "main",
+                ggWorktreeMode: .inherit
+            )
         )
         let resolver = RightPaneSelectionStateResolver(
             selectedWorktreeId: wt.id,

--- a/docs/superpowers/plans/2026-07-22-new-worktree-gg-mode.md
+++ b/docs/superpowers/plans/2026-07-22-new-worktree-gg-mode.md
@@ -1,0 +1,580 @@
+# New Worktree GG Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the new-worktree GG Boolean with an `Inherit` / `On` / `Off` policy picker that drives both creation behavior and the persisted worktree override.
+
+**Architecture:** Extract the linked-worktree policy decision already used by `GGWorktreeContextResolver` and reuse it from `GGStackCreateMode` so dialog creation and runtime gating cannot drift. Apply the raw policy to the optimistic worktree before selection, persist explicit overrides only after successful reconciliation, and make the dialog render creation fields and validation from the effective policy while retaining the raw selection.
+
+**Tech Stack:** Swift 5.9+, SwiftUI for macOS, Swift Observation, Swift Testing (`import Testing`), XcodeGen/Xcode.
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Tests use Swift Testing (`import Testing`), not XCTest.
+- The raw selection is exactly `GGWorktreeMode.inherit`, `.on`, or `.off`; `Inherit` stays visibly selected while helper text reports its current effective value.
+- `Inherit` persists no `ggWorktreeModes` entry; `On` and `Off` persist explicit overrides under the stable worktree identity.
+- A selected policy that effectively enables GG uses the existing stack-name field, `<branch_username>/<stack-name>` composition, and configured GG base.
+- A selected policy that effectively disables GG uses the existing regular branch field and freely selected base.
+- App-wide disablement, missing gg installation, and remote projects are hard creation stops; an explicit `On` must remain available when only the project default is Off.
+- Missing `branch_username` blocks confirmation only when the effective creation behavior is GG.
+- The optimistic worktree receives its in-memory mode before immediate selection; explicit modes are saved only after successful topology reconciliation and removed on failure.
+- Do not introduce architectural changes outside this creation/policy flow.
+- Do not add agent or model attributions to code, documentation, commits, or the PR.
+- `project.yml` is not expected to change. If it does, run `xcodegen` and commit both `project.yml` and `Alas.xcodeproj` changes.
+
+---
+
+### Task 1: Share GG policy resolution with worktree creation
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/GG/GGWorktreeContext.swift`
+- Modify: `Alas/Sources/Integrations/GG/GGStackCreateMode.swift`
+- Test: `AlasTests/Integrations/GGWorktreeContextTests.swift`
+- Test: `AlasTests/GGStackCreateModeTests.swift`
+
+**Interfaces:**
+- Consumes: `GGProjectMode`, `GGWorktreeMode`, repository GG-config presence, and the existing app/CLI/remote hard gates.
+- Produces: `GGWorktreeContextResolver.isPolicyEnabled(projectMode:worktreeOverride:isMainWorktree:repoHasGGConfig:) -> Bool` and `GGStackCreateMode.createsStack(masterEnabled:ggInstalled:isRemoteProject:projectMode:worktreeMode:repoHasGGConfig:) -> Bool` for Task 3.
+
+- [ ] **Step 1: Add direct failing tests for the extracted policy resolver**
+
+Add tests that exercise linked inheritance, the main-worktree implicit Off default, and explicit overrides:
+
+```swift
+@Test func policyResolverPreservesWorktreeSemantics() {
+    #expect(GGWorktreeContextResolver.isPolicyEnabled(
+        projectMode: .auto,
+        worktreeOverride: .inherit,
+        isMainWorktree: false,
+        repoHasGGConfig: true
+    ))
+    #expect(!GGWorktreeContextResolver.isPolicyEnabled(
+        projectMode: .on,
+        worktreeOverride: .inherit,
+        isMainWorktree: true,
+        repoHasGGConfig: true
+    ))
+    #expect(GGWorktreeContextResolver.isPolicyEnabled(
+        projectMode: .off,
+        worktreeOverride: .on,
+        isMainWorktree: false,
+        repoHasGGConfig: false
+    ))
+    #expect(!GGWorktreeContextResolver.isPolicyEnabled(
+        projectMode: .on,
+        worktreeOverride: .off,
+        isMainWorktree: false,
+        repoHasGGConfig: true
+    ))
+}
+```
+
+- [ ] **Step 2: Add failing creation-policy matrix tests**
+
+Add `GGStackCreateModeTests` cases proving all raw modes, inherited project modes, and hard stops:
+
+```swift
+@Test func creationPolicyUsesRawModeAndLinkedRepositoryDefault() {
+    #expect(createsStack(projectMode: .auto, worktreeMode: .inherit, hasConfig: true))
+    #expect(!createsStack(projectMode: .auto, worktreeMode: .inherit, hasConfig: false))
+    #expect(!createsStack(projectMode: .off, worktreeMode: .inherit, hasConfig: true))
+    #expect(createsStack(projectMode: .on, worktreeMode: .inherit, hasConfig: false))
+    #expect(createsStack(projectMode: .off, worktreeMode: .on, hasConfig: false))
+    #expect(!createsStack(projectMode: .on, worktreeMode: .off, hasConfig: true))
+}
+
+@Test func creationPolicyHonorsHardStops() {
+    #expect(!createsStack(masterEnabled: false))
+    #expect(!createsStack(ggInstalled: false))
+    #expect(!createsStack(isRemoteProject: true))
+}
+
+private func createsStack(
+    masterEnabled: Bool = true,
+    ggInstalled: Bool = true,
+    isRemoteProject: Bool = false,
+    projectMode: GGProjectMode = .auto,
+    worktreeMode: GGWorktreeMode = .inherit,
+    hasConfig: Bool = true
+) -> Bool {
+    GGStackCreateMode.createsStack(
+        masterEnabled: masterEnabled,
+        ggInstalled: ggInstalled,
+        isRemoteProject: isRemoteProject,
+        projectMode: projectMode,
+        worktreeMode: worktreeMode,
+        repoHasGGConfig: hasConfig
+    )
+}
+```
+
+- [ ] **Step 3: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGWorktreeContextTests \
+  -only-testing:AlasTests/GGStackCreateModeTests
+```
+
+Expected: compilation fails because `isPolicyEnabled` and `createsStack` do not exist.
+
+- [ ] **Step 4: Extract the existing policy switch and add the creation resolver**
+
+Add this pure helper to `GGWorktreeContextResolver` and replace the inline `policyEnabled` switch in `resolve` with a call to it:
+
+```swift
+static func isPolicyEnabled(
+    projectMode: GGProjectMode,
+    worktreeOverride: GGWorktreeMode,
+    isMainWorktree: Bool,
+    repoHasGGConfig: Bool
+) -> Bool {
+    switch worktreeOverride {
+    case .on:
+        return true
+    case .off:
+        return false
+    case .inherit:
+        if isMainWorktree { return false }
+        switch projectMode {
+        case .off: return false
+        case .auto: return repoHasGGConfig
+        case .on: return true
+        }
+    }
+}
+```
+
+Add this creation-specific hard-gate wrapper to `GGStackCreateMode`:
+
+```swift
+static func createsStack(
+    masterEnabled: Bool,
+    ggInstalled: Bool,
+    isRemoteProject: Bool,
+    projectMode: GGProjectMode,
+    worktreeMode: GGWorktreeMode,
+    repoHasGGConfig: Bool
+) -> Bool {
+    guard masterEnabled, ggInstalled, !isRemoteProject else { return false }
+    return GGWorktreeContextResolver.isPolicyEnabled(
+        projectMode: projectMode,
+        worktreeOverride: worktreeMode,
+        isMainWorktree: false,
+        repoHasGGConfig: repoHasGGConfig
+    )
+}
+```
+
+- [ ] **Step 5: Run the focused tests and verify GREEN**
+
+Run the Step 3 command again.
+
+Expected: both suites pass with zero failures.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add Alas/Sources/Integrations/GG/GGWorktreeContext.swift \
+  Alas/Sources/Integrations/GG/GGStackCreateMode.swift \
+  AlasTests/Integrations/GGWorktreeContextTests.swift \
+  AlasTests/GGStackCreateModeTests.swift
+git commit -m "refactor: share GG worktree policy resolution"
+```
+
+---
+
+### Task 2: Carry and persist GG mode through worktree creation
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Test: `AlasTests/AppStateCleanupTests.swift`
+
+**Interfaces:**
+- Consumes: the existing `ProjectsManager.setGGWorktreeMode`, `removeGGWorktreeMode`, `saveProjects`, and `RightPaneStore.reevaluateGGGate` APIs.
+- Produces: `AppState.createWorktree(..., launchSurface:ggWorktreeMode:)` with a default of `.inherit`, used by Task 3 without changing CLI or delegated callers.
+
+- [ ] **Step 1: Add failing success and failure lifecycle tests**
+
+Add real-repository tests beside the existing `createWorktree` tests:
+
+```swift
+@Test func createWorktreeAppliesAndKeepsExplicitGGMode() async throws {
+    let repo = try await makeRepo(name: "create-gg-off")
+    defer { try? FileManager.default.removeItem(at: repo) }
+    let state = AppState()
+    let project = try await state.projectsManager.addProject(
+        path: repo,
+        displayName: "create-gg-off",
+        color: "#5fb7c4"
+    )
+    try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+    let id = await state.createWorktree(
+        projectId: project.id,
+        base: "main",
+        branch: "regular-branch",
+        destination: repo.appendingPathComponent("wt-gg-off"),
+        runStartup: false,
+        launchSurface: .none,
+        ggWorktreeMode: .off
+    )
+
+    #expect(state.selectedWorktreeId == id)
+    #expect(state.projectsManager.ggWorktreeMode(projectId: project.id, worktreeId: id) == .off)
+    try await waitForOperationState(state.projectsManager, id: id, equals: nil)
+    #expect(state.projectsManager.ggWorktreeMode(projectId: project.id, worktreeId: id) == .off)
+}
+
+@Test func failedCreateRemovesUnpersistedGGMode() async throws {
+    let repo = try await makeRepo(name: "create-gg-fail")
+    defer { try? FileManager.default.removeItem(at: repo) }
+    let state = AppState()
+    let project = try await state.projectsManager.addProject(
+        path: repo,
+        displayName: "create-gg-fail",
+        color: "#5fb7c4"
+    )
+    try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+    let id = await state.createWorktree(
+        projectId: project.id,
+        base: "missing-base",
+        branch: "failed-stack",
+        destination: repo.appendingPathComponent("wt-gg-fail"),
+        runStartup: false,
+        launchSurface: .none,
+        ggWorktreeMode: .on
+    )
+
+    try await waitForOperationStateMatching(state.projectsManager, id: id) {
+        if case .createFailed = $0 { return true }
+        return false
+    }
+    #expect(state.projectsManager.ggWorktreeMode(projectId: project.id, worktreeId: id) == .inherit)
+}
+```
+
+- [ ] **Step 2: Run the lifecycle tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/AppStateCleanupTests/createWorktreeAppliesAndKeepsExplicitGGMode \
+  -only-testing:AlasTests/AppStateCleanupTests/failedCreateRemovesUnpersistedGGMode
+```
+
+Expected: compilation fails because `createWorktree` has no `ggWorktreeMode` argument.
+
+- [ ] **Step 3: Add the raw mode to the creation API and optimistic phase**
+
+Extend the signature without breaking existing callers:
+
+```swift
+func createWorktree(
+    projectId: String,
+    base: String,
+    branch: String,
+    destination: URL,
+    runStartup: Bool,
+    launchSurface: WorktreeLaunchSurface,
+    ggWorktreeMode: GGWorktreeMode = .inherit
+) async -> String
+```
+
+Immediately after `insertOptimisticWorktree(optimistic)` and before selection, apply the raw value directly through `ProjectsManager`:
+
+```swift
+projectsManager.setGGWorktreeMode(
+    projectId: projectId,
+    worktreeId: optimistic.id,
+    mode: ggWorktreeMode
+)
+```
+
+- [ ] **Step 4: Persist only after successful reconciliation**
+
+After `refreshProjectWorktrees` succeeds and before launch handling, reapply the mode to `newWorktree.id`, save explicit overrides, and reevaluate the affected gate:
+
+```swift
+projectsManager.setGGWorktreeMode(
+    projectId: project.id,
+    worktreeId: newWorktree.id,
+    mode: ggWorktreeMode
+)
+if ggWorktreeMode != .inherit {
+    saveProjects()
+}
+rightPaneStore.reevaluateGGGate(worktreeId: newWorktree.id)
+```
+
+Add a focused cleanup helper and call it from both creation failure paths before publishing `.createFailed`:
+
+```swift
+private func discardUnpersistedGGWorktreeMode(
+    projectId: String,
+    worktreeId: String,
+    mode: GGWorktreeMode
+) {
+    guard mode != .inherit else { return }
+    projectsManager.removeGGWorktreeMode(projectId: projectId, worktreeId: worktreeId)
+    rightPaneStore.reevaluateGGGate(worktreeId: worktreeId)
+}
+```
+
+- [ ] **Step 5: Run the focused lifecycle tests and verify GREEN**
+
+Run the Step 2 command again.
+
+Expected: both tests pass with zero failures.
+
+- [ ] **Step 6: Run all AppState cleanup tests**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/AppStateCleanupTests
+```
+
+Expected: the suite passes with zero failures.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add Alas/Sources/App/AppState.swift AlasTests/AppStateCleanupTests.swift
+git commit -m "feat: persist GG mode during worktree creation"
+```
+
+---
+
+### Task 3: Replace the GG creation toggle with the three-state picker
+
+**Files:**
+- Modify: `Alas/Sources/Dialogs/NewWorktreeDialog.swift`
+- Test: `AlasTests/NewWorktreeDialogTests.swift`
+
+**Interfaces:**
+- Consumes: `GGStackCreateMode.createsStack(...)` from Task 1 and the `ggWorktreeMode` creation argument from Task 2.
+- Produces: a single raw `GGWorktreeMode` dialog selection that controls the displayed input, base pinning, validation, helper copy, and persisted creation request.
+
+- [ ] **Step 1: Replace Boolean-helper tests with failing three-state tests**
+
+Remove `stackModeSurvivesOnlyWhenAvailabilityEnabled` and update `activeName` calls to use `createsGGStack:`. Add tests for explanatory copy, repository reset, and validation:
+
+```swift
+@Test func inheritedGGDescriptionReportsEffectiveMode() {
+    #expect(NewWorktreeDialog.ggModeDescription(mode: .inherit, createsGGStack: true) ==
+        "Uses repository default: On.")
+    #expect(NewWorktreeDialog.ggModeDescription(mode: .inherit, createsGGStack: false) ==
+        "Uses repository default: Off. Creates a regular Git branch.")
+}
+
+@Test func explicitGGDescriptionsExplainCreation() {
+    #expect(NewWorktreeDialog.ggModeDescription(mode: .on, createsGGStack: true) ==
+        "GG enabled for this worktree.")
+    #expect(NewWorktreeDialog.ggModeDescription(mode: .off, createsGGStack: false) ==
+        "GG disabled for this worktree. Creates a regular Git branch.")
+}
+
+@Test func repositoryChangeResetsGGModeToInherit() {
+    #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(current: .on) == .inherit)
+    #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(current: .off) == .inherit)
+}
+
+@Test func canCreateBlocksMissingUsernameOnlyForEffectiveGG() {
+    #expect(!NewWorktreeDialog.canCreate(
+        projectsEmpty: false,
+        branchEmpty: false,
+        ggConfigurationMissing: true
+    ))
+    #expect(NewWorktreeDialog.canCreate(
+        projectsEmpty: false,
+        branchEmpty: false,
+        ggConfigurationMissing: false
+    ))
+}
+```
+
+- [ ] **Step 2: Run dialog tests and verify RED**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/NewWorktreeDialogTests
+```
+
+Expected: compilation fails because the three new helpers and `ggConfigurationMissing` argument do not exist.
+
+- [ ] **Step 3: Replace dialog state and compute effective creation policy**
+
+Replace the Boolean state with:
+
+```swift
+@State private var ggMode: GGWorktreeMode = .inherit
+```
+
+Make availability depend only on the hard prerequisites, not `project.ggMode`, so explicit `On` remains possible:
+
+```swift
+let gatePassed = state.config.changes.stackedDiffsEnabled
+    && GGAvailability.shared.isInstalled
+    && project.host == nil
+```
+
+Add an effective creation property using Task 1's shared resolver:
+
+```swift
+private var createsGGStack: Bool {
+    guard let project = state.projects.first(where: { $0.id == projectId }) else { return false }
+    return GGStackCreateMode.createsStack(
+        masterEnabled: state.config.changes.stackedDiffsEnabled,
+        ggInstalled: GGAvailability.shared.isInstalled,
+        isRemoteProject: project.host != nil,
+        projectMode: project.ggMode,
+        worktreeMode: ggMode,
+        repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path)
+    )
+}
+```
+
+Use `createsGGStack` everywhere the old Boolean selected the active field, effective branch, or pinned base. Preserve `branch` and `stackName` as separate state values.
+
+- [ ] **Step 4: Render the segmented picker and helper state**
+
+Replace the old toggle row with a labeled segmented picker whenever availability is not hidden:
+
+```swift
+DialogField(label: "GG mode") {
+    Picker("GG mode", selection: $ggMode) {
+        Text("Inherit").tag(GGWorktreeMode.inherit)
+        Text("On").tag(GGWorktreeMode.on)
+        Text("Off").tag(GGWorktreeMode.off)
+    }
+    .pickerStyle(.segmented)
+}
+```
+
+Add and use these pure helpers:
+
+```swift
+nonisolated static func ggModeDescription(
+    mode: GGWorktreeMode,
+    createsGGStack: Bool
+) -> String {
+    switch mode {
+    case .inherit:
+        createsGGStack
+            ? "Uses repository default: On."
+            : "Uses repository default: Off. Creates a regular Git branch."
+    case .on:
+        "GG enabled for this worktree."
+    case .off:
+        "GG disabled for this worktree. Creates a regular Git branch."
+    }
+}
+
+nonisolated static func ggModeAfterRepositoryChange(current _: GGWorktreeMode) -> GGWorktreeMode {
+    .inherit
+}
+```
+
+Render the description beneath the picker. When effective GG is enabled and an `.enabled(username:)` availability exists, also retain the existing composed branch preview and add the pinned base when present. When effective GG is enabled but availability is `.disabled(hint:)`, render that hint and set `ggConfigurationMissing` to true. Explicit or inherited Off remains creatable.
+
+- [ ] **Step 5: Reset on repository changes, validate, and pass the raw mode**
+
+In the project change handler, set:
+
+```swift
+ggMode = Self.ggModeAfterRepositoryChange(current: ggMode)
+```
+
+Extend `canCreate` with `ggConfigurationMissing: Bool = false` and include `!ggConfigurationMissing` in its guard. Pass that value from both the confirm button and submit path.
+
+Pass the raw mode into creation:
+
+```swift
+let id = await state.createWorktree(
+    projectId: project.id,
+    base: base,
+    branch: effectiveBranch,
+    destination: dest,
+    runStartup: runStartup,
+    launchSurface: surface,
+    ggWorktreeMode: ggMode
+)
+```
+
+Remove `stackModeSurvives`, rename `activeName(createAsGGStack:...)` to `activeName(createsGGStack:...)`, and update its callers and tests.
+
+- [ ] **Step 6: Run dialog and GG policy tests and verify GREEN**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/NewWorktreeDialogTests \
+  -only-testing:AlasTests/GGStackCreateModeTests \
+  -only-testing:AlasTests/GGWorktreeContextTests
+```
+
+Expected: all three suites pass with zero failures.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add Alas/Sources/Dialogs/NewWorktreeDialog.swift AlasTests/NewWorktreeDialogTests.swift
+git commit -m "feat: add GG mode to new worktree creation"
+```
+
+---
+
+### Task 4: Run project-wide verification
+
+**Files:**
+- Modify only files required to fix failures caused by Tasks 1-3.
+
+**Interfaces:**
+- Consumes: the complete implementation from Tasks 1-3.
+- Produces: a regenerated project and a build/test-verified branch ready for final review and publication.
+
+- [ ] **Step 1: Regenerate the Xcode project**
+
+```bash
+xcodegen
+```
+
+Expected: generation succeeds. If the generated project changes, inspect and commit it only when the source project definition requires that change.
+
+- [ ] **Step 2: Build the macOS app**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit status 0 with no compiler errors.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: `** TEST SUCCEEDED **` with zero failures.
+
+- [ ] **Step 4: Inspect and commit any verification-only corrections**
+
+If Steps 1-3 required corrections, rerun the affected focused suite before the full commands and commit only those corrections:
+
+```bash
+git add Alas/Sources/App/AppState.swift \
+  Alas/Sources/Dialogs/NewWorktreeDialog.swift \
+  Alas/Sources/Integrations/GG/GGStackCreateMode.swift \
+  Alas/Sources/Integrations/GG/GGWorktreeContext.swift \
+  AlasTests/AppStateCleanupTests.swift \
+  AlasTests/GGStackCreateModeTests.swift \
+  AlasTests/Integrations/GGWorktreeContextTests.swift \
+  AlasTests/NewWorktreeDialogTests.swift
+git commit -m "fix: complete new worktree GG mode integration"
+```
+
+If no correction or generated-project diff exists, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-22-new-worktree-gg-mode-design.md
+++ b/docs/superpowers/specs/2026-07-22-new-worktree-gg-mode-design.md
@@ -1,0 +1,149 @@
+# New Worktree GG Mode
+
+Date: 2026-07-22
+Status: Approved design
+
+## Context
+
+The new-worktree dialog currently exposes a Boolean **Create as gg stack**
+toggle. That toggle only changes creation mechanics: when enabled, Alas builds
+the branch using gg's `<branch_username>/<stack-name>` convention and pins the
+base to gg's configured default. The selected value is not persisted as the
+new worktree's `GGWorktreeMode`.
+
+Every newly discovered linked worktree therefore starts with the sparse
+`.inherit` policy. In an `Auto` project whose repository has gg configuration,
+that inherited policy resolves to On. A regular branch can consequently show
+GG immediately after creation when its name also happens to match gg's branch
+prefix, even though **Create as gg stack** was left unchecked.
+
+The creation control should express both the requested creation behavior and
+the policy the worktree keeps afterward.
+
+## Goals
+
+- Replace the ambiguous Boolean with the existing three-state worktree GG
+  policy: `Inherit`, `On`, or `Off`.
+- Make the selected raw policy determine both worktree creation mechanics and
+  the persisted worktree override.
+- Preserve sparse persistence for `Inherit`.
+- Let users explicitly enable GG while the project default is Off and
+  explicitly disable it while the project default is Auto or On.
+- Explain the effective inherited behavior before the worktree is created.
+- Ensure any auto-launched ACP session observes the persisted policy from its
+  first GG context evaluation.
+
+## Non-goals
+
+- Changing project-level `Off`, `Auto`, or `On` semantics.
+- Changing the sidebar worktree **GG Mode** menu.
+- Changing gg's branch naming convention or configured stack base.
+- Running a new gg command as part of creation; the existing branch/base
+  creation mechanics remain authoritative.
+- Adding GG support for remote projects.
+
+## User Interface
+
+For local repositories where the app-wide integration and gg installation make
+GG creation available, replace **Create as gg stack** with a segmented picker
+labeled **GG mode**:
+
+- **Inherit**
+- **On**
+- **Off**
+
+The raw selection defaults to `Inherit` each time the dialog is presented and
+resets to `Inherit` when the selected repository changes. This prevents an
+explicit choice made for one repository from silently carrying into another.
+
+The dialog renders concise helper text below the picker. It states the effective
+mode and, when effective On, previews the branch and pinned base. Examples:
+
+> Uses repository default: On  
+> Branch: `nacho/my-feature`, based on `main`
+
+> GG disabled for this worktree. Creates a regular Git branch.
+
+`Inherit` always remains visibly selected as the raw policy even when its
+effective result is On or Off. The helper text communicates that result; the
+picker must not replace `Inherit` with the resolved value.
+
+If the selected policy resolves to GG On but `branch_username` is unavailable,
+the dialog explains what is missing and disables confirmation until the user
+chooses `Off` or resolves the configuration. The control must still allow an
+explicit `On` selection when the project default is Off, so its visibility
+cannot be gated by the project default itself. Remote projects retain their
+existing regular-worktree flow without this control.
+
+## Effective Creation Behavior
+
+The dialog derives a Boolean `createsGGStack` from the raw selection and the
+repository default for a new linked worktree:
+
+| Raw selection | Effective creation behavior |
+|---|---|
+| `Off` | Regular Git worktree |
+| `On` | GG branch naming and configured GG base |
+| `Inherit` + project `Off` | Regular Git worktree |
+| `Inherit` + project `Auto` | GG when repository GG config exists; otherwise regular |
+| `Inherit` + project `On` | GG |
+
+App-wide disablement, a missing gg installation, and a remote project remain
+hard availability stops. `branch_username` is a creation prerequisite only
+when `createsGGStack` is true.
+
+When `createsGGStack` is true, the dialog uses the existing stack-name field,
+branch composition, and pinned-base behavior. When false, it uses the existing
+regular branch field and freely selected base. Separate `branch` and
+`stackName` draft values remain intact while the selection changes, so toggling
+the mode does not destroy text the user already entered.
+
+`Inherit` is deliberately dynamic. It records no promise that the effective
+mode will stay equal to its value at creation time. Later project-default or
+repository-configuration changes continue to affect the worktree exactly as
+they do today.
+
+## Persistence And Creation Flow
+
+The dialog passes the raw `GGWorktreeMode` into the worktree-creation request.
+The creation path retains ownership of applying it because successful creation,
+topology refresh, persistence, selection, and launch already happen there.
+
+After Git creation and the successful topology refresh identify the final
+worktree, but before selecting it or launching a terminal or ACP session, the
+creation path applies the raw mode:
+
+- `Inherit`: remove or omit the worktree entry in `ggWorktreeModes`.
+- `On`: persist `.on` under the worktree's stable identity.
+- `Off`: persist `.off` under the worktree's stable identity.
+
+The project file is saved when an explicit override is applied. The affected
+right-pane GG gate is reevaluated after the policy update. A failed worktree
+creation does not leave an override behind.
+
+Applying the override before selection and auto-launch prevents a newly opened
+ACP session from attaching GG context based on a transient inherited policy.
+
+## Testing
+
+Focused Swift Testing coverage should include:
+
+- The creation-behavior matrix for all three raw modes and all project modes,
+  including `Auto` with and without repository GG configuration.
+- `On` remaining selectable when the project default is Off.
+- `Off` producing the regular branch and freely selected base in a GG-capable
+  repository.
+- `Inherit` in a GG-capable `Auto` repository producing the GG branch and base.
+- Raw `Inherit` remaining selected while helper text reports effective On or
+  Off.
+- Repository changes resetting the raw selection to `Inherit` without leaking
+  the previous repository's draft choice.
+- Missing `branch_username` blocking only modes whose creation behavior is GG.
+- Successful creation persisting `.on` and `.off`, while `Inherit` remains
+  absent from `ggWorktreeModes`.
+- Creation failure leaving no stale worktree override.
+- Persistence occurring before an auto-launched ACP session resolves GG
+  context.
+- Regression coverage for current regular-branch validation, GG branch
+  composition, and pinned-base behavior.
+

--- a/docs/superpowers/specs/2026-07-22-new-worktree-gg-mode-design.md
+++ b/docs/superpowers/specs/2026-07-22-new-worktree-gg-mode-design.md
@@ -109,17 +109,22 @@ The dialog passes the raw `GGWorktreeMode` into the worktree-creation request.
 The creation path retains ownership of applying it because successful creation,
 topology refresh, persistence, selection, and launch already happen there.
 
-After Git creation and the successful topology refresh identify the final
-worktree, but before selecting it or launching a terminal or ACP session, the
-creation path applies the raw mode:
+The creation path applies the raw mode in memory to the optimistic worktree
+before its immediate selection:
 
 - `Inherit`: remove or omit the worktree entry in `ggWorktreeModes`.
 - `On`: persist `.on` under the worktree's stable identity.
 - `Off`: persist `.off` under the worktree's stable identity.
 
-The project file is saved when an explicit override is applied. The affected
-right-pane GG gate is reevaluated after the policy update. A failed worktree
-creation does not leave an override behind.
+This in-memory phase ensures the selected optimistic row never evaluates GG
+using a policy other than the one chosen in the dialog. After Git creation and
+the successful topology refresh identify the final worktree, but before
+auto-launching a terminal or ACP session, the creation path reapplies the raw
+mode to the reconciled identity and saves the project file when the mode is an
+explicit override. The affected right-pane GG gate is then reevaluated.
+
+If creation fails, the unpersisted in-memory override is removed. A failed
+worktree creation therefore does not leave an override behind.
 
 Applying the override before selection and auto-launch prevents a newly opened
 ACP session from attaching GG context based on a transient inherited policy.
@@ -146,4 +151,3 @@ Focused Swift Testing coverage should include:
   context.
 - Regression coverage for current regular-branch validation, GG branch
   composition, and pinned-base behavior.
-


### PR DESCRIPTION
## Summary

- replace the new-worktree GG Boolean with an Inherit / On / Off mode picker
- share linked-worktree GG policy resolution between creation and runtime gating
- stage optimistic overrides in runtime state and persist explicit modes only after successful reconciliation
- preserve the selected raw mode when retrying a failed worktree creation

## Why

The previous “Create as gg stack” toggle controlled branch and base creation but did not persist a worktree policy. A new linked worktree therefore inherited the repository default, which could activate GG even when the creation toggle was left off. The new control maps directly to the persisted worktree policy while keeping inherited behavior explicit.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
- focused Swift Testing coverage for policy resolution, optimistic persistence, failure/retry behavior, dialog state, and preview formatting