### PR TITLE
fix(diff): break image-section rematerialization live-lock

### DIFF
--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -256,7 +256,7 @@ struct DiffReviewFileSection: View {
                 }
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
             }
-            if let pair = imageState.pair {
+            if let pair = displayedImagePair {
                 ImageDiffControls(pair: pair, state: imageState.presentation)
                     .background(
                         DiffReviewAccessibilityMarker(
@@ -682,6 +682,18 @@ struct DiffReviewFileSection: View {
         .accessibilityHidden(true)
     }
 
+    /// The pair from this section's own load, or — right after the review
+    /// stream's `LazyVStack` re-realizes this section (which resets
+    /// `imageState`) — the session-cached pair for the same provider. Reading
+    /// the cache directly here keeps the first body pass at full image height;
+    /// rendering empty/spinner for even one pass flips the section height and
+    /// destabilizes the lazy container's estimates (see
+    /// `DiffReviewImagePairCache`). The `.task` then re-populates `imageState`
+    /// from the same cache entry.
+    private var displayedImagePair: ImageDiffPair? {
+        imageState.pair ?? file.imageProvider.flatMap { DiffReviewImagePairCache.shared.pair(for: $0.id) }
+    }
+
     @ViewBuilder
     private var imageContent: some View {
         if imageState.isLoading {
@@ -696,7 +708,7 @@ struct DiffReviewFileSection: View {
                     )
                 )
         }
-        if let pair = imageState.pair {
+        if let pair = displayedImagePair {
             ImageDiffComparisonContent(
                 pair: pair,
                 state: imageState.presentation,

--- a/Alas/Sources/Center/DiffReview/DiffReviewImageState.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewImageState.swift
@@ -1,5 +1,50 @@
 import Observation
 
+/// Session-wide cache of loaded image pairs keyed by provider ID.
+///
+/// Provider IDs are content-addressed (revisions, paths, and a working-tree
+/// metadata token), so a cached pair never goes stale under its ID. The cache
+/// exists so a file section that the review stream's `LazyVStack` disposed and
+/// later re-realized renders its image at full height in its very first body
+/// pass — without it, every re-realization resets the section's `@State`,
+/// flashes a spinner, and flips the section height (spinner ↔ bounded image),
+/// which keeps the lazy container's size estimates oscillating and can
+/// live-lock the whole surface in a never-settling SwiftUI update loop.
+@MainActor
+final class DiffReviewImagePairCache {
+    static let shared = DiffReviewImagePairCache()
+
+    private let limit: Int
+    private var storage: [DiffReviewImageProviderID: ImageDiffPair] = [:]
+    private var recency: [DiffReviewImageProviderID] = []
+
+    init(limit: Int = 64) {
+        self.limit = max(1, limit)
+    }
+
+    func pair(for id: DiffReviewImageProviderID) -> ImageDiffPair? {
+        guard let pair = storage[id] else { return nil }
+        markRecentlyUsed(id)
+        return pair
+    }
+
+    func store(_ pair: ImageDiffPair, for id: DiffReviewImageProviderID) {
+        // Failed loads are transient (network, blob fetch), not content-addressed;
+        // caching them would make Retry a no-op.
+        guard !pair.hasFailure else { return }
+        storage[id] = pair
+        markRecentlyUsed(id)
+        while recency.count > limit {
+            storage.removeValue(forKey: recency.removeFirst())
+        }
+    }
+
+    private func markRecentlyUsed(_ id: DiffReviewImageProviderID) {
+        recency.removeAll { $0 == id }
+        recency.append(id)
+    }
+}
+
 @Observable
 @MainActor
 final class DiffReviewImageState {
@@ -10,17 +55,44 @@ final class DiffReviewImageState {
     let presentation = ImageDiffPresentationState()
 
     @ObservationIgnored private var currentProvider: DiffReviewImageProvider?
+    @ObservationIgnored private let cache: DiffReviewImagePairCache
+
+    init(cache: DiffReviewImagePairCache = .shared) {
+        self.cache = cache
+    }
 
     func load(provider: DiffReviewImageProvider) async {
         let capturedID = provider.id
         if providerID != capturedID {
+            // Skip the reset writes on a fresh instance: `@Observable` fires
+            // invalidation on every set regardless of value, and this runs from
+            // `.task` right after the first body pass of every (re)materialized
+            // section — a same-value write here re-dirties that body for nothing.
+            if providerID != nil {
+                pair = nil
+                retryGeneration = 0
+                presentation.resetForNewPair()
+            }
             providerID = capturedID
-            pair = nil
-            retryGeneration = 0
-            presentation.resetForNewPair()
         }
 
         currentProvider = provider
+
+        if pair == nil, let cached = cache.pair(for: capturedID) {
+            pair = cached
+            if isLoading {
+                isLoading = false
+            }
+            presentation.updateDisplayedPair(
+                cached,
+                identity: ImageDiffPairPresentationIdentity(
+                    pair: cached,
+                    relativePath: capturedID.afterPath
+                )
+            )
+            return
+        }
+
         let capturedGeneration = retryGeneration
         isLoading = true
         let loadedPair = await provider.load()
@@ -32,6 +104,7 @@ final class DiffReviewImageState {
             return
         }
 
+        cache.store(loadedPair, for: capturedID)
         pair = loadedPair
         isLoading = false
         presentation.updateDisplayedPair(
@@ -50,6 +123,12 @@ final class DiffReviewImageState {
     }
 
     func clear() {
+        // Already-clear is the steady state for every non-image file section,
+        // and this runs from `.task` on each (re)materialization. Writing the
+        // same values anyway would invalidate the section body every time.
+        guard providerID != nil || pair != nil || isLoading || retryGeneration != 0 || currentProvider != nil else {
+            return
+        }
         providerID = nil
         pair = nil
         isLoading = false

--- a/AlasTests/DiffReviewImageStateTests.swift
+++ b/AlasTests/DiffReviewImageStateTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct DiffReviewImageStateTests {
     @Test func lateResultFromOldProviderIsRejected() async {
         let gate = PairLoadGate()
-        let state = DiffReviewImageState()
+        let state = DiffReviewImageState(cache: DiffReviewImagePairCache())
         let old = provider(revision: "old") { await gate.wait() }
         let newPair = pair(color: .systemGreen)
         let new = provider(revision: "new") { newPair }
@@ -22,7 +22,7 @@ struct DiffReviewImageStateTests {
     }
 
     @Test func retryIncrementsOnlyTheCurrentSectionGeneration() async {
-        let state = DiffReviewImageState()
+        let state = DiffReviewImageState(cache: DiffReviewImagePairCache())
         let provider = provider(revision: "head") {
             ImageDiffPair(
                 before: .failed(.init(message: "Network error")),
@@ -40,7 +40,7 @@ struct DiffReviewImageStateTests {
     }
 
     @Test func clearingProviderRemovesLoadedPairAndRetryState() async {
-        let state = DiffReviewImageState()
+        let state = DiffReviewImageState(cache: DiffReviewImagePairCache())
         let loadedPair = pair(color: .systemGreen)
         let provider = provider(revision: "head") { loadedPair }
 
@@ -57,7 +57,7 @@ struct DiffReviewImageStateTests {
     @Test func lateFirstAttemptIsRejectedAfterRetryBegins() async {
         let firstAttemptGate = PairLoadGate()
         let retryGate = PairLoadGate()
-        let state = DiffReviewImageState()
+        let state = DiffReviewImageState(cache: DiffReviewImagePairCache())
         var attempt = 0
         let provider = provider(revision: "head") {
             attempt += 1
@@ -79,6 +79,106 @@ struct DiffReviewImageStateTests {
         await firstLoad.value
 
         #expect(state.pair?.afterImage === retryPair.afterImage)
+    }
+
+    @Test func rematerializedStateServesCachedPairWithoutReloading() async {
+        let cache = DiffReviewImagePairCache()
+        let loadedPair = pair(color: .systemGreen)
+        var loadCount = 0
+        let sharedProvider = provider(revision: "head") {
+            loadCount += 1
+            return loadedPair
+        }
+
+        let first = DiffReviewImageState(cache: cache)
+        await first.load(provider: sharedProvider)
+
+        // A lazily re-realized section gets a fresh @State instance; its load
+        // must resolve synchronously from the cache instead of re-fetching.
+        let rematerialized = DiffReviewImageState(cache: cache)
+        await rematerialized.load(provider: sharedProvider)
+
+        #expect(loadCount == 1)
+        #expect(rematerialized.pair?.afterImage === loadedPair.afterImage)
+        #expect(!rematerialized.isLoading)
+    }
+
+    @Test func failedPairsAreNotCached() async {
+        let cache = DiffReviewImagePairCache()
+        var loadCount = 0
+        let failingProvider = provider(revision: "head") {
+            loadCount += 1
+            return ImageDiffPair(
+                before: .failed(.init(message: "Network error")),
+                after: .missing,
+                oldPath: nil,
+                kind: .deleted
+            )
+        }
+
+        let first = DiffReviewImageState(cache: cache)
+        await first.load(provider: failingProvider)
+        let second = DiffReviewImageState(cache: cache)
+        await second.load(provider: failingProvider)
+
+        #expect(loadCount == 2)
+    }
+
+    @Test func clearOnAlreadyClearStateEmitsNoObservationEvents() {
+        let state = DiffReviewImageState(cache: DiffReviewImagePairCache())
+        let invalidations = InvalidationCounter()
+
+        withObservationTracking {
+            _ = state.pair
+            _ = state.isLoading
+            _ = state.providerID
+            _ = state.retryGeneration
+        } onChange: {
+            invalidations.increment()
+        }
+        state.clear()
+
+        #expect(invalidations.count == 0)
+    }
+
+    @Test func loadOnFreshStateDoesNotWritePairBeforeTheFetchCompletes() async {
+        let gate = PairLoadGate()
+        let state = DiffReviewImageState(cache: DiffReviewImagePairCache())
+        let pairInvalidations = InvalidationCounter()
+
+        withObservationTracking {
+            _ = state.pair
+        } onChange: {
+            pairInvalidations.increment()
+        }
+
+        let load = Task { await state.load(provider: provider(revision: "head") { await gate.wait() }) }
+        await Task.yield()
+        // The pre-fetch bookkeeping (provider adoption, isLoading) must not
+        // touch `pair`: a same-value nil write would re-dirty every section
+        // body right after materialization.
+        #expect(pairInvalidations.count == 0)
+
+        gate.resume(returning: pair(color: .systemGreen))
+        await load.value
+        #expect(pairInvalidations.count == 1)
+    }
+}
+
+private final class InvalidationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func increment() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
     }
 }
 

--- a/AlasTests/DiffReviewImageStateTests.swift
+++ b/AlasTests/DiffReviewImageStateTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Observation
 import Testing
 @testable import Alas
 


### PR DESCRIPTION
## Summary

The diff-review screen beachballs on Alas 0.13.1: a SwiftUI transaction never settles and the main thread sits at 100% inside a continuous `GraphHost.flushTransactions`.

Root cause is a regression from #911 (per-section image diffs). That change attached a `.task(id: file.imageProvider?.id)` and an `@Observable DiffReviewImageState` to **every** `DiffReviewFileSection`. When the review stream's `LazyVStack` disposes and re-realizes a section (which happens whenever its size estimates shift), the section's `@State` resets and the task re-runs:

- **Non-image files:** `imageState.clear()` wrote seven already-nil/false observable properties. Observation fires invalidation on *every* set, not just on change, so each re-realization re-dirtied the body it had just committed.
- **Image files:** a fresh state renders a short spinner (~40pt) before the async `provider.load()` swaps in a 360pt image. A section near the viewport boundary flips height every pass, the lazy container's estimates never converge, sections keep de/re-materializing, and the cycle restarts.

Either way the transaction re-dirties itself and `flushTransactions` runs every run-loop turn.

## Fix

Kept minimal and localized to the diff-review image path:

1. **Write-free observable bookkeeping** — `DiffReviewImageState.clear()` no-ops when already clear; `load()` skips the reset writes on a fresh instance. A same-value write no longer re-dirties the section body on every (re)materialization.
2. **`DiffReviewImagePairCache`** — a main-actor LRU (cap 64) keyed by the content-addressed `DiffReviewImageProviderID` (it includes a disk-metadata token, so entries never go stale; failed pairs are excluded so Retry still refetches). `load()` resolves synchronously from it, and `DiffReviewFileSection.displayedImagePair` bridges the cache into the **first** body pass after re-realization so the section renders at full image height immediately — no spinner flash, no height flap.

## Tests

- Existing `DiffReviewImageStateTests` now inject an isolated cache per test.
- New coverage: cache-hit-without-reload on rematerialization, failed-pairs-not-cached, and (via `withObservationTracking`) that clear-on-clear and pre-fetch bookkeeping emit zero observation events.

Full suite green locally: 6507 tests across 622 suites.

## Verification note

Re-sampling the live process wasn't possible from the authoring session (the running instance is still the stock 0.13.1 build). After launching this build: open a review with a mix of image and text files, scroll, then `sample Alas 5` — `GraphHost.flushTransactions` should no longer run continuously and the main thread should go idle at rest.