### PR TITLE
fix(diff): image diff scroll and drag panning

### DIFF
--- a/Alas/Sources/Center/ImageDiff/ImageDiffSideBySideView.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffSideBySideView.swift
@@ -39,6 +39,7 @@ struct ImageDiffSideBySideView: View {
     let afterLabel: String
     @Binding var transform: ImageDiffTransform
     @Environment(\.theme) private var theme
+    @GestureState private var dragTranslation: CGSize = .zero
 
     var body: some View {
         GeometryReader { proxy in
@@ -58,12 +59,11 @@ struct ImageDiffSideBySideView: View {
             ScrollEventCapturingView { dx, dy, isCommand in
                 if isCommand {
                     transform.applyZoomDelta((dy / 50.0))
-                } else {
-                    transform.applyPanDelta(dx: dx, dy: dy)
                 }
             }
         )
         .onTapGesture(count: 2) { transform.reset() }
+        .simultaneousGesture(panGesture)
     }
 
     @ViewBuilder
@@ -77,7 +77,12 @@ struct ImageDiffSideBySideView: View {
                     .interpolation(.none)
                     .aspectRatio(contentMode: .fit)
                     .scaleEffect(transform.scale)
-                    .offset(transform.offset)
+                    .offset(
+                        Self.displayOffset(
+                            committed: transform.offset,
+                            translation: dragTranslation
+                        )
+                    )
             case .missing, .failed:
                 if let message = Self.placeholderMessage(for: side, missingText: missingText) {
                     placeholder(message)
@@ -108,6 +113,16 @@ struct ImageDiffSideBySideView: View {
         }
     }
 
+    nonisolated static func displayOffset(
+        committed: CGSize,
+        translation: CGSize
+    ) -> CGSize {
+        CGSize(
+            width: committed.width + translation.width,
+            height: committed.height + translation.height
+        )
+    }
+
     private func placeholder(_ message: String) -> some View {
         Text(message)
             .font(.system(size: 12))
@@ -125,5 +140,18 @@ struct ImageDiffSideBySideView: View {
             Divider().background(theme.color("line"))
                 .frame(width: 1)
         }
+    }
+
+    private var panGesture: some Gesture {
+        DragGesture(minimumDistance: 1)
+            .updating($dragTranslation) { value, translation, _ in
+                translation = value.translation
+            }
+            .onEnded { value in
+                transform.applyPanDelta(
+                    dx: value.translation.width,
+                    dy: value.translation.height
+                )
+            }
     }
 }

--- a/Alas/Sources/Center/ImageDiff/ScrollEventCapturingView.swift
+++ b/Alas/Sources/Center/ImageDiff/ScrollEventCapturingView.swift
@@ -9,6 +9,12 @@ struct ScrollEventCapturingView: NSViewRepresentable {
     let onScroll: (CGFloat, CGFloat, Bool) -> Void
     // (deltaX, deltaY, modifierFlagsContainsCommand)
 
+    static func shouldCaptureScroll(
+        modifierFlags: NSEvent.ModifierFlags
+    ) -> Bool {
+        modifierFlags.contains(.command)
+    }
+
     func makeNSView(context: Context) -> Backing {
         let v = Backing()
         v.onScroll = onScroll
@@ -23,8 +29,18 @@ struct ScrollEventCapturingView: NSViewRepresentable {
         var onScroll: ((CGFloat, CGFloat, Bool) -> Void)?
         override var acceptsFirstResponder: Bool { true }
         override func scrollWheel(with event: NSEvent) {
-            let isCommand = event.modifierFlags.contains(.command)
-            onScroll?(event.scrollingDeltaX, event.scrollingDeltaY, isCommand)
+            guard ScrollEventCapturingView.shouldCaptureScroll(
+                modifierFlags: event.modifierFlags
+            ) else {
+                nextResponder?.scrollWheel(with: event)
+                return
+            }
+
+            onScroll?(
+                event.scrollingDeltaX,
+                event.scrollingDeltaY,
+                true
+            )
         }
     }
 }

--- a/AlasTests/ImageDiffSideBySideViewTests.swift
+++ b/AlasTests/ImageDiffSideBySideViewTests.swift
@@ -35,4 +35,14 @@ struct ImageDiffSideBySideViewTests {
         #expect(t.offset.width == 15)
         #expect(t.offset.height == 10)
     }
+
+    @Test func unmodifiedScrollIsNotCapturedByImageViewer() {
+        #expect(!ScrollEventCapturingView.shouldCaptureScroll(modifierFlags: []))
+    }
+
+    @Test func commandScrollIsCapturedByImageViewer() {
+        #expect(
+            ScrollEventCapturingView.shouldCaptureScroll(modifierFlags: [.command])
+        )
+    }
 }

--- a/AlasTests/ImageDiffSideBySideViewTests.swift
+++ b/AlasTests/ImageDiffSideBySideViewTests.swift
@@ -36,6 +36,15 @@ struct ImageDiffSideBySideViewTests {
         #expect(t.offset.height == 10)
     }
 
+    @Test func dragTranslationIsAddedToCommittedPanOffset() {
+        let offset = ImageDiffSideBySideView.displayOffset(
+            committed: CGSize(width: 12, height: -8),
+            translation: CGSize(width: 5, height: 11)
+        )
+
+        #expect(offset == CGSize(width: 17, height: 3))
+    }
+
     @Test func unmodifiedScrollIsNotCapturedByImageViewer() {
         #expect(!ScrollEventCapturingView.shouldCaptureScroll(modifierFlags: []))
     }

--- a/docs/superpowers/specs/2026-07-24-image-diff-click-drag-pan-design.md
+++ b/docs/superpowers/specs/2026-07-24-image-diff-click-drag-pan-design.md
@@ -1,0 +1,44 @@
+# Image Diff Click-Drag Pan Design
+
+## Problem
+
+The side-by-side image diff overlays an AppKit view that consumes every
+scroll-wheel event. Unmodified wheel and trackpad scrolling therefore pans the
+images instead of reaching the enclosing vertically scrolling diff review.
+
+## Interaction
+
+- Unmodified wheel and trackpad scrolling passes through the image viewer to
+  the enclosing scroll view.
+- Command-scroll remains an explicit zoom gesture and is consumed by the image
+  viewer.
+- Panning requires a primary-button click and drag anywhere on the side-by-side
+  image canvas.
+- Both panes keep using the same transform, so panning and zooming remain
+  synchronized.
+- Double-click and the existing reset control continue to restore the identity
+  transform.
+
+## Implementation
+
+`ScrollEventCapturingView` will decide whether it handled a scroll event. It
+will forward unhandled events through the AppKit responder chain so an enclosing
+`ScrollView` can process them.
+
+`ImageDiffSideBySideView` will attach a SwiftUI `DragGesture` to the comparison
+canvas. A transient translation will update the displayed offset while the
+pointer is held; ending the gesture will commit that translation to
+`ImageDiffTransform`. The gesture will not alter scale or the existing zoom
+path.
+
+## Testing
+
+Focused tests will cover:
+
+- unmodified scroll events are not captured by the image viewer;
+- Command-scroll events remain captured for zoom;
+- drag translation is combined with the existing committed pan offset;
+- committing a drag preserves the accumulated transform.
+
+The standard project generation, build, and test commands will verify the
+integrated change.


### PR DESCRIPTION
## Summary
- Forward ordinary image-diff scroll events to the enclosing diff scroll view.
- Keep Command-scroll zoom behavior for side-by-side image diffs.
- Add click-drag panning with transient drag feedback and focused regression coverage.

## Root Cause
The side-by-side image diff AppKit bridge captured every scroll-wheel event and the SwiftUI view treated non-command scroll deltas as pan input. That meant vertical scrolling over side-by-side images dragged the images instead of scrolling the diff review.

## Test Plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (6,506 tests passed)\n- `git diff --check origin/main..HEAD`