### PR TITLE
feat(acp): improve transcript markdown rendering

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -77,14 +77,19 @@ enum ACPMarkdownInlineRenderer {
         )
     }
 
-    static func plainText(_ source: String) -> String {
+    static func plainText(
+        _ source: String,
+        memoizeInlineMarkdown: Bool = true
+    ) -> String {
         let plan = makePlan(source)
         var text = plan.markdownSource
         for image in plan.images {
             text = text.replacingOccurrences(of: image.placeholder, with: image.alt)
         }
         text = removingSubscriptMarkers(from: text, markers: plan.subscriptMarkers)
-        return NSAttributedString(ACPMarkdownText.inlineMarkdown(text)).string
+        return NSAttributedString(
+            ACPMarkdownText.inlineMarkdown(text, memoize: memoizeInlineMarkdown)
+        ).string
     }
 
     static func makeAttributedString(

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -72,7 +72,10 @@ struct ACPMarkdownText: View {
                     HStack(alignment: .top, spacing: 6) {
                         ACPMarkdownTaskCheckbox(
                             isChecked: item.isChecked,
-                            accessibilityLabel: ACPMarkdownInlineRenderer.plainText(item.text)
+                            accessibilityLabel: ACPMarkdownInlineRenderer.plainText(
+                                item.text,
+                                memoizeInlineMarkdown: renderBlock.memoizesInlineMarkdown
+                            )
                         )
                             .frame(width: 16, height: 16)
                             .padding(.top, 1)

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -478,6 +478,7 @@ private struct ACPMarkdownTaskCheckbox: NSViewRepresentable {
     }
 
     func updateNSView(_ button: NSButton, context: Context) {
+        button.isEnabled = false
         button.state = isChecked ? .on : .off
         button.setAccessibilityLabel(accessibilityLabel)
     }

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -19,6 +19,7 @@ struct ACPMarkdownText: View {
     var typography: ACPChatTypography = .default
     var showsCodeBlockCopyButton: Bool = true
     @Environment(\.theme) private var theme
+    @State private var tableViewportWidth: CGFloat = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -133,12 +134,17 @@ struct ACPMarkdownText: View {
         memoizesInlineMarkdown: Bool
     ) -> some View {
         let columnCount = max(header.count, rows.map(\.count).max() ?? 0)
+        let columnWidth = Self.tableColumnWidth(
+            availableWidth: tableViewportWidth,
+            columnCount: columnCount
+        )
         return ScrollView(.horizontal, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
                 tableRow(
                     cells: header,
                     isHeader: true,
                     columnCount: columnCount,
+                    columnWidth: columnWidth,
                     memoizesInlineMarkdown: memoizesInlineMarkdown
                 )
                 Rectangle().fill(theme.color("line")).frame(height: 0.5)
@@ -147,6 +153,7 @@ struct ACPMarkdownText: View {
                         cells: r,
                         isHeader: false,
                         columnCount: columnCount,
+                        columnWidth: columnWidth,
                         memoizesInlineMarkdown: memoizesInlineMarkdown
                     )
                     if r != rows.last {
@@ -154,6 +161,12 @@ struct ACPMarkdownText: View {
                     }
                 }
             }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onGeometryChange(for: CGFloat.self) { geometry in
+            geometry.size.width
+        } action: { width in
+            tableViewportWidth = width
         }
         .background(theme.color("bg-1").opacity(0.4))
         .clipShape(RoundedRectangle(cornerRadius: 6))
@@ -164,6 +177,7 @@ struct ACPMarkdownText: View {
         cells: [String],
         isHeader: Bool,
         columnCount: Int,
+        columnWidth: CGFloat,
         memoizesInlineMarkdown: Bool
     ) -> some View {
         HStack(alignment: .top, spacing: 0) {
@@ -178,12 +192,22 @@ struct ACPMarkdownText: View {
                 )
                     .frame(minWidth: 80, alignment: .leading)
                     .padding(.horizontal, 10).padding(.vertical, 6)
+                    .frame(width: columnWidth, alignment: .leading)
                 if i < columnCount - 1 {
                     Rectangle().fill(theme.color("line-soft")).frame(width: 0.5)
                 }
             }
         }
         .background(isHeader ? theme.color("bg-2").opacity(0.5) : Color.clear)
+    }
+
+    static func tableColumnWidth(
+        availableWidth: CGFloat,
+        columnCount: Int,
+        dividerWidth: CGFloat = 0.5
+    ) -> CGFloat {
+        guard columnCount > 0 else { return 0 }
+        return max(100, (availableWidth - dividerWidth * CGFloat(columnCount - 1)) / CGFloat(columnCount))
     }
 
     // MARK: - Inline memoization

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -65,6 +65,28 @@ struct ACPMarkdownText: View {
                 memoizesInlineMarkdown: renderBlock.memoizesInlineMarkdown
             )
                 .frame(maxWidth: .infinity, alignment: .leading)
+        case .taskList(let items):
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    HStack(alignment: .top, spacing: 6) {
+                        ACPMarkdownTaskCheckbox(
+                            isChecked: item.isChecked,
+                            accessibilityLabel: ACPMarkdownInlineRenderer.plainText(item.text)
+                        )
+                            .frame(width: 16, height: 16)
+                            .padding(.top, 1)
+                        ACPMarkdownInlineTextView(
+                            source: item.text,
+                            typography: typography,
+                            role: .body,
+                            theme: theme,
+                            memoizesInlineMarkdown: renderBlock.memoizesInlineMarkdown
+                        )
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         case .quote(let text):
             HStack(alignment: .top, spacing: 10) {
                 Rectangle()
@@ -225,10 +247,16 @@ struct ACPMarkdownText: View {
     enum Block: Equatable {
         case heading(level: Int, text: String)
         case paragraph(String)
+        case taskList([TaskItem])
         case quote(String)
         case code(language: String?, body: String)
         case streamingCode(language: String?, body: String)
         case table(header: [String], rows: [[String]])
+    }
+
+    struct TaskItem: Equatable {
+        let isChecked: Bool
+        let text: String
     }
 
     private struct RenderBlock {
@@ -331,6 +359,24 @@ struct ACPMarkdownText: View {
         return line[afterMarker...].allSatisfy(\.isWhitespace)
     }
 
+    private static func matchTaskItem(_ line: String) -> TaskItem? {
+        guard line.count >= 5 else { return nil }
+        let marker = String(line.prefix(5))
+        let isChecked: Bool
+        switch marker {
+        case "- [ ]": isChecked = false
+        case "- [x]", "- [X]": isChecked = true
+        default: return nil
+        }
+
+        let remainder = line.dropFirst(5)
+        guard remainder.isEmpty || remainder.first?.isWhitespace == true else { return nil }
+        return TaskItem(
+            isChecked: isChecked,
+            text: String(remainder.drop(while: \.isWhitespace))
+        )
+    }
+
     static func parse(_ text: String) -> [Block] {
         var blocks: [Block] = []
         var i = 0
@@ -393,19 +439,47 @@ struct ACPMarkdownText: View {
                 continue
             }
 
+            // Task list: collect contiguous top-level GitHub-style items.
+            if let task = matchTaskItem(line) {
+                var items = [task]
+                i += 1
+                while i < lines.count, let task = matchTaskItem(lines[i]) {
+                    items.append(task)
+                    i += 1
+                }
+                blocks.append(.taskList(items))
+                continue
+            }
+
             // Paragraph: collect until blank or block-start.
             var para: [String] = [line]
             i += 1
             while i < lines.count {
                 let next = lines[i].trimmingCharacters(in: .whitespaces)
                 if next.isEmpty { break }
-                if matchFence(lines[i]) != nil || next.hasPrefix(">") || matchHeading(next) != nil { break }
+                if matchFence(lines[i]) != nil || next.hasPrefix(">") || matchHeading(next) != nil || matchTaskItem(lines[i]) != nil { break }
                 para.append(lines[i])
                 i += 1
             }
             blocks.append(.paragraph(para.joined(separator: "\n")))
         }
         return blocks
+    }
+}
+
+private struct ACPMarkdownTaskCheckbox: NSViewRepresentable {
+    let isChecked: Bool
+    let accessibilityLabel: String
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton(checkboxWithTitle: "", target: nil, action: nil)
+        button.isEnabled = false
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        button.state = isChecked ? .on : .off
+        button.setAccessibilityLabel(accessibilityLabel)
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -2234,6 +2234,8 @@ enum DiffReviewInlineFeedbackMarkdown {
             switch block {
             case .heading(_, let text), .paragraph(let text), .quote(let text):
                 return ACPMarkdownInlineRenderer.plainText(text)
+            case .taskList(let items):
+                return items.map { ACPMarkdownInlineRenderer.plainText($0.text) }.joined(separator: " ")
             case .code(_, let body), .streamingCode(_, let body):
                 return body
             case .table(let header, let rows):

--- a/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
@@ -5,6 +5,22 @@ import Testing
 @MainActor
 @Suite("ACPMarkdownBlockCache")
 struct ACPMarkdownBlockCacheTests {
+    @Test("table columns distribute available width after dividers")
+    func tableColumnsDistributeAvailableWidth() {
+        let width = ACPMarkdownText.tableColumnWidth(availableWidth: 720, columnCount: 3)
+        #expect(abs(width - 719.0 / 3.0) < 0.001)
+    }
+
+    @Test("table columns retain their minimum width")
+    func tableColumnsRetainMinimumWidth() {
+        #expect(ACPMarkdownText.tableColumnWidth(availableWidth: 600, columnCount: 8) == 100)
+    }
+
+    @Test("table columns have no width without columns")
+    func tableColumnsHaveNoWidthWithoutColumns() {
+        #expect(ACPMarkdownText.tableColumnWidth(availableWidth: 720, columnCount: 0) == 0)
+    }
+
     @Test("two paragraphs separated by blank line both become stable once a third arrives")
     func paragraphsPromoteOnBoundary() async {
         let cache = ACPMarkdownBlockCache()

--- a/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
@@ -76,6 +76,74 @@ struct ACPMarkdownBlockCacheTests {
         #expect(cached == direct)
     }
 
+    @Test("contiguous top-level task lines parse into one task list")
+    func parsesTaskListItems() {
+        #expect(ACPMarkdownText.parse("""
+        - [ ] **Write** `tests`
+        - [x] [Review](https://example.com)
+        - [X]
+        """) == [
+            .taskList([
+                .init(isChecked: false, text: "**Write** `tests`"),
+                .init(isChecked: true, text: "[Review](https://example.com)"),
+                .init(isChecked: true, text: ""),
+            ]),
+        ])
+    }
+
+    @Test("ordinary and indented task-looking bullets remain paragraph text")
+    func taskLookingBulletsFallBackToParagraphs() {
+        #expect(ACPMarkdownText.parse("""
+        * [ ] alternate marker
+          - [ ] nested item
+        - [ ]not a task
+        """) == [
+            .paragraph("""
+            * [ ] alternate marker
+              - [ ] nested item
+            - [ ]not a task
+            """),
+        ])
+    }
+
+    @Test("task list ends before following prose")
+    func taskListToProseBoundary() {
+        #expect(ACPMarkdownText.parse("""
+        Before tasks
+        - [ ] First task
+        - [x] Second task
+        After tasks
+        """) == [
+            .paragraph("Before tasks"),
+            .taskList([
+                .init(isChecked: false, text: "First task"),
+                .init(isChecked: true, text: "Second task"),
+            ]),
+            .paragraph("After tasks"),
+        ])
+    }
+
+    @Test("cached task list parsing matches direct parsing")
+    func taskListCacheParityWithDirectParse() {
+        let raw = """
+        Intro
+
+        - [ ] First task
+        - [X] **Second** task
+
+        Closing paragraph.
+        """
+        let cache = ACPMarkdownBlockCache()
+        cache.update(with: raw)
+        let cached = cache.stableBlocks + ACPMarkdownText.parse(cache.tailUnparsed)
+
+        #expect(cached == ACPMarkdownText.parse(raw))
+        #expect(cached.contains(where: { block in
+            if case .taskList = block { return true }
+            return false
+        }))
+    }
+
     @Test("streaming updates scan only the appended markdown tail")
     func streamingUpdatesScanOnlyAppendedTail() async {
         let cache = ACPMarkdownBlockCache()

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -402,6 +402,31 @@ struct ACPMarkdownInlineRendererTests {
         }
     }
 
+    @Test("task items render read-only checkboxes")
+    func taskItemsRenderReadOnlyCheckboxes() throws {
+        let host = NSHostingView(
+            rootView: ACPMarkdownText(raw: """
+            - [ ] **Open** task
+            - [x] `Done` task
+            """)
+            .environment(\.theme, try Theme.loadBundled(id: "cool-slate"))
+            .frame(width: 620, height: 140)
+        )
+        host.frame = NSRect(x: 0, y: 0, width: 620, height: 140)
+        host.layoutSubtreeIfNeeded()
+
+        let checkboxes = allSubviews(of: host).compactMap { $0 as? NSButton }
+        #expect(checkboxes.count == 2)
+        #expect(checkboxes.map(\.isEnabled) == [false, false])
+        #expect(checkboxes.map(\.state) == [.off, .on])
+
+        let labels = allSubviews(of: host).compactMap { $0 as? NSTextView }.map(\.string)
+        #expect(labels.contains("Open task"))
+        #expect(labels.contains("Done task"))
+        #expect(!labels.joined().contains("**"))
+        #expect(!labels.joined().contains("`"))
+    }
+
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -7,6 +7,19 @@ import Testing
 @MainActor
 @Suite("ACP markdown inline renderer")
 struct ACPMarkdownInlineRendererTests {
+    @Test("non-memoized plain text does not populate inline cache")
+    func nonMemoizedPlainTextDoesNotPopulateInlineCache() {
+        ACPMarkdownText.removeAllInlineCacheObjectsForTesting()
+
+        #expect(
+            ACPMarkdownInlineRenderer.plainText(
+                "streamed **task**",
+                memoizeInlineMarkdown: false
+            ) == "streamed task"
+        )
+        #expect(ACPMarkdownText.inlineCacheInsertionCountForTesting == 0)
+    }
+
     @Test("badge image size is capped with aspect ratio")
     func badgeImageSizeIsCapped() {
         let size = ACPMarkdownInlineRenderer.displaySize(

--- a/docs/superpowers/specs/2026-07-29-acp-markdown-table-task-list-design.md
+++ b/docs/superpowers/specs/2026-07-29-acp-markdown-table-task-list-design.md
@@ -1,0 +1,54 @@
+# ACP Markdown Table and Task-List Rendering
+
+## Goal
+
+Improve ACP transcript Markdown so tables use the full available message width and GitHub-style task-list items render as read-only checkboxes.
+
+## Scope
+
+The change applies only to `ACPMarkdownText`, the renderer used for ACP transcript content and the other existing surfaces that embed it. The general Markdown file preview remains unchanged.
+
+Supported task markers are top-level `- [ ]`, `- [x]`, and `- [X]` items. Ordinary unordered lists and text that merely contains bracket characters retain their current rendering.
+
+## Table Layout
+
+Keep the existing table block parser, visual styling, and horizontal scrolling. The table renderer measures its available width and derives an outer column width:
+
+`max(100, availableWidth / columnCount)`
+
+Every cell, including its existing horizontal padding, uses that minimum. The 100-point floor preserves the current effective 80-point text width plus padding. A table with a small number of columns therefore fills the transcript column, while a table with enough columns to exceed the available width retains horizontal scrolling. Cell text continues to wrap within its assigned column.
+
+The width calculation will be isolated as a small testable helper. Empty or malformed tables continue to follow the parser's existing fallback behavior.
+
+## Task Lists
+
+Add a task-list block containing a sequence of items with:
+
+- a Boolean checked state;
+- the item's inline Markdown source.
+
+The block parser recognizes contiguous supported task-item lines before paragraph collection. It stops when it reaches a blank line or a line that is not a supported task item. This keeps task items together without changing ordinary paragraph and list parsing.
+
+Each task item renders as a row containing a native checkbox and `ACPMarkdownInlineTextView`. The checkbox reflects the parsed checked state and is disabled so transcript content cannot be edited. The label continues through the existing inline renderer, preserving links, emphasis, inline code, image handling, typography, selection, and caching behavior.
+
+## Accessibility and Interaction
+
+The checkbox exposes native checked or unchecked semantics and a disabled interaction state. The label remains selectable and retains its existing link behavior. Rendering introduces no state mutation or transcript update path.
+
+## Testing
+
+Focused Swift Testing coverage will verify:
+
+- checked and unchecked task items parse into one task-list block;
+- both lowercase and uppercase checked markers are accepted;
+- ordinary bullets remain paragraphs;
+- task labels retain their Markdown source for the inline renderer;
+- table column widths fill the available width when possible;
+- tables with many columns retain the current effective minimum and overflow horizontally;
+- cached block parsing remains equal to direct parsing for task-list content.
+
+The full project generation, build, and test commands required by `AGENTS.md` will run before completion.
+
+## Non-Goals
+
+This change does not add editable tasks, nested task lists, alternate bullet markers, task persistence, table sorting, resizable columns, or changes to the general Markdown preview.

--- a/docs/superpowers/specs/2026-07-29-acp-markdown-table-task-list-design.md
+++ b/docs/superpowers/specs/2026-07-29-acp-markdown-table-task-list-design.md
@@ -14,9 +14,9 @@ Supported task markers are top-level `- [ ]`, `- [x]`, and `- [X]` items. Ordina
 
 Keep the existing table block parser, visual styling, and horizontal scrolling. The table renderer measures its available width and derives an outer column width:
 
-`max(100, availableWidth / columnCount)`
+`max(100, (availableWidth - dividerWidth * (columnCount - 1)) / columnCount)`
 
-Every cell, including its existing horizontal padding, uses that minimum. The 100-point floor preserves the current effective 80-point text width plus padding. A table with a small number of columns therefore fills the transcript column, while a table with enough columns to exceed the available width retains horizontal scrolling. Cell text continues to wrap within its assigned column.
+The 0.5-point dividers are subtracted before the remainder is shared across columns, so the outer cell widths and dividers exactly fill the available width. Every cell, including its existing horizontal padding, uses that minimum. The 100-point floor preserves the current effective 80-point text width plus padding. A table with a small number of columns therefore fills the transcript column, while a table with enough columns to exceed the available width retains horizontal scrolling. Cell text continues to wrap within its assigned column.
 
 The width calculation will be isolated as a small testable helper. Empty or malformed tables continue to follow the parser's existing fallback behavior.
 


### PR DESCRIPTION
## Summary

- expand ACP Markdown tables across the available transcript width
- render GitHub task-list items as disabled native macOS checkboxes
- preserve inline Markdown rendering, accessibility labels, cache parity, and horizontal overflow

## Validation

- xcodegen
- macOS build
- focused ACP Markdown tests: 48 passed
- full macOS test suite: 6,608 tests passed