### PR TITLE
feat(ui): add semantic right sidebar section icons

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -621,6 +621,7 @@
 		713173965C4311772F6048E1 /* DiffReviewImageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE4396C610C7714AFDD6B41 /* DiffReviewImageState.swift */; };
 		7146CECD7FE56140D7A7AF50 /* MergeConflictTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */; };
 		71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */; };
+		720BE594FABAE15B8BC46F76 /* SectionHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56D60E58F278AC97579937E /* SectionHeaderTests.swift */; };
 		724CD1B1450DEC33DE6B0DE3 /* ComposerActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		725EDB42BF126786D99E359A /* CursorModelVariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */; };
@@ -2375,6 +2376,7 @@
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
 		B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInstaller.swift; sourceTree = "<group>"; };
+		B56D60E58F278AC97579937E /* SectionHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderTests.swift; sourceTree = "<group>"; };
 		B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGConfigReaderTests.swift; sourceTree = "<group>"; };
 		B586C7A794B846F3AD9228BD /* RemoteWeb */ = {isa = PBXFileReference; lastKnownFileType = folder; name = RemoteWeb; path = Alas/Resources/RemoteWeb; sourceTree = SOURCE_ROOT; };
 		B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneLSP.swift; sourceTree = "<group>"; };
@@ -3296,6 +3298,7 @@
 				F15CFDEF63A656129A3EFEEB /* RunScriptStoreTests.swift */,
 				200C4E9E9FBD356C8B051746 /* RunScriptTemplateTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
+				B56D60E58F278AC97579937E /* SectionHeaderTests.swift */,
 				4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */,
 				9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
