### PR TITLE
fix(terminal): preserve persistent tabs across Alas instances

### DIFF
--- a/Alas/Sources/Terminal/EnvBuilder.swift
+++ b/Alas/Sources/Terminal/EnvBuilder.swift
@@ -4,16 +4,8 @@ enum EnvBuilder {
     private static let strippedKeys: Set<String> = [
         "TERM", "TERMINFO", "TERMINFO_DIRS",
         "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "COLORTERM",
-        // zmx injects ZMX_SESSION into the shell it spawns. If Alas inherits
-        // that env (because Alas itself was launched from a zmx-attached
-        // terminal, or because we're building env for a sibling pane), passing
-        // it through means a subsequent `zmx attach <other>` from anywhere in
-        // the new shell falls into zmx's switchSesh path and re-attaches the
-        // pane to a different session. See zmx#151. Note: ZMX_SESSION_PREFIX
-        // is intentionally NOT stripped — it's a user-facing zmx config knob
-        // (prefixes session names for all commands), and as long as both
-        // spawned shells and Alas's own zmx CLI invocations see the same
-        // prefix, name resolution stays consistent.
+        // Do not copy an inherited zmx session identity. ZMX_SESSION_PREFIX
+        // remains inherited user configuration.
         "ZMX_SESSION",
     ]
 
@@ -29,6 +21,11 @@ enum EnvBuilder {
         var env: [String: String] = inheritParent
             ? parent.filter { !strippedKeys.contains($0.key) }
             : [:]
+        // Ghostty starts from the Alas process environment and overlays these
+        // values, so omission cannot remove a ZMX_SESSION inherited by an Alas
+        // instance launched from a persistent terminal. An empty value makes zmx
+        // take its normal attach path instead of switchSesh.
+        env["ZMX_SESSION"] = ""
         env["ALAS_REPO"] = project.name
         env["ALAS_BRANCH"] = worktree.branch
         env["ALAS_WORKTREE"] = worktree.path.path

--- a/Alas/Sources/Terminal/EnvBuilder.swift
+++ b/Alas/Sources/Terminal/EnvBuilder.swift
@@ -21,11 +21,13 @@ enum EnvBuilder {
         var env: [String: String] = inheritParent
             ? parent.filter { !strippedKeys.contains($0.key) }
             : [:]
-        // Ghostty starts from the Alas process environment and overlays these
-        // values, so omission cannot remove a ZMX_SESSION inherited by an Alas
-        // instance launched from a persistent terminal. An empty value makes zmx
-        // take its normal attach path instead of switchSesh.
-        env["ZMX_SESSION"] = ""
+        if project.host == nil {
+            // Local Ghostty starts from the Alas process environment and overlays
+            // these values, so omission cannot remove a ZMX_SESSION inherited by
+            // an Alas instance launched from a persistent terminal. An empty value
+            // makes zmx take its normal attach path instead of switchSesh.
+            env["ZMX_SESSION"] = ""
+        }
         env["ALAS_REPO"] = project.name
         env["ALAS_BRANCH"] = worktree.branch
         env["ALAS_WORKTREE"] = worktree.path.path

--- a/AlasTests/EnvBuilderTests.swift
+++ b/AlasTests/EnvBuilderTests.swift
@@ -114,6 +114,22 @@ struct EnvBuilderTests {
         #expect(env["ZMX_SESSION_PREFIX"] == "team-")
     }
 
+    @Test func remoteSessionDoesNotAddZmxSessionOverride() {
+        let project = ProjectConfig(
+            id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date(), host: "devbox"
+        )
+        let wt = Worktree(id: "w", projectId: "p", name: "m", branch: "m",
+                          path: URL(fileURLWithPath: "/wt"),
+                          status: .clean, lastActivity: Date())
+        let env = EnvBuilder.build(
+            project: project, worktree: wt, sessionId: "s",
+            socketPath: nil,
+            inheritParent: true,
+            parent: ["ZMX_SESSION": "alas-parent"]
+        )
+        #expect(env["ZMX_SESSION"] == nil)
+    }
+
     @Test func zmxDirIsEmittedWhenProvided() {
         let project = ProjectConfig(id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date())
         let wt = Worktree(id: "w", projectId: "p", name: "m", branch: "m",

--- a/AlasTests/EnvBuilderTests.swift
+++ b/AlasTests/EnvBuilderTests.swift
@@ -89,14 +89,12 @@ struct EnvBuilderTests {
         #expect(env["TERMINFO"] == nil)
     }
 
-    /// zmx injects ZMX_SESSION into the shells it spawns. If Alas inherits
-    /// that env and forwards it into a freshly-spawned pane, any later
-    /// `zmx attach <other>` from that shell silently hits zmx's switchSesh
-    /// path and re-binds the pane to a different daemon's session, leaving
-    /// one Alas tab piped into another tab's shell. See zmx#151.
-    /// `ZMX_SESSION_PREFIX` is left intact so user-configured prefixes flow
-    /// through to both the spawned shell and Alas's own zmx CLI calls.
-    @Test func stripsZmxSessionButKeepsPrefixFromInheritedParent() {
+    /// Ghostty starts with the Alas process environment and overlays the
+    /// dictionary returned by EnvBuilder. Omitting ZMX_SESSION therefore does
+    /// not remove a value inherited when Alas was launched from a zmx terminal;
+    /// an explicit empty override is required to make zmx perform a normal
+    /// multi-client attach. ZMX_SESSION_PREFIX remains inherited user config.
+    @Test func shadowsZmxSessionButKeepsPrefixFromInheritedParent() {
         let project = ProjectConfig(id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date())
         let wt = Worktree(id: "w", projectId: "p", name: "m", branch: "m",
                           path: URL(fileURLWithPath: "/wt"),
@@ -112,7 +110,7 @@ struct EnvBuilderTests {
             ]
         )
         #expect(env["PATH"] == "/x")
-        #expect(env["ZMX_SESSION"] == nil)
+        #expect(env["ZMX_SESSION"] == "")
         #expect(env["ZMX_SESSION_PREFIX"] == "team-")
     }
 

--- a/AlasTests/GhosttyConfigBuilderTests.swift
+++ b/AlasTests/GhosttyConfigBuilderTests.swift
@@ -115,4 +115,40 @@ struct GhosttyConfigBuilderTests {
             #expect(emitted["ZMX_SESSION"] == "")
         }
     }
+
+    @Test @MainActor func remoteSurfaceConfigurationDoesNotEmitZmxSessionOverride() {
+        let project = ProjectConfig(
+            id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date(), host: "devbox"
+        )
+        let worktree = Worktree(
+            id: "w", projectId: "p", name: "m", branch: "m",
+            path: URL(fileURLWithPath: "/wt"),
+            status: .clean, lastActivity: Date()
+        )
+        let env = EnvBuilder.build(
+            project: project,
+            worktree: worktree,
+            sessionId: "s",
+            socketPath: nil,
+            inheritParent: true,
+            parent: ["ZMX_SESSION": "alas-parent"]
+        )
+        let config = GhosttyConfigBuilder.makeSurfaceConfiguration(
+            cwd: worktree.path,
+            env: env,
+            executable: "/usr/bin/ssh",
+            args: ["-tt", "devbox"]
+        )
+
+        config.withCValue(nsView: NSObject(), userdata: nil) { cConfig in
+            let variables = UnsafeBufferPointer(
+                start: cConfig.env_vars,
+                count: cConfig.env_var_count
+            )
+            let emitted = Dictionary(uniqueKeysWithValues: variables.map {
+                (String(cString: $0.key), String(cString: $0.value))
+            })
+            #expect(emitted["ZMX_SESSION"] == nil)
+        }
+    }
 }

--- a/AlasTests/GhosttyConfigBuilderTests.swift
+++ b/AlasTests/GhosttyConfigBuilderTests.swift
@@ -81,4 +81,38 @@ struct GhosttyConfigBuilderTests {
 
         #expect(body.contains("shell-integration = none"))
     }
+
+    @Test @MainActor func surfaceConfigurationEmitsEmptyZmxSessionOverride() {
+        let project = ProjectConfig(id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date())
+        let worktree = Worktree(
+            id: "w", projectId: "p", name: "m", branch: "m",
+            path: URL(fileURLWithPath: "/wt"),
+            status: .clean, lastActivity: Date()
+        )
+        let env = EnvBuilder.build(
+            project: project,
+            worktree: worktree,
+            sessionId: "s",
+            socketPath: nil,
+            inheritParent: true,
+            parent: ["ZMX_SESSION": "alas-parent"]
+        )
+        let config = GhosttyConfigBuilder.makeSurfaceConfiguration(
+            cwd: worktree.path,
+            env: env,
+            executable: "/bin/zsh",
+            args: ["-l"]
+        )
+
+        config.withCValue(nsView: NSObject(), userdata: nil) { cConfig in
+            let variables = UnsafeBufferPointer(
+                start: cConfig.env_vars,
+                count: cConfig.env_var_count
+            )
+            let emitted = Dictionary(uniqueKeysWithValues: variables.map {
+                (String(cString: $0.key), String(cString: $0.value))
+            })
+            #expect(emitted["ZMX_SESSION"] == "")
+        }
+    }
 }

--- a/docs/superpowers/plans/2026-07-23-cross-instance-terminal-attach.md
+++ b/docs/superpowers/plans/2026-07-23-cross-instance-terminal-attach.md
@@ -1,0 +1,161 @@
+# Cross-Instance Persistent Terminal Attach Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent a second Alas instance launched from a persistent terminal from switching, closing, and killing the shared zmx-backed terminal session.
+
+**Architecture:** Explicitly shadow `ZMX_SESSION` with an empty environment override before Alas hands a local terminal configuration to Ghostty. Ghostty merges that override over the app process environment, and zmx interprets the empty value as no current session, allowing both Alas instances to attach as clients.
+
+**Tech Stack:** Swift 5.9+, Swift Testing, SwiftUI/AppKit macOS, embedded Ghostty, zmx
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Keep the fix limited to local terminal environment construction; do not change tab persistence, terminal exit handling, remote launch, or zmx lifecycle behavior.
+- Preserve `ZMX_SESSION_PREFIX`.
+- Do not add agent attribution.
+
+---
+
+### Task 1: Shadow inherited zmx session identity for Ghostty terminals
+
+**Files:**
+- Modify: `AlasTests/EnvBuilderTests.swift:91-122`
+- Modify: `AlasTests/GhosttyConfigBuilderTests.swift`
+- Modify: `Alas/Sources/Terminal/EnvBuilder.swift:3-35`
+
+**Interfaces:**
+- Consumes: `EnvBuilder.build(project:worktree:sessionId:socketPath:inheritParent:parent:zmxDir:) -> [String: String]`
+- Produces: An environment dictionary that always contains `"ZMX_SESSION": ""` for local Ghostty surface construction while preserving any inherited `ZMX_SESSION_PREFIX`.
+
+- [ ] **Step 1: Change the environment-builder regression test to require an explicit empty override**
+
+In `AlasTests/EnvBuilderTests.swift`, rename the test and change the assertion:
+
+```swift
+/// Ghostty starts with the Alas process environment and overlays the
+/// dictionary returned by EnvBuilder. Omitting ZMX_SESSION therefore does
+/// not remove a value inherited when Alas was launched from a zmx terminal;
+/// an explicit empty override is required to make zmx perform a normal
+/// multi-client attach. ZMX_SESSION_PREFIX remains inherited user config.
+@Test func shadowsZmxSessionButKeepsPrefixFromInheritedParent() {
+    let project = ProjectConfig(id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date())
+    let wt = Worktree(id: "w", projectId: "p", name: "m", branch: "m",
+                      path: URL(fileURLWithPath: "/wt"),
+                      status: .clean, lastActivity: Date())
+    let env = EnvBuilder.build(
+        project: project, worktree: wt, sessionId: "s",
+        socketPath: nil,
+        inheritParent: true,
+        parent: [
+            "PATH": "/x",
+            "ZMX_SESSION": "alas-foo",
+            "ZMX_SESSION_PREFIX": "team-",
+        ]
+    )
+    #expect(env["PATH"] == "/x")
+    #expect(env["ZMX_SESSION"] == "")
+    #expect(env["ZMX_SESSION_PREFIX"] == "team-")
+}
+```
+
+- [ ] **Step 2: Add a failing Ghostty surface-boundary regression test**
+
+Append this test to `GhosttyConfigBuilderTests`:
+
+```swift
+@Test @MainActor func surfaceConfigurationEmitsEmptyZmxSessionOverride() {
+    let project = ProjectConfig(id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date())
+    let worktree = Worktree(
+        id: "w", projectId: "p", name: "m", branch: "m",
+        path: URL(fileURLWithPath: "/wt"),
+        status: .clean, lastActivity: Date()
+    )
+    let env = EnvBuilder.build(
+        project: project,
+        worktree: worktree,
+        sessionId: "s",
+        socketPath: nil,
+        inheritParent: true,
+        parent: ["ZMX_SESSION": "alas-parent"]
+    )
+    let config = GhosttyConfigBuilder.makeSurfaceConfiguration(
+        cwd: worktree.path,
+        env: env,
+        executable: "/bin/zsh",
+        args: ["-l"]
+    )
+
+    config.withCValue(nsView: NSObject(), userdata: nil) { cConfig in
+        let variables = UnsafeBufferPointer(
+            start: cConfig.env_vars,
+            count: cConfig.env_var_count
+        )
+        let emitted = Dictionary(uniqueKeysWithValues: variables.map {
+            (String(cString: $0.key), String(cString: $0.value))
+        })
+        #expect(emitted["ZMX_SESSION"] == "")
+    }
+}
+```
+
+- [ ] **Step 3: Run the focused tests and verify both regressions fail for the expected reason**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/EnvBuilderTests \
+  -only-testing:AlasTests/GhosttyConfigBuilderTests
+```
+
+Expected: FAIL because `EnvBuilder` omits `ZMX_SESSION`, so both tests receive `nil` instead of `""`.
+
+- [ ] **Step 4: Implement the minimal environment override**
+
+In `Alas/Sources/Terminal/EnvBuilder.swift`, retain `ZMX_SESSION` in `strippedKeys` so an inherited non-empty value is never copied, update its comment to explain Ghostty's overlay behavior, and add the explicit override immediately after the inherited/empty environment dictionary is created:
+
+```swift
+var env: [String: String] = inheritParent
+    ? parent.filter { !strippedKeys.contains($0.key) }
+    : [:]
+// Ghostty starts from the Alas process environment and overlays these
+// values, so omission cannot remove a ZMX_SESSION inherited by an Alas
+// instance launched from a persistent terminal. An empty value makes zmx
+// take its normal attach path instead of switchSesh.
+env["ZMX_SESSION"] = ""
+```
+
+- [ ] **Step 5: Run the focused tests and verify they pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/EnvBuilderTests \
+  -only-testing:AlasTests/GhosttyConfigBuilderTests
+```
+
+Expected: PASS with no failures.
+
+- [ ] **Step 6: Run project verification**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: XcodeGen completes, the build succeeds, and all tests pass.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+rtk git add Alas/Sources/Terminal/EnvBuilder.swift \
+  AlasTests/EnvBuilderTests.swift \
+  AlasTests/GhosttyConfigBuilderTests.swift
+rtk git commit -m "fix(terminal): preserve tabs across Alas instances"
+```

--- a/docs/superpowers/plans/2026-07-23-cross-instance-terminal-attach.md
+++ b/docs/superpowers/plans/2026-07-23-cross-instance-terminal-attach.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent a second Alas instance launched from a persistent terminal from switching, closing, and killing the shared zmx-backed terminal session.
 
-**Architecture:** Explicitly shadow `ZMX_SESSION` with an empty environment override before Alas hands a local terminal configuration to Ghostty. Ghostty merges that override over the app process environment, and zmx interprets the empty value as no current session, allowing both Alas instances to attach as clients.
+**Architecture:** Explicitly shadow `ZMX_SESSION` with an empty environment override only before Alas hands a local terminal configuration to Ghostty. Ghostty merges that override over the app process environment, and zmx interprets the empty value as no current session, allowing both Alas instances to attach as clients. Remote project environments remain unchanged and do not add the override.
 
 **Tech Stack:** Swift 5.9+, Swift Testing, SwiftUI/AppKit macOS, embedded Ghostty, zmx
 
@@ -27,7 +27,7 @@
 
 **Interfaces:**
 - Consumes: `EnvBuilder.build(project:worktree:sessionId:socketPath:inheritParent:parent:zmxDir:) -> [String: String]`
-- Produces: An environment dictionary that always contains `"ZMX_SESSION": ""` for local Ghostty surface construction while preserving any inherited `ZMX_SESSION_PREFIX`.
+- Produces: An environment dictionary that contains `"ZMX_SESSION": ""` only for local Ghostty surface construction while preserving any inherited `ZMX_SESSION_PREFIX`; remote project environments retain the prior omission of `ZMX_SESSION`.
 
 - [ ] **Step 1: Change the environment-builder regression test to require an explicit empty override**
 
@@ -114,17 +114,19 @@ Expected: FAIL because `EnvBuilder` omits `ZMX_SESSION`, so both tests receive `
 
 - [ ] **Step 4: Implement the minimal environment override**
 
-In `Alas/Sources/Terminal/EnvBuilder.swift`, retain `ZMX_SESSION` in `strippedKeys` so an inherited non-empty value is never copied, update its comment to explain Ghostty's overlay behavior, and add the explicit override immediately after the inherited/empty environment dictionary is created:
+In `Alas/Sources/Terminal/EnvBuilder.swift`, retain `ZMX_SESSION` in `strippedKeys` so an inherited non-empty value is never copied. For local projects only (`project.host == nil`), add the explicit override immediately after the inherited/empty environment dictionary is created. Remote projects must keep the previous omission so the remote SSH environment is unchanged:
 
 ```swift
 var env: [String: String] = inheritParent
     ? parent.filter { !strippedKeys.contains($0.key) }
     : [:]
-// Ghostty starts from the Alas process environment and overlays these
-// values, so omission cannot remove a ZMX_SESSION inherited by an Alas
-// instance launched from a persistent terminal. An empty value makes zmx
-// take its normal attach path instead of switchSesh.
-env["ZMX_SESSION"] = ""
+if project.host == nil {
+    // Local Ghostty starts from the Alas process environment and overlays
+    // these values, so omission cannot remove a ZMX_SESSION inherited by an
+    // Alas instance launched from a persistent terminal. An empty value makes
+    // zmx take its normal attach path instead of switchSesh.
+    env["ZMX_SESSION"] = ""
+}
 ```
 
 - [ ] **Step 5: Run the focused tests and verify they pass**

--- a/docs/superpowers/specs/2026-07-23-cross-instance-terminal-attach-design.md
+++ b/docs/superpowers/specs/2026-07-23-cross-instance-terminal-attach-design.md
@@ -1,0 +1,67 @@
+# Cross-Instance Persistent Terminal Attach Design
+
+## Problem
+
+When terminal persistence is enabled, an agent running inside an Alas terminal
+can launch a second Alas build for validation. The second process inherits the
+agent terminal's `ZMX_SESSION` environment variable. Alas currently removes
+that key from the environment overrides it gives Ghostty, but Ghostty first
+copies the app process environment and then overlays those overrides. Omitting
+the key therefore leaves the inherited value present.
+
+When the restored terminal runs `zmx attach`, zmx sees the inherited
+`ZMX_SESSION` and interprets the command as a request to switch the existing
+client instead of attaching another client. The original Ghostty child exits,
+Alas treats that as the terminal process ending, and its normal close path
+removes the shared persisted tab and kills the zmx session. Consequently, the
+terminal tab disappears from both Alas instances.
+
+## Desired Behavior
+
+Two concurrently running Alas instances may attach to the same persisted zmx
+terminal session. Both instances display a live view of the same shell, and
+launching or attaching the second instance does not close the tab, terminate
+the shell, or remove shared persisted tab state.
+
+## Design
+
+For local Ghostty terminal surfaces, `EnvBuilder` will explicitly emit
+`ZMX_SESSION` with an empty value instead of merely omitting the inherited
+value. Ghostty's environment overlay then shadows any `ZMX_SESSION` inherited
+by the Alas process. zmx treats the empty value as no current session and
+follows its normal multi-client attach path.
+
+`ZMX_SESSION_PREFIX` remains inherited because it is user configuration and
+must stay consistent across attach, list, and kill operations.
+
+No tab ownership, persistence format, process-exit policy, or zmx lifecycle
+behavior changes. Remote terminal launch remains unchanged: its environment is
+separately filtered before the SSH command is created. `ZmxClient` subprocesses
+also remain unchanged because `Foundation.Process.environment` replaces the
+child environment rather than overlaying it.
+
+## Alternatives Considered
+
+- Launch zmx through `env -u ZMX_SESSION`. This removes the variable but adds a
+  command wrapper and extra quoting complexity to every local terminal launch.
+- Add environment-removal support to the embedded Ghostty API. This would be a
+  clean general capability, but requires a vendored Ghostty change and a much
+  larger integration surface than this bug warrants.
+
+## Testing
+
+- Update the `EnvBuilder` regression test to assert that an inherited
+  `ZMX_SESSION` becomes an explicit empty override while
+  `ZMX_SESSION_PREFIX` is preserved.
+- Add focused coverage that the surface configuration passes an explicit empty
+  environment override through to Ghostty's C configuration.
+- Run the focused terminal environment/configuration tests, then the project
+  build and test commands required by `AGENTS.md`.
+
+## Acceptance Criteria
+
+- Starting a second Alas instance from a persistent Alas terminal does not
+  remove the terminal tab from either instance.
+- Both instances can remain attached to and display the same zmx-backed shell.
+- Explicit tab close and terminal-process-exit behavior remain unchanged.
+- Non-persistent and remote terminal launch paths continue to work as before.


### PR DESCRIPTION
## Summary

- prevent a second Alas instance launched from a persistent terminal from inheriting the parent zmx session identity
- explicitly shadow `ZMX_SESSION` only for local Ghostty surfaces so zmx performs a normal multi-client attach
- preserve existing remote SSH behavior and `ZMX_SESSION_PREFIX`
- add direct environment and Ghostty C-boundary regressions for both local and remote terminals

## Root cause

Ghostty starts terminal processes with the Alas process environment and then overlays the environment supplied by `EnvBuilder`. Omitting inherited `ZMX_SESSION` from the overlay did not remove it when Alas itself was launched inside a zmx-backed terminal. zmx therefore interpreted the restored terminal's attach as a session switch, causing the original attach client to exit and Alas to close and kill the shared persisted terminal.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- 52 focused tests across `EnvBuilderTests`, `GhosttyConfigBuilderTests`, `RemoteTerminalLaunchTests`, and `TerminalServiceZmxTests`
- test-first RED/GREEN coverage for the local attach bug and remote-scope guard