### PR TITLE
feat(acp): add per-message session forking

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1158,6 +1158,7 @@
 		D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */; };
 		D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */; };
 		D215CAABE4DE2F5CE3CB0E93 /* DiffReviewFileSectionEqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */; };
+		D25BE4EC15C13F94BE20CC2C /* ACPSessionForkAttachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705D2002EB8BC3F1DDA0E93F /* ACPSessionForkAttachTests.swift */; };
 		D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */; };
 		D27A85DE79B3B62C6F91174A /* ReviewFeedbackBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0886F9B3096AC1264E3D337 /* ReviewFeedbackBundle.swift */; };
 		D28EE6309DBB51EFEDCEAC18 /* ACPSessionManagerLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C13707B79B7A4F4BB2608E /* ACPSessionManagerLeaseTests.swift */; };
@@ -2033,6 +2034,7 @@
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
 		705B34DF3EE049FA52E8ECFB /* IconSymbolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconSymbolTests.swift; sourceTree = "<group>"; };
+		705D2002EB8BC3F1DDA0E93F /* ACPSessionForkAttachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkAttachTests.swift; sourceTree = "<group>"; };
 		708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottleTests.swift; sourceTree = "<group>"; };
 		708FAE890F75BC58098E7DDC /* RunScriptTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptTemplate.swift; sourceTree = "<group>"; };
 		7094534860369BA79FC5A877 /* session-update-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-plan.json"; sourceTree = "<group>"; };
@@ -4440,6 +4442,7 @@
 				0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */,
 				52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */,
 				D2A24F057893BB2179C1900C /* ACPSessionDiscoveryTests.swift */,
+				705D2002EB8BC3F1DDA0E93F /* ACPSessionForkAttachTests.swift */,
 				4723038DCD9A70A7DB96D13E /* ACPSessionForkManagerTests.swift */,
 				EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */,
 				1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */,
@@ -6276,6 +6279,7 @@
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,
 				9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */,
 				0E2F2A2FD567CE04CF549C29 /* ACPSessionDiscoveryTests.swift in Sources */,
+				D25BE4EC15C13F94BE20CC2C /* ACPSessionForkAttachTests.swift in Sources */,
 				32F202FB1BC376A6B4088D08 /* ACPSessionForkManagerTests.swift in Sources */,
 				E0CC3918BF4D86FD20442922 /* ACPSessionForkPersistenceTests.swift in Sources */,
 				E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
 		32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */; };
 		32B3513F0BFC2F9B72763773 /* GitHubCLIProviderVerdictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */; };
+		32F202FB1BC376A6B4088D08 /* ACPSessionForkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4723038DCD9A70A7DB96D13E /* ACPSessionForkManagerTests.swift */; };
 		330D198F38767801994BF84C /* RemoteHostCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */; };
 		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
 		33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */; };
@@ -1233,6 +1234,7 @@
 		E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C511B229168DDEA87173A41 /* GGInboxStore.swift */; };
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
 		E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */; };
+		E0CC3918BF4D86FD20442922 /* ACPSessionForkPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */; };
 		E0F4EFE612252BDD7F999A70 /* ReviewFeedbackAgentSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
 		E19AEA6E45D16B5EEC1CE411 /* ACPMCPPromptPreamble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A1E612514DDA810791ED5 /* ACPMCPPromptPreamble.swift */; };
@@ -1801,6 +1803,7 @@
 		45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridge.swift; sourceTree = "<group>"; };
 		46554893BA6205CD856B99B5 /* AppStateKeepSessionsAliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateKeepSessionsAliveTests.swift; sourceTree = "<group>"; };
 		467E833E3CE05D82DB88C5C5 /* ReviewReadinessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReadinessModel.swift; sourceTree = "<group>"; };
+		4723038DCD9A70A7DB96D13E /* ACPSessionForkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkManagerTests.swift; sourceTree = "<group>"; };
 		472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerHydrationTests.swift; sourceTree = "<group>"; };
 		4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstallerTests.swift; sourceTree = "<group>"; };
 		47DEF5C084FA32A781ABDADD /* ReviewTargetPaletteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTargetPaletteModel.swift; sourceTree = "<group>"; };
@@ -2689,6 +2692,7 @@
 		EBD68C6A69930BE0F9437AAE /* RemoteMessageWireJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessageWireJSON.swift; sourceTree = "<group>"; };
 		EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfUpdaterTests.swift; sourceTree = "<group>"; };
 		EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionByteAccounting.swift; sourceTree = "<group>"; };
+		EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkPersistenceTests.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
 		EC35CACDC7D469C7D0382F31 /* ACPUserInputFormState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserInputFormState.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
@@ -4434,6 +4438,8 @@
 				0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */,
 				52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */,
 				D2A24F057893BB2179C1900C /* ACPSessionDiscoveryTests.swift */,
+				4723038DCD9A70A7DB96D13E /* ACPSessionForkManagerTests.swift */,
+				EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */,
 				1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */,
 				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
@@ -6267,6 +6273,8 @@
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,
 				9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */,
 				0E2F2A2FD567CE04CF549C29 /* ACPSessionDiscoveryTests.swift in Sources */,
+				32F202FB1BC376A6B4088D08 /* ACPSessionForkManagerTests.swift in Sources */,
+				E0CC3918BF4D86FD20442922 /* ACPSessionForkPersistenceTests.swift in Sources */,
 				E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -711,6 +711,7 @@
 		837559FFC9F1A560B58069A4 /* RemoteHelperACPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E54D3FBA0EB8B5DCF52179 /* RemoteHelperACPTransport.swift */; };
 		839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */; };
 		83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */; };
+		83A9882DD3D7FF85A18C1B18 /* ACPSessionForkRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F9D4F91573E92AE4964353 /* ACPSessionForkRunnerTests.swift */; };
 		84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */; };
 		847356E199302CCFDA9172DA /* ACPMCPStatusPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */; };
 		84AFBFC844DF35AF5D37445B /* ACPGoalPillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */; };
@@ -1426,6 +1427,7 @@
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
 		00B894D92F014C2ADB3CCC9B /* TreeSitterPython */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterPython; path = ThirdParty/TreeSitterPython; sourceTree = SOURCE_ROOT; };
 		00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModelBuilder.swift; sourceTree = "<group>"; };
+		00F9D4F91573E92AE4964353 /* ACPSessionForkRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkRunnerTests.swift; sourceTree = "<group>"; };
 		010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
 		013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjection.swift; sourceTree = "<group>"; };
 		01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupViewLayoutTests.swift; sourceTree = "<group>"; };
@@ -4441,6 +4443,7 @@
 				4723038DCD9A70A7DB96D13E /* ACPSessionForkManagerTests.swift */,
 				EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */,
 				1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */,
+				00F9D4F91573E92AE4964353 /* ACPSessionForkRunnerTests.swift */,
 				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
 				F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */,
@@ -6276,6 +6279,7 @@
 				32F202FB1BC376A6B4088D08 /* ACPSessionForkManagerTests.swift in Sources */,
 				E0CC3918BF4D86FD20442922 /* ACPSessionForkPersistenceTests.swift in Sources */,
 				E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */,
+				83A9882DD3D7FF85A18C1B18 /* ACPSessionForkRunnerTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
 				45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -566,6 +566,7 @@
 		6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */; };
 		66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */; };
 		671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A17A797374500E1FDD2382C /* PersistenceStore.swift */; };
+		67683DB8DF67CCAEF6DEF9A8 /* ACPSessionForkPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A2AA9654545DAB044C5DA7 /* ACPSessionForkPresentationTests.swift */; };
 		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
 		67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */; };
 		67D9FD383A299A29780C3DE2 /* BinaryFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8182DA33443DD22A370892B7 /* BinaryFileType.swift */; };
@@ -2720,6 +2721,7 @@
 		F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTopPaginationIndicator.swift; sourceTree = "<group>"; };
 		F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCFramerTests.swift; sourceTree = "<group>"; };
 		F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-blocks.json"; sourceTree = "<group>"; };
+		F0A2AA9654545DAB044C5DA7 /* ACPSessionForkPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkPresentationTests.swift; sourceTree = "<group>"; };
 		F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreTests.swift; sourceTree = "<group>"; };
 		F0D567F7F894902AD192D220 /* mason-lsps.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "mason-lsps.json"; sourceTree = "<group>"; };
 		F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackReadinessModelTests.swift; sourceTree = "<group>"; };
@@ -3806,6 +3808,7 @@
 				5733BF1C52BA0FCFB2724D57 /* ACPQueuedBubbleActionMetricsTests.swift */,
 				E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
+				F0A2AA9654545DAB044C5DA7 /* ACPSessionForkPresentationTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
 				39B7BC45B64591618784F650 /* ACPSlashPickerTests.swift */,
 				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
@@ -6283,6 +6286,7 @@
 				32F202FB1BC376A6B4088D08 /* ACPSessionForkManagerTests.swift in Sources */,
 				E0CC3918BF4D86FD20442922 /* ACPSessionForkPersistenceTests.swift in Sources */,
 				E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */,
+				67683DB8DF67CCAEF6DEF9A8 /* ACPSessionForkPresentationTests.swift in Sources */,
 				83A9882DD3D7FF85A18C1B18 /* ACPSessionForkRunnerTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 		4CFC511BB3BEFB139BDF66F6 /* MemoryReportWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3E23DCE2A602A87915ECE /* MemoryReportWindow.swift */; };
 		4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */; };
 		4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */; };
+		4DC40ADBDD5F113412B2087E /* ForkSourceBrokerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730AFD7C822A7A17A5F2637 /* ForkSourceBrokerService.swift */; };
 		4DEFF78597731750310ABE00 /* RemoteHelperWatchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F17DE68E81565014FC9454 /* RemoteHelperWatchSession.swift */; };
 		4DF50D8995FBF711085A40AF /* ReviewThreadMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CEB6C5C076B4147D587909 /* ReviewThreadMutations.swift */; };
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
@@ -2154,6 +2155,7 @@
 		86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackModels.swift; sourceTree = "<group>"; };
 		86D12B948CADE546FFD3A54C /* DiffReviewImageStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewImageStateTests.swift; sourceTree = "<group>"; };
 		8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownTextBareURLTests.swift; sourceTree = "<group>"; };
+		8730AFD7C822A7A17A5F2637 /* ForkSourceBrokerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkSourceBrokerService.swift; sourceTree = "<group>"; };
 		8792D7045679FE1E12AAFA04 /* GGWorktreeMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGWorktreeMenuModelTests.swift; sourceTree = "<group>"; };
 		87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariants.swift; sourceTree = "<group>"; };
 		881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputer.swift; sourceTree = "<group>"; };
@@ -4486,6 +4488,7 @@
 				DC3201ACD757677A7F42A8AE /* AlasMCPHTTPSupervisorTests.swift */,
 				FE7A4A7B920C0E748973F282 /* BuiltInAlasMCPTests.swift */,
 				336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */,
+				8730AFD7C822A7A17A5F2637 /* ForkSourceBrokerService.swift */,
 				532AA1B8AD5E8139D2EEE948 /* MCPAttachmentPlannerTests.swift */,
 				FE42251A40DA18A6DB0E7491 /* MCPRegistrationDecisionTests.swift */,
 				935CE58001BA1459A556B397 /* MCPRegistrationRegistryTests.swift */,
@@ -6500,6 +6503,7 @@
 				A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */,
 				DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */,
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
+				4DC40ADBDD5F113412B2087E /* ForkSourceBrokerService.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -494,6 +494,7 @@
 		575A4296D86E77D00A1E66A7 /* CommitTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */; };
 		5789FC76BEC6965E56C2DF3C /* ACPLaunchPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C0EBA9F81668C89977770E /* ACPLaunchPathResolver.swift */; };
 		57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */; };
+		57BE6CDE03CD3CD20C5430D8 /* ACPSessionForkDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A43599B405E7E263CE825 /* ACPSessionForkDivider.swift */; };
 		57C5E087A453B384485B4EE2 /* ChatFontCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF72CF0EA2F684D6ED3B43F5 /* ChatFontCatalogTests.swift */; };
 		57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */; };
 		5806E3E41DA735380E33BF76 /* DiffReviewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D1ECA099BBDCB5BB2EEC67 /* DiffReviewModels.swift */; };
@@ -1962,6 +1963,7 @@
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
 		621C13FD3A997CCB29273993 /* RemoteHostStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostStatusStoreTests.swift; sourceTree = "<group>"; };
 		626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionNameTests.swift; sourceTree = "<group>"; };
+		631A43599B405E7E263CE825 /* ACPSessionForkDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkDivider.swift; sourceTree = "<group>"; };
 		63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionDiscovery.swift; sourceTree = "<group>"; };
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
 		639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryTests.swift; sourceTree = "<group>"; };
@@ -4192,6 +4194,7 @@
 				AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */,
 				7DE5F609BDA1D7CE2DF4A491 /* ACPScrollDirectionClassifier.swift */,
 				B5E898E9F7E2680132FF54D4 /* ACPSelectChip.swift */,
+				631A43599B405E7E263CE825 /* ACPSessionForkDivider.swift */,
 				7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */,
 				6791BB640C39115289BF6D07 /* ACPSetupNudgeBanner.swift */,
 				93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */,
@@ -5561,6 +5564,7 @@
 				38B6857CDB7D094A46F653E2 /* ACPSessionByteAccounting.swift in Sources */,
 				D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */,
 				478AE77B9CB6E1FEDCCCC37C /* ACPSessionFork.swift in Sources */,
+				57BE6CDE03CD3CD20C5430D8 /* ACPSessionForkDivider.swift in Sources */,
 				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
 				C1FF6E6CE6AF5ABCF5C62115 /* ACPSessionOrchestrationCoordinator.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		4780D23AF088EC5923A17102 /* AlasCLIWorktreeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */; };
 		4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */; };
 		478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */; };
+		478AE77B9CB6E1FEDCCCC37C /* ACPSessionFork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5499A8C3A9E9EB6D00D86D90 /* ACPSessionFork.swift */; };
 		47906F46D5F1337F696C54C5 /* session-update-tool-call-update-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 274681651A972F6771B1930C /* session-update-tool-call-update-meta.json */; };
 		48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */; };
 		481DEBE64E91C54A81185D09 /* ACPAdapterVersionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */; };
@@ -1231,6 +1232,7 @@
 		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
 		E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C511B229168DDEA87173A41 /* GGInboxStore.swift */; };
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
+		E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */; };
 		E0F4EFE612252BDD7F999A70 /* ReviewFeedbackAgentSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E964C72322223859CC6AF8 /* ReviewFeedbackAgentSender.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
 		E19AEA6E45D16B5EEC1CE411 /* ACPMCPPromptPreamble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A1E612514DDA810791ED5 /* ACPMCPPromptPreamble.swift */; };
@@ -1552,6 +1554,7 @@
 		1A25C83033616FE27526C945 /* GGActionEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGActionEventsTests.swift; sourceTree = "<group>"; };
 		1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridgeTests.swift; sourceTree = "<group>"; };
 		1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatus.swift; sourceTree = "<group>"; };
+		1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkPolicyTests.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
 		1B0785F1FFC8008C74009584 /* session-update-available-models.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-available-models.json"; sourceTree = "<group>"; };
 		1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStashTests.swift; sourceTree = "<group>"; };
@@ -1879,6 +1882,7 @@
 		54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneSelectionStateResolverTests.swift; sourceTree = "<group>"; };
 		547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunnerQueueTests.swift; sourceTree = "<group>"; };
 		54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallContentTests.swift; sourceTree = "<group>"; };
+		5499A8C3A9E9EB6D00D86D90 /* ACPSessionFork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionFork.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
 		561094BA96058468F12002A1 /* ConflictsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictsSection.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
@@ -3854,6 +3858,7 @@
 				BBBEFD27FD7013D458435779 /* ACPSession.swift */,
 				EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */,
 				63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */,
+				5499A8C3A9E9EB6D00D86D90 /* ACPSessionFork.swift */,
 				94D30693F45966ED1456811E /* ACPSessionHydrator.swift */,
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
 				B7A590E6B7A73546D38D4F95 /* ACPSessionPersistence.swift */,
@@ -4429,6 +4434,7 @@
 				0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */,
 				52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */,
 				D2A24F057893BB2179C1900C /* ACPSessionDiscoveryTests.swift */,
+				1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */,
 				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
 				F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */,
@@ -5539,6 +5545,7 @@
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
 				38B6857CDB7D094A46F653E2 /* ACPSessionByteAccounting.swift in Sources */,
 				D11DB95BC2F7094756EBCAC3 /* ACPSessionDiscovery.swift in Sources */,
+				478AE77B9CB6E1FEDCCCC37C /* ACPSessionFork.swift in Sources */,
 				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
 				C1FF6E6CE6AF5ABCF5C62115 /* ACPSessionOrchestrationCoordinator.swift in Sources */,
@@ -6260,6 +6267,7 @@
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,
 				9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */,
 				0E2F2A2FD567CE04CF549C29 /* ACPSessionDiscoveryTests.swift in Sources */,
+				E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
 				45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */,

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -20,10 +20,11 @@ struct ACPBrokerDurableState: Equatable, Sendable {
 }
 
 struct ACPBrokerDurableCompletionReplayError: LocalizedError {
+    let outcome: ACPBrokerRPCOutcome
     let underlying: any Error
 
     var errorDescription: String? {
-        underlying.localizedDescription
+        outcome.error?.message ?? underlying.localizedDescription
     }
 }
 
@@ -312,15 +313,23 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             do {
                 try await attachAndReplay()
             } catch {
-                // `service.send` has already returned a final successful
-                // result. The operation is therefore durable at the broker
-                // even though this client could not replay its completion
-                // cursor. Callers that use stable operation keys may retry
-                // this exact operation; failures thrown by `service.send`
-                // itself never receive this classification.
-                if result.error == nil,
-                   result.pending != true || result.result != nil {
-                    throw ACPBrokerDurableCompletionReplayError(underlying: error)
+                // `service.send` has already returned a final outcome. The
+                // operation is therefore durable at the broker even though
+                // this client could not replay its completion cursor.
+                // Preserve both successful results (which callers using
+                // stable keys may retry) and terminal JSON-RPC errors (which
+                // fallback paths must eventually consume). Failures thrown
+                // by `service.send` itself never receive this classification.
+                if result.error != nil
+                    || result.pending != true
+                    || result.result != nil {
+                    throw ACPBrokerDurableCompletionReplayError(
+                        outcome: ACPBrokerRPCOutcome(
+                            result: result.result,
+                            error: result.error
+                        ),
+                        underlying: error
+                    )
                 }
                 throw error
             }

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -87,6 +87,12 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var preRegisteredOperationKeyRefCounts: [ACPBrokerOperationKey: Int] = [:]
     private var preRegisteredOperationCompletions:
         [ACPBrokerOperationKey: (outcome: ACPBrokerRPCOutcome, cursor: ACPBrokerEventCursor)] = [:]
+    // Operation snapshots carry terminal outcomes but not their journal
+    // cursors. Retain matching pre-registered outcomes separately so a
+    // failed startup replay can still classify the durable operation; a
+    // later client will replay the cursor before consuming the result.
+    private var preRegisteredOperationTerminalOutcomes:
+        [ACPBrokerOperationKey: ACPBrokerRPCOutcome] = [:]
     /// Ref-counted (not a plain `Set`) so two calls that happen to share an
     /// explicit `brokerOperationKey` — unlikely, but the type permits it —
     /// don't have one call's exit clear the flag out from under the other.
@@ -234,6 +240,16 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 self?.ackOperationCompletion(operationKey: key, cursor: completion.cursor)
             }
         )
+    }
+
+    func terminalOutcome(
+        forPreRegisteredOperationKey operationKey: String
+    ) -> ACPBrokerRPCOutcome? {
+        let key = ACPBrokerOperationKey(rawValue: operationKey)
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return preRegisteredOperationCompletions[key]?.outcome
+            ?? preRegisteredOperationTerminalOutcomes[key]
     }
 
     @discardableResult
@@ -622,6 +638,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             }
             if preRegisteredOperationKeyRefCounts[operationKey] != nil {
                 preRegisteredOperationCompletions[operationKey] = (outcome, event.cursor)
+                preRegisteredOperationTerminalOutcomes[operationKey] = outcome
             }
             stateLock.unlock()
         case .turnStateChanged(let state):
@@ -847,6 +864,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         stateLock.lock()
         if preRegisteredOperationCompletions[operationKey]?.cursor == cursor {
             preRegisteredOperationCompletions.removeValue(forKey: operationKey)
+            preRegisteredOperationTerminalOutcomes.removeValue(forKey: operationKey)
             Self.decrementRefCount(&preRegisteredOperationKeyRefCounts, for: operationKey)
             Self.decrementRefCount(&awaitedOperationKeyRefCounts, for: operationKey)
         }
@@ -891,10 +909,13 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         remoteSessionResult = snapshot.remoteSessionResult ?? remoteSessionResult
         for operation in snapshot.operations {
             let id = operation.adapterRequestId.jsonRPCID
-            if operation.terminalOutcome == nil {
-                pendingOutboundRequestIds.insert(id)
-            } else {
+            if let terminalOutcome = operation.terminalOutcome {
                 pendingOutboundRequestIds.remove(id)
+                if preRegisteredOperationKeyRefCounts[operation.operationKey] != nil {
+                    preRegisteredOperationTerminalOutcomes[operation.operationKey] = terminalOutcome
+                }
+            } else {
+                pendingOutboundRequestIds.insert(id)
             }
         }
         if turnState != snapshot.turnState {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -27,6 +27,23 @@ struct ACPBrokerDurableCompletionReplayError: LocalizedError {
     }
 }
 
+struct ACPBrokerReplayedOperationCompletion {
+    let outcome: ACPBrokerRPCOutcome
+    private let acknowledgement: @Sendable () -> Void
+
+    init(
+        outcome: ACPBrokerRPCOutcome,
+        acknowledgement: @escaping @Sendable () -> Void
+    ) {
+        self.outcome = outcome
+        self.acknowledgement = acknowledgement
+    }
+
+    func acknowledgeDurableConsumption() {
+        acknowledgement()
+    }
+}
+
 final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private let service: ACPBrokerServicing
     private let brokerId: ACPBrokerID
@@ -66,6 +83,9 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private var pendingInboundCursors: [JSONRPCID: ACPBrokerEventCursor] = [:]
     private var pendingOutboundRequestIds: Set<JSONRPCID> = []
     private var operationCompletionCursors: [ACPBrokerOperationKey: ACPBrokerEventCursor] = [:]
+    private var preRegisteredOperationKeyRefCounts: [ACPBrokerOperationKey: Int] = [:]
+    private var preRegisteredOperationCompletions:
+        [ACPBrokerOperationKey: (outcome: ACPBrokerRPCOutcome, cursor: ACPBrokerEventCursor)] = [:]
     /// Ref-counted (not a plain `Set`) so two calls that happen to share an
     /// explicit `brokerOperationKey` — unlikely, but the type permits it —
     /// don't have one call's exit clear the flag out from under the other.
@@ -190,9 +210,29 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     func preRegisterAwaitedOperationKeys(_ operationKeys: some Sequence<String>) {
         stateLock.lock()
         for key in operationKeys {
-            awaitedOperationKeyRefCounts[ACPBrokerOperationKey(rawValue: key), default: 0] += 1
+            let operationKey = ACPBrokerOperationKey(rawValue: key)
+            awaitedOperationKeyRefCounts[operationKey, default: 0] += 1
+            preRegisteredOperationKeyRefCounts[operationKey, default: 0] += 1
         }
         stateLock.unlock()
+    }
+
+    func replayedCompletion(
+        forPreRegisteredOperationKey operationKey: String
+    ) -> ACPBrokerReplayedOperationCompletion? {
+        let key = ACPBrokerOperationKey(rawValue: operationKey)
+        stateLock.lock()
+        guard let completion = preRegisteredOperationCompletions[key] else {
+            stateLock.unlock()
+            return nil
+        }
+        stateLock.unlock()
+        return ACPBrokerReplayedOperationCompletion(
+            outcome: completion.outcome,
+            acknowledgement: { [weak self] in
+                self?.ackOperationCompletion(operationKey: key, cursor: completion.cursor)
+            }
+        )
     }
 
     @discardableResult
@@ -292,7 +332,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 // deliberately no longer acks for, see above), there is no
                 // successful result a caller could still receive for this
                 // operationKey, so nothing else will ever call
-                // `ackResponse` for it. The `attachAndReplay()` just above
+                // `ackOperationCompletion` for it. The `attachAndReplay()` just above
                 // may have already dispatched this exact completion (with
                 // its error outcome) and, since this call registered
                 // interest before the RPC, protected its cursor — ack it
@@ -300,7 +340,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 // later durable event behind a completion nobody is coming
                 // back for.
                 if let cursor = currentOperationCompletionCursor(for: operationKey) {
-                    ackResponse(cursor: cursor)
+                    ackOperationCompletion(operationKey: operationKey, cursor: cursor)
                 }
                 throw ACPClientError.jsonrpc(error)
             }
@@ -314,7 +354,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 body: try (result.result ?? .null).data,
                 durableConsumptionAcknowledgement: { [weak self] in
                     if let cursor {
-                        self?.ackResponse(cursor: cursor)
+                        self?.ackOperationCompletion(operationKey: operationKey, cursor: cursor)
                     }
                 }
             )
@@ -544,7 +584,7 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 return
             }
             dispatchPendingRequest(request, cursor: event.cursor)
-        case .operationCompleted(let operationKey, _):
+        case .operationCompleted(let operationKey, let outcome):
             stateLock.lock()
             operationCompletionCursors[operationKey] = event.cursor
             // Protect this cursor from `ackAfterEarlierDurableEvents`
@@ -570,6 +610,9 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
             // permanently blocking every later ack.
             if awaitedOperationKeyRefCounts[operationKey] != nil {
                 unacknowledgedDurableEventCursors.insert(event.cursor)
+            }
+            if preRegisteredOperationKeyRefCounts[operationKey] != nil {
+                preRegisteredOperationCompletions[operationKey] = (outcome, event.cursor)
             }
             stateLock.unlock()
         case .turnStateChanged(let state):
@@ -788,8 +831,16 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         ackAfterEarlierDurableEvents(cursor: cursor)
     }
 
-    private func ackResponse(cursor: ACPBrokerEventCursor) {
+    private func ackOperationCompletion(
+        operationKey: ACPBrokerOperationKey,
+        cursor: ACPBrokerEventCursor
+    ) {
         stateLock.lock()
+        if preRegisteredOperationCompletions[operationKey]?.cursor == cursor {
+            preRegisteredOperationCompletions.removeValue(forKey: operationKey)
+            Self.decrementRefCount(&preRegisteredOperationKeyRefCounts, for: operationKey)
+            Self.decrementRefCount(&awaitedOperationKeyRefCounts, for: operationKey)
+        }
         unacknowledgedDurableEventCursors.remove(cursor)
         stateLock.unlock()
         ackAfterEarlierDurableEvents(cursor: cursor)
@@ -937,14 +988,20 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
 
     private func endAwaitingOperationCompletion(_ operationKey: ACPBrokerOperationKey) {
         stateLock.lock()
-        if let count = awaitedOperationKeyRefCounts[operationKey] {
-            if count <= 1 {
-                awaitedOperationKeyRefCounts.removeValue(forKey: operationKey)
-            } else {
-                awaitedOperationKeyRefCounts[operationKey] = count - 1
-            }
-        }
+        Self.decrementRefCount(&awaitedOperationKeyRefCounts, for: operationKey)
         stateLock.unlock()
+    }
+
+    private static func decrementRefCount(
+        _ refCounts: inout [ACPBrokerOperationKey: Int],
+        for operationKey: ACPBrokerOperationKey
+    ) {
+        guard let count = refCounts[operationKey] else { return }
+        if count <= 1 {
+            refCounts.removeValue(forKey: operationKey)
+        } else {
+            refCounts[operationKey] = count - 1
+        }
     }
 
     private func nextOperationKey(method: String) -> ACPBrokerOperationKey {

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -46,6 +46,8 @@ struct ACPBrokerReplayedOperationCompletion {
 }
 
 final class ACPBrokerClient: ACPClient, @unchecked Sendable {
+    let providesDurableOperationKeyDeduplication = true
+
     private let service: ACPBrokerServicing
     private let brokerId: ACPBrokerID
     private let sessionId: String

--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -19,6 +19,14 @@ struct ACPBrokerDurableState: Equatable, Sendable {
     let acknowledgedCursor: ACPBrokerEventCursor
 }
 
+struct ACPBrokerDurableCompletionReplayError: LocalizedError {
+    let underlying: any Error
+
+    var errorDescription: String? {
+        underlying.localizedDescription
+    }
+}
+
 final class ACPBrokerClient: ACPClient, @unchecked Sendable {
     private let service: ACPBrokerServicing
     private let brokerId: ACPBrokerID
@@ -261,7 +269,21 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 params: params
             ))
             markPendingOutboundRequest(id: result.requestId.jsonRPCID)
-            try await attachAndReplay()
+            do {
+                try await attachAndReplay()
+            } catch {
+                // `service.send` has already returned a final successful
+                // result. The operation is therefore durable at the broker
+                // even though this client could not replay its completion
+                // cursor. Callers that use stable operation keys may retry
+                // this exact operation; failures thrown by `service.send`
+                // itself never receive this classification.
+                if result.error == nil,
+                   result.pending != true || result.result != nil {
+                    throw ACPBrokerDurableCompletionReplayError(underlying: error)
+                }
+                throw error
+            }
             if let error = result.error {
                 clearPendingOutboundRequest(id: result.requestId.jsonRPCID)
                 // A terminal JSON-RPC error IS this operationKey's final,

--- a/Alas/Sources/ACP/Protocol/ACPClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPClient.swift
@@ -48,6 +48,10 @@ enum ACPClientError: LocalizedError {
 }
 
 protocol ACPClient: AnyObject {
+    /// Whether repeated requests carrying the same `brokerOperationKey` are
+    /// durably deduplicated across connection/process restarts.
+    var providesDurableOperationKeyDeduplication: Bool { get }
+
     /// Sends a request and awaits a JSON-RPC response (raw bytes of the `result` field).
     func send(_ request: ACPRequest) async throws -> ACPResponse
 
@@ -99,6 +103,8 @@ protocol ACPClient: AnyObject {
 }
 
 extension ACPClient {
+    var providesDurableOperationKeyDeduplication: Bool { false }
+
     var advertisesTerminalCapability: Bool { true }
 
     var elicitationRequests: AsyncStream<ACPElicitationRequest> {

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -110,14 +110,29 @@ final class ACPConnection: @unchecked Sendable {
         return try JSONDecoder().decode(ACPSessionListResult.self, from: resp.body)
     }
 
-    func forkSession(cwd: String, sessionId: String, mcpServers: [ACPMCPServer]) async throws -> ACPSessionNewResult {
+    func forkSession(
+        cwd: String,
+        sessionId: String,
+        mcpServers: [ACPMCPServer],
+        brokerOperationKey: String? = nil
+    ) async throws -> ACPSessionNewResult {
         let req = ACPRequest(
             method: "session/fork",
-            params: ACPSessionForkParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers)
+            params: ACPSessionForkParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers),
+            brokerOperationKey: brokerOperationKey
         )
         let resp = try await client.send(req)
-        defer { resp.acknowledgeDurableConsumption() }
-        return try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        deferDurableSessionResponse(resp)
+        return result
+    }
+
+    func closeSession(sessionId: String) async throws {
+        let response = try await client.send(ACPRequest(
+            method: "session/close",
+            params: ACPSessionCloseParams(sessionId: sessionId)
+        ))
+        response.acknowledgeDurableConsumption()
     }
 
     func cancel(sessionId: String) async throws {

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -122,8 +122,14 @@ final class ACPConnection: @unchecked Sendable {
             brokerOperationKey: brokerOperationKey
         )
         let resp = try await client.send(req)
-        let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
         deferDurableSessionResponse(resp)
+        let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+        guard !result.sessionId.isEmpty else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: [],
+                debugDescription: "session/fork response is missing sessionId"
+            ))
+        }
         return result
     }
 

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -771,6 +771,12 @@ struct ACPAgentSessionInfo: Codable, Equatable, Identifiable {
 typealias ACPSessionResumeParams = ACPSessionLoadParams
 typealias ACPSessionForkParams = ACPSessionLoadParams
 
+// MARK: - session/close
+
+struct ACPSessionCloseParams: Codable, Equatable {
+    let sessionId: String
+}
+
 // MARK: - session/cancel
 
 struct ACPSessionCancelParams: Codable, Equatable {

--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -2,6 +2,7 @@ import Foundation
 
 final class ACPMockClient: ACPClient, @unchecked Sendable {
     var advertisesTerminalCapability = true
+    let providesDurableOperationKeyDeduplication: Bool
 
     private(set) var sent: [ACPRequest] = []
     private var scripts: [String: (ACPRequest) throws -> Data] = [:]
@@ -33,7 +34,9 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
 
     var terminalResponses: [JSONRPCID: Result<Data, JSONRPCError>] = [:]
 
-    init() {
+    init(providesDurableOperationKeyDeduplication: Bool = false) {
+        self.providesDurableOperationKeyDeduplication =
+            providesDurableOperationKeyDeduplication
         var u: AsyncStream<ACPSessionUpdateParams>.Continuation!
         self.incomingUpdates = AsyncStream { u = $0 }
         self.updatesCont = u

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -247,8 +247,8 @@ final class ACPSession: ObservableObject, Identifiable {
     func canForkMessage(at index: Int) -> Bool {
         guard transcript.messages.indices.contains(index) else { return false }
         switch transcript.messages[index] {
-        case .user:
-            return true
+        case .user(_, _, let text, _, _):
+            return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case .agent:
             guard transcript.streamingState != .idle else { return true }
             return lastAgent() != index

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -43,7 +43,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     @Published var title: String
     @Published var titleSource: ACPSessionTitleSource
-    let origin: ACPSessionOrigin
+    private(set) var origin: ACPSessionOrigin
     @Published var availableModels: [ACPModelInfo] = []
     @Published var availableModes: [ACPModeInfo] = []
     @Published var availableConfigOptions: [ACPConfigOption] = []
@@ -308,6 +308,10 @@ final class ACPSession: ObservableObject, Identifiable {
         // Foundation cannot await main-actor methods from deinit; dispatch.
         let host = terminalHost
         Task { @MainActor in host.killAll() }
+    }
+
+    func markAsAgentForked() {
+        origin = .agentForked
     }
 
     func recordUserPrompt(

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -74,6 +74,13 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Runtime-only: re-learned on each attach, never persisted. Drives
     /// send-time hydration in `ACPSessionRunner.hydrate`.
     @Published var promptCapabilities: ACPInitializeResult.ACPPromptCapabilities = .init()
+    /// Session capabilities learned from ACP `initialize`.
+    /// Runtime-only: re-learned on each attach and used to select a fork
+    /// mechanism for this session.
+    @Published var sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities?
+    /// Persisted fork lineage hydrated with the session. A nil value means
+    /// this session was not created as a fork.
+    @Published var forkRecord: ACPSessionForkRecord?
     /// Auth methods learned from ACP `initialize`.
     /// Runtime-only: re-learned on each attach and used when an agent asks
     /// the client to authenticate before ACP can continue.
@@ -236,6 +243,19 @@ final class ACPSession: ObservableObject, Identifiable {
 
     var composerDraft: ACPComposerDraft { composer.draft }
     var composerDraftRevision: Int { composer.revision }
+
+    func canForkMessage(at index: Int) -> Bool {
+        guard transcript.messages.indices.contains(index) else { return false }
+        switch transcript.messages[index] {
+        case .user:
+            return true
+        case .agent:
+            guard transcript.streamingState != .idle else { return true }
+            return lastAgent() != index
+        default:
+            return false
+        }
+    }
 
     func replaceComposerDraft(_ draft: ACPComposerDraft) {
         composer.replaceDraft(draft)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -249,7 +249,10 @@ final class ACPSession: ObservableObject, Identifiable {
         switch transcript.messages[index] {
         case .user(_, _, let text, _, _):
             return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        case .agent:
+        case .agent(_, _, let buffer):
+            guard !buffer.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return false
+            }
             guard transcript.streamingState != .idle else { return true }
             return lastAgent() != index
         default:

--- a/Alas/Sources/ACP/Session/ACPSessionFork.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionFork.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+struct ACPForkMessageBoundary: Equatable, Sendable {
+    enum Kind: String, Equatable, Sendable {
+        case user
+        case agent
+    }
+
+    let stableID: String
+    let kind: Kind
+}
+
+struct ACPSessionForkTarget: Identifiable, Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let isSameAgent: Bool
+}
+
+enum ACPSessionForkCreationPhase: String, Codable, Equatable, Sendable {
+    case negotiatingNative
+    case ready
+}
+
+enum ACPSessionForkMechanism: String, Codable, Equatable, Sendable {
+    case nativeACP
+    case transcriptTransfer
+}
+
+struct ACPSessionForkRecord: Equatable, Sendable {
+    let targetSessionID: String
+    let sourceSessionID: String
+    let sourceAgentID: String
+    let sourceBoundarySequence: Int64
+    let inheritedMessageCount: Int
+    var phase: ACPSessionForkCreationPhase
+    var mechanism: ACPSessionForkMechanism?
+    var contextDeliveryPending: Bool
+}
+
+enum ACPSessionForkCandidate: Equatable {
+    case native
+    case transcript
+}
+
+enum ACPSessionForkCandidatePolicy {
+    static func candidate(
+        sourceAgentID: String,
+        targetAgentID: String,
+        boundaryIsRemoteHead: Bool,
+        sourceRemoteSessionID: String?,
+        forkCapability: Bool?
+    ) -> ACPSessionForkCandidate {
+        guard sourceAgentID == targetAgentID,
+              boundaryIsRemoteHead,
+              sourceRemoteSessionID?.isEmpty == false,
+              forkCapability != false
+        else { return .transcript }
+
+        return .native
+    }
+}
+
+struct ACPSessionForkConversationMessage: Equatable, Sendable {
+    enum Role: String, Equatable, Sendable {
+        case user
+        case agent
+    }
+
+    let role: Role
+    let text: String
+}
+
+struct ACPSessionForkSnapshot: Equatable, Sendable {
+    let sourceBoundarySequence: Int64
+    let messages: [ACPSessionForkConversationMessage]
+
+    func copiedMessages(targetSessionID: String, createdAt: Int64) throws -> [ACPStoredMessage] {
+        try messages.enumerated().map { index, message in
+            let kind: String
+            let payload: Data
+
+            switch message.role {
+            case .user:
+                kind = "user"
+                payload = try JSONEncoder().encode(CopiedUserPayload(
+                    messageId: nil,
+                    text: message.text,
+                    attachments: [],
+                    delegatedSource: nil
+                ))
+            case .agent:
+                kind = "agent"
+                payload = try JSONEncoder().encode(CopiedTextPayload(
+                    messageId: nil,
+                    text: message.text
+                ))
+            }
+
+            return ACPStoredMessage(
+                id: "msg-\(targetSessionID)-\(index)",
+                sessionId: targetSessionID,
+                kind: kind,
+                seq: Int64(index),
+                payload: payload,
+                createdAt: createdAt
+            )
+        }
+    }
+}
+
+enum ACPSessionForkSnapshotError: Error, Equatable {
+    case boundaryNotFound
+    case transcriptMismatch
+}
+
+enum ACPSessionForkSnapshotResolver {
+    @MainActor
+    static func resolve(
+        boundary: ACPForkMessageBoundary,
+        liveMessages: [ACPMessage],
+        storedMessages: [ACPStoredMessage]
+    ) throws -> ACPSessionForkSnapshot {
+        guard let boundaryIndex = liveMessages.firstIndex(where: { message in
+            message.stableId == boundary.stableID && message.forkBoundaryKind == boundary.kind
+        }) else {
+            throw ACPSessionForkSnapshotError.boundaryNotFound
+        }
+
+        guard storedMessages.count == liveMessages.count else {
+            throw ACPSessionForkSnapshotError.transcriptMismatch
+        }
+
+        let decoder = JSONDecoder()
+        let decoded = try storedMessages.map {
+            try ACPMessageWire.decode(kind: $0.kind, payload: $0.payload, decoder: decoder)
+        }
+
+        for index in 0...boundaryIndex {
+            guard matches(liveMessages[index], decoded[index]) else {
+                throw ACPSessionForkSnapshotError.transcriptMismatch
+            }
+        }
+
+        let conversation = decoded[0...boundaryIndex].compactMap { wire -> ACPSessionForkConversationMessage? in
+            switch wire {
+            case .user(_, let text, _, _):
+                text.isEmpty ? nil : .init(role: .user, text: text)
+            case .agent(_, let text):
+                text.isEmpty ? nil : .init(role: .agent, text: text)
+            case .thought, .toolCall, .fileEdit, .plan, .systemNotice:
+                nil
+            }
+        }
+
+        return ACPSessionForkSnapshot(
+            sourceBoundarySequence: storedMessages[boundaryIndex].seq,
+            messages: conversation
+        )
+    }
+
+    @MainActor
+    private static func matches(_ live: ACPMessage, _ stored: ACPMessageWire) -> Bool {
+        switch (live, stored) {
+        case let (.user(_, liveMessageID, liveText, _, _), .user(storedMessageID, storedText, _, _)):
+            liveMessageID == storedMessageID && liveText == storedText
+        case let (.agent(_, liveMessageID, liveText), .agent(storedMessageID, storedText)):
+            liveMessageID == storedMessageID && liveText.value == storedText
+        case let (.thought(_, liveMessageID, liveText), .thought(storedMessageID, storedText)):
+            liveMessageID == storedMessageID && liveText.value == storedText
+        case let (.toolCall(liveCall), .toolCall(storedCall)):
+            liveCall.toolCallId == storedCall.toolCallId
+        case (.fileEdit, .fileEdit), (.plan, .plan), (.systemNotice, .systemNotice):
+            true
+        default:
+            false
+        }
+    }
+}
+
+private extension ACPMessage {
+    var forkBoundaryKind: ACPForkMessageBoundary.Kind? {
+        switch self {
+        case .user:
+            .user
+        case .agent:
+            .agent
+        case .thought, .toolCall, .fileEdit, .plan, .systemNotice:
+            nil
+        }
+    }
+}
+
+private struct CopiedTextPayload: Codable {
+    let messageId: String?
+    let text: String
+}
+
+private struct CopiedUserPayload: Codable {
+    let messageId: String?
+    let text: String
+    let attachments: [ACPMessage.Attachment]
+    let delegatedSource: ACPDelegatedPromptSource?
+}

--- a/Alas/Sources/ACP/Session/ACPSessionFork.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionFork.swift
@@ -16,6 +16,37 @@ struct ACPSessionForkTarget: Identifiable, Equatable, Sendable {
     let isSameAgent: Bool
 }
 
+struct ACPForkAgentOption: Equatable {
+    let id: String
+    let displayName: String
+}
+
+enum ACPForkTargetPolicy {
+    static func targets(
+        sourceAgentID: String,
+        enabledAgents: [ACPForkAgentOption],
+        sourceAgent: ACPForkAgentOption?,
+        catalogAgentIDs: [String]
+    ) -> [ACPSessionForkTarget] {
+        var byID = Dictionary(uniqueKeysWithValues: enabledAgents.map { ($0.id, $0) })
+        if let sourceAgent {
+            byID[sourceAgent.id] = sourceAgent
+        }
+        let ordered = catalogAgentIDs.compactMap { byID[$0] }
+        let current = ordered.filter { $0.id == sourceAgentID }
+        let others = ordered.filter { $0.id != sourceAgentID }
+        return (current + others).map {
+            .init(id: $0.id, displayName: $0.displayName, isSameAgent: $0.id == sourceAgentID)
+        }
+    }
+}
+
+enum ACPMessageForkMenuPolicy {
+    static func showsForkAction(messageKind: String, isEligible: Bool, targetCount: Int) -> Bool {
+        (messageKind == "user" || messageKind == "agent") && isEligible && targetCount > 0
+    }
+}
+
 enum ACPSessionForkCreationPhase: String, Codable, Equatable, Sendable {
     case negotiatingNative
     case ready

--- a/Alas/Sources/ACP/Session/ACPSessionFork.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionFork.swift
@@ -28,7 +28,10 @@ enum ACPForkTargetPolicy {
         sourceAgent: ACPForkAgentOption?,
         catalogAgentIDs: [String]
     ) -> [ACPSessionForkTarget] {
-        var byID = Dictionary(uniqueKeysWithValues: enabledAgents.map { ($0.id, $0) })
+        var byID = Dictionary(
+            enabledAgents.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
         if let sourceAgent {
             byID[sourceAgent.id] = sourceAgent
         }

--- a/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
@@ -48,6 +48,7 @@ actor ACPSessionHydrator {
         // Malformed payloads are skipped (matching the legacy try? in
         // openSession) rather than failing the whole hydration.
         let stored = try store.loadMessages(sessionId: sessionId)
+        let forkRecord = try store.loadFork(targetSessionID: sessionId)
         let storedDraft = includeDraft ? try? store.loadComposerDraftRecord(sessionId: sessionId) : nil
         let queue = (try? store.loadQueue(sessionId: sessionId)) ?? []
         var staleSubmittedDraft = false
@@ -94,6 +95,7 @@ actor ACPSessionHydrator {
             wireMessages: wire,
             queue: queue,
             draft: draft,
+            forkRecord: forkRecord,
             recent: recent)
     }
 }
@@ -106,6 +108,7 @@ struct HydrationResult: Sendable {
     let wireMessages: [ACPMessageWire]
     let queue: [QueuedPrompt]
     let draft: ACPComposerDraft?
+    let forkRecord: ACPSessionForkRecord?
     let recent: [ACPSessionRow]
 
     func replacingRowLastOpenedAt(_ lastOpenedAt: Int64) -> HydrationResult {
@@ -126,6 +129,7 @@ struct HydrationResult: Sendable {
             wireMessages: wireMessages,
             queue: queue,
             draft: draft,
+            forkRecord: forkRecord,
             recent: recent)
     }
 
@@ -135,6 +139,7 @@ struct HydrationResult: Sendable {
             wireMessages: wireMessages,
             queue: queue,
             draft: draft,
+            forkRecord: forkRecord,
             recent: recent)
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2986,7 +2986,7 @@ extension ACPSessionManager {
                                 canSendTranscript: session.hasConversationTranscript
                             )
                         }
-                        if session.hasConversationTranscript {
+                        if !hasPendingForkContext, session.hasConversationTranscript {
                             session.contextRecoveryStatus = .sendingTranscript
                         }
                     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -772,7 +772,10 @@ final class ACPSessionManager: ObservableObject {
         if session.remoteSessionId == nil || session.remoteSessionId == result.row.remoteSessionId {
             session.remoteSessionId = result.row.remoteSessionId
         }
-        if result.row.contextRecoveryPending {
+        let forkContextPending = result.forkRecord?.phase == .ready
+            && result.forkRecord?.mechanism == .transcriptTransfer
+            && result.forkRecord?.contextDeliveryPending == true
+        if result.row.contextRecoveryPending, !forkContextPending {
             // Compute `canSendTranscript` against the FULL wire list rather
             // than `session.hasConversationTranscript`. Tail-first hydration
             // leaves only the last 30 messages in the in-memory transcript
@@ -2823,12 +2826,19 @@ extension ACPSessionManager {
             if shouldSuppressLoadReplay {
                 startRunnerIfNeeded()
             }
-            let pendingRecovery = persistedRows[sessionId]?.contextRecoveryPending == true
+            let hasPendingForkContext = session.forkRecord?.phase == .ready
+                && session.forkRecord?.mechanism == .transcriptTransfer
+                && session.forkRecord?.contextDeliveryPending == true
+            let pendingRecovery = !hasPendingForkContext
+                && persistedRows[sessionId]?.contextRecoveryPending == true
             var createdFreshRemoteSession = false
             let result: ACPSessionNewResult
             var restoreWarning: ACPSession.ContextRestoreWarning?
-            let hasRestorableContext = pendingRecovery || session.hasConversationTranscript
-            var shouldHoldQueueForRecovery = pendingRecovery && session.hasConversationTranscript
+            let hasRestorableContext = pendingRecovery
+                || (!hasPendingForkContext && session.hasConversationTranscript)
+            var shouldHoldQueueForRecovery = pendingRecovery
+                && !hasPendingForkContext
+                && session.hasConversationTranscript
             if firstRunAttach {
                 session.firstRunConnectingPhase = .creatingSession
             }
@@ -2843,7 +2853,7 @@ extension ACPSessionManager {
                 )
                 createdFreshRemoteSession = true
             } else if let remoteId = session.remoteSessionId, !remoteId.isEmpty {
-                if session.hasConversationTranscript {
+                if !hasPendingForkContext, session.hasConversationTranscript {
                     session.contextRecoveryStatus = .restoring
                 }
                 switch restoreOperation {
@@ -2887,7 +2897,7 @@ extension ACPSessionManager {
                             )
                         )
                         createdFreshRemoteSession = true
-                        if session.hasConversationTranscript {
+                        if !hasPendingForkContext, session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
                             if isWriter(for: sessionId) {
                                 persistContextRecoveryPending(sessionId: sessionId, pending: true)
@@ -2899,7 +2909,7 @@ extension ACPSessionManager {
                                 canSendTranscript: session.hasConversationTranscript
                             )
                         }
-                        if session.hasConversationTranscript {
+                        if !hasPendingForkContext, session.hasConversationTranscript {
                             session.contextRecoveryStatus = .sendingTranscript
                         }
                     }
@@ -2961,7 +2971,7 @@ extension ACPSessionManager {
                             )
                         )
                         createdFreshRemoteSession = true
-                        if session.hasConversationTranscript {
+                        if !hasPendingForkContext, session.hasConversationTranscript {
                             shouldHoldQueueForRecovery = true
                             // Guard the store write: if another instance took over
                             // while we were awaiting loadSession/newSession, do not
@@ -2993,7 +3003,7 @@ extension ACPSessionManager {
                     )
                 )
                 createdFreshRemoteSession = true
-                if session.hasConversationTranscript {
+                if !hasPendingForkContext, session.hasConversationTranscript {
                     shouldHoldQueueForRecovery = true
                     // Guard the store write: if another instance took over
                     // while we were awaiting newSession, do not persist
@@ -3008,7 +3018,7 @@ extension ACPSessionManager {
                         canSendTranscript: session.hasConversationTranscript
                     )
                 }
-                if session.hasConversationTranscript {
+                if !hasPendingForkContext, session.hasConversationTranscript {
                     session.contextRecoveryStatus = .sendingTranscript
                 }
             }
@@ -3017,7 +3027,7 @@ extension ACPSessionManager {
                     message: "Agent context could not be restored.",
                     canSendTranscript: session.hasConversationTranscript
                 )
-                if session.hasConversationTranscript {
+                if !hasPendingForkContext, session.hasConversationTranscript {
                     session.contextRecoveryStatus = .sendingTranscript
                 }
             }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1726,8 +1726,22 @@ final class ACPSessionManager: ObservableObject {
         // crash. Register it before start() so that replay can't have its
         // completion cursor acked past before the queue flusher (which only
         // runs once this function returns and the runner is registered)
-        // gets a chance to claim it.
-        client.preRegisterAwaitedOperationKeys(session.queue.map(\.brokerOperationKey))
+        // gets a chance to claim it. A negotiating fork has the same replay
+        // gap: its stable startup key must be protected until attach calls
+        // `session/fork` and persists the final mechanism.
+        var awaitedOperationKeys = session.queue.map(\.brokerOperationKey)
+        if let fork = session.forkRecord,
+           fork.phase == .negotiatingNative,
+           let source = try await persistence.loadSession(id: fork.sourceSessionID),
+           let sourceRemoteSessionID = source.remoteSessionId,
+           !sourceRemoteSessionID.isEmpty {
+            awaitedOperationKeys.append(Self.brokerStartupOperationKey(
+                sessionId: sessionId,
+                method: "session/fork",
+                remoteSessionId: sourceRemoteSessionID
+            ))
+        }
+        client.preRegisterAwaitedOperationKeys(awaitedOperationKeys)
         try await client.start()
         Self.applyBrokerTurnState(client.currentTurnState, to: session)
         return ACPConnection(client: client)
@@ -1748,6 +1762,135 @@ final class ACPSessionManager: ObservableObject {
             return "startup:\(sessionId):\(method):\(remoteSessionId)"
         }
         return "startup:\(sessionId):\(method)"
+    }
+
+    private func downgradeNegotiatingForkToTranscript(session: ACPSession) async {
+        guard var fork = session.forkRecord, fork.phase == .negotiatingNative else { return }
+        do {
+            try await persistence.finalizeFork(
+                targetSessionID: session.id,
+                mechanism: .transcriptTransfer,
+                remoteSessionID: nil
+            )
+        } catch {
+            persistenceError = error.localizedDescription
+        }
+        fork.phase = .ready
+        fork.mechanism = .transcriptTransfer
+        fork.contextDeliveryPending = true
+        session.forkRecord = fork
+    }
+
+    private func startForkTarget(
+        session: ACPSession,
+        fork: ACPSessionForkRecord,
+        initialized: ACPInitializeOutcome,
+        connection: ACPConnection,
+        wireMCPServers: [ACPMCPServer]
+    ) async throws -> (result: ACPSessionNewResult, createdFreshRemoteSession: Bool) {
+        var fork = fork
+        if initialized.sessionCapabilities.supportsFork,
+           let source = try await persistence.loadSession(id: fork.sourceSessionID),
+           let sourceRemoteSessionID = source.remoteSessionId,
+           !sourceRemoteSessionID.isEmpty {
+            let result: ACPSessionNewResult
+            do {
+                result = try await connection.forkSession(
+                    cwd: worktreePath,
+                    sessionId: sourceRemoteSessionID,
+                    mcpServers: wireMCPServers,
+                    brokerOperationKey: Self.brokerStartupOperationKey(
+                        sessionId: session.id,
+                        method: "session/fork",
+                        remoteSessionId: sourceRemoteSessionID
+                    )
+                )
+            } catch {
+                try await persistence.finalizeFork(
+                    targetSessionID: session.id,
+                    mechanism: .transcriptTransfer,
+                    remoteSessionID: nil
+                )
+                fork.phase = .ready
+                fork.mechanism = .transcriptTransfer
+                fork.contextDeliveryPending = true
+                session.forkRecord = fork
+                if ACPAuthFailure.message(from: error) != nil {
+                    throw error
+                }
+                let fallback = try await connection.newSession(
+                    cwd: worktreePath,
+                    mcpServers: wireMCPServers,
+                    brokerOperationKey: Self.brokerStartupOperationKey(
+                        sessionId: session.id,
+                        method: "session/new"
+                    )
+                )
+                return (fallback, true)
+            }
+
+            do {
+                try await persistence.finalizeFork(
+                    targetSessionID: session.id,
+                    mechanism: .nativeACP,
+                    remoteSessionID: result.sessionId
+                )
+            } catch {
+                try? await connection.closeSession(sessionId: result.sessionId)
+                let transcriptFinalized: Bool
+                do {
+                    try await persistence.finalizeFork(
+                        targetSessionID: session.id,
+                        mechanism: .transcriptTransfer,
+                        remoteSessionID: nil
+                    )
+                    transcriptFinalized = true
+                } catch {
+                    persistenceError = error.localizedDescription
+                    transcriptFinalized = false
+                }
+                fork.phase = .ready
+                fork.mechanism = .transcriptTransfer
+                fork.contextDeliveryPending = true
+                session.forkRecord = fork
+                if transcriptFinalized {
+                    connection.acknowledgeDurableSessionResponses()
+                }
+                await connection.shutdown()
+                throw error
+            }
+            fork.phase = .ready
+            fork.mechanism = .nativeACP
+            fork.contextDeliveryPending = false
+            session.forkRecord = fork
+            if var row = persistedRows[session.id] {
+                row.remoteSessionId = result.sessionId
+                row.origin = .agentForked
+                persistedRows[session.id] = row
+                replaceRecentRow(row)
+            }
+            connection.acknowledgeDurableSessionResponses()
+            return (result, false)
+        }
+
+        try await persistence.finalizeFork(
+            targetSessionID: session.id,
+            mechanism: .transcriptTransfer,
+            remoteSessionID: nil
+        )
+        fork.phase = .ready
+        fork.mechanism = .transcriptTransfer
+        fork.contextDeliveryPending = true
+        session.forkRecord = fork
+        let result = try await connection.newSession(
+            cwd: worktreePath,
+            mcpServers: wireMCPServers,
+            brokerOperationKey: Self.brokerStartupOperationKey(
+                sessionId: session.id,
+                method: "session/new"
+            )
+        )
+        return (result, true)
     }
 
     private static func applyBrokerTurnState(_ turnState: ACPBrokerTurnState, to session: ACPSession) {
@@ -2510,6 +2653,7 @@ extension ACPSessionManager {
         session.agentState = .spawning
 
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId) else {
+            await downgradeNegotiatingForkToTranscript(session: session)
             let reason = "No ACP launch spec for \(session.agentId)"
             session.setupState = .needsSetup(reason: reason)
             session.agentState = .failed(reason)
@@ -2518,6 +2662,7 @@ extension ACPSessionManager {
         }
         let setup = await evaluateSetup(for: spec)
         guard case .ready = setup else {
+            await downgradeNegotiatingForkToTranscript(session: session)
             session.setupState = setup.sessionSetupState
             session.agentState = .failed(setup.reasonText)
             await releaseWriterLease(sessionId: sessionId)
@@ -2582,6 +2727,7 @@ extension ACPSessionManager {
                 )
             }
         } catch {
+            await downgradeNegotiatingForkToTranscript(session: session)
             let msg = "Failed to launch agent: \(error.localizedDescription)"
             session.lastError = msg
             session.agentState = .failed(msg)
@@ -2749,6 +2895,7 @@ extension ACPSessionManager {
                     try await connection.authenticate(methodId: pendingAuthMethodId)
                     session.pendingAuthMethodId = nil
                 } catch {
+                    await downgradeNegotiatingForkToTranscript(session: session)
                     let reason = ACPAuthFailure.message(from: error) ?? error.localizedDescription
                     session.setupState = .needsAuth(methods: initialized.authMethods, reason: reason)
                     session.agentState = .failed(reason)
@@ -2842,7 +2989,17 @@ extension ACPSessionManager {
             if firstRunAttach {
                 session.firstRunConnectingPhase = .creatingSession
             }
-            if freshlyCreated {
+            if let fork = session.forkRecord, fork.phase == .negotiatingNative {
+                let started = try await startForkTarget(
+                    session: session,
+                    fork: fork,
+                    initialized: initialized,
+                    connection: connection,
+                    wireMCPServers: wireMCPServers
+                )
+                result = started.result
+                createdFreshRemoteSession = started.createdFreshRemoteSession
+            } else if freshlyCreated {
                 result = try await connection.newSession(
                     cwd: worktreePath,
                     mcpServers: wireMCPServers,
@@ -3177,6 +3334,7 @@ extension ACPSessionManager {
             }
             stderrTask.cancel()
         } catch {
+            await downgradeNegotiatingForkToTranscript(session: session)
             // Give stderr a moment to drain so the message is the real cause.
             try? await Task.sleep(nanoseconds: 200_000_000)
             stderrTask.cancel()

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1738,19 +1738,41 @@ final class ACPSessionManager: ObservableObject {
         // gap: its stable startup key must be protected until attach calls
         // `session/fork` and persists the final mechanism.
         var awaitedOperationKeys = session.queue.map(\.brokerOperationKey)
+        var negotiatingForkOperationKey: String?
         if let fork = session.forkRecord,
            fork.phase == .negotiatingNative,
            let source = try await persistence.loadSession(id: fork.sourceSessionID),
            let sourceRemoteSessionID = source.remoteSessionId,
            !sourceRemoteSessionID.isEmpty {
-            awaitedOperationKeys.append(Self.brokerStartupOperationKey(
+            let operationKey = Self.brokerStartupOperationKey(
                 sessionId: sessionId,
                 method: "session/fork",
                 remoteSessionId: sourceRemoteSessionID
-            ))
+            )
+            awaitedOperationKeys.append(operationKey)
+            negotiatingForkOperationKey = operationKey
         }
         client.preRegisterAwaitedOperationKeys(awaitedOperationKeys)
-        try await client.start()
+        do {
+            try await client.start()
+        } catch {
+            // `open` may reveal a completed fork in its operation snapshot
+            // before the following replay fails. Preserve that terminal
+            // classification across this construction boundary: otherwise
+            // the caller sees an ordinary launch failure and durably selects
+            // transcript fallback even when the native fork already exists.
+            let terminalOutcome = negotiatingForkOperationKey.flatMap {
+                client.terminalOutcome(forPreRegisteredOperationKey: $0)
+            }
+            await client.detach()
+            if let terminalOutcome {
+                throw ACPBrokerDurableCompletionReplayError(
+                    outcome: terminalOutcome,
+                    underlying: error
+                )
+            }
+            throw error
+        }
         Self.applyBrokerTurnState(client.currentTurnState, to: session)
         return ACPConnection(client: client)
     }
@@ -2857,14 +2879,20 @@ extension ACPSessionManager {
                 )
             }
         } catch {
-            do {
-                try await downgradeNegotiatingForkToTranscript(session: session)
-            } catch {
-                surfaceForkFallbackPersistenceFailure(error, on: session)
-                await releaseWriterLease(sessionId: sessionId)
-                return
+            let durableForkRetry = (error as? ACPBrokerDurableCompletionReplayError).flatMap {
+                $0.outcome.error == nil ? $0 : nil
             }
-            let msg = "Failed to launch agent: \(error.localizedDescription)"
+            if durableForkRetry == nil {
+                do {
+                    try await downgradeNegotiatingForkToTranscript(session: session)
+                } catch {
+                    surfaceForkFallbackPersistenceFailure(error, on: session)
+                    await releaseWriterLease(sessionId: sessionId)
+                    return
+                }
+            }
+            let surfacedError = durableForkRetry?.underlying ?? error
+            let msg = "Failed to launch agent: \(surfacedError.localizedDescription)"
             session.lastError = msg
             session.agentState = .failed(msg)
             await releaseWriterLease(sessionId: sessionId)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1897,11 +1897,30 @@ final class ACPSessionManager: ObservableObject {
         wireMCPServers: [ACPMCPServer]
     ) async throws -> (result: ACPSessionNewResult, createdFreshRemoteSession: Bool) {
         var fork = fork
-        let sourceRunner = runners[fork.sourceSessionID]
         let canAttemptNativeFork = initialized.sessionCapabilities.supportsFork
             && connection.client.providesDurableOperationKeyDeduplication
-        let nativeForkBarrierAcquired = canAttemptNativeFork
-            ? sourceRunner?.beginNativeForkBarrier() ?? true
+        let source = canAttemptNativeFork
+            ? try await persistence.loadSession(id: fork.sourceSessionID)
+            : nil
+        let sourceRemoteSessionID = source?.remoteSessionId
+        let forkOperationKey = sourceRemoteSessionID.flatMap { remoteSessionID in
+            remoteSessionID.isEmpty ? nil : Self.brokerStartupOperationKey(
+                sessionId: session.id,
+                method: "session/fork",
+                remoteSessionId: remoteSessionID
+            )
+        }
+        let hasReplayedForkCompletion = if let forkOperationKey,
+                                           let brokerClient = connection.client as? ACPBrokerClient {
+            brokerClient.replayedCompletion(
+                forPreRegisteredOperationKey: forkOperationKey
+            ) != nil
+        } else {
+            false
+        }
+        let sourceRunner = runners[fork.sourceSessionID]
+        let nativeForkBarrierAcquired = canAttemptNativeFork && !hasReplayedForkCompletion
+            ? await sourceRunner?.beginNativeForkBarrier() ?? false
             : false
         defer {
             if nativeForkBarrierAcquired {
@@ -1911,13 +1930,26 @@ final class ACPSessionManager: ObservableObject {
         if nativeForkBarrierAcquired {
             await sourceRunner?.flushPersistence()
         }
+        let sourceBoundaryMatches = if canAttemptNativeFork {
+            try await persistence.latestMessageSeq(sessionId: fork.sourceSessionID)
+                == fork.sourceBoundarySequence
+        } else {
+            false
+        }
+        let hasNativeForkAuthority = if hasReplayedForkCompletion {
+            true
+        } else if nativeForkBarrierAcquired,
+                  let sourceRunner,
+                  runners[fork.sourceSessionID] === sourceRunner {
+            await sourceRunner.confirmNativeForkBarrier()
+        } else {
+            false
+        }
         if canAttemptNativeFork,
-           nativeForkBarrierAcquired,
-           let source = try await persistence.loadSession(id: fork.sourceSessionID),
-           let sourceRemoteSessionID = source.remoteSessionId,
+           hasNativeForkAuthority,
+           let sourceRemoteSessionID,
            !sourceRemoteSessionID.isEmpty,
-           try await persistence.latestMessageSeq(sessionId: fork.sourceSessionID)
-                == fork.sourceBoundarySequence {
+           sourceBoundaryMatches {
             let result: ACPSessionNewResult
             do {
                 result = try await connection.forkSession(

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -14,6 +14,11 @@ private enum ACPMirrorRefreshPolicy {
     static let inactivePollNanos: UInt64 = 30_000_000_000
 }
 
+enum ACPSessionForkCreationError: Error, Equatable {
+    case sourceUnavailable
+    case sourceReadOnly
+}
+
 @MainActor
 final class ACPSessionManager: ObservableObject {
     typealias ACPSetupEvaluator = @MainActor (_ spec: ACPLaunchSpec) async -> ACPSetupResult
@@ -507,6 +512,99 @@ final class ACPSessionManager: ObservableObject {
         return session
     }
 
+    func createFork(
+        sourceSessionID: ACPSession.ID,
+        boundary: ACPForkMessageBoundary,
+        targetAgentID: String,
+        autoRunDefault: Bool
+    ) async throws -> ACPSession {
+        guard let source = sessions[sourceSessionID], source.hydrationState == .ready else {
+            throw ACPSessionForkCreationError.sourceUnavailable
+        }
+        if !_ownedLeases.contains(sourceSessionID) {
+            guard await acquireWriterLease(sessionId: sourceSessionID) else {
+                throw ACPSessionForkCreationError.sourceReadOnly
+            }
+        }
+
+        await awaitBackfill(id: sourceSessionID)
+        await flushAllPersistence()
+        let storedMessages = try await persistence.loadMessages(sessionId: sourceSessionID)
+        let snapshot = try ACPSessionForkSnapshotResolver.resolve(
+            boundary: boundary,
+            liveMessages: source.transcript.messages,
+            storedMessages: storedMessages
+        )
+        let boundaryIsRemoteHead = snapshot.sourceBoundarySequence == storedMessages.last?.seq
+        let candidate = ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: source.agentId,
+            targetAgentID: targetAgentID,
+            boundaryIsRemoteHead: boundaryIsRemoteHead,
+            sourceRemoteSessionID: source.remoteSessionId,
+            forkCapability: source.sessionCapabilities?.supportsFork
+        )
+
+        let targetID = UUID().uuidString
+        let now = Int64(Date().timeIntervalSince1970)
+        let copiedMessages = try snapshot.copiedMessages(targetSessionID: targetID, createdAt: now)
+        let targetTitle = source.title == "New session"
+            ? "New session (fork)"
+            : "\(source.title) (fork)"
+        let targetRow = ACPSessionRow(
+            id: targetID,
+            agentId: targetAgentID,
+            title: targetTitle,
+            titleSource: .generated,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: autoRunDefault,
+            createdAt: now,
+            updatedAt: now,
+            lastOpenedAt: now,
+            archived: false
+        )
+        let forkRecord = ACPSessionForkRecord(
+            targetSessionID: targetID,
+            sourceSessionID: sourceSessionID,
+            sourceAgentID: source.agentId,
+            sourceBoundarySequence: snapshot.sourceBoundarySequence,
+            inheritedMessageCount: copiedMessages.count,
+            phase: candidate == .native ? .negotiatingNative : .ready,
+            mechanism: candidate == .native ? nil : .transcriptTransfer,
+            contextDeliveryPending: candidate == .transcript
+        )
+
+        try await persistence.createFork(
+            session: targetRow,
+            messages: copiedMessages,
+            record: forkRecord
+        )
+
+        let target = ACPSession(
+            id: targetRow.id,
+            agentId: targetRow.agentId,
+            worktreeId: worktreeId,
+            title: targetRow.title,
+            titleSource: targetRow.titleSource,
+            origin: targetRow.origin,
+            createdAt: Date(timeIntervalSince1970: TimeInterval(targetRow.createdAt)),
+            hydrationState: .ready
+        )
+        target.autoRunEnabled = targetRow.autoRun
+        target.forkRecord = forkRecord
+        for message in copiedMessages {
+            target.transcript.appendMessage(try ACPMessageCodec.decode(
+                kind: message.kind,
+                payload: message.payload
+            ))
+        }
+        sessions[targetID] = target
+        persistedRows[targetID] = targetRow
+        recent.removeAll { $0.id == targetID }
+        recent.insert(targetRow, at: 0)
+        return target
+    }
+
     /// Returns a cached session or a `.loading` placeholder. Cache hits
     /// are O(1); cache misses do a single indexed `loadSession` query
     /// against SQLite so we don't insert orphan loading entries for
@@ -670,6 +768,7 @@ final class ACPSessionManager: ObservableObject {
         }
         session.currentModel = result.row.currentModel
         session.currentMode = result.row.currentMode
+        session.forkRecord = result.forkRecord
         if session.remoteSessionId == nil || session.remoteSessionId == result.row.remoteSessionId {
             session.remoteSessionId = result.row.remoteSessionId
         }
@@ -2531,6 +2630,7 @@ extension ACPSessionManager {
                 )
             )
             session.promptCapabilities = initialized.promptCapabilities
+            session.sessionCapabilities = initialized.sessionCapabilities
             session.authMethods = initialized.authMethods
             session.adapterSupportsHTTPMCP = initialized.mcpCapabilities.http
             let projectContext = mcpProjectContextProvider?()

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1898,7 +1898,9 @@ final class ACPSessionManager: ObservableObject {
     ) async throws -> (result: ACPSessionNewResult, createdFreshRemoteSession: Bool) {
         var fork = fork
         let sourceRunner = runners[fork.sourceSessionID]
-        let nativeForkBarrierAcquired = initialized.sessionCapabilities.supportsFork
+        let canAttemptNativeFork = initialized.sessionCapabilities.supportsFork
+            && connection.client.providesDurableOperationKeyDeduplication
+        let nativeForkBarrierAcquired = canAttemptNativeFork
             ? sourceRunner?.beginNativeForkBarrier() ?? true
             : false
         defer {
@@ -1909,7 +1911,7 @@ final class ACPSessionManager: ObservableObject {
         if nativeForkBarrierAcquired {
             await sourceRunner?.flushPersistence()
         }
-        if initialized.sessionCapabilities.supportsFork,
+        if canAttemptNativeFork,
            nativeForkBarrierAcquired,
            let source = try await persistence.loadSession(id: fork.sourceSessionID),
            let sourceRemoteSessionID = source.remoteSessionId,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1897,7 +1897,20 @@ final class ACPSessionManager: ObservableObject {
         wireMCPServers: [ACPMCPServer]
     ) async throws -> (result: ACPSessionNewResult, createdFreshRemoteSession: Bool) {
         var fork = fork
+        let sourceRunner = runners[fork.sourceSessionID]
+        let nativeForkBarrierAcquired = initialized.sessionCapabilities.supportsFork
+            ? sourceRunner?.beginNativeForkBarrier() ?? true
+            : false
+        defer {
+            if nativeForkBarrierAcquired {
+                sourceRunner?.endNativeForkBarrier()
+            }
+        }
+        if nativeForkBarrierAcquired {
+            await sourceRunner?.flushPersistence()
+        }
         if initialized.sessionCapabilities.supportsFork,
+           nativeForkBarrierAcquired,
            let source = try await persistence.loadSession(id: fork.sourceSessionID),
            let sourceRemoteSessionID = source.remoteSessionId,
            !sourceRemoteSessionID.isEmpty,
@@ -3642,8 +3655,7 @@ extension ACPSessionManager {
               let prompt = transcriptContextPrompt(for: session, agentName: agentName)
         else { return false }
 
-        session.contextRecoveryStatus = .sendingTranscript
-        runner.sendRecoveryContext(prompt) { delivered in
+        guard runner.sendRecoveryContext(prompt, onCompleted: { delivered in
             if delivered {
                 self.persistContextRecoveryPending(sessionId: sessionId, pending: false)
                 session.contextRestoreWarning = nil
@@ -3651,7 +3663,8 @@ extension ACPSessionManager {
             } else {
                 session.contextRecoveryStatus = .failed("Transcript recovery failed.")
             }
-        }
+        }) else { return false }
+        session.contextRecoveryStatus = .sendingTranscript
         return true
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -14,6 +14,14 @@ private enum ACPMirrorRefreshPolicy {
     static let inactivePollNanos: UInt64 = 30_000_000_000
 }
 
+private struct ACPForkDurableRetryError: LocalizedError {
+    let underlying: any Error
+
+    var errorDescription: String? {
+        underlying.localizedDescription
+    }
+}
+
 enum ACPSessionForkCreationError: Error, Equatable {
     case sourceUnavailable
     case sourceReadOnly
@@ -1774,6 +1782,7 @@ final class ACPSessionManager: ObservableObject {
             )
         } catch {
             persistenceError = error.localizedDescription
+            return
         }
         fork.phase = .ready
         fork.mechanism = .transcriptTransfer
@@ -1806,6 +1815,14 @@ final class ACPSessionManager: ObservableObject {
                     )
                 )
             } catch {
+                // A broker may have completed the keyed fork even when the
+                // trailing replay/transport step failed locally. Keep the
+                // durable negotiation intact so reattach can claim that same
+                // completion instead of issuing an unrelated session/new.
+                if connection.client is ACPBrokerClient,
+                   !Self.isDefinitiveForkFailure(error) {
+                    throw ACPForkDurableRetryError(underlying: error)
+                }
                 try await persistence.finalizeFork(
                     targetSessionID: session.id,
                     mechanism: .transcriptTransfer,
@@ -1815,6 +1832,7 @@ final class ACPSessionManager: ObservableObject {
                 fork.mechanism = .transcriptTransfer
                 fork.contextDeliveryPending = true
                 session.forkRecord = fork
+                connection.acknowledgeDurableSessionResponses()
                 if ACPAuthFailure.message(from: error) != nil {
                     throw error
                 }
@@ -1849,14 +1867,13 @@ final class ACPSessionManager: ObservableObject {
                     persistenceError = error.localizedDescription
                     transcriptFinalized = false
                 }
-                fork.phase = .ready
-                fork.mechanism = .transcriptTransfer
-                fork.contextDeliveryPending = true
-                session.forkRecord = fork
                 if transcriptFinalized {
+                    fork.phase = .ready
+                    fork.mechanism = .transcriptTransfer
+                    fork.contextDeliveryPending = true
+                    session.forkRecord = fork
                     connection.acknowledgeDurableSessionResponses()
                 }
-                await connection.shutdown()
                 throw error
             }
             fork.phase = .ready
@@ -1891,6 +1908,16 @@ final class ACPSessionManager: ObservableObject {
             )
         )
         return (result, true)
+    }
+
+    private static func isDefinitiveForkFailure(_ error: any Error) -> Bool {
+        if error is DecodingError || error is JSONRPCError {
+            return true
+        }
+        if case ACPClientError.jsonrpc = error {
+            return true
+        }
+        return false
     }
 
     private static func applyBrokerTurnState(_ turnState: ACPBrokerTurnState, to session: ACPSession) {
@@ -3334,13 +3361,23 @@ extension ACPSessionManager {
             }
             stderrTask.cancel()
         } catch {
-            await downgradeNegotiatingForkToTranscript(session: session)
+            let durableRetry = error as? ACPForkDurableRetryError
+            let wasNegotiatingFork = session.forkRecord?.phase == .negotiatingNative
+            if durableRetry == nil {
+                await downgradeNegotiatingForkToTranscript(session: session)
+                if wasNegotiatingFork, session.forkRecord?.phase == .ready {
+                    connection.acknowledgeDurableSessionResponses()
+                }
+            }
             // Give stderr a moment to drain so the message is the real cause.
             try? await Task.sleep(nanoseconds: 200_000_000)
             stderrTask.cancel()
             let tail = stderrBuffer.tail()
-            let authReason = ACPAuthFailure.message(from: error)
-            let baseMessage = authReason ?? (error as? JSONRPCError)?.message ?? error.localizedDescription
+            let surfacedError = durableRetry?.underlying ?? error
+            let authReason = ACPAuthFailure.message(from: surfacedError)
+            let baseMessage = authReason
+                ?? (surfacedError as? JSONRPCError)?.message
+                ?? surfacedError.localizedDescription
             let base = "ACP session attach failed: \(baseMessage)"
             let full = tail.isEmpty ? base : base + "\nstderr: " + tail
             session.lastError = full
@@ -3353,7 +3390,13 @@ extension ACPSessionManager {
             }
             startedRunner?.stop()
             await startedRunner?.flushPersistence()
-            await connection.shutdown()
+            let shouldPreserveBroker = connection.client is ACPBrokerClient
+                && session.forkRecord?.phase == .negotiatingNative
+            if durableRetry != nil || shouldPreserveBroker {
+                await connection.detach()
+            } else {
+                await connection.shutdown()
+            }
             await releaseWriterLease(sessionId: sessionId)
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -14,11 +14,11 @@ private enum ACPMirrorRefreshPolicy {
     static let inactivePollNanos: UInt64 = 30_000_000_000
 }
 
-private struct ACPForkDurableRetryError: LocalizedError {
+private struct ACPForkFallbackPersistenceError: LocalizedError {
     let underlying: any Error
 
     var errorDescription: String? {
-        underlying.localizedDescription
+        "Failed to persist fork fallback: \(underlying.localizedDescription)"
     }
 }
 
@@ -1772,8 +1772,9 @@ final class ACPSessionManager: ObservableObject {
         return "startup:\(sessionId):\(method)"
     }
 
-    private func downgradeNegotiatingForkToTranscript(session: ACPSession) async {
-        guard var fork = session.forkRecord, fork.phase == .negotiatingNative else { return }
+    @discardableResult
+    private func downgradeNegotiatingForkToTranscript(session: ACPSession) async throws -> Bool {
+        guard var fork = session.forkRecord, fork.phase == .negotiatingNative else { return false }
         do {
             try await persistence.finalizeFork(
                 targetSessionID: session.id,
@@ -1782,12 +1783,24 @@ final class ACPSessionManager: ObservableObject {
             )
         } catch {
             persistenceError = error.localizedDescription
-            return
+            throw ACPForkFallbackPersistenceError(underlying: error)
         }
         fork.phase = .ready
         fork.mechanism = .transcriptTransfer
         fork.contextDeliveryPending = true
         session.forkRecord = fork
+        return true
+    }
+
+    private func surfaceForkFallbackPersistenceFailure(
+        _ error: any Error,
+        on session: ACPSession
+    ) {
+        let message = (error as? ACPForkFallbackPersistenceError)?.localizedDescription
+            ?? ACPForkFallbackPersistenceError(underlying: error).localizedDescription
+        session.lastError = message
+        session.contextRecoveryStatus = nil
+        session.agentState = .failed(message)
     }
 
     private func startForkTarget(
@@ -1801,7 +1814,9 @@ final class ACPSessionManager: ObservableObject {
         if initialized.sessionCapabilities.supportsFork,
            let source = try await persistence.loadSession(id: fork.sourceSessionID),
            let sourceRemoteSessionID = source.remoteSessionId,
-           !sourceRemoteSessionID.isEmpty {
+           !sourceRemoteSessionID.isEmpty,
+           try await persistence.latestMessageSeq(sessionId: fork.sourceSessionID)
+                == fork.sourceBoundarySequence {
             let result: ACPSessionNewResult
             do {
                 result = try await connection.forkSession(
@@ -1815,13 +1830,12 @@ final class ACPSessionManager: ObservableObject {
                     )
                 )
             } catch {
-                // A broker may have completed the keyed fork even when the
-                // trailing replay/transport step failed locally. Keep the
-                // durable negotiation intact so reattach can claim that same
-                // completion instead of issuing an unrelated session/new.
-                if connection.client is ACPBrokerClient,
-                   !Self.isDefinitiveForkFailure(error) {
-                    throw ACPForkDurableRetryError(underlying: error)
+                // Only a typed broker error proves that the keyed operation
+                // completed successfully before replay failed. A plain
+                // transport error may have happened before the broker
+                // accepted the send and must take the transcript fallback.
+                if error is ACPBrokerDurableCompletionReplayError {
+                    throw error
                 }
                 try await persistence.finalizeFork(
                     targetSessionID: session.id,
@@ -1908,16 +1922,6 @@ final class ACPSessionManager: ObservableObject {
             )
         )
         return (result, true)
-    }
-
-    private static func isDefinitiveForkFailure(_ error: any Error) -> Bool {
-        if error is DecodingError || error is JSONRPCError {
-            return true
-        }
-        if case ACPClientError.jsonrpc = error {
-            return true
-        }
-        return false
     }
 
     private static func applyBrokerTurnState(_ turnState: ACPBrokerTurnState, to session: ACPSession) {
@@ -2680,7 +2684,13 @@ extension ACPSessionManager {
         session.agentState = .spawning
 
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId) else {
-            await downgradeNegotiatingForkToTranscript(session: session)
+            do {
+                try await downgradeNegotiatingForkToTranscript(session: session)
+            } catch {
+                surfaceForkFallbackPersistenceFailure(error, on: session)
+                await releaseWriterLease(sessionId: sessionId)
+                return
+            }
             let reason = "No ACP launch spec for \(session.agentId)"
             session.setupState = .needsSetup(reason: reason)
             session.agentState = .failed(reason)
@@ -2689,7 +2699,13 @@ extension ACPSessionManager {
         }
         let setup = await evaluateSetup(for: spec)
         guard case .ready = setup else {
-            await downgradeNegotiatingForkToTranscript(session: session)
+            do {
+                try await downgradeNegotiatingForkToTranscript(session: session)
+            } catch {
+                surfaceForkFallbackPersistenceFailure(error, on: session)
+                await releaseWriterLease(sessionId: sessionId)
+                return
+            }
             session.setupState = setup.sessionSetupState
             session.agentState = .failed(setup.reasonText)
             await releaseWriterLease(sessionId: sessionId)
@@ -2754,7 +2770,13 @@ extension ACPSessionManager {
                 )
             }
         } catch {
-            await downgradeNegotiatingForkToTranscript(session: session)
+            do {
+                try await downgradeNegotiatingForkToTranscript(session: session)
+            } catch {
+                surfaceForkFallbackPersistenceFailure(error, on: session)
+                await releaseWriterLease(sessionId: sessionId)
+                return
+            }
             let msg = "Failed to launch agent: \(error.localizedDescription)"
             session.lastError = msg
             session.agentState = .failed(msg)
@@ -2922,7 +2944,17 @@ extension ACPSessionManager {
                     try await connection.authenticate(methodId: pendingAuthMethodId)
                     session.pendingAuthMethodId = nil
                 } catch {
-                    await downgradeNegotiatingForkToTranscript(session: session)
+                    do {
+                        try await downgradeNegotiatingForkToTranscript(session: session)
+                    } catch {
+                        surfaceForkFallbackPersistenceFailure(error, on: session)
+                        if connection.client is ACPBrokerClient {
+                            await connection.detach()
+                        } else {
+                            await connection.shutdown()
+                        }
+                        return
+                    }
                     let reason = ACPAuthFailure.message(from: error) ?? error.localizedDescription
                     session.setupState = .needsAuth(methods: initialized.authMethods, reason: reason)
                     session.agentState = .failed(reason)
@@ -3361,28 +3393,39 @@ extension ACPSessionManager {
             }
             stderrTask.cancel()
         } catch {
-            let durableRetry = error as? ACPForkDurableRetryError
+            let durableRetry = error as? ACPBrokerDurableCompletionReplayError
             let wasNegotiatingFork = session.forkRecord?.phase == .negotiatingNative
+            var downgradePersistenceError: (any Error)?
             if durableRetry == nil {
-                await downgradeNegotiatingForkToTranscript(session: session)
-                if wasNegotiatingFork, session.forkRecord?.phase == .ready {
-                    connection.acknowledgeDurableSessionResponses()
+                do {
+                    try await downgradeNegotiatingForkToTranscript(session: session)
+                    if wasNegotiatingFork, session.forkRecord?.phase == .ready {
+                        connection.acknowledgeDurableSessionResponses()
+                    }
+                } catch {
+                    downgradePersistenceError = error
                 }
             }
             // Give stderr a moment to drain so the message is the real cause.
             try? await Task.sleep(nanoseconds: 200_000_000)
             stderrTask.cancel()
             let tail = stderrBuffer.tail()
-            let surfacedError = durableRetry?.underlying ?? error
+            let surfacedError = downgradePersistenceError
+                ?? durableRetry?.underlying
+                ?? error
             let authReason = ACPAuthFailure.message(from: surfacedError)
             let baseMessage = authReason
                 ?? (surfacedError as? JSONRPCError)?.message
                 ?? surfacedError.localizedDescription
-            let base = "ACP session attach failed: \(baseMessage)"
+            let base = downgradePersistenceError == nil
+                ? "ACP session attach failed: \(baseMessage)"
+                : baseMessage
             let full = tail.isEmpty ? base : base + "\nstderr: " + tail
             session.lastError = full
             session.contextRecoveryStatus = nil
-            if let authReason {
+            if downgradePersistenceError != nil {
+                session.agentState = .failed(full)
+            } else if let authReason {
                 session.setupState = .needsAuth(methods: session.authMethods, reason: authReason)
                 session.agentState = .failed(authReason)
             } else {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -529,88 +529,108 @@ final class ACPSessionManager: ObservableObject {
         guard let source = sessions[sourceSessionID], source.hydrationState == .ready else {
             throw ACPSessionForkCreationError.sourceUnavailable
         }
+        let acquiredSnapshotLease: Bool
         if !_ownedLeases.contains(sourceSessionID) {
             guard await acquireWriterLease(sessionId: sourceSessionID) else {
                 throw ACPSessionForkCreationError.sourceReadOnly
             }
+            acquiredSnapshotLease = true
+        } else {
+            guard await confirmedWriterLease(for: sourceSessionID) else {
+                throw ACPSessionForkCreationError.sourceReadOnly
+            }
+            acquiredSnapshotLease = false
         }
 
-        await awaitBackfill(id: sourceSessionID)
-        await flushAllPersistence()
-        let storedMessages = try await persistence.loadMessages(sessionId: sourceSessionID)
-        let snapshot = try ACPSessionForkSnapshotResolver.resolve(
-            boundary: boundary,
-            liveMessages: source.transcript.messages,
-            storedMessages: storedMessages
-        )
-        let boundaryIsRemoteHead = snapshot.sourceBoundarySequence == storedMessages.last?.seq
-        let candidate = ACPSessionForkCandidatePolicy.candidate(
-            sourceAgentID: source.agentId,
-            targetAgentID: targetAgentID,
-            boundaryIsRemoteHead: boundaryIsRemoteHead,
-            sourceRemoteSessionID: source.remoteSessionId,
-            forkCapability: source.sessionCapabilities?.supportsFork
-        )
+        let result: Result<ACPSession, Error>
+        do {
+            await awaitBackfill(id: sourceSessionID)
+            await flushAllPersistence()
+            let storedMessages = try await persistence.loadMessages(sessionId: sourceSessionID)
+            let snapshot = try ACPSessionForkSnapshotResolver.resolve(
+                boundary: boundary,
+                liveMessages: source.transcript.messages,
+                storedMessages: storedMessages
+            )
+            let boundaryIsRemoteHead = snapshot.sourceBoundarySequence == storedMessages.last?.seq
+            let sourceContextDeliveryPending = source.forkRecord?.mechanism == .transcriptTransfer
+                && source.forkRecord?.contextDeliveryPending == true
+            let candidate = sourceContextDeliveryPending
+                ? ACPSessionForkCandidate.transcript
+                : ACPSessionForkCandidatePolicy.candidate(
+                    sourceAgentID: source.agentId,
+                    targetAgentID: targetAgentID,
+                    boundaryIsRemoteHead: boundaryIsRemoteHead,
+                    sourceRemoteSessionID: source.remoteSessionId,
+                    forkCapability: source.sessionCapabilities?.supportsFork
+                )
 
-        let targetID = UUID().uuidString
-        let now = Int64(Date().timeIntervalSince1970)
-        let copiedMessages = try snapshot.copiedMessages(targetSessionID: targetID, createdAt: now)
-        let targetTitle = source.title == "New session"
-            ? "New session (fork)"
-            : "\(source.title) (fork)"
-        let targetRow = ACPSessionRow(
-            id: targetID,
-            agentId: targetAgentID,
-            title: targetTitle,
-            titleSource: .generated,
-            currentModel: nil,
-            currentMode: nil,
-            autoRun: autoRunDefault,
-            createdAt: now,
-            updatedAt: now,
-            lastOpenedAt: now,
-            archived: false
-        )
-        let forkRecord = ACPSessionForkRecord(
-            targetSessionID: targetID,
-            sourceSessionID: sourceSessionID,
-            sourceAgentID: source.agentId,
-            sourceBoundarySequence: snapshot.sourceBoundarySequence,
-            inheritedMessageCount: copiedMessages.count,
-            phase: candidate == .native ? .negotiatingNative : .ready,
-            mechanism: candidate == .native ? nil : .transcriptTransfer,
-            contextDeliveryPending: candidate == .transcript
-        )
+            let targetID = UUID().uuidString
+            let now = Int64(Date().timeIntervalSince1970)
+            let copiedMessages = try snapshot.copiedMessages(targetSessionID: targetID, createdAt: now)
+            let targetTitle = source.title == "New session"
+                ? "New session (fork)"
+                : "\(source.title) (fork)"
+            let targetRow = ACPSessionRow(
+                id: targetID,
+                agentId: targetAgentID,
+                title: targetTitle,
+                titleSource: .generated,
+                currentModel: nil,
+                currentMode: nil,
+                autoRun: autoRunDefault,
+                createdAt: now,
+                updatedAt: now,
+                lastOpenedAt: now,
+                archived: false
+            )
+            let forkRecord = ACPSessionForkRecord(
+                targetSessionID: targetID,
+                sourceSessionID: sourceSessionID,
+                sourceAgentID: source.agentId,
+                sourceBoundarySequence: snapshot.sourceBoundarySequence,
+                inheritedMessageCount: copiedMessages.count,
+                phase: candidate == .native ? .negotiatingNative : .ready,
+                mechanism: candidate == .native ? nil : .transcriptTransfer,
+                contextDeliveryPending: candidate == .transcript
+            )
 
-        try await persistence.createFork(
-            session: targetRow,
-            messages: copiedMessages,
-            record: forkRecord
-        )
+            try await persistence.createFork(
+                session: targetRow,
+                messages: copiedMessages,
+                record: forkRecord
+            )
 
-        let target = ACPSession(
-            id: targetRow.id,
-            agentId: targetRow.agentId,
-            worktreeId: worktreeId,
-            title: targetRow.title,
-            titleSource: targetRow.titleSource,
-            origin: targetRow.origin,
-            createdAt: Date(timeIntervalSince1970: TimeInterval(targetRow.createdAt)),
-            hydrationState: .ready
-        )
-        target.autoRunEnabled = targetRow.autoRun
-        target.forkRecord = forkRecord
-        for message in copiedMessages {
-            target.transcript.appendMessage(try ACPMessageCodec.decode(
-                kind: message.kind,
-                payload: message.payload
-            ))
+            let target = ACPSession(
+                id: targetRow.id,
+                agentId: targetRow.agentId,
+                worktreeId: worktreeId,
+                title: targetRow.title,
+                titleSource: targetRow.titleSource,
+                origin: targetRow.origin,
+                createdAt: Date(timeIntervalSince1970: TimeInterval(targetRow.createdAt)),
+                hydrationState: .ready
+            )
+            target.autoRunEnabled = targetRow.autoRun
+            target.forkRecord = forkRecord
+            for message in copiedMessages {
+                target.transcript.appendMessage(try ACPMessageCodec.decode(
+                    kind: message.kind,
+                    payload: message.payload
+                ))
+            }
+            sessions[targetID] = target
+            persistedRows[targetID] = targetRow
+            recent.removeAll { $0.id == targetID }
+            recent.insert(targetRow, at: 0)
+            result = .success(target)
+        } catch {
+            result = .failure(error)
         }
-        sessions[targetID] = target
-        persistedRows[targetID] = targetRow
-        recent.removeAll { $0.id == targetID }
-        recent.insert(targetRow, at: 0)
-        return target
+        if acquiredSnapshotLease {
+            await releaseWriterLease(sessionId: sourceSessionID)
+        }
+        return try result.get()
     }
 
     /// Returns a cached session or a `.loading` placeholder. Cache hits

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1913,6 +1913,30 @@ final class ACPSessionManager: ObservableObject {
         fork.mechanism = .transcriptTransfer
         fork.contextDeliveryPending = true
         session.forkRecord = fork
+        if let source = try await persistence.loadSession(id: fork.sourceSessionID),
+           let sourceRemoteSessionID = source.remoteSessionId,
+           !sourceRemoteSessionID.isEmpty,
+           let brokerClient = connection.client as? ACPBrokerClient {
+            let operationKey = Self.brokerStartupOperationKey(
+                sessionId: session.id,
+                method: "session/fork",
+                remoteSessionId: sourceRemoteSessionID
+            )
+            if let replayed = brokerClient.replayedCompletion(
+                forPreRegisteredOperationKey: operationKey
+            ) {
+                if replayed.outcome.error == nil,
+                   let result = replayed.outcome.result,
+                   let forked = try? JSONDecoder().decode(
+                       ACPSessionNewResult.self,
+                       from: result.data
+                   ),
+                   !forked.sessionId.isEmpty {
+                    try? await connection.closeSession(sessionId: forked.sessionId)
+                }
+                replayed.acknowledgeDurableConsumption()
+            }
+        }
         let result = try await connection.newSession(
             cwd: worktreePath,
             mcpServers: wireMCPServers,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2005,6 +2005,7 @@ final class ACPSessionManager: ObservableObject {
             fork.mechanism = .nativeACP
             fork.contextDeliveryPending = false
             session.forkRecord = fork
+            session.markAsAgentForked()
             if var row = persistedRows[session.id] {
                 row.remoteSessionId = result.sessionId
                 row.origin = .agentForked

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1803,6 +1803,70 @@ final class ACPSessionManager: ObservableObject {
         session.agentState = .failed(message)
     }
 
+    private func releaseReplayedForkCompletionForTranscriptFallback(
+        targetSessionID: ACPSession.ID,
+        sourceRemoteSessionID: String,
+        connection: ACPConnection
+    ) async {
+        guard let brokerClient = connection.client as? ACPBrokerClient else { return }
+        let operationKey = Self.brokerStartupOperationKey(
+            sessionId: targetSessionID,
+            method: "session/fork",
+            remoteSessionId: sourceRemoteSessionID
+        )
+        guard let replayed = brokerClient.replayedCompletion(
+            forPreRegisteredOperationKey: operationKey
+        ) else {
+            return
+        }
+        if replayed.outcome.error == nil,
+           let result = replayed.outcome.result,
+           let forked = try? JSONDecoder().decode(
+               ACPSessionNewResult.self,
+               from: result.data
+           ),
+           !forked.sessionId.isEmpty {
+            try? await connection.closeSession(sessionId: forked.sessionId)
+        }
+        replayed.acknowledgeDurableConsumption()
+    }
+
+    private func startTranscriptFallbackSession(
+        targetSessionID: ACPSession.ID,
+        sourceRemoteSessionID: String,
+        connection: ACPConnection,
+        wireMCPServers: [ACPMCPServer]
+    ) async throws -> ACPSessionNewResult {
+        await releaseReplayedForkCompletionForTranscriptFallback(
+            targetSessionID: targetSessionID,
+            sourceRemoteSessionID: sourceRemoteSessionID,
+            connection: connection
+        )
+        do {
+            let result = try await connection.newSession(
+                cwd: worktreePath,
+                mcpServers: wireMCPServers,
+                brokerOperationKey: Self.brokerStartupOperationKey(
+                    sessionId: targetSessionID,
+                    method: "session/new"
+                )
+            )
+            await releaseReplayedForkCompletionForTranscriptFallback(
+                targetSessionID: targetSessionID,
+                sourceRemoteSessionID: sourceRemoteSessionID,
+                connection: connection
+            )
+            return result
+        } catch {
+            await releaseReplayedForkCompletionForTranscriptFallback(
+                targetSessionID: targetSessionID,
+                sourceRemoteSessionID: sourceRemoteSessionID,
+                connection: connection
+            )
+            throw error
+        }
+    }
+
     private func startForkTarget(
         session: ACPSession,
         fork: ACPSessionForkRecord,
@@ -1830,11 +1894,14 @@ final class ACPSessionManager: ObservableObject {
                     )
                 )
             } catch {
-                // Only a typed broker error proves that the keyed operation
-                // completed successfully before replay failed. A plain
-                // transport error may have happened before the broker
-                // accepted the send and must take the transcript fallback.
-                if error is ACPBrokerDurableCompletionReplayError {
+                // A successful durable broker completion must retry the
+                // stable fork key so its returned session can be persisted.
+                // A terminal JSON-RPC completion is equally durable, but it
+                // selects transcript fallback and its replayed cursor must be
+                // consumed there. A plain transport error may have happened
+                // before the broker accepted the send and also falls back.
+                let durableReplay = error as? ACPBrokerDurableCompletionReplayError
+                if let durableReplay, durableReplay.outcome.error == nil {
                     throw error
                 }
                 try await persistence.finalizeFork(
@@ -1847,16 +1914,25 @@ final class ACPSessionManager: ObservableObject {
                 fork.contextDeliveryPending = true
                 session.forkRecord = fork
                 connection.acknowledgeDurableSessionResponses()
-                if ACPAuthFailure.message(from: error) != nil {
-                    throw error
+                await releaseReplayedForkCompletionForTranscriptFallback(
+                    targetSessionID: session.id,
+                    sourceRemoteSessionID: sourceRemoteSessionID,
+                    connection: connection
+                )
+                let fallbackError: any Error
+                if let terminalError = durableReplay?.outcome.error {
+                    fallbackError = ACPClientError.jsonrpc(terminalError)
+                } else {
+                    fallbackError = error
                 }
-                let fallback = try await connection.newSession(
-                    cwd: worktreePath,
-                    mcpServers: wireMCPServers,
-                    brokerOperationKey: Self.brokerStartupOperationKey(
-                        sessionId: session.id,
-                        method: "session/new"
-                    )
+                if ACPAuthFailure.message(from: fallbackError) != nil {
+                    throw fallbackError
+                }
+                let fallback = try await startTranscriptFallbackSession(
+                    targetSessionID: session.id,
+                    sourceRemoteSessionID: sourceRemoteSessionID,
+                    connection: connection,
+                    wireMCPServers: wireMCPServers
                 )
                 return (fallback, true)
             }
@@ -1915,27 +1991,14 @@ final class ACPSessionManager: ObservableObject {
         session.forkRecord = fork
         if let source = try await persistence.loadSession(id: fork.sourceSessionID),
            let sourceRemoteSessionID = source.remoteSessionId,
-           !sourceRemoteSessionID.isEmpty,
-           let brokerClient = connection.client as? ACPBrokerClient {
-            let operationKey = Self.brokerStartupOperationKey(
-                sessionId: session.id,
-                method: "session/fork",
-                remoteSessionId: sourceRemoteSessionID
+           !sourceRemoteSessionID.isEmpty {
+            let result = try await startTranscriptFallbackSession(
+                targetSessionID: session.id,
+                sourceRemoteSessionID: sourceRemoteSessionID,
+                connection: connection,
+                wireMCPServers: wireMCPServers
             )
-            if let replayed = brokerClient.replayedCompletion(
-                forPreRegisteredOperationKey: operationKey
-            ) {
-                if replayed.outcome.error == nil,
-                   let result = replayed.outcome.result,
-                   let forked = try? JSONDecoder().decode(
-                       ACPSessionNewResult.self,
-                       from: result.data
-                   ),
-                   !forked.sessionId.isEmpty {
-                    try? await connection.closeSession(sessionId: forked.sessionId)
-                }
-                replayed.acknowledgeDurableConsumption()
-            }
+            return (result, true)
         }
         let result = try await connection.newSession(
             cwd: worktreePath,
@@ -3417,7 +3480,13 @@ extension ACPSessionManager {
             }
             stderrTask.cancel()
         } catch {
-            let durableRetry = error as? ACPBrokerDurableCompletionReplayError
+            let durableReplay = error as? ACPBrokerDurableCompletionReplayError
+            let durableRetry = durableReplay.flatMap {
+                $0.outcome.error == nil ? $0 : nil
+            }
+            let terminalReplayError: (any Error)? = durableReplay?.outcome.error.map {
+                ACPClientError.jsonrpc($0)
+            }
             let wasNegotiatingFork = session.forkRecord?.phase == .negotiatingNative
             var downgradePersistenceError: (any Error)?
             if durableRetry == nil {
@@ -3435,6 +3504,7 @@ extension ACPSessionManager {
             stderrTask.cancel()
             let tail = stderrBuffer.tail()
             let surfacedError = downgradePersistenceError
+                ?? terminalReplayError
                 ?? durableRetry?.underlying
                 ?? error
             let authReason = ACPAuthFailure.message(from: surfacedError)

--- a/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
@@ -66,6 +66,34 @@ actor ACPSessionPersistence {
         try openedStore().loadSession(id: id)
     }
 
+    func createFork(
+        session: ACPSessionRow,
+        messages: [ACPStoredMessage],
+        record: ACPSessionForkRecord
+    ) throws {
+        try openedStore().createFork(session: session, messages: messages, record: record)
+    }
+
+    func loadFork(targetSessionID: String) throws -> ACPSessionForkRecord? {
+        try openedStore().loadFork(targetSessionID: targetSessionID)
+    }
+
+    func finalizeFork(
+        targetSessionID: String,
+        mechanism: ACPSessionForkMechanism,
+        remoteSessionID: String?
+    ) throws {
+        try openedStore().finalizeFork(
+            targetSessionID: targetSessionID,
+            mechanism: mechanism,
+            remoteSessionID: remoteSessionID
+        )
+    }
+
+    func clearForkContextDeliveryPending(targetSessionID: String) throws {
+        try openedStore().clearForkContextDeliveryPending(targetSessionID: targetSessionID)
+    }
+
     func loadSession(agentId: String, remoteSessionId: String) throws -> ACPSessionRow? {
         try openedStore().loadSession(agentId: agentId, remoteSessionId: remoteSessionId)
     }

--- a/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
@@ -94,6 +94,22 @@ actor ACPSessionPersistence {
         try openedStore().clearForkContextDeliveryPending(targetSessionID: targetSessionID)
     }
 
+    @discardableResult
+    func clearForkContextDeliveryPending(
+        targetSessionID: String,
+        fence: ACPSessionLeaseFence?
+    ) throws -> Bool {
+        let store = try openedStore()
+        let operation = {
+            try store.clearForkContextDeliveryPending(targetSessionID: targetSessionID)
+        }
+        if let fence {
+            return try store.withLeaseFence(fence, operation) != nil
+        }
+        try operation()
+        return true
+    }
+
     func loadSession(agentId: String, remoteSessionId: String) throws -> ACPSessionRow? {
         try openedStore().loadSession(agentId: agentId, remoteSessionId: remoteSessionId)
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1317,16 +1317,55 @@ extension ACPSessionRunner {
         }
     }
 
-    private func persistForkContextDelivered() {
+    private func persistForkContextDelivered(
+        acknowledging acknowledgement: ACPDurableConsumptionAcknowledgement? = nil
+    ) {
         guard holdsLeaseForWrite() else { return }
         let fence = leaseFenceProvider()
         let sessionId = sessionId
-        enqueuePersistence { persistence in
-            _ = try await persistence.clearForkContextDeliveryPending(
+        if let acknowledgement {
+            enqueuePersistence({ persistence in
+                try await persistence.clearForkContextDeliveryPending(
+                    targetSessionID: sessionId,
+                    fence: fence
+                )
+            }, completion: { persisted in
+                if persisted == true {
+                    acknowledgement()
+                }
+            })
+        } else {
+            enqueuePersistence { persistence in
+                _ = try await persistence.clearForkContextDeliveryPending(
+                    targetSessionID: sessionId,
+                    fence: fence
+                )
+            }
+        }
+    }
+
+    private func persistForkContextDeliveredAndQueue(
+        acknowledging acknowledgement: ACPDurableConsumptionAcknowledgement?
+    ) {
+        guard holdsLeaseForWrite() else { return }
+        let items = session.queue
+        let fence = leaseFenceProvider()
+        let sessionId = sessionId
+        enqueuePersistence({ persistence in
+            guard try await persistence.clearForkContextDeliveryPending(
                 targetSessionID: sessionId,
                 fence: fence
+            ) else { return false }
+            return try await persistence.upsertQueue(
+                sessionId: sessionId,
+                items: items,
+                fence: fence
             )
-        }
+        }, completion: { persisted in
+            if persisted == true {
+                acknowledgement?()
+            }
+        })
     }
 
     /// Drain the queue head if the runner is still live, setup is not
@@ -1665,11 +1704,12 @@ extension ACPSessionRunner {
                     sessionId: remoteId,
                     blocks: wireBlocks,
                     brokerOperationKey: brokerOperationKey,
-                    acknowledgeDurableConsumption: queuedItemId == nil
+                    acknowledgeDurableConsumption: queuedItemId == nil && pendingForkContext == nil
                 )
                 await MainActor.run {
                     let isActivePrompt = self.activePromptID == promptID
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
+                    let deliveredForkContext = pendingForkContext != nil
                     // The agent received the preamble whenever the RPC above
                     // succeeded, regardless of whether this prompt is still
                     // "active" by the time we get back on the main actor —
@@ -1685,12 +1725,24 @@ extension ACPSessionRunner {
                        fork.contextDeliveryPending {
                         fork.contextDeliveryPending = false
                         self.session.forkRecord = fork
-                        self.persistForkContextDelivered()
+                    }
+                    if deliveredForkContext {
+                        if queuedItemId == nil {
+                            self.persistForkContextDelivered(acknowledging: promptAcknowledgement)
+                        } else if !isActivePrompt {
+                            self.persistForkContextDelivered(acknowledging: promptAcknowledgement)
+                        }
                     }
                     if isActivePrompt {
                         if queuedItemId != nil {
                             _ = self.session.popQueueHead()
-                            self.persistQueue(acknowledging: promptAcknowledgement)
+                            if deliveredForkContext {
+                                self.persistForkContextDeliveredAndQueue(
+                                    acknowledging: promptAcknowledgement
+                                )
+                            } else {
+                                self.persistQueue(acknowledging: promptAcknowledgement)
+                            }
                         }
                         self.activePromptID = nil
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1303,6 +1303,18 @@ extension ACPSessionRunner {
         }
     }
 
+    private func persistForkContextDelivered() {
+        guard holdsLeaseForWrite() else { return }
+        let fence = leaseFenceProvider()
+        let sessionId = sessionId
+        enqueuePersistence { persistence in
+            _ = try await persistence.clearForkContextDeliveryPending(
+                targetSessionID: sessionId,
+                fence: fence
+            )
+        }
+    }
+
     /// Drain the queue head if the runner is still live, setup is not
     /// blocked on auth, no prompt owns the transport, transcript state is
     /// `.idle`, the head is `.pending`, and the head has no `lastError`.
@@ -1573,17 +1585,28 @@ extension ACPSessionRunner {
                 // hydrate off-main so file reads + encoding don't block UI.
                 let promptCapabilities = self.session.promptCapabilities
                 let pendingPreamble = self.session.pendingMCPPreamble
+                let pendingForkContext: String? = {
+                    guard let fork = self.session.forkRecord,
+                          fork.phase == .ready,
+                          fork.mechanism == .transcriptTransfer,
+                          fork.contextDeliveryPending
+                    else { return nil }
+                    return ACPTranscriptMarkdown.forkContext(
+                        sourceAgentID: fork.sourceAgentID,
+                        messages: Array(self.session.transcript.messages.prefix(fork.inheritedMessageCount))
+                    )
+                }()
                 var wireBlocks = await Self.hydrate(
                     blocks,
                     promptCapabilities: promptCapabilities,
                     worktreePath: self.worktreePath
                 )
-                // Wire-only MCP context preamble: prepended for the agent,
-                // never part of the recorded transcript — `recordUserPrompt`
-                // above already ran on the original `blocks`.
-                if let pendingPreamble {
-                    wireBlocks.insert(.text(pendingPreamble), at: 0)
-                }
+                // Wire-only context is prepended for the agent and never part
+                // of the recorded transcript — recording above used `blocks`.
+                var privateBlocks: [ACPContentBlock] = []
+                if let pendingPreamble { privateBlocks.append(.text(pendingPreamble)) }
+                if let pendingForkContext { privateBlocks.append(.text(pendingForkContext)) }
+                wireBlocks.insert(contentsOf: privateBlocks, at: 0)
                 guard await self.hasConfirmedLeaseForSideEffect() else {
                     throw CancellationError()
                 }
@@ -1605,6 +1628,13 @@ extension ACPSessionRunner {
                         self.session.pendingMCPPreamble = nil
                         self.session.mcpPreambleSent = true
                         self.persistMCPPreambleSent()
+                    }
+                    if pendingForkContext != nil,
+                       var fork = self.session.forkRecord,
+                       fork.contextDeliveryPending {
+                        fork.contextDeliveryPending = false
+                        self.session.forkRecord = fork
+                        self.persistForkContextDelivered()
                     }
                     if isActivePrompt {
                         if queuedItemId != nil {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -105,6 +105,10 @@ final class ACPSessionRunner {
     /// restored snapshot ahead of the steer's replacement prompt. Once
     /// the redirect is in flight, normal drain semantics resume.
     private var steerInProgress: Bool = false
+    /// Holds an idle source session at its persisted remote head while
+    /// `session/fork` is in flight. New prompts remain queued until the
+    /// target adapter has created the branch.
+    private var nativeForkBarrierActive = false
     var onUnexpectedDisconnect: (() -> Void)?
 
     /// How many trailing rows to retain in `lastPersistedPayloads`. Only the
@@ -1223,6 +1227,16 @@ extension ACPSessionRunner {
         draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
+        if nativeForkBarrierActive {
+            guard !blocks.isEmpty else {
+                Task { @MainActor in onPromptFinished?(false) }
+                return
+            }
+            session.enqueue(blocks: blocks, draft: draft)
+            persistQueue()
+            Task { @MainActor in onPromptFinished?(true) }
+            return
+        }
         let route = ACPSubmitRoute.resolve(
             intent: intent,
             state: session.transcript.streamingState,
@@ -1326,7 +1340,8 @@ extension ACPSessionRunner {
     /// `.idle` and calls back here.
     func flushQueueIfIdle() {
         guard holdsLeaseForWrite() else { return }
-        guard !steerInProgress,
+        guard !nativeForkBarrierActive,
+              !steerInProgress,
               session.agentState == .ready,
               activePromptID == nil,
               session.transcript.streamingState == .idle,
@@ -1346,6 +1361,25 @@ extension ACPSessionRunner {
         )
     }
 
+    func beginNativeForkBarrier() -> Bool {
+        guard !nativeForkBarrierActive,
+              !steerInProgress,
+              session.agentState == .ready,
+              activePromptID == nil,
+              session.transcript.streamingState == .idle,
+              session.transcript.pendingUserInputs.isEmpty,
+              session.queue.isEmpty
+        else { return false }
+        nativeForkBarrierActive = true
+        return true
+    }
+
+    func endNativeForkBarrier() {
+        guard nativeForkBarrierActive else { return }
+        nativeForkBarrierActive = false
+        flushQueueIfIdle()
+    }
+
     /// User clicked the row-local "send now" affordance for a queued item.
     /// While idle this just promotes the item to the drainable head. While a
     /// turn is active, it behaves like steering: cancel the current turn,
@@ -1355,6 +1389,12 @@ extension ACPSessionRunner {
         guard let idx = session.queue.firstIndex(where: { $0.id == id }),
               session.queue[idx].status == .pending
         else { return }
+
+        if nativeForkBarrierActive {
+            guard session.forceQueueItem(id: id) else { return }
+            persistQueue()
+            return
+        }
 
         if session.transcript.streamingState == .idle,
            activePromptID == nil,
@@ -1706,10 +1746,12 @@ extension ACPSessionRunner {
         }
     }
 
+    @discardableResult
     func sendRecoveryContext(
         _ prompt: String,
         onCompleted: (@MainActor (_ delivered: Bool) -> Void)? = nil
-    ) {
+    ) -> Bool {
+        guard !nativeForkBarrierActive else { return false }
         flushPendingIncomingUpdates()
         let promptID = nextPromptID
         nextPromptID += 1
@@ -1768,6 +1810,7 @@ extension ACPSessionRunner {
                 }
             }
         }
+        return true
     }
 
     /// First text block as the user-facing preview. Used when recording

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1361,23 +1361,34 @@ extension ACPSessionRunner {
         )
     }
 
-    func beginNativeForkBarrier() -> Bool {
-        guard !nativeForkBarrierActive,
-              !steerInProgress,
-              session.agentState == .ready,
-              activePromptID == nil,
-              session.transcript.streamingState == .idle,
-              session.transcript.pendingUserInputs.isEmpty,
-              session.queue.isEmpty
+    func beginNativeForkBarrier() async -> Bool {
+        guard canBeginNativeForkBarrier,
+              await hasConfirmedLeaseForSideEffect(),
+              canBeginNativeForkBarrier
         else { return false }
         nativeForkBarrierActive = true
         return true
+    }
+
+    func confirmNativeForkBarrier() async -> Bool {
+        guard nativeForkBarrierActive else { return false }
+        return await hasConfirmedLeaseForSideEffect()
     }
 
     func endNativeForkBarrier() {
         guard nativeForkBarrierActive else { return }
         nativeForkBarrierActive = false
         flushQueueIfIdle()
+    }
+
+    private var canBeginNativeForkBarrier: Bool {
+        !nativeForkBarrierActive
+            && !steerInProgress
+            && session.agentState == .ready
+            && activePromptID == nil
+            && session.transcript.streamingState == .idle
+            && session.transcript.pendingUserInputs.isEmpty
+            && session.queue.isEmpty
     }
 
     /// User clicked the row-local "send now" affordance for a queued item.

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 14
+    static let targetSchemaVersion = 15
     let path: String
     let db: SQLiteDatabase
 
@@ -41,6 +41,7 @@ final class ACPSessionStore {
         if current < 12 { try migrate_to_v12() }
         if current < 13 { try migrate_to_v13() }
         if current < 14 { try migrate_to_v14() }
+        if current < 15 { try migrate_to_v15() }
         try recoverFromConcurrentWriters()
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
@@ -236,6 +237,21 @@ final class ACPSessionStore {
         WHERE acp_broker_id IS NOT NULL
         """)
     }
+
+    private func migrate_to_v15() throws {
+        try db.exec("""
+        CREATE TABLE IF NOT EXISTS session_forks (
+          target_session_id          TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          source_session_id          TEXT NOT NULL,
+          source_agent_id            TEXT NOT NULL,
+          source_boundary_seq        INTEGER NOT NULL,
+          inherited_message_count    INTEGER NOT NULL,
+          phase                      TEXT NOT NULL,
+          mechanism                  TEXT,
+          context_delivery_pending   INTEGER NOT NULL DEFAULT 0
+        )
+        """)
+    }
 }
 
 struct ACPSessionLease: Equatable, Sendable {
@@ -334,6 +350,108 @@ extension ACPSessionStore {
 }
 
 extension ACPSessionStore {
+    func createFork(
+        session: ACPSessionRow,
+        messages: [ACPStoredMessage],
+        record: ACPSessionForkRecord
+    ) throws {
+        try db.transaction {
+            try upsertSession(session)
+            for message in messages {
+                try appendMessage(
+                    sessionId: message.sessionId,
+                    id: message.id,
+                    kind: message.kind,
+                    seq: message.seq,
+                    payload: message.payload,
+                    createdAt: message.createdAt
+                )
+            }
+            try upsertFork(record)
+        }
+    }
+
+    func upsertFork(_ record: ACPSessionForkRecord) throws {
+        try db.exec("""
+        INSERT INTO session_forks (
+          target_session_id, source_session_id, source_agent_id,
+          source_boundary_seq, inherited_message_count, phase,
+          mechanism, context_delivery_pending
+        ) VALUES (?,?,?,?,?,?,?,?)
+        ON CONFLICT(target_session_id) DO UPDATE SET
+          source_session_id = excluded.source_session_id,
+          source_agent_id = excluded.source_agent_id,
+          source_boundary_seq = excluded.source_boundary_seq,
+          inherited_message_count = excluded.inherited_message_count,
+          phase = excluded.phase,
+          mechanism = excluded.mechanism,
+          context_delivery_pending = excluded.context_delivery_pending
+        """, bindings: [
+            record.targetSessionID,
+            record.sourceSessionID,
+            record.sourceAgentID,
+            record.sourceBoundarySequence,
+            record.inheritedMessageCount,
+            record.phase.rawValue,
+            record.mechanism?.rawValue,
+            record.contextDeliveryPending ? 1 : 0
+        ])
+    }
+
+    func loadFork(targetSessionID: String) throws -> ACPSessionForkRecord? {
+        let rows = try db.query(
+            "SELECT * FROM session_forks WHERE target_session_id = ?",
+            bindings: [targetSessionID]
+        )
+        guard let row = rows.first,
+              let phaseValue = row["phase"] as? String,
+              let phase = ACPSessionForkCreationPhase(rawValue: phaseValue)
+        else { return nil }
+        return ACPSessionForkRecord(
+            targetSessionID: row["target_session_id"] as? String ?? "",
+            sourceSessionID: row["source_session_id"] as? String ?? "",
+            sourceAgentID: row["source_agent_id"] as? String ?? "",
+            sourceBoundarySequence: (row["source_boundary_seq"] as? Int64) ?? 0,
+            inheritedMessageCount: Int((row["inherited_message_count"] as? Int64) ?? 0),
+            phase: phase,
+            mechanism: (row["mechanism"] as? String).flatMap(ACPSessionForkMechanism.init(rawValue:)),
+            contextDeliveryPending: ((row["context_delivery_pending"] as? Int64) ?? 0) != 0
+        )
+    }
+
+    func finalizeFork(
+        targetSessionID: String,
+        mechanism: ACPSessionForkMechanism,
+        remoteSessionID: String?
+    ) throws {
+        try db.transaction {
+            try db.exec("""
+            UPDATE session_forks
+            SET phase = ?, mechanism = ?, context_delivery_pending = ?
+            WHERE target_session_id = ?
+            """, bindings: [
+                ACPSessionForkCreationPhase.ready.rawValue,
+                mechanism.rawValue,
+                mechanism == .transcriptTransfer ? 1 : 0,
+                targetSessionID
+            ])
+            if let remoteSessionID {
+                try db.exec(
+                    "UPDATE sessions SET remote_session_id = ?, origin = ? WHERE id = ?",
+                    bindings: [remoteSessionID, ACPSessionOrigin.agentForked.rawValue, targetSessionID]
+                )
+            }
+        }
+    }
+
+    func clearForkContextDeliveryPending(targetSessionID: String) throws {
+        try db.exec("""
+        UPDATE session_forks
+        SET context_delivery_pending = 0
+        WHERE target_session_id = ?
+        """, bindings: [targetSessionID])
+    }
+
     func upsertSession(_ s: ACPSessionRow, preserveTitle: Bool = false) throws {
         try db.exec("""
         INSERT INTO sessions (id, agent_id, title, title_source, remote_session_id, origin, context_recovery_pending,

--- a/Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift
@@ -43,6 +43,21 @@ enum ACPTranscriptMarkdown {
         }
     }
 
+    @MainActor
+    static func forkContext(sourceAgentID: String, messages: [ACPMessage]) -> String? {
+        let markdown = document(
+            title: "Imported conversation",
+            agentName: sourceAgentID,
+            messages: messages
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !markdown.isEmpty else { return nil }
+        return """
+        The conversation below was imported from \(sourceAgentID). Use it as background context for this branch. Provider-specific tool state, hidden context, and attachments were not transferred. Do not summarize or repeat the imported conversation unless I ask.
+
+        \(markdown)
+        """
+    }
+
     /// Session title → filesystem-safe `.md` filename.
     static func sanitizedFilename(title: String) -> String {
         let base = trimmedNonEmpty(title).flatMap { $0 == "New session" ? nil : $0 } ?? "acp-session"

--- a/Alas/Sources/ACP/UI/ACPMessageGutter.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageGutter.swift
@@ -36,6 +36,9 @@ struct ACPMessageGutter<Content: View>: View {
     /// a reference to the live buffer so copy reads the latest text without a
     /// per-row closure recreated on every list evaluation.
     let copySource: CopySource
+    let forkBoundary: ACPForkMessageBoundary?
+    let forkTargets: [ACPSessionForkTarget]
+    let onFork: (ACPForkMessageBoundary, String) -> Void
     @ViewBuilder var content: Content
 
     @StateObject private var hover = ACPDelayedHoverVisibility()
@@ -74,7 +77,13 @@ struct ACPMessageGutter<Content: View>: View {
     }
 
     private var dotsMenu: some View {
-        ACPMessageActionsButton(copySource: copySource, tint: theme.color("fg-muted"))
+        ACPMessageActionsButton(
+            copySource: copySource,
+            forkBoundary: forkBoundary,
+            forkTargets: forkTargets,
+            onFork: onFork,
+            tint: theme.color("fg-muted")
+        )
             .frame(width: 19, height: 19)
             .background(theme.color("bg-3").opacity(0.85))
             .clipShape(RoundedRectangle(cornerRadius: 5))
@@ -89,10 +98,18 @@ struct ACPMessageGutter<Content: View>: View {
 
 private struct ACPMessageActionsButton: NSViewRepresentable {
     let copySource: ACPMessageCopySource
+    let forkBoundary: ACPForkMessageBoundary?
+    let forkTargets: [ACPSessionForkTarget]
+    let onFork: (ACPForkMessageBoundary, String) -> Void
     let tint: Color
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(copySource: copySource)
+        Coordinator(
+            copySource: copySource,
+            forkBoundary: forkBoundary,
+            forkTargets: forkTargets,
+            onFork: onFork
+        )
     }
 
     func makeNSView(context: Context) -> NSButton {
@@ -105,15 +122,29 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
 
     func updateNSView(_ button: NSButton, context: Context) {
         context.coordinator.copySource = copySource
+        context.coordinator.forkBoundary = forkBoundary
+        context.coordinator.forkTargets = forkTargets
+        context.coordinator.onFork = onFork
         button.contentTintColor = NSColor(tint)
     }
 
     @MainActor
     final class Coordinator: NSObject {
         var copySource: ACPMessageCopySource
+        var forkBoundary: ACPForkMessageBoundary?
+        var forkTargets: [ACPSessionForkTarget]
+        var onFork: (ACPForkMessageBoundary, String) -> Void
 
-        init(copySource: ACPMessageCopySource) {
+        init(
+            copySource: ACPMessageCopySource,
+            forkBoundary: ACPForkMessageBoundary?,
+            forkTargets: [ACPSessionForkTarget],
+            onFork: @escaping (ACPForkMessageBoundary, String) -> Void
+        ) {
             self.copySource = copySource
+            self.forkBoundary = forkBoundary
+            self.forkTargets = forkTargets
+            self.onFork = onFork
         }
 
         @objc func showMenu(_ sender: NSButton) {
@@ -125,6 +156,26 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
             )
             copyItem.target = self
             menu.addItem(copyItem)
+            if forkBoundary != nil, !forkTargets.isEmpty {
+                menu.addItem(.separator())
+                let forkItem = NSMenuItem(title: "Fork from here", action: nil, keyEquivalent: "")
+                let submenu = NSMenu()
+                for target in forkTargets {
+                    let title = target.isSameAgent
+                        ? "\(target.displayName)\tSame agent"
+                        : target.displayName
+                    let item = NSMenuItem(
+                        title: title,
+                        action: #selector(forkFromHere(_:)),
+                        keyEquivalent: ""
+                    )
+                    item.target = self
+                    item.representedObject = target.id
+                    submenu.addItem(item)
+                }
+                forkItem.submenu = submenu
+                menu.addItem(forkItem)
+            }
             menu.popUp(
                 positioning: copyItem,
                 at: NSPoint(x: 0, y: sender.bounds.height + 2),
@@ -136,6 +187,13 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
             let text = copySource.markdown
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(text, forType: .string)
+        }
+
+        @objc private func forkFromHere(_ sender: NSMenuItem) {
+            guard let boundary = forkBoundary,
+                  let targetID = sender.representedObject as? String
+            else { return }
+            onFork(boundary, targetID)
         }
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -1500,6 +1500,7 @@ struct ACPMessageList: View {
                 session: session,
                 onOpenDiff: onOpenDiff,
                 onLoadFullToolCallContent: onLoadFullToolCallContent,
+                isForkEligible: session.canForkMessage(at: visibleRow.index),
                 forkTargets: forkTargets,
                 onFork: onFork
             )
@@ -1560,6 +1561,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     let session: ACPSession
     let onOpenDiff: (String) -> Void
     let onLoadFullToolCallContent: (String) async -> String?
+    let isForkEligible: Bool
     let forkTargets: [ACPSessionForkTarget]
     let onFork: (ACPForkMessageBoundary, String) -> Void
 
@@ -1604,10 +1606,6 @@ struct ACPTranscriptRowContent: View, Equatable {
         let trustedImageRoot: URL?
         let isForkEligible: Bool
         let forkTargets: [ACPSessionForkTarget]
-    }
-
-    private var isForkEligible: Bool {
-        session.canForkMessage(at: messageIndex)
     }
 
     var body: some View {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -32,6 +32,8 @@ struct ACPMessageList: View {
     let onLoadFullToolCallContent: (String) async -> String?
     let forkTargets: [ACPSessionForkTarget]
     let onFork: (ACPForkMessageBoundary, String) -> Void
+    let onOpenForkSource: (String) -> Void
+    let agentDisplayName: (String) -> String
     @Environment(\.theme) private var theme
     @State private var scrollViewRef = ACPWeakScrollViewRef()
     @State private var latestTopVisibleAnchor = ACPMutableScrollAnchor()
@@ -174,6 +176,19 @@ struct ACPMessageList: View {
                             }
                             ForEach(visibleRows) { row in
                                 visibleRow(row)
+                                if let fork = session.forkRecord,
+                                   fork.phase == .ready,
+                                   row.index == fork.inheritedMessageCount - 1,
+                                   let mechanism = fork.mechanism {
+                                    ACPSessionForkDivider(
+                                        presentation: .init(
+                                            sourceAgentName: agentDisplayName(fork.sourceAgentID),
+                                            mechanism: mechanism
+                                        ),
+                                        onOpenSource: { onOpenForkSource(fork.sourceSessionID) }
+                                    )
+                                    .id("__fork_divider__")
+                                }
                             }
                             if Self.shouldShowBottomPaginationSentinel(
                                 visibleTail: transcript.visibleTailBound,

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -30,6 +30,8 @@ struct ACPMessageList: View {
     /// to `ACPSessionManager.reloadFullToolCallContent`. Returns nil when
     /// the row is gone or the payload is undecodable.
     let onLoadFullToolCallContent: (String) async -> String?
+    let forkTargets: [ACPSessionForkTarget]
+    let onFork: (ACPForkMessageBoundary, String) -> Void
     @Environment(\.theme) private var theme
     @State private var scrollViewRef = ACPWeakScrollViewRef()
     @State private var latestTopVisibleAnchor = ACPMutableScrollAnchor()
@@ -1489,6 +1491,7 @@ struct ACPMessageList: View {
             let message = transcript.messages[visibleRow.index]
             ACPTranscriptRowContent(
                 stableId: visibleRow.stableId,
+                messageIndex: visibleRow.index,
                 message: message,
                 contentMaxWidth: contentMaxWidth,
                 typography: typography,
@@ -1496,7 +1499,9 @@ struct ACPMessageList: View {
                 transcript: transcript,
                 session: session,
                 onOpenDiff: onOpenDiff,
-                onLoadFullToolCallContent: onLoadFullToolCallContent
+                onLoadFullToolCallContent: onLoadFullToolCallContent,
+                forkTargets: forkTargets,
+                onFork: onFork
             )
             .equatable()
             .background(rowFrameReporter(id: visibleRow.stableId))
@@ -1522,6 +1527,7 @@ struct ACPMessageList: View {
 struct ACPTranscriptRowContent: View, Equatable {
     // Compared (render-relevant values):
     let stableId: String
+    let messageIndex: Int
     let message: ACPMessage
     let contentMaxWidth: CGFloat
     let typography: ACPChatTypography
@@ -1554,17 +1560,21 @@ struct ACPTranscriptRowContent: View, Equatable {
     let session: ACPSession
     let onOpenDiff: (String) -> Void
     let onLoadFullToolCallContent: (String) async -> String?
+    let forkTargets: [ACPSessionForkTarget]
+    let onFork: (ACPForkMessageBoundary, String) -> Void
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         equalityKey(
             stableId: lhs.stableId, message: lhs.message,
             contentMaxWidth: lhs.contentMaxWidth, typography: lhs.typography,
-            trustedImageRoot: lhs.trustedImageRoot
+            trustedImageRoot: lhs.trustedImageRoot,
+            isForkEligible: lhs.isForkEligible, forkTargets: lhs.forkTargets
         )
         == equalityKey(
             stableId: rhs.stableId, message: rhs.message,
             contentMaxWidth: rhs.contentMaxWidth, typography: rhs.typography,
-            trustedImageRoot: rhs.trustedImageRoot
+            trustedImageRoot: rhs.trustedImageRoot,
+            isForkEligible: rhs.isForkEligible, forkTargets: rhs.forkTargets
         )
     }
 
@@ -1575,11 +1585,14 @@ struct ACPTranscriptRowContent: View, Equatable {
         message: ACPMessage,
         contentMaxWidth: CGFloat,
         typography: ACPChatTypography,
-        trustedImageRoot: URL?
+        trustedImageRoot: URL?,
+        isForkEligible: Bool = false,
+        forkTargets: [ACPSessionForkTarget] = []
     ) -> EqualityKey {
         EqualityKey(
             stableId: stableId, message: message, contentMaxWidth: contentMaxWidth,
-            typography: typography, trustedImageRoot: trustedImageRoot
+            typography: typography, trustedImageRoot: trustedImageRoot,
+            isForkEligible: isForkEligible, forkTargets: forkTargets
         )
     }
 
@@ -1589,12 +1602,23 @@ struct ACPTranscriptRowContent: View, Equatable {
         let contentMaxWidth: CGFloat
         let typography: ACPChatTypography
         let trustedImageRoot: URL?
+        let isForkEligible: Bool
+        let forkTargets: [ACPSessionForkTarget]
+    }
+
+    private var isForkEligible: Bool {
+        session.canForkMessage(at: messageIndex)
     }
 
     var body: some View {
         switch message {
         case .user(_, _, let text, let attachments, let delegatedSource):
-            ACPMessageGutter(copySource: .text(text)) {
+            ACPMessageGutter(
+                copySource: .text(text),
+                forkBoundary: forkBoundary(kind: .user),
+                forkTargets: forkTargets,
+                onFork: onFork
+            ) {
                 UserMessageRow(
                     text: text,
                     attachments: attachments,
@@ -1604,7 +1628,12 @@ struct ACPTranscriptRowContent: View, Equatable {
                 )
             }
         case .agent(_, _, let buf):
-            ACPMessageGutter(copySource: .streaming(buf)) {
+            ACPMessageGutter(
+                copySource: .streaming(buf),
+                forkBoundary: forkBoundary(kind: .agent),
+                forkTargets: forkTargets,
+                onFork: onFork
+            ) {
                 AgentMessageRow(
                     messageId: stableId,
                     transcript: transcript,
@@ -1627,6 +1656,15 @@ struct ACPTranscriptRowContent: View, Equatable {
         case .systemNotice(_, let text):
             ACPSystemNoticeView(text: text)
         }
+    }
+
+    private func forkBoundary(kind: ACPForkMessageBoundary.Kind) -> ACPForkMessageBoundary? {
+        guard ACPMessageForkMenuPolicy.showsForkAction(
+            messageKind: message.kind,
+            isEligible: isForkEligible,
+            targetCount: forkTargets.count
+        ) else { return nil }
+        return ACPForkMessageBoundary(stableID: stableId, kind: kind)
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPSessionForkDivider.swift
+++ b/Alas/Sources/ACP/UI/ACPSessionForkDivider.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct ACPSessionForkPresentation: Equatable {
+    let title: String
+    let notice: String?
+
+    init(sourceAgentName: String, mechanism: ACPSessionForkMechanism) {
+        switch mechanism {
+        case .nativeACP:
+            title = "Forked from \(sourceAgentName)"
+            notice = nil
+        case .transcriptTransfer:
+            title = "Conversation imported from \(sourceAgentName)"
+            notice = "Provider-specific tool state, hidden context, and attachments were not transferred. This chat shares the source chat’s current worktree."
+        }
+    }
+}
+
+struct ACPSessionForkDivider: View {
+    let presentation: ACPSessionForkPresentation
+    let onOpenSource: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                Rectangle().fill(theme.color("line")).frame(height: 1)
+                Button(presentation.title, action: onOpenSource)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(theme.color("accent"))
+                    .help("Open source chat")
+                Rectangle().fill(theme.color("line")).frame(height: 1)
+            }
+            if let notice = presentation.notice {
+                Text(notice)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("fg-muted"))
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -401,7 +401,22 @@ private struct ACPSessionView: View {
                     sessionId: sessionId, toolCallId: toolCallId)
             },
             forkTargets: state.acpForkTargets(sourceAgentID: session.agentId),
-            onFork: { _, _ in }
+            onFork: { boundary, targetAgentID in
+                state.forkACPSession(
+                    worktree: worktree,
+                    sourceSessionID: sessionId,
+                    boundary: boundary,
+                    targetAgentID: targetAgentID
+                )
+            },
+            onOpenForkSource: { sourceSessionID in
+                Task {
+                    await state.openExistingACPSession(sessionId: sourceSessionID)
+                }
+            },
+            agentDisplayName: { agentID in
+                state.agent(id: agentID)?.displayName ?? agentID
+            }
         )
     }
 

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -399,7 +399,9 @@ private struct ACPSessionView: View {
             onLoadFullToolCallContent: { toolCallId in
                 await manager.reloadFullToolCallContent(
                     sessionId: sessionId, toolCallId: toolCallId)
-            }
+            },
+            forkTargets: state.acpForkTargets(sourceAgentID: session.agentId),
+            onFork: { _, _ in }
         )
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -321,6 +321,19 @@ final class AppState {
         return agentRegistry.agents.first(where: { $0.id == id })
     }
 
+    func acpForkTargets(sourceAgentID: String) -> [ACPSessionForkTarget] {
+        ACPForkTargetPolicy.targets(
+            sourceAgentID: sourceAgentID,
+            enabledAgents: agentRegistry.enabled().map {
+                ACPForkAgentOption(id: $0.id, displayName: $0.displayName)
+            },
+            sourceAgent: agentRegistry.agents.first(where: { $0.id == sourceAgentID }).map {
+                ACPForkAgentOption(id: $0.id, displayName: $0.displayName)
+            },
+            catalogAgentIDs: ACPLaunchCatalog.specs.map(\.agentID)
+        )
+    }
+
     /// Recompute `agentRegistry` from `config.agents` + a fresh detection
     /// scan. Safe to call repeatedly.
     func rescanAgents() {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5253,6 +5253,35 @@ final class AppState {
         tabs.append(acpSession: state, to: worktree.id)
     }
 
+    func forkACPSession(
+        worktree: Worktree,
+        sourceSessionID: ACPSession.ID,
+        boundary: ACPForkMessageBoundary,
+        targetAgentID: String
+    ) {
+        guard let manager = acpManager(for: worktree) else { return }
+        Task { @MainActor in
+            do {
+                let target = try await manager.createFork(
+                    sourceSessionID: sourceSessionID,
+                    boundary: boundary,
+                    targetAgentID: targetAgentID,
+                    autoRunDefault: config.harness.acpAutoRunByDefault
+                )
+                let tabState = ACPSessionTabState(sessionId: target.id, title: target.title)
+                let tab = tabs.append(acpSession: tabState, to: worktree.id)
+                tabs.activate(worktreeId: worktree.id, tabId: tab.id)
+                await manager.attach(
+                    to: target.id,
+                    freshlyCreated: true
+                )
+            } catch {
+                manager.liveSession(for: sourceSessionID)?.lastError =
+                    "Could not create fork: \(error.localizedDescription)"
+            }
+        }
+    }
+
     /// Route a prepared handoff into the active ACP tab when its composer is
     /// safely empty; otherwise preserve the current draft and open a new tab.
     func openACPHandoff(agentID: String, initialPrompt: String) {

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -195,6 +195,39 @@ struct ACPConnectionTests {
         #expect(params.mcpServers == mcpServers)
     }
 
+    @Test("forkSession carries broker key and defers durable acknowledgement")
+    func forkSessionDurableRPC() async throws {
+        let mock = ACPMockClient()
+        let acknowledgement = DurableAcknowledgementRecorder()
+        mock.scriptResponse(method: "session/fork") { _ in
+            ACPResponse(
+                body: try JSONEncoder().encode(ACPSessionNewResult(
+                    sessionId: "forked",
+                    availableModels: [],
+                    availableModes: [],
+                    currentModel: nil,
+                    currentMode: nil,
+                    promptSuggestions: []
+                )),
+                durableConsumptionAcknowledgement: { acknowledgement.record() }
+            )
+        }
+        let connection = ACPConnection(client: mock)
+
+        let result = try await connection.forkSession(
+            cwd: "/tmp/wt",
+            sessionId: "source-remote",
+            mcpServers: [],
+            brokerOperationKey: "startup:target:session/fork:source-remote"
+        )
+
+        #expect(result.sessionId == "forked")
+        #expect(mock.sent.last?.brokerOperationKey == "startup:target:session/fork:source-remote")
+        #expect(acknowledgement.count == 0)
+        connection.acknowledgeDurableSessionResponses()
+        #expect(acknowledgement.count == 1)
+    }
+
     @Test("listSessions sends cwd and opaque cursor and decodes a page")
     func listSessionsRPC() async throws {
         let mock = ACPMockClient()
@@ -280,5 +313,22 @@ struct ACPConnectionTests {
         let conn = ACPConnection(client: mock)
         let result = try await conn.setConfigOption(sessionId: "s", configId: "effort", value: .string("high"))
         #expect(result.isEmpty)
+    }
+}
+
+private final class DurableAcknowledgementRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func record() {
+        lock.lock()
+        value += 1
+        lock.unlock()
     }
 }

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -228,6 +228,41 @@ struct ACPConnectionTests {
         #expect(acknowledgement.count == 1)
     }
 
+    @Test("forkSession rejects an empty session id without consuming its durable response")
+    func forkSessionRejectsEmptySessionID() async throws {
+        let mock = ACPMockClient()
+        let acknowledgement = DurableAcknowledgementRecorder()
+        mock.scriptResponse(method: "session/fork") { _ in
+            ACPResponse(
+                body: try JSONEncoder().encode(ACPSessionNewResult(
+                    sessionId: "",
+                    availableModels: [],
+                    availableModes: [],
+                    currentModel: nil,
+                    currentMode: nil,
+                    promptSuggestions: []
+                )),
+                durableConsumptionAcknowledgement: { acknowledgement.record() }
+            )
+        }
+        let connection = ACPConnection(client: mock)
+
+        do {
+            _ = try await connection.forkSession(
+                cwd: "/tmp/wt",
+                sessionId: "source-remote",
+                mcpServers: []
+            )
+            Issue.record("Expected an empty fork session id to be rejected")
+        } catch is DecodingError {
+            // Expected.
+        }
+
+        #expect(acknowledgement.count == 0)
+        connection.acknowledgeDurableSessionResponses()
+        #expect(acknowledgement.count == 1)
+    }
+
     @Test("listSessions sends cwd and opaque cursor and decodes a page")
     func listSessionsRPC() async throws {
         let mock = ACPMockClient()

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -144,6 +144,36 @@ struct ACPSessionForkAttachTests {
             == "startup:target:session/fork:persisted-source-remote")
     }
 
+    @Test("source advancing past the copied boundary falls back before native fork")
+    func sourceHeadMismatchFallsBackToTranscript() async throws {
+        let store = try seededForkStore()
+        try store.appendMessage(
+            sessionId: "source",
+            id: "msg-source-1",
+            kind: "agent",
+            seq: 1,
+            payload: Data(),
+            createdAt: 1
+        )
+        let client = ACPMockClient()
+        scriptInitialize(client, supportsFork: true)
+        scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(target.remoteSessionId == "new-remote")
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .ready)
+        #expect(fork.mechanism == .transcriptTransfer)
+        #expect(fork.contextDeliveryPending == true)
+    }
+
     @Test("setup failure durably downgrades a negotiating fork before surfacing the error")
     func setupFailureDowngradesNegotiatingFork() async throws {
         let store = try seededForkStore()
@@ -198,8 +228,8 @@ struct ACPSessionForkAttachTests {
         #expect(fork.contextDeliveryPending == true)
     }
 
-    @Test("downgrade persistence failure keeps the fork negotiating")
-    func downgradePersistenceFailureKeepsForkNegotiating() async throws {
+    @Test("downgrade persistence failure blocks the normal setup failure UI")
+    func downgradePersistenceFailureBlocksNormalFailureUI() async throws {
         let store = try seededForkStore()
         try installFinalizeFailure(mechanism: .transcriptTransfer, store: store)
         let manager = ACPSessionManager(
@@ -212,8 +242,14 @@ struct ACPSessionForkAttachTests {
 
         await manager.attach(to: target.id, freshlyCreated: true)
 
-        #expect(target.setupState == .needsSetup(reason: "adapter missing"))
-        #expect(target.agentState == .failed("adapter missing"))
+        #expect(target.setupState != .needsSetup(reason: "adapter missing"))
+        if case .failed(let reason) = target.agentState {
+            #expect(reason.contains("Failed to persist fork fallback"))
+            #expect(!reason.contains("adapter missing"))
+        } else {
+            Issue.record("Expected a durability-specific failure")
+        }
+        #expect(target.lastError?.contains("Failed to persist fork fallback") == true)
         #expect(target.forkRecord?.phase == .negotiatingNative)
         #expect(target.forkRecord?.mechanism == nil)
         #expect(target.forkRecord?.contextDeliveryPending == false)
@@ -276,6 +312,32 @@ struct ACPSessionForkAttachTests {
         #expect(acknowledgements.values == ["close", "fork"])
     }
 
+    @Test("broker pre-send failure durably falls back to transcript transfer")
+    func brokerPreSendFailureFallsBackToTranscript() async throws {
+        let store = try seededForkStore()
+        let broker = ForkPreSendFailureBrokerService()
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(await broker.sentMethods == ["session/fork", "session/new"])
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+        #expect(target.remoteSessionId == "new-remote")
+        #expect(manager.runners[target.id] != nil)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .ready)
+        #expect(fork.mechanism == .transcriptTransfer)
+    }
+
     @Test("broker replay failure keeps negotiation and reuses the durable fork key")
     func brokerReplayFailureRetriesStableForkOperation() async throws {
         let store = try seededForkStore()
@@ -332,6 +394,14 @@ struct ACPSessionForkAttachTests {
             id: "source",
             remoteSessionID: sourceRemoteSessionID
         ))
+        try store.appendMessage(
+            sessionId: "source",
+            id: "msg-source-0",
+            kind: "user",
+            seq: 0,
+            payload: Data(),
+            createdAt: 0
+        )
         try store.createFork(
             session: row(id: "target", remoteSessionID: nil),
             messages: [],
@@ -468,6 +538,108 @@ private final class ForkAcknowledgementRecorder: @unchecked Sendable {
 
 private enum ForkReplayBrokerError: Error {
     case trailingReplayFailure
+    case preSendFailure
+}
+
+private actor ForkPreSendFailureBrokerService: ACPBrokerServicing {
+    private var nextRequestID: UInt64 = 0
+    private(set) var sentMethods: [String] = []
+
+    func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
+        ACPBrokerOpenResult(
+            snapshot: snapshot(
+                brokerId: params.brokerId,
+                sessionId: params.sessionId,
+                acknowledgedCursor: .init(rawValue: 0)
+            ),
+            adopted: false
+        )
+    }
+
+    func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
+        ACPBrokerAttachResult(
+            snapshot: snapshot(
+                brokerId: params.brokerId,
+                sessionId: "target",
+                acknowledgedCursor: params.acknowledgedCursor
+            ),
+            events: []
+        )
+    }
+
+    func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        sentMethods.append(params.method)
+        if params.method == "session/fork" {
+            throw ForkReplayBrokerError.preSendFailure
+        }
+        nextRequestID += 1
+        return ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: nextRequestID),
+            replayed: false,
+            result: .object([
+                "sessionId": .string("new-remote"),
+                "availableModels": .array([]),
+                "availableModes": .array([]),
+                "promptSuggestions": .array([]),
+                "configOptions": .array([])
+            ]),
+            pending: false
+        )
+    }
+
+    func notify(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    private func snapshot(
+        brokerId: ACPBrokerID,
+        sessionId: String,
+        acknowledgedCursor: ACPBrokerEventCursor
+    ) -> ACPBrokerSnapshot {
+        ACPBrokerSnapshot(
+            metadata: ACPBrokerMetadata(
+                brokerId: brokerId,
+                generation: ACPBrokerGeneration(rawValue: 11),
+                alasSessionId: sessionId,
+                adapterProgram: "mock",
+                adapterArgs: [],
+                cwd: "/tmp/wt",
+                envKeys: [],
+                createdAtMillis: 10
+            ),
+            initializeResult: .object([
+                "protocolVersion": .number(1),
+                "agentCapabilities": .object([
+                    "sessionCapabilities": .object([
+                        "fork": .object([:])
+                    ])
+                ]),
+                "authMethods": .array([])
+            ]),
+            remoteSessionResult: nil,
+            turnState: .idle,
+            acknowledgedCursor: acknowledgedCursor,
+            journalTail: acknowledgedCursor,
+            pendingRequests: [],
+            operations: []
+        )
+    }
 }
 
 private actor ForkReplayBrokerService: ACPBrokerServicing {

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -33,6 +33,155 @@ struct ACPSessionForkAttachTests {
         #expect(fork.contextDeliveryPending == false)
     }
 
+    @Test("native fork holds later source prompts until the remote branch exists")
+    func nativeForkSerializesLaterSourcePrompt() async throws {
+        let store = try seededForkStore()
+        let sourceClient = ACPMockClient()
+        scriptInitialize(sourceClient, supportsFork: true)
+        scriptSessionResult(sourceClient, method: "session/load", sessionId: "source-remote")
+
+        let forkGate = ForkAttachGate()
+        let targetClient = ACPMockClient()
+        scriptInitialize(targetClient, supportsFork: true)
+        targetClient.scriptAsync(method: "session/fork") { _ in
+            await forkGate.enterAndWait()
+            return try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "forked-remote",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        var clients = [sourceClient, targetClient]
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in
+                ACPConnection(client: clients.removeFirst())
+            }
+        )
+        let source = try #require(manager.placeholderSession(id: "source"))
+        await manager.hydrateIfNeeded(id: source.id)
+        await manager.attach(to: source.id, freshlyCreated: false)
+        let target = try await hydratedTarget(manager)
+
+        let attachTask = Task {
+            await manager.attach(to: target.id, freshlyCreated: true)
+        }
+        try await waitUntil {
+            targetClient.sent.contains { $0.method == "session/fork" }
+        }
+
+        source.contextRestoreWarning = .init(
+            message: "Agent context could not be restored.",
+            canSendTranscript: true
+        )
+        #expect(manager.sendTranscriptAsContext(
+            sessionId: source.id,
+            agentName: "Claude"
+        ) == false)
+        #expect(source.contextRecoveryStatus != .sendingTranscript)
+
+        var submitCompleted: Bool?
+        #expect(manager.submit(
+            sessionId: source.id,
+            text: "After the branch",
+            attachments: [],
+            intent: .auto
+        ) { submitCompleted = $0 })
+        try await waitUntil { submitCompleted != nil }
+
+        #expect(sourceClient.sent.contains { $0.method == "session/prompt" } == false)
+        #expect(source.queue.count == 1)
+        #expect(submitCompleted == true)
+
+        await forkGate.release()
+        await attachTask.value
+        try await waitUntil {
+            sourceClient.sent.contains { $0.method == "session/prompt" }
+        }
+    }
+
+    @Test("native fork drains source persistence before revalidating the boundary")
+    func nativeForkDrainsSourcePersistenceBeforeBoundaryCheck() async throws {
+        let store = try seededForkStore()
+        let sourceClient = ACPMockClient()
+        scriptInitialize(sourceClient, supportsFork: true)
+        scriptSessionResult(sourceClient, method: "session/load", sessionId: "source-remote")
+        sourceClient.script(method: "session/prompt") { _ in Data("null".utf8) }
+
+        let initializeGate = ForkAttachGate()
+        let targetClient = ACPMockClient()
+        targetClient.scriptAsync(method: "initialize") { _ in
+            await initializeGate.enterAndWait()
+            return try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(
+                    sessionCapabilities: .init(fork: .init())
+                ),
+                authMethods: []
+            ))
+        }
+        scriptSessionResult(targetClient, method: "session/fork", sessionId: "forked-remote")
+        scriptSessionResult(targetClient, method: "session/new", sessionId: "new-remote")
+        var clients = [sourceClient, targetClient]
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in
+                ACPConnection(client: clients.removeFirst())
+            }
+        )
+        let source = try #require(manager.placeholderSession(id: "source"))
+        await manager.hydrateIfNeeded(id: source.id)
+        await manager.attach(to: source.id, freshlyCreated: false)
+        let target = try await hydratedTarget(manager)
+
+        let attachTask = Task {
+            await manager.attach(to: target.id, freshlyCreated: true)
+        }
+        try await waitUntil {
+            targetClient.sent.contains { $0.method == "initialize" }
+        }
+
+        let writeLock = ForkSQLiteWriteLock(path: store.path)
+        defer { writeLock.release() }
+        let (locked, lockContinuation) = AsyncStream<Void>.makeStream()
+        let lockTask = Task.detached {
+            try writeLock.hold {
+                lockContinuation.yield()
+                lockContinuation.finish()
+            }
+        }
+        var lockIterator = locked.makeAsyncIterator()
+        _ = await lockIterator.next()
+
+        source.transcript.appendMessage(.user(
+            id: UUID(),
+            text: "Advanced source",
+            attachments: []
+        ))
+        let sourceRunner = try #require(manager.runners[source.id])
+        #expect(sourceRunner.persistIndices([1]))
+
+        await initializeGate.release()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(targetClient.sent.contains { $0.method == "session/fork" } == false)
+
+        writeLock.release()
+        try await lockTask.value
+        await attachTask.value
+        #expect(targetClient.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+    }
+
     @Test("negotiating native fork recovers the durable response after relaunch")
     func negotiatingNativeForkRecoversAfterRelaunch() async throws {
         let storeA = try seededForkStore()
@@ -602,7 +751,11 @@ struct ACPSessionForkAttachTests {
             id: "msg-source-0",
             kind: "user",
             seq: 0,
-            payload: Data(),
+            payload: try ACPMessageCodec.encode(.user(
+                id: UUID(),
+                text: "Source prompt",
+                attachments: []
+            )),
             createdAt: 0
         )
         try store.createFork(
@@ -733,9 +886,48 @@ struct ACPSessionForkAttachTests {
             try await Task.sleep(for: .milliseconds(10))
         }
     }
+
+    private actor ForkAttachGate {
+        private var released = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func enterAndWait() async {
+            guard !released else { return }
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func release() {
+            released = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
 }
 
 private struct ForkAttachTestTimeout: Error {}
+
+private final class ForkSQLiteWriteLock: @unchecked Sendable {
+    let path: String
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+
+    init(path: String) {
+        self.path = path
+    }
+
+    func hold(didLock: @Sendable () -> Void) throws {
+        let database = try SQLiteDatabase(path: path)
+        try database.exec("BEGIN IMMEDIATE")
+        didLock()
+        releaseSemaphore.wait()
+        try database.exec("ROLLBACK")
+    }
+
+    func release() {
+        releaseSemaphore.signal()
+    }
+}
 
 private final class ForkAcknowledgementRecorder: @unchecked Sendable {
     private let lock = NSLock()

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -11,10 +11,13 @@ struct ACPSessionForkAttachTests {
         let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
-        #expect(manager.sessions["source"] == nil)
+        #expect(manager.runners["source"] != nil)
         await manager.attach(to: target.id, freshlyCreated: true)
 
         #expect(client.sent.map(\.method) == ["initialize", "session/fork"])
@@ -41,12 +44,65 @@ struct ACPSessionForkAttachTests {
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/fork", sessionId: "orphaned-remote")
         scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
         await manager.attach(to: target.id, freshlyCreated: true)
 
         #expect(client.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(target.remoteSessionId == "new-remote")
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+    }
+
+    @Test("missing source runner falls back without issuing session/fork")
+    func missingSourceRunnerFallsBackWithoutForking() async throws {
+        let store = try seededForkStore()
+        let client = durableMockClient()
+        scriptInitialize(client, supportsFork: true)
+        scriptSessionResult(client, method: "session/fork", sessionId: "orphaned-remote")
+        scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        #expect(manager.runners["source"] == nil)
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(target.remoteSessionId == "new-remote")
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+    }
+
+    @Test("source lease takeover falls back without issuing session/fork")
+    func sourceLeaseTakeoverFallsBackWithoutForking() async throws {
+        let store = try seededForkStore()
+        let client = durableMockClient()
+        scriptInitialize(client, supportsFork: true)
+        scriptSessionResult(client, method: "session/fork", sessionId: "orphaned-remote")
+        scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
+        let target = try await hydratedTarget(manager)
+        try store.seizeLease(
+            sessionId: "source",
+            instanceId: "other-instance",
+            pid: Int64(getpid()),
+            now: Int64(Date().timeIntervalSince1970)
+        )
+
+        #expect(manager.runners["source"] != nil)
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(manager.runners["source"] == nil)
         #expect(target.remoteSessionId == "new-remote")
         #expect(target.forkRecord?.phase == .ready)
         #expect(target.forkRecord?.mechanism == .transcriptTransfer)
@@ -298,7 +354,10 @@ struct ACPSessionForkAttachTests {
         let client = ACPMockClient()
         scriptInitialize(client, supportsFork: false)
         scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
         await manager.attach(to: target.id, freshlyCreated: true)
@@ -328,7 +387,10 @@ struct ACPSessionForkAttachTests {
             ))
         }
         scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
         await manager.attach(to: target.id, freshlyCreated: true)
@@ -353,7 +415,10 @@ struct ACPSessionForkAttachTests {
                 data: nil
             ))
         }
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
         await manager.attach(to: target.id, freshlyCreated: true)
@@ -391,10 +456,13 @@ struct ACPSessionForkAttachTests {
         let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
-        #expect(manager.sessions["source"] == nil)
+        #expect(manager.runners["source"] != nil)
         await manager.attach(to: target.id, freshlyCreated: true)
 
         let params = try #require(client.sent.last?.params as? ACPSessionForkParams)
@@ -417,7 +485,10 @@ struct ACPSessionForkAttachTests {
         let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
         await manager.attach(to: target.id, freshlyCreated: true)
@@ -550,7 +621,10 @@ struct ACPSessionForkAttachTests {
                 }
             )
         }
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
         await manager.attach(to: target.id, freshlyCreated: true)
@@ -575,12 +649,9 @@ struct ACPSessionForkAttachTests {
     func brokerPreSendFailureFallsBackToTranscript() async throws {
         let store = try seededForkStore()
         let broker = ForkPreSendFailureBrokerService()
-        let manager = ACPSessionManager(
-            worktreeId: "wt",
-            worktreePath: "/tmp/wt",
+        let manager = try await makeManagerWithAttachedBrokerSource(
             store: store,
-            setupEvaluator: { _ in .ready },
-            brokerServiceFactory: { broker }
+            targetService: broker
         )
         let target = try await hydratedTarget(manager)
 
@@ -601,12 +672,9 @@ struct ACPSessionForkAttachTests {
     func brokerReplayFailureRetriesStableForkOperation() async throws {
         let store = try seededForkStore()
         let broker = ForkReplayBrokerService()
-        let manager = ACPSessionManager(
-            worktreeId: "wt",
-            worktreePath: "/tmp/wt",
+        let manager = try await makeManagerWithAttachedBrokerSource(
             store: store,
-            setupEvaluator: { _ in .ready },
-            brokerServiceFactory: { broker }
+            targetService: broker
         )
         let target = try await hydratedTarget(manager)
 
@@ -636,12 +704,9 @@ struct ACPSessionForkAttachTests {
     func repeatedStartupReplayFailurePreservesCompletedNativeFork() async throws {
         let store = try seededForkStore()
         let broker = ForkReplayBrokerService(failSecondStartupReplay: true)
-        let manager = ACPSessionManager(
-            worktreeId: "wt",
-            worktreePath: "/tmp/wt",
+        let manager = try await makeManagerWithAttachedBrokerSource(
             store: store,
-            setupEvaluator: { _ in .ready },
-            brokerServiceFactory: { broker }
+            targetService: broker
         )
         let target = try await hydratedTarget(manager)
 
@@ -678,12 +743,9 @@ struct ACPSessionForkAttachTests {
             message: "Method not found",
             data: nil
         ))
-        let manager = ACPSessionManager(
-            worktreeId: "wt",
-            worktreePath: "/tmp/wt",
+        let manager = try await makeManagerWithAttachedBrokerSource(
             store: store,
-            setupEvaluator: { _ in .ready },
-            brokerServiceFactory: { broker }
+            targetService: broker
         )
         let target = try await hydratedTarget(manager)
 
@@ -706,12 +768,9 @@ struct ACPSessionForkAttachTests {
     func sourceMismatchClosesAndReleasesReplayedFork() async throws {
         let store = try seededForkStore()
         let broker = ForkReplayBrokerService()
-        let manager = ACPSessionManager(
-            worktreeId: "wt",
-            worktreePath: "/tmp/wt",
+        let manager = try await makeManagerWithAttachedBrokerSource(
             store: store,
-            setupEvaluator: { _ in .ready },
-            brokerServiceFactory: { broker }
+            targetService: broker
         )
         let target = try await hydratedTarget(manager)
 
@@ -750,7 +809,10 @@ struct ACPSessionForkAttachTests {
         let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
-        let manager = makeManager(store: store, client: client)
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
         let target = try await hydratedTarget(manager)
 
         await manager.attach(to: target.id, freshlyCreated: true)
@@ -827,6 +889,66 @@ struct ACPSessionForkAttachTests {
             setupEvaluator: { _ in .ready },
             connectionFactory: { _, _, _ in ACPConnection(client: client) }
         )
+    }
+
+    private func makeManagerWithAttachedSource(
+        store: ACPSessionStore,
+        targetClient: ACPMockClient
+    ) async throws -> ACPSessionManager {
+        let sourceClient = ACPMockClient()
+        scriptInitialize(sourceClient, supportsFork: true)
+        let sourceRemoteSessionID = try #require(
+            try store.loadSession(id: "source")?.remoteSessionId
+        )
+        scriptSessionResult(
+            sourceClient,
+            method: "session/load",
+            sessionId: sourceRemoteSessionID
+        )
+        var clients = [sourceClient, targetClient]
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in
+                ACPConnection(client: clients.removeFirst())
+            }
+        )
+        let source = try #require(manager.placeholderSession(id: "source"))
+        await manager.hydrateIfNeeded(id: source.id)
+        await manager.attach(to: source.id, freshlyCreated: false)
+        #expect(manager.runners[source.id] != nil)
+        return manager
+    }
+
+    private func makeManagerWithAttachedBrokerSource<Service: ACPBrokerServicing>(
+        store: ACPSessionStore,
+        targetService: Service
+    ) async throws -> ACPSessionManager {
+        let sourceRemoteSessionID = try #require(
+            try store.loadSession(id: "source")?.remoteSessionId
+        )
+        let sourceService = ForkSourceBrokerService(remoteSessionID: sourceRemoteSessionID)
+        var providedSourceService = false
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: {
+                if !providedSourceService {
+                    providedSourceService = true
+                    return sourceService
+                }
+                return targetService
+            }
+        )
+        let source = try #require(manager.placeholderSession(id: "source"))
+        await manager.hydrateIfNeeded(id: source.id)
+        await manager.attach(to: source.id, freshlyCreated: false)
+        #expect(manager.runners[source.id] != nil)
+        return manager
     }
 
     private func hydratedTarget(_ manager: ACPSessionManager) async throws -> ACPSession {

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -8,7 +8,7 @@ struct ACPSessionForkAttachTests {
     @Test("negotiating fork uses native ACP and persists the returned remote session")
     func negotiatingForkUsesNativeACP() async throws {
         let store = try seededForkStore()
-        let client = ACPMockClient()
+        let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
         let manager = makeManager(store: store, client: client)
@@ -34,6 +34,25 @@ struct ACPSessionForkAttachTests {
         #expect(fork.contextDeliveryPending == false)
     }
 
+    @Test("non-durable connection falls back without issuing session/fork")
+    func nonDurableConnectionFallsBackWithoutForking() async throws {
+        let store = try seededForkStore()
+        let client = ACPMockClient()
+        scriptInitialize(client, supportsFork: true)
+        scriptSessionResult(client, method: "session/fork", sessionId: "orphaned-remote")
+        scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(target.remoteSessionId == "new-remote")
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+    }
+
     @Test("native fork holds later source prompts until the remote branch exists")
     func nativeForkSerializesLaterSourcePrompt() async throws {
         let store = try seededForkStore()
@@ -42,7 +61,7 @@ struct ACPSessionForkAttachTests {
         scriptSessionResult(sourceClient, method: "session/load", sessionId: "source-remote")
 
         let forkGate = ForkAttachGate()
-        let targetClient = ACPMockClient()
+        let targetClient = durableMockClient()
         scriptInitialize(targetClient, supportsFork: true)
         targetClient.scriptAsync(method: "session/fork") { _ in
             await forkGate.enterAndWait()
@@ -116,7 +135,7 @@ struct ACPSessionForkAttachTests {
         sourceClient.script(method: "session/prompt") { _ in Data("null".utf8) }
 
         let initializeGate = ForkAttachGate()
-        let targetClient = ACPMockClient()
+        let targetClient = durableMockClient()
         targetClient.scriptAsync(method: "initialize") { _ in
             await initializeGate.enterAndWait()
             return try JSONEncoder().encode(ACPInitializeResult(
@@ -299,7 +318,7 @@ struct ACPSessionForkAttachTests {
     @Test("session/fork JSON-RPC failure falls back on the same connection")
     func forkJSONRPCFailureFallsBackOnSameConnection() async throws {
         let store = try seededForkStore()
-        let client = ACPMockClient()
+        let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         client.script(method: "session/fork") { _ in
             throw ACPClientError.jsonrpc(.init(
@@ -325,7 +344,7 @@ struct ACPSessionForkAttachTests {
     @Test("fork auth failure finalizes transcript fallback and keeps needs-auth state")
     func forkAuthFailurePreservesNeedsAuth() async throws {
         let store = try seededForkStore()
-        let client = ACPMockClient()
+        let client = durableMockClient()
         scriptInitialize(client, supportsFork: true, authMethods: [terminalAuthMethod()])
         client.script(method: "session/fork") { _ in
             throw ACPClientError.jsonrpc(.init(
@@ -369,7 +388,7 @@ struct ACPSessionForkAttachTests {
     @Test("native fork resolves the source remote ID from persistence")
     func nativeForkResolvesSourceFromPersistence() async throws {
         let store = try seededForkStore(sourceRemoteSessionID: "persisted-source-remote")
-        let client = ACPMockClient()
+        let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
         let manager = makeManager(store: store, client: client)
@@ -395,7 +414,7 @@ struct ACPSessionForkAttachTests {
             payload: Data(),
             createdAt: 1
         )
-        let client = ACPMockClient()
+        let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
         let manager = makeManager(store: store, client: client)
@@ -503,7 +522,7 @@ struct ACPSessionForkAttachTests {
     func nativeFinalizationFailureClosesRemoteAndOrdersAcknowledgements() async throws {
         let store = try seededForkStore()
         try installFinalizeFailure(mechanism: .nativeACP, store: store)
-        let client = ACPMockClient()
+        let client = durableMockClient()
         let acknowledgements = ForkAcknowledgementRecorder()
         scriptInitialize(client, supportsFork: true)
         client.scriptResponse(method: "session/fork") { _ in
@@ -728,7 +747,7 @@ struct ACPSessionForkAttachTests {
 
     private func nativeForkOperationKey() async throws -> String? {
         let store = try seededForkStore()
-        let client = ACPMockClient()
+        let client = durableMockClient()
         scriptInitialize(client, supportsFork: true)
         scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
         let manager = makeManager(store: store, client: client)
@@ -737,6 +756,10 @@ struct ACPSessionForkAttachTests {
         await manager.attach(to: target.id, freshlyCreated: true)
 
         return client.sent.first { $0.method == "session/fork" }?.brokerOperationKey
+    }
+
+    private func durableMockClient() -> ACPMockClient {
+        ACPMockClient(providesDurableOperationKeyDeduplication: true)
     }
 
     private func seededForkStore(

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -21,6 +21,7 @@ struct ACPSessionForkAttachTests {
         #expect(client.sent.last?.brokerOperationKey == "startup:target:session/fork:source-remote")
         #expect(manager.runners[target.id] != nil)
         #expect(target.remoteSessionId == "forked-remote")
+        #expect(target.origin == .agentForked)
         #expect(target.forkRecord?.phase == .ready)
         #expect(target.forkRecord?.mechanism == .nativeACP)
         #expect(target.forkRecord?.contextDeliveryPending == false)

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -33,6 +33,96 @@ struct ACPSessionForkAttachTests {
         #expect(fork.contextDeliveryPending == false)
     }
 
+    @Test("negotiating native fork recovers the durable response after relaunch")
+    func negotiatingNativeForkRecoversAfterRelaunch() async throws {
+        let storeA = try seededForkStore()
+        do {
+            let managerA = ACPSessionManager(
+                worktreeId: "wt",
+                worktreePath: "/tmp/wt",
+                store: storeA
+            )
+            let target = try await hydratedTarget(managerA)
+            #expect(target.forkRecord?.phase == .negotiatingNative)
+            managerA.shutdownBackgroundTasks()
+            await managerA.releaseAllOwnedLeases()
+        }
+
+        let storeB = try ACPSessionStore(path: storeA.path)
+        let broker = ForkRelaunchBrokerService(forkResponseAvailable: true)
+        let managerB = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: storeB,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+        let restored = try await hydratedTarget(managerB)
+
+        await managerB.attach(to: restored.id, freshlyCreated: false)
+
+        #expect(restored.forkRecord?.phase == .ready)
+        #expect(restored.forkRecord?.mechanism == .nativeACP)
+        #expect(restored.remoteSessionId == "forked-remote")
+        let sent = await broker.sent
+        #expect(sent.filter { $0.method == "session/fork" }.count == 1)
+        #expect(await broker.replayedForkCount == 1)
+        #expect(sent.first { $0.method == "session/fork" }?.operationKey
+            == ACPBrokerOperationKey(
+                rawValue: "startup:target:session/fork:source-remote"
+            ))
+
+        await managerB.detach(sessionId: restored.id)
+        managerB.shutdownBackgroundTasks()
+        await managerB.releaseAllOwnedLeases()
+    }
+
+    @Test("unavailable durable fork response falls back after relaunch without an unkeyed fork")
+    func unavailableDurableForkResponseFallsBackAfterRelaunch() async throws {
+        let storeA = try seededForkStore()
+        do {
+            let managerA = ACPSessionManager(
+                worktreeId: "wt",
+                worktreePath: "/tmp/wt",
+                store: storeA
+            )
+            _ = try await hydratedTarget(managerA)
+            managerA.shutdownBackgroundTasks()
+            await managerA.releaseAllOwnedLeases()
+        }
+
+        let storeB = try ACPSessionStore(path: storeA.path)
+        let broker = ForkRelaunchBrokerService(forkResponseAvailable: false)
+        let managerB = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: storeB,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+        let restored = try await hydratedTarget(managerB)
+
+        await managerB.attach(to: restored.id, freshlyCreated: false)
+
+        #expect(restored.forkRecord?.phase == .ready)
+        #expect(restored.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(restored.forkRecord?.contextDeliveryPending == true)
+        let sent = await broker.sent
+        #expect(sent.map(\.method) == ["session/fork", "session/new"])
+        let forkRequests = sent.filter { $0.method == "session/fork" }
+        #expect(forkRequests.count == 1)
+        #expect(await broker.replayedForkCount == 1)
+        #expect(forkRequests.allSatisfy {
+            $0.operationKey == ACPBrokerOperationKey(
+                rawValue: "startup:target:session/fork:source-remote"
+            )
+        })
+
+        await managerB.detach(sessionId: restored.id)
+        managerB.shutdownBackgroundTasks()
+        await managerB.releaseAllOwnedLeases()
+    }
+
     @Test("missing fork capability falls back to transcript transfer and session/new")
     func missingForkCapabilityFallsBackToTranscript() async throws {
         let store = try seededForkStore()
@@ -667,6 +757,180 @@ private final class ForkAcknowledgementRecorder: @unchecked Sendable {
 private enum ForkReplayBrokerError: Error {
     case trailingReplayFailure
     case preSendFailure
+}
+
+private actor ForkRelaunchBrokerService: ACPBrokerServicing {
+    private static let forkOperationKey = ACPBrokerOperationKey(
+        rawValue: "startup:target:session/fork:source-remote"
+    )
+    private static let forkCompletionCursor = ACPBrokerEventCursor(rawValue: 2)
+
+    let forkResponseAvailable: Bool
+    private(set) var sent: [ACPBrokerSendParams] = []
+    private(set) var replayedForkCount = 0
+    private var nextRequestID: UInt64 = 0
+
+    init(forkResponseAvailable: Bool) {
+        self.forkResponseAvailable = forkResponseAvailable
+    }
+
+    func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
+        ACPBrokerOpenResult(
+            snapshot: snapshot(
+                brokerId: params.brokerId,
+                sessionId: params.sessionId,
+                acknowledgedCursor: .init(rawValue: 0)
+            ),
+            adopted: true
+        )
+    }
+
+    func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
+        let events = params.acknowledgedCursor < Self.forkCompletionCursor
+            ? [forkCompletionEvent]
+            : []
+        return ACPBrokerAttachResult(
+            snapshot: snapshot(
+                brokerId: params.brokerId,
+                sessionId: "target",
+                acknowledgedCursor: params.acknowledgedCursor
+            ),
+            events: events
+        )
+    }
+
+    func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        sent.append(params)
+        nextRequestID += 1
+        switch params.method {
+        case "session/fork":
+            guard params.operationKey == Self.forkOperationKey else {
+                return ACPBrokerSendResult(
+                    requestId: ACPBrokerAdapterRequestID(rawValue: nextRequestID),
+                    replayed: false,
+                    error: JSONRPCError(
+                        code: -32602,
+                        message: "session/fork did not reuse the durable operation key",
+                        data: nil
+                    ),
+                    pending: false
+                )
+            }
+            replayedForkCount += 1
+            return ACPBrokerSendResult(
+                requestId: ACPBrokerAdapterRequestID(rawValue: nextRequestID),
+                replayed: true,
+                result: forkOutcome.result,
+                error: forkOutcome.error,
+                pending: false
+            )
+        case "session/new":
+            return ACPBrokerSendResult(
+                requestId: ACPBrokerAdapterRequestID(rawValue: nextRequestID),
+                replayed: false,
+                result: sessionResult(id: "new-remote"),
+                pending: false
+            )
+        default:
+            return ACPBrokerSendResult(
+                requestId: ACPBrokerAdapterRequestID(rawValue: nextRequestID),
+                replayed: false,
+                result: .null,
+                pending: false
+            )
+        }
+    }
+
+    func notify(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    private func sessionResult(id: String) -> ACPBrokerJSONValue {
+        .object([
+            "sessionId": .string(id),
+            "availableModels": .array([]),
+            "availableModes": .array([]),
+            "promptSuggestions": .array([]),
+            "configOptions": .array([])
+        ])
+    }
+
+    private var forkOutcome: ACPBrokerRPCOutcome {
+        ACPBrokerRPCOutcome(
+            result: forkResponseAvailable ? sessionResult(id: "forked-remote") : nil,
+            error: nil
+        )
+    }
+
+    private var forkCompletionEvent: ACPBrokerEvent {
+        ACPBrokerEvent(
+            cursor: Self.forkCompletionCursor,
+            kind: .operationCompleted(
+                operationKey: Self.forkOperationKey,
+                outcome: forkOutcome
+            )
+        )
+    }
+
+    private func snapshot(
+        brokerId: ACPBrokerID,
+        sessionId: String,
+        acknowledgedCursor: ACPBrokerEventCursor
+    ) -> ACPBrokerSnapshot {
+        ACPBrokerSnapshot(
+            metadata: ACPBrokerMetadata(
+                brokerId: brokerId,
+                generation: ACPBrokerGeneration(rawValue: 13),
+                alasSessionId: sessionId,
+                adapterProgram: "mock",
+                adapterArgs: [],
+                cwd: "/tmp/wt",
+                envKeys: [],
+                createdAtMillis: 10
+            ),
+            initializeResult: .object([
+                "protocolVersion": .number(1),
+                "agentCapabilities": .object([
+                    "sessionCapabilities": .object([
+                        "fork": .object([:])
+                    ])
+                ]),
+                "authMethods": .array([])
+            ]),
+            remoteSessionResult: nil,
+            turnState: .idle,
+            acknowledgedCursor: acknowledgedCursor,
+            journalTail: Self.forkCompletionCursor,
+            pendingRequests: [],
+            operations: [
+                ACPBrokerOperationSnapshot(
+                    operationKey: Self.forkOperationKey,
+                    adapterRequestId: ACPBrokerAdapterRequestID(rawValue: 1),
+                    method: "session/fork",
+                    params: .object([
+                        "sessionId": .string("source-remote")
+                    ]),
+                    terminalOutcome: forkOutcome
+                )
+            ]
+        )
+    }
 }
 
 private actor ForkPreSendFailureBrokerService: ACPBrokerServicing {

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -1,0 +1,323 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSessionManager fork attach")
+struct ACPSessionForkAttachTests {
+    @Test("negotiating fork uses native ACP and persists the returned remote session")
+    func negotiatingForkUsesNativeACP() async throws {
+        let store = try seededForkStore()
+        let client = ACPMockClient()
+        scriptInitialize(client, supportsFork: true)
+        scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        #expect(manager.sessions["source"] == nil)
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/fork"])
+        #expect(client.sent.last?.brokerOperationKey == "startup:target:session/fork:source-remote")
+        #expect(manager.runners[target.id] != nil)
+        #expect(target.remoteSessionId == "forked-remote")
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .nativeACP)
+        #expect(target.forkRecord?.contextDeliveryPending == false)
+        let row = try #require(try store.loadSession(id: "target"))
+        #expect(row.remoteSessionId == "forked-remote")
+        #expect(row.origin == .agentForked)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .ready)
+        #expect(fork.mechanism == .nativeACP)
+        #expect(fork.contextDeliveryPending == false)
+    }
+
+    @Test("missing fork capability falls back to transcript transfer and session/new")
+    func missingForkCapabilityFallsBackToTranscript() async throws {
+        let store = try seededForkStore()
+        let client = ACPMockClient()
+        scriptInitialize(client, supportsFork: false)
+        scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(manager.runners[target.id] != nil)
+        #expect(target.remoteSessionId == "new-remote")
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .ready)
+        #expect(fork.mechanism == .transcriptTransfer)
+        #expect(fork.contextDeliveryPending == true)
+    }
+
+    @Test("session/fork JSON-RPC failure falls back on the same connection")
+    func forkJSONRPCFailureFallsBackOnSameConnection() async throws {
+        let store = try seededForkStore()
+        let client = ACPMockClient()
+        scriptInitialize(client, supportsFork: true)
+        client.script(method: "session/fork") { _ in
+            throw ACPClientError.jsonrpc(.init(
+                code: -32601,
+                message: "Method not found",
+                data: nil
+            ))
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "new-remote")
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/fork", "session/new"])
+        #expect(manager.runners[target.id] != nil)
+        #expect(target.remoteSessionId == "new-remote")
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+        #expect(client.shutdownCount == 0)
+    }
+
+    @Test("fork auth failure finalizes transcript fallback and keeps needs-auth state")
+    func forkAuthFailurePreservesNeedsAuth() async throws {
+        let store = try seededForkStore()
+        let client = ACPMockClient()
+        scriptInitialize(client, supportsFork: true, authMethods: [terminalAuthMethod()])
+        client.script(method: "session/fork") { _ in
+            throw ACPClientError.jsonrpc(.init(
+                code: -32000,
+                message: "login required",
+                data: nil
+            ))
+        }
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/fork"])
+        #expect(manager.runners[target.id] == nil)
+        if case .needsAuth(let methods, let reason) = target.setupState {
+            #expect(methods.map(\.id) == ["claude-login"])
+            #expect(reason == "login required")
+        } else {
+            Issue.record("Expected needs-auth setup state")
+        }
+        #expect(target.agentState == .failed("login required"))
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .ready)
+        #expect(fork.mechanism == .transcriptTransfer)
+        #expect(fork.contextDeliveryPending == true)
+    }
+
+    @Test("reattaching the same target reuses the stable native fork operation key")
+    func reattachReusesStableForkOperationKey() async throws {
+        let first = try await nativeForkOperationKey()
+        let second = try await nativeForkOperationKey()
+
+        #expect(first == "startup:target:session/fork:source-remote")
+        #expect(second == first)
+    }
+
+    @Test("native fork resolves the source remote ID from persistence")
+    func nativeForkResolvesSourceFromPersistence() async throws {
+        let store = try seededForkStore(sourceRemoteSessionID: "persisted-source-remote")
+        let client = ACPMockClient()
+        scriptInitialize(client, supportsFork: true)
+        scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        #expect(manager.sessions["source"] == nil)
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        let params = try #require(client.sent.last?.params as? ACPSessionForkParams)
+        #expect(params.sessionId == "persisted-source-remote")
+        #expect(client.sent.last?.brokerOperationKey
+            == "startup:target:session/fork:persisted-source-remote")
+    }
+
+    @Test("setup failure durably downgrades a negotiating fork before surfacing the error")
+    func setupFailureDowngradesNegotiatingFork() async throws {
+        let store = try seededForkStore()
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .missing(reason: "adapter missing") }
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(target.setupState == .needsSetup(reason: "adapter missing"))
+        #expect(target.agentState == .failed("adapter missing"))
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .ready)
+        #expect(fork.mechanism == .transcriptTransfer)
+        #expect(fork.contextDeliveryPending == true)
+    }
+
+    @Test("launch failure durably downgrades a negotiating fork before surfacing the error")
+    func launchFailureDowngradesNegotiatingFork() async throws {
+        let store = try seededForkStore()
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in
+                throw ACPClientError.notRunning
+            }
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        if case .failed(let reason) = target.agentState {
+            #expect(reason.contains("Failed to launch agent"))
+        } else {
+            Issue.record("Expected launch failure")
+        }
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .ready)
+        #expect(fork.mechanism == .transcriptTransfer)
+        #expect(fork.contextDeliveryPending == true)
+    }
+
+    private func nativeForkOperationKey() async throws -> String? {
+        let store = try seededForkStore()
+        let client = ACPMockClient()
+        scriptInitialize(client, supportsFork: true)
+        scriptSessionResult(client, method: "session/fork", sessionId: "forked-remote")
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        return client.sent.first { $0.method == "session/fork" }?.brokerOperationKey
+    }
+
+    private func seededForkStore(
+        sourceRemoteSessionID: String = "source-remote"
+    ) throws -> ACPSessionStore {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            id: "source",
+            remoteSessionID: sourceRemoteSessionID
+        ))
+        try store.createFork(
+            session: row(id: "target", remoteSessionID: nil),
+            messages: [],
+            record: .init(
+                targetSessionID: "target",
+                sourceSessionID: "source",
+                sourceAgentID: "claude",
+                sourceBoundarySequence: 0,
+                inheritedMessageCount: 0,
+                phase: .negotiatingNative,
+                mechanism: nil,
+                contextDeliveryPending: false
+            )
+        )
+        return store
+    }
+
+    private func row(id: String, remoteSessionID: String?) -> ACPSessionRow {
+        ACPSessionRow(
+            id: id,
+            agentId: "claude",
+            title: id.capitalized,
+            titleSource: .placeholder,
+            remoteSessionId: remoteSessionID,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        )
+    }
+
+    private func makeManager(
+        store: ACPSessionStore,
+        client: ACPMockClient
+    ) -> ACPSessionManager {
+        ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+    }
+
+    private func hydratedTarget(_ manager: ACPSessionManager) async throws -> ACPSession {
+        let target = try #require(manager.placeholderSession(id: "target"))
+        await manager.hydrateIfNeeded(id: target.id)
+        return target
+    }
+
+    private func scriptInitialize(
+        _ client: ACPMockClient,
+        supportsFork: Bool,
+        authMethods: [ACPInitializeResult.ACPAuthMethod] = []
+    ) {
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(
+                    sessionCapabilities: .init(
+                        fork: supportsFork ? .init() : nil
+                    )
+                ),
+                authMethods: authMethods
+            ))
+        }
+    }
+
+    private func terminalAuthMethod() -> ACPInitializeResult.ACPAuthMethod {
+        .init(
+            id: "claude-login",
+            name: "Claude Login",
+            kind: .terminal
+        )
+    }
+
+    private func scriptSessionResult(
+        _ client: ACPMockClient,
+        method: String,
+        sessionId: String
+    ) {
+        client.script(method: method) { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: sessionId,
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+    }
+
+    private func tmpStorePath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-fork-attach-\(UUID().uuidString).sqlite")
+            .path
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -373,6 +373,44 @@ struct ACPSessionForkAttachTests {
         #expect(await broker.acknowledgedCursors == [ACPBrokerEventCursor(rawValue: 2)])
     }
 
+    @Test("repeated startup replay failure preserves a completed native fork for retry")
+    func repeatedStartupReplayFailurePreservesCompletedNativeFork() async throws {
+        let store = try seededForkStore()
+        let broker = ForkReplayBrokerService(failSecondStartupReplay: true)
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+        #expect(target.forkRecord?.phase == .negotiatingNative)
+
+        await manager.reattach(to: target.id)
+
+        #expect(target.forkRecord?.phase == .negotiatingNative)
+        #expect(target.forkRecord?.mechanism == nil)
+        #expect(try store.loadFork(targetSessionID: "target")?.phase == .negotiatingNative)
+        #expect(await broker.sentOperationKeys == [
+            ACPBrokerOperationKey(rawValue: "startup:target:session/fork:source-remote")
+        ])
+        #expect(await broker.detachCount == 2)
+
+        await manager.reattach(to: target.id)
+
+        #expect(await broker.sentOperationKeys == [
+            ACPBrokerOperationKey(rawValue: "startup:target:session/fork:source-remote"),
+            ACPBrokerOperationKey(rawValue: "startup:target:session/fork:source-remote")
+        ])
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .nativeACP)
+        #expect(target.remoteSessionId == "forked-remote")
+        #expect(await broker.acknowledgedCursors == [ACPBrokerEventCursor(rawValue: 2)])
+    }
+
     @Test("terminal fork error replay is released before fallback session/new")
     func terminalForkErrorReplayIsReleasedBeforeFallbackSessionNew() async throws {
         let store = try seededForkStore()
@@ -734,6 +772,7 @@ private actor ForkPreSendFailureBrokerService: ACPBrokerServicing {
 
 private actor ForkReplayBrokerService: ACPBrokerServicing {
     private let forkError: JSONRPCError?
+    private let failSecondStartupReplay: Bool
     private var attachCount = 0
     private var replayEvents: [ACPBrokerEvent] = []
     private var nextCursor: UInt64 = 2
@@ -741,9 +780,14 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
     private(set) var sentMethods: [String] = []
     private(set) var closedSessionIDs: [String] = []
     private(set) var acknowledgedCursors: [ACPBrokerEventCursor] = []
+    private(set) var detachCount = 0
 
-    init(forkError: JSONRPCError? = nil) {
+    init(
+        forkError: JSONRPCError? = nil,
+        failSecondStartupReplay: Bool = false
+    ) {
         self.forkError = forkError
+        self.failSecondStartupReplay = failSecondStartupReplay
     }
 
     func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
@@ -760,6 +804,9 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
         case 2:
             throw ForkReplayBrokerError.trailingReplayFailure
         case 3:
+            if failSecondStartupReplay {
+                throw ForkReplayBrokerError.trailingReplayFailure
+            }
             return ACPBrokerAttachResult(
                 snapshot: snapshot(
                     brokerId: params.brokerId,
@@ -843,7 +890,8 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
     }
 
     func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
-        ACPBrokerSimpleOK(ok: true)
+        detachCount += 1
+        return ACPBrokerSimpleOK(ok: true)
     }
 
     func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
@@ -900,7 +948,18 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
             acknowledgedCursor: acknowledgedCursor,
             journalTail: replayEvents.last?.cursor ?? acknowledgedCursor,
             pendingRequests: [],
-            operations: []
+            operations: replayEvents.compactMap { event in
+                guard case .operationCompleted(let operationKey, let outcome) = event.kind else {
+                    return nil
+                }
+                return ACPBrokerOperationSnapshot(
+                    operationKey: operationKey,
+                    adapterRequestId: ACPBrokerAdapterRequestID(rawValue: event.cursor.rawValue),
+                    method: sentOperationKeys.first == operationKey ? "session/fork" : "unknown",
+                    params: .object([:]),
+                    terminalOutcome: outcome
+                )
+            }
         )
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -198,6 +198,119 @@ struct ACPSessionForkAttachTests {
         #expect(fork.contextDeliveryPending == true)
     }
 
+    @Test("downgrade persistence failure keeps the fork negotiating")
+    func downgradePersistenceFailureKeepsForkNegotiating() async throws {
+        let store = try seededForkStore()
+        try installFinalizeFailure(mechanism: .transcriptTransfer, store: store)
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .missing(reason: "adapter missing") }
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(target.setupState == .needsSetup(reason: "adapter missing"))
+        #expect(target.agentState == .failed("adapter missing"))
+        #expect(target.forkRecord?.phase == .negotiatingNative)
+        #expect(target.forkRecord?.mechanism == nil)
+        #expect(target.forkRecord?.contextDeliveryPending == false)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .negotiatingNative)
+        #expect(fork.mechanism == nil)
+        #expect(fork.contextDeliveryPending == false)
+    }
+
+    @Test("native finalization failure closes the remote before acknowledging transcript fallback")
+    func nativeFinalizationFailureClosesRemoteAndOrdersAcknowledgements() async throws {
+        let store = try seededForkStore()
+        try installFinalizeFailure(mechanism: .nativeACP, store: store)
+        let client = ACPMockClient()
+        let acknowledgements = ForkAcknowledgementRecorder()
+        scriptInitialize(client, supportsFork: true)
+        client.scriptResponse(method: "session/fork") { _ in
+            ACPResponse(
+                body: try JSONEncoder().encode(ACPSessionNewResult(
+                    sessionId: "orphaned-remote",
+                    availableModels: [],
+                    availableModes: [],
+                    currentModel: nil,
+                    currentMode: nil,
+                    promptSuggestions: []
+                )),
+                durableConsumptionAcknowledgement: {
+                    acknowledgements.record("fork")
+                }
+            )
+        }
+        client.scriptResponse(method: "session/close") { request in
+            let params = try #require(request.params as? ACPSessionCloseParams)
+            #expect(params.sessionId == "orphaned-remote")
+            return ACPResponse(
+                body: Data(),
+                durableConsumptionAcknowledgement: {
+                    acknowledgements.record("close")
+                }
+            )
+        }
+        let manager = makeManager(store: store, client: client)
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/fork", "session/close"])
+        #expect(manager.runners[target.id] == nil)
+        #expect(target.remoteSessionId == nil)
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+        let row = try #require(try store.loadSession(id: "target"))
+        #expect(row.remoteSessionId == nil)
+        #expect(row.origin == .alasCreated)
+        let fork = try #require(try store.loadFork(targetSessionID: "target"))
+        #expect(fork.phase == .ready)
+        #expect(fork.mechanism == .transcriptTransfer)
+        #expect(fork.contextDeliveryPending == true)
+        #expect(acknowledgements.values == ["close", "fork"])
+    }
+
+    @Test("broker replay failure keeps negotiation and reuses the durable fork key")
+    func brokerReplayFailureRetriesStableForkOperation() async throws {
+        let store = try seededForkStore()
+        let broker = ForkReplayBrokerService()
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(target.forkRecord?.phase == .negotiatingNative)
+        #expect(target.forkRecord?.mechanism == nil)
+        #expect(try store.loadFork(targetSessionID: "target")?.phase == .negotiatingNative)
+        #expect(await broker.sentOperationKeys == [
+            ACPBrokerOperationKey(rawValue: "startup:target:session/fork:source-remote")
+        ])
+        #expect(await broker.acknowledgedCursors.isEmpty)
+
+        await manager.reattach(to: target.id)
+
+        #expect(await broker.sentOperationKeys == [
+            ACPBrokerOperationKey(rawValue: "startup:target:session/fork:source-remote"),
+            ACPBrokerOperationKey(rawValue: "startup:target:session/fork:source-remote")
+        ])
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .nativeACP)
+        #expect(target.remoteSessionId == "forked-remote")
+        #expect(await broker.acknowledgedCursors == [ACPBrokerEventCursor(rawValue: 2)])
+    }
+
     private func nativeForkOperationKey() async throws -> String? {
         let store = try seededForkStore()
         let client = ACPMockClient()
@@ -319,5 +432,167 @@ struct ACPSessionForkAttachTests {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-fork-attach-\(UUID().uuidString).sqlite")
             .path
+    }
+
+    private func installFinalizeFailure(
+        mechanism: ACPSessionForkMechanism,
+        store: ACPSessionStore
+    ) throws {
+        try store.db.exec("""
+        CREATE TRIGGER fail_\(mechanism.rawValue)_fork_finalize
+        BEFORE UPDATE OF mechanism ON session_forks
+        WHEN NEW.mechanism = '\(mechanism.rawValue)'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced \(mechanism.rawValue) finalization failure');
+        END
+        """)
+    }
+}
+
+private final class ForkAcknowledgementRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func record(_ value: String) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
+    }
+}
+
+private enum ForkReplayBrokerError: Error {
+    case trailingReplayFailure
+}
+
+private actor ForkReplayBrokerService: ACPBrokerServicing {
+    private var attachCount = 0
+    private(set) var sentOperationKeys: [ACPBrokerOperationKey] = []
+    private(set) var acknowledgedCursors: [ACPBrokerEventCursor] = []
+
+    func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
+        ACPBrokerOpenResult(snapshot: snapshot(
+            brokerId: params.brokerId,
+            sessionId: params.sessionId,
+            acknowledgedCursor: .init(rawValue: 0)
+        ), adopted: false)
+    }
+
+    func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
+        attachCount += 1
+        switch attachCount {
+        case 2:
+            throw ForkReplayBrokerError.trailingReplayFailure
+        case 3:
+            return ACPBrokerAttachResult(
+                snapshot: snapshot(
+                    brokerId: params.brokerId,
+                    sessionId: "target",
+                    acknowledgedCursor: params.acknowledgedCursor
+                ),
+                events: [forkCompletionEvent]
+            )
+        default:
+            return ACPBrokerAttachResult(
+                snapshot: snapshot(
+                    brokerId: params.brokerId,
+                    sessionId: "target",
+                    acknowledgedCursor: params.acknowledgedCursor
+                ),
+                events: []
+            )
+        }
+    }
+
+    func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        sentOperationKeys.append(params.operationKey)
+        return ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: UInt64(sentOperationKeys.count)),
+            replayed: sentOperationKeys.count > 1,
+            result: forkResult,
+            pending: false
+        )
+    }
+
+    func notify(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK {
+        acknowledgedCursors.append(params.cursor)
+        return ACPBrokerSimpleOK(ok: true)
+    }
+
+    func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    private var forkResult: ACPBrokerJSONValue {
+        .object([
+            "sessionId": .string("forked-remote"),
+            "availableModels": .array([]),
+            "availableModes": .array([]),
+            "promptSuggestions": .array([]),
+            "configOptions": .array([])
+        ])
+    }
+
+    private var forkCompletionEvent: ACPBrokerEvent {
+        ACPBrokerEvent(
+            cursor: ACPBrokerEventCursor(rawValue: 2),
+            kind: .operationCompleted(
+                operationKey: ACPBrokerOperationKey(
+                    rawValue: "startup:target:session/fork:source-remote"
+                ),
+                outcome: ACPBrokerRPCOutcome(result: forkResult, error: nil)
+            )
+        )
+    }
+
+    private func snapshot(
+        brokerId: ACPBrokerID,
+        sessionId: String,
+        acknowledgedCursor: ACPBrokerEventCursor
+    ) -> ACPBrokerSnapshot {
+        ACPBrokerSnapshot(
+            metadata: ACPBrokerMetadata(
+                brokerId: brokerId,
+                generation: ACPBrokerGeneration(rawValue: 7),
+                alasSessionId: sessionId,
+                adapterProgram: "mock",
+                adapterArgs: [],
+                cwd: "/tmp/wt",
+                envKeys: [],
+                createdAtMillis: 10
+            ),
+            initializeResult: .object([
+                "protocolVersion": .number(1),
+                "agentCapabilities": .object([
+                    "sessionCapabilities": .object([
+                        "fork": .object([:])
+                    ])
+                ]),
+                "authMethods": .array([])
+            ]),
+            remoteSessionResult: nil,
+            turnState: .idle,
+            acknowledgedCursor: acknowledgedCursor,
+            journalTail: ACPBrokerEventCursor(rawValue: 2),
+            pendingRequests: [],
+            operations: []
+        )
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -373,6 +373,49 @@ struct ACPSessionForkAttachTests {
         #expect(await broker.acknowledgedCursors == [ACPBrokerEventCursor(rawValue: 2)])
     }
 
+    @Test("source mismatch closes and releases a replayed fork before session/new")
+    func sourceMismatchClosesAndReleasesReplayedFork() async throws {
+        let store = try seededForkStore()
+        let broker = ForkReplayBrokerService()
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+        try store.appendMessage(
+            sessionId: "source",
+            id: "msg-source-1",
+            kind: "agent",
+            seq: 1,
+            payload: Data(),
+            createdAt: 1
+        )
+
+        await manager.reattach(to: target.id)
+
+        #expect(await broker.sentMethods == [
+            "session/fork",
+            "session/close",
+            "session/new"
+        ])
+        #expect(await broker.closedSessionIDs == ["forked-remote"])
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.remoteSessionId == "new-remote")
+        try await waitUntil {
+            await broker.acknowledgedCursors == [
+                ACPBrokerEventCursor(rawValue: 2),
+                ACPBrokerEventCursor(rawValue: 3),
+                ACPBrokerEventCursor(rawValue: 4)
+            ]
+        }
+    }
+
     private func nativeForkOperationKey() async throws -> String? {
         let store = try seededForkStore()
         let client = ACPMockClient()
@@ -517,7 +560,22 @@ struct ACPSessionForkAttachTests {
         END
         """)
     }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping @MainActor () async -> Bool
+    ) async throws {
+        let start = ContinuousClock.now
+        while !(await predicate()) {
+            if ContinuousClock.now - start > timeout {
+                throw ForkAttachTestTimeout()
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
 }
+
+private struct ForkAttachTestTimeout: Error {}
 
 private final class ForkAcknowledgementRecorder: @unchecked Sendable {
     private let lock = NSLock()
@@ -644,7 +702,11 @@ private actor ForkPreSendFailureBrokerService: ACPBrokerServicing {
 
 private actor ForkReplayBrokerService: ACPBrokerServicing {
     private var attachCount = 0
+    private var replayEvents: [ACPBrokerEvent] = []
+    private var nextCursor: UInt64 = 2
     private(set) var sentOperationKeys: [ACPBrokerOperationKey] = []
+    private(set) var sentMethods: [String] = []
+    private(set) var closedSessionIDs: [String] = []
     private(set) var acknowledgedCursors: [ACPBrokerEventCursor] = []
 
     func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
@@ -667,7 +729,7 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
                     sessionId: "target",
                     acknowledgedCursor: params.acknowledgedCursor
                 ),
-                events: [forkCompletionEvent]
+                events: replayEvents
             )
         default:
             return ACPBrokerAttachResult(
@@ -676,17 +738,50 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
                     sessionId: "target",
                     acknowledgedCursor: params.acknowledgedCursor
                 ),
-                events: []
+                events: replayEvents
             )
         }
     }
 
     func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        sentMethods.append(params.method)
         sentOperationKeys.append(params.operationKey)
+        let result: ACPBrokerJSONValue
+        switch params.method {
+        case "session/fork":
+            result = forkResult
+        case "session/close":
+            let closeParams = try JSONDecoder().decode(
+                ACPSessionCloseParams.self,
+                from: params.params.data
+            )
+            closedSessionIDs.append(closeParams.sessionId)
+            result = .null
+        case "session/new":
+            result = sessionNewResult
+        default:
+            result = .null
+        }
+        let wasReplayed = replayEvents.contains(where: { event in
+            if case .operationCompleted(let operationKey, _) = event.kind {
+                return operationKey == params.operationKey
+            }
+            return false
+        })
+        if !wasReplayed {
+            replayEvents.append(ACPBrokerEvent(
+                cursor: ACPBrokerEventCursor(rawValue: nextCursor),
+                kind: .operationCompleted(
+                    operationKey: params.operationKey,
+                    outcome: ACPBrokerRPCOutcome(result: result, error: nil)
+                )
+            ))
+            nextCursor += 1
+        }
         return ACPBrokerSendResult(
             requestId: ACPBrokerAdapterRequestID(rawValue: UInt64(sentOperationKeys.count)),
-            replayed: sentOperationKeys.count > 1,
-            result: forkResult,
+            replayed: wasReplayed,
+            result: result,
             pending: false
         )
     }
@@ -722,16 +817,14 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
         ])
     }
 
-    private var forkCompletionEvent: ACPBrokerEvent {
-        ACPBrokerEvent(
-            cursor: ACPBrokerEventCursor(rawValue: 2),
-            kind: .operationCompleted(
-                operationKey: ACPBrokerOperationKey(
-                    rawValue: "startup:target:session/fork:source-remote"
-                ),
-                outcome: ACPBrokerRPCOutcome(result: forkResult, error: nil)
-            )
-        )
+    private var sessionNewResult: ACPBrokerJSONValue {
+        .object([
+            "sessionId": .string("new-remote"),
+            "availableModels": .array([]),
+            "availableModes": .array([]),
+            "promptSuggestions": .array([]),
+            "configOptions": .array([])
+        ])
     }
 
     private func snapshot(
@@ -762,7 +855,7 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
             remoteSessionResult: nil,
             turnState: .idle,
             acknowledgedCursor: acknowledgedCursor,
-            journalTail: ACPBrokerEventCursor(rawValue: 2),
+            journalTail: replayEvents.last?.cursor ?? acknowledgedCursor,
             pendingRequests: [],
             operations: []
         )

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -373,6 +373,38 @@ struct ACPSessionForkAttachTests {
         #expect(await broker.acknowledgedCursors == [ACPBrokerEventCursor(rawValue: 2)])
     }
 
+    @Test("terminal fork error replay is released before fallback session/new")
+    func terminalForkErrorReplayIsReleasedBeforeFallbackSessionNew() async throws {
+        let store = try seededForkStore()
+        let broker = ForkReplayBrokerService(forkError: JSONRPCError(
+            code: -32601,
+            message: "Method not found",
+            data: nil
+        ))
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            brokerServiceFactory: { broker }
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(await broker.sentMethods == ["session/fork", "session/new"])
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.remoteSessionId == "new-remote")
+        #expect(manager.runners[target.id] != nil)
+        try await waitUntil {
+            await broker.acknowledgedCursors == [
+                ACPBrokerEventCursor(rawValue: 2),
+                ACPBrokerEventCursor(rawValue: 3)
+            ]
+        }
+    }
+
     @Test("source mismatch closes and releases a replayed fork before session/new")
     func sourceMismatchClosesAndReleasesReplayedFork() async throws {
         let store = try seededForkStore()
@@ -701,6 +733,7 @@ private actor ForkPreSendFailureBrokerService: ACPBrokerServicing {
 }
 
 private actor ForkReplayBrokerService: ACPBrokerServicing {
+    private let forkError: JSONRPCError?
     private var attachCount = 0
     private var replayEvents: [ACPBrokerEvent] = []
     private var nextCursor: UInt64 = 2
@@ -708,6 +741,10 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
     private(set) var sentMethods: [String] = []
     private(set) var closedSessionIDs: [String] = []
     private(set) var acknowledgedCursors: [ACPBrokerEventCursor] = []
+
+    init(forkError: JSONRPCError? = nil) {
+        self.forkError = forkError
+    }
 
     func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
         ACPBrokerOpenResult(snapshot: snapshot(
@@ -746,10 +783,12 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
     func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
         sentMethods.append(params.method)
         sentOperationKeys.append(params.operationKey)
-        let result: ACPBrokerJSONValue
+        let result: ACPBrokerJSONValue?
+        let error: JSONRPCError?
         switch params.method {
         case "session/fork":
-            result = forkResult
+            result = forkError == nil ? forkResult : nil
+            error = forkError
         case "session/close":
             let closeParams = try JSONDecoder().decode(
                 ACPSessionCloseParams.self,
@@ -757,10 +796,13 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
             )
             closedSessionIDs.append(closeParams.sessionId)
             result = .null
+            error = nil
         case "session/new":
             result = sessionNewResult
+            error = nil
         default:
             result = .null
+            error = nil
         }
         let wasReplayed = replayEvents.contains(where: { event in
             if case .operationCompleted(let operationKey, _) = event.kind {
@@ -773,7 +815,7 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
                 cursor: ACPBrokerEventCursor(rawValue: nextCursor),
                 kind: .operationCompleted(
                     operationKey: params.operationKey,
-                    outcome: ACPBrokerRPCOutcome(result: result, error: nil)
+                    outcome: ACPBrokerRPCOutcome(result: result, error: error)
                 )
             ))
             nextCursor += 1
@@ -782,6 +824,7 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
             requestId: ACPBrokerAdapterRequestID(rawValue: UInt64(sentOperationKeys.count)),
             replayed: wasReplayed,
             result: result,
+            error: error,
             pending: false
         )
     }

--- a/AlasTests/ACP/Session/ACPSessionForkManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkManagerTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP session fork manager")
+struct ACPSessionForkManagerTests {
+    @Test("createFork copies through selected boundary and leaves source unchanged")
+    func createsLocalFork() async throws {
+        let path = temporaryPath()
+        let store = try ACPSessionStore(path: path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let source = manager.createSession(agentId: "claude")
+        await manager.flushPersistence()
+        let user: ACPMessage = .user(id: UUID(), text: "one", attachments: [])
+        let agent: ACPMessage = .agent(id: UUID(), StreamingText("two"))
+        let later: ACPMessage = .user(id: UUID(), text: "three", attachments: [])
+        for message in [user, agent, later] {
+            let index = source.transcript.messages.count
+            source.transcript.appendMessage(message)
+            try store.appendMessage(
+                sessionId: source.id,
+                id: "msg-\(source.id)-\(index)",
+                kind: message.kind,
+                seq: Int64(index),
+                payload: try ACPMessageCodec.encode(message),
+                createdAt: Int64(index)
+            )
+        }
+        let sourceBefore = try store.loadMessages(sessionId: source.id)
+
+        let target = try await manager.createFork(
+            sourceSessionID: source.id,
+            boundary: .init(stableID: agent.stableId, kind: .agent),
+            targetAgentID: "codex",
+            autoRunDefault: false
+        )
+
+        #expect(target.agentId == "codex")
+        #expect(target.title == "New session (fork)")
+        #expect(target.transcript.messages.count == 2)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(try store.loadMessages(sessionId: source.id) == sourceBefore)
+    }
+
+    @Test("streaming agent is ineligible while earlier messages remain eligible")
+    func messageEligibility() {
+        let session = ACPSession(
+            id: "s", agentId: "claude", worktreeId: "wt",
+            title: "Session", hydrationState: .ready
+        )
+        session.transcript.appendMessage(.user(id: UUID(), text: "old", attachments: []))
+        session.transcript.appendMessage(.agent(id: UUID(), StreamingText("old answer")))
+        session.transcript.appendMessage(.user(id: UUID(), text: "new", attachments: []))
+        session.transcript.appendMessage(.agent(id: UUID(), StreamingText("partial")))
+        session.transcript.streamingState = .streaming
+
+        #expect(session.canForkMessage(at: 0))
+        #expect(session.canForkMessage(at: 1))
+        #expect(session.canForkMessage(at: 2))
+        #expect(!session.canForkMessage(at: 3))
+    }
+
+    private func temporaryPath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-fork-manager-\(UUID()).sqlite").path
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionForkManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkManagerTests.swift
@@ -41,6 +41,22 @@ struct ACPSessionForkManagerTests {
         #expect(target.transcript.messages.count == 2)
         #expect(target.forkRecord?.mechanism == .transcriptTransfer)
         #expect(try store.loadMessages(sessionId: source.id) == sourceBefore)
+
+        let targetID = target.id
+        await manager.releaseAllOwnedLeases()
+        let restoredStore = try ACPSessionStore(path: path)
+        let restoredManager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: restoredStore
+        )
+        let restored = try #require(restoredManager.placeholderSession(id: targetID))
+        await restoredManager.hydrateIfNeeded(id: targetID)
+        await restoredManager.awaitBackfill(id: targetID)
+
+        #expect(restored.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(restored.forkRecord?.contextDeliveryPending == true)
+        #expect(restored.transcript.messages.count == 2)
     }
 
     @Test("streaming agent is ineligible while earlier messages remain eligible")

--- a/AlasTests/ACP/Session/ACPSessionForkManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkManagerTests.swift
@@ -59,6 +59,182 @@ struct ACPSessionForkManagerTests {
         #expect(restored.transcript.messages.count == 2)
     }
 
+    @Test("pending transcript context prevents a native child fork")
+    func pendingTranscriptContextForcesTranscriptTransfer() async throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let root = manager.createSession(agentId: "claude")
+        await manager.flushPersistence()
+        let message: ACPMessage = .agent(id: UUID(), StreamingText("Root answer"))
+        root.transcript.appendMessage(message)
+        try store.appendMessage(
+            sessionId: root.id,
+            id: "msg-\(root.id)-0",
+            kind: message.kind,
+            seq: 0,
+            payload: try ACPMessageCodec.encode(message),
+            createdAt: 0
+        )
+
+        let pendingSource = try await manager.createFork(
+            sourceSessionID: root.id,
+            boundary: .init(stableID: message.stableId, kind: .agent),
+            targetAgentID: "codex",
+            autoRunDefault: false
+        )
+        pendingSource.remoteSessionId = "remote-pending-source"
+        pendingSource.sessionCapabilities = .init(fork: .init())
+        let pendingBoundary = try #require(pendingSource.transcript.messages.last)
+
+        let target = try await manager.createFork(
+            sourceSessionID: pendingSource.id,
+            boundary: .init(stableID: pendingBoundary.stableId, kind: .agent),
+            targetAgentID: "codex",
+            autoRunDefault: false
+        )
+
+        #expect(pendingSource.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(pendingSource.forkRecord?.contextDeliveryPending == true)
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(target.forkRecord?.contextDeliveryPending == true)
+    }
+
+    @Test("createFork releases a lease acquired only for a successful snapshot")
+    func successfulSnapshotReleasesTemporaryLease() async throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            instanceId: "forker"
+        )
+        let source = manager.createSession(agentId: "claude")
+        await manager.flushPersistence()
+        let message: ACPMessage = .agent(id: UUID(), StreamingText("Answer"))
+        source.transcript.appendMessage(message)
+        try store.appendMessage(
+            sessionId: source.id,
+            id: "msg-\(source.id)-0",
+            kind: message.kind,
+            seq: 0,
+            payload: try ACPMessageCodec.encode(message),
+            createdAt: 0
+        )
+
+        _ = try await manager.createFork(
+            sourceSessionID: source.id,
+            boundary: .init(stableID: message.stableId, kind: .agent),
+            targetAgentID: "codex",
+            autoRunDefault: false
+        )
+
+        #expect(try store.loadLease(sessionId: source.id) == nil)
+        #expect(!manager._ownedLeases.contains(source.id))
+    }
+
+    @Test("createFork releases a temporary snapshot lease after an error")
+    func failedSnapshotReleasesTemporaryLease() async throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            instanceId: "forker"
+        )
+        let source = manager.createSession(agentId: "claude")
+        await manager.flushPersistence()
+
+        await #expect(throws: ACPSessionForkSnapshotError.self) {
+            try await manager.createFork(
+                sourceSessionID: source.id,
+                boundary: .init(stableID: "missing", kind: .agent),
+                targetAgentID: "codex",
+                autoRunDefault: false
+            )
+        }
+
+        #expect(try store.loadLease(sessionId: source.id) == nil)
+        #expect(!manager._ownedLeases.contains(source.id))
+    }
+
+    @Test("createFork preserves a source lease that was already owned")
+    func successfulSnapshotPreservesExistingLease() async throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            instanceId: "forker"
+        )
+        let source = manager.createSession(agentId: "claude")
+        await manager.flushPersistence()
+        let message: ACPMessage = .agent(id: UUID(), StreamingText("Answer"))
+        source.transcript.appendMessage(message)
+        try store.appendMessage(
+            sessionId: source.id,
+            id: "msg-\(source.id)-0",
+            kind: message.kind,
+            seq: 0,
+            payload: try ACPMessageCodec.encode(message),
+            createdAt: 0
+        )
+        #expect(await manager.acquireWriterLease(sessionId: source.id))
+
+        _ = try await manager.createFork(
+            sourceSessionID: source.id,
+            boundary: .init(stableID: message.stableId, kind: .agent),
+            targetAgentID: "codex",
+            autoRunDefault: false
+        )
+
+        #expect(try store.loadLease(sessionId: source.id)?.ownerInstance == "forker")
+        #expect(manager._ownedLeases.contains(source.id))
+        await manager.releaseWriterLease(sessionId: source.id)
+    }
+
+    @Test("createFork rejects a cached source lease lost to takeover")
+    func staleOwnedLeaseIsRejected() async throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            instanceId: "forker"
+        )
+        let source = manager.createSession(agentId: "claude")
+        await manager.flushPersistence()
+        let message: ACPMessage = .agent(id: UUID(), StreamingText("Answer"))
+        source.transcript.appendMessage(message)
+        try store.appendMessage(
+            sessionId: source.id,
+            id: "msg-\(source.id)-0",
+            kind: message.kind,
+            seq: 0,
+            payload: try ACPMessageCodec.encode(message),
+            createdAt: 0
+        )
+        #expect(await manager.acquireWriterLease(sessionId: source.id))
+        try store.seizeLease(
+            sessionId: source.id,
+            instanceId: "other-instance",
+            pid: Int64(getpid()),
+            now: Int64(Date().timeIntervalSince1970)
+        )
+
+        await #expect(throws: ACPSessionForkCreationError.sourceReadOnly) {
+            try await manager.createFork(
+                sourceSessionID: source.id,
+                boundary: .init(stableID: message.stableId, kind: .agent),
+                targetAgentID: "codex",
+                autoRunDefault: false
+            )
+        }
+
+        #expect(try store.loadLease(sessionId: source.id)?.ownerInstance == "other-instance")
+        #expect(!manager._ownedLeases.contains(source.id))
+    }
+
     @Test("streaming agent is ineligible while earlier messages remain eligible")
     func messageEligibility() {
         let session = ACPSession(

--- a/AlasTests/ACP/Session/ACPSessionForkPersistenceTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkPersistenceTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP session fork persistence")
+struct ACPSessionForkPersistenceTests {
+    @Test("fork row, copied messages, and metadata commit together")
+    func atomicCreateAndLoad() throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        let row = targetRow(id: "target")
+        let messages = [
+            ACPStoredMessage(
+                id: "msg-target-0", sessionId: "target", kind: "user", seq: 0,
+                payload: Data(#"{"messageId":null,"text":"hello","attachments":[],"delegatedSource":null}"#.utf8),
+                createdAt: 1
+            )
+        ]
+        let record = forkRecord(target: "target", phase: .ready, mechanism: .transcriptTransfer)
+
+        try store.createFork(session: row, messages: messages, record: record)
+
+        #expect(try store.loadSession(id: "target") == row)
+        #expect(try store.loadMessages(sessionId: "target") == messages)
+        #expect(try store.loadFork(targetSessionID: "target") == record)
+    }
+
+    @Test("fork create rolls back when a copied message conflicts")
+    func atomicRollback() throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        try store.upsertSession(targetRow(id: "existing"))
+        try store.appendMessage(
+            sessionId: "existing", id: "collision", kind: "system", seq: 0,
+            payload: Data(#"{"messageId":null,"text":"existing"}"#.utf8), createdAt: 0
+        )
+        let conflicting = ACPStoredMessage(
+            id: "collision", sessionId: "target", kind: "user", seq: 0,
+            payload: Data(#"{"messageId":null,"text":"fork","attachments":[],"delegatedSource":null}"#.utf8),
+            createdAt: 1
+        )
+
+        var didThrow = false
+        do {
+            try store.createFork(
+                session: targetRow(id: "target"),
+                messages: [conflicting],
+                record: forkRecord(target: "target", phase: .ready, mechanism: .transcriptTransfer)
+            )
+        } catch {
+            didThrow = true
+        }
+        #expect(didThrow)
+        #expect(try store.loadSession(id: "target") == nil)
+        #expect(try store.loadFork(targetSessionID: "target") == nil)
+    }
+
+    @Test("finalize and clear pending context survive hydration")
+    func finalizeAndHydrate() async throws {
+        let path = temporaryPath()
+        let persistence = ACPSessionPersistence(path: path)
+        let initial = forkRecord(target: "target", phase: .negotiatingNative, mechanism: nil)
+        try await persistence.createFork(
+            session: targetRow(id: "target"),
+            messages: [],
+            record: initial
+        )
+        try await persistence.finalizeFork(
+            targetSessionID: "target",
+            mechanism: .transcriptTransfer,
+            remoteSessionID: nil
+        )
+
+        let hydrated = try await persistence.hydrate(sessionId: "target")
+        #expect(hydrated.forkRecord?.phase == .ready)
+        #expect(hydrated.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(hydrated.forkRecord?.contextDeliveryPending == true)
+
+        try await persistence.clearForkContextDeliveryPending(targetSessionID: "target")
+        #expect(try await persistence.loadFork(targetSessionID: "target")?.contextDeliveryPending == false)
+    }
+
+    private func temporaryPath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-fork-\(UUID()).sqlite").path
+    }
+
+    private func targetRow(id: String) -> ACPSessionRow {
+        .init(
+            id: id, agentId: "codex", title: "Source (fork)",
+            titleSource: .generated, currentModel: nil, currentMode: nil,
+            autoRun: false, createdAt: 1, updatedAt: 1, lastOpenedAt: 1,
+            archived: false
+        )
+    }
+
+    private func forkRecord(
+        target: String,
+        phase: ACPSessionForkCreationPhase,
+        mechanism: ACPSessionForkMechanism?
+    ) -> ACPSessionForkRecord {
+        .init(
+            targetSessionID: target,
+            sourceSessionID: "source",
+            sourceAgentID: "claude",
+            sourceBoundarySequence: 2,
+            inheritedMessageCount: 1,
+            phase: phase,
+            mechanism: mechanism,
+            contextDeliveryPending: mechanism == .transcriptTransfer
+        )
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift
@@ -44,6 +44,46 @@ struct ACPSessionForkPolicyTests {
         ) == .native)
     }
 
+    @Test("attachment-only user messages are not fork boundaries")
+    func attachmentOnlyUserMessageIsIneligible() {
+        let session = ACPSession(
+            id: "source",
+            agentId: "claude",
+            worktreeId: "wt",
+            title: "Source"
+        )
+        session.transcript.appendMessage(.user(
+            id: UUID(),
+            text: " \n ",
+            attachments: [
+                .init(
+                    uri: "file:///tmp/image.png",
+                    name: "image.png",
+                    mimeType: "image/png"
+                )
+            ]
+        ))
+
+        #expect(session.canForkMessage(at: 0) == false)
+    }
+
+    @Test("duplicate enabled agent ids preserve the first catalog definition")
+    func duplicateEnabledAgentIDsAreDeduplicated() {
+        let targets = ACPForkTargetPolicy.targets(
+            sourceAgentID: "claude",
+            enabledAgents: [
+                .init(id: "claude", displayName: "Claude"),
+                .init(id: "claude", displayName: "Custom duplicate")
+            ],
+            sourceAgent: nil,
+            catalogAgentIDs: ["claude"]
+        )
+
+        #expect(targets == [
+            .init(id: "claude", displayName: "Claude", isSameAgent: true)
+        ])
+    }
+
     @Test("snapshot is inclusive and conversation-only")
     func conversationOnlySnapshot() throws {
         let user: ACPMessage = .user(

--- a/AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP session fork policy")
+struct ACPSessionForkPolicyTests {
+    @Test("native candidate requires same agent, remote head, id, and non-negative capability knowledge")
+    func nativeCandidateRequirements() {
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "claude",
+            boundaryIsRemoteHead: true,
+            sourceRemoteSessionID: "remote-1",
+            forkCapability: true
+        ) == .native)
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "codex",
+            boundaryIsRemoteHead: true,
+            sourceRemoteSessionID: "remote-1",
+            forkCapability: true
+        ) == .transcript)
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "claude",
+            boundaryIsRemoteHead: false,
+            sourceRemoteSessionID: "remote-1",
+            forkCapability: true
+        ) == .transcript)
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "claude",
+            boundaryIsRemoteHead: true,
+            sourceRemoteSessionID: nil,
+            forkCapability: true
+        ) == .transcript)
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "claude",
+            boundaryIsRemoteHead: true,
+            sourceRemoteSessionID: "remote-1",
+            forkCapability: nil
+        ) == .native)
+    }
+
+    @Test("snapshot is inclusive and conversation-only")
+    func conversationOnlySnapshot() throws {
+        let user: ACPMessage = .user(
+            id: UUID(), messageId: "u1", text: "Question",
+            attachments: [.init(uri: "file:///tmp/image.png", name: "image.png", mimeType: "image/png")]
+        )
+        let tool: ACPMessage = .toolCall(.init(
+            toolCallId: "tc1", title: "Read", status: "completed",
+            content: "secret tool output", locations: []
+        ))
+        let agent: ACPMessage = .agent(
+            id: UUID(), messageId: "a1", StreamingText("Answer")
+        )
+        let stored = try [user, tool, agent].enumerated().map { index, message in
+            ACPStoredMessage(
+                id: "source-\(index)",
+                sessionId: "source",
+                kind: message.kind,
+                seq: Int64(index),
+                payload: try ACPMessageCodec.encode(message),
+                createdAt: Int64(index)
+            )
+        }
+
+        let snapshot = try ACPSessionForkSnapshotResolver.resolve(
+            boundary: .init(stableID: agent.stableId, kind: .agent),
+            liveMessages: [user, tool, agent],
+            storedMessages: stored
+        )
+
+        #expect(snapshot.sourceBoundarySequence == 2)
+        #expect(snapshot.messages == [
+            .init(role: .user, text: "Question"),
+            .init(role: .agent, text: "Answer")
+        ])
+        let copied = try snapshot.copiedMessages(targetSessionID: "target", createdAt: 10)
+        #expect(copied.map(\.kind) == ["user", "agent"])
+        #expect(copied.map(\.seq) == [0, 1])
+        let copiedUser = try ACPMessageWire.decode(kind: copied[0].kind, payload: copied[0].payload)
+        guard case .user(_, _, let attachments, let delegatedSource) = copiedUser else {
+            Issue.record("Expected copied user message")
+            return
+        }
+        #expect(attachments.isEmpty)
+        #expect(delegatedSource == nil)
+    }
+
+    @Test("snapshot rejects a stale or mismatched boundary")
+    func staleBoundaryFails() throws {
+        let message: ACPMessage = .user(id: UUID(), text: "live", attachments: [])
+        let storedMessage: ACPMessage = .user(id: UUID(), text: "different", attachments: [])
+        let stored = ACPStoredMessage(
+            id: "m0", sessionId: "source", kind: "user", seq: 0,
+            payload: try ACPMessageCodec.encode(storedMessage), createdAt: 0
+        )
+
+        #expect(throws: ACPSessionForkSnapshotError.self) {
+            _ = try ACPSessionForkSnapshotResolver.resolve(
+                boundary: .init(stableID: message.stableId, kind: .user),
+                liveMessages: [message],
+                storedMessages: [stored]
+            )
+        }
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift
@@ -67,6 +67,25 @@ struct ACPSessionForkPolicyTests {
         #expect(session.canForkMessage(at: 0) == false)
     }
 
+    @Test("completed agent messages require visible text")
+    func completedAgentMessageRequiresVisibleText() {
+        let session = ACPSession(
+            id: "source",
+            agentId: "claude",
+            worktreeId: "wt",
+            title: "Source"
+        )
+        session.transcript.messages = [
+            .agent(id: UUID(), StreamingText("Answer")),
+            .agent(id: UUID(), StreamingText("")),
+            .agent(id: UUID(), StreamingText(" \n "))
+        ]
+
+        #expect(session.canForkMessage(at: 0))
+        #expect(session.canForkMessage(at: 1) == false)
+        #expect(session.canForkMessage(at: 2) == false)
+    }
+
     @Test("duplicate enabled agent ids preserve the first catalog definition")
     func duplicateEnabledAgentIDsAreDeduplicated() {
         let targets = ACPForkTargetPolicy.targets(

--- a/AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift
@@ -5,6 +5,101 @@ import Testing
 @MainActor
 @Suite("ACP session fork context delivery")
 struct ACPSessionForkRunnerTests {
+    @Test("transcript fork survives relaunch and delivers context on the first prompt")
+    func transcriptForkSurvivesRelaunch() async throws {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-fork-relaunch-\(UUID()).sqlite").path
+        let targetID: String
+        let inheritedCount = 2
+        do {
+            let storeA = try ACPSessionStore(path: path)
+            let managerA = ACPSessionManager(
+                worktreeId: "wt",
+                worktreePath: "/tmp/wt",
+                store: storeA
+            )
+            let source = managerA.createSession(agentId: "claude")
+            await managerA.flushPersistence()
+            let inherited: [ACPMessage] = [
+                .user(id: UUID(), text: "Question", attachments: []),
+                .agent(id: UUID(), StreamingText("Answer"))
+            ]
+            for (index, message) in inherited.enumerated() {
+                source.transcript.appendMessage(message)
+                try storeA.appendMessage(
+                    sessionId: source.id,
+                    id: "msg-\(source.id)-\(index)",
+                    kind: message.kind,
+                    seq: Int64(index),
+                    payload: try ACPMessageCodec.encode(message),
+                    createdAt: Int64(index)
+                )
+            }
+            let target = try await managerA.createFork(
+                sourceSessionID: source.id,
+                boundary: .init(stableID: inherited[1].stableId, kind: .agent),
+                targetAgentID: "codex",
+                autoRunDefault: false
+            )
+            targetID = target.id
+            managerA.shutdownBackgroundTasks()
+            await managerA.releaseAllOwnedLeases()
+        }
+
+        let storeB = try ACPSessionStore(path: path)
+        let mock = ACPMockClient()
+        mock.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(),
+                authMethods: []
+            ))
+        }
+        mock.script(method: "session/new") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "fresh-remote",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let managerB = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: storeB,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: mock) }
+        )
+        let restored = try #require(managerB.placeholderSession(id: targetID))
+        await managerB.hydrateIfNeeded(id: targetID)
+        await managerB.awaitBackfill(id: targetID)
+
+        #expect(restored.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(restored.forkRecord?.contextDeliveryPending == true)
+        #expect(restored.transcript.messages.count == inheritedCount)
+
+        await managerB.attach(to: targetID, freshlyCreated: false)
+        let runner = try #require(managerB.runners[targetID])
+        runner.sendNow(blocks: [.text("Continue")], queuedItemId: nil)
+        try await waitUntil {
+            mock.sent.contains { $0.method == "session/prompt" }
+                && restored.forkRecord?.contextDeliveryPending == false
+        }
+        await runner.flushPersistence()
+
+        #expect(try storeB.loadFork(
+            targetSessionID: restored.id
+        )?.contextDeliveryPending == false)
+        #expect(restored.transcript.messages.count == inheritedCount + 1)
+
+        await managerB.detach(sessionId: targetID)
+        managerB.shutdownBackgroundTasks()
+        await managerB.releaseAllOwnedLeases()
+    }
+
     @Test("fork context serializes the inherited conversation")
     func forkContextSerializesInheritedConversation() {
         let context = ACPTranscriptMarkdown.forkContext(

--- a/AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP session fork context delivery")
+struct ACPSessionForkRunnerTests {
+    @Test("fork context serializes the inherited conversation")
+    func forkContextSerializesInheritedConversation() {
+        let context = ACPTranscriptMarkdown.forkContext(
+            sourceAgentID: "claude",
+            messages: [
+                .user(id: UUID(), text: "Question", attachments: []),
+                .agent(id: UUID(), StreamingText("Answer"))
+            ]
+        )
+
+        #expect(context?.contains("The conversation below was imported from claude.") == true)
+        #expect(context?.contains("## You\n\nQuestion") == true)
+        #expect(context?.contains("## claude\n\nAnswer") == true)
+    }
+
+    @Test("first prompt sends inherited context privately and clears it durably")
+    func firstPromptDeliversPrivateContext() async throws {
+        let (runner, mock, session, persistence) = try await makeRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+
+        runner.sendNow(blocks: [.text("Continue")], queuedItemId: nil)
+
+        try await waitUntil {
+            mock.sent.contains { $0.method == "session/prompt" }
+                && session.forkRecord?.contextDeliveryPending == false
+        }
+        await runner.flushPersistence()
+
+        let request = try #require(mock.sent.first { $0.method == "session/prompt" })
+        let promptBlocks = try #require(request.params as? ACPSessionPromptParams).prompt
+        #expect(promptBlocks == [
+            .text(try #require(ACPTranscriptMarkdown.forkContext(
+                sourceAgentID: "claude",
+                messages: Array(session.transcript.messages.prefix(2))
+            ))),
+            .text("Continue")
+        ])
+        #expect(session.transcript.messages.count == 3)
+        #expect(try await persistence.loadFork(targetSessionID: session.id)?.contextDeliveryPending == false)
+    }
+
+    @Test("failed first prompt keeps private context pending for a queue retry")
+    func failedFirstPromptKeepsContextPending() async throws {
+        let (runner, mock, session, persistence) = try await makeRunner()
+        mock.script(method: "session/prompt") { _ in throw ACPClientError.notRunning }
+        session.enqueue(blocks: [.text("Continue")])
+        runner.persistQueue()
+
+        runner.flushQueueIfIdle()
+        try await waitUntil { session.queue.first?.lastError != nil }
+
+        #expect(session.forkRecord?.contextDeliveryPending == true)
+        #expect(try await persistence.loadFork(targetSessionID: session.id)?.contextDeliveryPending == true)
+        #expect(session.transcript.messages.count == 3)
+        #expect(session.transcript.messages.allSatisfy {
+            ACPTranscriptMarkdown.messageBody($0)?.contains("The conversation below was imported") != true
+        })
+
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.queue[0].lastError = nil
+        runner.flushQueueIfIdle()
+        try await waitUntil { session.queue.isEmpty }
+
+        let userMessages = session.transcript.messages.filter {
+            if case .user = $0 { return true }
+            return false
+        }
+        #expect(userMessages.count == 2)
+    }
+
+    private func makeRunner() async throws -> (
+        ACPSessionRunner,
+        ACPMockClient,
+        ACPSession,
+        ACPSessionPersistence
+    ) {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-fork-runner-\(UUID()).sqlite").path
+        let persistence = ACPSessionPersistence(path: path)
+        let inherited = [
+            ACPMessage.user(id: UUID(), text: "Question", attachments: []),
+            ACPMessage.agent(id: UUID(), StreamingText("Answer"))
+        ]
+        let row = ACPSessionRow(
+            id: "target", agentId: "codex", title: "Fork",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false
+        )
+        let fork = ACPSessionForkRecord(
+            targetSessionID: row.id,
+            sourceSessionID: "source",
+            sourceAgentID: "claude",
+            sourceBoundarySequence: 2,
+            inheritedMessageCount: 2,
+            phase: .ready,
+            mechanism: .transcriptTransfer,
+            contextDeliveryPending: true
+        )
+        let stored = try ACPSessionForkSnapshot(
+            sourceBoundarySequence: 2,
+            messages: [
+                .init(role: ACPSessionForkConversationMessage.Role.user, text: "Question"),
+                .init(role: ACPSessionForkConversationMessage.Role.agent, text: "Answer")
+            ]
+        ).copiedMessages(targetSessionID: row.id, createdAt: 0)
+        try await persistence.createFork(session: row, messages: stored, record: fork)
+
+        let session = ACPSession(id: row.id, agentId: row.agentId, worktreeId: "wt", title: row.title)
+        session.agentState = .ready
+        session.forkRecord = fork
+        for message in inherited {
+            session.transcript.appendMessage(message)
+        }
+        let mock = ACPMockClient()
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: nil,
+            sessionId: session.id,
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            persistence: persistence
+        )
+        return (runner, mock, session, persistence)
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while !condition() {
+            guard DispatchTime.now().uptimeNanoseconds < deadline else {
+                throw TimeoutError()
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    private struct TimeoutError: Error {}
+}

--- a/AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift
@@ -141,6 +141,212 @@ struct ACPSessionForkRunnerTests {
         #expect(try await persistence.loadFork(targetSessionID: session.id)?.contextDeliveryPending == false)
     }
 
+    @Test("direct first prompt acknowledgement follows durable context delivery")
+    func directFirstPromptAcknowledgesAfterContextDeliveryPersistence() async throws {
+        let (runner, mock, session, persistence) = try await makeRunner()
+        let acknowledgement = ForkPromptAcknowledgementRecorder()
+        let path = persistence.path
+        let sessionID = session.id
+        mock.scriptResponse(method: "session/prompt") { _ in
+            ACPResponse(
+                body: Data("null".utf8),
+                durableConsumptionAcknowledgement: {
+                    acknowledgement.recordPersistedForkState(
+                        path: path,
+                        targetSessionID: sessionID
+                    )
+                }
+            )
+        }
+
+        runner.sendNow(blocks: [.text("Continue")], queuedItemId: nil)
+
+        try await waitUntil { acknowledgement.recordedCount == 1 }
+        await runner.flushPersistence()
+
+        #expect(acknowledgement.persistedPendingStates == [false])
+    }
+
+    @Test("failed fork marker persistence leaves direct prompt unacknowledged")
+    func failedForkMarkerPersistenceDoesNotAcknowledgeDirectPrompt() async throws {
+        let (runner, mock, session, persistence) = try await makeRunner()
+        let acknowledgement = ForkPromptAcknowledgementRecorder()
+        let database = try SQLiteDatabase(path: persistence.path)
+        try database.exec("DROP TABLE session_forks")
+        let path = persistence.path
+        let sessionID = session.id
+        mock.scriptResponse(method: "session/prompt") { _ in
+            ACPResponse(
+                body: Data("null".utf8),
+                durableConsumptionAcknowledgement: {
+                    acknowledgement.recordPersistedForkState(
+                        path: path,
+                        targetSessionID: sessionID
+                    )
+                }
+            )
+        }
+
+        runner.sendNow(blocks: [.text("Continue")], queuedItemId: nil)
+
+        try await waitUntil {
+            mock.sent.contains { $0.method == "session/prompt" }
+                && session.forkRecord?.contextDeliveryPending == false
+        }
+        await runner.flushPersistence()
+
+        #expect(acknowledgement.recordedCount == 0)
+    }
+
+    @Test("queued first prompt acknowledgement follows context delivery and queue removal")
+    func queuedFirstPromptAcknowledgesAfterContextDeliveryAndQueuePersistence() async throws {
+        let (runner, mock, session, persistence) = try await makeRunner()
+        let acknowledgement = ForkPromptAcknowledgementRecorder()
+        let path = persistence.path
+        let sessionID = session.id
+        mock.scriptResponse(method: "session/prompt") { _ in
+            ACPResponse(
+                body: Data("null".utf8),
+                durableConsumptionAcknowledgement: {
+                    acknowledgement.recordPersistedForkAndQueueState(
+                        path: path,
+                        targetSessionID: sessionID
+                    )
+                }
+            )
+        }
+        session.enqueue(blocks: [.text("Continue")])
+        runner.persistQueue()
+        await runner.flushPersistence()
+
+        runner.flushQueueIfIdle()
+
+        try await waitUntil { acknowledgement.recordedCount == 1 }
+        await runner.flushPersistence()
+
+        #expect(acknowledgement.persistedPendingStates == [false])
+        #expect(acknowledgement.persistedQueueCounts == [0])
+    }
+
+    @Test("failed fork marker persistence leaves queued first prompt unacknowledged")
+    func failedForkMarkerPersistenceDoesNotAcknowledgeQueuedPrompt() async throws {
+        let (runner, mock, session, persistence) = try await makeRunner()
+        let acknowledgement = ForkPromptAcknowledgementRecorder()
+        session.enqueue(blocks: [.text("Continue")])
+        runner.persistQueue()
+        await runner.flushPersistence()
+        let database = try SQLiteDatabase(path: persistence.path)
+        try database.exec("DROP TABLE session_forks")
+        let path = persistence.path
+        let sessionID = session.id
+        mock.scriptResponse(method: "session/prompt") { _ in
+            ACPResponse(
+                body: Data("null".utf8),
+                durableConsumptionAcknowledgement: {
+                    acknowledgement.recordPersistedForkAndQueueState(
+                        path: path,
+                        targetSessionID: sessionID
+                    )
+                }
+            )
+        }
+
+        runner.flushQueueIfIdle()
+
+        try await waitUntil { session.queue.isEmpty }
+        await runner.flushPersistence()
+
+        #expect(acknowledgement.recordedCount == 0)
+    }
+
+    @Test("stale queued completion acknowledges after prior queue removal and context delivery")
+    func staleQueuedCompletionAcknowledgesAfterPersistedState() async throws {
+        let (runner, mock, session, persistence) = try await makeRunner()
+        let acknowledgement = ForkPromptAcknowledgementRecorder()
+        let promptStarted = ForkPromptGate()
+        let finishPrompt = ForkPromptGate()
+        let path = persistence.path
+        let sessionID = session.id
+        mock.scriptResponse(method: "session/prompt") { _ in
+            await promptStarted.open()
+            await finishPrompt.wait()
+            return ACPResponse(
+                body: Data("null".utf8),
+                durableConsumptionAcknowledgement: {
+                    acknowledgement.recordPersistedForkAndQueueState(
+                        path: path,
+                        targetSessionID: sessionID
+                    )
+                }
+            )
+        }
+        session.enqueue(blocks: [.text("Continue")])
+        runner.persistQueue()
+        await runner.flushPersistence()
+        runner.flushQueueIfIdle()
+        await promptStarted.wait()
+
+        // Model steer's ordered queue removal and prompt invalidation without
+        // starting a successor prompt that would obscure this stale completion.
+        session.queue.removeAll()
+        runner.persistQueue()
+        runner.invalidateActivePrompt()
+        await runner.flushPersistence()
+        #expect(try await persistence.loadQueue(sessionId: session.id).isEmpty)
+
+        await finishPrompt.open()
+        try await waitUntil { session.forkRecord?.contextDeliveryPending == false }
+        await runner.flushPersistence()
+
+        #expect(acknowledgement.persistedPendingStates == [false])
+        #expect(acknowledgement.persistedQueueCounts == [0])
+    }
+
+    @Test("out-of-order prompts each acknowledge captured fork context")
+    func outOfOrderPromptsEachAcknowledgeCapturedForkContext() async throws {
+        let (runner, mock, session, persistence) = try await makeRunner()
+        let acknowledgement = ForkPromptAcknowledgementRecorder()
+        let sequence = ForkPromptSequence()
+        let firstStarted = ForkPromptGate()
+        let secondStarted = ForkPromptGate()
+        let finishFirst = ForkPromptGate()
+        let finishSecond = ForkPromptGate()
+        let path = persistence.path
+        let sessionID = session.id
+        mock.scriptResponse(method: "session/prompt") { _ in
+            switch await sequence.next() {
+            case 1:
+                await firstStarted.open()
+                await finishFirst.wait()
+            default:
+                await secondStarted.open()
+                await finishSecond.wait()
+            }
+            return ACPResponse(
+                body: Data("null".utf8),
+                durableConsumptionAcknowledgement: {
+                    acknowledgement.recordPersistedForkState(
+                        path: path,
+                        targetSessionID: sessionID
+                    )
+                }
+            )
+        }
+
+        runner.sendNow(blocks: [.text("First")], queuedItemId: nil)
+        await firstStarted.wait()
+        runner.sendNow(blocks: [.text("Second")], queuedItemId: nil)
+        await secondStarted.wait()
+
+        await finishSecond.open()
+        try await waitUntil { acknowledgement.recordedCount == 1 }
+        await finishFirst.open()
+        try await waitUntil { acknowledgement.recordedCount == 2 }
+        await runner.flushPersistence()
+
+        #expect(acknowledgement.persistedPendingStates == [false, false])
+    }
+
     @Test("failed first prompt keeps private context pending for a queue retry")
     func failedFirstPromptKeepsContextPending() async throws {
         let (runner, mock, session, persistence) = try await makeRunner()
@@ -239,4 +445,90 @@ struct ACPSessionForkRunnerTests {
     }
 
     private struct TimeoutError: Error {}
+}
+
+private actor ForkPromptGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let continuations = waiters
+        waiters.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}
+
+private actor ForkPromptSequence {
+    private var value = 0
+
+    func next() -> Int {
+        value += 1
+        return value
+    }
+}
+
+private final class ForkPromptAcknowledgementRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [Bool?] = []
+    private var queueCounts: [Int?] = []
+
+    var recordedCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return states.count
+    }
+
+    var persistedPendingStates: [Bool?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return states
+    }
+
+    var persistedQueueCounts: [Int?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return queueCounts
+    }
+
+    func recordPersistedForkState(path: String, targetSessionID: String) {
+        let pending: Bool?
+        do {
+            pending = try ACPSessionStore(path: path)
+                .loadFork(targetSessionID: targetSessionID)?
+                .contextDeliveryPending
+        } catch {
+            pending = nil
+        }
+        lock.lock()
+        states.append(pending)
+        lock.unlock()
+    }
+
+    func recordPersistedForkAndQueueState(path: String, targetSessionID: String) {
+        let state: (pending: Bool?, queueCount: Int?)
+        do {
+            let store = try ACPSessionStore(path: path)
+            state = (
+                try store.loadFork(targetSessionID: targetSessionID)?.contextDeliveryPending,
+                try store.loadQueue(sessionId: targetSessionID).count
+            )
+        } catch {
+            state = (nil, nil)
+        }
+        lock.lock()
+        states.append(state.pending)
+        queueCounts.append(state.queueCount)
+        lock.unlock()
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -1072,6 +1072,44 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadSession(id: "local")?.contextRecoveryPending == false)
     }
 
+    @Test("load fallback keeps pending fork context out of generic recovery")
+    func loadFallbackDefersPendingForkContextUntilFirstPrompt() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let inherited = try ACPSessionForkSnapshot(
+            sourceBoundarySequence: 0,
+            messages: [.init(role: .user, text: "Prior context")]
+        ).copiedMessages(targetSessionID: "local", createdAt: 0)
+        let fork = ACPSessionForkRecord(
+            targetSessionID: "local",
+            sourceSessionID: "source",
+            sourceAgentID: "claude",
+            sourceBoundarySequence: 0,
+            inheritedMessageCount: 1,
+            phase: .ready,
+            mechanism: .transcriptTransfer,
+            contextDeliveryPending: true
+        )
+        try store.createFork(session: row(remoteSessionId: "remote-old"), messages: inherited, record: fork)
+
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32601, message: "Method not found", data: nil)
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/new"])
+        #expect(session.contextRecoveryStatus != .sendingTranscript)
+        #expect(session.contextRestoreWarning == nil)
+        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == false)
+        #expect(session.forkRecord?.contextDeliveryPending == true)
+    }
+
     @Test("failed automatic transcript recovery keeps queued prompt blocked")
     func failedAutomaticTranscriptRecoveryKeepsQueuedPromptBlocked() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ForkSourceBrokerService.swift
+++ b/AlasTests/ACP/Session/ForkSourceBrokerService.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import Alas
+
+actor ForkSourceBrokerService: ACPBrokerServicing {
+    private let remoteSessionID: String
+    private var nextRequestID: UInt64 = 0
+
+    init(remoteSessionID: String) {
+        self.remoteSessionID = remoteSessionID
+    }
+
+    func open(_ params: ACPBrokerOpenParams) async throws -> ACPBrokerOpenResult {
+        ACPBrokerOpenResult(
+            snapshot: snapshot(
+                brokerId: params.brokerId,
+                sessionId: params.sessionId,
+                acknowledgedCursor: .init(rawValue: 0)
+            ),
+            adopted: false
+        )
+    }
+
+    func attach(_ params: ACPBrokerAttachParams) async throws -> ACPBrokerAttachResult {
+        ACPBrokerAttachResult(
+            snapshot: snapshot(
+                brokerId: params.brokerId,
+                sessionId: "source",
+                acknowledgedCursor: params.acknowledgedCursor
+            ),
+            events: []
+        )
+    }
+
+    func send(_ params: ACPBrokerSendParams) async throws -> ACPBrokerSendResult {
+        nextRequestID += 1
+        let result: ACPBrokerJSONValue = if params.method == "session/load" {
+            .object([
+                "sessionId": .string(remoteSessionID),
+                "availableModels": .array([]),
+                "availableModes": .array([]),
+                "promptSuggestions": .array([]),
+                "configOptions": .array([])
+            ])
+        } else {
+            .null
+        }
+        return ACPBrokerSendResult(
+            requestId: ACPBrokerAdapterRequestID(rawValue: nextRequestID),
+            replayed: false,
+            result: result,
+            pending: false
+        )
+    }
+
+    func notify(_ params: ACPBrokerNotifyParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func respond(_ params: ACPBrokerRespondParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func ack(_ params: ACPBrokerAckParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func detach(_ params: ACPBrokerDetachParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    func close(_ params: ACPBrokerCloseParams) async throws -> ACPBrokerSimpleOK {
+        ACPBrokerSimpleOK(ok: true)
+    }
+
+    private func snapshot(
+        brokerId: ACPBrokerID,
+        sessionId: String,
+        acknowledgedCursor: ACPBrokerEventCursor
+    ) -> ACPBrokerSnapshot {
+        ACPBrokerSnapshot(
+            metadata: ACPBrokerMetadata(
+                brokerId: brokerId,
+                generation: ACPBrokerGeneration(rawValue: 1),
+                alasSessionId: sessionId,
+                adapterProgram: "mock",
+                adapterArgs: [],
+                cwd: "/tmp/wt",
+                envKeys: [],
+                createdAtMillis: 10
+            ),
+            initializeResult: .object([
+                "protocolVersion": .number(1),
+                "agentCapabilities": .object([
+                    "sessionCapabilities": .object([
+                        "load": .object([:]),
+                        "fork": .object([:])
+                    ])
+                ]),
+                "authMethods": .array([])
+            ]),
+            remoteSessionResult: nil,
+            turnState: .idle,
+            acknowledgedCursor: acknowledgedCursor,
+            journalTail: acknowledgedCursor,
+            pendingRequests: [],
+            operations: []
+        )
+    }
+}

--- a/AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift
+++ b/AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP session fork presentation")
+struct ACPSessionForkPresentationTests {
+    @Test("current target is first and remaining targets preserve ACP catalog order")
+    func targetOrdering() {
+        let targets = ACPForkTargetPolicy.targets(
+            sourceAgentID: "codex",
+            enabledAgents: [
+                .init(id: "claude", displayName: "Claude"),
+                .init(id: "gemini", displayName: "Gemini"),
+            ],
+            sourceAgent: .init(id: "codex", displayName: "Codex"),
+            catalogAgentIDs: ["claude", "gemini", "codex"]
+        )
+        #expect(targets.map(\.id) == ["codex", "claude", "gemini"])
+        #expect(targets.first?.isSameAgent == true)
+    }
+
+    @Test("message menu only offers fork for eligible rows")
+    func menuEligibility() {
+        #expect(ACPMessageForkMenuPolicy.showsForkAction(
+            messageKind: "user", isEligible: true, targetCount: 2
+        ))
+        #expect(!ACPMessageForkMenuPolicy.showsForkAction(
+            messageKind: "agent", isEligible: false, targetCount: 2
+        ))
+        #expect(!ACPMessageForkMenuPolicy.showsForkAction(
+            messageKind: "tool_call", isEligible: true, targetCount: 2
+        ))
+    }
+}

--- a/AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift
+++ b/AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift
@@ -4,6 +4,19 @@ import Testing
 @MainActor
 @Suite("ACP session fork presentation")
 struct ACPSessionForkPresentationTests {
+    @Test("native and transcript forks use honest divider copy")
+    func dividerCopy() {
+        #expect(ACPSessionForkPresentation(
+            sourceAgentName: "Claude", mechanism: .nativeACP
+        ).title == "Forked from Claude")
+        let imported = ACPSessionForkPresentation(
+            sourceAgentName: "Claude", mechanism: .transcriptTransfer
+        )
+        #expect(imported.title == "Conversation imported from Claude")
+        #expect(imported.notice ==
+            "Provider-specific tool state, hidden context, and attachments were not transferred. This chat shares the source chat’s current worktree.")
+    }
+
     @Test("current target is first and remaining targets preserve ACP catalog order")
     func targetOrdering() {
         let targets = ACPForkTargetPolicy.targets(

--- a/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
@@ -38,7 +38,9 @@ struct ACPTranscriptRowContentTests {
     func rowContentEqualitySnapshotsForkEligibility() {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         let message = ACPMessage.user(id: UUID(), text: "hello", attachments: [])
-        let targets = [.init(id: "claude", displayName: "Claude", isSameAgent: true)]
+        let targets: [ACPSessionForkTarget] = [
+            .init(id: "claude", displayName: "Claude", isSameAgent: true)
+        ]
 
         func row(isForkEligible: Bool) -> ACPTranscriptRowContent {
             ACPTranscriptRowContent(

--- a/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
@@ -18,6 +18,38 @@ struct ACPTranscriptRowContentTests {
         #expect(a == b)
     }
 
+    @Test("equality detects fork action availability changes")
+    @MainActor
+    func rowContentEqualityDetectsForkAvailabilityChange() {
+        let msg = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil,
+            isForkEligible: false, forkTargets: [])
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil,
+            isForkEligible: true, forkTargets: [])
+        #expect(a != b)
+    }
+
+    @Test("equality detects fork target changes")
+    @MainActor
+    func rowContentEqualityDetectsForkTargetChange() {
+        let msg = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil,
+            isForkEligible: true,
+            forkTargets: [.init(id: "claude", displayName: "Claude", isSameAgent: true)])
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg, contentMaxWidth: 800,
+            typography: .default, trustedImageRoot: nil,
+            isForkEligible: true,
+            forkTargets: [.init(id: "codex", displayName: "Codex", isSameAgent: true)])
+        #expect(a != b)
+    }
+
     @Test("equality detects a message change")
     @MainActor
     func rowContentEqualityDetectsMessageChange() {

--- a/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
@@ -33,6 +33,34 @@ struct ACPTranscriptRowContentTests {
         #expect(a != b)
     }
 
+    @Test("row equality snapshots fork eligibility")
+    @MainActor
+    func rowContentEqualitySnapshotsForkEligibility() {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let message = ACPMessage.user(id: UUID(), text: "hello", attachments: [])
+        let targets = [.init(id: "claude", displayName: "Claude", isSameAgent: true)]
+
+        func row(isForkEligible: Bool) -> ACPTranscriptRowContent {
+            ACPTranscriptRowContent(
+                stableId: message.stableId,
+                messageIndex: 0,
+                message: message,
+                contentMaxWidth: 800,
+                typography: .default,
+                trustedImageRoot: nil,
+                transcript: session.transcript,
+                session: session,
+                onOpenDiff: { _ in },
+                onLoadFullToolCallContent: { _ in nil },
+                isForkEligible: isForkEligible,
+                forkTargets: targets,
+                onFork: { _, _ in }
+            )
+        }
+
+        #expect(row(isForkEligible: false) != row(isForkEligible: true))
+    }
+
     @Test("equality detects fork target changes")
     @MainActor
     func rowContentEqualityDetectsForkTargetChange() {

--- a/docs/superpowers/plans/2026-07-24-acp-session-fork.md
+++ b/docs/superpowers/plans/2026-07-24-acp-session-fork.md
@@ -1,0 +1,1769 @@
+# ACP Session Fork Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-message ACP chat forking that uses native same-agent `session/fork` at the remote head and durable conversation transfer for earlier checkpoints or different providers.
+
+**Architecture:** A pure fork-domain layer resolves a stable message boundary against the fully persisted source transcript and chooses a native candidate or transcript transfer. `ACPSessionStore` atomically creates the local target plus copied conversation rows and fork metadata; `ACPSessionManager.attach` then either performs native fork on the target's own connection or creates a normal remote session whose first real prompt privately carries the inherited context. The existing message `…` menu supplies the target agent, while a persisted fork divider presents lineage and links back to the source chat.
+
+**Tech Stack:** Swift 5.9+, SwiftUI and AppKit on macOS, ACP JSON-RPC, SQLite persistence, Swift Testing, XcodeGen.
+
+**Design:** `docs/superpowers/specs/2026-07-24-acp-session-fork-design.md`
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Tests use Swift Testing (`import Testing`), not XCTest.
+- Prefix every shell command with `rtk`.
+- Do not add agent attribution to commits, PR bodies, docs, comments, or code.
+- A fork is a conversation branch in the source worktree's current filesystem state; it does not create or rewind a Git worktree.
+- Eligible boundaries are completed user messages and completed agent responses only.
+- Copy only user and agent text; omit attachments, thoughts, tool calls, tool output, file edits, plans, system notices, permissions, questions, queued prompts, and drafts.
+- Use native ACP fork only for the same agent at the exact persisted remote head with a remote source ID and advertised fork capability.
+- Use transcript transfer for earlier checkpoints, cross-provider targets, known-missing capabilities, and non-auth native-fork errors. When runtime capability state is not yet known, persist a native candidate and decide after target initialization.
+- Open the local target tab after the atomic local snapshot commit; do not generate an agent response until the user sends a real prompt.
+- Keep transcript-transfer context private and pending until the first real prompt succeeds.
+- The source transcript and persisted source rows must remain unchanged.
+- Run `xcodegen`, `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`, and `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` before completion.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/ACP/Session/ACPSessionFork.swift`
+  - Own fork boundary, target, phase, mechanism, persisted metadata, policy, snapshot resolution, and copied-message encoding.
+- Create `Alas/Sources/ACP/UI/ACPSessionForkDivider.swift`
+  - Render persisted lineage, transcript-transfer limitations, and source navigation.
+- Create `AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift`
+  - Cover mechanism selection, boundary resolution, filtering, payload rewriting, and mismatch failure.
+- Create `AlasTests/ACP/Session/ACPSessionForkPersistenceTests.swift`
+  - Cover schema migration, atomic target creation, finalization, pending-context clearing, and hydration.
+- Create `AlasTests/ACP/Session/ACPSessionForkManagerTests.swift`
+  - Cover full-backfill boundary creation, source immutability, in-memory materialization, and restart state.
+- Create `AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift`
+  - Cover one-time private context injection and retry behavior.
+- Create `AlasTests/ACP/Session/ACPSessionForkAttachTests.swift`
+  - Cover native fork success, broker operation keys, graceful fallback, and relaunch reconciliation.
+- Create `AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift`
+  - Cover target ordering, menu eligibility, divider copy, and source-link policy.
+- Modify `Alas/Sources/ACP/Protocol/ACPMessages.swift`
+  - Add the stable `session/close` parameter used for best-effort orphan cleanup.
+- Modify `Alas/Sources/ACP/Protocol/ACPConnection.swift`
+  - Make fork responses durable, accept a broker operation key, and add best-effort session close.
+- Modify `Alas/Sources/ACP/Session/ACPSessionStore.swift`
+  - Add schema v15 and transactional fork CRUD.
+- Modify `Alas/Sources/ACP/Session/ACPSessionPersistence.swift`
+  - Expose actor-isolated fork operations.
+- Modify `Alas/Sources/ACP/Session/ACPSessionHydrator.swift`
+  - Include fork metadata in hydration and mirror snapshots.
+- Modify `Alas/Sources/ACP/Session/ACPSession.swift`
+  - Retain runtime session capabilities, hydrated fork metadata, and message eligibility.
+- Modify `Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift`
+  - Serialize the inherited prefix into the exact private background-context prompt.
+- Modify `Alas/Sources/ACP/Session/ACPSessionRunner.swift`
+  - Prepend pending fork context to the first real wire prompt and clear it after success.
+- Modify `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+  - Create local forks, resolve durable boundaries, negotiate native fork inside attach, and finalize fallback.
+- Modify `Alas/Sources/ACP/UI/ACPMessageGutter.swift`
+  - Add the native target-agent submenu.
+- Modify `Alas/Sources/ACP/UI/ACPMessageList.swift`
+  - Pass stable fork boundaries into row actions and insert the persisted divider.
+- Modify `Alas/Sources/ACP/UI/ACPTabView.swift`
+  - Supply targets/callbacks and route source navigation.
+- Modify `Alas/Sources/App/AppState.swift`
+  - Order enabled ACP targets, create/focus fork tabs, schedule attach, and present creation errors.
+
+---
+
+### Task 1: Fork Domain, Mechanism Policy, and Durable Snapshot
+
+**Files:**
+- Create: `Alas/Sources/ACP/Session/ACPSessionFork.swift`
+- Create: `AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift`
+
+**Interfaces:**
+- Consumes: `ACPMessage`, `ACPMessageWire.decode(kind:payload:)`, `ACPStoredMessage`, and `ACPInitializeResult.ACPAgentSessionCapabilities`.
+- Produces: `ACPForkMessageBoundary`, `ACPSessionForkTarget`, `ACPSessionForkCreationPhase`, `ACPSessionForkMechanism`, `ACPSessionForkRecord`, `ACPSessionForkCandidatePolicy.candidate(...)`, `ACPSessionForkSnapshotResolver.resolve(...)`, and `ACPSessionForkSnapshot.copiedMessages(targetSessionID:createdAt:)`.
+
+- [ ] **Step 1: Write failing policy and snapshot tests**
+
+Create `AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift` with:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP session fork policy")
+struct ACPSessionForkPolicyTests {
+    @Test("native candidate requires same agent, remote head, id, and non-negative capability knowledge")
+    func nativeCandidateRequirements() {
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "claude",
+            boundaryIsRemoteHead: true,
+            sourceRemoteSessionID: "remote-1",
+            forkCapability: true
+        ) == .native)
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "codex",
+            boundaryIsRemoteHead: true,
+            sourceRemoteSessionID: "remote-1",
+            forkCapability: true
+        ) == .transcript)
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "claude",
+            boundaryIsRemoteHead: false,
+            sourceRemoteSessionID: "remote-1",
+            forkCapability: true
+        ) == .transcript)
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "claude",
+            boundaryIsRemoteHead: true,
+            sourceRemoteSessionID: nil,
+            forkCapability: true
+        ) == .transcript)
+        #expect(ACPSessionForkCandidatePolicy.candidate(
+            sourceAgentID: "claude",
+            targetAgentID: "claude",
+            boundaryIsRemoteHead: true,
+            sourceRemoteSessionID: "remote-1",
+            forkCapability: nil
+        ) == .native)
+    }
+
+    @Test("snapshot is inclusive and conversation-only")
+    func conversationOnlySnapshot() throws {
+        let user: ACPMessage = .user(
+            id: UUID(), messageId: "u1", text: "Question",
+            attachments: [.init(uri: "file:///tmp/image.png", name: "image.png", mimeType: "image/png")]
+        )
+        let tool: ACPMessage = .toolCall(.init(
+            toolCallId: "tc1", title: "Read", status: "completed",
+            content: "secret tool output", locations: []
+        ))
+        let agent: ACPMessage = .agent(
+            id: UUID(), messageId: "a1", StreamingText("Answer")
+        )
+        let stored = try [user, tool, agent].enumerated().map { index, message in
+            ACPStoredMessage(
+                id: "source-\(index)",
+                sessionId: "source",
+                kind: message.kind,
+                seq: Int64(index),
+                payload: try ACPMessageCodec.encode(message),
+                createdAt: Int64(index)
+            )
+        }
+
+        let snapshot = try ACPSessionForkSnapshotResolver.resolve(
+            boundary: .init(stableID: agent.stableId, kind: .agent),
+            liveMessages: [user, tool, agent],
+            storedMessages: stored
+        )
+
+        #expect(snapshot.sourceBoundarySequence == 2)
+        #expect(snapshot.messages == [
+            .init(role: .user, text: "Question"),
+            .init(role: .agent, text: "Answer")
+        ])
+        let copied = try snapshot.copiedMessages(targetSessionID: "target", createdAt: 10)
+        #expect(copied.map(\.kind) == ["user", "agent"])
+        #expect(copied.map(\.seq) == [0, 1])
+        let copiedUser = try ACPMessageWire.decode(kind: copied[0].kind, payload: copied[0].payload)
+        guard case .user(_, _, let attachments, let delegatedSource) = copiedUser else {
+            Issue.record("Expected copied user message")
+            return
+        }
+        #expect(attachments.isEmpty)
+        #expect(delegatedSource == nil)
+    }
+
+    @Test("snapshot rejects a stale or mismatched boundary")
+    func staleBoundaryFails() throws {
+        let message: ACPMessage = .user(id: UUID(), text: "live", attachments: [])
+        let storedMessage: ACPMessage = .user(id: UUID(), text: "different", attachments: [])
+        let stored = ACPStoredMessage(
+            id: "m0", sessionId: "source", kind: "user", seq: 0,
+            payload: try ACPMessageCodec.encode(storedMessage), createdAt: 0
+        )
+
+        #expect(throws: ACPSessionForkSnapshotError.self) {
+            _ = try ACPSessionForkSnapshotResolver.resolve(
+                boundary: .init(stableID: message.stableId, kind: .user),
+                liveMessages: [message],
+                storedMessages: [stored]
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify the missing-type failure**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkPolicyTests test
+```
+
+Expected: FAIL at compile time because the fork-domain types do not exist.
+
+- [ ] **Step 3: Implement the fork domain and snapshot resolver**
+
+Create `Alas/Sources/ACP/Session/ACPSessionFork.swift` with these public-to-module declarations and implementations:
+
+```swift
+import Foundation
+
+struct ACPForkMessageBoundary: Equatable, Sendable {
+    enum Kind: String, Equatable, Sendable { case user, agent }
+    let stableID: String
+    let kind: Kind
+}
+
+struct ACPSessionForkTarget: Identifiable, Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let isSameAgent: Bool
+}
+
+enum ACPSessionForkCreationPhase: String, Codable, Equatable, Sendable {
+    case negotiatingNative
+    case ready
+}
+
+enum ACPSessionForkMechanism: String, Codable, Equatable, Sendable {
+    case nativeACP
+    case transcriptTransfer
+}
+
+struct ACPSessionForkRecord: Equatable, Sendable {
+    let targetSessionID: String
+    let sourceSessionID: String
+    let sourceAgentID: String
+    let sourceBoundarySequence: Int64
+    let inheritedMessageCount: Int
+    var phase: ACPSessionForkCreationPhase
+    var mechanism: ACPSessionForkMechanism?
+    var contextDeliveryPending: Bool
+}
+
+enum ACPSessionForkCandidate: Equatable { case native, transcript }
+
+enum ACPSessionForkCandidatePolicy {
+    static func candidate(
+        sourceAgentID: String,
+        targetAgentID: String,
+        boundaryIsRemoteHead: Bool,
+        sourceRemoteSessionID: String?,
+        forkCapability: Bool?
+    ) -> ACPSessionForkCandidate {
+        guard sourceAgentID == targetAgentID,
+              boundaryIsRemoteHead,
+              sourceRemoteSessionID?.isEmpty == false,
+              forkCapability != false
+        else { return .transcript }
+        return .native
+    }
+}
+
+struct ACPSessionForkConversationMessage: Equatable, Sendable {
+    enum Role: String, Equatable, Sendable { case user, agent }
+    let role: Role
+    let text: String
+}
+
+struct ACPSessionForkSnapshot: Equatable, Sendable {
+    let sourceBoundarySequence: Int64
+    let messages: [ACPSessionForkConversationMessage]
+
+    func copiedMessages(targetSessionID: String, createdAt: Int64) throws -> [ACPStoredMessage] {
+        try messages.enumerated().map { index, message in
+            let payload: Data
+            let kind: String
+            switch message.role {
+            case .user:
+                kind = "user"
+                payload = try JSONEncoder().encode(CopiedUserPayload(
+                    messageId: nil, text: message.text, attachments: [], delegatedSource: nil
+                ))
+            case .agent:
+                kind = "agent"
+                payload = try JSONEncoder().encode(CopiedTextPayload(messageId: nil, text: message.text))
+            }
+            return ACPStoredMessage(
+                id: "msg-\(targetSessionID)-\(index)",
+                sessionId: targetSessionID,
+                kind: kind,
+                seq: Int64(index),
+                payload: payload,
+                createdAt: createdAt
+            )
+        }
+    }
+}
+
+enum ACPSessionForkSnapshotError: Error, Equatable {
+    case boundaryNotFound
+    case transcriptMismatch
+}
+
+enum ACPSessionForkSnapshotResolver {
+    @MainActor
+    static func resolve(
+        boundary: ACPForkMessageBoundary,
+        liveMessages: [ACPMessage],
+        storedMessages: [ACPStoredMessage]
+    ) throws -> ACPSessionForkSnapshot {
+        guard let boundaryIndex = liveMessages.firstIndex(where: { $0.stableId == boundary.stableID }),
+              storedMessages.count == liveMessages.count
+        else { throw ACPSessionForkSnapshotError.boundaryNotFound }
+
+        let decoded = try storedMessages.map {
+            try ACPMessageWire.decode(kind: $0.kind, payload: $0.payload)
+        }
+        for index in 0...boundaryIndex {
+            guard matches(liveMessages[index], decoded[index]) else {
+                throw ACPSessionForkSnapshotError.transcriptMismatch
+            }
+        }
+
+        let conversation = decoded[0...boundaryIndex].compactMap { wire -> ACPSessionForkConversationMessage? in
+            switch wire {
+            case .user(_, let text, _, _):
+                return text.isEmpty ? nil : .init(role: .user, text: text)
+            case .agent(_, let text):
+                return text.isEmpty ? nil : .init(role: .agent, text: text)
+            default:
+                return nil
+            }
+        }
+        return .init(
+            sourceBoundarySequence: storedMessages[boundaryIndex].seq,
+            messages: conversation
+        )
+    }
+
+    @MainActor
+    private static func matches(_ live: ACPMessage, _ stored: ACPMessageWire) -> Bool {
+        switch (live, stored) {
+        case let (.user(_, liveID, liveText, _, _), .user(storedID, storedText, _, _)):
+            return liveID == storedID && liveText == storedText
+        case let (.agent(_, liveID, liveText), .agent(storedID, storedText)):
+            return liveID == storedID && liveText.value == storedText
+        case let (.thought(_, liveID, liveText), .thought(storedID, storedText)):
+            return liveID == storedID && liveText.value == storedText
+        case let (.toolCall(liveCall), .toolCall(storedCall)):
+            return liveCall.toolCallId == storedCall.toolCallId
+        case (.fileEdit, .fileEdit), (.plan, .plan), (.systemNotice, .systemNotice):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+private struct CopiedTextPayload: Codable {
+    let messageId: String?
+    let text: String
+}
+
+private struct CopiedUserPayload: Codable {
+    let messageId: String?
+    let text: String
+    let attachments: [ACPMessage.Attachment]
+    let delegatedSource: ACPDelegatedPromptSource?
+}
+```
+
+- [ ] **Step 4: Run the focused tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkPolicyTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the domain layer**
+
+```bash
+rtk git add Alas/Sources/ACP/Session/ACPSessionFork.swift AlasTests/ACP/Session/ACPSessionForkPolicyTests.swift
+rtk git commit -m "feat(acp): define session fork snapshots"
+```
+
+---
+
+### Task 2: Fork Persistence and Hydration
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/ACPSessionStore.swift:4-225`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionStore.swift:240-830`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionPersistence.swift:20-560`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionHydrator.swift:40-145`
+- Create: `AlasTests/ACP/Session/ACPSessionForkPersistenceTests.swift`
+
+**Interfaces:**
+- Consumes: Task 1's `ACPSessionForkRecord`, `ACPSessionForkMechanism`, `ACPSessionForkCreationPhase`, and copied `[ACPStoredMessage]`.
+- Produces: `ACPSessionStore.createFork(session:messages:record:)`, `loadFork(targetSessionID:)`, `finalizeFork(targetSessionID:mechanism:remoteSessionID:)`, `clearForkContextDeliveryPending(targetSessionID:)`, matching actor methods on `ACPSessionPersistence`, and `HydrationResult.forkRecord`.
+
+- [ ] **Step 1: Write failing atomicity and hydration tests**
+
+Create `AlasTests/ACP/Session/ACPSessionForkPersistenceTests.swift` with a suite that:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP session fork persistence")
+struct ACPSessionForkPersistenceTests {
+    @Test("fork row, copied messages, and metadata commit together")
+    func atomicCreateAndLoad() throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        let row = targetRow(id: "target")
+        let messages = [
+            ACPStoredMessage(
+                id: "msg-target-0", sessionId: "target", kind: "user", seq: 0,
+                payload: Data(#"{"messageId":null,"text":"hello","attachments":[],"delegatedSource":null}"#.utf8),
+                createdAt: 1
+            )
+        ]
+        let record = forkRecord(target: "target", phase: .ready, mechanism: .transcriptTransfer)
+
+        try store.createFork(session: row, messages: messages, record: record)
+
+        #expect(try store.loadSession(id: "target") == row)
+        #expect(try store.loadMessages(sessionId: "target") == messages)
+        #expect(try store.loadFork(targetSessionID: "target") == record)
+    }
+
+    @Test("fork create rolls back when a copied message conflicts")
+    func atomicRollback() throws {
+        let store = try ACPSessionStore(path: temporaryPath())
+        try store.upsertSession(targetRow(id: "existing"))
+        try store.appendMessage(
+            sessionId: "existing", id: "collision", kind: "system", seq: 0,
+            payload: Data(#"{"messageId":null,"text":"existing"}"#.utf8), createdAt: 0
+        )
+        let conflicting = ACPStoredMessage(
+            id: "collision", sessionId: "target", kind: "user", seq: 0,
+            payload: Data(#"{"messageId":null,"text":"fork","attachments":[],"delegatedSource":null}"#.utf8),
+            createdAt: 1
+        )
+
+        var didThrow = false
+        do {
+            try store.createFork(
+                session: targetRow(id: "target"),
+                messages: [conflicting],
+                record: forkRecord(target: "target", phase: .ready, mechanism: .transcriptTransfer)
+            )
+        } catch {
+            didThrow = true
+        }
+        #expect(didThrow)
+        #expect(try store.loadSession(id: "target") == nil)
+        #expect(try store.loadFork(targetSessionID: "target") == nil)
+    }
+
+    @Test("finalize and clear pending context survive hydration")
+    func finalizeAndHydrate() async throws {
+        let path = temporaryPath()
+        let persistence = ACPSessionPersistence(path: path)
+        let initial = forkRecord(target: "target", phase: .negotiatingNative, mechanism: nil)
+        try await persistence.createFork(
+            session: targetRow(id: "target"),
+            messages: [],
+            record: initial
+        )
+        try await persistence.finalizeFork(
+            targetSessionID: "target",
+            mechanism: .transcriptTransfer,
+            remoteSessionID: nil
+        )
+
+        let hydrated = try await persistence.hydrate(sessionId: "target")
+        #expect(hydrated.forkRecord?.phase == .ready)
+        #expect(hydrated.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(hydrated.forkRecord?.contextDeliveryPending == true)
+
+        try await persistence.clearForkContextDeliveryPending(targetSessionID: "target")
+        #expect(try await persistence.loadFork(targetSessionID: "target")?.contextDeliveryPending == false)
+    }
+
+    private func temporaryPath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-fork-\(UUID()).sqlite").path
+    }
+
+    private func targetRow(id: String) -> ACPSessionRow {
+        .init(
+            id: id, agentId: "codex", title: "Source (fork)",
+            titleSource: .generated, currentModel: nil, currentMode: nil,
+            autoRun: false, createdAt: 1, updatedAt: 1, lastOpenedAt: 1,
+            archived: false
+        )
+    }
+
+    private func forkRecord(
+        target: String,
+        phase: ACPSessionForkCreationPhase,
+        mechanism: ACPSessionForkMechanism?
+    ) -> ACPSessionForkRecord {
+        .init(
+            targetSessionID: target,
+            sourceSessionID: "source",
+            sourceAgentID: "claude",
+            sourceBoundarySequence: 2,
+            inheritedMessageCount: 1,
+            phase: phase,
+            mechanism: mechanism,
+            contextDeliveryPending: mechanism == .transcriptTransfer
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused persistence suite**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkPersistenceTests test
+```
+
+Expected: FAIL because schema v15 and fork persistence APIs do not exist.
+
+- [ ] **Step 3: Add schema v15 and store CRUD**
+
+In `ACPSessionStore`:
+
+```swift
+static let targetSchemaVersion = 15
+```
+
+Call `migrate_to_v15()` from `migrate()` and implement:
+
+```swift
+private func migrate_to_v15() throws {
+    try db.exec("""
+    CREATE TABLE IF NOT EXISTS session_forks (
+      target_session_id          TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+      source_session_id          TEXT NOT NULL,
+      source_agent_id            TEXT NOT NULL,
+      source_boundary_seq        INTEGER NOT NULL,
+      inherited_message_count    INTEGER NOT NULL,
+      phase                      TEXT NOT NULL,
+      mechanism                  TEXT,
+      context_delivery_pending   INTEGER NOT NULL DEFAULT 0
+    )
+    """)
+}
+```
+
+Add store methods whose transaction bodies are:
+
+```swift
+func createFork(
+    session: ACPSessionRow,
+    messages: [ACPStoredMessage],
+    record: ACPSessionForkRecord
+) throws {
+    try db.transaction {
+        try upsertSession(session)
+        for message in messages {
+            try appendMessage(
+                sessionId: message.sessionId,
+                id: message.id,
+                kind: message.kind,
+                seq: message.seq,
+                payload: message.payload,
+                createdAt: message.createdAt
+            )
+        }
+        try upsertFork(record)
+    }
+}
+
+func finalizeFork(
+    targetSessionID: String,
+    mechanism: ACPSessionForkMechanism,
+    remoteSessionID: String?
+) throws {
+    try db.transaction {
+        try db.exec("""
+        UPDATE session_forks
+        SET phase = ?, mechanism = ?, context_delivery_pending = ?
+        WHERE target_session_id = ?
+        """, bindings: [
+            ACPSessionForkCreationPhase.ready.rawValue,
+            mechanism.rawValue,
+            mechanism == .transcriptTransfer ? 1 : 0,
+            targetSessionID
+        ])
+        if let remoteSessionID {
+            try db.exec(
+                "UPDATE sessions SET remote_session_id = ?, origin = ? WHERE id = ?",
+                bindings: [remoteSessionID, ACPSessionOrigin.agentForked.rawValue, targetSessionID]
+            )
+        }
+    }
+}
+
+func clearForkContextDeliveryPending(targetSessionID: String) throws {
+    try db.exec("""
+    UPDATE session_forks
+    SET context_delivery_pending = 0
+    WHERE target_session_id = ?
+    """, bindings: [targetSessionID])
+}
+```
+
+Implement `upsertFork(_:)` and `loadFork(targetSessionID:)` by binding every
+`ACPSessionForkRecord` field exactly to the v15 columns. `source_session_id`
+must not be a foreign key, so deleting a source never deletes the target.
+
+- [ ] **Step 4: Expose actor APIs and hydrate metadata**
+
+Add one-line forwarding methods to `ACPSessionPersistence`:
+
+```swift
+func createFork(session: ACPSessionRow, messages: [ACPStoredMessage], record: ACPSessionForkRecord) throws
+func loadFork(targetSessionID: String) throws -> ACPSessionForkRecord?
+func finalizeFork(targetSessionID: String, mechanism: ACPSessionForkMechanism, remoteSessionID: String?) throws
+func clearForkContextDeliveryPending(targetSessionID: String) throws
+```
+
+Add `let forkRecord: ACPSessionForkRecord?` to `HydrationResult`, load it in
+`ACPSessionHydrator.loadSnapshot`, and preserve it in
+`replacingRowLastOpenedAt` and `replacingRecent`.
+
+- [ ] **Step 5: Run persistence and hydration tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkPersistenceTests -only-testing:AlasTests/ACPSessionHydratorTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit persistence**
+
+```bash
+rtk git add Alas/Sources/ACP/Session/ACPSessionStore.swift Alas/Sources/ACP/Session/ACPSessionPersistence.swift Alas/Sources/ACP/Session/ACPSessionHydrator.swift AlasTests/ACP/Session/ACPSessionForkPersistenceTests.swift
+rtk git commit -m "feat(acp): persist session fork lineage"
+```
+
+---
+
+### Task 3: Manager-Owned Local Fork Creation
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/ACPSession.swift:25-310`
+- Modify: `Alas/Sources/ACP/Session/ACPSession.swift:1180-1220`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift:450-740`
+- Create: `AlasTests/ACP/Session/ACPSessionForkManagerTests.swift`
+
+**Interfaces:**
+- Consumes: Tasks 1-2's snapshot resolver and persistence APIs plus `ACPSessionManager.awaitBackfill(id:)` and `flushAllPersistence()`.
+- Produces: `ACPSession.sessionCapabilities`, `ACPSession.forkRecord`, `ACPSession.canForkMessage(at:)`, and `ACPSessionManager.createFork(sourceSessionID:boundary:targetAgentID:autoRunDefault:) async throws -> ACPSession`.
+
+- [ ] **Step 1: Write failing manager tests**
+
+Create `AlasTests/ACP/Session/ACPSessionForkManagerTests.swift` with tests that:
+
+```swift
+@MainActor
+@Suite("ACP session fork manager")
+struct ACPSessionForkManagerTests {
+    @Test("createFork copies through selected boundary and leaves source unchanged")
+    func createsLocalFork() async throws {
+        let path = temporaryPath()
+        let store = try ACPSessionStore(path: path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let source = manager.createSession(agentId: "claude")
+        let user: ACPMessage = .user(id: UUID(), text: "one", attachments: [])
+        let agent: ACPMessage = .agent(id: UUID(), StreamingText("two"))
+        let later: ACPMessage = .user(id: UUID(), text: "three", attachments: [])
+        for message in [user, agent, later] {
+            let index = source.transcript.messages.count
+            source.transcript.appendMessage(message)
+            try store.appendMessage(
+                sessionId: source.id,
+                id: "msg-\(source.id)-\(index)",
+                kind: message.kind,
+                seq: Int64(index),
+                payload: try ACPMessageCodec.encode(message),
+                createdAt: Int64(index)
+            )
+        }
+        let sourceBefore = try store.loadMessages(sessionId: source.id)
+
+        let target = try await manager.createFork(
+            sourceSessionID: source.id,
+            boundary: .init(stableID: agent.stableId, kind: .agent),
+            targetAgentID: "codex",
+            autoRunDefault: false
+        )
+
+        #expect(target.agentId == "codex")
+        #expect(target.title == "New session (fork)")
+        #expect(target.transcript.messages.count == 2)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
+        #expect(try store.loadMessages(sessionId: source.id) == sourceBefore)
+    }
+
+    @Test("streaming agent is ineligible while earlier messages remain eligible")
+    func messageEligibility() {
+        let session = ACPSession(
+            id: "s", agentId: "claude", worktreeId: "wt",
+            title: "Session", hydrationState: .ready
+        )
+        session.transcript.appendMessage(.user(id: UUID(), text: "old", attachments: []))
+        session.transcript.appendMessage(.agent(id: UUID(), StreamingText("old answer")))
+        session.transcript.appendMessage(.user(id: UUID(), text: "new", attachments: []))
+        session.transcript.appendMessage(.agent(id: UUID(), StreamingText("partial")))
+        session.transcript.streamingState = .streaming
+
+        #expect(session.canForkMessage(at: 0))
+        #expect(session.canForkMessage(at: 1))
+        #expect(session.canForkMessage(at: 2))
+        #expect(!session.canForkMessage(at: 3))
+    }
+}
+```
+
+Include the same `temporaryPath()` helper pattern used by
+`ACPSessionManagerTests`.
+
+- [ ] **Step 2: Run the manager suite and verify failure**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkManagerTests test
+```
+
+Expected: FAIL because fork state and manager creation APIs are missing.
+
+- [ ] **Step 3: Add runtime fork state and eligibility**
+
+In `ACPSession` add:
+
+```swift
+@Published var sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities?
+@Published var forkRecord: ACPSessionForkRecord?
+
+func canForkMessage(at index: Int) -> Bool {
+    guard transcript.messages.indices.contains(index) else { return false }
+    switch transcript.messages[index] {
+    case .user:
+        return true
+    case .agent:
+        guard transcript.streamingState != .idle else { return true }
+        return lastAgent() != index
+    default:
+        return false
+    }
+}
+```
+
+In `ACPSessionManager.applyHydration`, assign `result.forkRecord` to
+`session.forkRecord`. In the attach initialize path, assign
+`initialized.sessionCapabilities` to `session.sessionCapabilities`.
+
+- [ ] **Step 4: Implement atomic local fork creation**
+
+Add this manager entry point:
+
+```swift
+func createFork(
+    sourceSessionID: ACPSession.ID,
+    boundary: ACPForkMessageBoundary,
+    targetAgentID: String,
+    autoRunDefault: Bool
+) async throws -> ACPSession
+```
+
+Its body must:
+
+1. Require a live, hydrated source and call
+   `acquireWriterLease(sessionId: sourceSessionID)` when this manager does not
+   already own its writer lease. Throw `ACPSessionForkCreationError.sourceReadOnly`
+   when the lease cannot be acquired.
+2. Call `awaitBackfill(id:)`, `flushAllPersistence()`, then
+   `persistence.loadMessages(sessionId:)`.
+3. Call `ACPSessionForkSnapshotResolver.resolve`.
+4. Set `boundaryIsRemoteHead` by comparing
+   `snapshot.sourceBoundarySequence == storedMessages.last?.seq`.
+5. Select a candidate with `source.sessionCapabilities?.supportsFork`. A nil
+   runtime value intentionally creates a native candidate when the other
+   preconditions hold; target initialization makes the final capability
+   decision.
+6. Build a target row whose title is
+   `source.title == "New session" ? "New session (fork)" : "\(source.title) (fork)"`.
+7. Set the initial record to `.negotiatingNative` with nil mechanism and
+   pending false for a native candidate; otherwise `.ready`,
+   `.transcriptTransfer`, and pending true.
+8. Call the single atomic `persistence.createFork`.
+9. Materialize a ready in-memory target from the copied rows, assign its
+   `forkRecord`, insert it into `sessions`, `persistedRows`, and `recent`, and
+   return it.
+
+Do not use `createSession` followed by message writes; that would violate the
+atomic target contract.
+
+- [ ] **Step 5: Run manager, persistence, and hydration suites**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkManagerTests -only-testing:AlasTests/ACPSessionForkPersistenceTests -only-testing:AlasTests/ACPSessionManagerHydrationTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit local fork creation**
+
+```bash
+rtk git add Alas/Sources/ACP/Session/ACPSession.swift Alas/Sources/ACP/Session/ACPSessionManager.swift AlasTests/ACP/Session/ACPSessionForkManagerTests.swift
+rtk git commit -m "feat(acp): create durable local chat forks"
+```
+
+---
+
+### Task 4: One-Time Private Transcript Context
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift:1-85`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionPersistence.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionRunner.swift:1280-1320`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionRunner.swift:1470-1630`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift:2690-2920`
+- Create: `AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift`
+
+**Interfaces:**
+- Consumes: `ACPSession.forkRecord`, inherited prefix count, existing `ACPTranscriptMarkdown.document`, and runner prompt-block injection.
+- Produces: `ACPTranscriptMarkdown.forkContext(sourceAgentID:messages:) -> String?`, `ACPSessionRunner` one-time injection, and durable pending-context clearing.
+
+- [ ] **Step 1: Write failing serializer and runner tests**
+
+Add tests proving:
+
+```swift
+let context = ACPTranscriptMarkdown.forkContext(
+    sourceAgentID: "claude",
+    messages: [
+        .user(id: UUID(), text: "Question", attachments: []),
+        .agent(id: UUID(), StreamingText("Answer"))
+    ]
+)
+#expect(context?.contains("The conversation below was imported from claude.") == true)
+#expect(context?.contains("## You\n\nQuestion") == true)
+#expect(context?.contains("## claude\n\nAnswer") == true)
+```
+
+In `ACPSessionForkRunnerTests`, construct an `ACPMockClient`, a target session
+with a `.transcriptTransfer` fork record and `inheritedMessageCount == 2`, then
+call `sendNow(blocks:[.text("Continue")], queuedItemId:nil)`. Script
+`session/prompt`, wait for the request, and assert:
+
+```swift
+#expect(promptBlocks == [
+    .text(try #require(ACPTranscriptMarkdown.forkContext(
+        sourceAgentID: "claude",
+        messages: Array(session.transcript.messages.prefix(2))
+    ))),
+    .text("Continue")
+])
+#expect(session.transcript.messages.count == 3)
+#expect(try await persistence.loadFork(targetSessionID: session.id)?.contextDeliveryPending == false)
+```
+
+Add a separate test with a fresh pending target whose scripted prompt throws
+`ACPClientError.notRunning`; assert pending remains true, the private inherited
+context is absent from visible messages, and retry does not append a duplicate
+visible user prompt.
+
+- [ ] **Step 2: Run the focused runner suite**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkRunnerTests test
+```
+
+Expected: FAIL because fork context serialization and runner injection are absent.
+
+- [ ] **Step 3: Add the exact context serializer**
+
+Add to `ACPTranscriptMarkdown`:
+
+```swift
+@MainActor
+static func forkContext(sourceAgentID: String, messages: [ACPMessage]) -> String? {
+    let markdown = document(
+        title: "Imported conversation",
+        agentName: sourceAgentID,
+        messages: messages
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !markdown.isEmpty else { return nil }
+    return """
+    The conversation below was imported from \(sourceAgentID). Use it as background context for this branch. Provider-specific tool state, hidden context, and attachments were not transferred. Do not summarize or repeat the imported conversation unless I ask.
+
+    \(markdown)
+    """
+}
+```
+
+- [ ] **Step 4: Inject and clear pending fork context**
+
+In `sendNow`, capture the pending context before hydration:
+
+```swift
+let pendingForkContext: String? = {
+    guard let fork = self.session.forkRecord,
+          fork.phase == .ready,
+          fork.mechanism == .transcriptTransfer,
+          fork.contextDeliveryPending
+    else { return nil }
+    return ACPTranscriptMarkdown.forkContext(
+        sourceAgentID: fork.sourceAgentID,
+        messages: Array(self.session.transcript.messages.prefix(fork.inheritedMessageCount))
+    )
+}()
+```
+
+Insert `pendingForkContext` after MCP preamble and before the user's hydrated
+blocks, preserving this wire order:
+
+```swift
+var privateBlocks: [ACPContentBlock] = []
+if let pendingMCPPreamble { privateBlocks.append(.text(pendingMCPPreamble)) }
+if let pendingForkContext { privateBlocks.append(.text(pendingForkContext)) }
+wireBlocks.insert(contentsOf: privateBlocks, at: 0)
+```
+
+After successful `connection.prompt`, clear the in-memory flag and enqueue:
+
+```swift
+if pendingForkContext != nil,
+   var fork = self.session.forkRecord,
+   fork.contextDeliveryPending {
+    fork.contextDeliveryPending = false
+    self.session.forkRecord = fork
+    self.persistForkContextDelivered()
+}
+```
+
+Implement `persistForkContextDelivered()` like `persistMCPPreambleSent()`, using
+the lease fence. Add this exact overload to `ACPSessionPersistence`:
+
+```swift
+@discardableResult
+func clearForkContextDeliveryPending(
+    targetSessionID: String,
+    fence: ACPSessionLeaseFence?
+) throws -> Bool {
+    let store = try openedStore()
+    let operation = {
+        try store.clearForkContextDeliveryPending(targetSessionID: targetSessionID)
+    }
+    if let fence {
+        return try store.withLeaseFence(fence, operation) != nil
+    }
+    try operation()
+    return true
+}
+```
+
+The runner enqueues this fenced overload with its current
+`leaseFenceProvider()` value and updates the in-memory flag only after
+`connection.prompt` succeeds.
+
+In manager attach recovery, exclude sessions with pending fork context from
+the generic `contextRecoveryPending` / `sendTranscriptAsContext` path. Their
+inherited context must wait for the first real prompt.
+
+- [ ] **Step 5: Run runner and existing recovery tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkRunnerTests -only-testing:AlasTests/ACPSessionRunnerTests -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit private context delivery**
+
+```bash
+rtk git add Alas/Sources/ACP/Session/ACPTranscriptMarkdown.swift Alas/Sources/ACP/Session/ACPSessionPersistence.swift Alas/Sources/ACP/Session/ACPSessionRunner.swift Alas/Sources/ACP/Session/ACPSessionManager.swift AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift
+rtk git commit -m "feat(acp): deliver fork context on first prompt"
+```
+
+---
+
+### Task 5: Native ACP Fork Negotiation and Graceful Fallback
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Protocol/ACPMessages.swift:720-790`
+- Modify: `Alas/Sources/ACP/Protocol/ACPConnection.swift:90-125`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift:1630-1665`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift:2690-2925`
+- Modify: `AlasTests/ACP/Protocol/ACPConnectionTests.swift`
+- Create: `AlasTests/ACP/Session/ACPSessionForkAttachTests.swift`
+
+**Interfaces:**
+- Consumes: persisted `.negotiatingNative` record from Task 3 and normal manager attach setup/MCP planning.
+- Produces: `ACPConnection.forkSession(cwd:sessionId:mcpServers:brokerOperationKey:)`, `ACPConnection.closeSession(sessionId:)`, stable startup operation keys, and attach-time native/fallback finalization.
+
+- [ ] **Step 1: Add failing protocol tests**
+
+Extend `ACPConnectionTests` with:
+
+```swift
+@Test("forkSession carries broker key and defers durable acknowledgement")
+func forkSessionDurableRPC() async throws {
+    let mock = ACPMockClient()
+    let acknowledgement = DurableAcknowledgementRecorder()
+    mock.scriptResponse(method: "session/fork") { _ in
+        ACPResponse(
+            body: try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "forked", availableModels: [], availableModes: [],
+                currentModel: nil, currentMode: nil, promptSuggestions: []
+            )),
+            durableConsumptionAcknowledgement: { acknowledgement.record() }
+        )
+    }
+    let connection = ACPConnection(client: mock)
+
+    let result = try await connection.forkSession(
+        cwd: "/tmp/wt",
+        sessionId: "source-remote",
+        mcpServers: [],
+        brokerOperationKey: "startup:target:session/fork:source-remote"
+    )
+
+    #expect(result.sessionId == "forked")
+    #expect(mock.sent.last?.brokerOperationKey == "startup:target:session/fork:source-remote")
+    #expect(acknowledgement.count == 0)
+    connection.acknowledgeDurableSessionResponses()
+    #expect(acknowledgement.count == 1)
+}
+```
+
+Add this file-private helper to `ACPConnectionTests.swift`:
+
+```swift
+private final class DurableAcknowledgementRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func record() {
+        lock.lock()
+        value += 1
+        lock.unlock()
+    }
+}
+```
+
+- [ ] **Step 2: Run protocol tests and verify failure**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPConnectionTests test
+```
+
+Expected: FAIL because fork does not accept a broker key or defer acknowledgement.
+
+- [ ] **Step 3: Make fork durable and add best-effort close**
+
+Add:
+
+```swift
+struct ACPSessionCloseParams: Codable, Equatable {
+    let sessionId: String
+}
+```
+
+Change `forkSession` to:
+
+```swift
+func forkSession(
+    cwd: String,
+    sessionId: String,
+    mcpServers: [ACPMCPServer],
+    brokerOperationKey: String? = nil
+) async throws -> ACPSessionNewResult {
+    let req = ACPRequest(
+        method: "session/fork",
+        params: ACPSessionForkParams(cwd: cwd, sessionId: sessionId, mcpServers: mcpServers),
+        brokerOperationKey: brokerOperationKey
+    )
+    let resp = try await client.send(req)
+    let result = try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
+    deferDurableSessionResponse(resp)
+    return result
+}
+
+func closeSession(sessionId: String) async throws {
+    let response = try await client.send(ACPRequest(
+        method: "session/close",
+        params: ACPSessionCloseParams(sessionId: sessionId)
+    ))
+    response.acknowledgeDurableConsumption()
+}
+```
+
+- [ ] **Step 4: Write failing attach negotiation tests**
+
+In `ACPSessionForkAttachTests`, use the connection factory pattern from
+`ACPSessionManagerAttachRestoreTests` to cover:
+
+- `.negotiatingNative` + advertised fork sends `initialize`, `session/fork`,
+  persists `.nativeACP` plus returned remote ID, and registers the returned
+  connection as the target runner.
+- Missing fork capability finalizes `.transcriptTransfer`, then sends
+  `session/new`.
+- `session/fork` throwing `ACPClientError.jsonrpc` finalizes transcript and
+  sends `session/new` on the same connection.
+- Auth failure finalizes transcript but preserves the existing needs-auth
+  surface.
+- Reattaching the same target uses the same
+  `startup:<target>:session/fork:<sourceRemote>` broker key.
+- A source session absent from `manager.sessions` still resolves its remote ID
+  through `persistence.loadSession(id:)`.
+
+- [ ] **Step 5: Add the attach startup branch**
+
+Immediately before the current `if freshlyCreated` startup selection in
+`ACPSessionManager.attach`, add a branch for
+`session.forkRecord?.phase == .negotiatingNative`. Resolve the source remote ID
+from `try await persistence.loadSession(id: fork.sourceSessionID)` rather than
+requiring the source to remain materialized in `sessions`.
+
+The branch must:
+
+```swift
+if var fork = session.forkRecord, fork.phase == .negotiatingNative {
+    if initialized.sessionCapabilities.supportsFork,
+       let source = try await persistence.loadSession(id: fork.sourceSessionID),
+       let sourceRemoteID = source.remoteSessionId,
+       !sourceRemoteID.isEmpty {
+        do {
+            result = try await connection.forkSession(
+                cwd: worktreePath,
+                sessionId: sourceRemoteID,
+                mcpServers: wireMCPServers,
+                brokerOperationKey: Self.brokerStartupOperationKey(
+                    sessionId: sessionId,
+                    method: "session/fork",
+                    remoteSessionId: sourceRemoteID
+                )
+            )
+            try await persistence.finalizeFork(
+                targetSessionID: sessionId,
+                mechanism: .nativeACP,
+                remoteSessionID: result.sessionId
+            )
+            fork.phase = .ready
+            fork.mechanism = .nativeACP
+            fork.contextDeliveryPending = false
+            session.forkRecord = fork
+        } catch {
+            try await persistence.finalizeFork(
+                targetSessionID: sessionId,
+                mechanism: .transcriptTransfer,
+                remoteSessionID: nil
+            )
+            fork.phase = .ready
+            fork.mechanism = .transcriptTransfer
+            fork.contextDeliveryPending = true
+            session.forkRecord = fork
+            if ACPAuthFailure.message(from: error) != nil { throw error }
+            result = try await connection.newSession(
+                cwd: worktreePath,
+                mcpServers: wireMCPServers,
+                brokerOperationKey: Self.brokerStartupOperationKey(
+                    sessionId: sessionId,
+                    method: "session/new"
+                )
+            )
+            createdFreshRemoteSession = true
+        }
+    } else {
+        try await persistence.finalizeFork(
+            targetSessionID: sessionId,
+            mechanism: .transcriptTransfer,
+            remoteSessionID: nil
+        )
+        fork.phase = .ready
+        fork.mechanism = .transcriptTransfer
+        fork.contextDeliveryPending = true
+        session.forkRecord = fork
+        result = try await connection.newSession(
+            cwd: worktreePath,
+            mcpServers: wireMCPServers,
+            brokerOperationKey: Self.brokerStartupOperationKey(
+                sessionId: sessionId,
+                method: "session/new"
+            )
+        )
+        createdFreshRemoteSession = true
+    }
+}
+```
+
+Implement the branch as a private
+`startForkTarget(session:fork:initialized:connection:wireMCPServers:)` helper
+returning `(result: ACPSessionNewResult, createdFreshRemoteSession: Bool)`.
+The attach selection assigns both tuple members before joining the existing
+runner-registration path.
+
+Add `downgradeNegotiatingForkToTranscript(session:) async` and call it before
+every existing attach return caused by setup, launch, authentication, or
+connection failure while the record is `.negotiatingNative`. It persists
+`.ready` + `.transcriptTransfer` + pending context and mirrors those values
+into `session.forkRecord` before the normal failure UI is set. A retry then
+uses the normal fresh `session/new` path.
+
+If native remote creation succeeds but local finalization fails, call
+`try? await connection.closeSession(sessionId: result.sessionId)`, then
+`try? await persistence.finalizeFork(targetSessionID: sessionId,
+mechanism: .transcriptTransfer, remoteSessionID: nil)`, mirror the transcript
+state in memory, and shut down the connection.
+
+In `makeBrokerConnection`, pre-register the stable fork operation key alongside
+restored queue keys whenever the hydrated record is `.negotiatingNative` and
+the persisted source row has a remote ID. This protects a replayed completion
+until `forkSession` consumes it. Reusing the same key delegates idempotence to
+the broker; a broker transport failure with no durable completion follows the
+transcript fallback and must never issue an unkeyed `session/fork`.
+
+Call `connection.acknowledgeDurableSessionResponses()` only after the final
+fork mechanism and remote ID are durable.
+
+- [ ] **Step 6: Run protocol and attach suites**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPConnectionTests -only-testing:AlasTests/ACPSessionForkAttachTests -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit native negotiation**
+
+```bash
+rtk git add Alas/Sources/ACP/Protocol/ACPMessages.swift Alas/Sources/ACP/Protocol/ACPConnection.swift Alas/Sources/ACP/Session/ACPSessionManager.swift AlasTests/ACP/Protocol/ACPConnectionTests.swift AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+rtk git commit -m "feat(acp): negotiate native session forks"
+```
+
+---
+
+### Task 6: Native Message Menu and Target Ordering
+
+**Files:**
+- Modify: `Alas/Sources/ACP/UI/ACPMessageGutter.swift:1-190`
+- Modify: `Alas/Sources/ACP/UI/ACPMessageList.swift:1-40`
+- Modify: `Alas/Sources/ACP/UI/ACPMessageList.swift:1450-1630`
+- Modify: `Alas/Sources/ACP/UI/ACPTabView.swift:310-410`
+- Modify: `Alas/Sources/App/AppState.swift:5180-5275`
+- Create: `AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift`
+
+**Interfaces:**
+- Consumes: Task 1's `ACPSessionForkTarget` and `ACPForkMessageBoundary`, Task 3's `canForkMessage(at:)`, `AgentRegistry.enabled()`, and `ACPLaunchCatalog.specs`.
+- Produces: `AppState.acpForkTargets(sourceAgentID:)`, row-level `onFork`, and the AppKit submenu.
+
+- [ ] **Step 1: Write failing ordering and eligibility tests**
+
+Create `ACPSessionForkPresentationTests` with:
+
+```swift
+@MainActor
+@Suite("ACP session fork presentation")
+struct ACPSessionForkPresentationTests {
+    @Test("current target is first and remaining targets preserve ACP catalog order")
+    func targetOrdering() {
+        let targets = ACPForkTargetPolicy.targets(
+            sourceAgentID: "codex",
+            enabledAgents: [
+                .init(id: "claude", displayName: "Claude"),
+                .init(id: "gemini", displayName: "Gemini"),
+            ],
+            sourceAgent: .init(id: "codex", displayName: "Codex"),
+            catalogAgentIDs: ["claude", "gemini", "codex"]
+        )
+        #expect(targets.map(\.id) == ["codex", "claude", "gemini"])
+        #expect(targets.first?.isSameAgent == true)
+    }
+
+    @Test("message menu only offers fork for eligible rows")
+    func menuEligibility() {
+        #expect(ACPMessageForkMenuPolicy.showsForkAction(
+            messageKind: "user", isEligible: true, targetCount: 2
+        ))
+        #expect(!ACPMessageForkMenuPolicy.showsForkAction(
+            messageKind: "agent", isEligible: false, targetCount: 2
+        ))
+        #expect(!ACPMessageForkMenuPolicy.showsForkAction(
+            messageKind: "tool_call", isEligible: true, targetCount: 2
+        ))
+    }
+}
+```
+
+Define a small test input type inside the test or production policy instead of
+constructing full `AgentDefinition` values.
+
+- [ ] **Step 2: Run the presentation suite and verify failure**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkPresentationTests test
+```
+
+Expected: FAIL because target and menu policies are missing.
+
+- [ ] **Step 3: Add pure target/menu policies**
+
+In `ACPSessionFork.swift`, add:
+
+```swift
+struct ACPForkAgentOption: Equatable {
+    let id: String
+    let displayName: String
+}
+
+enum ACPForkTargetPolicy {
+    static func targets(
+        sourceAgentID: String,
+        enabledAgents: [ACPForkAgentOption],
+        sourceAgent: ACPForkAgentOption?,
+        catalogAgentIDs: [String]
+    ) -> [ACPSessionForkTarget] {
+        var byID = Dictionary(uniqueKeysWithValues: enabledAgents.map { ($0.id, $0) })
+        if let sourceAgent {
+            byID[sourceAgent.id] = sourceAgent
+        }
+        let ordered = catalogAgentIDs.compactMap { byID[$0] }
+        let current = ordered.filter { $0.id == sourceAgentID }
+        let others = ordered.filter { $0.id != sourceAgentID }
+        return (current + others).map {
+            .init(id: $0.id, displayName: $0.displayName, isSameAgent: $0.id == sourceAgentID)
+        }
+    }
+}
+
+enum ACPMessageForkMenuPolicy {
+    static func showsForkAction(messageKind: String, isEligible: Bool, targetCount: Int) -> Bool {
+        (messageKind == "user" || messageKind == "agent") && isEligible && targetCount > 0
+    }
+}
+```
+
+- [ ] **Step 4: Extend the AppKit message menu**
+
+Add to `ACPMessageGutter`:
+
+```swift
+let forkBoundary: ACPForkMessageBoundary?
+let forkTargets: [ACPSessionForkTarget]
+let onFork: (ACPForkMessageBoundary, String) -> Void
+```
+
+Pass these through `ACPMessageActionsButton` and update its coordinator on
+every `updateNSView`. In `Coordinator.showMenu`, after `Copy message`, add a
+separator and a parent `NSMenuItem(title:"Fork from here", ...)` only when the
+boundary exists and targets are non-empty. Build its submenu:
+
+```swift
+let submenu = NSMenu()
+for target in forkTargets {
+    let title = target.isSameAgent
+        ? "\(target.displayName)\tSame agent"
+        : target.displayName
+    let item = NSMenuItem(
+        title: title,
+        action: #selector(forkFromHere(_:)),
+        keyEquivalent: ""
+    )
+    item.target = self
+    item.representedObject = target.id
+    submenu.addItem(item)
+}
+forkItem.submenu = submenu
+menu.addItem(forkItem)
+```
+
+Implement `forkFromHere(_:)` by requiring the current boundary and represented
+target ID, then calling `onFork(boundary, targetID)`.
+
+- [ ] **Step 5: Wire row boundaries and targets**
+
+Add `forkTargets` and `onFork` to `ACPMessageList`, then to
+`ACPTranscriptRowContent`. For user/agent cases, create the boundary only when
+`session.canForkMessage(at: rowIndex)` is true. Add `messageIndex: Int` to
+`ACPTranscriptRowContent` so it can make:
+
+```swift
+let boundary = ACPForkMessageBoundary(
+    stableID: stableId,
+    kind: message.kind == "user" ? .user : .agent
+)
+```
+
+Include fork eligibility and targets in `ACPTranscriptRowContent.EqualityKey`
+so enabling/disabling the action cannot be hidden by `.equatable()`.
+
+In `AppState`, implement `acpForkTargets(sourceAgentID:)` using
+`agentRegistry.enabled()` for alternative targets,
+`agentRegistry.agents.first(where: { $0.id == sourceAgentID })` for the current
+target, and `ACPLaunchCatalog.specs.map(\.agentID)` for the ACP-only ordering.
+
+- [ ] **Step 6: Run UI policy and message-row tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkPresentationTests -only-testing:AlasTests/ACPMessageStableIdTests -only-testing:AlasTests/ACPTranscriptRowContentTests test
+```
+
+The existing equality suite is declared as
+`ACPTranscriptRowContentTests` in
+`AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift`; keep the new equality
+assertions in that suite and use
+`-only-testing:AlasTests/ACPTranscriptRowContentTests`.
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the menu**
+
+```bash
+rtk git add Alas/Sources/ACP/Session/ACPSessionFork.swift Alas/Sources/ACP/UI/ACPMessageGutter.swift Alas/Sources/ACP/UI/ACPMessageList.swift Alas/Sources/ACP/UI/ACPTabView.swift Alas/Sources/App/AppState.swift AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift
+rtk git commit -m "feat(acp): add per-message fork menu"
+```
+
+---
+
+### Task 7: Fork Tab Creation, Divider, and Source Navigation
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPSessionForkDivider.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPMessageList.swift:155-250`
+- Modify: `Alas/Sources/ACP/UI/ACPMessageList.swift:1450-1520`
+- Modify: `Alas/Sources/ACP/UI/ACPTabView.swift:310-410`
+- Modify: `Alas/Sources/App/AppState.swift:5180-5310`
+- Modify: `AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift`
+
+**Interfaces:**
+- Consumes: `ACPSessionManager.createFork`, `ACPSession.forkRecord`, Task 6's row callback and target list, `openExistingACPSession`.
+- Produces: `AppState.forkACPSession(...)`, `ACPSessionForkPresentation`, `ACPSessionForkDivider`, and source-session navigation.
+
+- [ ] **Step 1: Add failing divider-copy tests**
+
+Extend `ACPSessionForkPresentationTests`:
+
+```swift
+@Test("native and transcript forks use honest divider copy")
+func dividerCopy() {
+    #expect(ACPSessionForkPresentation(
+        sourceAgentName: "Claude", mechanism: .nativeACP
+    ).title == "Forked from Claude")
+    let imported = ACPSessionForkPresentation(
+        sourceAgentName: "Claude", mechanism: .transcriptTransfer
+    )
+    #expect(imported.title == "Conversation imported from Claude")
+    #expect(imported.notice ==
+        "Provider-specific tool state, hidden context, and attachments were not transferred. This chat shares the source chat’s current worktree.")
+}
+```
+
+- [ ] **Step 2: Run the presentation suite**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkPresentationTests test
+```
+
+Expected: FAIL because the divider presentation type is missing.
+
+- [ ] **Step 3: Implement divider presentation and view**
+
+Create `ACPSessionForkDivider.swift`:
+
+```swift
+import SwiftUI
+
+struct ACPSessionForkPresentation: Equatable {
+    let title: String
+    let notice: String?
+
+    init(sourceAgentName: String, mechanism: ACPSessionForkMechanism) {
+        switch mechanism {
+        case .nativeACP:
+            title = "Forked from \(sourceAgentName)"
+            notice = nil
+        case .transcriptTransfer:
+            title = "Conversation imported from \(sourceAgentName)"
+            notice = "Provider-specific tool state, hidden context, and attachments were not transferred. This chat shares the source chat’s current worktree."
+        }
+    }
+}
+
+struct ACPSessionForkDivider: View {
+    let presentation: ACPSessionForkPresentation
+    let onOpenSource: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                Rectangle().fill(theme.color("line")).frame(height: 1)
+                Button(presentation.title, action: onOpenSource)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(theme.color("accent"))
+                    .help("Open source chat")
+                Rectangle().fill(theme.color("line")).frame(height: 1)
+            }
+            if let notice = presentation.notice {
+                Text(notice)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("fg-muted"))
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+```
+
+- [ ] **Step 4: Insert the divider after the inherited prefix**
+
+Add `onOpenForkSource: (String) -> Void` and
+`agentDisplayName: (String) -> String` to `ACPMessageList`. Immediately after
+each `visibleRow(row)`, render the divider when:
+
+```swift
+if let fork = session.forkRecord,
+   fork.phase == .ready,
+   row.index == fork.inheritedMessageCount - 1,
+   let mechanism = fork.mechanism {
+    ACPSessionForkDivider(
+        presentation: .init(
+            sourceAgentName: agentDisplayName(fork.sourceAgentID),
+            mechanism: mechanism
+        ),
+        onOpenSource: { onOpenForkSource(fork.sourceSessionID) }
+    )
+    .id("__fork_divider__")
+}
+```
+
+- [ ] **Step 5: Implement AppState creation and source navigation**
+
+Add:
+
+```swift
+func forkACPSession(
+    worktree: Worktree,
+    sourceSessionID: ACPSession.ID,
+    boundary: ACPForkMessageBoundary,
+    targetAgentID: String
+) {
+    guard let manager = acpManager(for: worktree) else { return }
+    Task { @MainActor in
+        do {
+            let target = try await manager.createFork(
+                sourceSessionID: sourceSessionID,
+                boundary: boundary,
+                targetAgentID: targetAgentID,
+                autoRunDefault: config.harness.acpAutoRunByDefault
+            )
+            let tabState = ACPSessionTabState(sessionId: target.id, title: target.title)
+            let tab = tabs.append(acpSession: tabState, to: worktree.id)
+            tabs.activate(worktreeId: worktree.id, tabId: tab.id)
+            await manager.attach(
+                to: target.id,
+                freshlyCreated: true
+            )
+        } catch {
+            manager.liveSession(for: sourceSessionID)?.lastError =
+                "Could not create fork: \(error.localizedDescription)"
+        }
+    }
+}
+```
+
+Pass this callback from `ACPTabView` through `ACPMessageList`. Route
+`onOpenForkSource` to `await state.openExistingACPSession(sessionId:)` in the
+same worktree manager; existing tab-focus behavior handles an already-open or
+archived source.
+
+Treat a negotiating native target as a startup operation inside attach rather
+than a restored remote session: Task 5's fork branch must precede the existing
+`if freshlyCreated` branch. Immediate transcript forks and native fallbacks use
+the same `freshlyCreated: true` call and therefore create `session/new`;
+negotiating targets are intercepted by the fork branch.
+
+- [ ] **Step 6: Run presentation, manager, and AppState-adjacent tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPSessionForkPresentationTests -only-testing:AlasTests/ACPSessionForkManagerTests -only-testing:AlasTests/ACPSessionManagerTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the complete interaction**
+
+```bash
+rtk git add Alas/Sources/ACP/UI/ACPSessionForkDivider.swift Alas/Sources/ACP/UI/ACPMessageList.swift Alas/Sources/ACP/UI/ACPTabView.swift Alas/Sources/App/AppState.swift Alas/Sources/ACP/Session/ACPSessionManager.swift AlasTests/ACP/UI/ACPSessionForkPresentationTests.swift
+rtk git commit -m "feat(acp): open and present forked chats"
+```
+
+---
+
+### Task 8: Relaunch Recovery and Full Verification
+
+**Files:**
+- Modify: `AlasTests/ACP/Session/ACPSessionForkAttachTests.swift`
+- Modify: `AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift`
+- Modify: `AlasTests/ACP/Session/ACPSessionForkManagerTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: the complete fork creation, attach, persistence, and prompt paths from Tasks 1-7.
+- Produces: regression coverage for app relaunch and the final verified build.
+
+- [ ] **Step 1: Add a relaunch regression for transcript forks**
+
+Add a test that creates a transcript fork with manager A, discards manager A,
+constructs manager B on the same database, hydrates the target, attaches a mock
+fresh remote session, sends the first real prompt, and asserts:
+
+```swift
+#expect(restored.forkRecord?.mechanism == .transcriptTransfer)
+#expect(restored.forkRecord?.contextDeliveryPending == true)
+#expect(restored.transcript.messages.count == inheritedCount)
+// After successful first prompt:
+#expect(try store.loadFork(targetSessionID: restored.id)?.contextDeliveryPending == false)
+#expect(restored.transcript.messages.count == inheritedCount + 1)
+```
+
+- [ ] **Step 2: Add a relaunch regression for negotiating native forks**
+
+Seed a `.negotiatingNative` fork and a mock broker-backed connection that
+returns the same durable response for the stable startup operation key. Hydrate
+with a new manager and assert:
+
+```swift
+#expect(restored.forkRecord?.phase == .ready)
+#expect(restored.forkRecord?.mechanism == .nativeACP)
+#expect(restored.remoteSessionId == "forked-remote")
+#expect(mock.sent.filter { $0.method == "session/fork" }.count == 1)
+```
+
+Add the unavailable-response case and assert it becomes
+`.transcriptTransfer` with pending context instead of issuing an unkeyed fork.
+
+- [ ] **Step 3: Run every focused fork suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ACPSessionForkPolicyTests \
+  -only-testing:AlasTests/ACPSessionForkPersistenceTests \
+  -only-testing:AlasTests/ACPSessionForkManagerTests \
+  -only-testing:AlasTests/ACPSessionForkRunnerTests \
+  -only-testing:AlasTests/ACPSessionForkAttachTests \
+  -only-testing:AlasTests/ACPSessionForkPresentationTests \
+  test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Regenerate the Xcode project**
+
+Run:
+
+```bash
+rtk xcodegen
+```
+
+Expected: `Alas.xcodeproj/project.pbxproj` includes every new source and test
+file and exits successfully.
+
+- [ ] **Step 5: Run the required quiet build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit status 0 with no compiler errors.
+
+- [ ] **Step 6: Run the complete required test suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: all Alas tests pass.
+
+- [ ] **Step 7: Check formatting and commit final recovery coverage**
+
+Run:
+
+```bash
+rtk git diff --check
+rtk git status --short
+```
+
+Expected: no whitespace errors; only the intended fork implementation, tests,
+plan/spec, and regenerated project changes are present.
+
+Commit:
+
+```bash
+rtk git add AlasTests/ACP/Session/ACPSessionForkAttachTests.swift AlasTests/ACP/Session/ACPSessionForkRunnerTests.swift AlasTests/ACP/Session/ACPSessionForkManagerTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "test(acp): cover session fork recovery"
+```

--- a/docs/superpowers/specs/2026-07-24-acp-session-fork-design.md
+++ b/docs/superpowers/specs/2026-07-24-acp-session-fork-design.md
@@ -1,0 +1,465 @@
+# ACP Session Fork Design
+
+**Date:** 2026-07-24  
+**Status:** Design approved, ready for implementation planning
+
+## Context
+
+Alas already decodes the ACP agent capability for `session/fork` and exposes a
+typed `ACPConnection.forkSession` call, but it does not turn a remote fork into
+an independently persisted and runnable Alas chat.
+
+The current ACP
+[session-fork RFD](https://agentclientprotocol.com/rfds/session-fork) remains a
+draft. Its request forks an entire remote session at its current head. The RFD
+reserves the capability object for a future message-ID checkpoint, but the
+current request cannot fork at an arbitrary message.
+
+Alas can provide the missing checkpoint behavior because it owns a durable
+local transcript. It can copy the conversation through a selected message into
+a new local session and supply that conversation privately to a fresh target
+agent. This also enables cross-provider forks, where a provider-native remote
+fork is impossible.
+
+This design treats a fork as a conversation branch in the same worktree. It
+does not rewind files or create a Git worktree.
+
+## Goals
+
+- Add `Fork from here` to the existing per-message `…` menu.
+- Let the user fork through any completed user or agent message.
+- Let the user target the current ACP agent or another enabled ACP agent.
+- Use native ACP `session/fork` when it exactly implements the requested fork.
+- Fall back to a portable textual transcript for arbitrary checkpoints and
+  cross-provider forks.
+- Show inherited conversation history in the new chat with clear provenance.
+- Keep the source session unchanged.
+- Persist creation and pending context durably so relaunch and retry are safe.
+- Reuse the current worktree, project MCP configuration, permission policy, and
+  normal target-agent setup flows.
+
+## Non-Goals
+
+- Rewinding Git or filesystem state to the selected message.
+- Creating or selecting another worktree.
+- Forking a partial streaming response.
+- Copying thoughts, tool calls, tool output, file-edit cards, plans, system
+  notices, pending permissions, pending questions, queued prompts, or drafts.
+- Transferring binary/image attachments or embedded context.
+- Preserving provider-private tool state in transcript-transfer forks.
+- Synchronizing later messages between the source and fork.
+- Supporting a future ACP message-ID fork extension before it is specified and
+  implemented by agents.
+
+## Product Contract
+
+### Fork point
+
+`Fork from here` is available on completed textual user and agent messages.
+The selected message is inclusive: the target inherits eligible conversation
+messages from the beginning of the source chat through that message.
+
+The currently streaming agent response is not an eligible boundary. Completed
+earlier messages remain eligible while a later turn is active.
+
+### Worktree state
+
+The fork opens in the source session's current worktree and sees that
+worktree's current filesystem state. The conversation checkpoint and filesystem
+state are intentionally independent. Both chats may continue to operate in the
+same worktree.
+
+### Snapshot contents
+
+The inherited snapshot contains only:
+
+- Completed user message text, without attachments.
+- Completed agent message text.
+
+It preserves message order and Markdown. The visible inherited transcript and
+the privately transferred target context use the same snapshot, so the UI does
+not imply that the target received omitted material.
+
+### Initial target state
+
+Choosing a target opens a new tab immediately. The tab:
+
+- Uses the title `<source title> (fork)`.
+- Shows the inherited conversation.
+- Shows an empty, focused composer.
+- Does not ask the target agent to respond automatically.
+
+The first real user prompt begins the new branch.
+
+## Interaction Design
+
+The existing native message menu becomes:
+
+```text
+Copy message
+────────────
+Fork from here  ▸
+    Claude       Same agent
+    Codex
+    Gemini
+```
+
+The current agent is first. Remaining enabled agents with an
+`ACPLaunchCatalog` entry follow their existing configured order. The current
+agent remains available even when it does not support native ACP fork because
+Alas can use transcript transfer.
+
+After the inherited messages, the target transcript shows a fork divider that
+links to the source session.
+
+- Native fork: `Forked from <agent>`
+- Transcript fork: `Conversation imported from <agent>`
+
+Transcript forks also show a compact notice:
+
+> Provider-specific tool state, hidden context, and attachments were not
+> transferred. This chat shares the source chat's current worktree.
+
+If the source session is archived, following the divider reopens it through the
+normal existing-session path.
+
+## Mechanism Selection
+
+One pure policy selects the mechanism.
+
+Use `nativeACP` only when all of these are true:
+
+- Target agent equals source agent.
+- Selected message is the latest completed source message.
+- Source has a non-empty remote session ID.
+- The source agent advertises the ACP fork capability.
+
+Use `transcriptTransfer` for every other case.
+
+This lets the product expose one consistent action while retaining richer
+provider context when native forking precisely matches the requested boundary.
+The final mechanism is persisted and never changes after the creation phase
+reaches `ready`.
+
+## Architecture
+
+### `ACPSessionForkCoordinator`
+
+A dedicated coordinator owns the operation. UI code supplies:
+
+```swift
+struct ACPSessionForkRequest {
+    let sourceSessionID: ACPSession.ID
+    let boundary: ACPForkMessageBoundary
+    let targetAgentID: String
+}
+```
+
+The coordinator:
+
+1. Resolves the selected row to a durable source-message sequence.
+2. Loads the complete eligible prefix.
+3. Selects a native candidate or immediate transcript transfer.
+4. Atomically persists the target session, copied messages, and fork creation
+   metadata.
+5. Publishes the target session for `AppState` to open immediately.
+6. Negotiates native fork in the new tab's connecting phase when selected,
+   degrading to transcript transfer when native negotiation is unavailable.
+7. Atomically finalizes the mechanism and, for native success, the remote
+   session ID.
+8. Hands a successful native connection to the target runner, or starts the
+   normal fresh-session attach path for transcript transfer.
+
+The coordinator does not own tabs or message-menu presentation. `AppState`
+opens the returned local session using the normal ACP-session tab path.
+
+### Durable boundary resolution
+
+Long sessions hydrate tail-first, and the rendered list contains only a moving
+window. Forking must not treat a visible array index as a durable transcript
+index.
+
+The message row passes a stable message identity in
+`ACPForkMessageBoundary`. Before creating the snapshot, the manager:
+
+1. Awaits any in-flight transcript backfill.
+2. Re-resolves that stable identity in the completed full transcript.
+3. Flushes source message persistence.
+4. Loads persisted message rows through the resolved absolute sequence.
+
+If the selected identity disappears or no longer resolves to the same
+completed user/agent message, creation fails without modifying either session.
+
+### Fork persistence
+
+Fork metadata belongs with the target session in the existing per-worktree ACP
+database. Conceptually it records:
+
+```swift
+struct ACPSessionForkMetadata {
+    let targetSessionID: ACPSession.ID
+    let sourceSessionID: ACPSession.ID
+    let sourceAgentID: String
+    let sourceBoundarySequence: Int64
+    let inheritedMessageCount: Int
+    var phase: ACPSessionForkCreationPhase
+    var mechanism: ACPSessionForkMechanism?
+    var contextDeliveryPending: Bool
+}
+
+enum ACPSessionForkCreationPhase: String {
+    case negotiatingNative
+    case ready
+}
+
+enum ACPSessionForkMechanism: String {
+    case nativeACP
+    case transcriptTransfer
+}
+```
+
+The target session row, copied target-local message rows, and fork metadata are
+inserted in one SQLite transaction. Copied messages receive target-local
+storage IDs and contiguous target-local sequences.
+
+An immediate transcript fork is inserted as `ready` with mechanism
+`transcriptTransfer` and pending context. A native candidate is inserted as
+`negotiatingNative` with no final mechanism, no sendable runner, and pending
+context disabled. Its composer may accept a queued draft, but prompt delivery
+waits until the phase becomes `ready`. Native success leaves pending context
+disabled; fallback atomically enables it while finalizing
+`transcriptTransfer`.
+
+The snapshot Markdown is not stored separately. While context delivery is
+pending, Alas regenerates it from the first `inheritedMessageCount` messages in
+the target session. This avoids two durable copies of the same potentially
+large content.
+
+Transcript-transfer targets are ordinary Alas-created remote sessions with fork
+metadata. Native targets use the existing `agentForked` origin and store the
+remote session ID returned by the agent.
+
+### Runtime session capability
+
+`ACPSession` retains the initialized session capabilities at runtime, as it
+already does for prompt and MCP capabilities. They are re-learned on attach and
+are not persisted. A known missing fork capability selects transcript transfer
+immediately. If capability state is unavailable but the other native
+preconditions hold, the coordinator creates a `negotiatingNative` target and
+learns the capability from that target's initialization. A missing capability
+then finalizes the target as transcript transfer.
+
+### Native connection handoff
+
+Native fork must not assume that the resulting remote session can immediately
+be reopened through a separate `session/resume`.
+
+After the local target is visible, the coordinator initializes a target-agent
+connection, invokes `session/fork`, atomically finalizes the local metadata and
+remote ID, and hands that live connection plus `ACPSessionNewResult` to the
+normal runner startup path. The source runner and connection remain unchanged.
+
+The target runner then owns the connection exactly as if normal attach had
+created it. Models, modes, configuration options, suggestions, MCP status, and
+remote session ID come from the fork result and normal initialization.
+
+The fork request uses a stable broker operation key derived from the local
+target ID. Startup reconciliation consumes a durable native response when one
+exists. If no unambiguous native result is available after relaunch, Alas does
+not reissue the fork: it finalizes the existing local target as transcript
+transfer and follows normal attach. This avoids creating duplicate remote
+forks.
+
+If finalizing local native state fails after the remote fork succeeds, the
+coordinator best-effort closes the new remote session and shuts down its
+connection before downgrading the still-persisted local target to transcript
+transfer. Remote cleanup is not part of the local atomicity guarantee; the
+source session still remains unchanged.
+
+### Transcript context delivery
+
+Transcript forks create a normal fresh remote session. They retain
+`contextDeliveryPending` until the target's first real user prompt succeeds.
+
+At that first send, the runner:
+
+1. Regenerates the conversation Markdown from the inherited target prefix.
+2. Prepends a private instruction explaining that it is background context and
+   must not be repeated unless asked.
+3. Sends that private context and the user's real prompt in the same ACP prompt
+   request.
+4. Records only the user's real prompt in the visible transcript.
+5. Clears `contextDeliveryPending` after successful delivery.
+
+This follows the existing durable pending-preamble pattern. A relaunch or
+failed send retains the pending marker. Native forks never add transcript
+context because the provider already owns the inherited context.
+
+## Data Flow
+
+### Transcript-transfer fork
+
+1. User selects a completed message and target agent.
+2. UI captures a stable boundary and calls the coordinator.
+3. Coordinator resolves and loads the persisted conversation prefix.
+4. Coordinator atomically creates the target with copied messages and pending
+   context.
+5. AppState opens the target tab and normal attach creates a fresh remote
+   session.
+6. User writes the first new prompt.
+7. Runner sends private inherited context plus that prompt.
+8. Successful delivery clears the pending marker.
+
+### Native fork
+
+1. User selects the latest completed message and current agent.
+2. Coordinator resolves and loads the persisted inherited prefix.
+3. Coordinator atomically persists a `negotiatingNative` target and AppState
+   opens its tab.
+4. Coordinator initializes a target connection and calls `session/fork` with
+   the source remote session ID and current MCP attachment plan.
+5. Coordinator atomically finalizes the returned remote session ID and native
+   mechanism.
+6. The target runner adopts the live connection.
+7. The first new prompt is sent normally, without transcript injection.
+
+## Error Handling
+
+### Graceful native fallback
+
+The coordinator falls back to transcript transfer in the same target operation
+when:
+
+- Fork capability is absent.
+- `session/fork` returns method-not-found or explicitly unsupported.
+- The agent reports that the source remote session cannot be forked.
+
+The persisted mechanism and divider reflect the fallback. The user is not left
+with a failed native placeholder when a portable fork is possible.
+
+### Setup, authentication, and connection failures
+
+If the target agent needs setup or authentication, or its process cannot
+connect, a native candidate finalizes as transcript transfer and the local fork
+remains available with inherited history. The tab uses the existing setup,
+authentication, failure, and retry surfaces when its normal fresh-session
+attach is attempted. Pending context remains durable.
+
+### Persistence failure
+
+If the atomic local transaction fails, Alas creates no target session and
+opens no tab. The source chat presents a concise `Could not create fork`
+error using the persistence error description.
+
+### First-prompt failure
+
+A failed first prompt keeps `contextDeliveryPending` and follows normal
+queue/retry behavior. It must not append a second copy of the inherited
+conversation or a duplicate visible user prompt.
+
+### Source changes during creation
+
+The source may continue receiving later messages. They are outside the captured
+durable boundary and never enter the target. If the selected boundary itself
+cannot be re-resolved as the same completed message, the operation fails
+instead of guessing.
+
+## Testing
+
+### Mechanism policy
+
+- Same agent + latest completed message + remote ID + fork capability selects
+  native ACP.
+- Earlier checkpoint selects transcript transfer.
+- Different target agent selects transcript transfer.
+- Missing capability or remote ID selects transcript transfer.
+- A later streaming response means an earlier selected message is not the
+  latest completed head for native selection.
+
+### Snapshot construction
+
+- Snapshot is inclusive of the selected boundary.
+- Durable boundary resolution remains correct after tail-first hydration and
+  backfill.
+- Only user and agent text is copied.
+- Attachments and every excluded message kind are omitted.
+- Copied rows receive contiguous target-local sequence numbers and identities.
+- Source messages remain byte-for-byte unchanged.
+
+### Persistence
+
+- Session, copied messages, and fork metadata commit atomically.
+- Injected transaction failure leaves no orphan session or messages.
+- Metadata and pending delivery survive manager eviction and app relaunch.
+- An interrupted `negotiatingNative` phase consumes a durable native result
+  when available and otherwise becomes a ready transcript fork without
+  reissuing an ambiguous remote fork.
+- Snapshot Markdown regenerates from exactly the inherited target prefix.
+
+### Coordinator and protocol
+
+- Native success calls `session/fork` with source remote ID, worktree path, and
+  current MCP servers plus a stable target-derived broker operation key.
+- Native result and live connection are adopted by the new runner.
+- Capability absence, method-not-found, explicit unsupported, and
+  non-forkable-source errors fall back to transcript transfer.
+- Setup/auth/process failure preserves the local fork and exposes normal
+  recovery state.
+
+### Runner
+
+- First transcript-fork prompt sends private context and real prompt together.
+- Private context is not recorded as a visible message.
+- Failed delivery retains pending context.
+- Successful delivery clears pending context.
+- Retry and relaunch send one inherited context payload and do not duplicate
+  visible messages.
+- Native fork prompts never include transcript context.
+
+### UI policy
+
+- Completed user and agent messages expose the submenu.
+- A streaming agent message does not expose a fork action.
+- Current agent is first and labeled `Same agent`.
+- Other enabled ACP agents preserve configured order.
+- Divider and notice text match the persisted mechanism.
+- Source divider navigation reopens or focuses the source session.
+
+### Verification
+
+Run the focused ACP protocol, persistence, manager/coordinator, runner, and UI
+policy suites. Then run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+The repository's full required test command remains the final implementation
+gate.
+
+## Anticipated Implementation Areas
+
+- New `ACPSessionForkCoordinator` and pure mechanism/snapshot policy types
+  under `Alas/Sources/ACP/Session`.
+- `Alas/Sources/ACP/Protocol/ACPConnection.swift`
+  - Native fork durable-response behavior and best-effort remote close.
+- `Alas/Sources/ACP/Session/ACPSession.swift`
+  - Runtime session capabilities and fork presentation state.
+- `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+  - Boundary resolution, connection handoff, runner startup, and source-link
+    navigation support.
+- `Alas/Sources/ACP/Session/ACPSessionPersistence.swift`
+  - Snapshot loading and atomic fork creation.
+- `Alas/Sources/ACP/Session/ACPSessionStore.swift`
+  - Fork metadata schema and transactional writes.
+- `Alas/Sources/ACP/Session/ACPSessionRunner.swift`
+  - One-time private context delivery.
+- `Alas/Sources/ACP/UI/ACPMessageGutter.swift`
+  - Native target-agent submenu.
+- `Alas/Sources/ACP/UI/ACPMessageList.swift`
+  - Completed-message boundary wiring and fork divider.
+- `Alas/Sources/App/AppState.swift`
+  - Coordinator ownership and target-tab opening.
+- New focused fork policy, coordinator, persistence, runner, and UI-policy
+  tests under `AlasTests/ACP`.


### PR DESCRIPTION
## Summary

- add a per-message Fork action with same-agent and cross-provider targets
- use native ACP `session/fork` when supported, with durable idempotent broker recovery
- fall back to private transcript context transfer for other providers
- persist fork lineage, restore forks across relaunches, and present source navigation in forked chats

## User impact

Users can branch an ACP conversation from an eligible message into a new chat, either with the current agent or another configured provider, without mutating the source chat.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused ACP fork policy, persistence, manager, runner, attach/recovery, presentation, transcript-row, protocol, and restore suites

The full local scheme was also started, but an unrelated `ContentSearcherTests.findsMatchesAcrossFiles` test stalled at a host Git subprocess boundary while macOS Directory Services was failing UID/cache lookup. CI remains the authoritative full-suite validation.