### PR TITLE
feat(run): Improve new run script creation dialog

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -783,6 +783,7 @@
 		9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */; };
 		91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C69060B922A729DD807920 /* LSPURI.swift */; };
 		929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */; };
+		92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */; };
 		92EEAFAEFB3E637FB72174A8 /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 2B4C3DD473FF121828FD3CA5 /* TreeSitterYAML */; };
 		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
 		93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */; };
@@ -2583,6 +2584,7 @@
 		DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRow.swift; sourceTree = "<group>"; };
 		DA89D4C70102BCF7B6B2450B /* ACPManagedAdapterDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagedAdapterDescriptor.swift; sourceTree = "<group>"; };
 		DAA7CD14A8FA2D335A59B062 /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
+		DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRunScriptDialog.swift; sourceTree = "<group>"; };
 		DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetailsTests.swift; sourceTree = "<group>"; };
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
 		DC3201ACD757677A7F42A8AE /* AlasMCPHTTPSupervisorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasMCPHTTPSupervisorTests.swift; sourceTree = "<group>"; };
@@ -2938,6 +2940,7 @@
 		0BBB2C6C4347C245481650DA /* RunScripts */ = {
 			isa = PBXGroup;
 			children = (
+				DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */,
 				E3AF2511A18895DBE494798E /* RunScript.swift */,
 				730E9629FD89AA4BDCB3C57F /* RunScriptCreation.swift */,
 				1892610460CE642A24A4F322 /* RunScriptDialog.swift */,
@@ -5920,6 +5923,7 @@
 				0890C803E92308809BE12930 /* MergeWordDiff.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
+				92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */,
 				11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */,
 				F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */,
 				004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1358,6 +1358,7 @@
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
 		F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FC38D03727F34855EB521 /* AlasFieldTests.swift */; };
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
+		F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */; };
 		F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
@@ -1579,6 +1580,7 @@
 		220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModelTests.swift; sourceTree = "<group>"; };
 		22677ECD3E098EBE6389D776 /* session-new-request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-new-request.json"; sourceTree = "<group>"; };
 		22CF502ECFD2763E52CB022F /* DiffInlineCommentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentModel.swift; sourceTree = "<group>"; };
+		23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRunScriptCreationTests.swift; sourceTree = "<group>"; };
 		23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCommandShellTests.swift; sourceTree = "<group>"; };
 		2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallProgressSheet.swift; sourceTree = "<group>"; };
 		239125BB939233233D405EB8 /* ACPChipStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipStateTests.swift; sourceTree = "<group>"; };
@@ -3043,6 +3045,7 @@
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
 				FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */,
+				23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */,
 				EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
 				6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */,
@@ -6354,6 +6357,7 @@
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
 				996B67B45E7247CDED5F98EF /* AppStateRemoteWorktreePathTests.swift in Sources */,
+				F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */,
 				07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -687,6 +687,7 @@
 		804D11E10C7478C00C0F5C40 /* DraftCommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */; };
 		806A8D3076BDF74084FF05AB /* ACPVisibleRowsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */; };
 		809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */; };
+		80AEF86E91561F880A3A0376 /* RunScriptCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6128B044F59DB08F2383F7B /* RunScriptCreationTests.swift */; };
 		8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */; };
 		81214C5FDACA47C2FFC15E9E /* HoverWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */; };
 		814193F0CC55B784481AA40A /* InstallSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A27D815CB567E3FEF2D3E6B /* InstallSourceTests.swift */; };
@@ -1183,6 +1184,7 @@
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
 		D8254D678C89FC54678A1A88 /* RemoteHelperInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB9832AA15DF6888553C7E /* RemoteHelperInstallerTests.swift */; };
 		D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */; };
+		D86A62438175F76CFC7DCFAD /* RunScriptCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730E9629FD89AA4BDCB3C57F /* RunScriptCreation.swift */; };
 		D8741FB38F9FB2C180FE37E3 /* AppStateCreateWorktreeLaunchSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8A5932B664C88F20BF00CA /* AppStateCreateWorktreeLaunchSurfaceTests.swift */; };
 		D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */; };
 		D87EC73A848929FFB819888C /* SpacesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */; };
@@ -2036,6 +2038,7 @@
 		72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiffTests.swift; sourceTree = "<group>"; };
 		729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentModelTests.swift; sourceTree = "<group>"; };
 		72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAvatarPresetProviderTests.swift; sourceTree = "<group>"; };
+		730E9629FD89AA4BDCB3C57F /* RunScriptCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptCreation.swift; sourceTree = "<group>"; };
 		73539FDFE4BDBD4D3B4DE546 /* ACPFirstRunConnectingPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPhase.swift; sourceTree = "<group>"; };
 		737A9A3D11EA28582CA5D061 /* ACPFirstRunConnectingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingView.swift; sourceTree = "<group>"; };
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
@@ -2554,6 +2557,7 @@
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D5DAD29A75E3651CA720017D /* RemoteAccessPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAccessPolicy.swift; sourceTree = "<group>"; };
 		D60051A6C7BEE35773F3FBB9 /* tool-call-content-terminal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-terminal.json"; sourceTree = "<group>"; };
+		D6128B044F59DB08F2383F7B /* RunScriptCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptCreationTests.swift; sourceTree = "<group>"; };
 		D64C0B7363363C77718B446C /* CopilotInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstaller.swift; sourceTree = "<group>"; };
 		D65BEFA85B6671FDE505A30D /* CommitMessageEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitMessageEditorView.swift; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
@@ -2933,6 +2937,7 @@
 			isa = PBXGroup;
 			children = (
 				E3AF2511A18895DBE494798E /* RunScript.swift */,
+				730E9629FD89AA4BDCB3C57F /* RunScriptCreation.swift */,
 				1892610460CE642A24A4F322 /* RunScriptDialog.swift */,
 				4C4B9AC0713D961FC7E1DE22 /* RunScriptPaletteEnvironment.swift */,
 				CC2A20311755AEE2EDD25815 /* RunScriptPaletteModel.swift */,
@@ -3258,6 +3263,7 @@
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
+				D6128B044F59DB08F2383F7B /* RunScriptCreationTests.swift */,
 				7097AF3FAAB8D3FB80151A8B /* RunScriptLaunchTests.swift */,
 				D93ED8BA7A9EE46B37ED48EC /* RunScriptMetadataTests.swift */,
 				ACAF0D9BAB4658B356FBBBAA /* RunScriptPaletteModelTests.swift */,
@@ -6050,6 +6056,7 @@
 				E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */,
 				7B85B033B476943E77867BA3 /* RootView.swift in Sources */,
 				B14D567062F568BBA1631562 /* RunScript.swift in Sources */,
+				D86A62438175F76CFC7DCFAD /* RunScriptCreation.swift in Sources */,
 				AA69A96A8A26844CC6A47F09 /* RunScriptDialog.swift in Sources */,
 				0561D8980B46B5000799E7EE /* RunScriptPaletteEnvironment.swift in Sources */,
 				96EC9BEE1A4467683D0F6808 /* RunScriptPaletteModel.swift in Sources */,
@@ -6687,6 +6694,7 @@
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
 				4186372EBF16A9C7CB38F558 /* RightPaneStoreBaseBranchTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
+				80AEF86E91561F880A3A0376 /* RunScriptCreationTests.swift in Sources */,
 				15378467EC7C0D413FF094D2 /* RunScriptLaunchTests.swift in Sources */,
 				2B85898841D3090D3C7E3169 /* RunScriptMetadataTests.swift in Sources */,
 				AC286DF7EDE24F24BAD146AF /* RunScriptPaletteModelTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1040,6 +1040,7 @@
 		BEF1C5E442CA7EB29929FCC6 /* FileSearchRankerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F50B2E7675F40749566F54 /* FileSearchRankerTests.swift */; };
 		BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */; };
 		BF0A3B3A162F31E86DB13404 /* session-update-current-model.json in Resources */ = {isa = PBXBuildFile; fileRef = 02347E4D2EA79A5CB8DF82DC /* session-update-current-model.json */; };
+		BF776A9CE2409594D67DE4BF /* AlasSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8F14A2CEAE4B8404213C73 /* AlasSegmentedControl.swift */; };
 		BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
 		BFADE15EC5D60235EF2ACBE1 /* ImageDiffPairLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB8043A52927E5E935E2F9B /* ImageDiffPairLoaderTests.swift */; };
@@ -1551,6 +1552,7 @@
 		1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServicePullTests.swift; sourceTree = "<group>"; };
 		1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGProjectMode.swift; sourceTree = "<group>"; };
 		1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHIntegrationTests.swift; sourceTree = "<group>"; };
+		1C8F14A2CEAE4B8404213C73 /* AlasSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasSegmentedControl.swift; sourceTree = "<group>"; };
 		1CA759D2C99D1FEE3C67A1BA /* RemoteImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageCacheTests.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
@@ -3529,6 +3531,7 @@
 				CA554728676F9D3B5E2C05FA /* .gitkeep */,
 				B4C486F9097A2B145D101E2C /* AlasButton.swift */,
 				D9E6D61B213F3378243B4A26 /* AlasField.swift */,
+				1C8F14A2CEAE4B8404213C73 /* AlasSegmentedControl.swift */,
 				A98D0A96093087BF4C284053 /* AlasSlider.swift */,
 				1841997CCBDB9611576B930C /* AlasToggle.swift */,
 				524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */,
