### PR TITLE
fix(search): apply data-based row identity to the other pickers

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -77,14 +77,18 @@ struct ACPMentionPickerView: View {
                             .padding(.horizontal, 10).padding(.vertical, 10)
                     } else {
                         ForEach(Array(ranked.enumerated()), id: \.element) { idx, file in
-                            row(idx: idx, file: file).id(idx)
+                            // Data-based id (the file URL), not the row
+                            // position: a positional id freezes LazyVStack rows
+                            // against the ranked list changing as you type.
+                            row(idx: idx, file: file).id(file)
                         }
                     }
                 }
                 .padding(.vertical, 4)
             }
             .onChange(of: highlight) { _, new in
-                proxy.scrollTo(new, anchor: .center)
+                guard ranked.indices.contains(new) else { return }
+                proxy.scrollTo(ranked[new], anchor: .center)
             }
         }
     }

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -206,7 +206,10 @@ private struct DropdownPanel: View {
                     LazyVStack(alignment: .leading, spacing: 1) {
                         ForEach(Array(filtered.enumerated()), id: \.element.id) { idx, item in
                             row(idx: idx, item: item)
-                                .id(idx)
+                                // Data-based id, not the row position: a
+                                // positional id freezes LazyVStack rows against
+                                // the substring filter shrinking the list.
+                                .id(item.id)
                         }
                         if filtered.isEmpty {
                             Text("No matches")
@@ -218,8 +221,10 @@ private struct DropdownPanel: View {
                     .padding(.vertical, 4)
                 }
                 .onChange(of: keyboardScrollTick) { _, _ in
+                    let items = filtered
+                    guard items.indices.contains(highlight) else { return }
                     withAnimation(.easeOut(duration: 0.10)) {
-                        proxy.scrollTo(highlight, anchor: .center)
+                        proxy.scrollTo(items[highlight].id, anchor: .center)
                     }
                 }
             }

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -187,12 +187,18 @@ private struct DropdownPanel: View {
     private var showSearch: Bool { items.count > 5 }
 
     private var filtered: [ACPSelectChip.Item] {
-        ACPSelectChip.filteredItems(
+        let matches = ACPSelectChip.filteredItems(
             items,
             query: query,
             searchDescriptions: searchDescriptions,
             searchIdentifiers: searchIdentifiers
         )
+        // Item ids come from agent-supplied model/mode/option lists that
+        // aren't validated upstream. Drop duplicate ids so the row `.id()`
+        // and ForEach identity stay unique — duplicate SwiftUI list ids are
+        // undefined behavior.
+        var seen = Set<String>()
+        return matches.filter { seen.insert($0.id).inserted }
     }
 
     var body: some View {

--- a/Alas/Sources/ACP/UI/ACPSlashPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPSlashPicker.swift
@@ -110,18 +110,16 @@ struct ACPSlashPickerView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, 10).padding(.vertical, 6)
                     } else {
-                        // Identity is positional (offset == idx), matching
-                        // the row's `.id(idx)` and the index-based
-                        // `selectedIndex` / `scrollTo`. Using `\.element` here
-                        // would collide when the agent emits duplicate
-                        // commands and would disagree with `.id(idx)` when
-                        // the filtered list reorders on every keystroke —
-                        // the LazyVStack then recycles cells by element id but
-                        // re-identifies the row by index, leaving blank
-                        // recycled rows interspersed with live ones.
-                        ForEach(Array(items.enumerated()), id: \.offset) { idx, s in
+                        // Identity is the command string, kept consistent
+                        // across the ForEach `id:`, the row `.id()` and
+                        // `scrollTo`. The model de-duplicates by command in its
+                        // init, so commands are unique here — no element-id
+                        // collision. A positional id would instead freeze
+                        // LazyVStack rows against the list re-sorting on every
+                        // keystroke, leaving stale rows on screen.
+                        ForEach(Array(items.enumerated()), id: \.element.command) { idx, s in
                             row(s, isSelected: idx == model.selectedIndex)
-                                .id(idx)
+                                .id(s.command)
                                 .contentShape(Rectangle())
                                 .onTapGesture { onPick(s) }
                         }
@@ -130,8 +128,9 @@ struct ACPSlashPickerView: View {
                 .padding(.vertical, 4)
             }
             .onChange(of: model.selectedIndex) { _, new in
+                guard items.indices.contains(new) else { return }
                 withAnimation(.easeOut(duration: 0.08)) {
-                    proxy.scrollTo(new, anchor: .center)
+                    proxy.scrollTo(items[new].command, anchor: .center)
                 }
             }
         }

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -200,7 +200,9 @@ struct AgentLauncherDialog: View {
                                 },
                                 onHover: { appState.agentLauncher.selectedIndex = idx }
                             )
-                            .id(idx)
+                            // Data-based id, not the row position: a positional
+                            // id freezes LazyVStack rows against query filtering.
+                            .id(agent.id)
                         }
                     }
                 }
