### PR TITLE
feat(gg): surface stack sync in Prepare

### DIFF
--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -55,23 +55,18 @@ struct GGStackDrawer: View {
     @State private var isRefreshing = false
 
     private var model: GGStackReadinessModel? {
-        if rps.ggStackLoadState == .loaded, let stack = rps.ggStack {
-            return GGStackReadinessModel.make(
-                stack: stack,
-                action: rps.ggActionState,
-                liveBehindBase: Self.liveBehindBaseOverride(
-                    stack: stack,
-                    selectedBaseBranch: rps.baseBranch,
-                    behindBase: rps.behindBase
-                ),
-                hasBlockingGitOperation: Self.hasBlockingGitOperation(
-                    mergeOperation: rps.mergeOp.current,
-                    pausedGGOperation: rps.ggActionState.pausedOperation
-                ),
-                effectiveConfig: rps.ggEffectiveConfig,
-                localChanges: rps.ggLocalChangeStatistics,
-                undoCandidate: rps.ggUndoCandidate
-            )
+        if let loadedStackModel = GGStackReadinessProjection.make(
+            stackLoadState: rps.ggStackLoadState,
+            stack: rps.ggStack,
+            action: rps.ggActionState,
+            selectedBaseBranch: rps.baseBranch,
+            behindBase: rps.behindBase,
+            mergeOperation: rps.mergeOp.current,
+            effectiveConfig: rps.ggEffectiveConfig,
+            localChanges: rps.ggLocalChangeStatistics,
+            undoCandidate: rps.ggUndoCandidate
+        ) {
+            return loadedStackModel
         }
         if rps.ggActionState.pausedOperation == nil, rps.ggUndoCandidate != nil {
             let inFlight = rps.ggActionState.inFlightAction
@@ -102,22 +97,6 @@ struct GGStackDrawer: View {
             context: rps.ggContext,
             loadState: rps.ggStackLoadState
         )
-    }
-
-    static func liveBehindBaseOverride(
-        stack: GGStack,
-        selectedBaseBranch: String,
-        behindBase: GitService.BehindStatus?
-    ) -> Int? {
-        guard selectedBaseBranch == stack.base else { return nil }
-        return behindBase?.count
-    }
-
-    static func hasBlockingGitOperation(
-        mergeOperation: MergeOperation?,
-        pausedGGOperation: GGPausedOperation?
-    ) -> Bool {
-        mergeOperation != nil && pausedGGOperation == nil
     }
 
     var body: some View {

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -1,5 +1,54 @@
 import Foundation
 
+struct GGStackReadinessProjection {
+    @MainActor
+    static func make(
+        stackLoadState: GGStackLoadState,
+        stack: GGStack?,
+        action: GGStackActionState,
+        selectedBaseBranch: String,
+        behindBase: GitService.BehindStatus?,
+        mergeOperation: MergeOperation?,
+        effectiveConfig: GGEffectiveConfig,
+        localChanges: GGLocalChangeStatistics,
+        undoCandidate: GGUndoCandidate?
+    ) -> GGStackReadinessModel? {
+        guard stackLoadState == .loaded, let stack else { return nil }
+        return GGStackReadinessModel.make(
+            stack: stack,
+            action: action,
+            liveBehindBase: liveBehindBaseOverride(
+                stack: stack,
+                selectedBaseBranch: selectedBaseBranch,
+                behindBase: behindBase
+            ),
+            hasBlockingGitOperation: hasBlockingGitOperation(
+                mergeOperation: mergeOperation,
+                pausedGGOperation: action.pausedOperation
+            ),
+            effectiveConfig: effectiveConfig,
+            localChanges: localChanges,
+            undoCandidate: undoCandidate
+        )
+    }
+
+    static func liveBehindBaseOverride(
+        stack: GGStack,
+        selectedBaseBranch: String,
+        behindBase: GitService.BehindStatus?
+    ) -> Int? {
+        guard selectedBaseBranch == stack.base else { return nil }
+        return behindBase?.count
+    }
+
+    static func hasBlockingGitOperation(
+        mergeOperation: MergeOperation?,
+        pausedGGOperation: GGPausedOperation?
+    ) -> Bool {
+        mergeOperation != nil && pausedGGOperation == nil
+    }
+}
+
 /// Pure presentation policy for the stack drawer. GG remains authoritative
 /// at execution time; this model only selects the action the current snapshot
 /// calls for and describes its effect.

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -14,6 +14,20 @@ enum ChangesPreparationCardText {
     }
 }
 
+struct ChangesPreparationReconciliationPresentation: Equatable {
+    let spinnerColorToken: String?
+    let accessibilityValue: String?
+
+    static func make(
+        for action: GGStackReadinessModel.Action
+    ) -> ChangesPreparationReconciliationPresentation {
+        ChangesPreparationReconciliationPresentation(
+            spinnerColorToken: action.emphasis == .primary ? "bg-0" : nil,
+            accessibilityValue: action.isInFlight ? "In progress" : nil
+        )
+    }
+}
+
 struct ChangesPreparationCard: View {
     let model: ChangesPreparationModel
     let onReviewChanges: () -> Void
@@ -203,12 +217,17 @@ struct ChangesPreparationCard: View {
     }
 
     private func ggReconciliationButton(_ action: GGStackReadinessModel.Action) -> some View {
-        Button {
+        let presentation = ChangesPreparationReconciliationPresentation.make(for: action)
+        return Button {
             onGGStackAction(action.kind)
         } label: {
             HStack(spacing: 8) {
                 if action.isInFlight {
-                    Spinner(lineWidth: 1.5, duration: 0.7)
+                    Spinner(
+                        lineWidth: 1.5,
+                        duration: 0.7,
+                        color: presentation.spinnerColorToken.map { theme.color($0) }
+                    )
                         .frame(width: 11, height: 11)
                         .accessibilityHidden(true)
                 } else {
@@ -262,6 +281,7 @@ struct ChangesPreparationCard: View {
                 .strokeBorder(theme.color("line").opacity(0.65), lineWidth: 0.75)
         )
         .help(action.detail ?? action.title)
+        .accessibilityValue(presentation.accessibilityValue ?? "")
         .accessibilityIdentifier("changes-preparation-gg-reconciliation")
     }
 

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -215,18 +215,28 @@ struct ChangesPreparationCard: View {
                     Icon(
                         name: ggReconciliationIconName(for: action.kind),
                         size: 11,
-                        color: theme.color("fg-dim")
+                        color: action.emphasis == .primary
+                            ? theme.color("bg-0")
+                            : theme.color("fg-dim")
                     )
                 }
                 VStack(alignment: .leading, spacing: 1) {
                     Text(action.title)
                         .font(.system(size: 11.5, weight: .semibold))
-                        .foregroundColor(theme.color("fg"))
+                        .foregroundColor(
+                            action.emphasis == .primary
+                                ? theme.color("bg-0")
+                                : theme.color("fg")
+                        )
                         .lineLimit(1)
                     if let detail = action.detail {
                         Text(detail)
                             .font(.system(size: 10.5))
-                            .foregroundColor(theme.color("fg-faint"))
+                            .foregroundColor(
+                                action.emphasis == .primary
+                                    ? theme.color("bg-0").opacity(0.78)
+                                    : theme.color("fg-faint")
+                            )
                             .lineLimit(1)
                     }
                 }
@@ -241,7 +251,11 @@ struct ChangesPreparationCard: View {
         .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(theme.color("bg-2").opacity(0.72))
+                .fill(
+                    action.emphasis == .primary
+                        ? theme.color("accent")
+                        : theme.color("bg-2").opacity(0.72)
+                )
         )
         .overlay(
             RoundedRectangle(cornerRadius: 6)

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -19,6 +19,7 @@ struct ChangesPreparationCard: View {
     let onReviewChanges: () -> Void
     let onDraftCommit: () -> Void
     let onGGAction: (GGChangesPreparationAction) -> Void
+    let onGGStackAction: (GGStackActionKind) -> Void
     let onReviewRequestAction: (ReviewReadinessActionKind) -> Void
 
     @Environment(\.theme) private var theme
@@ -28,6 +29,9 @@ struct ChangesPreparationCard: View {
             header
             if let reviewAction = model.reviewAction {
                 primaryReviewButton(reviewAction)
+            }
+            if let reconciliationAction = model.reconciliationAction {
+                ggReconciliationButton(reconciliationAction)
             }
             if !model.ggActions.isEmpty {
                 HStack(spacing: 6) {
@@ -198,6 +202,55 @@ struct ChangesPreparationCard: View {
         .accessibilityIdentifier("changes-preparation-gg-\(ggIdentifier(for: action.kind))")
     }
 
+    private func ggReconciliationButton(_ action: GGStackReadinessModel.Action) -> some View {
+        Button {
+            onGGStackAction(action.kind)
+        } label: {
+            HStack(spacing: 8) {
+                if action.isInFlight {
+                    Spinner(lineWidth: 1.5, duration: 0.7)
+                        .frame(width: 11, height: 11)
+                        .accessibilityHidden(true)
+                } else {
+                    Icon(
+                        name: ggReconciliationIconName(for: action.kind),
+                        size: 11,
+                        color: theme.color("fg-dim")
+                    )
+                }
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(action.title)
+                        .font(.system(size: 11.5, weight: .semibold))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(1)
+                    if let detail = action.detail {
+                        Text(detail)
+                            .font(.system(size: 10.5))
+                            .foregroundColor(theme.color("fg-faint"))
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 4)
+            }
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, minHeight: 40, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(!action.isEnabled)
+        .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(theme.color("bg-2").opacity(0.72))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line").opacity(0.65), lineWidth: 0.75)
+        )
+        .help(action.detail ?? action.title)
+        .accessibilityIdentifier("changes-preparation-gg-reconciliation")
+    }
+
     private func ggSubtitle(for action: ChangesPreparationModel.GGAction) -> String {
         if let disabledReason = action.disabledReason {
             return disabledReason
@@ -225,6 +278,14 @@ struct ChangesPreparationCard: View {
         case .newStackCommit: "new"
         case .amendCurrent: "amend"
         case .absorbIntoStack: "absorb"
+        }
+    }
+
+    private func ggReconciliationIconName(for action: GGStackActionKind) -> String {
+        switch action {
+        case .rebase: "arrow.triangle.2.circlepath"
+        case .sync: "arrow.clockwise"
+        default: "arrow.clockwise"
         }
     }
 

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -54,13 +54,14 @@ struct ChangesPreparationModel: Equatable {
     let reviewAction: ReviewAction?
     let draftAction: DraftAction?
     let reviewRequestActions: [ReviewRequestAction]
+    let reconciliationAction: GGStackReadinessModel.Action?
     let ggActions: [GGAction]
 
     var primaryAction: ReviewAction? { reviewAction }
 
     var isVisible: Bool {
         if !ggActions.isEmpty {
-            return reviewAction != nil || ggAction(.newStackCommit)?.isEnabled == true
+            return reconciliationAction != nil || reviewAction != nil || ggAction(.newStackCommit)?.isEnabled == true
         }
         return reviewAction != nil || draftAction != nil || !reviewRequestActions.isEmpty
     }
@@ -101,6 +102,7 @@ struct ChangesPreparationModel: Equatable {
 
         reviewAction = builtReviewAction
         draftAction = builtDraftAction
+        reconciliationAction = nil
         ggActions = []
         let builtActions = Self.compactReviewRequestActions(from: readinessActions)
         let effectiveAheadCommitCount = local?.aheadCommitCount ?? aheadCommitCount
@@ -119,7 +121,8 @@ struct ChangesPreparationModel: Equatable {
         capabilities: GGCapabilities,
         hasLoadedCommit: Bool = true,
         mutationDisabledReason: String? = nil,
-        newCommitDisabledReason: String? = nil
+        newCommitDisabledReason: String? = nil,
+        reconciliationAction: GGStackReadinessModel.Action? = nil
     ) -> ChangesPreparationModel {
         let summary = ReviewChangesTriggerSummary.summary(for: changes)
         let stagedChanges = changes.filter { $0.stage == .staged }
@@ -135,6 +138,7 @@ struct ChangesPreparationModel: Equatable {
             hasLoadedCommit: hasLoadedCommit,
             mutationDisabledReason: mutationDisabledReason,
             newCommitDisabledReason: newCommitDisabledReason,
+            reconciliationAction: reconciliationAction,
             reviewSummary: summary
         )
     }
@@ -145,7 +149,8 @@ struct ChangesPreparationModel: Equatable {
         capabilities: GGCapabilities,
         hasLoadedCommit: Bool = true,
         mutationDisabledReason: String? = nil,
-        newCommitDisabledReason: String? = nil
+        newCommitDisabledReason: String? = nil,
+        reconciliationAction: GGStackReadinessModel.Action? = nil
     ) -> ChangesPreparationModel {
         let summary = staged.hasChanges
             ? ReviewChangesTriggerSummary(
@@ -161,6 +166,7 @@ struct ChangesPreparationModel: Equatable {
             hasLoadedCommit: hasLoadedCommit,
             mutationDisabledReason: mutationDisabledReason,
             newCommitDisabledReason: newCommitDisabledReason,
+            reconciliationAction: reconciliationAction,
             reviewSummary: summary
         )
     }
@@ -176,6 +182,7 @@ struct ChangesPreparationModel: Equatable {
         hasLoadedCommit: Bool,
         mutationDisabledReason: String?,
         newCommitDisabledReason: String?,
+        reconciliationAction: GGStackReadinessModel.Action?,
         reviewSummary: ReviewChangesTriggerSummary?
     ) -> ChangesPreparationModel {
         let reviewAction = reviewSummary.map {
@@ -199,6 +206,7 @@ struct ChangesPreparationModel: Equatable {
                 : "Update GG to amend staged changes safely")
         return ChangesPreparationModel(
             reviewAction: reviewAction,
+            reconciliationAction: reconciliationAction,
             ggActions: [
                 GGAction(
                     kind: .newStackCommit,
@@ -225,10 +233,15 @@ struct ChangesPreparationModel: Equatable {
         )
     }
 
-    private init(reviewAction: ReviewAction?, ggActions: [GGAction]) {
+    private init(
+        reviewAction: ReviewAction?,
+        reconciliationAction: GGStackReadinessModel.Action?,
+        ggActions: [GGAction]
+    ) {
         self.reviewAction = reviewAction
         draftAction = nil
         reviewRequestActions = []
+        self.reconciliationAction = reconciliationAction
         self.ggActions = ggActions
     }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -86,21 +86,13 @@ struct ChangesTabView: View {
     }
 
     private var ggReadinessModel: GGStackReadinessModel? {
-        guard rps.ggStackLoadState == .loaded, let stack = rps.ggStack else {
-            return nil
-        }
-        return GGStackReadinessModel.make(
-            stack: stack,
+        GGStackReadinessProjection.make(
+            stackLoadState: rps.ggStackLoadState,
+            stack: rps.ggStack,
             action: rps.ggActionState,
-            liveBehindBase: GGStackDrawer.liveBehindBaseOverride(
-                stack: stack,
-                selectedBaseBranch: rps.baseBranch,
-                behindBase: rps.behindBase
-            ),
-            hasBlockingGitOperation: GGStackDrawer.hasBlockingGitOperation(
-                mergeOperation: rps.mergeOp.current,
-                pausedGGOperation: rps.ggActionState.pausedOperation
-            ),
+            selectedBaseBranch: rps.baseBranch,
+            behindBase: rps.behindBase,
+            mergeOperation: rps.mergeOp.current,
             effectiveConfig: rps.ggEffectiveConfig,
             localChanges: rps.ggLocalChangeStatistics,
             undoCandidate: rps.ggUndoCandidate
@@ -175,7 +167,8 @@ struct ChangesTabView: View {
     }
 
     private var scrollContent: some View {
-        LazyVStack(alignment: .leading, spacing: 0, pinnedViews: .sectionHeaders) {
+        let preparation = preparationModel
+        return LazyVStack(alignment: .leading, spacing: 0, pinnedViews: .sectionHeaders) {
             if let err = rps.sidebarError {
                 InlineErrorStrip(
                     message: err,
@@ -219,10 +212,10 @@ struct ChangesTabView: View {
             )
 
             if Self.shouldShowChangesPreparationCard(
-                preparationIsVisible: preparationModel.isVisible
+                preparationIsVisible: preparation.isVisible
             ) {
                 ChangesPreparationCard(
-                    model: preparationModel,
+                    model: preparation,
                     onReviewChanges: openReviewChangesTab,
                     onDraftCommit: openDraftTab,
                     onGGAction: handleGGPreparationAction,

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -195,6 +195,9 @@ struct ChangesTabView: View {
                     onReviewChanges: openReviewChangesTab,
                     onDraftCommit: openDraftTab,
                     onGGAction: handleGGPreparationAction,
+                    onGGStackAction: { action in
+                        rps.onGGStackAction(action, appState: appState)
+                    },
                     onReviewRequestAction: { action in
                         rps.handleReviewReadinessAction(action, appState: appState)
                     }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -30,7 +30,8 @@ struct ChangesTabView: View {
                     stackLoadState: rps.ggStackLoadState,
                     stack: rps.ggStack,
                     currentHeadSHA: rps.currentHeadSHA
-                )
+                ),
+                reconciliationAction: Self.reconciliationAction(from: ggReadinessModel)
             )
         }
         let readiness = ReviewReadinessModel(
@@ -81,6 +82,28 @@ struct ChangesTabView: View {
             pausedOperation: rps.ggActionState.pausedOperation,
             inFlightAction: rps.ggActionState.inFlightAction,
             mergeOperation: rps.mergeOp.current
+        )
+    }
+
+    private var ggReadinessModel: GGStackReadinessModel? {
+        guard rps.ggStackLoadState == .loaded, let stack = rps.ggStack else {
+            return nil
+        }
+        return GGStackReadinessModel.make(
+            stack: stack,
+            action: rps.ggActionState,
+            liveBehindBase: GGStackDrawer.liveBehindBaseOverride(
+                stack: stack,
+                selectedBaseBranch: rps.baseBranch,
+                behindBase: rps.behindBase
+            ),
+            hasBlockingGitOperation: GGStackDrawer.hasBlockingGitOperation(
+                mergeOperation: rps.mergeOp.current,
+                pausedGGOperation: rps.ggActionState.pausedOperation
+            ),
+            effectiveConfig: rps.ggEffectiveConfig,
+            localChanges: rps.ggLocalChangeStatistics,
+            undoCandidate: rps.ggUndoCandidate
         )
     }
 
@@ -141,6 +164,14 @@ struct ChangesTabView: View {
             return "Checkout the stack head to create a new stack commit."
         }
         return nil
+    }
+
+    static func reconciliationAction(
+        from readiness: GGStackReadinessModel?
+    ) -> GGStackReadinessModel.Action? {
+        readiness?.primaryActions.first {
+            $0.kind == .sync || $0.kind == .rebase
+        }
     }
 
     private var scrollContent: some View {

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -171,7 +171,7 @@ struct CommitsSectionView: View {
     ) -> Bool {
         inFlightAction == nil
             && pausedGGOperation == nil
-            && !GGStackDrawer.hasBlockingGitOperation(
+            && !GGStackReadinessProjection.hasBlockingGitOperation(
                 mergeOperation: mergeOperation,
                 pausedGGOperation: pausedGGOperation
             )
@@ -273,7 +273,7 @@ struct CommitsSectionView: View {
             capabilities: GGAvailability.shared.capabilities,
             inFlightAction: rps.ggActionState.inFlightAction,
             pausedOperation: rps.ggActionState.pausedOperation,
-            hasBlockingGitOperation: GGStackDrawer.hasBlockingGitOperation(
+            hasBlockingGitOperation: GGStackReadinessProjection.hasBlockingGitOperation(
                 mergeOperation: rps.mergeOp.current,
                 pausedGGOperation: rps.ggActionState.pausedOperation
             ),

--- a/Alas/Sources/UI/Spinner.swift
+++ b/Alas/Sources/UI/Spinner.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct Spinner: View {
     var lineWidth: CGFloat = 2
     var duration: Double = 0.8
+    var color: Color?
 
     @State private var angle: Double = 0
     @Environment(\.theme) private var theme
@@ -10,7 +11,7 @@ struct Spinner: View {
     var body: some View {
         Circle()
             .trim(from: 0, to: 0.75)
-            .stroke(theme.color("accent"), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+            .stroke(color ?? theme.color("accent"), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
             .rotationEffect(.degrees(angle))
             .animation(.linear(duration: duration).repeatForever(autoreverses: false), value: angle)
             .onAppear { angle = 360 }

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -125,6 +125,60 @@ struct ChangesTabViewTests {
         ))
     }
 
+    @Test func prepareSelectsSyncForUnsyncedStack() {
+        let readiness = GGStackReadinessModel.make(
+            stack: stack(syncedCommits: 0, prState: .open),
+            action: GGStackActionState()
+        )
+
+        #expect(ChangesTabView.reconciliationAction(from: readiness)?.kind == .sync)
+    }
+
+    @Test func prepareSelectsSyncForPublishableStack() {
+        let readiness = GGStackReadinessModel.make(
+            stack: stack(syncedCommits: 1, prState: nil),
+            action: GGStackActionState()
+        )
+
+        #expect(ChangesTabView.reconciliationAction(from: readiness)?.kind == .sync)
+    }
+
+    @Test func prepareSelectsSyncWithRebaseDetailForAutoRebase() {
+        let readiness = GGStackReadinessModel.make(
+            stack: stack(syncedCommits: 1, behindBase: 2, prState: .open),
+            action: GGStackActionState(),
+            effectiveConfig: .init(syncAutoRebase: true, syncBehindThreshold: 1)
+        )
+
+        let action = ChangesTabView.reconciliationAction(from: readiness)
+        #expect(action?.kind == .sync)
+        #expect(action?.detail == "Includes rebase onto main")
+    }
+
+    @Test func prepareSelectsRebaseForManualRebase() {
+        let readiness = GGStackReadinessModel.make(
+            stack: stack(syncedCommits: 1, behindBase: 2, prState: .open),
+            action: GGStackActionState(),
+            effectiveConfig: .init(syncAutoRebase: false, syncBehindThreshold: 1)
+        )
+
+        #expect(ChangesTabView.reconciliationAction(from: readiness)?.kind == .rebase)
+    }
+
+    @Test func prepareOmitsNonReconciliationReadiness() {
+        let readiness = GGStackReadinessModel.make(
+            stack: stack(
+                syncedCommits: 1,
+                prState: .open,
+                approved: true,
+                ciStatus: .success
+            ),
+            action: GGStackActionState()
+        )
+
+        #expect(ChangesTabView.reconciliationAction(from: readiness) == nil)
+    }
+
     private func stack(
         currentPosition: Int?,
         entries: [GGStackEntry] = [
@@ -149,6 +203,34 @@ struct ChangesTabViewTests {
             currentPosition: currentPosition,
             behindBase: nil,
             entries: entries
+        )
+    }
+
+    private func stack(
+        syncedCommits: Int,
+        behindBase: Int? = nil,
+        prState: GGPRState?,
+        approved: Bool = false,
+        ciStatus: GGCIStatus? = nil
+    ) -> GGStack {
+        let entry = GGStackEntry(
+            position: 1,
+            sha: "1111111",
+            title: "First",
+            prNumber: prState == nil ? nil : 101,
+            prState: prState,
+            approved: approved,
+            ciStatus: ciStatus,
+            isCurrent: true
+        )
+        return GGStack(
+            name: "feat",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: syncedCommits,
+            currentPosition: 1,
+            behindBase: behindBase,
+            entries: [entry]
         )
     }
 }

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -161,16 +161,16 @@ struct GGStackReadinessModelTests {
         #expect(model.summaryChip.contains("2"))
     }
 
-    @Test func drawerUsesLiveBehindBaseOnlyForMatchingStackBase() {
+    @Test func projectionUsesLiveBehindBaseOnlyForMatchingStackBase() {
         let stack = stack([entry(position: 1, prState: nil)], synced: 1, behind: 0)
         let behind = GitService.BehindStatus(ref: "origin/main", sha: "abc", count: 2, probedAt: Date())
 
-        #expect(GGStackDrawer.liveBehindBaseOverride(
+        #expect(GGStackReadinessProjection.liveBehindBaseOverride(
             stack: stack,
             selectedBaseBranch: "main",
             behindBase: behind
         ) == 2)
-        #expect(GGStackDrawer.liveBehindBaseOverride(
+        #expect(GGStackReadinessProjection.liveBehindBaseOverride(
             stack: stack,
             selectedBaseBranch: "release",
             behindBase: behind
@@ -187,21 +187,90 @@ struct GGStackReadinessModelTests {
         #expect(model.actions.allSatisfy { !$0.isEnabled })
     }
 
-    @Test func drawerTreatsPlainGitOperationAsBlockingOnlyWhenGGIsNotPaused() {
+    @Test func projectionTreatsPlainGitOperationAsBlockingOnlyWhenGGIsNotPaused() {
         let operation = MergeOperation.merge(sourceBranch: "main")
 
-        #expect(GGStackDrawer.hasBlockingGitOperation(
+        #expect(GGStackReadinessProjection.hasBlockingGitOperation(
             mergeOperation: operation,
             pausedGGOperation: nil
         ))
-        #expect(!GGStackDrawer.hasBlockingGitOperation(
+        #expect(!GGStackReadinessProjection.hasBlockingGitOperation(
             mergeOperation: operation,
             pausedGGOperation: GGPausedOperation(pausedBy: .sync)
         ))
-        #expect(!GGStackDrawer.hasBlockingGitOperation(
+        #expect(!GGStackReadinessProjection.hasBlockingGitOperation(
             mergeOperation: nil,
             pausedGGOperation: nil
         ))
+    }
+
+    @Test func sharedProjectionUsesMatchingLiveBehindAndEffectiveConfig() {
+        let staleStack = stack([entry(position: 1, prState: .open)], synced: 1, behind: 0)
+        let behind = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "abc",
+            count: 2,
+            probedAt: Date()
+        )
+
+        let model = GGStackReadinessProjection.make(
+            stackLoadState: .loaded,
+            stack: staleStack,
+            action: GGStackActionState(),
+            selectedBaseBranch: "main",
+            behindBase: behind,
+            mergeOperation: nil,
+            effectiveConfig: .init(syncAutoRebase: true, syncBehindThreshold: 1),
+            localChanges: .zero,
+            undoCandidate: nil
+        )
+
+        #expect(model?.primaryActions.first?.kind == .sync)
+        #expect(model?.primaryActions.first?.detail == "Includes rebase onto main")
+        #expect(model?.facts.contains { $0.label == "Behind base" && $0.value == "2" } == true)
+    }
+
+    @Test func sharedProjectionIgnoresMismatchedLiveBehindAndAppliesBlockingGate() {
+        let stack = stack([entry(position: 1, prState: nil)], synced: 1, behind: 0)
+        let behind = GitService.BehindStatus(
+            ref: "origin/release",
+            sha: "abc",
+            count: 2,
+            probedAt: Date()
+        )
+
+        let model = GGStackReadinessProjection.make(
+            stackLoadState: .loaded,
+            stack: stack,
+            action: GGStackActionState(),
+            selectedBaseBranch: "release",
+            behindBase: behind,
+            mergeOperation: .merge(sourceBranch: "main"),
+            effectiveConfig: .defaults,
+            localChanges: .zero,
+            undoCandidate: nil
+        )
+
+        #expect(model?.primaryActions.first?.kind == .sync)
+        #expect(model?.primaryActions.first?.detail == nil)
+        #expect(model?.primaryActions.first?.isEnabled == false)
+        #expect(model?.facts.contains { $0.label == "Behind base" && $0.value == "0" } == true)
+    }
+
+    @Test func sharedProjectionRequiresLoadedStack() {
+        let stack = stack([entry(position: 1, prState: nil)])
+
+        #expect(GGStackReadinessProjection.make(
+            stackLoadState: .loading,
+            stack: stack,
+            action: GGStackActionState(),
+            selectedBaseBranch: "main",
+            behindBase: nil,
+            mergeOperation: nil,
+            effectiveConfig: .defaults,
+            localChanges: .zero,
+            undoCandidate: nil
+        ) == nil)
     }
 
     @Test func freshLandableStackSelectsLandPrimary() {

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -166,6 +166,38 @@ struct ChangesPreparationModelTests {
         #expect(model.reconciliationAction == reconciliationAction)
     }
 
+    @Test func primaryInFlightReconciliationUsesContrastingProgressPresentation() {
+        let action = GGStackReadinessModel.Action(
+            kind: .sync,
+            title: "Sync stack",
+            detail: nil,
+            isEnabled: false,
+            isInFlight: true,
+            emphasis: .primary
+        )
+
+        let presentation = ChangesPreparationReconciliationPresentation.make(for: action)
+
+        #expect(presentation.spinnerColorToken == "bg-0")
+        #expect(presentation.accessibilityValue == "In progress")
+    }
+
+    @Test func normalIdleReconciliationKeepsDefaultProgressPresentation() {
+        let action = GGStackReadinessModel.Action(
+            kind: .rebase,
+            title: "Rebase onto main",
+            detail: nil,
+            isEnabled: true,
+            isInFlight: false,
+            emphasis: .normal
+        )
+
+        let presentation = ChangesPreparationReconciliationPresentation.make(for: action)
+
+        #expect(presentation.spinnerColorToken == nil)
+        #expect(presentation.accessibilityValue == nil)
+    }
+
     @Test func oldGGDisablesOnlyUnsafeAmendWithUpdateReason() {
         let model = ChangesPreparationModel.makeGG(
             staged: .init(files: 1, insertions: 2, deletions: 1),

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -115,6 +115,57 @@ struct ChangesPreparationModelTests {
         #expect(!model.isVisible)
     }
 
+    @Test func ggReconciliationMakesEmptyPreparationVisible() {
+        let reconciliationAction = GGStackReadinessModel.Action(
+            kind: .sync,
+            title: "Sync stack",
+            detail: nil,
+            isEnabled: true,
+            isInFlight: false,
+            emphasis: .primary
+        )
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities,
+            reconciliationAction: reconciliationAction
+        )
+
+        #expect(model.reconciliationAction == reconciliationAction)
+        #expect(model.isVisible)
+    }
+
+    @Test func synchronizedEmptyGGPreparationRemainsHidden() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities,
+            reconciliationAction: nil
+        )
+
+        #expect(model.reconciliationAction == nil)
+        #expect(!model.isVisible)
+    }
+
+    @Test func ggReconciliationPreservesReadinessPresentation() {
+        let reconciliationAction = GGStackReadinessModel.Action(
+            kind: .sync,
+            title: "Sync stack",
+            detail: "Includes rebase onto main",
+            isEnabled: false,
+            isInFlight: true,
+            emphasis: .primary
+        )
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities,
+            reconciliationAction: reconciliationAction
+        )
+
+        #expect(model.reconciliationAction == reconciliationAction)
+    }
+
     @Test func oldGGDisablesOnlyUnsafeAmendWithUpdateReason() {
         let model = ChangesPreparationModel.makeGG(
             staged: .init(files: 1, insertions: 2, deletions: 1),

--- a/docs/superpowers/plans/2026-07-23-gg-prepare-sync-action.md
+++ b/docs/superpowers/plans/2026-07-23-gg-prepare-sync-action.md
@@ -1,0 +1,353 @@
+# GG Prepare Sync Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the GG Prepare card visible and actionable whenever the current stack readiness state requires Sync or Rebase.
+
+**Architecture:** `GGStackReadinessModel` remains the only component that decides whether stack reconciliation is needed. `ChangesTabView` passes its current Sync/Rebase action into `ChangesPreparationModel`, which owns Prepare visibility, while `ChangesPreparationCard` renders and dispatches that action through the existing GG stack action path.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Observation, Swift Testing, XcodeGen
+
+---
+
+### Task 1: Add Reconciliation To The Prepare Model And Card
+
+**Files:**
+- Modify: `Alas/Sources/Right/ChangesPreparationModel.swift`
+- Modify: `Alas/Sources/Right/ChangesPreparationCard.swift`
+- Modify: `Alas/Sources/Right/ChangesTabView.swift`
+- Test: `AlasTests/Right/ChangesPreparationModelTests.swift`
+
+- [ ] **Step 1: Write failing model tests**
+
+Add tests that construct `GGStackReadinessModel.Action` values directly and
+pass them through `ChangesPreparationModel.makeGG`:
+
+```swift
+@Test func ggReconciliationMakesEmptyPreparationVisible() {
+    let sync = GGStackReadinessModel.Action(
+        kind: .sync,
+        title: "Sync stack",
+        detail: nil,
+        isEnabled: true,
+        isInFlight: false,
+        emphasis: .primary
+    )
+    let model = ChangesPreparationModel.makeGG(
+        staged: .zero,
+        hasDraft: false,
+        capabilities: stagedOnlyCapabilities,
+        reconciliationAction: sync
+    )
+
+    #expect(model.reconciliationAction == sync)
+    #expect(model.isVisible)
+}
+
+@Test func synchronizedEmptyGGPreparationRemainsHidden() {
+    let model = ChangesPreparationModel.makeGG(
+        staged: .zero,
+        hasDraft: false,
+        capabilities: stagedOnlyCapabilities,
+        reconciliationAction: nil
+    )
+
+    #expect(model.reconciliationAction == nil)
+    #expect(!model.isVisible)
+}
+```
+
+Also add one preservation test with an in-flight auto-rebase Sync action:
+
+```swift
+@Test func ggReconciliationPreservesReadinessPresentation() {
+    let action = GGStackReadinessModel.Action(
+        kind: .sync,
+        title: "Sync stack",
+        detail: "Includes rebase onto main",
+        isEnabled: false,
+        isInFlight: true,
+        emphasis: .primary
+    )
+    let model = ChangesPreparationModel.makeGG(
+        staged: .zero,
+        hasDraft: false,
+        capabilities: stagedOnlyCapabilities,
+        reconciliationAction: action
+    )
+
+    #expect(model.reconciliationAction == action)
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ChangesPreparationModelTests test
+```
+
+Expected: compilation fails because `reconciliationAction` is not yet part of
+`ChangesPreparationModel.makeGG` or the model.
+
+- [ ] **Step 3: Add the minimal model contract**
+
+In `ChangesPreparationModel`:
+
+```swift
+let reconciliationAction: GGStackReadinessModel.Action?
+```
+
+Add a defaulted `reconciliationAction: GGStackReadinessModel.Action? = nil`
+parameter to both public `makeGG` overloads and thread it through the private
+factory. Assign it in the GG-only private initializer. Assign `nil` in the
+non-GG initializer.
+
+Update GG visibility without changing non-GG behavior:
+
+```swift
+var isVisible: Bool {
+    if !ggActions.isEmpty {
+        return reconciliationAction != nil
+            || reviewAction != nil
+            || ggAction(.newStackCommit)?.isEnabled == true
+    }
+    return reviewAction != nil || draftAction != nil || !reviewRequestActions.isEmpty
+}
+```
+
+- [ ] **Step 4: Render the readiness action in Prepare**
+
+In `ChangesPreparationCard`, render `model.reconciliationAction` after the
+optional review button and before the GG destination row:
+
+```swift
+if let reconciliationAction = model.reconciliationAction {
+    ggReconciliationButton(reconciliationAction)
+}
+```
+
+Implement a full-width button using the existing card colors, `Spinner` for
+`isInFlight`, a sync/rebase icon selected from `action.kind`, `action.title`,
+and optional `action.detail`. Preserve `action.isEnabled` and expose
+`changes-preparation-gg-reconciliation` as its accessibility identifier.
+
+Add a dedicated callback:
+
+```swift
+let onGGStackAction: (GGStackActionKind) -> Void
+```
+
+The button dispatches `onGGStackAction(action.kind)`. Do not merge Sync/Rebase
+into `GGChangesPreparationAction`, whose cases remain working-tree
+destinations.
+
+Update the `ChangesPreparationCard` construction in `ChangesTabView` so the
+new callback compiles and routes through the existing mutation path:
+
+```swift
+onGGStackAction: { action in
+    rps.onGGStackAction(action, appState: appState)
+}
+```
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ChangesPreparationModelTests test
+```
+
+Expected: `ChangesPreparationModelTests` passes.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add Alas/Sources/Right/ChangesPreparationModel.swift \
+  Alas/Sources/Right/ChangesPreparationCard.swift \
+  Alas/Sources/Right/ChangesTabView.swift \
+  AlasTests/Right/ChangesPreparationModelTests.swift
+git commit -m "feat(gg): add reconciliation to Prepare"
+```
+
+### Task 2: Derive And Route The GG Readiness Action
+
+**Files:**
+- Modify: `Alas/Sources/Right/ChangesTabView.swift`
+- Test: `AlasTests/ChangesTabViewTests.swift`
+
+- [ ] **Step 1: Write failing integration-policy tests**
+
+Add a helper in `ChangesTabViewTests` that creates `GGStack` fixtures with
+configurable `syncedCommits`, `behindBase`, and `prState`. Exercise the real
+`GGStackReadinessModel.make` policy and the new Prepare filter:
+
+```swift
+@Test func prepareSelectsSyncForChangedOrPublishableStack() {
+    let unsynced = GGStackReadinessModel.make(
+        stack: stack(syncedCommits: 0, prState: .open),
+        action: GGStackActionState()
+    )
+    let publishable = GGStackReadinessModel.make(
+        stack: stack(syncedCommits: 1, prState: nil),
+        action: GGStackActionState()
+    )
+
+    #expect(ChangesTabView.reconciliationAction(from: unsynced)?.kind == .sync)
+    #expect(ChangesTabView.reconciliationAction(from: publishable)?.kind == .sync)
+}
+
+@Test func prepareSelectsConfiguredBaseReconciliation() {
+    let auto = GGStackReadinessModel.make(
+        stack: stack(syncedCommits: 1, behindBase: 2, prState: .open),
+        action: GGStackActionState(),
+        effectiveConfig: .init(syncAutoRebase: true, syncBehindThreshold: 1)
+    )
+    let manual = GGStackReadinessModel.make(
+        stack: stack(syncedCommits: 1, behindBase: 2, prState: .open),
+        action: GGStackActionState(),
+        effectiveConfig: .init(syncAutoRebase: false, syncBehindThreshold: 1)
+    )
+
+    #expect(ChangesTabView.reconciliationAction(from: auto)?.kind == .sync)
+    #expect(ChangesTabView.reconciliationAction(from: auto)?.detail == "Includes rebase onto main")
+    #expect(ChangesTabView.reconciliationAction(from: manual)?.kind == .rebase)
+}
+
+@Test func prepareOmitsNonReconciliationReadiness() {
+    let readyToLand = GGStackReadinessModel.make(
+        stack: stack(syncedCommits: 1, prState: .open, approved: true, ci: .success),
+        action: GGStackActionState()
+    )
+
+    #expect(ChangesTabView.reconciliationAction(from: readyToLand) == nil)
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ChangesTabViewTests test
+```
+
+Expected: compilation fails because
+`ChangesTabView.reconciliationAction(from:)` does not exist.
+
+- [ ] **Step 3: Build readiness from the same drawer inputs**
+
+Add a private `ggReadinessModel` property to `ChangesTabView`. When
+`ggStackLoadState == .loaded` and `ggStack` exists, call
+`GGStackReadinessModel.make` with:
+
+```swift
+stack: stack
+action: rps.ggActionState
+liveBehindBase: GGStackDrawer.liveBehindBaseOverride(
+    stack: stack,
+    selectedBaseBranch: rps.baseBranch,
+    behindBase: rps.behindBase
+)
+hasBlockingGitOperation: GGStackDrawer.hasBlockingGitOperation(
+    mergeOperation: rps.mergeOp.current,
+    pausedGGOperation: rps.ggActionState.pausedOperation
+)
+effectiveConfig: rps.ggEffectiveConfig
+localChanges: rps.ggLocalChangeStatistics
+undoCandidate: rps.ggUndoCandidate
+```
+
+Return `nil` for unloaded/empty/failed stack states.
+
+- [ ] **Step 4: Filter and pass reconciliation into Prepare**
+
+Add this pure helper:
+
+```swift
+static func reconciliationAction(
+    from readiness: GGStackReadinessModel?
+) -> GGStackReadinessModel.Action? {
+    readiness?.primaryActions.first {
+        $0.kind == .sync || $0.kind == .rebase
+    }
+}
+```
+
+Pass it to `ChangesPreparationModel.makeGG`:
+
+```swift
+reconciliationAction: Self.reconciliationAction(from: ggReadinessModel)
+```
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ChangesTabViewTests \
+  -only-testing:AlasTests/ChangesPreparationModelTests \
+  -only-testing:AlasTests/GGStackReadinessModelTests test
+```
+
+Expected: all selected suites pass.
+
+- [ ] **Step 6: Run project verification**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: XcodeGen succeeds, the macOS build exits zero, and the full test
+suite reports no failures.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add Alas/Sources/Right/ChangesTabView.swift \
+  AlasTests/ChangesTabViewTests.swift \
+  Alas.xcodeproj
+git commit -m "feat(gg): surface stack sync in Prepare"
+```
+
+If `xcodegen` produces no project diff, do not stage `Alas.xcodeproj`.
+
+### Task 3: Final Review And Publication Readiness
+
+**Files:**
+- Review: all changes since `origin/main`
+
+- [ ] **Step 1: Review the complete diff against the design**
+
+Confirm:
+
+- Prepare appears for Sync and Rebase readiness only.
+- GG readiness remains the single reconciliation policy.
+- fully synchronized clean stacks do not show an empty Prepare card.
+- the drawer and existing working-tree destinations are unchanged.
+- action title, detail, enablement, and in-flight state are preserved.
+
+- [ ] **Step 2: Run final verification from a clean index**
+
+Run:
+
+```bash
+git diff --check
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+git status --short
+```
+
+Expected: no whitespace errors, build and tests pass, and the worktree is
+clean.

--- a/docs/superpowers/specs/2026-07-23-gg-prepare-sync-action-design.md
+++ b/docs/superpowers/specs/2026-07-23-gg-prepare-sync-action-design.md
@@ -1,0 +1,59 @@
+# GG Prepare Sync Action
+
+## Problem
+
+The Changes pane hides its Prepare card for a clean GG worktree because
+`ChangesPreparationModel` currently considers only working-tree changes and
+draft state. A GG stack can still require reconciliation when its commits have
+not been published, a published commit has been rewritten, or the stack is
+behind its base. In those states the stack drawer offers the appropriate
+action, but the more prominent Prepare surface does not.
+
+## Design
+
+Use `GGStackReadinessModel` as the single source of truth for stack
+reconciliation actions. `ChangesTabView` will derive the same readiness model
+used by `GGStackDrawer` and pass its current reconciliation action into
+`ChangesPreparationModel`.
+
+Prepare will surface only readiness actions whose kind is `sync` or `rebase`:
+
+- An unpublished or rewritten stack entry shows **Sync stack**.
+- A stack behind its base shows **Sync stack** when sync is allowed to perform
+  the configured rebase. Its detail states that the action includes a rebase.
+- A stack that requires a separate manual rebase shows
+  **Rebase onto `<base>`**. After that succeeds and state refreshes, Prepare
+  shows **Sync stack** if publication work remains.
+- A fully synchronized stack with no working-tree preparation actions keeps
+  Prepare hidden.
+
+The existing GG destination actions remain unchanged. The reconciliation
+action is added to the same Prepare card and routes through the existing
+`RightPaneState.onGGStackAction` path. The GG drawer remains unchanged.
+
+## State And Safety
+
+The Prepare action copies its title, detail, enabled state, and in-flight state
+from `GGStackReadinessModel.Action`. This preserves the existing GG mutation
+gate, blocking Git-operation handling, live base-behind override, and effective
+GG sync configuration without duplicating policy.
+
+Local staged or unstaged files do not change sync semantics. Sync continues to
+exclude working-tree changes, while the existing preparation destinations
+remain available for those files.
+
+## Testing
+
+Focused model and routing tests will cover:
+
+- unsynced stack commits make Prepare visible with **Sync stack**;
+- a publishable entry still selects Sync when the synced count matches;
+- base divergence selects Sync with auto-rebase detail;
+- manual-rebase configuration selects Rebase first;
+- a fully synchronized stack does not make an otherwise empty Prepare card
+  visible;
+- the new Prepare actions route to the existing `.sync` and `.rebase` stack
+  actions.
+
+Existing `GGStackReadinessModel` tests remain the authoritative coverage for
+the underlying reconciliation decision.


### PR DESCRIPTION
## Summary

- surface GG Sync/Rebase readiness in Prepare even when the working tree is clean
- reuse a shared GG readiness projection so Prepare and the stack drawer agree on upstream differences, base divergence, blocking operations, and effective config
- preserve in-flight, emphasis, and accessibility presentation while keeping fully synchronized stacks hidden

## Test plan

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- affected Swift Testing suites: `ChangesPreparationModelTests`, `ChangesTabViewTests`, `GGStackReadinessModelTests`
- full suite executed locally; remaining failures are the opt-in SSH integration group without `ALAS_SSH_INTEGRATION=1` and one pre-existing intermittent draft-composer focus test