### PR TITLE
fix(diff): Keep diff word wrap pane-local and off by default

### DIFF
--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -231,6 +231,7 @@ struct CenterPaneView: View {
                                 rps.requestDiscardFile(path: s.relativePath)
                             }
                         )
+                        .id(s.id)
                         .task(id: rightPaneActivationKey) {
                             activateRightPaneStateForCenterTab()
                         }

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -25,6 +25,7 @@ struct CommitEditorTabView: View {
     @State private var error: String?
     @State private var pendingDropFile: PendingCommitFileDrop?
     @State private var pendingDropHunk: PendingCommitHunkDrop?
+    @State private var wrapLines = false
     @State private var showWhitespace = false
 
     // Files/diff divider drag: transient during the drag, committed to
@@ -37,7 +38,11 @@ struct CommitEditorTabView: View {
 
     private static let minPaneWidth: CGFloat = 140
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
+        DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $wrapLines,
+            showWhitespace: $showWhitespace
+        )
     }
 
     private var dirty: Bool {

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -22,6 +22,7 @@ struct CommitTabView: View {
 
     @State private var headerExpanded: Bool = false
     @State private var reviewSessionLaunchError: String?
+    @State private var wrapLines = false
     @State private var showWhitespace = false
 
     @Environment(\.theme) private var theme
@@ -29,7 +30,11 @@ struct CommitTabView: View {
     private let reviewLoader = CommitReviewLoader()
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
+        DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $wrapLines,
+            showWhitespace: $showWhitespace
+        )
     }
 
     static func reviewSessionTarget(

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -23,13 +23,18 @@ struct DraftCommitTabView: View {
     @State private var selectedFileID: DiffReviewFileID?
     @State private var loadingSession = false
     @State private var railCollapsed = false
+    @State private var wrapLines = false
     @State private var showWhitespace = false
 
     @Environment(\.theme) private var theme
     private let git = GitService()
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
+        DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $wrapLines,
+            showWhitespace: $showWhitespace
+        )
     }
 
     private var trimmedSubject: String {

--- a/Alas/Sources/Center/Diff/DiffPreferenceBindings.swift
+++ b/Alas/Sources/Center/Diff/DiffPreferenceBindings.swift
@@ -2,10 +2,16 @@ import SwiftUI
 
 struct DiffPreferenceBindings {
     let appState: AppState
+    private let wrapLinesStorage: Binding<Bool>
     private let showWhitespaceStorage: Binding<Bool>
 
-    init(appState: AppState, showWhitespace: Binding<Bool>) {
+    init(
+        appState: AppState,
+        wrapLines: Binding<Bool>,
+        showWhitespace: Binding<Bool>
+    ) {
         self.appState = appState
+        self.wrapLinesStorage = wrapLines
         self.showWhitespaceStorage = showWhitespace
     }
 
@@ -21,14 +27,7 @@ struct DiffPreferenceBindings {
     }
 
     var wrapLines: Binding<Bool> {
-        Binding(
-            get: { appState.config.changes.diffWrapLines },
-            set: { newValue in
-                guard appState.config.changes.diffWrapLines != newValue else { return }
-                appState.config.changes.diffWrapLines = newValue
-                appState.saveConfig()
-            }
-        )
+        wrapLinesStorage
     }
 
     var showWhitespace: Binding<Bool> {

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -47,6 +47,7 @@ struct DiffTabView: View {
     @State private var pendingDraftBody = ""
     @State private var draftComposerFocusRequestGeneration = 0
     @State private var reviewExpandedCollapsedRowIDs: Set<String> = []
+    @State private var wrapLines = false
     @State private var showWhitespace = false
     @StateObject private var renderContextCache = DiffTabRenderContextCache()
     @FocusState private var draftComposerFocused: Bool
@@ -181,7 +182,11 @@ struct DiffTabView: View {
     }
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
+        DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $wrapLines,
+            showWhitespace: $showWhitespace
+        )
     }
 
     private var lspContext: DiffPaneLSPContext? {

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -44,6 +44,7 @@ struct ReviewTabView: View {
     @State private var pendingReview: PendingReview?
     @State private var pendingReviewRailCollapsed = false
     @State private var showVerdictSheet = false
+    @State private var wrapLines = false
     @State private var showWhitespace = false
 
     var body: some View {
@@ -655,7 +656,11 @@ struct ReviewTabView: View {
     }
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
+        DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $wrapLines,
+            showWhitespace: $showWhitespace
+        )
     }
 
     // MARK: - Verdict submission

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -91,6 +91,7 @@ struct ReviewChangesTabView: View {
     @State private var activeLoadKey: String?
     @State private var activeLoadID = UUID()
     @State private var reviewSessionLaunchError: String?
+    @State private var wrapLines = false
     @State private var showWhitespace = false
 
     var body: some View {
@@ -458,7 +459,11 @@ struct ReviewChangesTabView: View {
     }
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
+        DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $wrapLines,
+            showWhitespace: $showWhitespace
+        )
     }
 
     private var reviewFeedbackAgentSender: ReviewFeedbackAgentSender {

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -28,6 +28,7 @@ struct DraftReviewRequestTabView: View {
     @State private var draftCommentScrollController = DiffReviewDraftCommentScrollController()
     @State private var generation: Task<Void, Never>? = nil
     @State private var reviewSessionLaunchError: String?
+    @State private var wrapLines = false
     @State private var showWhitespace = false
 
     @Environment(\.theme) private var theme
@@ -74,7 +75,11 @@ struct DraftReviewRequestTabView: View {
     }
 
     private var diffPreferences: DiffPreferenceBindings {
-        DiffPreferenceBindings(appState: appState, showWhitespace: $showWhitespace)
+        DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $wrapLines,
+            showWhitespace: $showWhitespace
+        )
     }
 
     var body: some View {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -362,12 +362,20 @@ struct ReviewSessionTabView: View {
 
     private var layoutModeBinding: Binding<DiffLayoutMode> {
         guard let appState else { return $localLayoutMode }
-        return DiffPreferenceBindings(appState: appState, showWhitespace: $localShowWhitespace).layoutMode
+        return DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $localWrapLines,
+            showWhitespace: $localShowWhitespace
+        ).layoutMode
     }
 
     private var wrapLinesBinding: Binding<Bool> {
         guard let appState else { return $localWrapLines }
-        return DiffPreferenceBindings(appState: appState, showWhitespace: $localShowWhitespace).wrapLines
+        return DiffPreferenceBindings(
+            appState: appState,
+            wrapLines: $localWrapLines,
+            showWhitespace: $localShowWhitespace
+        ).wrapLines
     }
 
     private var showWhitespaceBinding: Binding<Bool> {

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -337,7 +337,6 @@ struct AppConfig: Codable, Equatable {
         }
         var comparisonMode: ChangesComparisonMode
         var diffLayoutMode: DiffLayoutMode
-        var diffWrapLines: Bool
         var diffShowWhitespace: Bool
         /// Master switch for the gg stacked-diffs integration. On by
         /// default — without gg installed the later gates hide all UI.
@@ -346,7 +345,7 @@ struct AppConfig: Codable, Equatable {
         enum CodingKeys: String, CodingKey {
             case aiToolId, prompt, reviewRequestPrompt, mergeBulkResolvePrompt,
                  mergeSingleResolvePrompt, comparisonMode,
-                 diffLayoutMode, diffWrapLines, diffShowWhitespace, stackedDiffsEnabled
+                 diffLayoutMode, diffShowWhitespace, stackedDiffsEnabled
         }
     }
 
@@ -467,7 +466,6 @@ struct AppConfig: Codable, Equatable {
             mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
             comparisonMode: .auto,
             diffLayoutMode: .split,
-            diffWrapLines: false,
             diffShowWhitespace: false
         ),
         agents: Agents(
@@ -704,7 +702,6 @@ extension AppConfig {
                 return (legacyTrackUpstream == true) ? .branchUpstream : .auto
             }()
             let diffLayoutMode = (try? changesContainer.decode(DiffLayoutMode.self, forKey: .diffLayoutMode)) ?? .split
-            let diffWrapLines = (try? changesContainer.decode(Bool.self, forKey: .diffWrapLines)) ?? false
             let diffShowWhitespace = (try? changesContainer.decode(Bool.self, forKey: .diffShowWhitespace)) ?? false
             changes = Changes(
                 aiToolId: toolId,
@@ -714,7 +711,6 @@ extension AppConfig {
                 mergeSingleResolvePrompt: singleResolve,
                 comparisonMode: comparisonMode,
                 diffLayoutMode: diffLayoutMode,
-                diffWrapLines: diffWrapLines,
                 diffShowWhitespace: diffShowWhitespace
             )
             changes.stackedDiffsEnabled =
@@ -728,7 +724,6 @@ extension AppConfig {
                 mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
                 comparisonMode: .auto,
                 diffLayoutMode: .split,
-                diffWrapLines: false,
                 diffShowWhitespace: false
             )
         }

--- a/AlasTests/AppConfigChangesTests.swift
+++ b/AlasTests/AppConfigChangesTests.swift
@@ -197,7 +197,6 @@ struct AppConfigChangesTests {
 
     @Test func defaultsHaveDiffDisplayPreferences() {
         #expect(AppConfig.defaults.changes.diffLayoutMode == .split)
-        #expect(AppConfig.defaults.changes.diffWrapLines == false)
         #expect(AppConfig.defaults.changes.diffShowWhitespace == false)
     }
 
@@ -242,19 +241,37 @@ struct AppConfigChangesTests {
         """
         let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
         #expect(cfg.changes.diffLayoutMode == .split)
-        #expect(cfg.changes.diffWrapLines == false)
         #expect(cfg.changes.diffShowWhitespace == false)
     }
 
     @Test func roundTripsDiffDisplayPreferences() throws {
         var cfg = AppConfig.defaults
         cfg.changes.diffLayoutMode = .stacked
-        cfg.changes.diffWrapLines = true
         cfg.changes.diffShowWhitespace = true
         let data = try JSONEncoder().encode(cfg)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.changes.diffLayoutMode == .stacked)
-        #expect(decoded.changes.diffWrapLines == true)
         #expect(decoded.changes.diffShowWhitespace == true)
+    }
+
+    @Test func ignoresAndDropsLegacyDiffWrapLines() throws {
+        let json = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(AppConfig.defaults))
+                as? [String: Any]
+        )
+        var legacy = json
+        var changes = try #require(legacy["changes"] as? [String: Any])
+        changes["diffWrapLines"] = true
+        legacy["changes"] = changes
+
+        let legacyData = try JSONSerialization.data(withJSONObject: legacy)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: legacyData)
+        let encodedData = try JSONEncoder().encode(decoded)
+        let encoded = try #require(
+            JSONSerialization.jsonObject(with: encodedData) as? [String: Any]
+        )
+        let encodedChanges = try #require(encoded["changes"] as? [String: Any])
+
+        #expect(encodedChanges["diffWrapLines"] == nil)
     }
 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -536,7 +536,6 @@ struct DiffPaneViewTests {
 
         let state = AppState(store: MemoryStore())
         state.config.changes.diffLayoutMode = .split
-        state.config.changes.diffWrapLines = false
         var missCount = 0
         var view = DiffTabView(
             worktreePath: repo,
@@ -559,7 +558,6 @@ struct DiffPaneViewTests {
         #expect(visibleCodeTextViews(in: controller.view).count == 2)
 
         state.config.changes.diffLayoutMode = .stacked
-        state.config.changes.diffWrapLines = true
         try await waitForRenderPass(controller: controller) {
             visibleCodeTextViews(in: controller.view).count == 1
         }
@@ -574,7 +572,6 @@ struct DiffPaneViewTests {
 
         let state = AppState(store: MemoryStore())
         state.config.changes.diffLayoutMode = .stacked
-        state.config.changes.diffWrapLines = false
         let view = DiffTabView(
             worktreePath: repo,
             relativePath: "Sources/App.swift",
@@ -2440,7 +2437,6 @@ let second = true
     @Test func diffPreferenceBindingsPersistLayoutButKeepWrapAndWhitespacePaneLocal() {
         let appState = AppState(store: MemoryStore())
         appState.config.changes.diffLayoutMode = .split
-        appState.config.changes.diffWrapLines = false
         var firstWrapLines = false
         var secondWrapLines = false
         var firstWhitespace = false
@@ -2461,7 +2457,6 @@ let second = true
         )
 
         #expect(appState.config.changes.diffLayoutMode == .stacked)
-        #expect(appState.config.changes.diffWrapLines == false)
         #expect(first.wrapLines.wrappedValue == true)
         #expect(second.wrapLines.wrappedValue == false)
         #expect(first.showWhitespace.wrappedValue == true)

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -164,8 +164,20 @@ struct DiffPaneViewTests {
         )
     }
 
+    private final class WriteRecorder {
+        var writeCount = 0
+    }
+
     private struct MemoryStore: PersistenceStoreProtocol {
-        func write<T: Encodable>(_: T, to _: URL) throws {}
+        let recorder: WriteRecorder?
+
+        init(recorder: WriteRecorder? = nil) {
+            self.recorder = recorder
+        }
+
+        func write<T: Encodable>(_: T, to _: URL) throws {
+            recorder?.writeCount += 1
+        }
         func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
     }
 
@@ -2435,7 +2447,8 @@ let second = true
     }
 
     @Test func diffPreferenceBindingsPersistLayoutButKeepWrapAndWhitespacePaneLocal() {
-        let appState = AppState(store: MemoryStore())
+        let recorder = WriteRecorder()
+        let appState = AppState(store: MemoryStore(recorder: recorder))
         appState.config.changes.diffLayoutMode = .split
         var firstWrapLines = false
         var secondWrapLines = false
@@ -2447,8 +2460,12 @@ let second = true
             wrapLines: Binding(get: { firstWrapLines }, set: { firstWrapLines = $0 }),
             showWhitespace: Binding(get: { firstWhitespace }, set: { firstWhitespace = $0 })
         )
-        first.layoutMode.wrappedValue = .stacked
         first.wrapLines.wrappedValue = true
+        #expect(recorder.writeCount == 0)
+
+        first.layoutMode.wrappedValue = .stacked
+        #expect(recorder.writeCount == 1)
+
         first.showWhitespace.wrappedValue = true
         let second = DiffPreferenceBindings(
             appState: appState,
@@ -2461,6 +2478,21 @@ let second = true
         #expect(second.wrapLines.wrappedValue == false)
         #expect(first.showWhitespace.wrappedValue == true)
         #expect(second.showWhitespace.wrappedValue == false)
+    }
+
+    @Test func diffTabsProvideDistinctPresentationIdentityForDirectSwitches() {
+        let first = DiffTabState(
+            id: "first-diff",
+            title: "First diff",
+            relativePath: "Sources/First.swift"
+        )
+        let second = DiffTabState(
+            id: "second-diff",
+            title: "Second diff",
+            relativePath: "Sources/Second.swift"
+        )
+
+        #expect(first.id != second.id)
     }
 
     @Test func collapsedContextControllerTogglesHiddenRows() throws {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -2437,16 +2437,18 @@ let second = true
         #expect(DiffFeedbackLaneGeometry.containerWidth(for: .init(width: 900, height: nil)) == 900)
     }
 
-    @Test func diffPreferenceBindingsPersistLayoutAndWrapButKeepWhitespaceLocal() {
-        let appState = AppState()
+    @Test func diffPreferenceBindingsPersistLayoutButKeepWrapAndWhitespacePaneLocal() {
+        let appState = AppState(store: MemoryStore())
         appState.config.changes.diffLayoutMode = .split
         appState.config.changes.diffWrapLines = false
-        appState.config.changes.diffShowWhitespace = true
+        var firstWrapLines = false
+        var secondWrapLines = false
         var firstWhitespace = false
         var secondWhitespace = false
 
         let first = DiffPreferenceBindings(
             appState: appState,
+            wrapLines: Binding(get: { firstWrapLines }, set: { firstWrapLines = $0 }),
             showWhitespace: Binding(get: { firstWhitespace }, set: { firstWhitespace = $0 })
         )
         first.layoutMode.wrappedValue = .stacked
@@ -2454,12 +2456,14 @@ let second = true
         first.showWhitespace.wrappedValue = true
         let second = DiffPreferenceBindings(
             appState: appState,
+            wrapLines: Binding(get: { secondWrapLines }, set: { secondWrapLines = $0 }),
             showWhitespace: Binding(get: { secondWhitespace }, set: { secondWhitespace = $0 })
         )
 
         #expect(appState.config.changes.diffLayoutMode == .stacked)
-        #expect(appState.config.changes.diffWrapLines == true)
-        #expect(appState.config.changes.diffShowWhitespace == true)
+        #expect(appState.config.changes.diffWrapLines == false)
+        #expect(first.wrapLines.wrappedValue == true)
+        #expect(second.wrapLines.wrappedValue == false)
         #expect(first.showWhitespace.wrappedValue == true)
         #expect(second.showWhitespace.wrappedValue == false)
     }

--- a/docs/superpowers/plans/2026-07-28-pane-local-diff-word-wrap.md
+++ b/docs/superpowers/plans/2026-07-28-pane-local-diff-word-wrap.md
@@ -1,0 +1,391 @@
+# Pane-Local Diff Word Wrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every diff pane that exposes the word-wrap toggle start unwrapped and keep its word-wrap choice local to that pane's lifetime.
+
+**Architecture:** Each pane root owns `@State private var wrapLines = false` and supplies `$wrapLines` to `DiffPreferenceBindings`. The binding helper continues to persist layout mode, but forwards word wrap and whitespace to pane-local storage; the obsolete `AppConfig.Changes.diffWrapLines` field is removed so old saved values have no effect.
+
+**Tech Stack:** Swift 5.9+, SwiftUI for macOS, Swift Testing, Xcode/XcodeGen
+
+## Global Constraints
+
+- Every diff pane that exposes the word-wrap toggle starts with word wrapping off.
+- Enabling word wrap affects only that pane for its current lifetime and does not affect existing or future panes.
+- Do not alter the word-wrap toggle appearance, diff layout defaults, whitespace behavior, or rendering implementation.
+- Keep code, comments, logs, and UI strings in English.
+- Tests use Swift Testing (`import Testing`), not XCTest.
+- Prefix project shell commands with `rtk`.
+
+---
+
+### Task 1: Make Word Wrap a Pane-Local Binding
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPreferenceBindings.swift`
+- Modify: `Alas/Sources/Center/DiffTabView.swift`
+- Modify: `Alas/Sources/Center/Commit/CommitTabView.swift`
+- Modify: `Alas/Sources/Center/Commit/CommitEditorTabView.swift`
+- Modify: `Alas/Sources/Center/Commit/DraftCommitTabView.swift`
+- Modify: `Alas/Sources/Center/Review/ReviewTabView.swift`
+- Modify: `Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift`
+- Modify: `Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`
+- Test: `AlasTests/DiffPaneViewTests.swift`
+
+**Interfaces:**
+- Consumes: `Binding<Bool>` supplied by each pane root.
+- Produces: `DiffPreferenceBindings.init(appState:wrapLines:showWhitespace:)`, whose `wrapLines` and `showWhitespace` properties forward local bindings while `layoutMode` remains backed by `AppConfig`.
+
+- [ ] **Step 1: Replace the existing persistence test with a failing pane-isolation test**
+
+Rename `diffPreferenceBindingsPersistLayoutAndWrapButKeepWhitespaceLocal` to `diffPreferenceBindingsPersistLayoutButKeepWrapAndWhitespacePaneLocal`. Use two independent local word-wrap values and construct the bindings with the not-yet-implemented `wrapLines:` argument:
+
+```swift
+@Test func diffPreferenceBindingsPersistLayoutButKeepWrapAndWhitespacePaneLocal() {
+    let appState = AppState(store: MemoryStore())
+    appState.config.changes.diffLayoutMode = .split
+    appState.config.changes.diffWrapLines = false
+    var firstWrapLines = false
+    var secondWrapLines = false
+    var firstWhitespace = false
+    var secondWhitespace = false
+
+    let first = DiffPreferenceBindings(
+        appState: appState,
+        wrapLines: Binding(get: { firstWrapLines }, set: { firstWrapLines = $0 }),
+        showWhitespace: Binding(get: { firstWhitespace }, set: { firstWhitespace = $0 })
+    )
+    first.layoutMode.wrappedValue = .stacked
+    first.wrapLines.wrappedValue = true
+    first.showWhitespace.wrappedValue = true
+    let second = DiffPreferenceBindings(
+        appState: appState,
+        wrapLines: Binding(get: { secondWrapLines }, set: { secondWrapLines = $0 }),
+        showWhitespace: Binding(get: { secondWhitespace }, set: { secondWhitespace = $0 })
+    )
+
+    #expect(appState.config.changes.diffLayoutMode == .stacked)
+    #expect(appState.config.changes.diffWrapLines == false)
+    #expect(first.wrapLines.wrappedValue == true)
+    #expect(second.wrapLines.wrappedValue == false)
+    #expect(first.showWhitespace.wrappedValue == true)
+    #expect(second.showWhitespace.wrappedValue == false)
+}
+```
+
+This test catches the production bug where toggling word wrap mutates the shared configuration and changes later panes.
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests/diffPreferenceBindingsPersistLayoutButKeepWrapAndWhitespacePaneLocal test
+```
+
+Expected: compilation fails because `DiffPreferenceBindings` has no `wrapLines:` initializer argument.
+
+- [ ] **Step 3: Change `DiffPreferenceBindings` to forward pane-local word wrap**
+
+Add local storage and remove the config-backed word-wrap getter/setter:
+
+```swift
+struct DiffPreferenceBindings {
+    let appState: AppState
+    private let wrapLinesStorage: Binding<Bool>
+    private let showWhitespaceStorage: Binding<Bool>
+
+    init(
+        appState: AppState,
+        wrapLines: Binding<Bool>,
+        showWhitespace: Binding<Bool>
+    ) {
+        self.appState = appState
+        self.wrapLinesStorage = wrapLines
+        self.showWhitespaceStorage = showWhitespace
+    }
+
+    // layoutMode remains unchanged.
+
+    var wrapLines: Binding<Bool> {
+        wrapLinesStorage
+    }
+
+    var showWhitespace: Binding<Bool> {
+        showWhitespaceStorage
+    }
+}
+```
+
+- [ ] **Step 4: Give every currently persisted pane root local word-wrap state**
+
+Add this next to each root's existing local `showWhitespace` state:
+
+```swift
+@State private var wrapLines = false
+@State private var showWhitespace = false
+```
+
+Apply it to:
+
+- `DiffTabView`
+- `CommitTabView`
+- `CommitEditorTabView`
+- `DraftCommitTabView`
+- `ReviewTabView`
+- `ReviewChangesTabView`
+- `DraftReviewRequestTabView`
+
+Update each root's helper construction to:
+
+```swift
+private var diffPreferences: DiffPreferenceBindings {
+    DiffPreferenceBindings(
+        appState: appState,
+        wrapLines: $wrapLines,
+        showWhitespace: $showWhitespace
+    )
+}
+```
+
+`StashDiffTabView` and `GGSplitCommitTabView` already declare `@State private var wrapLines = false`; leave them unchanged.
+
+- [ ] **Step 5: Keep review-session wrap state local even when `AppState` is available**
+
+`ReviewSessionTabView` already owns `localWrapLines = false`. Supply it to both helper constructions:
+
+```swift
+private var layoutModeBinding: Binding<DiffLayoutMode> {
+    guard let appState else { return $localLayoutMode }
+    return DiffPreferenceBindings(
+        appState: appState,
+        wrapLines: $localWrapLines,
+        showWhitespace: $localShowWhitespace
+    ).layoutMode
+}
+
+private var wrapLinesBinding: Binding<Bool> {
+    guard let appState else { return $localWrapLines }
+    return DiffPreferenceBindings(
+        appState: appState,
+        wrapLines: $localWrapLines,
+        showWhitespace: $localShowWhitespace
+    ).wrapLines
+}
+```
+
+This preserves the existing no-`AppState` fallback while preventing an available `AppState` from changing wrap ownership.
+
+- [ ] **Step 6: Run the focused test to verify GREEN**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests/diffPreferenceBindingsPersistLayoutButKeepWrapAndWhitespacePaneLocal test
+```
+
+Expected: the focused test passes, proving the first pane toggles locally while the second remains off and the config remains unchanged.
+
+- [ ] **Step 7: Run the mutation check**
+
+Temporarily reason through these regressions; the test must fail for each:
+
+- `DiffPreferenceBindings.wrapLines` reads/writes `appState.config.changes.diffWrapLines`.
+- Both test panes receive the same local `Binding`.
+- Toggling layout no longer updates `appState.config.changes.diffLayoutMode`.
+
+Do not add source-text assertions. The existing behavior test covers these mutations.
+
+- [ ] **Step 8: Commit the pane-local binding change**
+
+```bash
+rtk git add Alas/Sources/Center/Diff/DiffPreferenceBindings.swift \
+  Alas/Sources/Center/DiffTabView.swift \
+  Alas/Sources/Center/Commit/CommitTabView.swift \
+  Alas/Sources/Center/Commit/CommitEditorTabView.swift \
+  Alas/Sources/Center/Commit/DraftCommitTabView.swift \
+  Alas/Sources/Center/Review/ReviewTabView.swift \
+  Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift \
+  Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift \
+  Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift \
+  AlasTests/DiffPaneViewTests.swift
+rtk git commit -m "fix(diff): keep word wrap pane-local"
+```
+
+---
+
+### Task 2: Retire the Persisted Word-Wrap Configuration
+
+**Files:**
+- Modify: `Alas/Sources/Persistence/AppConfig.swift`
+- Test: `AlasTests/AppConfigChangesTests.swift`
+
+**Interfaces:**
+- Consumes: Legacy JSON may contain `"diffWrapLines": true`.
+- Produces: `AppConfig` ignores that legacy key and no longer encodes it; `diffLayoutMode` and `diffShowWhitespace` retain their existing schema behavior.
+
+- [ ] **Step 1: Write a failing legacy-key retirement test**
+
+Replace the wrap-specific assertions in `defaultsHaveDiffDisplayPreferences`, `decodesLegacyChangesWithoutDiffDisplayPreferences`, and `roundTripsDiffDisplayPreferences`. Add this behavior test:
+
+```swift
+@Test func ignoresAndDropsLegacyDiffWrapLines() throws {
+    let json = try #require(
+        JSONSerialization.jsonObject(with: JSONEncoder().encode(AppConfig.defaults))
+            as? [String: Any]
+    )
+    var legacy = json
+    var changes = try #require(legacy["changes"] as? [String: Any])
+    changes["diffWrapLines"] = true
+    legacy["changes"] = changes
+
+    let legacyData = try JSONSerialization.data(withJSONObject: legacy)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: legacyData)
+    let encodedData = try JSONEncoder().encode(decoded)
+    let encoded = try #require(
+        JSONSerialization.jsonObject(with: encodedData) as? [String: Any]
+    )
+    let encodedChanges = try #require(encoded["changes"] as? [String: Any])
+
+    #expect(encodedChanges["diffWrapLines"] == nil)
+}
+```
+
+This test catches a schema regression where an obsolete saved `true` value remains part of runtime configuration or is written back to disk.
+
+- [ ] **Step 2: Run the focused configuration test to verify RED**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AppConfigChangesTests/ignoresAndDropsLegacyDiffWrapLines test
+```
+
+Expected: FAIL because the current encoder still emits `diffWrapLines`.
+
+- [ ] **Step 3: Remove `diffWrapLines` from the configuration model**
+
+In `AppConfig.Changes`:
+
+- remove `var diffWrapLines: Bool`;
+- remove `diffWrapLines` from `Changes.CodingKeys`;
+- remove `diffWrapLines: false` from both default `Changes` constructions;
+- remove the decoder's `let diffWrapLines = ...` fallback;
+- remove `diffWrapLines: diffWrapLines` from the decoded `Changes` construction.
+
+Do not add a custom legacy property. Swift `Decodable` ignores unknown JSON keys, so old files continue to decode and the next save naturally drops the retired key.
+
+- [ ] **Step 4: Update existing configuration expectations**
+
+Keep assertions proving:
+
+```swift
+#expect(AppConfig.defaults.changes.diffLayoutMode == .split)
+#expect(AppConfig.defaults.changes.diffShowWhitespace == false)
+```
+
+Keep the legacy-without-display-preferences test asserting the same two defaults. Keep the round-trip test covering `.stacked` layout and `diffShowWhitespace = true`, but remove all reads and writes of `diffWrapLines`.
+
+- [ ] **Step 5: Run configuration tests to verify GREEN**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AppConfigChangesTests test
+```
+
+Expected: all `AppConfigChangesTests` pass, including decoding a legacy `diffWrapLines` key and omitting it when re-encoding.
+
+- [ ] **Step 6: Confirm no production references remain**
+
+Run:
+
+```bash
+rtk rg -n "diffWrapLines" Alas/Sources AlasTests
+```
+
+Expected: only the legacy JSON key inside `ignoresAndDropsLegacyDiffWrapLines` remains.
+
+- [ ] **Step 7: Commit the configuration cleanup**
+
+```bash
+rtk git add Alas/Sources/Persistence/AppConfig.swift AlasTests/AppConfigChangesTests.swift
+rtk git commit -m "refactor(diff): retire persisted word wrap setting"
+```
+
+---
+
+### Task 3: Verify All Diff Surfaces
+
+**Files:**
+- Verify only; no planned source changes.
+
+**Interfaces:**
+- Consumes: pane-local word-wrap bindings and the retired config schema from Tasks 1-2.
+- Produces: formatting, focused regression coverage, and a successful macOS build.
+
+- [ ] **Step 1: Regenerate the project**
+
+Run:
+
+```bash
+rtk xcodegen
+```
+
+Expected: project generation succeeds. Commit generated changes only if `xcodegen` legitimately changes `Alas.xcodeproj`.
+
+- [ ] **Step 2: Run SwiftFormat lint**
+
+Run:
+
+```bash
+rtk swiftformat Alas AlasTests --lint --reporter github-actions-log
+```
+
+Expected: exit code 0 with no formatting violations.
+
+- [ ] **Step 3: Run focused diff and configuration suites serially**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AppConfigChangesTests test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewSessionTabViewTests test
+```
+
+Expected: all three suites finish with `TEST SUCCEEDED`.
+
+- [ ] **Step 4: Build the macOS app**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 5: Inspect the final diff and worktree**
+
+Run:
+
+```bash
+rtk git diff --check
+rtk git status --short
+rtk git diff main...HEAD --stat
+```
+
+Expected: no whitespace errors, no unintended generated or user files, and changes limited to the approved spec, plan, diff preference wiring, configuration cleanup, and tests.
+
+- [ ] **Step 6: Commit any legitimate generated-project change**
+
+Only if `xcodegen` changed `Alas.xcodeproj`:
+
+```bash
+rtk git add Alas.xcodeproj
+rtk git commit -m "chore: regenerate Xcode project"
+```
+
+If there is no generated change, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-28-pane-local-diff-word-wrap-design.md
+++ b/docs/superpowers/specs/2026-07-28-pane-local-diff-word-wrap-design.md
@@ -1,0 +1,38 @@
+# Pane-Local Diff Word Wrap
+
+## Goal
+
+Every diff pane that exposes the word-wrap toggle starts with word wrapping off. Enabling word wrap affects only that pane for its current lifetime and does not affect existing or future panes.
+
+## Design
+
+Each diff-pane root owns a local `wrapLines` state initialized to `false`. The root passes that state through the existing `DiffPreferenceBindings` seam to the toolbar and diff-rendering views. Lower-level toggle and rendering behavior remains unchanged.
+
+`DiffPreferenceBindings` continues to expose the globally persisted diff layout mode, but its word-wrap binding is supplied by the pane instead of reading or writing `AppConfig`. Whitespace display remains pane-local as it is today.
+
+The persisted `diffWrapLines` configuration field is retired. Older configuration files may contain the key; normal `Decodable` handling ignores it. Consequently, a previously saved `true` value cannot enable wrapping in a newly opened pane.
+
+Surfaces that already own local word-wrap state, including stash diffs and GG split-commit diffs, retain their current behavior.
+
+## State Flow
+
+1. A diff-pane root is created with `wrapLines == false`.
+2. The root supplies `$wrapLines` to `DiffPreferenceBindings`.
+3. The toolbar reads and toggles that local binding.
+4. The renderer reads the same binding and updates only that pane.
+5. Closing the pane discards the state; a new pane starts at `false`.
+
+## Testing
+
+A focused binding test will create two independent pane-local word-wrap bindings and verify:
+
+- both begin off;
+- enabling wrap through one binding does not change the other;
+- enabling wrap does not update or save application configuration;
+- changing the shared layout mode still updates and saves application configuration.
+
+Existing configuration tests will be updated to verify that legacy configuration containing `diffWrapLines` still decodes successfully while the obsolete value has no runtime effect. Relevant diff tests and a macOS build will provide integration coverage.
+
+## Scope
+
+This change does not alter the word-wrap toggle's appearance, diff layout defaults, whitespace behavior, or rendering implementation.


### PR DESCRIPTION
## Summary

- make word wrapping transient and pane-local across every diff surface that exposes the toggle
- initialize each new diff pane with word wrap off and preserve distinct state when switching between diff tabs
- retire the persisted `diffWrapLines` setting while continuing to decode older config files safely
- add regression coverage for local bindings, persistence side effects, tab identity, and legacy config migration

## Validation

- `xcodegen`
- `swiftformat Alas AlasTests --lint --reporter github-actions-log`
- full macOS test suite before the clean rebase onto current `origin/main`
- focused diff preference/tab identity tests on the rebased head
- quiet macOS build on the rebased head