### PR TITLE
fix(gg): mode submenu flicker

### DIFF
--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -44,6 +44,34 @@ struct GGWorktreeMenuModel: Equatable {
 }
 
 struct WorktreeRowView: View {
+    struct GGModeMenuItem: Equatable, Identifiable {
+        let mode: GGWorktreeMode
+        let title: String
+        let isSelected: Bool
+
+        var id: GGWorktreeMode { mode }
+    }
+
+    nonisolated static func ggModeMenuItems(selectedMode: GGWorktreeMode) -> [GGModeMenuItem] {
+        [
+            GGModeMenuItem(
+                mode: .inherit,
+                title: "Inherit repository default",
+                isSelected: selectedMode == .inherit
+            ),
+            GGModeMenuItem(
+                mode: .on,
+                title: "On",
+                isSelected: selectedMode == .on
+            ),
+            GGModeMenuItem(
+                mode: .off,
+                title: "Off",
+                isSelected: selectedMode == .off
+            )
+        ]
+    }
+
     static func stackSummaryTooltip(merged: Int, total: Int) -> String {
         stackSummaryText(merged: merged, total: total)
     }
@@ -234,13 +262,16 @@ struct WorktreeRowView: View {
                 }
                 Divider()
                 if ggMenuModel.isVisible {
-                    Picker("GG Mode", selection: Binding(
-                        get: { ggMenuModel.selectedMode },
-                        set: { mode in onSetGGWorktreeMode(mode) }
-                    )) {
-                        Text("Inherit repository default").tag(GGWorktreeMode.inherit)
-                        Text("On").tag(GGWorktreeMode.on)
-                        Text("Off").tag(GGWorktreeMode.off)
+                    Menu("GG Mode") {
+                        ForEach(Self.ggModeMenuItems(selectedMode: ggMenuModel.selectedMode)) { item in
+                            Toggle(item.title, isOn: Binding(
+                                get: { item.isSelected },
+                                set: { isOn in
+                                    guard isOn, item.mode != ggMenuModel.selectedMode else { return }
+                                    onSetGGWorktreeMode(item.mode)
+                                }
+                            ))
+                        }
                     }
                     if let explanation = ggMenuModel.inactiveExplanation {
                         Divider()

--- a/AlasTests/GGWorktreeMenuModelTests.swift
+++ b/AlasTests/GGWorktreeMenuModelTests.swift
@@ -98,6 +98,14 @@ struct GGWorktreeMenuModelTests {
         #expect(model.showsStatusIndicator)
     }
 
+    @Test func ggModeMenuItemsExposeStableLabelsAndSelectionState() {
+        let items = WorktreeRowView.ggModeMenuItems(selectedMode: .on)
+
+        #expect(items.map(\.mode) == [.inherit, .on, .off])
+        #expect(items.map(\.title) == ["Inherit repository default", "On", "Off"])
+        #expect(items.map(\.isSelected) == [false, true, false])
+    }
+
     private func menuModel(
         selectedMode: GGWorktreeMode,
         context: GGWorktreeContext,


### PR DESCRIPTION
## Summary
Fixes the GG mode context-menu submenu flickering while trying to select one of its child modes. The old SwiftUI `Picker` inside a macOS context menu could rebuild the nested menu while AppKit was tracking child items; this replaces it with stable explicit menu rows.

## Changes
- Replaced the GG mode `Picker` with a `Menu` of explicit `Button` items so submenu children remain stable during interaction.
- Preserved the selected-mode checkmark and avoided no-op state writes for the already selected mode.
- Added coverage for the GG mode menu item order, labels, and selection state.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GGWorktreeMenuModelTests test`
- Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` ran, but the first run hit two unrelated flaky failures: `DiffReviewSurfaceTests/fileSectionRefocusesDraftComposerAfterSelectingDifferentGutterRows()` and `ACPTerminalTests/releaseReachesOrphans()`. Rerunning both suites passed.
