### PR TITLE
fix(sidebar): Use stack icon for gg sidebar badge

### DIFF
--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -169,10 +169,11 @@ struct WorktreeRowView: View {
                             .accessibilityElement(children: .ignore)
                             .accessibilityLabel(Self.stackSummaryAccessibilityLabel(merged: stack.merged, total: stack.total))
                         } else if ggMenuModel.showsStatusIndicator {
-                            Text("GG")
-                                .font(.system(size: 10.5, weight: .medium, design: .monospaced))
-                                .foregroundColor(theme.color("accent"))
+                            GGSidebarStackShape()
+                                .fill(theme.color("accent"))
+                                .frame(width: 9, height: 9)
                                 .help("gg is active for this worktree.")
+                                .accessibilityLabel("gg is active for this worktree.")
                         }
                         if let summary = harnessSummary {
                             Spacer()


### PR DESCRIPTION
<!-- gg:managed:start -->
- Replace the textual GG badge with the existing stack glyph
- Preserve the active gg help text and accessibility label
<!-- gg:managed:end -->