@@ -208,7 +210,10 @@ struct AgentLauncherDialog: View {
             }
             .frame(minHeight: 180, maxHeight: 320)
             .onChange(of: appState.agentLauncher.scrollToSelectionTick) { _, _ in
-                proxy.scrollTo(appState.agentLauncher.selectedIndex, anchor: .center)
+                let index = appState.agentLauncher.selectedIndex
+                if agents.indices.contains(index) {
+                    proxy.scrollTo(agents[index].id, anchor: .center)
+                }
             }
         }
     }

--- a/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
@@ -25,7 +25,10 @@ struct CompletionPopup: View {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
                             rowView(row)
-                                .id(index)
+                                // Data-based id, not the row position: a
+                                // positional id freezes LazyVStack rows against
+                                // the completion list being re-queried as you type.
+                                .id(row.id)
                                 .background(index == selection ? Color.accentColor.opacity(0.24) : Color.clear)
                                 .contentShape(Rectangle())
                                 .onTapGesture { onChoose(index) }
@@ -58,9 +61,10 @@ struct CompletionPopup: View {
 
     private func scrollSelection(_ selection: Int, proxy: ScrollViewProxy) {
         guard rows.indices.contains(selection) else { return }
+        let id = rows[selection].id
         DispatchQueue.main.async {
             withAnimation(nil) {
-                proxy.scrollTo(selection, anchor: .center)
+                proxy.scrollTo(id, anchor: .center)
             }
         }
     }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -95,7 +95,7 @@ struct RepoSelectorDialog: View {
         return ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(renderedRows) { renderedRow in
+                    ForEach(renderedRows, id: \.row.stableId) { renderedRow in
                         RepoSelectorRowView(
                             row: renderedRow.row,
                             isSelected: renderedRow.index == appState.repoSelector.selectedIndex,
@@ -114,7 +114,10 @@ struct RepoSelectorDialog: View {
                                 appState.repoSelector.setSelectedIndex(renderedRow.index, in: rows)
                             }
                         )
-                        .id(renderedRow.index)
+                        // Content-derived id (not the row position): a
+                        // positional id freezes LazyVStack rows against the
+                        // list reordering on each keystroke.
+                        .id(renderedRow.row.stableId)
                     }
                 }
                 .padding(.vertical, 4)
@@ -125,7 +128,10 @@ struct RepoSelectorDialog: View {
                 // .center would re-center on every arrow press, shifting the
                 // list under the cursor and triggering hover-induced
                 // selection bouncing.
-                proxy.scrollTo(appState.repoSelector.selectedIndex)
+                let index = appState.repoSelector.selectedIndex
+                if rows.indices.contains(index) {
+                    proxy.scrollTo(rows[index].stableId)
+                }
             }
         }
     }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -95,7 +95,7 @@ struct RepoSelectorDialog: View {
         return ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(renderedRows, id: \.row.stableId) { renderedRow in
+                    ForEach(renderedRows) { renderedRow in
                         RepoSelectorRowView(
                             row: renderedRow.row,
                             isSelected: renderedRow.index == appState.repoSelector.selectedIndex,
@@ -114,10 +114,13 @@ struct RepoSelectorDialog: View {
                                 appState.repoSelector.setSelectedIndex(renderedRow.index, in: rows)
                             }
                         )
-                        // Content-derived id (not the row position): a
-                        // positional id freezes LazyVStack rows against the
-                        // list reordering on each keystroke.
-                        .id(renderedRow.row.stableId)
+                        // `RepoSelectorRenderedRow.id` is `"<index>:<stableId>"`
+                        // — unique (the same worktree can appear in both the
+                        // Recent and project sections, so a bare stableId would
+                        // collide) and content-aware (the stableId component
+                        // changes when the row at a position changes, so
+                        // LazyVStack rebuilds instead of caching a stale row).
+                        .id(renderedRow.id)
                     }
                 }
                 .padding(.vertical, 4)
@@ -129,8 +132,8 @@ struct RepoSelectorDialog: View {
                 // list under the cursor and triggering hover-induced
                 // selection bouncing.
                 let index = appState.repoSelector.selectedIndex
-                if rows.indices.contains(index) {
-                    proxy.scrollTo(rows[index].stableId)
+                if renderedRows.indices.contains(index) {
+                    proxy.scrollTo(renderedRows[index].id)
                 }
             }
         }

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
@@ -136,7 +136,9 @@ struct ReviewTargetDialog: View {
                     }
                     ForEach(Array(entries.enumerated()), id: \.element.id) { index, entry in
                         worktreeRow(entry, isSelected: index == model.selectedIndex)
-                            .id(index)
+                            // Data-based id, not the row position: a positional
+                            // id freezes LazyVStack rows against filtering.
+                            .id(entry.id)
                             .onTapGesture {
                                 model.setSelectedIndex(index, selectable: entries.map { _ in true })
                                 Task { await model.activateSelection(environment: environment) }
@@ -154,7 +156,9 @@ struct ReviewTargetDialog: View {
             }
             .frame(minHeight: 200, maxHeight: 420)
             .onChange(of: model.scrollToSelectionTick) { _, _ in
-                proxy.scrollTo(model.selectedIndex)
+                if entries.indices.contains(model.selectedIndex) {
+                    proxy.scrollTo(entries[model.selectedIndex].id)
+                }
             }
         }
     }
@@ -214,7 +218,7 @@ struct ReviewTargetDialog: View {
         return ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                    ForEach(Array(rows.enumerated()), id: \.element.stableId) { index, row in
                         targetRowView(
                             row,
                             index: index,
@@ -222,14 +226,18 @@ struct ReviewTargetDialog: View {
                             selectedCommit: selectedCommit,
                             selectable: selectable
                         )
-                        .id(index)
+                        // Content-derived id so filtering rebuilds rows instead
+                        // of leaving stale LazyVStack cells at fixed positions.
+                        .id(row.stableId)
                     }
                 }
                 .padding(.vertical, 4)
             }
             .frame(minHeight: 200, maxHeight: 420)
             .onChange(of: model.scrollToSelectionTick) { _, _ in
-                proxy.scrollTo(model.selectedIndex)
+                if rows.indices.contains(model.selectedIndex) {
+                    proxy.scrollTo(rows[model.selectedIndex].stableId)
+                }
             }
         }
     }

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -34,6 +34,19 @@ final class ReviewTargetPaletteModel {
             case .header, .message: return false
             }
         }
