### PR TITLE
fix(diff): lazily render accessory segments

### DIFF
--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -848,76 +848,27 @@ struct DiffReviewFileSection: View {
     ) -> some View {
         let displayGroup = group.displayGroup
         if group.containsLocalAccessories {
-            LazyVStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
                 segmentedHunkHeader(displayGroup)
-                ForEach(group.segments) { segment in
-                    if !segment.rows.isEmpty {
-                        ForEach(segment.blocks) { block in
-                            switch block {
-                            case .rows(let rowSeg):
-                                DiffPaneTextDocumentView(
-                                    group: DiffDisplayGroup(
-                                        id: "\(segment.id)-\(rowSeg.id)",
-                                        header: displayGroup.header,
-                                        sourceHunk: displayGroup.sourceHunk,
-                                        rows: rowSeg.rows,
-                                        rowsSignature: rowSeg.rowsSignature
-                                    ),
-                                    expandedCollapsedRowIDs: expandedCollapsedRowIDs,
-                                    layoutMode: layoutMode,
-                                    wrapLines: wrapLines,
-                                    showWhitespace: showWhitespace,
-                                    fileExtension: LanguageRegistry.highlighterExtension(forPath: file.summary.path),
-                                    codeFontFamily: codeFontFamily,
-                                    codeFontSize: codeFontSize,
-                                    theme: theme,
-                                    lspContext: lspContext,
-                                    activeCommentHighlight: activeHighlight(for: rowSeg.rows),
-                                    allowsReviewLineSelection: allowsDraftCommentCreation,
-                                    onReviewLineSelected: beginPendingDraft,
-                                    onContextExpansion: loadContextAndExpand
-                                )
-                                .fixedSize(horizontal: false, vertical: true)
-                            case .thread(let thread):
-                                DiffFeedbackLaneView(
-                                    lane: DiffFeedbackLaneResolver.lane(for: thread),
-                                    layoutMode: layoutMode,
-                                    rows: segment.rows
-                                ) {
-                                    DiffInlineCommentCard(
-                                        thread: thread,
-                                        onReply: { body in onReply(thread, body) },
-                                        onStageReply: { body in onStageReply(thread, body) },
-                                        onResolve: { onResolve(thread) },
-                                        onUnresolve: { onUnresolve(thread) },
-                                        onEdit: { comment, newBody in onEdit(thread, comment, newBody) },
-                                        onDelete: { comment in onDelete(thread, comment) },
-                                        canReply: canReply && thread.viewerCanReply,
-                                        canResolve: canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
-                                        canAddToReview: canAddToReview,
-                                        onActiveChange: { active in
-                                            activeThreadID = active ? thread.id : (activeThreadID == thread.id ? nil : activeThreadID)
-                                        }
-                                    )
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                }
-                            case .annotation(let annotation):
-                                DiffFeedbackLaneView(
-                                    lane: DiffFeedbackLaneResolver.lane(for: annotation),
-                                    layoutMode: layoutMode,
-                                    rows: segment.rows
-                                ) {
-                                    DiffInlineAnnotationCard(annotation: annotation)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                }
-                            }
+                if let requiredIndex = group.segments.firstIndex(where: { segment in
+                    segment.draftComments.contains { commandedDraftCommentIDs.contains($0.id) }
+                }) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(group.segments[..<requiredIndex]) { segment in
+                            accessorySegment(segment, displayGroup: displayGroup)
                         }
                     }
-                    if !segment.draftComments.isEmpty {
-                        draftCommentStack(segment.draftComments, rows: segment.rows)
+                    accessorySegment(group.segments[requiredIndex], displayGroup: displayGroup)
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(group.segments[(requiredIndex + 1)...]) { segment in
+                            accessorySegment(segment, displayGroup: displayGroup)
+                        }
                     }
-                    if segment.showsComposer {
-                        draftComposer(rows: segment.rows)
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(group.segments) { segment in
+                            accessorySegment(segment, displayGroup: displayGroup)
+                        }
                     }
                 }
             }
@@ -963,6 +914,81 @@ struct DiffReviewFileSection: View {
                     )
                 }
             )