@@ -5599,6 +5602,7 @@
 				2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */,
 				B06544FDB162DD8CDCD9EAF2 /* AlasHookCommand.swift in Sources */,
 				824FA55A813A3AE1034EE7D1 /* AlasMCPHTTPSupervisor.swift in Sources */,
+				BF776A9CE2409594D67DE4BF /* AlasSegmentedControl.swift in Sources */,
 				214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */,
 				F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */,
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 
 extension AppState {
@@ -165,26 +164,42 @@ extension AppState {
             )
             return
         }
-        guard let name = promptForRunScriptName() else { return }
-        let dir = scope == .repo
-            ? RunScriptStore.repoScriptsDir(worktreeRoot: worktree.path)
-            : Paths.runScriptsGlobalDir
-        let url = dir.appendingPathComponent(RunScriptTemplate.fileName(for: name))
-        do {
-            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            guard !FileManager.default.fileExists(atPath: url.path) else {
-                throw CocoaError(.fileWriteFileExists, userInfo: [
-                    NSLocalizedDescriptionKey: "A script named \"\(url.lastPathComponent)\" already exists."
-                ])
-            }
-            try RunScriptTemplate.contents(name: name).data(using: .utf8)!
-                .write(to: url, options: .withoutOverwriting)
-            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
-        } catch {
-            showFileActionError(title: "New Script Failed", message: error.localizedDescription)
+        guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
+            showFileActionError(
+                title: "New Script Failed",
+                message: "The originating project is no longer available."
+            )
             return
         }
-        switch scope {
+        pendingRunScriptCreation = RunScriptCreationPresentation(
+            scope: scope,
+            projectId: project.id,
+            worktreeId: worktree.id,
+            repositoryName: project.name
+        )
+    }
+
+    func createPendingRunScript(
+        name: String,
+        onExit: RunScriptOnExit,
+        globalDir: URL = Paths.runScriptsGlobalDir
+    ) throws {
+        guard let presentation = pendingRunScriptCreation,
+              let worktree = worktree(withId: presentation.worktreeId),
+              worktree.projectId == presentation.projectId
+        else {
+            throw RunScriptCreationError.worktreeUnavailable
+        }
+
+        let url = try RunScriptCreator.create(
+            scope: presentation.scope,
+            name: name,
+            onExit: onExit,
+            worktreeRoot: worktree.path,
+            globalDir: globalDir
+        )
+
+        switch presentation.scope {
         case .repo:
             openFile(
                 relativePath: "\(RunScriptStore.repoScriptsRelativeDir)/\(url.lastPathComponent)",
@@ -199,6 +214,11 @@ extension AppState {
                 editable: true
             )
         }
+        pendingRunScriptCreation = nil
+    }
+
+    func cancelPendingRunScriptCreation() {
+        pendingRunScriptCreation = nil
     }
 
     // MARK: - Palette
@@ -216,22 +236,4 @@ extension AppState {
         )
     }
 
-    private func promptForRunScriptName() -> String? {
-        let alert = NSAlert()
-        alert.messageText = "New Run Script"
-        alert.informativeText = "Name for the new script."
-        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
-        field.placeholderString = "Dev Server"
-        // NSAlert doesn't reliably cascade the app's forced dark appearance
-        // (WindowAppearance.apply) to a manually-added accessory view, which
-        // otherwise leaves the bezel rendering with a mismatched, muddy tint.
-        field.appearance = NSApp.effectiveAppearance
-        alert.accessoryView = field
-        alert.addButton(withTitle: "Create")
-        alert.addButton(withTitle: "Cancel")
-        alert.window.initialFirstResponder = field
-        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
-        let name = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        return name.isEmpty ? nil : name
-    }
 }

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -235,5 +235,4 @@ extension AppState {
             newScript: { [weak self] scope in self?.newRunScript(scope: scope, in: worktree) }
         )
     }
-
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -226,6 +226,7 @@ final class AppState {
     var isAgentLauncherOpen: Bool = false
     var isReviewPaletteOpen: Bool = false
     var isRunScriptPaletteOpen: Bool = false
+    var pendingRunScriptCreation: RunScriptCreationPresentation?
     var isKeyboardOverlayOpen: Bool {
         isSearchOpen || isRepoSelectorOpen || isAgentLauncherOpen || isReviewPaletteOpen || isRunScriptPaletteOpen
     }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -354,6 +354,12 @@ private struct RootPresentationHandlers: ViewModifier {
                 presetProjectId: presentation.projectId
             )
         }
