### PR TITLE
fix(gg): preserve first worktree name keystroke

### DIFF
--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -27,7 +27,7 @@ struct NewWorktreeDialog: View {
     @State private var branch: String = ""
     @State private var stackName: String = ""
     @State private var runStartup: Bool = true
-    @State private var ggMode: GGWorktreeMode = .off
+    @State private var ggMode: GGWorktreeMode
     @State private var openAfterCreate: Bool = true
     @State private var launchMode: AppConfig.LauncherMode = .terminal
     /// The launcher mode to persist — preserves the user's intent even when
@@ -49,10 +49,15 @@ struct NewWorktreeDialog: View {
         self.state = state
         self._presented = presented
         self.presetProjectId = presetProjectId
-        self._projectId = State(initialValue: Self.initialProjectId(
+        let initialSelection = Self.initialSelection(
             presetProjectId: presetProjectId,
-            projects: state.projects
-        ))
+            projects: state.projects,
+            repoHasGGConfig: { project in
+                GGStackGate.repoHasGGConfig(repoPath: project.path)
+            }
+        )
+        self._projectId = State(initialValue: initialSelection.projectId)
+        self._ggMode = State(initialValue: initialSelection.ggMode)
     }
 
     var body: some View {
@@ -515,6 +520,27 @@ struct NewWorktreeDialog: View {
         resolvedPresetProject(presetProjectId: presetProjectId, projects: projects)?.id
             ?? projects.first?.id
             ?? ""
+    }
+
+    nonisolated static func initialSelection(
+        presetProjectId: String?,
+        projects: [ProjectConfig],
+        repoHasGGConfig: (ProjectConfig) -> Bool
+    ) -> (projectId: String, ggMode: GGWorktreeMode) {
+        guard let project = resolvedPresetProject(
+            presetProjectId: presetProjectId,
+            projects: projects
+        ) ?? projects.first else {
+            return ("", .off)
+        }
+
+        return (
+            project.id,
+            initialGGMode(
+                projectMode: project.ggMode,
+                repoHasGGConfig: repoHasGGConfig(project)
+            )
+        )
     }
 
     nonisolated static func showsRepositorySelector(

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -52,6 +52,67 @@ struct NewWorktreeDialogTests {
         )?.id == "repo-b")
     }
 
+    @Test func initialSelectionEnablesStackedDiffsBeforeFirstRender() {
+        let selection = NewWorktreeDialog.initialSelection(
+            presetProjectId: nil,
+            projects: [Self.project(id: "repo-a", ggMode: .auto)],
+            repoHasGGConfig: { $0.id == "repo-a" }
+        )
+
+        #expect(selection.projectId == "repo-a")
+        #expect(selection.ggMode == .on)
+    }
+
+    @Test func initialSelectionDisablesStackedDiffsBeforeFirstRender() {
+        let selection = NewWorktreeDialog.initialSelection(
+            presetProjectId: nil,
+            projects: [Self.project(id: "repo-a", ggMode: .off)],
+            repoHasGGConfig: { _ in true }
+        )
+
+        #expect(selection.projectId == "repo-a")
+        #expect(selection.ggMode == .off)
+    }
+
+    @Test func initialSelectionUsesValidPresetProjectPolicy() {
+        let selection = NewWorktreeDialog.initialSelection(
+            presetProjectId: "repo-b",
+            projects: [
+                Self.project(id: "repo-a", ggMode: .off),
+                Self.project(id: "repo-b", ggMode: .on),
+            ],
+            repoHasGGConfig: { _ in false }
+        )
+
+        #expect(selection.projectId == "repo-b")
+        #expect(selection.ggMode == .on)
+    }
+
+    @Test func initialSelectionFallsBackToFirstProjectForStalePreset() {
+        let selection = NewWorktreeDialog.initialSelection(
+            presetProjectId: "missing",
+            projects: [
+                Self.project(id: "repo-a", ggMode: .off),
+                Self.project(id: "repo-b", ggMode: .on),
+            ],
+            repoHasGGConfig: { _ in true }
+        )
+
+        #expect(selection.projectId == "repo-a")
+        #expect(selection.ggMode == .off)
+    }
+
+    @Test func initialSelectionIsOffWithoutProjects() {
+        let selection = NewWorktreeDialog.initialSelection(
+            presetProjectId: nil,
+            projects: [],
+            repoHasGGConfig: { _ in true }
+        )
+
+        #expect(selection.projectId.isEmpty)
+        #expect(selection.ggMode == .off)
+    }
+
     @Test func initialProjectIdUsesValidPreset() {
         let projects = [Self.project(id: "repo-a"), Self.project(id: "repo-b")]
 
@@ -188,13 +249,17 @@ struct NewWorktreeDialogTests {
         ))
     }
 
