### PR TITLE
docs(run): Clarify run script activation comment

### DIFF
--- a/Alas/Sources/RunScripts/RunScriptPaletteModel.swift
+++ b/Alas/Sources/RunScripts/RunScriptPaletteModel.swift
@@ -110,7 +110,7 @@ final class RunScriptPaletteModel {
         return script
     }
 
-    /// Enter: run/focus a script, or create a new one from the trailing rows.
+    /// Enter: run/focus or edit a script depending on mode, or create a new one from the trailing rows.
     func activateSelection(environment env: RunScriptPaletteEnvironment) {
         let rows = rows()
         guard rows.indices.contains(selectedIndex) else { return }


### PR DESCRIPTION
## Summary

Follow-up to #930. Greptile flagged that the `activateSelection` doc comment still described only the run path, even though the new palette mode can route Enter to editing.

## Changes

- Clarify the comment so it documents both run/focus and edit-mode activation.

## Verification

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RunScriptPaletteModelTests -only-testing:AlasTests/AppStateOverlayTests test` (`17` targeted tests passed)
