### PR TITLE
fix(sidebar): mute pending stack indicator

### DIFF
--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -52,6 +52,10 @@ struct WorktreeRowView: View {
         stackSummaryText(merged: merged, total: total)
     }
 
+    static func pendingStackIndicatorColorToken() -> String {
+        "fg-faint"
+    }
+
     private static func stackSummaryText(merged: Int, total: Int) -> String {
         "gg stack · \(merged) of \(total) commit\(total == 1 ? "" : "s") merged"
     }
@@ -170,7 +174,7 @@ struct WorktreeRowView: View {
                             .accessibilityLabel(Self.stackSummaryAccessibilityLabel(merged: stack.merged, total: stack.total))
                         } else if ggMenuModel.showsStatusIndicator {
                             GGSidebarStackShape()
-                                .fill(theme.color("accent"))
+                                .fill(theme.color(Self.pendingStackIndicatorColorToken()))
                                 .frame(width: 9, height: 9)
                                 .help("gg is active for this worktree.")
                                 .accessibilityLabel("gg is active for this worktree.")

--- a/AlasTests/WorktreeRowHeightTests.swift
+++ b/AlasTests/WorktreeRowHeightTests.swift
@@ -20,6 +20,10 @@ struct WorktreeRowHeightTests {
             == "gg stack · 2 of 3 commits merged")
     }
 
+    @Test func pendingGGStackIndicatorUsesMutedColorUntilCommitSyncs() {
+        #expect(WorktreeRowView.pendingStackIndicatorColorToken() == "fg-faint")
+    }
+
     @Test func rowHeightIsStableWithAndWithoutBadge() throws {
         let withoutBadge = try renderHeight(harnessSummary: nil)
         let withBadge = try renderHeight(harnessSummary: .init(


### PR DESCRIPTION
## Summary

- Mute the pending gg stack sidebar indicator before any synced stack summary exists.
- Add regression coverage for the pending stack indicator color token.

## Root cause

The left sidebar used the `accent` theme token whenever gg was active but the worktree did not yet have a `GGStackSummary`. That made an unsynced/no-commit-synced stack look accented before there was synced stack state to report.

## Validation

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test -only-testing:AlasTests/WorktreeRowHeightTests`
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was attempted locally but hung silently for about 17 minutes and was interrupted.