-    private static func project(id: String) -> ProjectConfig {
+    private static func project(
+        id: String,
+        ggMode: GGProjectMode = .auto
+    ) -> ProjectConfig {
         ProjectConfig(
             id: id,
             name: "nacho/\(id)",
             path: "/tmp/\(id)",
             color: "#5fb7c4",
-            addedAt: Date(timeIntervalSince1970: 0)
+            addedAt: Date(timeIntervalSince1970: 0),
+            ggMode: ggMode
         )
     }
 

--- a/docs/superpowers/specs/2026-07-28-new-worktree-stacked-diffs-initial-input-design.md
+++ b/docs/superpowers/specs/2026-07-28-new-worktree-stacked-diffs-initial-input-design.md
@@ -1,0 +1,88 @@
+# New Worktree Stacked Diffs Initial Input
+
+Date: 2026-07-28
+Status: Approved design
+
+## Problem
+
+`NewWorktreeDialog` resolves its initial repository before the first render, but
+its stacked-diffs mode still starts as `.off`. The first render therefore binds
+the focused name field to the regular `branch` draft. During `.onAppear`, the
+dialog resolves the repository policy and can switch the mode to `.on`, which
+rebinds the same visible field to the independent `stackName` draft.
+
+If the user types before that transition completes, the input is stored in
+`branch` and immediately disappears when the field switches to `stackName`.
+This makes the first keystroke appear to be dropped.
+
+## Desired Behavior
+
+- The initial name field uses the correct regular-branch or stack-name draft
+  before it can accept input.
+- A keystroke entered immediately after the dialog appears remains visible.
+- Regular branch and stack-name drafts remain independent when the user
+  manually toggles Stacked Diffs Mode.
+- Selecting another repository continues to replace the current mode with that
+  repository's resolved default.
+- Existing focus, validation, creation, and branch-composition behavior remains
+  unchanged.
+
+## Design
+
+Resolve the initial repository and its effective stacked-diffs mode together in
+the dialog initializer. Seed both `projectId` and `ggMode` state before SwiftUI
+evaluates the first body.
+
+The initial mode uses the existing policy path:
+
+1. Resolve the valid preset project, falling back to the first project.
+2. Read whether that repository has GG configuration.
+3. Pass the project's policy and configuration result through
+   `GGWorktreeContextResolver.isPolicyEnabled`.
+4. Store the result as the explicit `.on` or `.off` dialog mode.
+
+Keep the existing `.onAppear` mode application as a defensive fallback for
+state that changes between view construction and presentation. In the normal
+path, it reapplies the already-selected value and does not change the field's
+binding.
+
+Keep the repository-change handler unchanged. It must continue to resolve the
+new repository's explicit default after the user chooses a different
+repository.
+
+No changes are needed in `AlasField`, the input filter, or the independent
+`branch` and `stackName` state.
+
+## Alternatives Considered
+
+### Use one shared name draft
+
+This would give the editor a stable binding, but would remove the approved
+behavior where regular-branch and stack-name drafts survive manual mode
+toggles independently.
+
+### Hide or disable the field until appearance initialization completes
+
+This would prevent early typing, but would add a visible presentation and focus
+transition.
+
+### Delay focus asynchronously
+
+This would narrow the race without removing it and would make correctness
+depend on event timing.
+
+## Testing
+
+Add focused Swift Testing coverage for the initial-state resolver:
+
+- a repository whose effective policy is enabled starts in `.on`;
+- a repository whose effective policy is disabled starts in `.off`;
+- a valid preset is used instead of the first repository;
+- a missing preset falls back to the first repository;
+- no repositories produces an empty project ID and `.off`.
+
+Retain the existing tests that prove regular branch and stack-name drafts are
+independent and that repository changes resolve a new explicit mode.
+
+Run the focused `NewWorktreeDialogTests`, SwiftFormat lint, `xcodegen`, the
+required macOS build, and the required test suite before completion.


### PR DESCRIPTION
## Summary

- resolve the initial repository and its effective Stacked Diffs Mode together before the New Worktree dialog first renders
- seed both `projectId` and `ggMode` from that atomic selection so immediate input targets the correct branch or stack-name draft
- preserve independent branch and stack-name drafts when toggling mode manually
- add focused regression coverage for enabled, disabled, preset, stale-preset, and empty-project initialization

## Root cause

The dialog resolved its initial repository before the first render, but `ggMode` still started as `.off` and changed during `onAppear`. A fast first keystroke could therefore be stored in the regular branch draft immediately before the field switched to the independent stack-name draft, making the character appear to be dropped.

## Verification

- `rtk swiftformat Alas AlasTests --lint --reporter github-actions-log`
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-stacked-diffs-input-green -only-testing:AlasTests/NewWorktreeDialogTests test`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-stacked-diffs-input-build -quiet build`
- `rtk git diff --check`

The broad local test invocation compiled but stalled before starting `xctest`, so GitHub Actions remains the exhaustive suite gate.