+        .sheet(item: $state.pendingRunScriptCreation) { presentation in
+            NewRunScriptDialog(
+                state: state,
+                presentation: presentation
+            )
+        }
         .alert(
             "'\(state.pendingForceDeleteWorktree?.branch ?? "")' \(state.pendingForceDeleteWorktree?.reason.alertTitleSuffix ?? "requires force delete.")",
             isPresented: Binding(

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -30,8 +30,6 @@ struct NewWorktreeDialog: View {
     @State private var isLoadingBranches = false
     @State private var branchLoadError: String?
     @State private var createErrorMessage: String?
-    @FocusState private var focusedGGModeSegment: GGWorktreeMode?
-    @FocusState private var focusedLaunchSurfaceSegment: NewWorktreeLaunchSurfaceSegment?
 
     @Environment(\.theme) var theme
 
@@ -487,21 +485,13 @@ struct NewWorktreeDialog: View {
 
     private var ggModeSegmented: some View {
         HStack(spacing: 0) {
-            HStack(spacing: 2) {
-                ForEach(Self.ggModeSegments, id: \.mode) { segmentItem in
-                    segment(
-                        id: segmentItem.mode,
-                        isSelected: ggMode == segmentItem.mode,
-                        icon: nil,
-                        label: segmentItem.label,
-                        isEnabled: true,
-                        focusedSegment: $focusedGGModeSegment
-                    ) {
-                        ggMode = segmentItem.mode
-                    }
-                }
-            }
-            .modifier(SegmentedContainerStyle(theme: theme))
+            AlasSegmentedControl(
+                selection: ggMode,
+                options: Self.ggModeSegments.map {
+                    AlasSegmentedOption(id: $0.mode, label: $0.label)
+                },
+                onSelect: { ggMode = $0 }
+            )
             Spacer(minLength: 0)
         }
     }
@@ -541,125 +531,53 @@ struct NewWorktreeDialog: View {
 
     private var launchSurfaceSegmented: some View {
         HStack(spacing: 0) {
-            HStack(spacing: 2) {
-                segment(
-                    id: .none,
-                    isSelected: !openAfterCreate,
-                    icon: "circle.slash",
-                    label: "No tab",
-                    isEnabled: true,
-                    focusedSegment: $focusedLaunchSurfaceSegment
-                ) {
-                    openAfterCreate = false
-                }
-                segment(
-                    id: .terminal,
-                    isSelected: openAfterCreate && launchMode == .terminal,
-                    icon: "terminal",
-                    label: "Terminal",
-                    isEnabled: true,
-                    focusedSegment: $focusedLaunchSurfaceSegment
-                ) {
-                    openAfterCreate = true
-                    launchMode = .terminal
-                    persistableLaunchMode = .terminal
-                    launchAgentId = Self.resolvedLaunchAgent(
-                        initialAgentId: launchAgentId,
-                        mode: .terminal,
-                        enabledAgents: state.agentRegistry.enabled()
-                    )
-                }
-                segment(
-                    id: .acp,
-                    isSelected: openAfterCreate && launchMode == .acp,
-                    icon: "sparkle",
-                    label: "Chat",
-                    isEnabled: acpSegmentEnabled,
-                    disabledHelp: "Enable an ACP-capable agent in Settings → Agents.",
-                    focusedSegment: $focusedLaunchSurfaceSegment
-                ) {
-                    openAfterCreate = true
-                    launchMode = .acp
-                    persistableLaunchMode = .acp
-                    launchAgentId = Self.resolvedLaunchAgent(
-                        initialAgentId: launchAgentId,
-                        mode: .acp,
-                        enabledAgents: state.agentRegistry.enabled()
-                    )
-                }
-            }
-            .modifier(SegmentedContainerStyle(theme: theme))
+            AlasSegmentedControl(
+                selection: selectedLaunchSurfaceSegment,
+                options: [
+                    AlasSegmentedOption(id: .none, label: "No tab", icon: "circle.slash"),
+                    AlasSegmentedOption(id: .terminal, label: "Terminal", icon: "terminal"),
+                    AlasSegmentedOption(
+                        id: .acp,
+                        label: "Chat",
+                        icon: "sparkle",
+                        isEnabled: acpSegmentEnabled,
+                        disabledHelp: "Enable an ACP-capable agent in Settings → Agents."
+                    ),
+                ],
+                onSelect: selectLaunchSurface
+            )
             Spacer(minLength: 0)
         }
     }
 
-    private func segment<Segment: Hashable>(
-        id: Segment,
-        isSelected: Bool,
-        icon: String?,
-        label: String,
-        isEnabled: Bool,
-        disabledHelp: String? = nil,
-        focusedSegment: FocusState<Segment?>.Binding,
-        action: @escaping () -> Void
-    ) -> some View {
-        let isFocused = focusedSegment.wrappedValue == id
-        return Button(action: action) {
-            HStack(spacing: 5) {
-                if let icon {
-                    Icon(name: icon, size: 11,
-                         color: isSelected ? theme.color("fg") : theme.color("fg-muted"))
-                }
-                Text(label)
-                    .font(.system(size: 11.5, weight: isSelected ? .semibold : .medium))
-                    .foregroundColor(isSelected ? theme.color("fg") : theme.color("fg-muted"))
-            }
-            .padding(.horizontal, 9)
-            .frame(height: 22)
-            .background(
-                ZStack {
-                    if isSelected {
-                        RoundedRectangle(cornerRadius: 4).fill(theme.color("bg-3"))
-                        RoundedRectangle(cornerRadius: 4)
-                            .stroke(Color.white.opacity(0.04), lineWidth: 1)
-                            .blendMode(.plusLighter)
-                    }
-                }
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 4)
-                    .strokeBorder(theme.color("accent"), lineWidth: isFocused ? 1 : 0)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 4))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .focusable(isEnabled)
-        .focused(focusedSegment, equals: id)
-        .disabled(!isEnabled)
-        .opacity(isEnabled ? 1 : 0.4)
-        .modifier(SegmentHelpModifier(text: isEnabled ? nil : disabledHelp))
+    private var selectedLaunchSurfaceSegment: NewWorktreeLaunchSurfaceSegment {
+        if !openAfterCreate { return .none }
+        return launchMode == .terminal ? .terminal : .acp
     }
 
-    private struct SegmentedContainerStyle: ViewModifier {
-        let theme: Theme
-
-        func body(content: Content) -> some View {
-            content
-                .padding(2)
-                .background(theme.color("seg-container-bg"))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-        }
-    }
-
-    private struct SegmentHelpModifier: ViewModifier {
-        let text: String?
-        func body(content: Content) -> some View {
-            if let text { content.help(text) } else { content }
+    private func selectLaunchSurface(_ segment: NewWorktreeLaunchSurfaceSegment) {
+        switch segment {
+        case .none:
+            openAfterCreate = false
+        case .terminal:
+            openAfterCreate = true
+            launchMode = .terminal
+            persistableLaunchMode = .terminal
+            launchAgentId = Self.resolvedLaunchAgent(
+                initialAgentId: launchAgentId,
+                mode: .terminal,
+                enabledAgents: state.agentRegistry.enabled()
+            )
+        case .acp:
+            guard acpSegmentEnabled else { return }
+            openAfterCreate = true
+            launchMode = .acp
+            persistableLaunchMode = .acp
+            launchAgentId = Self.resolvedLaunchAgent(
+                initialAgentId: launchAgentId,
+                mode: .acp,
+                enabledAgents: state.agentRegistry.enabled()
+            )
         }
     }
 

--- a/Alas/Sources/RunScripts/NewRunScriptDialog.swift
+++ b/Alas/Sources/RunScripts/NewRunScriptDialog.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct NewRunScriptDialog: View {
+    static let defaultOnExit = RunScriptOnExit.keep
+
+    @Bindable var state: AppState
+    let presentation: RunScriptCreationPresentation
+
+    @State private var name = ""
+    @State private var onExit = Self.defaultOnExit
+    @State private var errorMessage: String?
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        DialogContainer(
+            title: "New run script",
+            subtitle: presentation.subtitle,
+            content: {
+                DialogField(label: "Script name") {
+                    AlasField(
+                        text: $name,
+                        placeholder: "Dev Server",
+                        focusOnAppear: true,
+                        onSubmit: submit
+                    )
+                }
+                DialogField(label: "When script exits") {
+                    HStack(spacing: 0) {
+                        AlasSegmentedControl(
+                            selection: onExit,
+                            options: [
+                                AlasSegmentedOption(id: .keep, label: "Keep pane open"),
+                                AlasSegmentedOption(id: .close, label: "Close pane"),
+                            ],
+                            onSelect: {
+                                onExit = $0
+                                errorMessage = nil
+                            }
+                        )
+                        Spacer(minLength: 0)
+                    }
+                }
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.system(size: 11))
+                        .foregroundColor(.red)
+                }
+            },
+            cancelTitle: "Cancel",
+            confirmTitle: "Create script",
+            confirmStyle: .primary,
+            onCancel: state.cancelPendingRunScriptCreation,
+            onConfirm: submit,
+            confirmEnabled: Self.canCreate(name: name)
+        )
+        .onChange(of: name) { _, _ in
+            errorMessage = nil
+        }
+    }
+
+    nonisolated static func canCreate(name: String) -> Bool {
+        RunScriptCreator.normalizedName(name) != nil
+    }
+
+    private func submit() {
+        guard Self.canCreate(name: name) else { return }
+        do {
+            try state.createPendingRunScript(name: name, onExit: onExit)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Alas/Sources/RunScripts/RunScript.swift
+++ b/Alas/Sources/RunScripts/RunScript.swift
@@ -11,7 +11,7 @@ enum RunScriptScope: String, Codable, Sendable, CaseIterable {
     }
 }
 
-enum RunScriptOnExit: String, Sendable {
+enum RunScriptOnExit: String, Sendable, Hashable {
     /// Return to the interactive shell prompt when the script exits.
     case keep
     /// Close the pane when the script exits (`exitOnCompletion` semantics).

--- a/Alas/Sources/RunScripts/RunScriptCreation.swift
+++ b/Alas/Sources/RunScripts/RunScriptCreation.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+struct RunScriptCreationPresentation: Identifiable, Equatable {
+    let id: UUID
+    let scope: RunScriptScope
+    let projectId: String
+    let worktreeId: String
+    let repositoryName: String
+
+    init(
+        id: UUID = UUID(),
+        scope: RunScriptScope,
+        projectId: String,
+        worktreeId: String,
+        repositoryName: String
+    ) {
+        self.id = id
+        self.scope = scope
+        self.projectId = projectId
+        self.worktreeId = worktreeId
+        self.repositoryName = repositoryName
+    }
+
+    var subtitle: String {
+        switch scope {
+        case .repo:
+            "Create a script in .alas/scripts/ for \(repositoryName)."
+        case .global:
+            "Create a script available in every local worktree."
+        }
+    }
+}
+
+enum RunScriptCreationError: LocalizedError, Equatable {
+    case emptyName
+    case fileExists(String)
+    case worktreeUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            "Enter a script name."
+        case .fileExists(let fileName):
+            "A script named \"\(fileName)\" already exists."
+        case .worktreeUnavailable:
+            "The originating worktree is no longer available."
+        }
+    }
+}
+
+enum RunScriptCreator {
+    static func normalizedName(_ rawName: String) -> String? {
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
+    }
+
+    static func create(
+        scope: RunScriptScope,
+        name rawName: String,
+        onExit: RunScriptOnExit,
+        worktreeRoot: URL,
+        globalDir: URL = Paths.runScriptsGlobalDir,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        guard let name = normalizedName(rawName) else {
+            throw RunScriptCreationError.emptyName
+        }
+        let directory = scope == .repo
+            ? RunScriptStore.repoScriptsDir(worktreeRoot: worktreeRoot)
+            : globalDir
+        let url = directory.appendingPathComponent(RunScriptTemplate.fileName(for: name))
+
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        guard !fileManager.fileExists(atPath: url.path) else {
+            throw RunScriptCreationError.fileExists(url.lastPathComponent)
+        }
+        let data = Data(RunScriptTemplate.contents(name: name, onExit: onExit).utf8)
+        try data.write(to: url, options: .withoutOverwriting)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+}

--- a/Alas/Sources/RunScripts/RunScriptTemplate.swift
+++ b/Alas/Sources/RunScripts/RunScriptTemplate.swift
@@ -19,11 +19,14 @@ enum RunScriptTemplate {
         return (slug.isEmpty ? "script" : slug) + ".sh"
     }
 
-    static func contents(name: String) -> String {
+    static func contents(
+        name: String,
+        onExit: RunScriptOnExit = .keep
+    ) -> String {
         """
         #!/bin/zsh
         # alas-name: \(name)
-        # alas-on-exit: keep
+        # alas-on-exit: \(onExit.rawValue)
 
         """
     }

--- a/Alas/Sources/UI/AlasSegmentedControl.swift
+++ b/Alas/Sources/UI/AlasSegmentedControl.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct AlasSegmentedOption<ID: Hashable> {
+    let id: ID
+    let label: String
+    let icon: String?
+    let isEnabled: Bool
+    let disabledHelp: String?
+
+    init(
+        id: ID,
+        label: String,
+        icon: String? = nil,
+        isEnabled: Bool = true,
+        disabledHelp: String? = nil
+    ) {
+        self.id = id
+        self.label = label
+        self.icon = icon
+        self.isEnabled = isEnabled
+        self.disabledHelp = disabledHelp
+    }
+}
+
+struct AlasSegmentedControl<ID: Hashable>: View {
+    let selection: ID
+    let options: [AlasSegmentedOption<ID>]
+    let onSelect: (ID) -> Void
+
+    @FocusState private var focusedOption: ID?
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(options, id: \.id) { option in
+                segment(option)
+            }
+        }
+        .padding(2)
+        .background(theme.color("seg-container-bg"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func segment(_ option: AlasSegmentedOption<ID>) -> some View {
+        let isSelected = selection == option.id
+        let isFocused = focusedOption == option.id
+
+        return Button {
+            onSelect(option.id)
+        } label: {
+            HStack(spacing: 5) {
+                if let icon = option.icon {
+                    Icon(
+                        name: icon,
+                        size: 11,
+                        color: isSelected ? theme.color("fg") : theme.color("fg-muted")
+                    )
+                }
+                Text(option.label)
+                    .font(.system(size: 11.5, weight: isSelected ? .semibold : .medium))
+                    .foregroundColor(isSelected ? theme.color("fg") : theme.color("fg-muted"))
+            }
+            .padding(.horizontal, 9)
+            .frame(height: 22)
+            .background {
+                if isSelected {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 4).fill(theme.color("bg-3"))
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(Color.white.opacity(0.04), lineWidth: 1)
+                            .blendMode(.plusLighter)
+                    }
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(theme.color("accent"), lineWidth: isFocused ? 1 : 0)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusable(option.isEnabled)
+        .focused($focusedOption, equals: option.id)
+        .disabled(!option.isEnabled)
+        .opacity(option.isEnabled ? 1 : 0.4)
+        .modifier(AlasSegmentHelpModifier(
+            text: option.isEnabled ? nil : option.disabledHelp
+        ))
+    }
+}
+
+private struct AlasSegmentHelpModifier: ViewModifier {
+    let text: String?
+
+    func body(content: Content) -> some View {
+        if let text {
+            content.help(text)
+        } else {
+            content
+        }
+    }
+}

--- a/AlasTests/AppStateRunScriptCreationTests.swift
+++ b/AlasTests/AppStateRunScriptCreationTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct AppStateRunScriptCreationTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    private func fixture() throws -> (AppState, ProjectConfig, Worktree, URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let project = ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: root.path,
+            color: "blue",
+            addedAt: Date()
+        )
+        let worktree = Worktree(
+            id: "worktree",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: root,
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = AppState(store: MemoryStore())
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        return (state, project, worktree, root)
+    }
+
+    @Test func newScriptRecordsPendingPresentation() throws {
+        let (state, project, worktree, root) = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        state.newRunScript(scope: .repo, in: worktree)
+
+        #expect(state.pendingRunScriptCreation?.scope == .repo)
+        #expect(state.pendingRunScriptCreation?.projectId == project.id)
+        #expect(state.pendingRunScriptCreation?.worktreeId == worktree.id)
+        #expect(state.pendingRunScriptCreation?.repositoryName == project.name)
+    }
+
+    @Test func repoCreationWritesAndOpensRelativeEditor() throws {
+        let (state, _, worktree, root) = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        state.newRunScript(scope: .repo, in: worktree)
+
+        try state.createPendingRunScript(name: " Dev Server ", onExit: .close)
+
+        #expect(state.pendingRunScriptCreation == nil)
+        let tab = try #require(state.tabs.activeTab(forWorktree: worktree.id))
+        guard case .editor(let editor) = tab else {
+            Issue.record("expected repo editor tab")
+            return
+        }
+        #expect(editor.relativePath == ".alas/scripts/dev-server.sh")
+        #expect(!editor.isExternal)
+    }
+
+    @Test func globalCreationUsesInjectedDirectoryAndOpensExternalEditor() throws {
+        let (state, _, worktree, root) = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let global = root.appendingPathComponent("global", isDirectory: true)
+        state.newRunScript(scope: .global, in: worktree)
+
+        try state.createPendingRunScript(
+            name: "Build",
+            onExit: .keep,
+            globalDir: global
+        )
+
+        let tab = try #require(state.tabs.activeTab(forWorktree: worktree.id))
+        guard case .editor(let editor) = tab else {
+            Issue.record("expected global editor tab")
+            return
+        }
+        #expect(editor.externalAbsolutePath == global.appendingPathComponent("build.sh").path)
+        #expect(editor.externalEditable)
+    }
+
+    @Test func failurePreservesPendingPresentation() throws {
+        let (state, project, worktree, root) = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        state.pendingRunScriptCreation = RunScriptCreationPresentation(
+            scope: .repo,
+            projectId: project.id,
+            worktreeId: "missing",
+            repositoryName: project.name
+        )
+
+        #expect(throws: RunScriptCreationError.worktreeUnavailable) {
+            try state.createPendingRunScript(name: "Build", onExit: .keep)
+        }
+        #expect(state.pendingRunScriptCreation != nil)
+        #expect(!FileManager.default.fileExists(
+            atPath: root.appendingPathComponent(".alas/scripts/build.sh").path
+        ))
+    }
+}

--- a/AlasTests/AppStateRunScriptCreationTests.swift
+++ b/AlasTests/AppStateRunScriptCreationTests.swift
@@ -82,7 +82,7 @@ struct AppStateRunScriptCreationTests {
             return
         }
         #expect(editor.externalAbsolutePath == global.appendingPathComponent("build.sh").path)
-        #expect(editor.externalEditable)
+        #expect(editor.externalEditable == true)
     }
 
     @Test func failurePreservesPendingPresentation() throws {

--- a/AlasTests/RunScriptCreationTests.swift
+++ b/AlasTests/RunScriptCreationTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RunScriptCreationTests {
+    @Test func presentationDescribesRepoAndGlobalScopes() {
+        let repo = RunScriptCreationPresentation(
+            scope: .repo,
+            projectId: "project",
+            worktreeId: "worktree",
+            repositoryName: "Alas"
+        )
+        let global = RunScriptCreationPresentation(
+            scope: .global,
+            projectId: "project",
+            worktreeId: "worktree",
+            repositoryName: "Alas"
+        )
+
+        #expect(repo.subtitle == "Create a script in .alas/scripts/ for Alas.")
+        #expect(global.subtitle == "Create a script available in every local worktree.")
+    }
+
+    @Test func normalizedNameTrimsAndRejectsWhitespace() {
+        #expect(RunScriptCreator.normalizedName("  Dev Server \n") == "Dev Server")
+        #expect(RunScriptCreator.normalizedName(" \n\t") == nil)
+    }
+
+    @Test func createWritesSelectedMetadataAndExecutablePermissions() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let url = try RunScriptCreator.create(
+            scope: .repo,
+            name: " Dev Server ",
+            onExit: .close,
+            worktreeRoot: root,
+            globalDir: root.appendingPathComponent("global")
+        )
+
+        #expect(url == root.appendingPathComponent(".alas/scripts/dev-server.sh"))
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains("# alas-name: Dev Server"))
+        #expect(contents.contains("# alas-on-exit: close"))
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o755)
+    }
+
+    @Test func createUsesInjectedGlobalDirectory() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let global = root.appendingPathComponent("global", isDirectory: true)
+
+        let url = try RunScriptCreator.create(
+            scope: .global,
+            name: "Build",
+            onExit: .keep,
+            worktreeRoot: root.appendingPathComponent("worktree"),
+            globalDir: global
+        )
+
+        #expect(url == global.appendingPathComponent("build.sh"))
+    }
+
+    @Test func duplicateReturnsFileExistsWithoutOverwriting() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        _ = try RunScriptCreator.create(
+            scope: .repo,
+            name: "Build",
+            onExit: .keep,
+            worktreeRoot: root,
+            globalDir: root.appendingPathComponent("global")
+        )
+
+        #expect(throws: RunScriptCreationError.fileExists("build.sh")) {
+            try RunScriptCreator.create(
+                scope: .repo,
+                name: "Build",
+                onExit: .close,
+                worktreeRoot: root,
+                globalDir: root.appendingPathComponent("global")
+            )
+        }
+        let contents = try String(
+            contentsOf: root.appendingPathComponent(".alas/scripts/build.sh"),
+            encoding: .utf8
+        )
+        #expect(contents.contains("# alas-on-exit: keep"))
+    }
+}

