### PR TITLE
fix(gg): Update new worktree GG mode control

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 		686BB3FB9735836CFCAAE0D1 /* MCPRegistrationDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE42251A40DA18A6DB0E7491 /* MCPRegistrationDecisionTests.swift */; };
 		68D58F9361C2C31EE200479A /* ACPBrokerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A27D9BBDE49BF3A41FAFB7 /* ACPBrokerClient.swift */; };
 		69C592752249412BC8A6EF3C /* GGInboxHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB6D67179D2557D3A255AA3 /* GGInboxHostTests.swift */; };
+		6A080E2F35BD0D925D5F7BD5 /* GGStackIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCDB66D0948AF52EBA880CD /* GGStackIcon.swift */; };
 		6A10E9DF8A052DBDFF477863 /* OpenCodeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */; };
 		6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */; };
 		6A5B87FF631136E5246D0F38 /* AgentLauncherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */; };
@@ -1479,6 +1480,7 @@
 		0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionQueueAPITests.swift; sourceTree = "<group>"; };
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
 		0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionPrompt.swift; sourceTree = "<group>"; };
+		0BCDB66D0948AF52EBA880CD /* GGStackIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackIcon.swift; sourceTree = "<group>"; };
 		0C4F66F89778A1995407BB50 /* ACPElicitation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitation.swift; sourceTree = "<group>"; };
 		0C5373F76231F229D3F96AF3 /* session-update-config-option.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-option.json"; sourceTree = "<group>"; };
 		0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabLoadingIndicatorTests.swift; sourceTree = "<group>"; };
@@ -5061,6 +5063,7 @@
 				B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */,
 				D7860DF249939BC7FC1EBD76 /* GGStackDrawer.swift */,
 				ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */,
+				0BCDB66D0948AF52EBA880CD /* GGStackIcon.swift */,
 				86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */,
 				4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */,
 				B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */,
@@ -5794,6 +5797,7 @@
 				E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */,
 				3AFEB19356A2BC5E7B6E1E4A /* GGStackDrawer.swift in Sources */,
 				4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */,
+				6A080E2F35BD0D925D5F7BD5 /* GGStackIcon.swift in Sources */,
 				93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */,
 				8ADC05EBB9FE7D278508A941 /* GGStackReadinessModel.swift in Sources */,
 				DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */,

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -19,7 +19,7 @@ struct NewWorktreeDialog: View {
     @State private var branch: String = ""
     @State private var stackName: String = ""
     @State private var runStartup: Bool = true
-    @State private var ggMode: GGWorktreeMode = .inherit
+    @State private var ggMode: GGWorktreeMode = .off
     @State private var openAfterCreate: Bool = true
     @State private var launchMode: AppConfig.LauncherMode = .terminal
     /// The launcher mode to persist — preserves the user's intent even when
@@ -146,6 +146,7 @@ struct NewWorktreeDialog: View {
                     projects: state.projects
                 )
             }
