### PR TITLE
fix(ui): remove segmented focus ring

### DIFF
--- a/Alas/Sources/UI/AlasSegmentedControl.swift
+++ b/Alas/Sources/UI/AlasSegmentedControl.swift
@@ -27,7 +27,6 @@ struct AlasSegmentedControl<ID: Hashable>: View {
     let options: [AlasSegmentedOption<ID>]
     let onSelect: (ID) -> Void
 
-    @FocusState private var focusedOption: ID?
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -47,7 +46,6 @@ struct AlasSegmentedControl<ID: Hashable>: View {
 
     private func segment(_ option: AlasSegmentedOption<ID>) -> some View {
         let isSelected = selection == option.id
-        let isFocused = focusedOption == option.id
 
         return Button {
             onSelect(option.id)
@@ -76,16 +74,13 @@ struct AlasSegmentedControl<ID: Hashable>: View {
                     }
                 }
             }
-            .overlay(
-                RoundedRectangle(cornerRadius: 4)
-                    .strokeBorder(theme.color("accent"), lineWidth: isFocused ? 1 : 0)
-            )
             .clipShape(RoundedRectangle(cornerRadius: 4))
+            .shadow(color: isSelected ? Color.black.opacity(0.25) : .clear, radius: 1, x: 0, y: 1)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .focusable(option.isEnabled)
-        .focused($focusedOption, equals: option.id)
+        .focusEffectDisabled()
         .disabled(!option.isEnabled)
         .opacity(option.isEnabled ? 1 : 0.4)
         .modifier(AlasSegmentHelpModifier(


### PR DESCRIPTION
## Summary

- Remove the custom accent focus overlay from `AlasSegmentedControl`.
- Disable the visible focus effect on segmented control buttons while keeping them focusable.
- Restore the subtle selected-segment shadow used by the older segmented controls.

## Root Cause

The shared `AlasSegmentedControl` introduced for 0.13.2 tracked segment focus with `@FocusState` and drew an accent-colored overlay when a segment became focused. The new worktree dialog reused that control, so keyboard focus made the launch-surface segmented control show the blue ring that was not present in 0.13.1.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (6528 tests in 624 suites)