--- a/AlasTests/RunScriptTemplateTests.swift
+++ b/AlasTests/RunScriptTemplateTests.swift
@@ -8,18 +8,25 @@ struct RunScriptTemplateTests {
         #expect(RunScriptTemplate.fileName(for: "build.sh") == "build-sh.sh")
     }
 
-    @Test func contentsEmbedNameAndDefaults() {
-        let contents = RunScriptTemplate.contents(name: "Dev Server")
+    @Test func contentsEmbedNameAndKeepDefault() {
+        let contents = RunScriptTemplate.contents(name: "Dev Server", onExit: .keep)
         #expect(contents.hasPrefix("#!/bin/zsh\n"))
         #expect(contents.contains("# alas-name: Dev Server"))
         #expect(contents.contains("# alas-on-exit: keep"))
         #expect(contents.hasSuffix("\n"))
     }
 
+    @Test func contentsEmbedCloseOnExit() {
+        let contents = RunScriptTemplate.contents(name: "Dev Server", onExit: .close)
+        #expect(contents.contains("# alas-on-exit: close"))
+        let meta = RunScriptMetadata.parse(fileName: "dev-server.sh", contents: contents)
+        #expect(meta.onExit == .close)
+    }
+
     @Test func templateRoundTripsThroughMetadataParser() {
         let meta = RunScriptMetadata.parse(
             fileName: RunScriptTemplate.fileName(for: "Dev Server"),
-            contents: RunScriptTemplate.contents(name: "Dev Server")
+            contents: RunScriptTemplate.contents(name: "Dev Server", onExit: .keep)
         )
         #expect(meta.displayName == "Dev Server")
         #expect(meta.onExit == .keep)

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -12,6 +12,30 @@ struct TouchTargetSmokeTests {
         try! ThemeStore().current
     }
 
+    @Test func newRunScriptDialogDefaultsAndValidationMatchDesign() {
+        #expect(NewRunScriptDialog.defaultOnExit == .keep)
+        #expect(!NewRunScriptDialog.canCreate(name: " \n"))
+        #expect(NewRunScriptDialog.canCreate(name: "Dev Server"))
+    }
+
+    @Test func newRunScriptDialogRendersWithoutCrashing() {
+        let state = AppState()
+        let presentation = RunScriptCreationPresentation(
+            scope: .repo,
+            projectId: "project",
+            worktreeId: "worktree",
+            repositoryName: "Alas"
+        )
+        let view = NewRunScriptDialog(state: state, presentation: presentation)
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(controller.view.fittingSize.width == DialogContainerLayout.defaultWidth)
+        #expect(controller.view.fittingSize.height > 0)
+    }
+
     @Test func segmentedControlRendersWithoutCrashing() {
         let view = Seg(value: .constant(MarkdownViewMode.editor),
                        options: [(.editor, "Editor"), (.preview, "Preview")])

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -30,6 +30,30 @@ struct TouchTargetSmokeTests {
         #expect(controller.view != nil)
     }
 
+    @Test func alasSegmentedControlRendersEnabledAndDisabledOptions() {
+        enum Choice: Hashable { case keep, close }
+        let view = AlasSegmentedControl(
+            selection: Choice.keep,
+            options: [
+                AlasSegmentedOption(id: .keep, label: "Keep pane open"),
+                AlasSegmentedOption(
+                    id: .close,
+                    label: "Close pane",
+                    isEnabled: false,
+                    disabledHelp: "Unavailable"
+                ),
+            ],
+            onSelect: { _ in }
+        )
+        .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(controller.view.fittingSize.width > 0)
+        #expect(controller.view.fittingSize.height > 0)
+    }
+
     @Test func tabBarViewRendersWithoutCrashing() {
         let tab = Tab.editor(EditorTabState(
             id: "t1",

--- a/docs/superpowers/plans/2026-07-24-new-run-script-dialog.md
+++ b/docs/superpowers/plans/2026-07-24-new-run-script-dialog.md
@@ -1,0 +1,1091 @@
+# New Run Script Dialog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the native new-run-script alert with an Alas-styled sheet that lets users choose whether the script pane stays open or closes on exit.
+
+**Architecture:** Extract the custom worktree segmented selector into a reusable SwiftUI control, then introduce a small run-script creation model that owns normalization and filesystem writes. `AppState` coordinates presentation, worktree resolution, creation, and editor opening; `NewRunScriptDialog` owns only transient form and inline-error state.
+
+**Tech Stack:** Swift 5.9, SwiftUI for macOS 15, AppKit hosting tests, Swift Testing, XcodeGen, `FileManager`.
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Preserve `# alas-on-exit: keep` as the default for both repo and global scripts.
+- Use the accurate UI labels **Keep pane open** and **Close pane**.
+- Keep filename slugification and existing run/focus/restart/pane-exit semantics unchanged.
+- Do not add dependencies or perform unrelated refactors.
+- After adding Swift files, run `xcodegen` and include the regenerated `Alas.xcodeproj/project.pbxproj`.
+- Prefix shell commands with `rtk`.
+- Do not add agent attribution to code, commits, or documentation.
+
+---
+
+### Task 1: Extract the reusable Alas segmented control
+
+**Files:**
+- Create: `Alas/Sources/UI/AlasSegmentedControl.swift`
+- Modify: `Alas/Sources/Dialogs/NewWorktreeDialog.swift:1-34,482-638`
+- Modify: `AlasTests/TouchTargetSmokeTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: `Theme`, `Icon`, and SwiftUI `FocusState`.
+- Produces:
+  - `AlasSegmentedOption<ID: Hashable>`
+  - `AlasSegmentedControl<ID: Hashable>`
+  - initializer `init(selection: ID, options: [AlasSegmentedOption<ID>], onSelect: @escaping (ID) -> Void)`
+
+- [ ] **Step 1: Add a smoke test that requires the reusable control**
+
+Append this test to `TouchTargetSmokeTests`:
+
+```swift
+@Test func alasSegmentedControlRendersEnabledAndDisabledOptions() {
+    enum Choice: Hashable { case keep, close }
+    let view = AlasSegmentedControl(
+        selection: Choice.keep,
+        options: [
+            AlasSegmentedOption(id: .keep, label: "Keep pane open"),
+            AlasSegmentedOption(
+                id: .close,
+                label: "Close pane",
+                isEnabled: false,
+                disabledHelp: "Unavailable"
+            ),
+        ],
+        onSelect: { _ in }
+    )
+    .environment(\.theme, currentTheme())
+
+    let controller = NSHostingController(rootView: view)
+    controller.view.layoutSubtreeIfNeeded()
+
+    #expect(controller.view.fittingSize.width > 0)
+    #expect(controller.view.fittingSize.height > 0)
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify the missing type fails**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/TouchTargetSmokeTests/alasSegmentedControlRendersEnabledAndDisabledOptions test
+```
+
+Expected: FAIL to compile because `AlasSegmentedControl` and `AlasSegmentedOption` do not exist.
+
+- [ ] **Step 3: Implement the reusable control**
+
+Create `Alas/Sources/UI/AlasSegmentedControl.swift`:
+
+```swift
+import SwiftUI
+
+struct AlasSegmentedOption<ID: Hashable> {
+    let id: ID
+    let label: String
+    let icon: String?
+    let isEnabled: Bool
+    let disabledHelp: String?
+
+    init(
+        id: ID,
+        label: String,
+        icon: String? = nil,
+        isEnabled: Bool = true,
+        disabledHelp: String? = nil
+    ) {
+        self.id = id
+        self.label = label
+        self.icon = icon
+        self.isEnabled = isEnabled
+        self.disabledHelp = disabledHelp
+    }
+}
+
+struct AlasSegmentedControl<ID: Hashable>: View {
+    let selection: ID
+    let options: [AlasSegmentedOption<ID>]
+    let onSelect: (ID) -> Void
+
+    @FocusState private var focusedOption: ID?
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(options, id: \.id) { option in
+                segment(option)
+            }
+        }
+        .padding(2)
+        .background(theme.color("seg-container-bg"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func segment(_ option: AlasSegmentedOption<ID>) -> some View {
+        let isSelected = selection == option.id
+        let isFocused = focusedOption == option.id
+        return Button {
+            onSelect(option.id)
+        } label: {
+            HStack(spacing: 5) {
+                if let icon = option.icon {
+                    Icon(
+                        name: icon,
+                        size: 11,
+                        color: isSelected ? theme.color("fg") : theme.color("fg-muted")
+                    )
+                }
+                Text(option.label)
+                    .font(.system(size: 11.5, weight: isSelected ? .semibold : .medium))
+                    .foregroundColor(isSelected ? theme.color("fg") : theme.color("fg-muted"))
+            }
+            .padding(.horizontal, 9)
+            .frame(height: 22)
+            .background {
+                if isSelected {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 4).fill(theme.color("bg-3"))
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(Color.white.opacity(0.04), lineWidth: 1)
+                            .blendMode(.plusLighter)
+                    }
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(theme.color("accent"), lineWidth: isFocused ? 1 : 0)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusable(option.isEnabled)
+        .focused($focusedOption, equals: option.id)
+        .disabled(!option.isEnabled)
+        .opacity(option.isEnabled ? 1 : 0.4)
+        .modifier(AlasSegmentHelpModifier(
+            text: option.isEnabled ? nil : option.disabledHelp
+        ))
+    }
+}
+
+private struct AlasSegmentHelpModifier: ViewModifier {
+    let text: String?
+
+    func body(content: Content) -> some View {
+        if let text {
+            content.help(text)
+        } else {
+            content
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Migrate both new-worktree selectors without changing behavior**
+
+Remove `focusedGGModeSegment`, `focusedLaunchSurfaceSegment`, the private
+`segment` function, `SegmentedContainerStyle`, and `SegmentHelpModifier` from
+`NewWorktreeDialog`.
+
+Replace `ggModeSegmented` with:
+
+```swift
+private var ggModeSegmented: some View {
+    HStack(spacing: 0) {
+        AlasSegmentedControl(
+            selection: ggMode,
+            options: Self.ggModeSegments.map {
+                AlasSegmentedOption(id: $0.mode, label: $0.label)
+            },
+            onSelect: { ggMode = $0 }
+        )
+        Spacer(minLength: 0)
+    }
+}
+```
+
+Replace `launchSurfaceSegmented` with:
+
+```swift
+private var launchSurfaceSegmented: some View {
+    HStack(spacing: 0) {
+        AlasSegmentedControl(
+            selection: selectedLaunchSurfaceSegment,
+            options: [
+                AlasSegmentedOption(id: .none, label: "No tab", icon: "circle.slash"),
+                AlasSegmentedOption(id: .terminal, label: "Terminal", icon: "terminal"),
+                AlasSegmentedOption(
+                    id: .acp,
+                    label: "Chat",
+                    icon: "sparkle",
+                    isEnabled: acpSegmentEnabled,
+                    disabledHelp: "Enable an ACP-capable agent in Settings → Agents."
+                ),
+            ],
+            onSelect: selectLaunchSurface
+        )
+        Spacer(minLength: 0)
+    }
+}
+
+private var selectedLaunchSurfaceSegment: NewWorktreeLaunchSurfaceSegment {
+    if !openAfterCreate { return .none }
+    return launchMode == .terminal ? .terminal : .acp
+}
+
+private func selectLaunchSurface(_ segment: NewWorktreeLaunchSurfaceSegment) {
+    switch segment {
+    case .none:
+        openAfterCreate = false
+    case .terminal:
+        openAfterCreate = true
+        launchMode = .terminal
+        persistableLaunchMode = .terminal
+        launchAgentId = Self.resolvedLaunchAgent(
+            initialAgentId: launchAgentId,
+            mode: .terminal,
+            enabledAgents: state.agentRegistry.enabled()
+        )
+    case .acp:
+        guard acpSegmentEnabled else { return }
+        openAfterCreate = true
+        launchMode = .acp
+        persistableLaunchMode = .acp
+        launchAgentId = Self.resolvedLaunchAgent(
+            initialAgentId: launchAgentId,
+            mode: .acp,
+            enabledAgents: state.agentRegistry.enabled()
+        )
+    }
+}
+```
+
+- [ ] **Step 5: Regenerate and run focused selector coverage**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/TouchTargetSmokeTests \
+  -only-testing:AlasTests/NewWorktreeDialogTests test
+```
+
+Expected: PASS. Existing new-worktree ordering, focusability policy, and launch-default tests remain green; the new control renders both enabled and disabled options.
+
+- [ ] **Step 6: Commit the extraction**
+
+```bash
+rtk git add Alas/Sources/UI/AlasSegmentedControl.swift \
+  Alas/Sources/Dialogs/NewWorktreeDialog.swift \
+  AlasTests/TouchTargetSmokeTests.swift \
+  Alas.xcodeproj/project.pbxproj
+rtk git commit -m "refactor(ui): share dialog segmented control"
+```
+
+---
+
+### Task 2: Add testable run-script creation primitives
+
+**Files:**
+- Create: `Alas/Sources/RunScripts/RunScriptCreation.swift`
+- Modify: `Alas/Sources/RunScripts/RunScript.swift:11-17`
+- Modify: `Alas/Sources/RunScripts/RunScriptTemplate.swift`
+- Create: `AlasTests/RunScriptCreationTests.swift`
+- Modify: `AlasTests/RunScriptTemplateTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: `RunScriptScope`, `RunScriptOnExit`, `RunScriptStore.repoScriptsDir`, and `RunScriptTemplate`.
+- Produces:
+  - `RunScriptCreationPresentation`
+  - `RunScriptCreationError`
+  - `RunScriptCreator.normalizedName(_:) -> String?`
+  - `RunScriptCreator.create(scope:name:onExit:worktreeRoot:globalDir:fileManager:) throws -> URL`
+  - `RunScriptTemplate.contents(name:onExit:) -> String`
+
+- [ ] **Step 1: Add failing template tests for both exit behaviors**
+
+Change the existing template tests to call the explicit exit argument and add
+the close case:
+
+```swift
+@Test func contentsEmbedNameAndKeepDefault() {
+    let contents = RunScriptTemplate.contents(name: "Dev Server", onExit: .keep)
+    #expect(contents.hasPrefix("#!/bin/zsh\n"))
+    #expect(contents.contains("# alas-name: Dev Server"))
+    #expect(contents.contains("# alas-on-exit: keep"))
+    #expect(contents.hasSuffix("\n"))
+}
+
+@Test func contentsEmbedCloseOnExit() {
+    let contents = RunScriptTemplate.contents(name: "Dev Server", onExit: .close)
+    #expect(contents.contains("# alas-on-exit: close"))
+    let meta = RunScriptMetadata.parse(fileName: "dev-server.sh", contents: contents)
+    #expect(meta.onExit == .close)
+}
+```
+
+Keep the round-trip test, but pass `onExit: .keep`.
+
+- [ ] **Step 2: Add failing creation-model tests**
+
+Create `AlasTests/RunScriptCreationTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+struct RunScriptCreationTests {
+    @Test func presentationDescribesRepoAndGlobalScopes() {
+        let repo = RunScriptCreationPresentation(
+            scope: .repo,
+            projectId: "project",
+            worktreeId: "worktree",
+            repositoryName: "Alas"
+        )
+        let global = RunScriptCreationPresentation(
+            scope: .global,
+            projectId: "project",
+            worktreeId: "worktree",
+            repositoryName: "Alas"
+        )
+
+        #expect(repo.subtitle == "Create a script in .alas/scripts/ for Alas.")
+        #expect(global.subtitle == "Create a script available in every local worktree.")
+    }
+
+    @Test func normalizedNameTrimsAndRejectsWhitespace() {
+        #expect(RunScriptCreator.normalizedName("  Dev Server \n") == "Dev Server")
+        #expect(RunScriptCreator.normalizedName(" \n\t") == nil)
+    }
+
+    @Test func createWritesSelectedMetadataAndExecutablePermissions() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let url = try RunScriptCreator.create(
+            scope: .repo,
+            name: " Dev Server ",
+            onExit: .close,
+            worktreeRoot: root,
+            globalDir: root.appendingPathComponent("global")
+        )
+
+        #expect(url == root.appendingPathComponent(".alas/scripts/dev-server.sh"))
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains("# alas-name: Dev Server"))
+        #expect(contents.contains("# alas-on-exit: close"))
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o755)
+    }
+
+    @Test func createUsesInjectedGlobalDirectory() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let global = root.appendingPathComponent("global", isDirectory: true)
+
+        let url = try RunScriptCreator.create(
+            scope: .global,
+            name: "Build",
+            onExit: .keep,
+            worktreeRoot: root.appendingPathComponent("worktree"),
+            globalDir: global
+        )
+
+        #expect(url == global.appendingPathComponent("build.sh"))
+    }
+
+    @Test func duplicateReturnsFileExistsWithoutOverwriting() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        _ = try RunScriptCreator.create(
+            scope: .repo,
+            name: "Build",
+            onExit: .keep,
+            worktreeRoot: root,
+            globalDir: root.appendingPathComponent("global")
+        )
+
+        #expect(throws: RunScriptCreationError.fileExists("build.sh")) {
+            try RunScriptCreator.create(
+                scope: .repo,
+                name: "Build",
+                onExit: .close,
+                worktreeRoot: root,
+                globalDir: root.appendingPathComponent("global")
+            )
+        }
+        let contents = try String(
+            contentsOf: root.appendingPathComponent(".alas/scripts/build.sh"),
+            encoding: .utf8
+        )
+        #expect(contents.contains("# alas-on-exit: keep"))
+    }
+}
+```
+
+- [ ] **Step 3: Regenerate and verify the new tests fail**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/RunScriptTemplateTests \
+  -only-testing:AlasTests/RunScriptCreationTests test
+```
+
+Expected: FAIL because the new presentation, creator, error, and template overload do not exist.
+
+- [ ] **Step 4: Implement exit-aware templates and creation primitives**
+
+Change `RunScriptOnExit` to support use as a segmented-control identifier:
+
+```swift
+enum RunScriptOnExit: String, Sendable, Hashable {
+    case keep
+    case close
+}
+```
+
+Change the template API:
+
+```swift
+static func contents(
+    name: String,
+    onExit: RunScriptOnExit = .keep
+) -> String {
+    """
+    #!/bin/zsh
+    # alas-name: \(name)
+    # alas-on-exit: \(onExit.rawValue)
+
+    """
+}
+```
+
+Create `Alas/Sources/RunScripts/RunScriptCreation.swift`:
+
+```swift
+import Foundation
+
+struct RunScriptCreationPresentation: Identifiable, Equatable {
+    let id: UUID
+    let scope: RunScriptScope
+    let projectId: String
+    let worktreeId: String
+    let repositoryName: String
+
+    init(
+        id: UUID = UUID(),
+        scope: RunScriptScope,
+        projectId: String,
+        worktreeId: String,
+        repositoryName: String
+    ) {
+        self.id = id
+        self.scope = scope
+        self.projectId = projectId
+        self.worktreeId = worktreeId
+        self.repositoryName = repositoryName
+    }
+
+    var subtitle: String {
+        switch scope {
+        case .repo:
+            "Create a script in .alas/scripts/ for \(repositoryName)."
+        case .global:
+            "Create a script available in every local worktree."
+        }
+    }
+}
+
+enum RunScriptCreationError: LocalizedError, Equatable {
+    case emptyName
+    case fileExists(String)
+    case worktreeUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            "Enter a script name."
+        case .fileExists(let fileName):
+            "A script named \"\(fileName)\" already exists."
+        case .worktreeUnavailable:
+            "The originating worktree is no longer available."
+        }
+    }
+}
+
+enum RunScriptCreator {
+    static func normalizedName(_ rawName: String) -> String? {
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
+    }
+
+    static func create(
+        scope: RunScriptScope,
+        name rawName: String,
+        onExit: RunScriptOnExit,
+        worktreeRoot: URL,
+        globalDir: URL = Paths.runScriptsGlobalDir,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        guard let name = normalizedName(rawName) else {
+            throw RunScriptCreationError.emptyName
+        }
+        let directory = scope == .repo
+            ? RunScriptStore.repoScriptsDir(worktreeRoot: worktreeRoot)
+            : globalDir
+        let url = directory.appendingPathComponent(RunScriptTemplate.fileName(for: name))
+
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        guard !fileManager.fileExists(atPath: url.path) else {
+            throw RunScriptCreationError.fileExists(url.lastPathComponent)
+        }
+        let data = Data(RunScriptTemplate.contents(name: name, onExit: onExit).utf8)
+        try data.write(to: url, options: .withoutOverwriting)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+}
+```
+
+- [ ] **Step 5: Regenerate and run the focused tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/RunScriptTemplateTests \
+  -only-testing:AlasTests/RunScriptCreationTests \
+  -only-testing:AlasTests/RunScriptMetadataTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the creation primitives**
+
+```bash
+rtk git add Alas/Sources/RunScripts/RunScript.swift \
+  Alas/Sources/RunScripts/RunScriptTemplate.swift \
+  Alas/Sources/RunScripts/RunScriptCreation.swift \
+  AlasTests/RunScriptTemplateTests.swift \
+  AlasTests/RunScriptCreationTests.swift \
+  Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(run): model run script creation options"
+```
+
+---
+
+### Task 3: Route script creation through AppState presentation state
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift:222-232`
+- Modify: `Alas/Sources/App/AppState+RunScripts.swift:1-2,158-235`
+- Create: `AlasTests/AppStateRunScriptCreationTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: `RunScriptCreationPresentation`, `RunScriptCreator`, `RunScriptOnExit`, `AppState.worktree(withId:)`, `openFile`, and `TabsManager.openExternalEditor`.
+- Produces:
+  - `AppState.pendingRunScriptCreation: RunScriptCreationPresentation?`
+  - `AppState.newRunScript(scope:in:)`
+  - `AppState.createPendingRunScript(name:onExit:globalDir:) throws`
+  - `AppState.cancelPendingRunScriptCreation()`
+
+- [ ] **Step 1: Add failing AppState orchestration tests**
+
+Create `AlasTests/AppStateRunScriptCreationTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct AppStateRunScriptCreationTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    private func fixture() throws -> (AppState, ProjectConfig, Worktree, URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let project = ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: root.path,
+            color: "blue",
+            addedAt: Date()
+        )
+        let worktree = Worktree(
+            id: "worktree",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: root,
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = AppState(store: MemoryStore())
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        return (state, project, worktree, root)
+    }
+
+    @Test func newScriptRecordsPendingPresentation() throws {
+        let (state, project, worktree, root) = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        state.newRunScript(scope: .repo, in: worktree)
+
+        #expect(state.pendingRunScriptCreation?.scope == .repo)
+        #expect(state.pendingRunScriptCreation?.projectId == project.id)
+        #expect(state.pendingRunScriptCreation?.worktreeId == worktree.id)
+        #expect(state.pendingRunScriptCreation?.repositoryName == project.name)
+    }
+
+    @Test func repoCreationWritesAndOpensRelativeEditor() throws {
+        let (state, _, worktree, root) = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        state.newRunScript(scope: .repo, in: worktree)
+
+        try state.createPendingRunScript(name: " Dev Server ", onExit: .close)
+
+        #expect(state.pendingRunScriptCreation == nil)
+        let tab = try #require(state.tabs.activeTab(forWorktree: worktree.id))
+        guard case .editor(let editor) = tab else {
+            Issue.record("expected repo editor tab")
+            return
+        }
+        #expect(editor.relativePath == ".alas/scripts/dev-server.sh")
+        #expect(!editor.isExternal)
+    }
+
+    @Test func globalCreationUsesInjectedDirectoryAndOpensExternalEditor() throws {
+        let (state, _, worktree, root) = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let global = root.appendingPathComponent("global", isDirectory: true)
+        state.newRunScript(scope: .global, in: worktree)
+
+        try state.createPendingRunScript(
+            name: "Build",
+            onExit: .keep,
+            globalDir: global
+        )
+
+        let tab = try #require(state.tabs.activeTab(forWorktree: worktree.id))
+        guard case .editor(let editor) = tab else {
+            Issue.record("expected global editor tab")
+            return
+        }
+        #expect(editor.externalAbsolutePath == global.appendingPathComponent("build.sh").path)
+        #expect(editor.externalEditable)
+    }
+
+    @Test func failurePreservesPendingPresentation() throws {
+        let (state, project, worktree, root) = try fixture()
+        defer { try? FileManager.default.removeItem(at: root) }
+        state.pendingRunScriptCreation = RunScriptCreationPresentation(
+            scope: .repo,
+            projectId: project.id,
+            worktreeId: "missing",
+            repositoryName: project.name
+        )
+
+        #expect(throws: RunScriptCreationError.worktreeUnavailable) {
+            try state.createPendingRunScript(name: "Build", onExit: .keep)
+        }
+        #expect(state.pendingRunScriptCreation != nil)
+        #expect(!FileManager.default.fileExists(
+            atPath: root.appendingPathComponent(".alas/scripts/build.sh").path
+        ))
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate and verify orchestration tests fail**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/AppStateRunScriptCreationTests test
+```
+
+Expected: FAIL because pending presentation state and creation methods do not exist.
+
+- [ ] **Step 3: Add pending state and replace the synchronous alert flow**
+
+Add beside the run-script palette state in `AppState`:
+
+```swift
+var pendingRunScriptCreation: RunScriptCreationPresentation?
+```
+
+Remove `promptForRunScriptName()` and the filesystem-writing body from
+`AppState+RunScripts.swift`. Remove `import AppKit` if no other AppKit symbol
+remains.
+
+Implement:
+
+```swift
+func newRunScript(scope: RunScriptScope, in worktree: Worktree) {
+    if scope == .repo, worktree.path.isRemoteAlasPath {
+        showFileActionError(
+            title: "New Script Failed",
+            message: "Run scripts are not supported on remote worktrees yet."
+        )
+        return
+    }
+    guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
+        showFileActionError(
+            title: "New Script Failed",
+            message: "The originating project is no longer available."
+        )
+        return
+    }
+    pendingRunScriptCreation = RunScriptCreationPresentation(
+        scope: scope,
+        projectId: project.id,
+        worktreeId: worktree.id,
+        repositoryName: project.name
+    )
+}
+
+func createPendingRunScript(
+    name: String,
+    onExit: RunScriptOnExit,
+    globalDir: URL = Paths.runScriptsGlobalDir
+) throws {
+    guard let presentation = pendingRunScriptCreation,
+          let worktree = worktree(withId: presentation.worktreeId),
+          worktree.projectId == presentation.projectId
+    else {
+        throw RunScriptCreationError.worktreeUnavailable
+    }
+
+    let url = try RunScriptCreator.create(
+        scope: presentation.scope,
+        name: name,
+        onExit: onExit,
+        worktreeRoot: worktree.path,
+        globalDir: globalDir
+    )
+
+    switch presentation.scope {
+    case .repo:
+        openFile(
+            relativePath: "\(RunScriptStore.repoScriptsRelativeDir)/\(url.lastPathComponent)",
+            worktreeId: worktree.id
+        )
+    case .global:
+        _ = tabs.openExternalEditor(
+            worktreeId: worktree.id,
+            absoluteURL: url,
+            revealLine: nil,
+            revealCharacter: nil,
+            editable: true
+        )
+    }
+    pendingRunScriptCreation = nil
+}
+
+func cancelPendingRunScriptCreation() {
+    pendingRunScriptCreation = nil
+}
+```
+
+Keep `RunScriptPaletteEnvironment.newScript` routing to
+`newRunScript(scope:in:)`; it now starts presentation instead of blocking on
+`NSAlert`.
+
+- [ ] **Step 4: Run focused AppState and run-script tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/AppStateRunScriptCreationTests \
+  -only-testing:AlasTests/AppStateOverlayTests \
+  -only-testing:AlasTests/RunScriptPaletteModelTests \
+  -only-testing:AlasTests/RunScriptCreationTests test
+```
+
+Expected: PASS. On failure, pending presentation remains non-`nil`; on success,
+the correct editor tab opens and pending state clears.
+
+- [ ] **Step 5: Commit AppState orchestration**
+
+```bash
+rtk git add Alas/Sources/App/AppState.swift \
+  Alas/Sources/App/AppState+RunScripts.swift \
+  AlasTests/AppStateRunScriptCreationTests.swift \
+  Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(run): present run script creation state"
+```
+
+---
+
+### Task 4: Build and present the styled new-run-script sheet
+
+**Files:**
+- Create: `Alas/Sources/RunScripts/NewRunScriptDialog.swift`
+- Modify: `Alas/Sources/App/RootView.swift:325-360`
+- Modify: `AlasTests/TouchTargetSmokeTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: `DialogContainer`, `DialogField`, `AlasField`, `AlasSegmentedControl`, `RunScriptCreationPresentation`, and the Task 3 `AppState` methods.
+- Produces:
+  - `NewRunScriptDialog`
+  - `NewRunScriptDialog.defaultOnExit == .keep`
+  - `NewRunScriptDialog.canCreate(name:) -> Bool`
+
+- [ ] **Step 1: Add failing dialog-state and rendering tests**
+
+Append to `TouchTargetSmokeTests`:
+
+```swift
+@Test func newRunScriptDialogDefaultsAndValidationMatchDesign() {
+    #expect(NewRunScriptDialog.defaultOnExit == .keep)
+    #expect(!NewRunScriptDialog.canCreate(name: " \n"))
+    #expect(NewRunScriptDialog.canCreate(name: "Dev Server"))
+}
+
+@Test func newRunScriptDialogRendersWithoutCrashing() {
+    let state = AppState()
+    let presentation = RunScriptCreationPresentation(
+        scope: .repo,
+        projectId: "project",
+        worktreeId: "worktree",
+        repositoryName: "Alas"
+    )
+    let view = NewRunScriptDialog(state: state, presentation: presentation)
+        .environment(\.theme, currentTheme())
+    let controller = NSHostingController(rootView: view)
+
+    controller.view.layoutSubtreeIfNeeded()
+
+    #expect(controller.view.fittingSize.width == DialogContainerLayout.defaultWidth)
+    #expect(controller.view.fittingSize.height > 0)
+}
+```
+
+- [ ] **Step 2: Regenerate and verify the dialog tests fail**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/TouchTargetSmokeTests/newRunScriptDialogDefaultsAndValidationMatchDesign \
+  -only-testing:AlasTests/TouchTargetSmokeTests/newRunScriptDialogRendersWithoutCrashing test
+```
+
+Expected: FAIL because `NewRunScriptDialog` does not exist.
+
+- [ ] **Step 3: Implement the SwiftUI sheet**
+
+Create `Alas/Sources/RunScripts/NewRunScriptDialog.swift`:
+
+```swift
+import SwiftUI
+
+struct NewRunScriptDialog: View {
+    static let defaultOnExit = RunScriptOnExit.keep
+
+    @Bindable var state: AppState
+    let presentation: RunScriptCreationPresentation
+
+    @State private var name = ""
+    @State private var onExit = Self.defaultOnExit
+    @State private var errorMessage: String?
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        DialogContainer(
+            title: "New run script",
+            subtitle: presentation.subtitle,
+            content: {
+                DialogField(label: "Script name") {
+                    AlasField(
+                        text: $name,
+                        placeholder: "Dev Server",
+                        focusOnAppear: true,
+                        onSubmit: submit
+                    )
+                }
+                DialogField(label: "When script exits") {
+                    HStack(spacing: 0) {
+                        AlasSegmentedControl(
+                            selection: onExit,
+                            options: [
+                                AlasSegmentedOption(id: .keep, label: "Keep pane open"),
+                                AlasSegmentedOption(id: .close, label: "Close pane"),
+                            ],
+                            onSelect: {
+                                onExit = $0
+                                errorMessage = nil
+                            }
+                        )
+                        Spacer(minLength: 0)
+                    }
+                }
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.system(size: 11))
+                        .foregroundColor(.red)
+                }
+            },
+            cancelTitle: "Cancel",
+            confirmTitle: "Create script",
+            confirmStyle: .primary,
+            onCancel: state.cancelPendingRunScriptCreation,
+            onConfirm: submit,
+            confirmEnabled: Self.canCreate(name: name)
+        )
+        .onChange(of: name) { _, _ in
+            errorMessage = nil
+        }
+    }
+
+    nonisolated static func canCreate(name: String) -> Bool {
+        RunScriptCreator.normalizedName(name) != nil
+    }
+
+    private func submit() {
+        guard Self.canCreate(name: name) else { return }
+        do {
+            try state.createPendingRunScript(name: name, onExit: onExit)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Present the sheet from RootView**
+
+After the new-worktree `.sheet(item:)` in `RootPresentationHandlers`, add:
+
+```swift
+.sheet(item: $state.pendingRunScriptCreation) { presentation in
+    NewRunScriptDialog(
+        state: state,
+        presentation: presentation
+    )
+}
+```
+
+Do not add another local `@State` copy. `AppState.pendingRunScriptCreation` is
+the single presentation source, so cancellation, successful creation, and
+programmatic teardown all dismiss the same sheet.
+
+- [ ] **Step 5: Regenerate and run all affected tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/TouchTargetSmokeTests \
+  -only-testing:AlasTests/NewWorktreeDialogTests \
+  -only-testing:AlasTests/AppStateRunScriptCreationTests \
+  -only-testing:AlasTests/RunScriptCreationTests \
+  -only-testing:AlasTests/RunScriptTemplateTests \
+  -only-testing:AlasTests/RunScriptMetadataTests \
+  -only-testing:AlasTests/RunScriptPaletteModelTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the dialog**
+
+```bash
+rtk git add Alas/Sources/RunScripts/NewRunScriptDialog.swift \
+  Alas/Sources/App/RootView.swift \
+  AlasTests/TouchTargetSmokeTests.swift \
+  Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(run): add styled new script dialog"
+```
+
+---
+
+### Task 5: Perform repository-required verification
+
+**Files:**
+- Verify only; no source changes expected.
+
+**Interfaces:**
+- Consumes: the completed Tasks 1-4.
+- Produces: evidence that generated project state, the macOS build, and the full test suite are green.
+
+- [ ] **Step 1: Confirm generated project state is clean**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk git diff --exit-code -- project.yml Alas.xcodeproj/project.pbxproj
+```
+
+Expected: both commands exit 0 with no diff.
+
+- [ ] **Step 2: Run the quiet macOS build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0 with no build errors.
+
+- [ ] **Step 3: Run the full macOS test suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 4: Inspect final scope and history**
+
+Run:
+
+```bash
+rtk git status --short
+rtk git log --oneline origin/main..HEAD
+rtk git diff --stat origin/main...HEAD
+```
+
+Expected: the worktree is clean; history contains the design and plan commits
+plus the four focused implementation commits; the diff is limited to the shared
+segmented control, run-script creation flow, dialog, tests, generated project,
+and approved design/plan documents.

--- a/docs/superpowers/specs/2026-07-24-new-run-script-dialog-design.md
+++ b/docs/superpowers/specs/2026-07-24-new-run-script-dialog-design.md
@@ -1,0 +1,116 @@
+# New Run Script Dialog
+
+## Problem
+
+Creating a repo or global run script currently opens a native `NSAlert` with a
+single unstyled name field. It does not match Alas's worktree-creation dialog,
+and every new script unconditionally receives `# alas-on-exit: keep`. Users
+must edit the generated metadata manually if the script's terminal pane should
+close when the script exits.
+
+## User Experience
+
+Replace the alert with an Alas sheet built from `DialogContainer`,
+`DialogField`, and `AlasField`.
+
+The sheet title is **New run script**. Its subtitle communicates the scope:
+
+- Repo: “Create a script in `.alas/scripts/` for `<repository>`.”
+- Global: “Create a script available in every local worktree.”
+
+The form contains:
+
+- **Script name**, focused when the sheet appears. It uses the same field
+  chrome and Return-to-submit behavior as the branch-name field in the new
+  worktree dialog. It uses a proportional font because the value is a
+  human-facing display name rather than a Git identifier.
+- **When script exits**, using the same segmented-control style as
+  **Open after create** in the new worktree dialog. Its choices are
+  **Keep pane open** and **Close pane**. **Keep pane open** is the default,
+  preserving current behavior.
+
+The footer contains **Cancel** and **Create script**. Creation is disabled
+while the trimmed name is empty. A successful creation closes the sheet and
+opens the generated script in the editor, preserving existing behavior.
+
+## Shared Segmented Control
+
+Extract the segment rendering currently private to `NewWorktreeDialog` into a
+reusable `AlasSegmentedControl`. The component owns:
+
+- container background, border, spacing, and corner radii;
+- selected and unselected text and icon styling;
+- keyboard focus and its accent focus ring;
+- disabled-option opacity and help text.
+
+Callers provide the options, selected identifier, and a selection callback.
+The new worktree dialog's **GG mode** and **Open after create** selectors move
+to this component without changing their options or side effects. The new run
+script dialog uses the same component for exit behavior. This targeted
+extraction makes the visual and interaction match durable without introducing
+a broader dialog-system refactor.
+
+## Presentation And Data Flow
+
+Introduce an identifiable pending run-script-creation request containing the
+script scope and originating worktree identifier.
+
+1. Selecting **New Repo Script…** or **New Global Script…** runs the existing
+   remote-worktree preflight and records a pending request.
+2. The run-script palette closes.
+3. `RootView` presents `NewRunScriptDialog` from the pending request.
+4. The dialog owns transient name, exit-behavior, and inline-error state.
+5. On confirmation, `AppState` resolves the request's worktree and performs
+   directory creation, collision detection, template writing, and executable
+   permission updates.
+6. `RunScriptTemplate` receives the selected `RunScriptOnExit` and emits
+   `# alas-on-exit: keep` or `# alas-on-exit: close`.
+7. Success clears the request, closes the sheet, and opens the repo script or
+   global external file in the originating worktree's editor area.
+
+Filesystem work and tab opening remain outside the view. Unlike the current
+synchronous alert, creation failures return to the dialog so it can preserve
+the user's form state.
+
+## Validation And Failure Handling
+
+Trim surrounding whitespace before deriving the display name and filename.
+Whitespace-only names cannot be submitted. Filename slugification remains
+unchanged.
+
+If the generated filename already exists, or directory creation, writing, or
+permission updates fail, keep the sheet open and show the failure inline.
+Preserve the entered name and exit-behavior selection.
+
+Repo scripts remain unavailable for remote worktrees, using the existing
+preflight error before presenting the sheet. If the originating worktree no
+longer exists when the user confirms, do not write a file; show an inline
+message that the worktree is no longer available. Global scripts retain the
+worktree identity only to choose where the created external editor tab opens.
+
+## Testing
+
+Focused Swift Testing coverage will verify:
+
+- templates emit both `keep` and `close`, and each round-trips through
+  `RunScriptMetadata`;
+- the dialog's exit-behavior state defaults to `keep`;
+- whitespace-only names are rejected and valid names are trimmed;
+- repo and global requests produce the correct subtitle and destination;
+- duplicate filenames return an error without discarding form state;
+- successful creation preserves executable permissions and opens the correct
+  repo-relative or global external editor path;
+- a missing originating worktree fails without writing;
+- the extracted segmented control preserves disabled-option and keyboard-focus
+  behavior relied on by the worktree dialog.
+
+Verification will run `xcodegen`, focused affected tests, the quiet macOS
+build, and the repository's full macOS test command.
+
+## Out Of Scope
+
+- Changing filename slugification.
+- Persisting a different default per scope or between creations.
+- Editing metadata for existing scripts through this dialog.
+- Adding additional run-script metadata such as `alas-cwd`.
+- Changing run, focus, restart, or pane-exit semantics.


### PR DESCRIPTION
## Summary
- replace the native run-script name alert with an Alas-styled New run script sheet
- add keep/close pane behavior selection and write it into script frontmatter
- share the dialog segmented control with new worktree creation

## Verification
- rtk xcodegen && rtk git diff --exit-code -- project.yml Alas.xcodeproj/project.pbxproj
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test