### PR TITLE
refactor(gg): rename stacked diffs mode UI

### DIFF
--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -13,6 +13,8 @@ struct NewWorktreeGGModeSegment: Equatable {
 }
 
 struct NewWorktreeDialog: View {
+    nonisolated static let ggModeFieldLabel = "Stacked Diffs Mode"
+
     @Bindable var state: AppState
     @Binding var presented: Bool
     var presetProjectId: String?
@@ -99,7 +101,7 @@ struct NewWorktreeDialog: View {
                         .foregroundColor(theme.color("fg"))
                 }
                 if ggStackAvailability != .hidden {
-                    DialogField(label: "GG mode") {
+                    DialogField(label: Self.ggModeFieldLabel) {
                         ggModeSegmented
                     }
                     Text(Self.ggModeDescription(mode: ggMode, createsGGStack: createsGGStack))

--- a/Alas/Sources/Integrations/GG/GGStackIcon.swift
+++ b/Alas/Sources/Integrations/GG/GGStackIcon.swift
@@ -6,6 +6,8 @@ enum GGStackIconVariant: Equatable {
 }
 
 struct GGStackIcon: View {
+    nonisolated static let systemName = "square.stack.3d.up"
+
     let variant: GGStackIconVariant
     let size: CGFloat
     let color: Color
@@ -22,8 +24,10 @@ struct GGStackIcon: View {
 
     var body: some View {
         ZStack {
-            GGStackShape()
-                .fill(color)
+            Image(systemName: Self.systemName)
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(color)
             if variant == .disabled {
                 Capsule()
                     .fill(color)
@@ -32,27 +36,5 @@ struct GGStackIcon: View {
             }
         }
         .frame(width: size, height: size)
-    }
-}
-
-private struct GGStackShape: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        let strokeHeight = min(rect.height / 9, 1)
-        let strokeWidth = min(rect.width, 7)
-        let x = rect.midX - strokeWidth / 2
-        let yPositions = [
-            rect.minY + 1,
-            rect.midY - strokeHeight / 2,
-            rect.maxY - strokeHeight - 1,
-        ]
-
-        for y in yPositions {
-            path.addRoundedRect(
-                in: CGRect(x: x, y: y, width: strokeWidth, height: strokeHeight),
-                cornerSize: CGSize(width: strokeHeight / 2, height: strokeHeight / 2)
-            )
-        }
-        return path
     }
 }

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 struct CommitRow: View {
     static let ggCheckoutTitle = "Checkout Commit"
-    static let ggContextMenuTitle = "GG"
+    static let ggContextMenuTitle = "Stacked Diffs (GG)"
+    static let ggContextMenuSystemImage = GGStackIcon.systemName
 
     enum ContextMenuAction: Hashable {
         case edit
@@ -76,7 +77,7 @@ struct CommitRow: View {
             }
             if let ggMenu {
                 Divider()
-                Menu(Self.ggContextMenuTitle, systemImage: "square.stack.3d.up") {
+                Menu(Self.ggContextMenuTitle, systemImage: Self.ggContextMenuSystemImage) {
                     ForEach(ggMenu.visibleItems) { item in
                         if item.isSeparator {
                             Divider()

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -44,6 +44,8 @@ struct GGWorktreeMenuModel: Equatable {
 }
 
 struct WorktreeRowView: View {
+    nonisolated static let ggModeMenuTitle = "Stacked Diffs Mode"
+
     struct GGModeMenuItem: Equatable, Identifiable {
         let mode: GGWorktreeMode
         let title: String
@@ -264,7 +266,7 @@ struct WorktreeRowView: View {
                 }
                 Divider()
                 if ggMenuModel.isVisible {
-                    Menu("GG Mode") {
+                    Menu(Self.ggModeMenuTitle) {
                         ForEach(Self.ggModeMenuItems(selectedMode: ggMenuModel.selectedMode)) { item in
                             Toggle(item.title, isOn: Binding(
                                 get: { item.isSelected },

--- a/AlasTests/CommitRowTests.swift
+++ b/AlasTests/CommitRowTests.swift
@@ -67,8 +67,10 @@ struct CommitRowTests {
         #expect(CommitRow.leadingContextMenuActions(canEdit: true, canReview: false) == [.edit])
     }
 
-    @Test func ggContextMenuUsesOneTypedActionSurface() {
-        #expect(CommitRow.ggContextMenuTitle == "GG")
+    @Test func ggContextMenuUsesStackedDiffsNameAndSharedIcon() {
+        #expect(CommitRow.ggContextMenuTitle == "Stacked Diffs (GG)")
+        #expect(CommitRow.ggContextMenuSystemImage == "square.stack.3d.up")
+        #expect(CommitRow.ggContextMenuSystemImage == GGStackIcon.systemName)
         #expect(GGCommitAction.checkout != .dropCommit)
     }
 

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -377,6 +377,10 @@ struct NewWorktreeDialogTests {
             "GG disabled for this worktree. Creates a regular Git branch.")
     }
 
+    @Test func ggModeFieldUsesStackedDiffsName() {
+        #expect(NewWorktreeDialog.ggModeFieldLabel == "Stacked Diffs Mode")
+    }
+
     @Test func ggBranchPreviewIncludesPinnedBase() {
         #expect(NewWorktreeDialog.ggBranchPreview(branch: "nacho/feature", base: "main") ==
             "Branch: nacho/feature, based on main")

--- a/AlasTests/WorktreeRowHeightTests.swift
+++ b/AlasTests/WorktreeRowHeightTests.swift
@@ -6,6 +6,10 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct WorktreeRowHeightTests {
+    @Test func ggModeMenuUsesStackedDiffsName() {
+        #expect(WorktreeRowView.ggModeMenuTitle == "Stacked Diffs Mode")
+    }
+
     @Test func ggStackTooltipUsesCommitTerminology() {
         #expect(WorktreeRowView.stackSummaryTooltip(merged: 1, total: 1)
             == "gg stack · 1 of 1 commit merged")

--- a/docs/superpowers/specs/2026-07-27-stacked-diffs-mode-naming-icon-design.md
+++ b/docs/superpowers/specs/2026-07-27-stacked-diffs-mode-naming-icon-design.md
@@ -1,0 +1,84 @@
+# Stacked Diffs Mode Naming and Icon
+
+Date: 2026-07-27
+Status: Approved design
+
+## Context
+
+Alas already presents the feature as `Stacked diffs` in Settings, but two mode
+controls still use `GG mode` and the commit contextual submenu is titled `GG`.
+The mode controls and sidebar also use a custom three-line stack glyph, while
+the commit submenu uses the `square.stack.3d.up` SF Symbol.
+
+The user-facing feature name should be consistent without hiding which tool
+provides commit-specific operations. Its icon should also be consistent across
+these surfaces.
+
+## Goals
+
+- Rename the New Worktree field to `Stacked Diffs Mode`.
+- Rename the worktree sidebar submenu to `Stacked Diffs Mode`.
+- Rename the commit contextual submenu to `Stacked Diffs (GG)`.
+- Use the commit submenu's `square.stack.3d.up` symbol everywhere the shared GG
+  stack icon currently appears.
+- Preserve the existing diagonal slash that distinguishes the Off variant.
+
+## Non-goals
+
+- Renaming GG-specific actions, installation controls, diagnostics, errors,
+  tooltips, or internal identifiers.
+- Changing stacked-diffs configuration, policy resolution, worktree creation,
+  stack operations, or menu availability.
+- Changing icon sizing, colors, spacing, or accessibility behavior.
+- Broadly replacing every user-facing occurrence of `GG` or `gg`.
+
+## User Interface
+
+The affected labels are:
+
+| Surface | Current | New |
+|---|---|---|
+| New Worktree field | `GG mode` | `Stacked Diffs Mode` |
+| Worktree sidebar submenu | `GG Mode` | `Stacked Diffs Mode` |
+| Commit contextual submenu | `GG` | `Stacked Diffs (GG)` |
+
+`Stacked Diffs Mode` makes the feature the primary concept in routine
+configuration. `Stacked Diffs (GG)` retains the provider name where the
+submenu exposes GG-specific commit operations.
+
+All three surfaces use `square.stack.3d.up` as their stack symbol. The New
+Worktree Off segment uses the same symbol with the existing diagonal slash
+overlay. The sidebar retains its current muted metadata styling and progress
+text.
+
+## Implementation Approach
+
+Keep `GGStackIcon` as the shared SwiftUI presentation component. Replace its
+custom three-stroke shape with an `Image` using `square.stack.3d.up`, while
+preserving the component's size, color, and normal/slashed variants.
+
+Expose the symbol name from the shared component and use it for the commit
+submenu's `systemImage` argument. This gives all affected surfaces one source
+of truth without changing their layout or behavior.
+
+Update the existing label constants or call sites in `NewWorktreeDialog`,
+`WorktreeRowView`, and `CommitRow`. No model, persistence, or service changes
+are required.
+
+## Testing and Verification
+
+Focused tests should verify:
+
+- The New Worktree field uses `Stacked Diffs Mode`.
+- The worktree sidebar submenu uses `Stacked Diffs Mode`.
+- The commit contextual submenu uses `Stacked Diffs (GG)`.
+- The shared stack icon and commit submenu reference the same SF Symbol.
+- Existing mode choices and the normal/slashed icon variants remain intact.
+
+Before completion:
+
+1. Run SwiftFormat lint.
+2. Regenerate the Xcode project.
+3. Run the focused New Worktree, sidebar, and commit-row tests.
+4. Run a macOS build.
+


### PR DESCRIPTION
## Summary

- Rename scoped GG mode/navigation UI labels to Stacked Diffs terminology.
- Use `Stacked Diffs Mode` for New Worktree and sidebar mode controls.
- Use `Stacked Diffs (GG)` for the commit contextual submenu.
- Replace the custom three-line GG stack glyph with the shared `square.stack.3d.up` SF Symbol while preserving the disabled slash overlay.

## Verification

- `rtk xcodebuild -quiet -derivedDataPath .build/codex-derived-data -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/NewWorktreeDialogTests -only-testing:AlasTests/WorktreeRowHeightTests -only-testing:AlasTests/CommitRowTests test`
- `rtk swiftformat Alas AlasTests --lint --reporter github-actions-log`
- `rtk xcodegen`
- `rtk git diff --check`
- `rtk xcodebuild -quiet -derivedDataPath .build/codex-derived-data -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`

Full local test gate was attempted but not completed locally because Xcode result bundles became unreadable after a stale DerivedData build-service lock and command-wrapper hangs. CI should provide the authoritative full-suite result for this PR.
