### PR TITLE
fix(search): keep Cmd-P result list in sync with the model

### DIFF
--- a/Alas/Sources/Search/Views/ContentResultGroup.swift
+++ b/Alas/Sources/Search/Views/ContentResultGroup.swift
@@ -16,11 +16,13 @@ struct ContentResultGroupView: View {
             ForEach(Array(group.hits.enumerated()), id: \.element.id) { offset, hit in
                 let absIndex = baseIndex + offset
                 hitRow(hit: hit, absIndex: absIndex, isSelected: absIndex == selectedIndex)
-                    // Identity stays the ForEach's `\.element.id` (the hit).
-                    // The dialog scrolls by the selected hit's id, so no
-                    // position `.id(absIndex)` override is needed — and adding
-                    // one would freeze rows against data changes (see
-                    // FileSearchDialog for the LazyVStack caching rationale).
+                    // Identity/scroll anchor is the hit id, not the row
+                    // position: a stable position id (`.id(absIndex)`) froze
+                    // rows against data changes (see FileSearchDialog for the
+                    // LazyVStack caching rationale), while a data-based id
+                    // changes with the hit and still lets the dialog's
+                    // `scrollTo(selected hit id)` reach it during keyboard nav.
+                    .id(hit.id)
             }
         }
         .padding(.vertical, 6)

--- a/Alas/Sources/Search/Views/ContentResultGroup.swift
+++ b/Alas/Sources/Search/Views/ContentResultGroup.swift
@@ -16,10 +16,11 @@ struct ContentResultGroupView: View {
             ForEach(Array(group.hits.enumerated()), id: \.element.id) { offset, hit in
                 let absIndex = baseIndex + offset
                 hitRow(hit: hit, absIndex: absIndex, isSelected: absIndex == selectedIndex)
-                    // Match the scroll-target id used by file rows so the
-                    // dialog's `ScrollViewReader.scrollTo(selectedIndex)`
-                    // can reach content hits as keyboard nav moves them.
-                    .id(absIndex)
+                    // Identity stays the ForEach's `\.element.id` (the hit).
+                    // The dialog scrolls by the selected hit's id, so no
+                    // position `.id(absIndex)` override is needed — and adding
+                    // one would freeze rows against data changes (see
+                    // FileSearchDialog for the LazyVStack caching rationale).
             }
         }
         .padding(.vertical, 6)

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -70,11 +70,14 @@ struct FileSearchDialog: View {
                                     onTap: { open(r) },
                                     onHover: { model.selectedIndex = idx }
                                 )
-                                // Identity is the ForEach's `\.element.id` (the
-                                // file). Do NOT override with `.id(position)`:
-                                // a stable position id lets LazyVStack cache the
-                                // row and never rebuild it when the file at that
-                                // position changes, freezing stale results.
+                                // Identity/scroll anchor is the file id, not the
+                                // row position. A stable position id (`.id(idx)`)
+                                // let LazyVStack cache the row and never rebuild
+                                // it when the file at that position changed,
+                                // freezing stale results; a data-based id changes
+                                // with the file and still gives `scrollTo` an
+                                // explicit target for keyboard navigation.
+                                .id(r.id)
                             }
                         case .content:
                             contentGroupViews(model: model)

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -70,7 +70,11 @@ struct FileSearchDialog: View {
                                     onTap: { open(r) },
                                     onHover: { model.selectedIndex = idx }
                                 )
-                                .id(idx)
+                                // Identity is the ForEach's `\.element.id` (the
+                                // file). Do NOT override with `.id(position)`:
+                                // a stable position id lets LazyVStack cache the
+                                // row and never rebuild it when the file at that
+                                // position changes, freezing stale results.
                             }
                         case .content:
                             contentGroupViews(model: model)
@@ -80,7 +84,17 @@ struct FileSearchDialog: View {
                 }
                 .frame(minHeight: 240, maxHeight: 460)
                 .onChange(of: model.scrollToSelectionTick) { _, _ in
-                    proxy.scrollTo(model.selectedIndex, anchor: .center)
+                    // Scroll target is the selected row's element id — matching
+                    // the identities the ForEach rows now use.
+                    let targetId: String? = switch model.kind {
+                    case .files:
+                        model.results.fileResults[safe: model.selectedIndex]?.id
+                    case .content:
+                        hit(at: model.selectedIndex, in: model.results.contentGroups)?.id
+                    }
+                    if let targetId {
+                        proxy.scrollTo(targetId, anchor: .center)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

Cmd-P file search appeared completely broken on macOS 26: typing a query was ignored — the list kept showing the files present when the dialog first opened, regardless of what you typed.

## Root cause

The search *logic* was fine the whole time — the fff backend returned correct matches, the model ranked and published them correctly, and the view's observation fired. The bug was purely in how the result list rendered.

Each row in the `LazyVStack` was stamped with a **position** id (`.id(idx)` for files, `.id(absIndex)` for content hits) so `ScrollViewReader.scrollTo(selectedIndex)` could target it. But a position id is **stable across searches** — row 0 is always id `0`, whether the query is empty or `test`. macOS 26's `LazyVStack` caches rows by identity and does not rebuild a row whose id hasn't changed, so the rows created at `open()` were never handed the new data. The model updated underneath, but the on-screen rows stayed frozen.

## Fix

Let each row keep the `ForEach`'s `\.element.id` identity (the file / hit), which *changes* when the content at a position changes and forces a rebuild. Drop the position `.id(...)` overrides, and retarget the scroll to the selected row's element id instead of its index.

The content-hit list shared the exact same pattern, so it's fixed too.

## Verification

- Reproduced against a fresh build with view-layer instrumentation: the model published correct filtered results while the list showed stale rows — confirming a render-identity bug, not a search bug.
- After the fix, the list tracks the query live in both file and content modes.
- `xcodebuild ... build` clean; focused search suites (`SearchModelTests`, `FileSearchRankerTests`, `FuzzyMatchTests`) green — 46 tests pass.