+        }
+    }
+
+    @ViewBuilder
+    private func accessorySegment(
+        _ segment: DiffReviewRenderContext.Segment,
+        displayGroup: DiffDisplayGroup
+    ) -> some View {
+        if !segment.rows.isEmpty {
+            ForEach(segment.blocks) { block in
+                switch block {
+                case .rows(let rowSeg):
+                    DiffPaneTextDocumentView(
+                        group: DiffDisplayGroup(
+                            id: "\(segment.id)-\(rowSeg.id)",
+                            header: displayGroup.header,
+                            sourceHunk: displayGroup.sourceHunk,
+                            rows: rowSeg.rows,
+                            rowsSignature: rowSeg.rowsSignature
+                        ),
+                        expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                        layoutMode: layoutMode,
+                        wrapLines: wrapLines,
+                        showWhitespace: showWhitespace,
+                        fileExtension: LanguageRegistry.highlighterExtension(forPath: file.summary.path),
+                        codeFontFamily: codeFontFamily,
+                        codeFontSize: codeFontSize,
+                        theme: theme,
+                        lspContext: lspContext,
+                        activeCommentHighlight: activeHighlight(for: rowSeg.rows),
+                        allowsReviewLineSelection: allowsDraftCommentCreation,
+                        onReviewLineSelected: beginPendingDraft,
+                        onContextExpansion: loadContextAndExpand
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                case .thread(let thread):
+                    DiffFeedbackLaneView(
+                        lane: DiffFeedbackLaneResolver.lane(for: thread),
+                        layoutMode: layoutMode,
+                        rows: segment.rows
+                    ) {
+                        DiffInlineCommentCard(
+                            thread: thread,
+                            onReply: { body in onReply(thread, body) },
+                            onStageReply: { body in onStageReply(thread, body) },
+                            onResolve: { onResolve(thread) },
+                            onUnresolve: { onUnresolve(thread) },
+                            onEdit: { comment, newBody in onEdit(thread, comment, newBody) },
+                            onDelete: { comment in onDelete(thread, comment) },
+                            canReply: canReply && thread.viewerCanReply,
+                            canResolve: canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
+                            canAddToReview: canAddToReview,
+                            onActiveChange: { active in
+                                activeThreadID = active ? thread.id : (activeThreadID == thread.id ? nil : activeThreadID)
+                            }
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                case .annotation(let annotation):
+                    DiffFeedbackLaneView(
+                        lane: DiffFeedbackLaneResolver.lane(for: annotation),
+                        layoutMode: layoutMode,
+                        rows: segment.rows
+                    ) {
+                        DiffInlineAnnotationCard(annotation: annotation)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        }
+        if !segment.draftComments.isEmpty {
+            draftCommentStack(segment.draftComments, rows: segment.rows)
+        }
+        if segment.showsComposer {
+            draftComposer(rows: segment.rows)
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -848,7 +848,7 @@ struct DiffReviewFileSection: View {
     ) -> some View {
         let displayGroup = group.displayGroup
         if group.containsLocalAccessories {
-            VStack(alignment: .leading, spacing: 0) {
+            LazyVStack(alignment: .leading, spacing: 0) {
                 segmentedHunkHeader(displayGroup)
                 ForEach(group.segments) { segment in
                     if !segment.rows.isEmpty {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -596,6 +596,7 @@ struct DiffReviewSurfaceTests {
         let section = DiffReviewFileSection(
             file: file,
             draftComments: comments,
+            draftCommentScrollTargetID: comments.last?.id,
             layoutMode: Binding(get: { layout }, set: { layout = $0 }),
             wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
             showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
@@ -615,6 +616,10 @@ struct DiffReviewSurfaceTests {
 
         let materializedSegments = allSubviews(of: controller.view)
             .compactMap { $0 as? DiffPaneTextDocumentContainerView }
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-review-draft-comment-draft-\(rowCount)",
+            in: controller.view
+        ) != nil)
         #expect(!materializedSegments.isEmpty)
         #expect(materializedSegments.count < rowCount / 2)
     }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -570,6 +570,55 @@ struct DiffReviewSurfaceTests {
         #expect(settledIdentities == initialIdentities)
     }
 
+    @Test func accessoryHunkBoundsSegmentMaterializationToScrollViewport() {
+        let path = "A.swift"
+        let rowCount = 200
+        let displayModel = largeSingleGroupDisplayModel(rowCount: rowCount, filePath: path)
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: path, additions: rowCount),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel,
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil
+        )
+        let comments = (1...rowCount).map { line in
+            draftComment(
+                id: "draft-\(line)",
+                fileID: file.id,
+                path: path,
+                startLine: line
+            )
+        }
+        var layout = DiffLayoutMode.stacked
+        var wrap = false
+        var whitespace = false
+        let section = DiffReviewFileSection(
+            file: file,
+            draftComments: comments,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = NSHostingController(rootView: ScrollView(.vertical) { section })
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 500)
+        for _ in 0..<5 {
+            controller.view.layoutSubtreeIfNeeded()
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.6))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let materializedSegments = allSubviews(of: controller.view)
+            .compactMap { $0 as? DiffPaneTextDocumentContainerView }
+        #expect(!materializedSegments.isEmpty)
+        #expect(materializedSegments.count < rowCount / 2)
+    }
+
     @Test func inlineFeedbackScrollRealizesTargetHunkWithoutEagerlyRenderingAllHunks() {
         let path = "Sources/App/LargeView.swift"
         let displayModel = largeDisplayModel(groupCount: 80, filePath: path)
@@ -3892,6 +3941,39 @@ struct DiffReviewSurfaceTests {
             )
         }
         return DiffDisplayModel(filePath: filePath, groups: groups)
+    }
+
+    private func largeSingleGroupDisplayModel(rowCount: Int, filePath: String) -> DiffDisplayModel {
+        let rows = (0..<rowCount).map { index in
+            let line = index + 1
+            return DiffDisplayRow(
+                id: "row-\(line)",
+                kind: .add,
+                old: nil,
+                new: diffLine(
+                    id: "line-\(line)",
+                    side: .new,
+                    newLine: line,
+                    text: "let value\(line) = \(line)",
+                    kind: .add,
+                    rowIndex: index
+                ),
+                collapsedLineCount: 0
+            )
+        }
+        let sourceHunk = ParsedDiff.Hunk(
+            header: "@@ -0,0 +1,\(rowCount) @@",
+            oldStart: 0,
+            newStart: 1,
+            lines: []
+        )
+        let group = DiffDisplayGroup(
+            id: "large-group",
+            header: sourceHunk.header,
+            sourceHunk: sourceHunk,
+            rows: rows
+        )
+        return DiffDisplayModel(filePath: filePath, groups: [group])
     }
 
     private func loadedSession(summaries: [DiffReviewFileSummary]) -> DiffReviewLoadedSession {


### PR DESCRIPTION
## Summary

- lazily materialize accessory-bearing diff hunk segments inside the shared file-section renderer
- keep `DiffPaneTextDocumentView` intrinsic measurement limited to viewport-realized segments
- add a regression test covering a 200-row hunk split into 200 accessory segments

## Root cause

The ordinary diff-group path already used `LazyVStack`, but the local-accessory path used an eager `VStack`. A large accessory-bearing file therefore constructed and measured every segment during layout, repeatedly driving the main thread through deeply nested SwiftUI stack measurement.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (6,589 tests in 630 suites)
- before sample: 1,320 / 3,277 main-thread samples in `DiffPaneTextDocumentContainerView.layout()`
- settled after sample: 0.0% CPU, 3,171 / 3,238 main-thread samples asleep in the run loop, with no `StackLayout` frames