+            applyGGModeDefault(for: projectId)
             if base.isEmpty {
                 base = Self.initialBase(
                     configuredDefault: state.config.worktrees.baseBranch,
@@ -159,8 +160,8 @@ struct NewWorktreeDialog: View {
             loadBranchesForSelectedProject()
         }
         .onChange(of: projectId) { _, _ in
+            applyGGModeDefault(for: projectId)
             applyLaunchDefaults(for: projectId)
-            ggMode = Self.ggModeAfterRepositoryChange(current: ggMode)
             // Seed the base for the new project synchronously so the picker
             // never shows the previous project's value; the async branch load
             // refines it (guarded: it skips pinned bases and user edits).
@@ -354,6 +355,17 @@ struct NewWorktreeDialog: View {
         )
     }
 
+    private func applyGGModeDefault(for selectedProjectId: String) {
+        guard let project = state.projects.first(where: { $0.id == selectedProjectId }) else {
+            ggMode = .off
+            return
+        }
+        ggMode = Self.initialGGMode(
+            projectMode: project.ggMode,
+            repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path)
+        )
+    }
+
     private func create() {
         guard let project = state.projects.first(where: { $0.id == projectId }) else { return }
         let dest = URL(fileURLWithPath: renderedPath)
@@ -438,8 +450,26 @@ struct NewWorktreeDialog: View {
         }
     }
 
-    nonisolated static func ggModeAfterRepositoryChange(current _: GGWorktreeMode) -> GGWorktreeMode {
-        .inherit
+    nonisolated static func initialGGMode(
+        projectMode: GGProjectMode,
+        repoHasGGConfig: Bool
+    ) -> GGWorktreeMode {
+        GGWorktreeContextResolver.isPolicyEnabled(
+            projectMode: projectMode,
+            worktreeOverride: .inherit,
+            isMainWorktree: false,
+            repoHasGGConfig: repoHasGGConfig
+        ) ? .on : .off
+    }
+
+    nonisolated static func ggModeAfterRepositoryChange(
+        projectMode: GGProjectMode,
+        repoHasGGConfig: Bool
+    ) -> GGWorktreeMode {
+        initialGGMode(
+            projectMode: projectMode,
+            repoHasGGConfig: repoHasGGConfig
+        )
     }
 
     nonisolated static func initialBase(
@@ -500,7 +530,6 @@ struct NewWorktreeDialog: View {
     }
 
     nonisolated static let ggModeSegments: [(mode: GGWorktreeMode, label: String)] = [
-        (.inherit, "Inherit"),
         (.on, "On"),
         (.off, "Off"),
     ]

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -6,6 +6,12 @@ enum NewWorktreeLaunchSurfaceSegment: Hashable {
     case acp
 }
 
+struct NewWorktreeGGModeSegment: Equatable {
+    let mode: GGWorktreeMode
+    let label: String
+    let icon: GGStackIconVariant
+}
+
 struct NewWorktreeDialog: View {
     @Bindable var state: AppState
     @Binding var presented: Bool
@@ -529,9 +535,9 @@ struct NewWorktreeDialog: View {
         return availableBranches.first ?? configuredDefault
     }
 
-    nonisolated static let ggModeSegments: [(mode: GGWorktreeMode, label: String)] = [
-        (.on, "On"),
-        (.off, "Off"),
+    nonisolated static let ggModeSegments: [NewWorktreeGGModeSegment] = [
+        .init(mode: .on, label: "On", icon: .stack),
+        .init(mode: .off, label: "Off", icon: .disabled),
     ]
 
     private var ggModeSegmented: some View {
@@ -539,7 +545,11 @@ struct NewWorktreeDialog: View {
             AlasSegmentedControl(
                 selection: ggMode,
                 options: Self.ggModeSegments.map {
-                    AlasSegmentedOption(id: $0.mode, label: $0.label)
+                    AlasSegmentedOption(
+                        id: $0.mode,
+                        label: $0.label,
+                        segmentedIcon: .gg($0.icon)
+                    )
                 },
                 onSelect: { ggMode = $0 }
             )

--- a/Alas/Sources/Integrations/GG/GGStackIcon.swift
+++ b/Alas/Sources/Integrations/GG/GGStackIcon.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+enum GGStackIconVariant: Equatable {
+    case stack
+    case disabled
+}
+
+struct GGStackIcon: View {
+    let variant: GGStackIconVariant
+    let size: CGFloat
+    let color: Color
+
+    init(
+        variant: GGStackIconVariant = .stack,
+        size: CGFloat,
+        color: Color
+    ) {
+        self.variant = variant
+        self.size = size
+        self.color = color
+    }
+
+    var body: some View {
+        ZStack {
+            GGStackShape()
+                .fill(color)
+            if variant == .disabled {
+                Capsule()
+                    .fill(color)
+                    .frame(width: 1, height: size)
+                    .rotationEffect(.degrees(-45))
+            }
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+private struct GGStackShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let strokeHeight = min(rect.height / 9, 1)
+        let strokeWidth = min(rect.width, 7)
+        let x = rect.midX - strokeWidth / 2
+        let yPositions = [
+            rect.minY + 1,
+            rect.midY - strokeHeight / 2,
+            rect.maxY - strokeHeight - 1,
+        ]
+
+        for y in yPositions {
+            path.addRoundedRect(
+                in: CGRect(x: x, y: y, width: strokeWidth, height: strokeHeight),
+                cornerSize: CGSize(width: strokeHeight / 2, height: strokeHeight / 2)
+            )
+        }
+        return path
+    }
+}

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -189,9 +189,10 @@ struct WorktreeRowView: View {
                         if let stack = stackSummary {
                             let summaryText = Self.stackSummaryTooltip(merged: stack.merged, total: stack.total)
                             HStack(spacing: 3) {
-                                GGSidebarStackShape()
-                                    .fill(theme.color("fg-faint"))
-                                    .frame(width: 9, height: 9)
+                                GGStackIcon(
+                                    size: 9,
+                                    color: theme.color("fg-faint")
+                                )
                                     .accessibilityHidden(true)
                                 Text("\(stack.merged)/\(stack.total)")
                                     .font(.system(size: 10.5, design: .monospaced))
@@ -201,9 +202,10 @@ struct WorktreeRowView: View {
                             .accessibilityElement(children: .ignore)
                             .accessibilityLabel(Self.stackSummaryAccessibilityLabel(merged: stack.merged, total: stack.total))
                         } else if ggMenuModel.showsStatusIndicator {
-                            GGSidebarStackShape()
-                                .fill(theme.color(Self.pendingStackIndicatorColorToken()))
-                                .frame(width: 9, height: 9)
+                            GGStackIcon(
+                                size: 9,
+                                color: theme.color(Self.pendingStackIndicatorColorToken())
+                            )
                                 .help("gg is active for this worktree.")
                                 .accessibilityLabel("gg is active for this worktree.")
                         }
@@ -306,29 +308,6 @@ struct WorktreeRowView: View {
         formatter.unitsStyle = .abbreviated
         return formatter
     }()
-}
-
-private struct GGSidebarStackShape: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        let strokeHeight = min(rect.height / 9, 1)
-        let strokeWidth = min(rect.width, 7)
-        let x = rect.midX - strokeWidth / 2
-        let yPositions = [
-            rect.minY + 1,
-            rect.midY - strokeHeight / 2,
-            rect.maxY - strokeHeight - 1
-        ]
-
-        for y in yPositions {
-            path.addRoundedRect(
-                in: CGRect(x: x, y: y, width: strokeWidth, height: strokeHeight),
-                cornerSize: CGSize(width: strokeHeight / 2, height: strokeHeight / 2)
-            )
-        }
-
-        return path
-    }
 }
 
 private extension String {

--- a/Alas/Sources/UI/AlasSegmentedControl.swift
+++ b/Alas/Sources/UI/AlasSegmentedControl.swift
@@ -1,9 +1,14 @@
 import SwiftUI
 
+enum AlasSegmentedIcon: Equatable {
+    case system(String)
+    case gg(GGStackIconVariant)
+}
+
 struct AlasSegmentedOption<ID: Hashable> {
     let id: ID
     let label: String
-    let icon: String?
+    let icon: AlasSegmentedIcon?
     let isEnabled: Bool
     let disabledHelp: String?
 
@@ -16,7 +21,21 @@ struct AlasSegmentedOption<ID: Hashable> {
     ) {
         self.id = id
         self.label = label
-        self.icon = icon
+        self.icon = icon.map(AlasSegmentedIcon.system)
+        self.isEnabled = isEnabled
+        self.disabledHelp = disabledHelp
+    }
+
+    init(
+        id: ID,
+        label: String,
+        segmentedIcon: AlasSegmentedIcon?,
+        isEnabled: Bool = true,
+        disabledHelp: String? = nil
+    ) {
+        self.id = id
+        self.label = label
+        self.icon = segmentedIcon
         self.isEnabled = isEnabled
         self.disabledHelp = disabledHelp
     }
@@ -54,11 +73,14 @@ struct AlasSegmentedControl<ID: Hashable>: View {
         } label: {
             HStack(spacing: 5) {
                 if let icon = option.icon {
-                    Icon(
-                        name: icon,
-                        size: 11,
-                        color: isSelected ? theme.color("fg") : theme.color("fg-muted")
-                    )
+                    let iconColor = isSelected ? theme.color("fg") : theme.color("fg-muted")
+                    switch icon {
+                    case .system(let name):
+                        Icon(name: name, size: 11, color: iconColor)
+                    case .gg(let variant):
+                        GGStackIcon(variant: variant, size: 11, color: iconColor)
+                            .accessibilityHidden(true)
+                    }
                 }
                 Text(option.label)
                     .font(.system(size: 11.5, weight: isSelected ? .semibold : .medium))

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -370,13 +370,6 @@ struct NewWorktreeDialogTests {
         #expect(result.persistableLaunchMode == .terminal)
     }
 
-    @Test func inheritedGGDescriptionReportsEffectiveMode() {
-        #expect(NewWorktreeDialog.ggModeDescription(mode: .inherit, createsGGStack: true) ==
-            "Uses repository default: On.")
-        #expect(NewWorktreeDialog.ggModeDescription(mode: .inherit, createsGGStack: false) ==
-            "Uses repository default: Off. Creates a regular Git branch.")
-    }
-
     @Test func explicitGGDescriptionsExplainCreation() {
         #expect(NewWorktreeDialog.ggModeDescription(mode: .on, createsGGStack: true) ==
             "GG enabled for this worktree.")
@@ -394,14 +387,39 @@ struct NewWorktreeDialogTests {
             "Branch: nacho/feature")
     }
 
-    @Test func repositoryChangeResetsGGModeToInherit() {
-        #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(current: .on) == .inherit)
-        #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(current: .off) == .inherit)
+    @Test(arguments: [
+        (GGProjectMode.off, false, GGWorktreeMode.off),
+        (GGProjectMode.off, true, GGWorktreeMode.off),
+        (GGProjectMode.on, false, GGWorktreeMode.on),
+        (GGProjectMode.on, true, GGWorktreeMode.on),
+        (GGProjectMode.auto, false, GGWorktreeMode.off),
+        (GGProjectMode.auto, true, GGWorktreeMode.on),
+    ])
+    func initialGGModeResolvesRepositoryPolicy(
+        projectMode: GGProjectMode,
+        repoHasGGConfig: Bool,
+        expected: GGWorktreeMode
+    ) {
+        #expect(NewWorktreeDialog.initialGGMode(
+            projectMode: projectMode,
+            repoHasGGConfig: repoHasGGConfig
+        ) == expected)
+    }
+
+    @Test func repositoryChangeReplacesExplicitChoiceWithNewRepositoryDefault() {
+        #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(
+            projectMode: .off,
+            repoHasGGConfig: true
+        ) == .off)
+        #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(
+            projectMode: .auto,
+            repoHasGGConfig: true
+        ) == .on)
     }
 
     @Test func ggModeSegmentsMatchDialogOrder() {
-        #expect(NewWorktreeDialog.ggModeSegments.map(\.mode) == [.inherit, .on, .off])
-        #expect(NewWorktreeDialog.ggModeSegments.map(\.label) == ["Inherit", "On", "Off"])
+        #expect(NewWorktreeDialog.ggModeSegments.map(\.mode) == [.on, .off])
+        #expect(NewWorktreeDialog.ggModeSegments.map(\.label) == ["On", "Off"])
     }
 
     @Test func canCreateBlocksMissingUsernameOnlyForEffectiveGG() {

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -417,9 +417,11 @@ struct NewWorktreeDialogTests {
         ) == .on)
     }
 
-    @Test func ggModeSegmentsMatchDialogOrder() {
-        #expect(NewWorktreeDialog.ggModeSegments.map(\.mode) == [.on, .off])
-        #expect(NewWorktreeDialog.ggModeSegments.map(\.label) == ["On", "Off"])
+    @Test func ggModeSegmentsMatchDialogOrderAndIcons() {
+        #expect(NewWorktreeDialog.ggModeSegments == [
+            NewWorktreeGGModeSegment(mode: .on, label: "On", icon: .stack),
+            NewWorktreeGGModeSegment(mode: .off, label: "Off", icon: .disabled),
+        ])
     }
 
     @Test func canCreateBlocksMissingUsernameOnlyForEffectiveGG() {

--- a/docs/superpowers/plans/2026-07-24-new-worktree-two-state-gg-mode.md
+++ b/docs/superpowers/plans/2026-07-24-new-worktree-two-state-gg-mode.md
@@ -1,0 +1,532 @@
+# New Worktree Two-State GG Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the new-worktree dialog's inherited GG policy choice with icon-led explicit On and Off choices initialized from the selected repository's effective policy.
+
+**Architecture:** Keep `GGWorktreeMode.inherit` for existing persistence and sidebar behavior, but resolve it to `.on` or `.off` at the dialog boundary. Extract the established custom three-line GG glyph into a reusable SwiftUI component with a slashed variant, then render that component through the dialog's shared segment renderer.
+
+**Tech Stack:** Swift 5.9+, SwiftUI for macOS, Swift Testing, XcodeGen, `xcodebuild`
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Do not change project-level GG policy, existing-worktree inheritance, GG availability, branch naming, stack-base pinning, or remote-project behavior.
+- Do not introduce a third visible or hidden creation state: every dialog creation passes explicit `.on` or `.off`.
+- Preserve the existing custom GG glyph geometry instead of replacing it with `line.3.horizontal`.
+- Prefix shell commands with `rtk`.
+- If `project.yml` changes, run `rtk xcodegen` and commit both `project.yml` and `Alas.xcodeproj`; this implementation should not require a `project.yml` change because source folders are discovered recursively.
+
+---
+
+## File Map
+
+- Create `Alas/Sources/Integrations/GG/GGStackIcon.swift`: shared three-line GG glyph, normal/slashed variants, and deterministic slash overlay.
+- Modify `Alas/Sources/Sidebar/WorktreeRowView.swift`: replace the private shape with the shared normal glyph and delete the duplicate private shape.
+- Modify `Alas/Sources/Dialogs/NewWorktreeDialog.swift`: resolve initial explicit GG mode, expose only On/Off segments, attach GG icon variants, and render system or GG icons through one segment helper.
+- Modify `AlasTests/NewWorktreeDialogTests.swift`: cover policy resolution, repository-reset semantics, explicit segment definitions, and icon variants.
+- Use existing `AlasTests/WorktreeRowHeightTests.swift` unchanged as the sidebar-layout regression after extracting the icon.
+
+---
+
+### Task 1: Resolve Repository Policy Into An Explicit Dialog Mode
+
+**Files:**
+- Modify: `AlasTests/NewWorktreeDialogTests.swift:340-375`
+- Modify: `Alas/Sources/Dialogs/NewWorktreeDialog.swift:18-25`
+- Modify: `Alas/Sources/Dialogs/NewWorktreeDialog.swift:125-160`
+- Modify: `Alas/Sources/Dialogs/NewWorktreeDialog.swift:414-435`
+- Modify: `Alas/Sources/Dialogs/NewWorktreeDialog.swift:482-505`
+
+**Interfaces:**
+- Consumes: `GGWorktreeContextResolver.isPolicyEnabled(projectMode:worktreeOverride:isMainWorktree:repoHasGGConfig:)`.
+- Produces: `NewWorktreeDialog.initialGGMode(projectMode:repoHasGGConfig:) -> GGWorktreeMode`.
+- Produces: `NewWorktreeDialog.ggModeAfterRepositoryChange(projectMode:repoHasGGConfig:) -> GGWorktreeMode`.
+- Produces: a dialog invariant that `ggMode` is `.on` or `.off` before creation.
+
+- [ ] **Step 1: Replace the inherited-mode tests with failing explicit-default tests**
+
+In `AlasTests/NewWorktreeDialogTests.swift`, replace
+`repositoryChangeResetsGGModeToInherit` and update the segment-order test:
+
+```swift
+@Test(arguments: [
+    (GGProjectMode.off, false, GGWorktreeMode.off),
+    (GGProjectMode.off, true, GGWorktreeMode.off),
+    (GGProjectMode.on, false, GGWorktreeMode.on),
+    (GGProjectMode.on, true, GGWorktreeMode.on),
+    (GGProjectMode.auto, false, GGWorktreeMode.off),
+    (GGProjectMode.auto, true, GGWorktreeMode.on),
+])
+func initialGGModeResolvesRepositoryPolicy(
+    projectMode: GGProjectMode,
+    repoHasGGConfig: Bool,
+    expected: GGWorktreeMode
+) {
+    #expect(NewWorktreeDialog.initialGGMode(
+        projectMode: projectMode,
+        repoHasGGConfig: repoHasGGConfig
+    ) == expected)
+}
+
+@Test func repositoryChangeReplacesExplicitChoiceWithNewRepositoryDefault() {
+    #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(
+        projectMode: .off,
+        repoHasGGConfig: true
+    ) == .off)
+    #expect(NewWorktreeDialog.ggModeAfterRepositoryChange(
+        projectMode: .auto,
+        repoHasGGConfig: true
+    ) == .on)
+}
+
+@Test func ggModeSegmentsMatchDialogOrder() {
+    #expect(NewWorktreeDialog.ggModeSegments.map(\.mode) == [.on, .off])
+    #expect(NewWorktreeDialog.ggModeSegments.map(\.label) == ["On", "Off"])
+}
+```
+
+Keep `explicitGGDescriptionsExplainCreation`. Remove
+`inheritedGGDescriptionReportsEffectiveMode`, because the dialog can no longer
+select `.inherit`.
+
+- [ ] **Step 2: Run the focused tests and verify the new API expectations fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/NewWorktreeDialogTests test
+```
+
+Expected: FAIL to compile because `initialGGMode(projectMode:repoHasGGConfig:)`
+does not exist and `ggModeAfterRepositoryChange` has the old signature.
+
+- [ ] **Step 3: Add the explicit policy resolver**
+
+In `NewWorktreeDialog.swift`, replace the old repository-change helper with:
+
+```swift
+nonisolated static func initialGGMode(
+    projectMode: GGProjectMode,
+    repoHasGGConfig: Bool
+) -> GGWorktreeMode {
+    GGWorktreeContextResolver.isPolicyEnabled(
+        projectMode: projectMode,
+        worktreeOverride: .inherit,
+        isMainWorktree: false,
+        repoHasGGConfig: repoHasGGConfig
+    ) ? .on : .off
+}
+
+nonisolated static func ggModeAfterRepositoryChange(
+    projectMode: GGProjectMode,
+    repoHasGGConfig: Bool
+) -> GGWorktreeMode {
+    initialGGMode(
+        projectMode: projectMode,
+        repoHasGGConfig: repoHasGGConfig
+    )
+}
+```
+
+Add a repository-scoped state seeder near `applyLaunchDefaults`:
+
+```swift
+private func applyGGModeDefault(for selectedProjectId: String) {
+    guard let project = state.projects.first(where: { $0.id == selectedProjectId }) else {
+        ggMode = .off
+        return
+    }
+    ggMode = Self.initialGGMode(
+        projectMode: project.ggMode,
+        repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path)
+    )
+}
+```
+
+Change the initial state declaration to:
+
+```swift
+@State private var ggMode: GGWorktreeMode = .off
+```
+
+- [ ] **Step 4: Seed the explicit mode on appearance and repository changes**
+
+In `.onAppear`, call the seeder after `projectId` is resolved and before the
+initial base is derived:
+
+```swift
+applyGGModeDefault(for: projectId)
+if base.isEmpty {
+    base = Self.initialBase(
+        configuredDefault: state.config.worktrees.baseBranch,
+        stackPinnedBase: stackPinnedBase
+    )
+}
+```
+
+In `.onChange(of: projectId)`, replace the inherited reset with:
+
+```swift
+applyGGModeDefault(for: projectId)
+applyLaunchDefaults(for: projectId)
+```
+
+Keep this before assigning `base`, so `stackPinnedBase` reflects the newly
+resolved repository default.
+
+- [ ] **Step 5: Expose only On and Off segments**
+
+Change the segment model temporarily to:
+
+```swift
+nonisolated static let ggModeSegments: [(mode: GGWorktreeMode, label: String)] = [
+    (.on, "On"),
+    (.off, "Off"),
+]
+```
+
+Keep the existing segment rendering text-only for this task. Task 2 adds the
+shared icon model without mixing visual extraction into policy behavior.
+
+- [ ] **Step 6: Run the focused tests and verify explicit defaults pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/NewWorktreeDialogTests test
+```
+
+Expected: PASS for `NewWorktreeDialogTests`, including all six policy cases and
+the two-segment order.
+
+- [ ] **Step 7: Commit the two-state behavior**
+
+```bash
+rtk git add Alas/Sources/Dialogs/NewWorktreeDialog.swift AlasTests/NewWorktreeDialogTests.swift
+rtk git commit -m "feat(gg): make new worktree mode explicit"
+```
+
+---
+
+### Task 2: Share The GG Stack Glyph And Add The Slashed Variant
+
+**Files:**
+- Create: `Alas/Sources/Integrations/GG/GGStackIcon.swift`
+- Modify: `Alas/Sources/Sidebar/WorktreeRowView.swift:145-180`
+- Modify: `Alas/Sources/Sidebar/WorktreeRowView.swift:276-300`
+- Modify: `Alas/Sources/Dialogs/NewWorktreeDialog.swift:482-505`
+- Modify: `Alas/Sources/Dialogs/NewWorktreeDialog.swift:590-640`
+- Modify: `AlasTests/NewWorktreeDialogTests.swift:365-380`
+- Verify unchanged: `AlasTests/WorktreeRowHeightTests.swift`
+
+**Interfaces:**
+- Produces: `enum GGStackIconVariant: Equatable { case stack, disabled }`.
+- Produces: `struct GGStackIcon: View` initialized with
+  `init(variant: GGStackIconVariant = .stack, size: CGFloat, color: Color)`.
+- Produces: `enum NewWorktreeSegmentIcon: Equatable` with `.system(String)` and
+  `.gg(GGStackIconVariant)`.
+- Produces: `struct NewWorktreeGGModeSegment: Equatable` with `mode`, `label`,
+  and `icon`.
+
+- [ ] **Step 1: Extend the segment test to require GG icon variants**
+
+Replace the Task 1 segment test with:
+
+```swift
+@Test func ggModeSegmentsMatchDialogOrderAndIcons() {
+    #expect(NewWorktreeDialog.ggModeSegments == [
+        NewWorktreeGGModeSegment(mode: .on, label: "On", icon: .stack),
+        NewWorktreeGGModeSegment(mode: .off, label: "Off", icon: .disabled),
+    ])
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify the missing types fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/NewWorktreeDialogTests test
+```
+
+Expected: FAIL to compile because `NewWorktreeGGModeSegment` and
+`GGStackIconVariant` do not exist.
+
+- [ ] **Step 3: Create the shared GG icon**
+
+Create `Alas/Sources/Integrations/GG/GGStackIcon.swift`:
+
+```swift
+import SwiftUI
+
+enum GGStackIconVariant: Equatable {
+    case stack
+    case disabled
+}
+
+struct GGStackIcon: View {
+    let variant: GGStackIconVariant
+    let size: CGFloat
+    let color: Color
+
+    init(
+        variant: GGStackIconVariant = .stack,
+        size: CGFloat,
+        color: Color
+    ) {
+        self.variant = variant
+        self.size = size
+        self.color = color
+    }
+
+    var body: some View {
+        ZStack {
+            GGStackShape()
+                .fill(color)
+            if variant == .disabled {
+                Capsule()
+                    .fill(color)
+                    .frame(width: 1, height: size + 2)
+                    .rotationEffect(.degrees(-45))
+            }
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+private struct GGStackShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let strokeHeight = min(rect.height / 9, 1)
+        let strokeWidth = min(rect.width, 7)
+        let x = rect.midX - strokeWidth / 2
+        let yPositions = [
+            rect.minY + 1,
+            rect.midY - strokeHeight / 2,
+            rect.maxY - strokeHeight - 1,
+        ]
+
+        for y in yPositions {
+            path.addRoundedRect(
+                in: CGRect(x: x, y: y, width: strokeWidth, height: strokeHeight),
+                cornerSize: CGSize(width: strokeHeight / 2, height: strokeHeight / 2)
+            )
+        }
+        return path
+    }
+}
+```
+
+- [ ] **Step 4: Replace both sidebar glyph call sites**
+
+In `WorktreeRowView.swift`, replace each:
+
+```swift
+GGSidebarStackShape()
+    .fill(theme.color(...))
+    .frame(width: 9, height: 9)
+```
+
+with the corresponding shared view:
+
+```swift
+GGStackIcon(
+    size: 9,
+    color: theme.color("fg-faint")
+)
+```
+
+and:
+
+```swift
+GGStackIcon(
+    size: 9,
+    color: theme.color("accent")
+)
+```
+
+Preserve the existing `.accessibilityHidden`, `.help`, and
+`.accessibilityLabel` modifiers at each call site. Delete the private
+`GGSidebarStackShape` definition from the bottom of the file.
+
+- [ ] **Step 5: Add typed dialog icon models**
+
+Above `NewWorktreeDialog`, add:
+
+```swift
+enum NewWorktreeSegmentIcon: Equatable {
+    case system(String)
+    case gg(GGStackIconVariant)
+}
+
+struct NewWorktreeGGModeSegment: Equatable {
+    let mode: GGWorktreeMode
+    let label: String
+    let icon: GGStackIconVariant
+}
+```
+
+Replace `ggModeSegments` with:
+
+```swift
+nonisolated static let ggModeSegments: [NewWorktreeGGModeSegment] = [
+    .init(mode: .on, label: "On", icon: .stack),
+    .init(mode: .off, label: "Off", icon: .disabled),
+]
+```
+
+At the GG segment call site, pass:
+
+```swift
+icon: .gg(segmentItem.icon),
+```
+
+For launch segments, wrap the existing symbol names:
+
+```swift
+icon: .system("circle.slash")
+icon: .system("terminal")
+icon: .system("sparkle")
+```
+
+- [ ] **Step 6: Render either system or GG segment icons**
+
+Change the segment helper parameter from `String?` to:
+
+```swift
+icon: NewWorktreeSegmentIcon?,
+```
+
+Inside the button label, replace the current optional `Icon` block with:
+
+```swift
+if let icon {
+    let iconColor = isSelected ? theme.color("fg") : theme.color("fg-muted")
+    switch icon {
+    case .system(let name):
+        Icon(name: name, size: 11, color: iconColor)
+    case .gg(let variant):
+        GGStackIcon(variant: variant, size: 11, color: iconColor)
+            .accessibilityHidden(true)
+    }
+}
+```
+
+The adjacent text remains the accessibility name for each segment, matching
+the launch-surface pattern.
+
+- [ ] **Step 7: Run focused dialog and sidebar regressions**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/NewWorktreeDialogTests \
+  -only-testing:AlasTests/WorktreeRowHeightTests test
+```
+
+Expected: PASS. `NewWorktreeDialogTests` confirms the On/Off icon model;
+`WorktreeRowHeightTests` confirms the extracted sidebar glyph preserves row
+height, tooltip terminology, and accessibility-label terminology.
+
+- [ ] **Step 8: Build the app for visual/compile validation**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0 with no compiler errors. Open the dialog and confirm the
+normal and slashed glyphs remain legible at the 11-point segment size.
+
+- [ ] **Step 9: Commit the shared icon**
+
+```bash
+rtk git add Alas/Sources/Integrations/GG/GGStackIcon.swift \
+  Alas/Sources/Sidebar/WorktreeRowView.swift \
+  Alas/Sources/Dialogs/NewWorktreeDialog.swift \
+  AlasTests/NewWorktreeDialogTests.swift
+rtk git commit -m "feat(gg): add mode icons to worktree creation"
+```
+
+---
+
+### Task 3: Required Full Verification
+
+**Files:**
+- Verify: `project.yml`
+- Verify: `Alas.xcodeproj`
+- Verify: all files changed by Tasks 1 and 2
+
+**Interfaces:**
+- Consumes: the explicit dialog-mode resolver and shared GG icon from Tasks 1
+  and 2.
+- Produces: evidence that generated project state, the app build, and the full
+  test suite are green.
+
+- [ ] **Step 1: Regenerate the Xcode project**
+
+Run:
+
+```bash
+rtk xcodegen
+```
+
+Expected: successful generation. Then run:
+
+```bash
+rtk git status --short
+```
+
+Expected: no `project.yml` or `Alas.xcodeproj` diff. If generation changes
+`Alas.xcodeproj`, inspect and include only the expected source-discovery change.
+
+- [ ] **Step 2: Run the required quiet macOS build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run the required full test suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: `** TEST SUCCEEDED **` with no failures.
+
+- [ ] **Step 4: Inspect final scope**
+
+Run:
+
+```bash
+rtk git status --short
+rtk git diff HEAD~2 --stat
+rtk git diff HEAD~2 --check
+```
+
+Expected: only the planned GG icon/dialog/test files are changed by the two
+implementation commits, and `git diff --check` reports no whitespace errors.
+
+- [ ] **Step 5: Commit generated state only if regeneration changed it**
+
+If and only if Step 1 produced an expected generated-project diff:
+
+```bash
+rtk git add Alas.xcodeproj
+rtk git commit -m "chore: regenerate Xcode project"
+```
+
+Otherwise, do not create an empty verification commit.

--- a/docs/superpowers/specs/2026-07-24-new-worktree-two-state-gg-mode-design.md
+++ b/docs/superpowers/specs/2026-07-24-new-worktree-two-state-gg-mode-design.md
@@ -1,0 +1,137 @@
+# New Worktree Two-State GG Mode
+
+Date: 2026-07-24
+Status: Approved design
+
+## Context
+
+The new-worktree dialog currently exposes `Inherit`, `On`, and `Off` as three
+text-only GG mode segments. `Inherit` is a persisted policy choice rather than
+a creation outcome, so the selected segment still needs helper text to explain
+whether the new worktree will actually use GG.
+
+The dialog should instead present the concrete result the user is about to
+create. Repository policy still provides the default, but it should not remain
+as a third visible or hidden state after the dialog initializes.
+
+## Goals
+
+- Replace the three GG mode segments with explicit `On` and `Off` choices.
+- Initialize that choice from the selected repository's effective inherited
+  policy.
+- Persist the visible choice as an explicit worktree override.
+- Add the existing three-line GG stack glyph to the `On` segment.
+- Represent `Off` with the same glyph crossed by a diagonal slash.
+- Reuse one GG glyph implementation in the dialog and sidebar.
+
+## Non-goals
+
+- Removing `.inherit` from `GGWorktreeMode` or changing existing worktrees.
+- Changing the sidebar worktree GG mode menu.
+- Changing project-level `Off`, `Auto`, or `On` policy semantics.
+- Changing GG availability, branch naming, stack-base pinning, or remote
+  project behavior.
+
+## User Interface
+
+When GG stack creation is available, the dialog shows a segmented control with
+two choices:
+
+- The `On` segment contains the three-line GG stack glyph followed by `On`.
+- The `Off` segment contains the same glyph with a diagonal slash followed by
+  `Off`.
+
+The icon size, label typography, selection treatment, focus behavior, and
+spacing follow the existing `Open after create` segmented control.
+
+The three-line shape is extracted from its sidebar-only location into a shared
+presentation component. The component supports a normal and slashed rendering
+while keeping the same deterministic custom geometry as the existing sidebar
+badge. It does not use `line.3.horizontal`, because that generic symbol does
+not exactly match the established GG glyph.
+
+The existing helper text remains and describes the explicit selected result:
+
+- `GG enabled for this worktree.`
+- `GG disabled for this worktree. Creates a regular Git branch.`
+
+The control retains its current visibility rules. Remote projects and projects
+where the app-wide or installation gates fail do not gain a GG mode control.
+
+## Initial State And Repository Changes
+
+The dialog resolves the selected repository's policy for a new linked worktree
+into a Boolean result:
+
+| Project policy | Repository has GG config | Initial selection |
+|---|---:|---|
+| `Off` | Either | `Off` |
+| `On` | Either | `On` |
+| `Auto` | Yes | `On` |
+| `Auto` | No | `Off` |
+
+This uses the existing GG policy resolver with an inherited worktree mode and
+`isMainWorktree` set to `false`. The resulting Boolean maps immediately to
+`.on` or `.off`.
+
+The dialog performs this initialization when it first selects a repository and
+again whenever the repository selection changes. A choice made for one
+repository therefore never leaks into another repository.
+
+There is no untouched or hidden inheritance state. Even if the user accepts
+the initial selection without interacting with the control, creation receives
+the corresponding explicit `.on` or `.off` value.
+
+## Creation Behavior
+
+The selected explicit mode continues to drive the existing `createsGGStack`
+calculation:
+
+- `On` uses the stack-name field, GG branch composition, and configured
+  stack-base pinning.
+- `Off` uses the regular branch-name field and freely selected base.
+
+The dialog passes only `.on` or `.off` to `createWorktree`. The existing
+creation and persistence path stores that explicit override under the created
+worktree's stable identity. Later changes to project policy or repository GG
+configuration do not change this worktree's selected mode.
+
+If `On` is selected but `branch_username` is unavailable, the existing
+configuration hint and disabled confirmation behavior remain unchanged.
+
+## Implementation Approach
+
+The recommended approach is a shared SwiftUI GG icon component:
+
+1. Move the current custom three-stroke shape out of
+   `WorktreeRowView.swift` into a reusable GG presentation file.
+2. Add a slashed variant by overlaying a deterministic diagonal stroke on the
+   same stack geometry.
+3. Use the shared normal glyph in the sidebar and the normal/slashed variants
+   in the new-worktree dialog.
+4. Change the dialog's segment definitions and initialization helpers to
+   expose only explicit modes.
+
+Using an SF Symbol would be less code but would change the established GG
+geometry. Duplicating the shape inside the dialog would keep the immediate diff
+small but create two sources of truth for the same product icon.
+
+## Testing
+
+Focused Swift Testing coverage should verify:
+
+- `Off`, `On`, and `Auto` project policies resolve to the expected initial
+  explicit mode, including `Auto` with and without repository GG config.
+- Changing repositories replaces the current choice with the newly selected
+  repository's resolved explicit default.
+- The segment model contains exactly `On` and `Off` in that order.
+- Both segments declare the intended normal or slashed GG icon.
+- The dialog never passes `.inherit` for a user-visible creation choice.
+- Existing explicit-mode descriptions, stack-name selection, branch preview,
+  pinned-base behavior, and missing-configuration validation continue to pass.
+- The shared normal glyph preserves the sidebar marker's layout and
+  accessibility behavior.
+
+Before completion, run the focused new-worktree and sidebar tests, regenerate
+the Xcode project if project configuration changes, and run the repository's
+required macOS build and test commands.


### PR DESCRIPTION
## Summary

- Replace the New Worktree dialog GG mode control with explicit On/Off choices.
- Resolve the initial choice from the selected repository's effective GG policy instead of exposing Inherit.
- Reuse the existing three-line GG stack glyph in the dialog and sidebar, with a slashed variant for Off.

## Verification

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/NewWorktreeDialogTests -only-testing:AlasTests/WorktreeRowHeightTests test`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
