### PR TITLE
fix(gg): remove duplicate GG mode label in new worktree dialog

### DIFF
--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -87,6 +87,7 @@ struct NewWorktreeDialog: View {
                             Text("Off").tag(GGWorktreeMode.off)
                         }
                         .pickerStyle(.segmented)
+                        .labelsHidden()
                     }
                     Text(Self.ggModeDescription(mode: ggMode, createsGGStack: createsGGStack))
                         .font(.system(size: 11))


### PR DESCRIPTION
The segmented Picker in the New Worktree dialog rendered its own "GG mode" label alongside the `DialogField` title, so "GG mode" showed up twice.

Hide the picker label with `.labelsHidden()` — the `DialogField` still provides the visible title and the accessibility label is preserved.

The GG mode field is only shown when stacked diffs are globally enabled, `gg` is installed, and the project is local, so this only affects users with GG mode on.