### PR TITLE
fix(gg): new worktree name field initialization

### DIFF
--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -9,9 +9,9 @@ enum NewWorktreeLaunchSurfaceSegment: Hashable {
 struct NewWorktreeDialog: View {
     @Bindable var state: AppState
     @Binding var presented: Bool
-    var presetProjectId: String? = nil
+    var presetProjectId: String?
 
-    @State private var projectId: String = ""
+    @State private var projectId: String
     // Defaults are seeded from the persisted Worktrees settings in .onAppear
     // (these literals are placeholders only — the real defaults come from
     // state.config.worktrees.{baseBranch,branchPrefix}).
@@ -32,6 +32,20 @@ struct NewWorktreeDialog: View {
     @State private var createErrorMessage: String?
 
     @Environment(\.theme) var theme
+
+    init(
+        state: AppState,
+        presented: Binding<Bool>,
+        presetProjectId: String? = nil
+    ) {
+        self.state = state
+        self._presented = presented
+        self.presetProjectId = presetProjectId
+        self._projectId = State(initialValue: Self.initialProjectId(
+            presetProjectId: presetProjectId,
+            projects: state.projects
+        ))
+    }
 
     var body: some View {
         DialogContainer(
@@ -127,11 +141,10 @@ struct NewWorktreeDialog: View {
         )
         .onAppear {
             if projectId.isEmpty {
-                if let preset = presetProjectId, state.projects.contains(where: { $0.id == preset }) {
-                    projectId = preset
-                } else {
-                    projectId = state.projects.first?.id ?? ""
-                }
+                projectId = Self.initialProjectId(
+                    presetProjectId: presetProjectId,
+                    projects: state.projects
+                )
             }
             if base.isEmpty {
                 base = Self.initialBase(
@@ -455,6 +468,15 @@ struct NewWorktreeDialog: View {
     ) -> ProjectConfig? {
         guard let presetProjectId else { return nil }
         return projects.first { $0.id == presetProjectId }
+    }
+
+    nonisolated static func initialProjectId(
+        presetProjectId: String?,
+        projects: [ProjectConfig]
+    ) -> String {
+        resolvedPresetProject(presetProjectId: presetProjectId, projects: projects)?.id
+            ?? projects.first?.id
+            ?? ""
     }
 
     nonisolated static func showsRepositorySelector(

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -52,6 +52,40 @@ struct NewWorktreeDialogTests {
         )?.id == "repo-b")
     }
 
+    @Test func initialProjectIdUsesValidPreset() {
+        let projects = [Self.project(id: "repo-a"), Self.project(id: "repo-b")]
+
+        #expect(NewWorktreeDialog.initialProjectId(
+            presetProjectId: "repo-b",
+            projects: projects
+        ) == "repo-b")
+    }
+
+    @Test func initialProjectIdFallsBackToFirstProjectForStalePreset() {
+        let projects = [Self.project(id: "repo-a"), Self.project(id: "repo-b")]
+
+        #expect(NewWorktreeDialog.initialProjectId(
+            presetProjectId: "missing",
+            projects: projects
+        ) == "repo-a")
+    }
+
+    @Test func initialProjectIdUsesFirstProjectWithoutPreset() {
+        let projects = [Self.project(id: "repo-a"), Self.project(id: "repo-b")]
+
+        #expect(NewWorktreeDialog.initialProjectId(
+            presetProjectId: nil,
+            projects: projects
+        ) == "repo-a")
+    }
+
+    @Test func initialProjectIdIsEmptyWithoutProjects() {
+        #expect(NewWorktreeDialog.initialProjectId(
+            presetProjectId: nil,
+            projects: []
+        ) == "")
+    }
+
     @Test func preferredBaseBranchChoosesMainWhenNoConfiguredDefault() {
         let selected = NewWorktreeDialog.preferredBaseBranch(
             availableBranches: ["trunk", "master", "main"],

--- a/docs/superpowers/specs/2026-07-24-new-worktree-gg-name-focus-design.md
+++ b/docs/superpowers/specs/2026-07-24-new-worktree-gg-name-focus-design.md
@@ -1,0 +1,69 @@
+# New Worktree GG Name Focus Design
+
+## Problem
+
+`NewWorktreeDialog` starts with an empty `projectId`. Its first render therefore
+treats the name field as a regular branch field and binds the focused
+`AlasField` to `branch`. The dialog selects its initial project in `.onAppear`.
+When that project inherits GG mode, the same visible field switches to the
+independent `stackName` binding. Keystrokes entered during this launch-time
+transition can land in `branch` and then disappear when the field starts
+displaying `stackName`.
+
+The branch-name input filter does not treat any ordinary letter specially. A
+leading `f` is commonly observed because it is often the first character typed
+while the binding transition is still in progress.
+
+## Desired Behavior
+
+- The name field uses the correct branch or stack-name binding on its first
+  render.
+- Focus is established once, without discarding early input.
+- Regular branch and GG stack-name drafts remain independent when the user
+  manually toggles GG mode.
+- Existing repository-switch behavior remains unchanged: selecting another
+  repository resets GG mode to inherit and retains the separate drafts.
+
+## Design
+
+Resolve the dialog's initial project ID in its initializer and use that value to
+initialize the `projectId` state before SwiftUI produces the first body. The
+resolution order remains the same as the current `.onAppear` logic:
+
+1. Use `presetProjectId` when it identifies an existing project.
+2. Otherwise use the first available project.
+3. Use an empty ID when there are no projects.
+
+Keep the defensive `.onAppear` fallback for cases where the state is empty when
+the view is first constructed or changes before presentation. With the normal
+sheet flow, `.onAppear` will see an already-resolved project and will not change
+the name field's binding.
+
+No changes are needed in `AlasField`, the input filter, GG mode evaluation, or
+the separate `branch` and `stackName` state.
+
+## Alternatives Considered
+
+### Delay the name field until `.onAppear`
+
+This prevents input before project resolution, but introduces a visible
+one-frame layout and focus transition.
+
+### Use one intermediary name draft
+
+This gives the editor a stable binding, but requires synchronization logic and
+risks changing the existing behavior that preserves independent branch and
+stack-name drafts.
+
+## Testing
+
+Add focused unit coverage for initial project-ID resolution:
+
+- a valid preset wins over project order;
+- a missing preset falls back to the first project;
+- no preset uses the first project;
+- no projects produces an empty ID.
+
+Retain the existing tests proving that regular branch and GG stack names are
+independent. Run the targeted test suite, regenerate the Xcode project, then run
+the required macOS build and full tests.


### PR DESCRIPTION
## Summary

- Initialize the New Worktree dialog's selected project before the first SwiftUI render.
- Keep regular branch and GG stack-name drafts independent.
- Add unit coverage for initial project selection with valid, stale, absent, and empty project inputs.

## Root Cause

The dialog previously started with an empty `projectId`, so the focused name field initially bound to the regular branch draft. `.onAppear` then selected the first or preset project; when that project inherited GG mode, the same visible field switched to the stack-name draft. Early keystrokes could land in the regular branch draft and disappear from the visible stack-name field.

## Validation

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