@@ -6754,6 +6757,7 @@
 				FF35D0B630AC692B24FA9909 /* SSHHostSuggestionsTests.swift in Sources */,
 				7DAAFE51C9C35BADB78B4A30 /* SSHIntegrationTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
+				720BE594FABAE15B8BC46F76 /* SectionHeaderTests.swift in Sources */,
 				2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */,
 				2B4CBD06D1568EBC1BD327E0 /* SemanticVersionTests.swift in Sources */,
 				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -112,6 +112,7 @@ struct CommitsSectionView: View {
             }
         } header: {
             SectionHeader(
+                role: ggStack == nil ? .commits : .stack,
                 title: Self.sectionTitle(ggStack: ggStack),
                 count: totalCount,
                 expanded: expanded,

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -77,7 +77,7 @@ struct RightPaneLoadingSkeletonView: View {
         switch activeTab {
         case .changes:
             VStack(alignment: .leading, spacing: 0) {
-                SkeletonSectionHeader(title: "Working tree")
+                SkeletonSectionHeader(role: .workingTree, title: "Working tree")
                 VStack(alignment: .leading, spacing: 6) {
                     SkeletonRow(widthFraction: 0.75)
                     SkeletonRow(widthFraction: 0.55)
@@ -87,7 +87,7 @@ struct RightPaneLoadingSkeletonView: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
 
-                SkeletonSectionHeader(title: "Commits")
+                SkeletonSectionHeader(role: .commits, title: "Commits")
                 VStack(alignment: .leading, spacing: 6) {
                     SkeletonRow(widthFraction: 0.8)
                     SkeletonRow(widthFraction: 0.6)
@@ -154,14 +154,19 @@ private struct CompactStateLabel: View {
 // MARK: - Skeleton primitives
 
 private struct SkeletonSectionHeader: View {
+    let role: SectionHeaderRole
     let title: String
     @Environment(\.theme) private var theme
 
     var body: some View {
         HStack(spacing: 6) {
-            // Matches the chevron slot in SectionHeader so the column
-            // alignment is the same as the real header.
-            Color.clear.frame(width: 14, height: 14)
+            SectionHeaderIcon(
+                role: role,
+                size: 10,
+                color: theme.color("fg-faint")
+            )
+                .frame(width: 14, height: 14)
+                .accessibilityHidden(true)
             Text(title.uppercased())
                 .font(.system(size: 10.5, weight: .semibold))
                 .tracking(0.5)

--- a/Alas/Sources/Right/SectionHeader.swift
+++ b/Alas/Sources/Right/SectionHeader.swift
@@ -1,8 +1,50 @@
 import SwiftUI
 
+enum SectionHeaderRole: Equatable {
+    enum IconKind: Equatable {
+        case standard(String)
+        case stack
+    }
+
+    case workingTree
+    case commits
+    case stack
+    case stashes
+
+    var iconKind: IconKind {
+        switch self {
+        case .workingTree: return .standard("diff")
+        case .commits: return .standard("commit")
+        case .stack: return .stack
+        case .stashes: return .standard("archivebox")
+        }
+    }
+
+    static func accessibilityValue(expanded: Bool) -> String {
+        expanded ? "Expanded" : "Collapsed"
+    }
+}
+
+struct SectionHeaderIcon: View {
+    let role: SectionHeaderRole
+    let size: CGFloat
+    let color: Color
+
+    @ViewBuilder
+    var body: some View {
+        switch role.iconKind {
+        case let .standard(name):
+            Icon(name: name, size: size, color: color)
+        case .stack:
+            GGStackIcon(size: size, color: color)
+        }
+    }
+}
+
 /// Top-level collapsible section header used inside the Changes tab
 /// ("Working tree", "Commits"). The whole row is the click target.
 struct SectionHeader<Trailing: View>: View {
+    let role: SectionHeaderRole
     let title: String
     let count: Int?
     let expanded: Bool
@@ -15,12 +57,22 @@ struct SectionHeader<Trailing: View>: View {
     var body: some View {
         Button(action: onToggle) {
             HStack(spacing: 6) {
-                Icon(name: expanded ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                // This is a stable section-identity icon, not an expansion
+                // indicator. Expansion state is conveyed by visible content
+                // and the button's accessibility value.
+                SectionHeaderIcon(
+                    role: role,
+                    size: 10,
+                    color: theme.color("fg-faint")
+                )
                     .frame(width: 14, height: 14)
+                    .accessibilityHidden(true)
                 Text(title.uppercased())
                     .font(.system(size: 10.5, weight: .semibold))
                     .tracking(0.5)
                     .foregroundColor(theme.color("fg-muted"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
                 if let count {
                     Text("\(count)")
                         .font(.system(size: 9.5, weight: .semibold))
@@ -44,11 +96,14 @@ struct SectionHeader<Trailing: View>: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityValue(SectionHeaderRole.accessibilityValue(expanded: expanded))
     }
 }
 
 extension SectionHeader where Trailing == EmptyView {
     init(
+        role: SectionHeaderRole,
         title: String,
         count: Int?,
         expanded: Bool,
@@ -56,6 +111,7 @@ extension SectionHeader where Trailing == EmptyView {
         onToggle: @escaping () -> Void
     ) {
         self.init(
+            role: role,
             title: title,
             count: count,
             expanded: expanded,

--- a/Alas/Sources/Right/StashesSectionView.swift
+++ b/Alas/Sources/Right/StashesSectionView.swift
@@ -25,6 +25,7 @@ struct StashesSectionView: View {
                 }
             } header: {
                 SectionHeader(
+                    role: .stashes,
                     title: "Stashes",
                     count: stashes.count,
                     expanded: expanded,

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -54,6 +54,7 @@ struct WorkingTreeSectionView: View {
             }
         } header: {
             SectionHeader(
+                role: .workingTree,
                 title: "Working tree",
                 count: changeGroups.count,
                 expanded: expanded,

--- a/AlasTests/ChevronStabilityTests.swift
+++ b/AlasTests/ChevronStabilityTests.swift
@@ -3,15 +3,14 @@ import SwiftUI
 import Testing
 @testable import Alas
 
-/// Verifies that the fixed-frame chevron approach keeps the title text
-/// anchored at the same horizontal position when toggling expand/collapse.
-/// Mirrors the pixel-scan strategy in ``RepoGroupViewLayoutTests``.
+/// Verifies that fixed leading-icon frames keep section titles anchored when
+/// expansion state changes. SubHeader still uses disclosure chevrons.
 @Suite(.serialized)
 @MainActor
 struct ChevronStabilityTests {
     // MARK: - SectionHeader
 
-    @Test func sectionHeaderTitleDoesNotShiftWhenToggled() throws {
+    @Test func sectionHeaderTitleDoesNotShiftBetweenExpansionStates() throws {
         let collapsedX = try titleMinX(sectionHeaderExpanded: false)
         let expandedX = try titleMinX(sectionHeaderExpanded: true)
 
@@ -31,6 +30,7 @@ struct ChevronStabilityTests {
 
     private func titleMinX(sectionHeaderExpanded expanded: Bool) throws -> Int {
         let view = SectionHeader(
+            role: .workingTree,
             title: "Working tree",
             count: 3,
             expanded: expanded,
@@ -38,8 +38,8 @@ struct ChevronStabilityTests {
         )
         .environment(\.theme, try ThemeStore().current)
 
-        // At @2x the chevron frame (14pt) + padding (12pt) + spacing (6pt) = 32pt → 64px.
-        // Chevron glyph can overflow up to ~48px. Scan from 50 to clear it.
+        // At @2x the semantic-icon frame (14pt) + padding (12pt) + spacing (6pt)
+        // places the title at 32pt. Scan from 50px to clear the icon.
         return try firstOpaqueX(view: view, width: 260, height: 40, scanFromPixel: 50)
     }
 

--- a/AlasTests/SectionHeaderTests.swift
+++ b/AlasTests/SectionHeaderTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct SectionHeaderTests {
+    @Test func semanticRolesUseTheExpectedIconKinds() {
+        #expect(SectionHeaderRole.workingTree.iconKind == .standard("diff"))
+        #expect(SectionHeaderRole.commits.iconKind == .standard("commit"))
+        #expect(SectionHeaderRole.stack.iconKind == .stack)
+        #expect(SectionHeaderRole.stashes.iconKind == .standard("archivebox"))
+    }
+
+    @Test func collapsedHeaderUsesCollapsedAccessibilityValue() {
+        #expect(SectionHeaderRole.accessibilityValue(expanded: false) == "Collapsed")
+    }
+
+    @Test func expandedHeaderUsesExpandedAccessibilityValue() {
+        #expect(SectionHeaderRole.accessibilityValue(expanded: true) == "Expanded")
+    }
+}

--- a/AlasTests/WorkingTreeStageAllActionTests.swift
+++ b/AlasTests/WorkingTreeStageAllActionTests.swift
@@ -35,6 +35,7 @@ struct WorkingTreeStageAllActionTests {
 
     @Test func sectionHeaderAcceptsStatsTuple() {
         let header = SectionHeader(
+            role: .commits,
             title: "Commits",
             count: 12,
             expanded: true,


### PR DESCRIPTION
<!-- gg:managed:start -->
Part of stack `use-stack-icon-in-sidebar`

Commit: 86152bf
<!-- gg:managed:end -->