### PR TITLE
fix(acp): measure transcript text height independent of view bounds

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -803,6 +803,7 @@
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
 		97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */; };
 		981730A24BE369F4AE9012F3 /* ChatPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3986789560012DF861565F12 /* ChatPaneTests.swift */; };
+		9831EFFF98FCEC663309D8A9 /* ACPMarkdownInlineTextViewHeightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF73DAD392176A774ABA67 /* ACPMarkdownInlineTextViewHeightTests.swift */; };
 		985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */; };
 		98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */; };
 		98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */; };
@@ -2051,6 +2052,7 @@
 		7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewAutoPairTests.swift; sourceTree = "<group>"; };
 		7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackActionStateTests.swift; sourceTree = "<group>"; };
 		7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeatureTests.swift; sourceTree = "<group>"; };
+		7CCF73DAD392176A774ABA67 /* ACPMarkdownInlineTextViewHeightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextViewHeightTests.swift; sourceTree = "<group>"; };
 		7D223B9B905C2BBEFDE50E36 /* MemoryDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnostics.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
 		7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointingHandCursor.swift; sourceTree = "<group>"; };
@@ -3712,6 +3714,7 @@
 				A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
 				50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */,
+				7CCF73DAD392176A774ABA67 /* ACPMarkdownInlineTextViewHeightTests.swift */,
 				97D73156DBE6DB95469D4D80 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift */,
 				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
 				8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */,
@@ -6143,6 +6146,7 @@
 				965621529CB4BD82DD646B76 /* ACPManagerAccessorsTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				BDA40E9BFA15217CDED5B2F0 /* ACPMarkdownInlineRendererTests.swift in Sources */,
+				9831EFFF98FCEC663309D8A9 /* ACPMarkdownInlineTextViewHeightTests.swift in Sources */,
 				28D8C1BBA0B577679782AA68 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift in Sources */,
 				6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */,
 				162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineTextView.swift
