### PR TITLE
feat(run): Add edit mode to run script palette

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -291,7 +291,7 @@ final class AppState {
         }
     }
 
-    func openRunScriptPaletteOverlay() {
+    func openRunScriptPaletteOverlay(mode: RunScriptPaletteModel.Mode = .run) {
         guard !isRunScriptPaletteOpen else { return }
         reviewPalette.close()
         isReviewPaletteOpen = false
@@ -301,7 +301,7 @@ final class AppState {
         isRepoSelectorOpen = false
         agentLauncher.reset()
         isAgentLauncherOpen = false
-        runScriptPalette.reset()
+        runScriptPalette.prepareForOpen(mode: mode)
         isRunScriptPaletteOpen = true
     }
 

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -115,7 +115,7 @@ struct CenterPaneView: View {
                 onRunScript: { script in state.runOrFocusScript(script, in: worktree) },
                 onRestartScript: { script in state.restartScript(script, in: worktree) },
                 onNewRunScript: { scope in state.newRunScript(scope: scope, in: worktree) },
-                onEditScripts: { state.openRunScriptPaletteOverlay() },
+                onEditScripts: { state.openRunScriptPaletteOverlay(mode: .edit) },
                 onRevealRightSidebar: {
                     state.config.rightPaneVisible = true
                     state.saveConfig()

--- a/Alas/Sources/RunScripts/RunScriptDialog.swift
+++ b/Alas/Sources/RunScripts/RunScriptDialog.swift
@@ -54,8 +54,11 @@ struct RunScriptDialog: View {
 
     private var inputRow: some View {
         HStack(spacing: 8) {
-            Icon(name: "play", size: 12, color: theme.color("fg-faint"))
-            TextField("Run script…", text: Bindable(appState.runScriptPalette).query)
+            Icon(name: appState.runScriptPalette.mode == .edit ? "pencil" : "play", size: 12, color: theme.color("fg-faint"))
+            TextField(
+                appState.runScriptPalette.mode == .edit ? "Edit script…" : "Run script…",
+                text: Bindable(appState.runScriptPalette).query
+            )
                 .textFieldStyle(.plain)
                 .focused($inputFocused)
                 .font(.system(size: 14))
@@ -169,7 +172,7 @@ struct RunScriptDialog: View {
 
     private func scriptRow(_ script: RunScript, isSelected: Bool) -> some View {
         HStack(spacing: 10) {
-            Icon(name: "play", size: 11, color: theme.color("fg-muted"))
+            Icon(name: appState.runScriptPalette.mode == .edit ? "pencil" : "play", size: 11, color: theme.color("fg-muted"))
             VStack(alignment: .leading, spacing: 1) {
                 Text(script.displayName)
                     .font(.system(size: 12.5, weight: .medium))
@@ -225,9 +228,13 @@ struct RunScriptDialog: View {
     private var footer: some View {
         HStack(spacing: 12) {
             label("↑↓ navigate")
-            label("↵ run / focus")
-            label("⌘↵ restart")
-            label("⌘E edit")
+            if appState.runScriptPalette.mode == .edit {
+                label("↵ edit")
+            } else {
+                label("↵ run / focus")
+                label("⌘↵ restart")
+                label("⌘E edit")
+            }
             label("esc close")
             Spacer()
         }
@@ -258,7 +265,9 @@ struct RunScriptDialog: View {
             appState.runScriptPalette.moveSelection(step: 1)
             return .handled
         case .return:
-            if press.modifiers.contains(.command) {
+            if appState.runScriptPalette.mode == .edit {
+                activate()
+            } else if press.modifiers.contains(.command) {
                 restart()
             } else {
                 activate()

--- a/Alas/Sources/RunScripts/RunScriptPaletteModel.swift
+++ b/Alas/Sources/RunScripts/RunScriptPaletteModel.swift
@@ -6,6 +6,11 @@ import Observation
 @Observable
 @MainActor
 final class RunScriptPaletteModel {
+    enum Mode {
+        case run
+        case edit
+    }
+
     enum Row: Equatable {
         case header(String)
         case script(RunScript)
@@ -18,6 +23,7 @@ final class RunScriptPaletteModel {
         }
     }
 
+    private(set) var mode: Mode = .run
     var query: String = "" {
         didSet {
             guard query != oldValue else { return }
@@ -29,13 +35,18 @@ final class RunScriptPaletteModel {
     private(set) var scrollToSelectionTick = 0
     private(set) var scripts: [RunScript] = []
 
-    func load(environment env: RunScriptPaletteEnvironment) {
+    func prepareForOpen(mode: Mode) {
         reset()
+        self.mode = mode
+    }
+
+    func load(environment env: RunScriptPaletteEnvironment) {
         scripts = env.scripts()
         snapSelectionToFirstSelectable()
     }
 
     func reset() {
+        mode = .run
         query = ""
         selectedIndex = 0
         scrollToSelectionTick = 0
@@ -104,7 +115,13 @@ final class RunScriptPaletteModel {
         let rows = rows()
         guard rows.indices.contains(selectedIndex) else { return }
         switch rows[selectedIndex] {
-        case .script(let script): env.run(script)
+        case .script(let script):
+            switch mode {
+            case .run:
+                env.run(script)
+            case .edit:
+                env.edit(script)
+            }
         case .newRepoScript:      env.newScript(.repo)
         case .newGlobalScript:    env.newScript(.global)
         case .header:             break

--- a/AlasTests/AppStateOverlayTests.swift
+++ b/AlasTests/AppStateOverlayTests.swift
@@ -144,4 +144,13 @@ struct AppStateOverlayTests {
         #expect(state.runScriptPalette.scripts == [script])
         #expect(state.runScriptPalette.query == "b")
     }
+
+    @Test func openingRunScriptPaletteCanPrepareEditMode() {
+        let state = AppState(store: MemoryStore())
+
+        state.openRunScriptPaletteOverlay(mode: .edit)
+
+        #expect(state.isRunScriptPaletteOpen)
+        #expect(state.runScriptPalette.mode == .edit)
+    }
 }

--- a/AlasTests/RunScriptPaletteModelTests.swift
+++ b/AlasTests/RunScriptPaletteModelTests.swift
@@ -61,6 +61,22 @@ struct RunScriptPaletteModelTests {
         #expect(ran == script("build"))
     }
 
+    @Test func enterEditsSelectedScriptInEditMode() {
+        var ran: RunScript?
+        var edited: RunScript?
+        let model = RunScriptPaletteModel()
+        let env = environment(
+            scripts: [script("build")],
+            onRun: { ran = $0 },
+            onEdit: { edited = $0 }
+        )
+        model.prepareForOpen(mode: .edit)
+        model.load(environment: env)
+        model.activateSelection(environment: env)
+        #expect(ran == nil)
+        #expect(edited == script("build"))
+    }
+
     @Test func newRowsInvokeNewScript() {
         var newScope: RunScriptScope?
         let model = RunScriptPaletteModel()


### PR DESCRIPTION
## Summary

The toolbar's `Edit Scripts...` action was opening the normal run-script palette, so selecting a script still ran or focused it unless the user knew about the hidden `Cmd+E` shortcut. This PR adds an explicit edit mode for that palette so the toolbar action matches its label.

## Changes

- Add a run/edit mode to `RunScriptPaletteModel` and prepare the palette with the requested mode when it opens.
- Route Enter/click activation to script editing in edit mode while keeping creation rows and the normal run mode unchanged.
- Update dialog placeholder text, row icons, and footer shortcuts so edit mode communicates the active behavior.
- Cover edit-mode opening and activation with Swift Testing tests.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (`6602` tests passed)
