### PR TITLE
fix(gg): make stack review chips clickable

### DIFF
--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -199,6 +199,9 @@ struct CommitsSectionView: View {
                     onRevert: { rps.runRevert(sha: commit.sha) },
                     ggMenu: ggMenu(for: commit),
                     onGGAction: { action in onGGAction(action, commit) },
+                    onGGOpenPR: ggOpenReviewRequestAction(for: commit).map { action in
+                        { onGGAction(action, commit) }
+                    },
                     stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),
                     codeHostKind: stackCodeHostKind
                 )
@@ -281,6 +284,16 @@ struct CommitsSectionView: View {
             canOpenSplitCommit: rps.requestGGSplitCommit != nil && rps.mergeOp.current == nil,
             providerReviewURL: providerReviewURL
         ))
+    }
+
+    private func ggOpenReviewRequestAction(for commit: CommitInfo) -> GGCommitAction? {
+        guard let entry = ggStack?.entry(matchingCommitSHA: commit.sha) else { return nil }
+        return Self.ggStackChipClickAction(for: entry, remote: rps.commitRemote)
+    }
+
+    static func ggStackChipClickAction(for entry: GGStackEntry, remote: CodeHostRemote?) -> GGCommitAction? {
+        guard let number = entry.prNumber, remote != nil else { return nil }
+        return .openProviderRequest(number: number)
     }
 
     private func openRemoteAction(for commit: CommitInfo, remote: CodeHostRemote?) -> (() -> Void)? {

--- a/AlasTests/CommitRowTests.swift
+++ b/AlasTests/CommitRowTests.swift
@@ -72,6 +72,53 @@ struct CommitRowTests {
         #expect(GGCommitAction.checkout != .dropCommit)
     }
 
+    @Test func ggStackChipClickOpensProviderReviewWhenRemoteIsKnown() {
+        let entry = GGStackEntry(
+            position: 1,
+            sha: "deadbee",
+            title: "Wire PR chip",
+            prNumber: 840
+        )
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+
+        #expect(
+            CommitsSectionView.ggStackChipClickAction(for: entry, remote: remote)
+                == .openProviderRequest(number: 840)
+        )
+    }
+
+    @Test func ggStackChipClickIsUnavailableWithoutProviderReviewTarget() {
+        let entryWithReview = GGStackEntry(
+            position: 1,
+            sha: "deadbee",
+            title: "PR without remote",
+            prNumber: 840
+        )
+        let entryWithoutReview = GGStackEntry(
+            position: 1,
+            sha: "deadbee",
+            title: "Local only"
+        )
+        let remote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "mrmans0n",
+            repository: "alas",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/mrmans0n/alas")!
+        )
+
+        #expect(CommitsSectionView.ggStackChipClickAction(for: entryWithoutReview, remote: remote) == nil)
+        #expect(CommitsSectionView.ggStackChipClickAction(for: entryWithReview, remote: nil) == nil)
+    }
+
     @MainActor
     @Test func copyFeedbackShowsThenDismisses() async throws {
         let feedback = CopyFeedbackState(displayNanoseconds: 10_000_000)


### PR DESCRIPTION
## Summary

- Wire the gg stack PR/MR chip in the Changes tab commit list to the existing provider-review open action.
- Keep the chip non-clickable when the stack entry has no PR/MR number or there is no known code-host remote.
- Add regression coverage for both routing cases.

## Root cause

`GGStackChip` already supported an `onTap` action, but `CommitsSectionView` never passed `onGGOpenPR` into `CommitRow`, so PR/MR chips rendered as static pills.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitRowTests test` — 9 tests passed
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` — ran full suite; failed only the 8 opt-in `SSHIntegrationTests` with `Expectation failed: enabled: set ALAS_SSH_INTEGRATION=1 to run` (6,368 passed, 8 failed, 4 skipped)