+
+        /// Stable, content-derived identity for SwiftUI list rows. Must not be
+        /// the row's position: a positional id lets LazyVStack cache a row and
+        /// never rebuild it when the filtered content at that position changes,
+        /// freezing stale rows (see FileSearchDialog for the full rationale).
+        var stableId: String {
+            switch self {
+            case .header(let title):  return "header:\(title)"
+            case .commit(let commit): return "commit:\(commit.sha)"
+            case .branch(let name):   return "branch:\(name)"
+            case .message(let text):  return "message:\(text)"
+            }
+        }
     }
 
     private(set) var level: Level = .worktrees


### PR DESCRIPTION
Follow-up to #901. That PR fixed the Cmd-P search list; this applies the same fix to every other filter/picker in the app that shared the anti-pattern.

## The pattern

Each picker renders its rows in a `LazyVStack` and stamped them with their **position** (`.id(idx)` / `.id(index)` / `.id(offset)`), scrolling to the selection by index. A position id is **stable** while the filtered/re-sorted data underneath it changes, so on macOS 26 the `LazyVStack` caches those rows and never rebuilds them — leaving stale rows on screen as you type. (This is the exact mechanism diagnosed in #901.)

## The fix

Give each row a stable, **content-derived** identity, kept consistent across the `ForEach` `id:`, the row `.id()`, and the `scrollTo` target, so a change in the content at a position forces a rebuild:

| Picker | Identity |
|---|---|
| `CompletionPopup` (LSP completions) | `row.id` |
| `RepoSelectorDialog` | `row.stableId` |
| `AgentLauncherDialog` | `agent.id` |
| `ReviewTargetDialog` (worktree + target lists) | `entry.id` / new `TargetRow.stableId` |
| `ACPSelectChip` | `item.id` |
| `ACPMentionPicker` | file URL |
| `ACPSlashPicker` | `command` (unique after the model's init de-dup) |

`ACPSlashPicker` previously used a *deliberate* positional identity (with a comment explaining it avoided element-id collisions from duplicate commands). Since the model de-duplicates by `command` in its `init`, `command` is unique in the filtered list, so all three identity sites can consistently use it — fixing the staleness without the blank-row mismatch the old comment warned about. Comment updated.

## Not changed

The LSP-install and update **progress sheets** also use `.id(idx)`, but they're a plain `VStack` (not lazy) and only ever **append** log lines, so a positional id is stable in both position and content — no staleness. Left as-is.

## Verification

- `xcodebuild ... build` clean.
- Model suites green: `ReviewTargetPaletteModelTests`, `RepoSelectorModelTests`, `AgentLauncherModelTests`.
- Same structural fix as #901, which was confirmed working at runtime.