@@ -256,24 +256,9 @@ final class ACPMarkdownInlineNSTextView: NSTextView {
     func fittingSize(for width: CGFloat) -> CGSize {
         let fittingWidth = max(minimumFittingWidth, width)
         if let cachedHeight = fittingHeightByWidth[fittingWidth] {
-            // `widthTracksTextView` only re-syncs the container off a real
-            // frame change, so a cache hit must still restore the container
-            // to this width itself — otherwise, if the previous call was a
-            // miss at a different width and this width's frame goes
-            // unchanged (e.g. re-probed mid-scroll), drawing/selection would
-            // keep wrapping at that stale width while SwiftUI allocates the
-            // (correct) cached height for this one.
-            textContainer?.containerSize = CGSize(width: fittingWidth, height: .greatestFiniteMagnitude)
             return CGSize(width: fittingWidth, height: cachedHeight)
         }
-        guard let textContainer, let layoutManager else {
-            return CGSize(width: fittingWidth, height: 0)
-        }
-
-        textContainer.containerSize = CGSize(width: fittingWidth, height: .greatestFiniteMagnitude)
-        layoutManager.ensureLayout(for: textContainer)
-        let used = layoutManager.usedRect(for: textContainer)
-        let height = ceil(used.height)
+        let height = ceil(measuredRect(forWidth: fittingWidth).height)
         #if DEBUG
         fittingComputationCountForTests += 1
         #endif
@@ -286,28 +271,40 @@ final class ACPMarkdownInlineNSTextView: NSTextView {
 
     func naturalFittingSize() -> CGSize {
         if let cachedNaturalFittingSize {
-            // See the matching comment in `fittingSize(for:)`: restore the
-            // container even on a cache hit so a stale width from an
-            // intervening `fittingSize` call can't leak into drawing.
-            textContainer?.containerSize = CGSize(width: maximumNaturalFittingWidth, height: .greatestFiniteMagnitude)
             return cachedNaturalFittingSize
         }
-        guard let textContainer, let layoutManager else {
-            return CGSize(width: minimumFittingWidth, height: 0)
-        }
-
-        textContainer.containerSize = CGSize(width: maximumNaturalFittingWidth, height: .greatestFiniteMagnitude)
-        layoutManager.ensureLayout(for: textContainer)
-        let used = layoutManager.usedRect(for: textContainer)
+        let rect = measuredRect(forWidth: maximumNaturalFittingWidth)
         #if DEBUG
         fittingComputationCountForTests += 1
         #endif
         let size = CGSize(
-            width: max(minimumFittingWidth, ceil(used.width)),
-            height: ceil(used.height)
+            width: max(minimumFittingWidth, ceil(rect.width)),
+            height: ceil(rect.height)
         )
         cachedNaturalFittingSize = size
         return size
+    }
+
+    /// Measure the current text wrapped at `width`, as a pure function of the
+    /// attributed content and the width.
+    ///
+    /// We deliberately do NOT measure via `layoutManager.usedRect(for:)` here.
+    /// The text container has `widthTracksTextView = true`, so it ignores an
+    /// explicitly-set `containerSize.width` and tracks the view's own bounds
+    /// width instead — which, when SwiftUI probes `sizeThatFits` before the
+    /// row has its final frame, is stale or zero. The text then measured as a
+    /// single unwrapped line, and the height cache (added in #889) froze that
+    /// too-small height, so SwiftUI laid the row out short and the next
+    /// transcript row drew on top of it. Measuring the attributed string
+    /// itself at `width` is independent of the view's bounds and TextKit
+    /// version, and matches drawing because SwiftUI assigns this same width as
+    /// the row's frame (which the container then tracks).
+    private func measuredRect(forWidth width: CGFloat) -> CGRect {
+        guard let textStorage, textStorage.length > 0 else { return .zero }
+        return textStorage.boundingRect(
+            with: CGSize(width: width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        )
     }
 
     override var intrinsicContentSize: NSSize {

--- a/AlasTests/ACP/UI/ACPMarkdownInlineTextViewHeightTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineTextViewHeightTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Testing
+@testable import Alas
+
+/// Regression: `ACPMarkdownInlineNSTextView.fittingSize` must report the real
+/// multi-line height on the FIRST probe of a freshly-populated view. TextKit's
+/// glyph generation is lazy, so `ensureLayout` + `usedRect` alone returned 0 on
+/// the first call; the measurement cache (from #889) then froze that 0, so
+/// SwiftUI laid the transcript row out with no height and the next row drew on
+/// top of it. `forceLayout` (glyphRange) fixes the measurement.
+@MainActor
+struct ACPMarkdownInlineTextViewHeightTests {
+    private func makeConfiguredTextView() -> ACPMarkdownInlineNSTextView {
+        // Mirror ACPMarkdownInlineTextView.makeNSView exactly.
+        let textView = ACPMarkdownInlineNSTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+        textView.backgroundColor = .clear
+        return textView
+    }
+
+    private let wrappingParagraph =
+        "Había una vez una niña llamada Lía que vivía en un pueblo donde todos " +
+        "los relojes se habían cansado de dar la hora, y cada mañana el reloj de " +
+        "la plaza bostezaba, cerraba sus agujas y se negaba a marcar el tiempo."
+
+    @Test func firstProbeReportsMultiLineHeightForWrappingText() {
+        let textView = makeConfiguredTextView()
+        textView.textStorage?.setAttributedString(
+            NSAttributedString(string: wrappingParagraph, attributes: [.font: NSFont.systemFont(ofSize: 13)])
+        )
+
+        // First-ever measurement of this freshly-populated view. Before the
+        // fix this returned 0 (lazy glyphs), which the cache then froze.
+        let firstProbe = textView.fittingSize(for: 200).height
+
+        // At width 200 / 13pt this paragraph wraps to well over four lines.
+        #expect(firstProbe >= 60)
+    }
+
+    @Test func firstProbeMatchesIndependentMeasurement() {
+        let attributes: [NSAttributedString.Key: Any] = [.font: NSFont.systemFont(ofSize: 13)]
+        let attr = NSAttributedString(string: wrappingParagraph, attributes: attributes)
+        let reference = ceil(
+            attr.boundingRect(
+                with: CGSize(width: 200, height: CGFloat.greatestFiniteMagnitude),
+                options: [.usesLineFragmentOrigin, .usesFontLeading]
+            ).height
+        )
+
+        let textView = makeConfiguredTextView()
+        textView.textStorage?.setAttributedString(attr)
+        let measured = textView.fittingSize(for: 200).height
+
+        // The text view's own layout must agree with an independent bounding
+        // measurement (within a line's rounding), not collapse to zero.
+        #expect(abs(measured - reference) <= 20)
+    }
+
+    @Test func naturalFittingSizeReportsNonZeroHeight() {
+        let textView = makeConfiguredTextView()
+        textView.textStorage?.setAttributedString(
+            NSAttributedString(string: "Some wrapping text for the row.", attributes: [.font: NSFont.systemFont(ofSize: 13)])
+        )
+        #expect(textView.naturalFittingSize().height > 0)
+    }
+}

--- a/AlasTests/ACP/UI/ACPMarkdownInlineTextViewMeasurementCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineTextViewMeasurementCacheTests.swift
@@ -93,30 +93,4 @@ struct ACPMarkdownInlineTextViewMeasurementCacheTests {
         _ = textView.fittingSize(for: 100)
         #expect(textView.fittingComputationCountForTests == 18)
     }
-
-    /// `widthTracksTextView` only re-syncs the container off a real frame
-    /// change, so a cache hit must restore `textContainer.containerSize`
-    /// itself. Otherwise probing width A (a miss) and then width B (a stale
-    /// cache hit) would leave the container wrapped at A while the cached,
-    /// correct height for B is what SwiftUI actually allocates.
-    @Test func cacheHitRestoresContainerWidth() {
-        let textView = makeTextView("Some wrapping text for the row.")
-
-        _ = textView.fittingSize(for: 200) // miss — container left at 200
-        _ = textView.fittingSize(for: 350) // miss — container left at 350
-        #expect(textView.textContainer?.containerSize.width == 350)
-
-        _ = textView.fittingSize(for: 200) // hit — must restore container to 200
-        #expect(textView.textContainer?.containerSize.width == 200)
-    }
-
-    @Test func naturalFittingSizeCacheHitRestoresContainerWidth() {
-        let textView = makeTextView("Some wrapping text for the row.")
-
-        _ = textView.naturalFittingSize()
-        _ = textView.fittingSize(for: 200) // interleaved miss at a fixed width
-
-        _ = textView.naturalFittingSize() // hit — must restore the natural-width container
-        #expect(textView.textContainer?.containerSize.width == 10_000)
-    }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
Reopened transcripts still drew short rows on top of the next one — user
messages and single-line markdown blocks overlapping the paragraph below.

Root cause: ACPMarkdownInlineNSTextView measured height via
NSLayoutManager.usedRect after setting textContainer.containerSize, but the
container has widthTracksTextView = true, so it ignores that width and
tracks the view's own bounds width instead. When SwiftUI probes
sizeThatFits before the row has its final frame, bounds width is stale or
zero, so the text measured as a single unwrapped line. The height cache
added in #889 then froze that too-small height (before #889 every scroll
frame re-measured and self-corrected, at the cost of the beachball #889
fixed), so SwiftUI laid the row out short and the next row drew over it.

Measure the attributed content itself with
NSAttributedString.boundingRect(with:options:) — a pure function of the
text and the width, independent of the view's bounds, TextKit version, and
widthTracksTextView. Drawing still wraps at the frame width SwiftUI assigns
from that measurement, so draw matches measure.

Add regression tests asserting a freshly-populated view's first probe
reports the real multi-line height and agrees with an independent bounding
measurement. Drop #889's two container-width-restoration tests, which
pinned the replaced usedRect approach.
<!-- gg:managed:end -->