### PR TITLE
feat(markdown): render native Mermaid diagrams

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */; };
 		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
 		1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */; };
+		1B8AED038B80C06EDA6DBC20 /* BeautifulMermaidBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C143F318273ED3A36BA3709 /* BeautifulMermaidBackend.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1BA6A97406CD857F02D81AE0 /* BuiltInAlasMCPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7A4A7B920C0E748973F282 /* BuiltInAlasMCPTests.swift */; };
 		1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */; };
@@ -399,6 +400,7 @@
 		443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */; };
 		445DAFBF3E820823AA2779B4 /* ACPElicitationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E1A9B42D47CC0244C24F7B /* ACPElicitationTests.swift */; };
 		449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */; };
+		44F6A0601A9F27FC09DB8387 /* BeautifulMermaid in Frameworks */ = {isa = PBXBuildFile; productRef = F1692E6406C1269703621C3B /* BeautifulMermaid */; };
 		45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC15742E7423AE2F3A203A /* ACPSessionInfoUpdateDecodeTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
 		45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC68B05B719B9235865027F /* ThreePaneSizing.swift */; };
@@ -555,6 +557,7 @@
 		629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */; };
 		63327D1ACC38C6559F2FDA99 /* CodeHostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B1108F04B06EAC224AB5B /* CodeHostProvider.swift */; };
 		636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */; };
+		63B3A5BB582C8C7ACE51E9E5 /* MermaidDiagramThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */; };
 		64402D666DBDAA9B98D641F6 /* ShortcutRecorderValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */; };
 		647E2B3A14A7722D514B113E /* TreeSitterC in Frameworks */ = {isa = PBXBuildFile; productRef = FF43B3EA560936C516C215A1 /* TreeSitterC */; };
 		64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F721FB733081A583D4053DDA /* FileTypeIconView.swift */; };
@@ -1008,6 +1011,7 @@
 		B7F21BA3E994F3A0990D4C06 /* ACPOrchestrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
 		B7F9949C9F8915C07A80F7C4 /* GGSplitCommitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */; };
+		B801A2B15E6B87DB9D5A2A2E /* MermaidModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657B321F57070FA58F5D5283 /* MermaidModels.swift */; };
 		B82F5295F500E46C381A8D52 /* ReviewLoopHandoffRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694DDEC8133EFBC33822BC26 /* ReviewLoopHandoffRoutingTests.swift */; };
 		B834ADF0BB988121361AF334 /* tool-call-content-blocks.json in Resources */ = {isa = PBXBuildFile; fileRef = F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */; };
 		B83DBBA1D5090E5E757B01F5 /* CloseTabConfirmationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */; };
@@ -1150,6 +1154,7 @@
 		D002012348D4DA7E124632BF /* SpacePagerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */; };
 		D02BB257817B709817CAB2B6 /* ACPRemoteMCPFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
+		D0E9985350ECD64F1D042345 /* MermaidModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */; };
 		D0F370E528AA4D07814AEB15 /* ACPMCPStatusPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C051018EB105E225122750C /* ACPMCPStatusPolicy.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
 		D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */; };
@@ -1204,6 +1209,7 @@
 		D8E808EF960CA0C10E59D44C /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8EB674A5221235F1C7594E /* SemanticVersion.swift */; };
 		D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */; };
 		D9C26E07021DC6938013FBBE /* RemoteServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3000211002A1A433AC8DBB3B /* RemoteServerError.swift */; };
+		D9E335CB096989ECD0A861F9 /* BeautifulMermaidBackendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5341B1BDF38DAE656D5B6849 /* BeautifulMermaidBackendTests.swift */; };
 		D9FD24854A41DF2E9214E078 /* ReviewDraftCommentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */; };
 		DA5ED6D708DD8C0B5563AB4F /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */; };
 		DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9E527A76820947F426A8 /* ACPFilesystem.swift */; };
@@ -1401,6 +1407,7 @@
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
 		FDE59101CBC2CA8CD6FFF91B /* ACPMCPExternalStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01291607F0A46E4A50104BB /* ACPMCPExternalStatus.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
+		FE3F355996C9362DA52687B9 /* MermaidDiagramTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD5EF425B826054367B9A98 /* MermaidDiagramTheme.swift */; };
 		FE5846F4401C702264817399 /* SpaceEmojiPickerSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */; };
 		FE5F2F9B468D045194B9443B /* ACPChatTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC558BE723378DCC7AA5B55 /* ACPChatTypography.swift */; };
 		FF23739CD41997C6DD44E18B /* ACPFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */; };
@@ -1881,6 +1888,7 @@
 		531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineDiffView.swift; sourceTree = "<group>"; };
 		532AA1B8AD5E8139D2EEE948 /* MCPAttachmentPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPAttachmentPlannerTests.swift; sourceTree = "<group>"; };
 		5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTabConfirmationPolicyTests.swift; sourceTree = "<group>"; };
+		5341B1BDF38DAE656D5B6849 /* BeautifulMermaidBackendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeautifulMermaidBackendTests.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C0EBA9F81668C89977770E /* ACPLaunchPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolver.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
@@ -1976,6 +1984,7 @@
 		650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometry.swift; sourceTree = "<group>"; };
 		652C404D30685CB2FE79BD81 /* BaseResolutionMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResolutionMappingTests.swift; sourceTree = "<group>"; };
 		6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineHighlighter.swift; sourceTree = "<group>"; };
+		657B321F57070FA58F5D5283 /* MermaidModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidModels.swift; sourceTree = "<group>"; };
 		65A1EB96EBED0DEDCA5CD094 /* JSONRPCStdioTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCStdioTransport.swift; sourceTree = "<group>"; };
 		65B5815D9BE36D3F835B5456 /* DiffReviewFileSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewFileSection.swift; sourceTree = "<group>"; };
 		65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstaller.swift; sourceTree = "<group>"; };
@@ -2176,6 +2185,7 @@
 		8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshot.swift; sourceTree = "<group>"; };
 		8C040E975A14DE31446BCEB7 /* ACPReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPReconnectPolicyTests.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
+		8C143F318273ED3A36BA3709 /* BeautifulMermaidBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeautifulMermaidBackend.swift; sourceTree = "<group>"; };
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
 		8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubCLIProviderTests.swift; sourceTree = "<group>"; };
 		8C511B229168DDEA87173A41 /* GGInboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxStore.swift; sourceTree = "<group>"; };
@@ -2280,6 +2290,7 @@
 		9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessKiller.swift; sourceTree = "<group>"; };
 		9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulseTransitionTests.swift; sourceTree = "<group>"; };
 		9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipe.swift; sourceTree = "<group>"; };
+		9FD5EF425B826054367B9A98 /* MermaidDiagramTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramTheme.swift; sourceTree = "<group>"; };
 		9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilter.swift; sourceTree = "<group>"; };
 		9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseChecker.swift; sourceTree = "<group>"; };
 		A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParserTests.swift; sourceTree = "<group>"; };
@@ -2459,6 +2470,7 @@
 		C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagedTests.swift; sourceTree = "<group>"; };
 		C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPromptCapabilitiesTests.swift; sourceTree = "<group>"; };
 		C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseCheckerTests.swift; sourceTree = "<group>"; };
+		C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidModelsTests.swift; sourceTree = "<group>"; };
 		C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextTests.swift; sourceTree = "<group>"; };
 		C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProviderTests.swift; sourceTree = "<group>"; };
 		C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecTests.swift; sourceTree = "<group>"; };
@@ -2534,6 +2546,7 @@
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesManagerTests.swift; sourceTree = "<group>"; };
 		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
+		CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramThemeTests.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
 		CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanChecklist.swift; sourceTree = "<group>"; };
 		CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModel.swift; sourceTree = "<group>"; };
@@ -2851,6 +2864,7 @@
 				03F3504B261E9E6C79C80DD5 /* TreeSitterHCL in Frameworks */,
 				32727E2775753CDBF02D4660 /* TreeSitterDockerfile in Frameworks */,
 				DB199FBEEABBC119FB26E32A /* Markdown in Frameworks */,
+				44F6A0601A9F27FC09DB8387 /* BeautifulMermaid in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3399,6 +3413,16 @@
 			path = Dialogs;
 			sourceTree = "<group>";
 		};
+		1F43A4E7E534C5039023AD63 /* Mermaid */ = {
+			isa = PBXGroup;
+			children = (
+				5341B1BDF38DAE656D5B6849 /* BeautifulMermaidBackendTests.swift */,
+				CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */,
+				C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */,
+			);
+			path = Mermaid;
+			sourceTree = "<group>";
+		};
 		1FFE2F486B5DB90050685166 /* Alas */ = {
 			isa = PBXGroup;
 			children = (
@@ -3523,8 +3547,19 @@
 				8AB0F2CC9E0D55089456FFA5 /* Editor */,
 				99296E46F8BEA6DE0DFBBBD2 /* Highlight */,
 				C9BE5D9821AF38B59009DD0B /* LSP */,
+				1F43A4E7E534C5039023AD63 /* Mermaid */,
 			);
 			path = Code;
+			sourceTree = "<group>";
+		};
+		2FD171827054628F0B773E76 /* Mermaid */ = {
+			isa = PBXGroup;
+			children = (
+				8C143F318273ED3A36BA3709 /* BeautifulMermaidBackend.swift */,
+				9FD5EF425B826054367B9A98 /* MermaidDiagramTheme.swift */,
+				657B321F57070FA58F5D5283 /* MermaidModels.swift */,
+			);
+			path = Mermaid;
 			sourceTree = "<group>";
 		};
 		31CE84DE21D266EF233D2D1E /* Features */ = {
@@ -3769,6 +3804,7 @@
 				08AFF75AE216ACC5E010B709 /* Highlight */,
 				98B31DB084754D0D15591339 /* LSP */,
 				84098DAEB1A8FCEF82386437 /* Markdown */,
+				2FD171827054628F0B773E76 /* Mermaid */,
 			);
 			path = Code;
 			sourceTree = "<group>";
@@ -5235,6 +5271,7 @@
 				E5B5088DE61D8706D3F358F9 /* TreeSitterHCL */,
 				B0B462D196CBF339A0F9B651 /* TreeSitterDockerfile */,
 				B69450B224F0C82A52D00662 /* Markdown */,
+				F1692E6406C1269703621C3B /* BeautifulMermaid */,
 			);
 			productName = Alas;
 			productReference = 519CFB3707E8DDBDECD6C5D1 /* Alas.app */;
@@ -5264,6 +5301,7 @@
 			mainGroup = 848F1B301BB31A69DEB82615;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				F2E544B61384EB937D0A6EF0 /* XCRemoteSwiftPackageReference "beautiful-mermaid-swift" */,
 				B9008B8C0F5A7E880C250FE4 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 				CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */,
 				64E0650CB5F6FFA2FBE793EA /* XCRemoteSwiftPackageReference "tree-sitter-bash" */,
@@ -5660,6 +5698,7 @@
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
 				4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */,
 				392B71BE02DAAAEC07CFD528 /* BaseResolutionMapping.swift in Sources */,
+				1B8AED038B80C06EDA6DBC20 /* BeautifulMermaidBackend.swift in Sources */,
 				67D9FD383A299A29780C3DE2 /* BinaryFileType.swift in Sources */,
 				C97F67F96D887D0A417F9FD3 /* BinaryPreviewTabView.swift in Sources */,
 				A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */,
@@ -5957,6 +5996,8 @@
 				8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */,
 				38DCAD9DA4B9418906700A25 /* MergeView3Way.swift in Sources */,
 				0890C803E92308809BE12930 /* MergeWordDiff.swift in Sources */,
+				FE3F355996C9362DA52687B9 /* MermaidDiagramTheme.swift in Sources */,
+				B801A2B15E6B87DB9D5A2A2E /* MermaidModels.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */,
@@ -6408,6 +6449,7 @@
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,
 				B3240B739972444A6CB14F7C /* BaseResolutionMappingTests.swift in Sources */,
+				D9E335CB096989ECD0A861F9 /* BeautifulMermaidBackendTests.swift in Sources */,
 				599302478830809946BF6D66 /* BinaryFileTypeTests.swift in Sources */,
 				CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */,
 				5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */,
@@ -6625,6 +6667,8 @@
 				7CA34C93E31EA98047AF6D81 /* MergeScrollCoordinatorTests.swift in Sources */,
 				72CF403FFD14D75FC0DD15E3 /* MergeView3WayLayoutTests.swift in Sources */,
 				9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */,
+				63B3A5BB582C8C7ACE51E9E5 /* MermaidDiagramThemeTests.swift in Sources */,
+				D0E9985350ECD64F1D042345 /* MermaidModelsTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
@@ -7219,6 +7263,14 @@
 				minimumVersion = 0.23.2;
 			};
 		};
+		F2E544B61384EB937D0A6EF0 /* XCRemoteSwiftPackageReference "beautiful-mermaid-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/lukilabs/beautiful-mermaid-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		FAF805B9CC533A5991566C9A /* XCRemoteSwiftPackageReference "tree-sitter-ruby" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tree-sitter/tree-sitter-ruby";
@@ -7349,6 +7401,11 @@
 		E5B5088DE61D8706D3F358F9 /* TreeSitterHCL */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TreeSitterHCL;
+		};
+		F1692E6406C1269703621C3B /* BeautifulMermaid */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F2E544B61384EB937D0A6EF0 /* XCRemoteSwiftPackageReference "beautiful-mermaid-swift" */;
+			productName = BeautifulMermaid;
 		};
 		F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		13E762EA8D84EFE6F0228806 /* AgentTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */; };
 		13FF5AC96D9F0C14264096D9 /* ImageDiffSideBySideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379D90AD620EAF6E84A04902 /* ImageDiffSideBySideView.swift */; };
 		14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2EB554CB6AF797545DB95D /* HeadReader.swift */; };
+		1493B3473D1CA13C68582A09 /* BeautifulMermaidSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A9FD2E7C30AA7C998FD071 /* BeautifulMermaidSmokeTests.swift */; };
 		14BC25FE7259A545420F28AA /* ComposerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */; };
 		14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */; };
 		14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */; };
@@ -2784,6 +2785,7 @@
 		F31E42DEC85081FEA8CA1BC3 /* ACPSessionLeaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLeaseTests.swift; sourceTree = "<group>"; };
 		F332906E17C5865856DBB90B /* ACPSessionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunner.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
+		F3A9FD2E7C30AA7C998FD071 /* BeautifulMermaidSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeautifulMermaidSmokeTests.swift; sourceTree = "<group>"; };
 		F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceCommitEditingTests.swift; sourceTree = "<group>"; };
 		F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspectorTests.swift; sourceTree = "<group>"; };
 		F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabViewTests.swift; sourceTree = "<group>"; };
@@ -3444,6 +3446,7 @@
 			isa = PBXGroup;
 			children = (
 				5341B1BDF38DAE656D5B6849 /* BeautifulMermaidBackendTests.swift */,
+				F3A9FD2E7C30AA7C998FD071 /* BeautifulMermaidSmokeTests.swift */,
 				B4C0622C1F5D9B46F429F896 /* MermaidAttachmentCoordinatorTests.swift */,
 				888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */,
 				CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */,
@@ -6496,6 +6499,7 @@
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,
 				B3240B739972444A6CB14F7C /* BaseResolutionMappingTests.swift in Sources */,
 				D9E335CB096989ECD0A861F9 /* BeautifulMermaidBackendTests.swift in Sources */,
+				1493B3473D1CA13C68582A09 /* BeautifulMermaidSmokeTests.swift in Sources */,
 				599302478830809946BF6D66 /* BinaryFileTypeTests.swift in Sources */,
 				CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */,
 				5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */; };
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
 		0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */; };
+		0BCDD4F3A4AE0B3944460D87 /* MermaidTextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BDAE2D9C420F635E81D9D3 /* MermaidTextAttachment.swift */; };
 		0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0C74DD1581313ABE6DA6F6D9 /* MermaidDiagramBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BD2664AF3A3B7665A1382A /* MermaidDiagramBlockView.swift */; };
@@ -1033,6 +1034,7 @@
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */; };
 		B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */; };
+		B966D129022E68797918D90F /* MermaidAttachmentCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C0622C1F5D9B46F429F896 /* MermaidAttachmentCoordinatorTests.swift */; };
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
 		B9D15679A5E813254E1DDCB6 /* ProviderReviewMutationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */; };
 		B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */; };
@@ -1107,6 +1109,7 @@
 		C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */; };
 		C71971EF735837CD260359C6 /* RemoteImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DABE7D3F41C67D28CA2C2F9 /* RemoteImageCache.swift */; };
 		C7658D1AF7744BB694D2388A /* ACPReconnectPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C040E975A14DE31446BCEB7 /* ACPReconnectPolicyTests.swift */; };
+		C78F2367F54AF4CDB16D842B /* MermaidAttachmentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC139B5700EEB08A086C80A /* MermaidAttachmentCoordinator.swift */; };
 		C7A839C87B7C9F70F5BD6631 /* CompletionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B0831638833C386E5CC9E8 /* CompletionEngine.swift */; };
 		C7AACF777FF0DAD9ACA426F3 /* AgentLifecycleEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */; };
 		C7AD6F2DDAE9E11920277D41 /* RemoteSessionGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */; };
@@ -1634,6 +1637,7 @@
 		2641F3E2016CE8C83E75BA5D /* SSHConfigParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHConfigParser.swift; sourceTree = "<group>"; };
 		2648D58703B6C53ED15D536A /* TreeSitterHCL */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterHCL; path = ThirdParty/TreeSitterHCL; sourceTree = SOURCE_ROOT; };
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
+		26BDAE2D9C420F635E81D9D3 /* MermaidTextAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidTextAttachment.swift; sourceTree = "<group>"; };
 		26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntentTests.swift; sourceTree = "<group>"; };
 		270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconImageStagingTests.swift; sourceTree = "<group>"; };
 		27192411BB5CB8F8F7AD09B2 /* RemoteRepoValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteRepoValidatorTests.swift; sourceTree = "<group>"; };
@@ -1871,6 +1875,7 @@
 		4D974BDA7FAE214495278557 /* ACPUserInputPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserInputPrompt.swift; sourceTree = "<group>"; };
 		4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPProcessLiveness.swift; sourceTree = "<group>"; };
 		4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLeafEncodeTests.swift; sourceTree = "<group>"; };
+		4DC139B5700EEB08A086C80A /* MermaidAttachmentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidAttachmentCoordinator.swift; sourceTree = "<group>"; };
 		4DC787CE0F5625F8114C9F6F /* MergeResultPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeResultPane.swift; sourceTree = "<group>"; };
 		4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeJSONRPCTransport.swift; sourceTree = "<group>"; };
 		4E678D9C5E3D9D39BDD2AA51 /* BinaryPreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryPreviewTabView.swift; sourceTree = "<group>"; };
@@ -2404,6 +2409,7 @@
 		B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThumbnailImageCacheTests.swift; sourceTree = "<group>"; };
 		B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneVisibilityTests.swift; sourceTree = "<group>"; };
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
+		B4C0622C1F5D9B46F429F896 /* MermaidAttachmentCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidAttachmentCoordinatorTests.swift; sourceTree = "<group>"; };
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
 		B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInstaller.swift; sourceTree = "<group>"; };
 		B56D60E58F278AC97579937E /* SectionHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderTests.swift; sourceTree = "<group>"; };
@@ -3438,6 +3444,7 @@
 			isa = PBXGroup;
 			children = (
 				5341B1BDF38DAE656D5B6849 /* BeautifulMermaidBackendTests.swift */,
+				B4C0622C1F5D9B46F429F896 /* MermaidAttachmentCoordinatorTests.swift */,
 				888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */,
 				CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */,
 				C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */,
@@ -3581,6 +3588,7 @@
 			isa = PBXGroup;
 			children = (
 				8C143F318273ED3A36BA3709 /* BeautifulMermaidBackend.swift */,
+				4DC139B5700EEB08A086C80A /* MermaidAttachmentCoordinator.swift */,
 				07BD2664AF3A3B7665A1382A /* MermaidDiagramBlockView.swift */,
 				4F002B796231A05FD113BDA3 /* MermaidDiagramLayout.swift */,
 				9FD5EF425B826054367B9A98 /* MermaidDiagramTheme.swift */,
@@ -3588,6 +3596,7 @@
 				657B321F57070FA58F5D5283 /* MermaidModels.swift */,
 				AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */,
 				515AFF3BF580DA12B16CD4BE /* MermaidRenderService.swift */,
+				26BDAE2D9C420F635E81D9D3 /* MermaidTextAttachment.swift */,
 			);
 			path = Mermaid;
 			sourceTree = "<group>";
@@ -6026,6 +6035,7 @@
 				8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */,
 				38DCAD9DA4B9418906700A25 /* MergeView3Way.swift in Sources */,
 				0890C803E92308809BE12930 /* MergeWordDiff.swift in Sources */,
+				C78F2367F54AF4CDB16D842B /* MermaidAttachmentCoordinator.swift in Sources */,
 				0C74DD1581313ABE6DA6F6D9 /* MermaidDiagramBlockView.swift in Sources */,
 				44E3D7C4CAC4E2481778C35F /* MermaidDiagramLayout.swift in Sources */,
 				FE3F355996C9362DA52687B9 /* MermaidDiagramTheme.swift in Sources */,
@@ -6033,6 +6043,7 @@
 				B801A2B15E6B87DB9D5A2A2E /* MermaidModels.swift in Sources */,
 				F8DFFC12D5F7F2E1F8F19A02 /* MermaidRenderCache.swift in Sources */,
 				8DC2ADB1F7CC8D4B9667BD94 /* MermaidRenderService.swift in Sources */,
+				0BCDD4F3A4AE0B3944460D87 /* MermaidTextAttachment.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */,
@@ -6703,6 +6714,7 @@
 				7CA34C93E31EA98047AF6D81 /* MergeScrollCoordinatorTests.swift in Sources */,
 				72CF403FFD14D75FC0DD15E3 /* MergeView3WayLayoutTests.swift in Sources */,
 				9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */,
+				B966D129022E68797918D90F /* MermaidAttachmentCoordinatorTests.swift in Sources */,
 				E099FB5101ED328389233B35 /* MermaidDiagramLayoutTests.swift in Sources */,
 				63B3A5BB582C8C7ACE51E9E5 /* MermaidDiagramThemeTests.swift in Sources */,
 				D0E9985350ECD64F1D042345 /* MermaidModelsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */; };
 		0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
+		0C74DD1581313ABE6DA6F6D9 /* MermaidDiagramBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BD2664AF3A3B7665A1382A /* MermaidDiagramBlockView.swift */; };
 		0C7A044AC34BF225A4149556 /* RemoteTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E25D0520B813E8AC9A7174 /* RemoteTerminalLaunchTests.swift */; };
 		0CDC1232955139B230B6600C /* ReviewDraftCommentAgentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
@@ -400,6 +401,7 @@
 		443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */; };
 		445DAFBF3E820823AA2779B4 /* ACPElicitationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E1A9B42D47CC0244C24F7B /* ACPElicitationTests.swift */; };
 		449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */; };
+		44E3D7C4CAC4E2481778C35F /* MermaidDiagramLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F002B796231A05FD113BDA3 /* MermaidDiagramLayout.swift */; };
 		44F6A0601A9F27FC09DB8387 /* BeautifulMermaid in Frameworks */ = {isa = PBXBuildFile; productRef = F1692E6406C1269703621C3B /* BeautifulMermaid */; };
 		45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC15742E7423AE2F3A203A /* ACPSessionInfoUpdateDecodeTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
@@ -454,6 +456,7 @@
 		4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		4F2BB7482C39B07F5E35E9D1 /* RemoteMessageWireJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD68C6A69930BE0F9437AAE /* RemoteMessageWireJSON.swift */; };
+		4F6177806CEB8E50F0D70F7B /* MermaidViewerStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A09AB192DD6181CD974283 /* MermaidViewerStateTests.swift */; };
 		4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */; };
 		4FD9E5FFB4C75850CF7B2FE7 /* StagedDiffLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */; };
 		4FE322C88A2B06C317DDA9B5 /* ReviewSessionTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */; };
@@ -636,6 +639,7 @@
 		7339339EEA3D52B6F5BDE5F0 /* LocalACPBrokerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB1A1E525DA701563EF56D5 /* LocalACPBrokerService.swift */; };
 		73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */; };
 		735B86E1E8F8F593049937BB /* ReviewSessionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */; };
+		736598702E6E1D1C006ED971 /* MermaidDiagramViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56A35888F0783BA6F296CED /* MermaidDiagramViewer.swift */; };
 		7374C72F780CEE12E81997B9 /* StashDiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E373805AEFD068B97BC33A82 /* StashDiffTabView.swift */; };
 		7377F6BACEEA621425E54FBC /* TreeSitterTOML in Frameworks */ = {isa = PBXBuildFile; productRef = 69EF3147FDD8F28F8D65D4FC /* TreeSitterTOML */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
@@ -1246,6 +1250,7 @@
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
 		E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C511B229168DDEA87173A41 /* GGInboxStore.swift */; };
+		E099FB5101ED328389233B35 /* MermaidDiagramLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */; };
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
 		E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */; };
 		E0CC3918BF4D86FD20442922 /* ACPSessionForkPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */; };
@@ -1484,6 +1489,7 @@
 		074A17527610230DCFBEA13C /* ACPMockClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClient.swift; sourceTree = "<group>"; };
 		07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestPromptEditorWindow.swift; sourceTree = "<group>"; };
 		07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityIconTintTests.swift; sourceTree = "<group>"; };
+		07BD2664AF3A3B7665A1382A /* MermaidDiagramBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramBlockView.swift; sourceTree = "<group>"; };
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffMode.swift; sourceTree = "<group>"; };
@@ -1868,6 +1874,7 @@
 		4E678D9C5E3D9D39BDD2AA51 /* BinaryPreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryPreviewTabView.swift; sourceTree = "<group>"; };
 		4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffBuilderTests.swift; sourceTree = "<group>"; };
 		4EDBC153EAE419F270EFF948 /* ACPRemoteNodeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteNodeEnvironmentTests.swift; sourceTree = "<group>"; };
+		4F002B796231A05FD113BDA3 /* MermaidDiagramLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramLayout.swift; sourceTree = "<group>"; };
 		4F03EE87AC76203E09C9F1C5 /* DiffFeedbackLane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffFeedbackLane.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
 		4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabsManagerTests.swift; sourceTree = "<group>"; };
@@ -2156,6 +2163,7 @@
 		843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostCapabilitiesTests.swift; sourceTree = "<group>"; };
 		8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStoreBaseBranchTests.swift; sourceTree = "<group>"; };
 		84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextView.swift; sourceTree = "<group>"; };
+		84A09AB192DD6181CD974283 /* MermaidViewerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidViewerStateTests.swift; sourceTree = "<group>"; };
 		84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCacheTests.swift; sourceTree = "<group>"; };
 		8501B285B416ECC49BCC22C3 /* DiffPaneTextDocumentBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentBuilderTests.swift; sourceTree = "<group>"; };
 		8526C9DB63760BDD2CE998BD /* fs-write.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fs-write.json"; sourceTree = "<group>"; };
@@ -2176,6 +2184,7 @@
 		881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputer.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinatorTests.swift; sourceTree = "<group>"; };
+		888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramLayoutTests.swift; sourceTree = "<group>"; };
 		88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOption.swift; sourceTree = "<group>"; };
 		88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTranscriptSync.swift; sourceTree = "<group>"; };
 		89034A1968C6BC371826314D /* ACPSessionOrchestrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -2771,6 +2780,7 @@
 		F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspectorTests.swift; sourceTree = "<group>"; };
 		F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabViewTests.swift; sourceTree = "<group>"; };
 		F4526714086C04ED5B472C90 /* DiffInlineCommentCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentCard.swift; sourceTree = "<group>"; };
+		F56A35888F0783BA6F296CED /* MermaidDiagramViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramViewer.swift; sourceTree = "<group>"; };
 		F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifierTests.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
@@ -3425,10 +3435,12 @@
 			isa = PBXGroup;
 			children = (
 				5341B1BDF38DAE656D5B6849 /* BeautifulMermaidBackendTests.swift */,
+				888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */,
 				CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */,
 				C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */,
 				93393A2C5EEEFFDB678FDA78 /* MermaidRenderCacheTests.swift */,
 				A107DA120039DD59C4F5CDD7 /* MermaidRenderServiceTests.swift */,
+				84A09AB192DD6181CD974283 /* MermaidViewerStateTests.swift */,
 			);
 			path = Mermaid;
 			sourceTree = "<group>";
@@ -3566,7 +3578,10 @@
 			isa = PBXGroup;
 			children = (
 				8C143F318273ED3A36BA3709 /* BeautifulMermaidBackend.swift */,
+				07BD2664AF3A3B7665A1382A /* MermaidDiagramBlockView.swift */,
+				4F002B796231A05FD113BDA3 /* MermaidDiagramLayout.swift */,
 				9FD5EF425B826054367B9A98 /* MermaidDiagramTheme.swift */,
+				F56A35888F0783BA6F296CED /* MermaidDiagramViewer.swift */,
 				657B321F57070FA58F5D5283 /* MermaidModels.swift */,
 				AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */,
 				515AFF3BF580DA12B16CD4BE /* MermaidRenderService.swift */,
@@ -6008,7 +6023,10 @@
 				8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */,
 				38DCAD9DA4B9418906700A25 /* MergeView3Way.swift in Sources */,
 				0890C803E92308809BE12930 /* MergeWordDiff.swift in Sources */,
+				0C74DD1581313ABE6DA6F6D9 /* MermaidDiagramBlockView.swift in Sources */,
+				44E3D7C4CAC4E2481778C35F /* MermaidDiagramLayout.swift in Sources */,
 				FE3F355996C9362DA52687B9 /* MermaidDiagramTheme.swift in Sources */,
+				736598702E6E1D1C006ED971 /* MermaidDiagramViewer.swift in Sources */,
 				B801A2B15E6B87DB9D5A2A2E /* MermaidModels.swift in Sources */,
 				F8DFFC12D5F7F2E1F8F19A02 /* MermaidRenderCache.swift in Sources */,
 				8DC2ADB1F7CC8D4B9667BD94 /* MermaidRenderService.swift in Sources */,
@@ -6681,10 +6699,12 @@
 				7CA34C93E31EA98047AF6D81 /* MergeScrollCoordinatorTests.swift in Sources */,
 				72CF403FFD14D75FC0DD15E3 /* MergeView3WayLayoutTests.swift in Sources */,
 				9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */,
+				E099FB5101ED328389233B35 /* MermaidDiagramLayoutTests.swift in Sources */,
 				63B3A5BB582C8C7ACE51E9E5 /* MermaidDiagramThemeTests.swift in Sources */,
 				D0E9985350ECD64F1D042345 /* MermaidModelsTests.swift in Sources */,
 				FCF61C2ECFE2CC61226F78D5 /* MermaidRenderCacheTests.swift in Sources */,
 				5ABD7DF29A68C38C8AA9EF37 /* MermaidRenderServiceTests.swift in Sources */,
+				4F6177806CEB8E50F0D70F7B /* MermaidViewerStateTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -485,6 +485,7 @@
 		551C15188490062DFC77A479 /* MemorySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */; };
 		552EBB79C20E7D939C7015A1 /* ACPMockClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074A17527610230DCFBEA13C /* ACPMockClient.swift */; };
 		5585C223E2CB23CD8650A5DC /* MergeActionGutter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */; };
+		559D6091E849B5D61F4FA8D0 /* DiffReviewInlineFeedbackMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3BB27D40FCCB5D76C622DA /* DiffReviewInlineFeedbackMarkdownTests.swift */; };
 		55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */; };
 		55C7881F382ACCEBCDB7D157 /* AgentsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */; };
 		55F30DD1D8943C46FD4D1608 /* session-update-tool-call-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 3E3ADEB5299C3FFB091D55EE /* session-update-tool-call-meta.json */; };
@@ -1578,6 +1579,7 @@
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		1A25C83033616FE27526C945 /* GGActionEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGActionEventsTests.swift; sourceTree = "<group>"; };
+		1A3BB27D40FCCB5D76C622DA /* DiffReviewInlineFeedbackMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewInlineFeedbackMarkdownTests.swift; sourceTree = "<group>"; };
 		1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridgeTests.swift; sourceTree = "<group>"; };
 		1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatus.swift; sourceTree = "<group>"; };
 		1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkPolicyTests.swift; sourceTree = "<group>"; };
@@ -3156,6 +3158,7 @@
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				27EEC16C786CE9430C1AC174 /* DiffReviewFileSectionEqualityTests.swift */,
 				86D12B948CADE546FFD3A54C /* DiffReviewImageStateTests.swift */,
+				1A3BB27D40FCCB5D76C622DA /* DiffReviewInlineFeedbackMarkdownTests.swift */,
 				A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */,
 				D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */,
 				AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */,
@@ -6548,6 +6551,7 @@
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				D215CAABE4DE2F5CE3CB0E93 /* DiffReviewFileSectionEqualityTests.swift in Sources */,
 				239B5F18337203930900D06B /* DiffReviewImageStateTests.swift in Sources */,
+				559D6091E849B5D61F4FA8D0 /* DiffReviewInlineFeedbackMarkdownTests.swift in Sources */,
 				59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */,
 				DE33366A35436471AE0DAE96 /* DiffReviewRenderBudgetTests.swift in Sources */,
 				BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -517,6 +517,7 @@
 		59F07BEDA39E5266B33DC47A /* ACPOrchestrationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */; };
 		59F39BAAD57023F090AEDA4F /* ACPImageStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */; };
 		5A0AE37CBA893BD09558C27E /* CIStatusStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FAF07CCA81D986D1C30D05 /* CIStatusStrip.swift */; };
+		5ABD7DF29A68C38C8AA9EF37 /* MermaidRenderServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A107DA120039DD59C4F5CDD7 /* MermaidRenderServiceTests.swift */; };
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
 		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
 		5BB2FF7F9DFFFEF75CA508A2 /* RemoteLSPLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89D9FFAC80BDE46A651A0F /* RemoteLSPLauncherTests.swift */; };
@@ -773,6 +774,7 @@
 		8D5D146F9BF86EE4D058A309 /* CodeHostProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */; };
 		8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */; };
 		8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */; };
+		8DC2ADB1F7CC8D4B9667BD94 /* MermaidRenderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515AFF3BF580DA12B16CD4BE /* MermaidRenderService.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8E8ABE6BBA778EEA4170423C /* MergeScrollCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */; };
 		8E988C41547B229AF19CBE31 /* ACPSessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A590E6B7A73546D38D4F95 /* ACPSessionPersistence.swift */; };
@@ -1377,6 +1379,7 @@
 		F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FC38D03727F34855EB521 /* AlasFieldTests.swift */; };
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
 		F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */; };
+		F8DFFC12D5F7F2E1F8F19A02 /* MermaidRenderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */; };
 		F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
@@ -1399,6 +1402,7 @@
 		FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */; };
 		FCC6BC72DF062AA572F5535F /* RemoteZmxInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
+		FCF61C2ECFE2CC61226F78D5 /* MermaidRenderCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93393A2C5EEEFFDB678FDA78 /* MermaidRenderCacheTests.swift */; };
 		FD4196C9F558CE954D94E060 /* RemoteTerminalScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C6579202DFD8E5FBF26DE5 /* RemoteTerminalScript.swift */; };
 		FD5AC98DEE4448EB95C49485 /* ACPUserInputFormStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */; };
 		FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */; };
@@ -1873,6 +1877,7 @@
 		50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinatesTests.swift; sourceTree = "<group>"; };
 		50B0831638833C386E5CC9E8 /* CompletionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngine.swift; sourceTree = "<group>"; };
 		50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineRendererTests.swift; sourceTree = "<group>"; };
+		515AFF3BF580DA12B16CD4BE /* MermaidRenderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderService.swift; sourceTree = "<group>"; };
 		515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavView.swift; sourceTree = "<group>"; };
 		519CFB3707E8DDBDECD6C5D1 /* Alas.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alas.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		51B868809675C4110044C92E /* SpacesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesManager.swift; sourceTree = "<group>"; };
@@ -2226,6 +2231,7 @@
 		93079B18AE14C7AA3516727D /* RemoteZmxInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteZmxInstallerTests.swift; sourceTree = "<group>"; };
 		932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstaller.swift; sourceTree = "<group>"; };
 		932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFeature.swift; sourceTree = "<group>"; };
+		93393A2C5EEEFFDB678FDA78 /* MermaidRenderCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderCacheTests.swift; sourceTree = "<group>"; };
 		9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSaveNormalizationTests.swift; sourceTree = "<group>"; };
 		934BCC470703CF2DF2303357 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
 		935CE58001BA1459A556B397 /* MCPRegistrationRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPRegistrationRegistryTests.swift; sourceTree = "<group>"; };
@@ -2295,6 +2301,7 @@
 		9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseChecker.swift; sourceTree = "<group>"; };
 		A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParserTests.swift; sourceTree = "<group>"; };
 		A02E6B12C5EC8FAA50202EEA /* GGUnstackSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGUnstackSheet.swift; sourceTree = "<group>"; };
+		A107DA120039DD59C4F5CDD7 /* MermaidRenderServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderServiceTests.swift; sourceTree = "<group>"; };
 		A1503D1CB549B39E499EFAB8 /* DiffInlineAnnotationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineAnnotationCard.swift; sourceTree = "<group>"; };
 		A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewModelsTests.swift; sourceTree = "<group>"; };
 		A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateStoreTests.swift; sourceTree = "<group>"; };
@@ -2339,6 +2346,7 @@
 		AA6486CAD3FE633F9B6F4ABF /* MCPAttachmentPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPAttachmentPlanner.swift; sourceTree = "<group>"; };
 		AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstallerTests.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
+		AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderCache.swift; sourceTree = "<group>"; };
 		AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabViewTests.swift; sourceTree = "<group>"; };
 		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
 		AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentAgentModelTests.swift; sourceTree = "<group>"; };
@@ -3419,6 +3427,8 @@
 				5341B1BDF38DAE656D5B6849 /* BeautifulMermaidBackendTests.swift */,
 				CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */,
 				C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */,
+				93393A2C5EEEFFDB678FDA78 /* MermaidRenderCacheTests.swift */,
+				A107DA120039DD59C4F5CDD7 /* MermaidRenderServiceTests.swift */,
 			);
 			path = Mermaid;
 			sourceTree = "<group>";
@@ -3558,6 +3568,8 @@
 				8C143F318273ED3A36BA3709 /* BeautifulMermaidBackend.swift */,
 				9FD5EF425B826054367B9A98 /* MermaidDiagramTheme.swift */,
 				657B321F57070FA58F5D5283 /* MermaidModels.swift */,
+				AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */,
+				515AFF3BF580DA12B16CD4BE /* MermaidRenderService.swift */,
 			);
 			path = Mermaid;
 			sourceTree = "<group>";
@@ -5998,6 +6010,8 @@
 				0890C803E92308809BE12930 /* MergeWordDiff.swift in Sources */,
 				FE3F355996C9362DA52687B9 /* MermaidDiagramTheme.swift in Sources */,
 				B801A2B15E6B87DB9D5A2A2E /* MermaidModels.swift in Sources */,
+				F8DFFC12D5F7F2E1F8F19A02 /* MermaidRenderCache.swift in Sources */,
+				8DC2ADB1F7CC8D4B9667BD94 /* MermaidRenderService.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */,
@@ -6669,6 +6683,8 @@
 				9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */,
 				63B3A5BB582C8C7ACE51E9E5 /* MermaidDiagramThemeTests.swift in Sources */,
 				D0E9985350ECD64F1D042345 /* MermaidModelsTests.swift in Sources */,
+				FCF61C2ECFE2CC61226F78D5 /* MermaidRenderCacheTests.swift in Sources */,
+				5ABD7DF29A68C38C8AA9EF37 /* MermaidRenderServiceTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,

--- a/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "beautiful-mermaid-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukilabs/beautiful-mermaid-swift",
+      "state" : {
+        "revision" : "6a23a29e91af8f5b3e9fc09945332ca193bd69ec",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "elk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukilabs/elk-swift",
+      "state" : {
+        "revision" : "32f8042e3509a4819f00ff9cd46e829ec2b26da0",
+        "version" : "1.0.2"
+      }
+    },
+    {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark.git",

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -122,6 +122,8 @@ struct ACPMarkdownText: View {
                 showsCopyButton: showsCodeBlockCopyButton,
                 highlightsSyntax: false
             )
+        case .mermaid(let source):
+            MermaidDiagramBlockView(source: source, profile: .transcript)
         case .table(let header, let rows):
             tableView(
                 header: header,
@@ -278,6 +280,7 @@ struct ACPMarkdownText: View {
         case quote(String)
         case code(language: String?, body: String)
         case streamingCode(language: String?, body: String)
+        case mermaid(source: String)
         case table(header: [String], rows: [[String]])
     }
 
@@ -425,7 +428,11 @@ struct ACPMarkdownText: View {
                 if closesBeforeEnd { i += 1 } // skip closing fence
                 let codeBody = body.joined(separator: "\n")
                 if closesBeforeEnd {
-                    blocks.append(.code(language: fence.language, body: codeBody))
+                    if MermaidFence.isMermaid(language: fence.language), !codeBody.isEmpty {
+                        blocks.append(.mermaid(source: codeBody))
+                    } else {
+                        blocks.append(.code(language: fence.language, body: codeBody))
+                    }
                 } else {
                     blocks.append(.streamingCode(language: fence.language, body: codeBody))
                 }

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -428,7 +428,10 @@ struct ACPMarkdownText: View {
                 if closesBeforeEnd { i += 1 } // skip closing fence
                 let codeBody = body.joined(separator: "\n")
                 if closesBeforeEnd {
-                    if MermaidFence.isMermaid(language: fence.language), !codeBody.isEmpty {
+                    let hasRenderableCode = !codeBody
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .isEmpty
+                    if MermaidFence.isMermaid(language: fence.language), hasRenderableCode {
                         blocks.append(.mermaid(source: codeBody))
                     } else {
                         blocks.append(.code(language: fence.language, body: codeBody))

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -18,6 +18,7 @@ struct ACPMarkdownText: View {
     var updateSourceID: ObjectIdentifier? = nil
     var typography: ACPChatTypography = .default
     var showsCodeBlockCopyButton: Bool = true
+    var noninteractiveTapAction: (() -> Void)? = nil
     @Environment(\.theme) private var theme
     @State private var tableViewportWidth: CGFloat = 0
 
@@ -25,6 +26,9 @@ struct ACPMarkdownText: View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(currentRenderBlocks().enumerated()), id: \.offset) { _, renderBlock in
                 view(for: renderBlock)
+                    .modifier(ACPMarkdownNoninteractiveTapModifier(
+                        action: renderBlock.block.allowsNoninteractiveTapAction ? noninteractiveTapAction : nil
+                    ))
             }
         }
     }
@@ -294,6 +298,21 @@ struct ACPMarkdownText: View {
         let memoizesInlineMarkdown: Bool
     }
 
+    private struct ACPMarkdownNoninteractiveTapModifier: ViewModifier {
+        let action: (() -> Void)?
+
+        @ViewBuilder
+        func body(content: Content) -> some View {
+            if let action {
+                content
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: action)
+            } else {
+                content
+            }
+        }
+    }
+
     /// Detect a GitHub-flavoured markdown table starting at `start`:
     ///   | h1 | h2 |
     ///   |----|----|
@@ -501,6 +520,17 @@ struct ACPMarkdownText: View {
             blocks.append(.paragraph(para.joined(separator: "\n")))
         }
         return blocks
+    }
+}
+
+private extension ACPMarkdownText.Block {
+    var allowsNoninteractiveTapAction: Bool {
+        switch self {
+        case .mermaid:
+            false
+        case .heading, .paragraph, .taskList, .quote, .code, .streamingCode, .table:
+            true
+        }
     }
 }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3685,7 +3685,7 @@ final class AppState {
     var hasActiveCodeEditorTab: Bool {
         guard case .editor(let state) = activeTab else { return false }
         let path = state.isExternal ? (state.externalAbsolutePath ?? "") : state.relativePath
-        return !MarkdownFileType.isMarkdown(relativePath: path)
+        return !MarkdownFileType.supportsRichPreview(relativePath: path)
     }
 
     var hasAnyDirtyEditorTab: Bool {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -31,6 +31,9 @@ struct RootView: View {
                 // launches render half-dark until the user toggles the theme.
                 WindowAppearance.apply(darkMode: state.themeStore.current.darkMode)
             }
+            .onChange(of: state.themeStore.current, initial: true) { _, theme in
+                MermaidDiagramViewerController.shared.updateTheme(theme)
+            }
             .background(WindowConfigurator(disablesSystemDrag: true))
             .frame(minWidth: 700, minHeight: 600)
             .ignoresSafeArea()

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -176,9 +176,9 @@ struct CenterPaneView: View {
                                         tabId: tab.id,
                                         allowsPaneFocus: allowsPaneFocus)
                     case .editor(let s):
-                        if MarkdownFileType.isMarkdown(relativePath: s.isExternal
-                                                        ? (s.externalAbsolutePath ?? "")
-                                                        : s.relativePath) {
+                        if MarkdownFileType.supportsRichPreview(relativePath: s.isExternal
+                                                                 ? (s.externalAbsolutePath ?? "")
+                                                                 : s.relativePath) {
                             MarkdownTabView(worktreePath: worktree.path,
                                             worktreeId: worktree.id,
                                             tabId: s.id,

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -458,7 +458,8 @@ final class DiffPaneLSPController {
             monospacedFontFamily: textView.font?.familyName ?? "JetBrainsMono Nerd Font",
             monospacedFontSize: max(1, Int((textView.font?.pointSize ?? 13).rounded())),
             baseDirectory: context.fileURL.deletingLastPathComponent(),
-            worktreeRoot: context.worktreeRoot
+            worktreeRoot: context.worktreeRoot,
+            mermaidProfile: .compact
         )
         let size = HoverFeatureTesting.computePreferredSize(for: renderResult)
         let anchor = textView.symbolAnchorRect(for: symbolRange)

--- a/Alas/Sources/Center/Diff/DiffPaneLSP.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneLSP.swift
@@ -469,7 +469,10 @@ final class DiffPaneLSPController {
             size: size,
             theme: theme,
             anchor: anchor,
-            in: textView
+            in: textView,
+            onWillPresentMermaidViewer: { [weak self] in
+                self?.hideHover()
+            }
         )
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -2224,8 +2224,13 @@ enum DiffReviewInlineFeedbackDisplayPolicy {
 enum DiffReviewInlineFeedbackMarkdown {
     private static let typography = ACPChatTypography(fontFamily: "", fontSize: 11)
 
-    static func view(_ source: String) -> some View {
-        ACPMarkdownText(raw: source, typography: typography, showsCodeBlockCopyButton: false)
+    static func view(_ source: String, noninteractiveTapAction: (() -> Void)? = nil) -> some View {
+        ACPMarkdownText(
+            raw: source,
+            typography: typography,
+            showsCodeBlockCopyButton: false,
+            noninteractiveTapAction: noninteractiveTapAction
+        )
     }
 
     @MainActor
@@ -2265,18 +2270,8 @@ struct ReviewDraftCommentCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            if isEditing {
-                cardContent
-            } else {
-                Button {
-                    onSelect(comment)
-                } label: {
-                    cardContent
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("diff-review-draft-comment-select-\(comment.id)")
-            }
+            cardContent
+                .background(selectionPressMarker)
 
             actionRow
         }
@@ -2309,6 +2304,8 @@ struct ReviewDraftCommentCard: View {
             RoundedRectangle(cornerRadius: 2)
                 .fill(statusColor)
                 .frame(width: 3)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: selectWhenNotEditing)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
@@ -2327,6 +2324,8 @@ struct ReviewDraftCommentCard: View {
                     }
                 }
                 .lineLimit(1)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: selectWhenNotEditing)
 
                 ForEach(providerStateLabels.indices, id: \.self) { index in
                     let label = providerStateLabels[index]
@@ -2354,14 +2353,20 @@ struct ReviewDraftCommentCard: View {
                     .accessibilityIdentifier("diff-review-draft-comment-editor-\(comment.id)")
                 } else {
                     VStack(alignment: .leading, spacing: 6) {
-                        DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
+                        DiffReviewInlineFeedbackMarkdown.view(
+                            comment.bodyMarkdown,
+                            noninteractiveTapAction: selectWhenNotEditing
+                        )
 
                         ForEach(comment.allReplies) { reply in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(reply.author.displayName)
                                     .font(.system(size: 10, weight: .semibold))
                                     .foregroundColor(theme.color("fg-faint"))
-                                DiffReviewInlineFeedbackMarkdown.view(reply.bodyMarkdown)
+                                DiffReviewInlineFeedbackMarkdown.view(
+                                    reply.bodyMarkdown,
+                                    noninteractiveTapAction: selectWhenNotEditing
+                                )
                                     .fixedSize(horizontal: false, vertical: true)
                             }
                             .padding(.leading, 8)
@@ -2378,6 +2383,22 @@ struct ReviewDraftCommentCard: View {
 
             Spacer(minLength: 0)
         }
+    }
+
+    @ViewBuilder
+    private var selectionPressMarker: some View {
+        if !isEditing {
+            ReviewDraftCommentActionPressMarker(
+                identifier: "diff-review-draft-comment-select-\(comment.id)",
+                label: "Select draft comment",
+                action: { onSelect(comment) }
+            )
+        }
+    }
+
+    private func selectWhenNotEditing() {
+        guard !isEditing else { return }
+        onSelect(comment)
     }
 
     @ViewBuilder
@@ -2726,44 +2747,14 @@ struct DiffReviewInlineFeedbackCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Button {
-                DiffReviewInlineFeedbackCardInteraction.select(item, onSelect: onSelect)
-            } label: {
-                HStack(alignment: .top, spacing: 8) {
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(statusColor)
-                        .frame(width: 3)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack(spacing: 6) {
-                            Text(item.providerName)
-                                .font(.system(size: 10, weight: .semibold))
-                                .foregroundColor(statusColor)
-
-                            if let author = item.author, !author.isEmpty {
-                                Text(author)
-                                    .font(.system(size: 10))
-                                    .foregroundColor(theme.color("fg-muted"))
-                            }
-
-                            if let line = item.anchor.line {
-                                Text("line \(line)")
-                                    .font(.system(size: 10))
-                                    .foregroundColor(theme.color("fg-faint"))
-                            }
-                        }
-                        .lineLimit(1)
-
-                        DiffReviewInlineFeedbackMarkdown.view(item.bodyPreview)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    Spacer(minLength: 0)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("diff-review-inline-feedback-select-\(item.id)")
+            cardContent
+                .background(
+                    ReviewDraftCommentActionPressMarker(
+                        identifier: "diff-review-inline-feedback-select-\(item.id)",
+                        label: "Select inline feedback",
+                        action: select
+                    )
+                )
 
             actionRow
         }
@@ -2785,6 +2776,48 @@ struct DiffReviewInlineFeedbackCard: View {
         .onHover { hovering in
             onHoverChange(Self.reportsHover(isHovered: hovering, isFocused: isFocused))
         }
+    }
+
+    private var cardContent: some View {
+        HStack(alignment: .top, spacing: 8) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(statusColor)
+                .frame(width: 3)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: select)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(item.providerName)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(statusColor)
+
+                    if let author = item.author, !author.isEmpty {
+                        Text(author)
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.color("fg-muted"))
+                    }
+
+                    if let line = item.anchor.line {
+                        Text("line \(line)")
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.color("fg-faint"))
+                    }
+                }
+                .lineLimit(1)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: select)
+
+                DiffReviewInlineFeedbackMarkdown.view(item.bodyPreview, noninteractiveTapAction: select)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func select() {
+        DiffReviewInlineFeedbackCardInteraction.select(item, onSelect: onSelect)
     }
 
     static func reportsHover(isHovered: Bool, isFocused: Bool) -> Bool {

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -2238,6 +2238,8 @@ enum DiffReviewInlineFeedbackMarkdown {
                 return items.map { ACPMarkdownInlineRenderer.plainText($0.text) }.joined(separator: " ")
             case .code(_, let body), .streamingCode(_, let body):
                 return body
+            case .mermaid(let source):
+                return source
             case .table(let header, let rows):
                 return ([header] + rows).map { row in
                     row.map { ACPMarkdownInlineRenderer.plainText($0) }.joined(separator: " ")

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -489,7 +489,7 @@ final class TabsManager {
         revealEndLine: Int? = nil
     ) -> Tab {
         let shouldRevealInMarkdownEditor = (revealLine != nil || revealCharacter != nil)
-            && MarkdownFileType.isMarkdown(relativePath: relativePath)
+            && MarkdownFileType.supportsRichPreview(relativePath: relativePath)
         if var file = byWorktree[worktreeId],
            let idx = file.tabs.firstIndex(where: {
                if case .editor(let s) = $0 { return s.relativePath == relativePath }
@@ -556,7 +556,7 @@ final class TabsManager {
     ) -> Tab {
         let absPath = absoluteURL.path
         let shouldRevealInMarkdownEditor = (revealLine != nil || revealCharacter != nil)
-            && MarkdownFileType.isMarkdown(relativePath: absPath)
+            && MarkdownFileType.supportsRichPreview(relativePath: absPath)
         if var file = byWorktree[worktreeId],
            let idx = file.tabs.firstIndex(where: {
                if case .editor(let s) = $0 { return s.externalAbsolutePath == absPath }

--- a/Alas/Sources/Code/LSP/Features/CompletionDocumentationRenderer.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionDocumentationRenderer.swift
@@ -14,7 +14,8 @@ enum CompletionDocumentationRenderer {
             theme: theme,
             monospacedFontFamily: monospacedFontFamily,
             monospacedFontSize: monospacedFontSize,
-            baseDirectory: URL(fileURLWithPath: "/")
+            baseDirectory: URL(fileURLWithPath: "/"),
+            mermaidProfile: .compact
         )
     }
 }

--- a/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
@@ -17,6 +17,7 @@ struct CompletionPopup: View {
     let documentation: MarkdownRenderResult?
     let theme: Theme
     let onChoose: (Int) -> Void
+    let onWillPresentMermaidViewer: () -> Void
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
@@ -47,7 +48,11 @@ struct CompletionPopup: View {
             if let documentation, documentation.attributedString.length > 0 {
                 Divider()
 
-                CompletionDocumentationView(result: documentation, theme: theme)
+                CompletionDocumentationView(
+                    result: documentation,
+                    theme: theme,
+                    onWillPresentMermaidViewer: onWillPresentMermaidViewer
+                )
                 .frame(width: 320, height: popupMaxHeight, alignment: .topLeading)
             }
         }
@@ -101,6 +106,7 @@ struct CompletionPopup: View {
 private struct CompletionDocumentationView: NSViewRepresentable {
     let result: MarkdownRenderResult
     let theme: Theme
+    let onWillPresentMermaidViewer: () -> Void
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSScrollView()
@@ -122,20 +128,29 @@ private struct CompletionDocumentationView: NSViewRepresentable {
         scrollView.borderType = .noBorder
 
         context.coordinator.textView = textView
-        textView.textStorage?.setAttributedString(result.attributedString)
+        context.coordinator.apply(result: result, theme: theme, to: textView)
         scrollView.backgroundColor = NSColor(theme.color("bg-1"))
         return scrollView
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
-        textView.textStorage?.setAttributedString(result.attributedString)
+        context.coordinator.apply(result: result, theme: theme, to: textView)
         textView.linkTextAttributes = linkAttributes(theme: theme)
         nsView.backgroundColor = NSColor(theme.color("bg-1"))
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(
+            onWillPresentMermaidViewer: onWillPresentMermaidViewer
+        )
+    }
+
+    static func dismantleNSView(
+        _ nsView: NSScrollView,
+        coordinator: Coordinator
+    ) {
+        coordinator.cancel()
     }
 
     private func linkAttributes(theme: Theme) -> [NSAttributedString.Key: Any] {
@@ -147,8 +162,44 @@ private struct CompletionDocumentationView: NSViewRepresentable {
 
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
+        let mermaidCoordinator: MermaidAttachmentCoordinator
+        var appliedRevision: UUID?
+
         weak var textView: NSTextView? {
             didSet { textView?.delegate = self }
+        }
+
+        init(onWillPresentMermaidViewer: @escaping () -> Void) {
+            self.mermaidCoordinator = MermaidAttachmentCoordinator(
+                mode: .compact,
+                onWillPresentViewer: onWillPresentMermaidViewer
+            )
+        }
+
+        func apply(
+            result: MarkdownRenderResult,
+            theme: Theme,
+            to textView: NSTextView
+        ) {
+            mermaidCoordinator.updateViewerTheme(theme)
+            guard appliedRevision != result.revision else { return }
+
+            mermaidCoordinator.cancelAll()
+            textView.textStorage?.setAttributedString(result.attributedString)
+            mermaidCoordinator.apply(
+                result.mermaidAttachments,
+                revision: result.revision,
+                to: textView,
+                onTextStorageDelta: nil
+            )
+            appliedRevision = result.revision
+        }
+
+        func cancel() {
+            mermaidCoordinator.cancelAll()
+            appliedRevision = nil
+            textView?.delegate = nil
+            textView = nil
         }
 
         func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {

--- a/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
@@ -16,6 +16,7 @@ struct CompletionPopup: View {
     let selection: Int
     let documentation: MarkdownRenderResult?
     let theme: Theme
+    let mermaidCancellation: MermaidRenderCancellation
     let onChoose: (Int) -> Void
     let onWillPresentMermaidViewer: () -> Void
 
@@ -51,6 +52,7 @@ struct CompletionPopup: View {
                 CompletionDocumentationView(
                     result: documentation,
                     theme: theme,
+                    mermaidCancellation: mermaidCancellation,
                     onWillPresentMermaidViewer: onWillPresentMermaidViewer
                 )
                 .frame(width: 320, height: popupMaxHeight, alignment: .topLeading)
@@ -106,6 +108,7 @@ struct CompletionPopup: View {
 private struct CompletionDocumentationView: NSViewRepresentable {
     let result: MarkdownRenderResult
     let theme: Theme
+    let mermaidCancellation: MermaidRenderCancellation
     let onWillPresentMermaidViewer: () -> Void
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -142,7 +145,8 @@ private struct CompletionDocumentationView: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
-            onWillPresentMermaidViewer: onWillPresentMermaidViewer
+            onWillPresentMermaidViewer: onWillPresentMermaidViewer,
+            mermaidCancellation: mermaidCancellation
         )
     }
 
@@ -169,11 +173,18 @@ private struct CompletionDocumentationView: NSViewRepresentable {
             didSet { textView?.delegate = self }
         }
 
-        init(onWillPresentMermaidViewer: @escaping () -> Void) {
+        init(
+            onWillPresentMermaidViewer: @escaping () -> Void,
+            mermaidCancellation: MermaidRenderCancellation
+        ) {
             self.mermaidCoordinator = MermaidAttachmentCoordinator(
                 mode: .compact,
                 onWillPresentViewer: onWillPresentMermaidViewer
             )
+            super.init()
+            mermaidCancellation.register { [weak self] in
+                self?.cancelRenders()
+            }
         }
 
         func apply(
@@ -196,10 +207,14 @@ private struct CompletionDocumentationView: NSViewRepresentable {
         }
 
         func cancel() {
-            mermaidCoordinator.cancelAll()
-            appliedRevision = nil
+            cancelRenders()
             textView?.delegate = nil
             textView = nil
+        }
+
+        func cancelRenders() {
+            mermaidCoordinator.cancelAll()
+            appliedRevision = nil
         }
 
         func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {

--- a/Alas/Sources/Code/LSP/Features/CompletionWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionWindowController.swift
@@ -11,6 +11,8 @@ final class CompletionWindowController {
 
     var isVisible: Bool { overlay.isVisible }
 
+    var screenFrame: NSRect? { overlay.screenFrame }
+
     func show(
         rows: [CompletionPopupRow],
         selection: Int,
@@ -27,7 +29,10 @@ final class CompletionWindowController {
             selection: selection,
             documentation: documentation,
             theme: theme,
-            onChoose: onChoose
+            onChoose: onChoose,
+            onWillPresentMermaidViewer: { [weak self] in
+                self?.hide()
+            }
         )
         if let hostingController {
             hostingController.rootView = root

--- a/Alas/Sources/Code/LSP/Features/CompletionWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionWindowController.swift
@@ -7,6 +7,7 @@ final class CompletionWindowController {
     private let listWidth: CGFloat = 320
 
     private let overlay = EditorOverlayPanel()
+    private let mermaidCancellation = MermaidRenderCancellation()
     private var hostingController: NSHostingController<CompletionPopup>?
 
     var isVisible: Bool { overlay.isVisible }
@@ -29,6 +30,7 @@ final class CompletionWindowController {
             selection: selection,
             documentation: documentation,
             theme: theme,
+            mermaidCancellation: mermaidCancellation,
             onChoose: onChoose,
             onWillPresentMermaidViewer: { [weak self] in
                 self?.hide()
@@ -49,6 +51,7 @@ final class CompletionWindowController {
     }
 
     func hide() {
+        mermaidCancellation.cancel()
         overlay.hide()
     }
 }

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -411,7 +411,10 @@ final class HoverFeature {
             size: preferredSize,
             theme: theme,
             anchor: anchor,
-            in: textView
+            in: textView,
+            onWillPresentMermaidViewer: { [weak self] in
+                self?.dismiss()
+            }
         )
         shownSymbolRange = symbolRange
         installMouseMonitor()

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -400,7 +400,8 @@ final class HoverFeature {
             theme: theme,
             monospacedFontFamily: family,
             monospacedFontSize: size,
-            baseDirectory: URL(fileURLWithPath: "/")
+            baseDirectory: URL(fileURLWithPath: "/"),
+            mermaidProfile: .compact
         )
         let preferredSize = HoverFeatureTesting.computePreferredSize(for: renderResult)
         let anchor = textView.symbolAnchorRect(for: symbolRange)

--- a/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
@@ -15,14 +15,13 @@ final class HoverWindowController {
         size: NSSize,
         theme: Theme,
         anchor: NSRect,
-        in textView: NSTextView
+        in textView: NSTextView,
+        onWillPresentMermaidViewer: @escaping () -> Void
     ) {
         let root = HoverPopupView(
             result: result,
             theme: theme,
-            onWillPresentMermaidViewer: { [weak self] in
-                self?.hide()
-            }
+            onWillPresentMermaidViewer: onWillPresentMermaidViewer
         )
         if let hostingController {
             hostingController.rootView = root

--- a/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @MainActor
 final class HoverWindowController {
     private let overlay = EditorOverlayPanel()
+    private let mermaidCancellation = MermaidRenderCancellation()
     private var hostingController: NSHostingController<HoverPopupView>?
 
     var isVisible: Bool { overlay.isVisible }
@@ -21,6 +22,7 @@ final class HoverWindowController {
         let root = HoverPopupView(
             result: result,
             theme: theme,
+            mermaidCancellation: mermaidCancellation,
             onWillPresentMermaidViewer: onWillPresentMermaidViewer
         )
         if let hostingController {
@@ -38,6 +40,7 @@ final class HoverWindowController {
     }
 
     func hide() {
+        mermaidCancellation.cancel()
         overlay.hide()
     }
 }
@@ -45,12 +48,14 @@ final class HoverWindowController {
 struct HoverPopupView: View {
     let result: MarkdownRenderResult
     let theme: Theme
+    let mermaidCancellation: MermaidRenderCancellation
     let onWillPresentMermaidViewer: () -> Void
 
     var body: some View {
         HoverPopupContent(
             result: result,
             theme: theme,
+            mermaidCancellation: mermaidCancellation,
             onWillPresentMermaidViewer: onWillPresentMermaidViewer
         )
             .background(Color(nsColor: NSColor(theme.color("bg-1"))))
@@ -65,6 +70,7 @@ struct HoverPopupView: View {
 private struct HoverPopupContent: NSViewRepresentable {
     let result: MarkdownRenderResult
     let theme: Theme
+    let mermaidCancellation: MermaidRenderCancellation
     let onWillPresentMermaidViewer: () -> Void
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -99,7 +105,8 @@ private struct HoverPopupContent: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
-            onWillPresentMermaidViewer: onWillPresentMermaidViewer
+            onWillPresentMermaidViewer: onWillPresentMermaidViewer,
+            mermaidCancellation: mermaidCancellation
         )
     }
 
@@ -119,11 +126,18 @@ private struct HoverPopupContent: NSViewRepresentable {
             didSet { textView?.delegate = self }
         }
 
-        init(onWillPresentMermaidViewer: @escaping () -> Void) {
+        init(
+            onWillPresentMermaidViewer: @escaping () -> Void,
+            mermaidCancellation: MermaidRenderCancellation
+        ) {
             self.mermaidCoordinator = MermaidAttachmentCoordinator(
                 mode: .compact,
                 onWillPresentViewer: onWillPresentMermaidViewer
             )
+            super.init()
+            mermaidCancellation.register { [weak self] in
+                self?.cancelRenders()
+            }
         }
 
         func apply(
@@ -146,10 +160,14 @@ private struct HoverPopupContent: NSViewRepresentable {
         }
 
         func cancel() {
-            mermaidCoordinator.cancelAll()
-            appliedRevision = nil
+            cancelRenders()
             textView?.delegate = nil
             textView = nil
+        }
+
+        func cancelRenders() {
+            mermaidCoordinator.cancelAll()
+            appliedRevision = nil
         }
 
         func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {

--- a/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
@@ -17,7 +17,13 @@ final class HoverWindowController {
         anchor: NSRect,
         in textView: NSTextView
     ) {
-        let root = HoverPopupView(result: result, theme: theme)
+        let root = HoverPopupView(
+            result: result,
+            theme: theme,
+            onWillPresentMermaidViewer: { [weak self] in
+                self?.hide()
+            }
+        )
         if let hostingController {
             hostingController.rootView = root
         } else {
@@ -40,9 +46,14 @@ final class HoverWindowController {
 struct HoverPopupView: View {
     let result: MarkdownRenderResult
     let theme: Theme
+    let onWillPresentMermaidViewer: () -> Void
 
     var body: some View {
-        HoverPopupContent(result: result, theme: theme)
+        HoverPopupContent(
+            result: result,
+            theme: theme,
+            onWillPresentMermaidViewer: onWillPresentMermaidViewer
+        )
             .background(Color(nsColor: NSColor(theme.color("bg-1"))))
             .overlay {
                 RoundedRectangle(cornerRadius: 6)
@@ -55,6 +66,7 @@ struct HoverPopupView: View {
 private struct HoverPopupContent: NSViewRepresentable {
     let result: MarkdownRenderResult
     let theme: Theme
+    let onWillPresentMermaidViewer: () -> Void
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSScrollView()
@@ -75,25 +87,70 @@ private struct HoverPopupContent: NSViewRepresentable {
         scrollView.borderType = .noBorder
 
         context.coordinator.textView = textView
-        textView.textStorage?.setAttributedString(result.attributedString)
+        context.coordinator.apply(result: result, theme: theme, to: textView)
         scrollView.backgroundColor = NSColor(theme.color("bg-1"))
         return scrollView
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
-        textView.textStorage?.setAttributedString(result.attributedString)
+        context.coordinator.apply(result: result, theme: theme, to: textView)
         nsView.backgroundColor = NSColor(theme.color("bg-1"))
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(
+            onWillPresentMermaidViewer: onWillPresentMermaidViewer
+        )
+    }
+
+    static func dismantleNSView(
+        _ nsView: NSScrollView,
+        coordinator: Coordinator
+    ) {
+        coordinator.cancel()
     }
 
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
+        let mermaidCoordinator: MermaidAttachmentCoordinator
+        var appliedRevision: UUID?
+
         weak var textView: NSTextView? {
             didSet { textView?.delegate = self }
+        }
+
+        init(onWillPresentMermaidViewer: @escaping () -> Void) {
+            self.mermaidCoordinator = MermaidAttachmentCoordinator(
+                mode: .compact,
+                onWillPresentViewer: onWillPresentMermaidViewer
+            )
+        }
+
+        func apply(
+            result: MarkdownRenderResult,
+            theme: Theme,
+            to textView: NSTextView
+        ) {
+            mermaidCoordinator.updateViewerTheme(theme)
+            guard appliedRevision != result.revision else { return }
+
+            mermaidCoordinator.cancelAll()
+            textView.textStorage?.setAttributedString(result.attributedString)
+            mermaidCoordinator.apply(
+                result.mermaidAttachments,
+                revision: result.revision,
+                to: textView,
+                onTextStorageDelta: nil
+            )
+            appliedRevision = result.revision
+        }
+
+        func cancel() {
+            mermaidCoordinator.cancelAll()
+            appliedRevision = nil
+            textView?.delegate = nil
+            textView = nil
         }
 
         func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {

--- a/Alas/Sources/Code/Markdown/MarkdownFileType.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownFileType.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-/// File-type detection for markdown documents. Matches by extension
-/// (`.md`, `.markdown`, `.mdx`, case-insensitive) and a small set of
-/// extension-less conventional filenames found in source repos.
+/// File-type detection for markdown documents and standalone Mermaid files.
 enum MarkdownFileType {
     private static let extensions: Set<String> = ["md", "markdown", "mdx"]
     private static let extensionlessNames: Set<String> = [
@@ -17,5 +15,14 @@ enum MarkdownFileType {
             return extensions.contains(ext)
         }
         return extensionlessNames.contains(filename.lowercased())
+    }
+
+    static func isStandaloneMermaid(relativePath: String) -> Bool {
+        let ext = ((relativePath as NSString).pathExtension).lowercased()
+        return ext == "mmd" || ext == "mermaid"
+    }
+
+    static func supportsRichPreview(relativePath: String) -> Bool {
+        isMarkdown(relativePath: relativePath) || isStandaloneMermaid(relativePath: relativePath)
     }
 }

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -20,8 +20,14 @@ final class MarkdownPreviewController: NSObject {
     private nonisolated(unsafe) var anchorObserver: NSObjectProtocol?
     private(set) var lastAppliedRevision: UUID?
 
-    init(theme: Theme) {
-        mermaidCoordinator = MermaidAttachmentCoordinator(theme: theme)
+    init(
+        theme: Theme,
+        mermaidService: MermaidRenderService = .shared
+    ) {
+        mermaidCoordinator = MermaidAttachmentCoordinator(
+            service: mermaidService,
+            theme: theme
+        )
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = true
         scroll.hasHorizontalScroller = false
@@ -125,6 +131,10 @@ final class MarkdownPreviewController: NSObject {
             .foregroundColor: NSColor(theme.color("accent")),
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
+    }
+
+    func dismantle() {
+        mermaidCoordinator.cancelAll()
     }
 
     func shiftAnchors(startingAt location: Int, by delta: Int) {

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -89,6 +89,8 @@ final class MarkdownPreviewController: NSObject {
     /// Replace the rendered content. Must be called on the main thread.
     func apply(result: MarkdownRenderResult) {
         guard result.revision != lastAppliedRevision else { return }
+        let sourceDisclosureSnapshot = mermaidCoordinator
+            .explicitSourceDisclosureSnapshot(in: textView)
         mermaidCoordinator.cancelAll()
         lastAppliedRevision = result.revision
         anchorRanges = result.anchorRanges
@@ -111,6 +113,10 @@ final class MarkdownPreviewController: NSObject {
             onTextStorageDelta: { [weak self] location, delta in
                 self?.shiftAnchors(startingAt: location, by: delta)
             }
+        )
+        mermaidCoordinator.restoreExplicitSourceDisclosures(
+            sourceDisclosureSnapshot,
+            in: textView
         )
     }
 
@@ -135,6 +141,10 @@ final class MarkdownPreviewController: NSObject {
 
     func dismantle() {
         mermaidCoordinator.cancelAll()
+    }
+
+    func showMermaidSourceForTesting(id: String) {
+        mermaidCoordinator.showSource(id: id, in: textView)
     }
 
     func shiftAnchors(startingAt location: Int, by delta: Int) {

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -16,9 +16,12 @@ final class MarkdownPreviewController: NSObject {
     let scrollView: NSScrollView
 
     private let imageLoader = MarkdownImageLoader()
+    private let mermaidCoordinator: MermaidAttachmentCoordinator
     private nonisolated(unsafe) var anchorObserver: NSObjectProtocol?
+    private(set) var lastAppliedRevision: UUID?
 
     init(theme: Theme) {
+        mermaidCoordinator = MermaidAttachmentCoordinator(theme: theme)
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = true
         scroll.hasHorizontalScroller = false
@@ -79,6 +82,9 @@ final class MarkdownPreviewController: NSObject {
 
     /// Replace the rendered content. Must be called on the main thread.
     func apply(result: MarkdownRenderResult) {
+        guard result.revision != lastAppliedRevision else { return }
+        mermaidCoordinator.cancelAll()
+        lastAppliedRevision = result.revision
         anchorRanges = result.anchorRanges
         textView.textStorage?.setAttributedString(result.attributedString)
         for ref in result.remoteImages {
@@ -92,6 +98,14 @@ final class MarkdownPreviewController: NSObject {
                 applyRemoteImage(cached, to: ref.attachment)
             }
         }
+        mermaidCoordinator.apply(
+            result.mermaidAttachments,
+            revision: result.revision,
+            to: textView,
+            onTextStorageDelta: { [weak self] location, delta in
+                self?.shiftAnchors(startingAt: location, by: delta)
+            }
+        )
     }
 
     /// Scroll the preview so the anchor at `slug` is at the top.
@@ -103,6 +117,7 @@ final class MarkdownPreviewController: NSObject {
     /// Refresh the chrome colors that depend on the current theme. Safe to
     /// call repeatedly; idempotent if the theme hasn't actually changed.
     func reapplyTheme(_ theme: Theme) {
+        mermaidCoordinator.updateViewerTheme(theme)
         let bg = NSColor(theme.color("bg-1"))
         scrollView.backgroundColor = bg
         textView.backgroundColor = bg
@@ -110,6 +125,23 @@ final class MarkdownPreviewController: NSObject {
             .foregroundColor: NSColor(theme.color("accent")),
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
+    }
+
+    func shiftAnchors(startingAt location: Int, by delta: Int) {
+        guard delta != 0 else { return }
+        for (slug, range) in anchorRanges {
+            if range.location >= location {
+                anchorRanges[slug] = NSRange(
+                    location: max(0, range.location + delta),
+                    length: range.length
+                )
+            } else if NSMaxRange(range) > location {
+                anchorRanges[slug] = NSRange(
+                    location: range.location,
+                    length: max(0, range.length + delta)
+                )
+            }
+        }
     }
 
     /// Install a loaded `NSImage` into the placeholder attachment, resize it
@@ -124,10 +156,34 @@ final class MarkdownPreviewController: NSObject {
         } else {
             attachment.bounds = NSRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
         }
-        if let storage = textView.textStorage {
-            let len = storage.length
-            storage.edited([.editedAttributes], range: NSRange(location: 0, length: len), changeInLength: 0)
+        guard let storage = textView.textStorage,
+              let range = attachmentRange(for: attachment, in: storage)
+        else { return }
+        storage.edited([.editedAttributes], range: range, changeInLength: 0)
+        for layoutManager in storage.layoutManagers {
+            layoutManager.invalidateLayout(
+                forCharacterRange: range,
+                actualCharacterRange: nil
+            )
+            layoutManager.invalidateDisplay(forCharacterRange: range)
         }
+    }
+
+    private func attachmentRange(
+        for attachment: NSTextAttachment,
+        in storage: NSTextStorage
+    ) -> NSRange? {
+        var found: NSRange?
+        storage.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: storage.length)
+        ) { value, range, stop in
+            guard let candidate = value as? NSTextAttachment,
+                  candidate === attachment else { return }
+            found = range
+            stop.pointee = true
+        }
+        return found
     }
 
     deinit {

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
@@ -28,4 +28,11 @@ struct MarkdownPreviewView: NSViewRepresentable {
         // disclosure across those duplicate updates.
         context.coordinator.apply(result: result)
     }
+
+    static func dismantleNSView(
+        _ nsView: NSScrollView,
+        coordinator: MarkdownPreviewController
+    ) {
+        coordinator.dismantle()
+    }
 }

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
@@ -23,6 +23,9 @@ struct MarkdownPreviewView: NSViewRepresentable {
         // value without recreating the coordinator, so we must push the new
         // chrome colors into the existing NSScrollView/NSTextView here.
         context.coordinator.reapplyTheme(theme)
+        // SwiftUI may call this repeatedly with the same value. The result's
+        // revision lets the controller preserve attachment tasks and source
+        // disclosure across those duplicate updates.
         context.coordinator.apply(result: result)
     }
 }

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -36,7 +36,7 @@ final class MarkdownRenderer {
     private var anchorRanges: [String: NSRange] = [:]
     private var remoteImages: [RemoteImageReference] = []
     private var mermaidAttachments: [MermaidAttachmentReference] = []
-    private var mermaidIndex = 0
+    private var mermaidSourceOccurrences: [String: Int] = [:]
     private var mermaidProfile: MermaidPresentationProfile = .full
     private var theme: Theme!
     private var monoFamily: String = "JetBrainsMono Nerd Font"
@@ -89,7 +89,7 @@ final class MarkdownRenderer {
         self.anchorRanges = [:]
         self.remoteImages = []
         self.mermaidAttachments = []
-        self.mermaidIndex = 0
+        self.mermaidSourceOccurrences = [:]
         self.mermaidProfile = mermaidProfile
         self.theme = theme
         self.monoFamily = monospacedFontFamily
@@ -337,8 +337,7 @@ final class MarkdownRenderer {
             let source = block.code.hasSuffix("\n")
                 ? String(block.code.dropLast())
                 : block.code
-            let id = "mermaid-\(mermaidIndex)"
-            mermaidIndex += 1
+            let id = mermaidID(for: source)
             let attachment = MermaidTextAttachment(
                 id: id,
                 source: source,
@@ -382,6 +381,25 @@ final class MarkdownRenderer {
             }
         }
         appendPlain("\n")
+    }
+
+    private func mermaidID(for source: String) -> String {
+        let key = Self.stableMermaidSourceKey(source)
+        let occurrence = mermaidSourceOccurrences[key, default: 0]
+        mermaidSourceOccurrences[key] = occurrence + 1
+        if occurrence == 0 {
+            return "mermaid-\(key)"
+        }
+        return "mermaid-\(key)-\(occurrence)"
+    }
+
+    static func stableMermaidSourceKey(_ source: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in source.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        return String(format: "%016llx", hash)
     }
 
     private struct RenderedTableCell {

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -37,6 +37,7 @@ final class MarkdownRenderer {
     private var remoteImages: [RemoteImageReference] = []
     private var mermaidAttachments: [MermaidAttachmentReference] = []
     private var mermaidSourceOccurrences: [String: Int] = [:]
+    private var mermaidSourceTotals: [String: Int] = [:]
     private var mermaidProfile: MermaidPresentationProfile = .full
     private var theme: Theme!
     private var monoFamily: String = "JetBrainsMono Nerd Font"
@@ -90,6 +91,7 @@ final class MarkdownRenderer {
         self.remoteImages = []
         self.mermaidAttachments = []
         self.mermaidSourceOccurrences = [:]
+        self.mermaidSourceTotals = Self.mermaidSourceTotals(in: document)
         self.mermaidProfile = mermaidProfile
         self.theme = theme
         self.monoFamily = monospacedFontFamily
@@ -332,12 +334,8 @@ final class MarkdownRenderer {
     }
 
     private func visitCodeBlock(_ block: CodeBlock) {
-        if MermaidFence.isMermaid(language: block.language),
-           !block.code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let source = block.code.hasSuffix("\n")
-                ? String(block.code.dropLast())
-                : block.code
-            let id = mermaidID(for: source)
+        if let source = Self.mermaidSource(from: block) {
+            let id = mermaidID(for: source, block: block)
             let attachment = MermaidTextAttachment(
                 id: id,
                 source: source,
@@ -383,8 +381,14 @@ final class MarkdownRenderer {
         appendPlain("\n")
     }
 
-    private func mermaidID(for source: String) -> String {
+    private func mermaidID(for source: String, block: CodeBlock) -> String {
         let key = Self.stableMermaidSourceKey(source)
+        if mermaidSourceTotals[key, default: 0] <= 1 {
+            return "mermaid-\(key)"
+        }
+        if let locationKey = Self.stableMermaidLocationKey(block.range) {
+            return "mermaid-\(key)-\(locationKey)"
+        }
         let occurrence = mermaidSourceOccurrences[key, default: 0]
         mermaidSourceOccurrences[key] = occurrence + 1
         if occurrence == 0 {
@@ -400,6 +404,46 @@ final class MarkdownRenderer {
             hash &*= 0x100000001b3
         }
         return String(format: "%016llx", hash)
+    }
+
+    private static func mermaidSource(from block: CodeBlock) -> String? {
+        guard MermaidFence.isMermaid(language: block.language),
+              !block.code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return block.code.hasSuffix("\n")
+            ? String(block.code.dropLast())
+            : block.code
+    }
+
+    private static func mermaidSourceTotals(in markup: Markup) -> [String: Int] {
+        var totals: [String: Int] = [:]
+        collectMermaidSourceTotals(in: markup, into: &totals)
+        return totals
+    }
+
+    private static func collectMermaidSourceTotals(
+        in markup: Markup,
+        into totals: inout [String: Int]
+    ) {
+        if let block = markup as? CodeBlock,
+           let source = mermaidSource(from: block) {
+            totals[stableMermaidSourceKey(source), default: 0] += 1
+        }
+        for child in markup.children {
+            collectMermaidSourceTotals(in: child, into: &totals)
+        }
+    }
+
+    private static func stableMermaidLocationKey(_ range: SourceRange?) -> String? {
+        guard let range else { return nil }
+        return [
+            range.lowerBound.line,
+            range.lowerBound.column,
+            range.upperBound.line,
+            range.upperBound.column
+        ]
+        .map(String.init)
+        .joined(separator: "-")
     }
 
     private struct RenderedTableCell {

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -7,9 +7,19 @@ import SwiftUI
 /// link-click handler and the async remote-image loader (filled in by
 /// later tasks).
 struct MarkdownRenderResult {
+    let revision: UUID
     let attributedString: NSAttributedString
     let anchorRanges: [String: NSRange]
     let remoteImages: [RemoteImageReference]
+    let mermaidAttachments: [MermaidAttachmentReference]
+}
+
+struct MermaidAttachmentReference {
+    let id: String
+    let source: String
+    let profile: MermaidPresentationProfile
+    let theme: MermaidDiagramTheme
+    let attachment: MermaidTextAttachment
 }
 
 /// Captures one `https://`-image attachment in the result. The
@@ -25,6 +35,9 @@ final class MarkdownRenderer {
     private var output: NSMutableAttributedString = .init()
     private var anchorRanges: [String: NSRange] = [:]
     private var remoteImages: [RemoteImageReference] = []
+    private var mermaidAttachments: [MermaidAttachmentReference] = []
+    private var mermaidIndex = 0
+    private var mermaidProfile: MermaidPresentationProfile = .full
     private var theme: Theme!
     private var monoFamily: String = "JetBrainsMono Nerd Font"
     private var monoSize: CGFloat = 13
@@ -69,11 +82,15 @@ final class MarkdownRenderer {
         monospacedFontFamily: String,
         monospacedFontSize: Int,
         baseDirectory: URL,
-        worktreeRoot: URL? = nil
+        worktreeRoot: URL? = nil,
+        mermaidProfile: MermaidPresentationProfile = .full
     ) -> MarkdownRenderResult {
         self.output = NSMutableAttributedString()
         self.anchorRanges = [:]
         self.remoteImages = []
+        self.mermaidAttachments = []
+        self.mermaidIndex = 0
+        self.mermaidProfile = mermaidProfile
         self.theme = theme
         self.monoFamily = monospacedFontFamily
         self.monoSize = CGFloat(monospacedFontSize)
@@ -93,9 +110,11 @@ final class MarkdownRenderer {
             visit(child)
         }
         return MarkdownRenderResult(
+            revision: UUID(),
             attributedString: output.copy() as! NSAttributedString,
             anchorRanges: anchorRanges,
-            remoteImages: remoteImages
+            remoteImages: remoteImages,
+            mermaidAttachments: mermaidAttachments
         )
     }
 
@@ -313,6 +332,30 @@ final class MarkdownRenderer {
     }
 
     private func visitCodeBlock(_ block: CodeBlock) {
+        if MermaidFence.isMermaid(language: block.language),
+           !block.code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let source = block.code.hasSuffix("\n")
+                ? String(block.code.dropLast())
+                : block.code
+            let id = "mermaid-\(mermaidIndex)"
+            mermaidIndex += 1
+            let attachment = MermaidTextAttachment(
+                id: id,
+                source: source,
+                profile: mermaidProfile
+            )
+            output.append(NSAttributedString(attachment: attachment))
+            output.append(NSAttributedString(string: "\n"))
+            mermaidAttachments.append(MermaidAttachmentReference(
+                id: id,
+                source: source,
+                profile: mermaidProfile,
+                theme: MermaidDiagramTheme(theme: theme),
+                attachment: attachment
+            ))
+            return
+        }
+
         let baseAttrs: [NSAttributedString.Key: Any] = [
             .font: monospaceFont(size: monoSize),
             .foregroundColor: NSColor(theme.color("fg")),

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -19,6 +19,7 @@ struct MarkdownTabView: View {
 
     @State private var renderCache = MarkdownPreviewCache<MarkdownRenderResult>()
     @State private var debounceTask: Task<Void, Never>?
+    @State private var mermaidPreviewSource = ""
 
     // Editor/preview divider drag: transient during the drag, committed to
     // the tab store (and disk) once on drag end.
@@ -41,6 +42,12 @@ struct MarkdownTabView: View {
 
     private var splitFraction: Double {
         appState.tabs.editorTabState(worktreeId: worktreeId, tabId: tabId)?.markdownSplitFraction ?? 0.5
+    }
+
+    private var isStandaloneMermaid: Bool {
+        MarkdownFileType.isStandaloneMermaid(
+            relativePath: externalAbsolutePath ?? relativePath
+        )
     }
 
     private var buffer: EditorBuffer {
@@ -187,7 +194,9 @@ struct MarkdownTabView: View {
 
     @ViewBuilder
     private var preview: some View {
-        if let renderResult = renderCache.value(for: renderIdentity) {
+        if isStandaloneMermaid {
+            MermaidDiagramBlockView(source: mermaidPreviewSource, profile: .full)
+        } else if let renderResult = renderCache.value(for: renderIdentity) {
             MarkdownPreviewView(result: renderResult, onLinkClick: handleLinkClick)
         } else {
             Color.clear.onAppear { scheduleRender(immediate: true) }
@@ -249,7 +258,10 @@ struct MarkdownTabView: View {
         }
         debounceTask?.cancel()
         let renderIdentity = self.renderIdentity
-        renderCache.beginRender(for: renderIdentity)
+        let isStandaloneMermaid = self.isStandaloneMermaid
+        if !isStandaloneMermaid {
+            renderCache.beginRender(for: renderIdentity)
+        }
         let buffer = self.buffer
         let theme = self.theme
         let fontFamily = appState.config.code.fontFamily
@@ -264,6 +276,10 @@ struct MarkdownTabView: View {
                 if Task.isCancelled { return }
             }
             let source = buffer.storage.string
+            if isStandaloneMermaid {
+                mermaidPreviewSource = source
+                return
+            }
             let parsed = MarkdownParser.parse(source)
             let result = MarkdownRenderer().render(
                 document: parsed.document,

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -195,7 +195,7 @@ struct MarkdownTabView: View {
     @ViewBuilder
     private var preview: some View {
         if isStandaloneMermaid {
-            MermaidDiagramBlockView(source: mermaidPreviewSource, profile: .full)
+            StandaloneMermaidPreviewView(source: mermaidPreviewSource)
         } else if let renderResult = renderCache.value(for: renderIdentity) {
             MarkdownPreviewView(result: renderResult, onLinkClick: handleLinkClick)
         } else {
@@ -357,6 +357,21 @@ struct MarkdownTabView: View {
             return
         }
         NSWorkspace.shared.open(url)
+    }
+}
+
+private struct StandaloneMermaidPreviewView: View {
+    let source: String
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        ScrollView(.vertical) {
+            MermaidDiagramBlockView(source: source, profile: .full)
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .background(theme.color("bg-1"))
     }
 }
 

--- a/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
+++ b/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
@@ -20,6 +20,19 @@ struct BeautifulMermaidBackend: MermaidRenderingBackend {
     static let maximumDimension = 8_192
     static let maximumPixels = 16_000_000
 
+    static func validateRaster(
+        width: Int,
+        height: Int
+    ) -> MermaidRenderFailure? {
+        guard width <= maximumDimension,
+              height <= maximumDimension,
+              width * height <= maximumPixels
+        else {
+            return .rasterTooLarge(width: width, height: height)
+        }
+        return nil
+    }
+
     func render(key: MermaidRenderKey) async -> MermaidRenderOutcome {
         let bytes = key.source.utf8.count
         guard bytes > 0 else { return .failed(.empty) }
@@ -38,10 +51,11 @@ struct BeautifulMermaidBackend: MermaidRenderingBackend {
             guard let cg = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else {
                 return .failed(.renderFailed("Renderer returned an image without pixels"))
             }
-            guard cg.width <= Self.maximumDimension,
-                  cg.height <= Self.maximumDimension,
-                  cg.width * cg.height <= Self.maximumPixels else {
-                return .failed(.rasterTooLarge(width: cg.width, height: cg.height))
+            if let failure = Self.validateRaster(
+                width: cg.width,
+                height: cg.height
+            ) {
+                return .failed(failure)
             }
             return .rendered(MermaidRenderedDiagram(
                 image: image,

--- a/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
+++ b/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
@@ -63,6 +63,9 @@ struct BeautifulMermaidBackend: MermaidRenderingBackend {
                 byteCost: cg.width * cg.height * 4
             ))
         } catch {
+            // BeautifulMermaid 1.0.4 does not expose typed errors for its
+            // parser or layout internals. Keep this mapping aligned with its
+            // public diagnostic strings when upgrading the dependency.
             let message = String(describing: error)
             if message.localizedCaseInsensitiveContains("unsupported") {
                 return .failed(.unsupported(message))

--- a/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
+++ b/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
@@ -63,14 +63,15 @@ struct BeautifulMermaidBackend: MermaidRenderingBackend {
             return .failed(.sourceTooLarge(actualBytes: bytes))
         }
         do {
-            let layout = try await Task.detached {
-                try MermaidRenderer.layout(key.source)
-            }.value
+            let layout = try MermaidRenderer.layout(key.source)
             if let failure = Self.preflightRaster(
                 layoutSize: CGSize(width: layout.width, height: layout.height),
                 scale: key.scale
             ) {
                 return .failed(failure)
+            }
+            guard !Task.isCancelled else {
+                return .failed(.renderFailed("Mermaid rendering cancelled"))
             }
             guard let image = try await MermaidRenderer.renderImageAsync(
                 source: key.source,

--- a/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
+++ b/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
@@ -1,0 +1,65 @@
+import AppKit
+import BeautifulMermaid
+
+extension MermaidDiagramTheme {
+    var nativeTheme: DiagramTheme {
+        DiagramTheme(
+            background: BMColor(hex: background),
+            foreground: BMColor(hex: foreground),
+            line: BMColor(hex: line),
+            accent: BMColor(hex: accent),
+            muted: BMColor(hex: muted),
+            surface: BMColor(hex: surface),
+            border: BMColor(hex: border)
+        )
+    }
+}
+
+struct BeautifulMermaidBackend: MermaidRenderingBackend {
+    static let maximumSourceBytes = 256 * 1024
+    static let maximumDimension = 8_192
+    static let maximumPixels = 16_000_000
+
+    func render(key: MermaidRenderKey) async -> MermaidRenderOutcome {
+        let bytes = key.source.utf8.count
+        guard bytes > 0 else { return .failed(.empty) }
+        guard bytes <= Self.maximumSourceBytes else {
+            return .failed(.sourceTooLarge(actualBytes: bytes))
+        }
+        do {
+            guard let image = try await MermaidRenderer.renderImageAsync(
+                source: key.source,
+                theme: key.theme.nativeTheme,
+                scale: CGFloat(key.scale)
+            ) else {
+                return .failed(.renderFailed("Renderer returned no image"))
+            }
+            var rect = CGRect(origin: .zero, size: image.size)
+            guard let cg = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else {
+                return .failed(.renderFailed("Renderer returned an image without pixels"))
+            }
+            guard cg.width <= Self.maximumDimension,
+                  cg.height <= Self.maximumDimension,
+                  cg.width * cg.height <= Self.maximumPixels else {
+                return .failed(.rasterTooLarge(width: cg.width, height: cg.height))
+            }
+            return .rendered(MermaidRenderedDiagram(
+                image: image,
+                pixelSize: CGSize(width: cg.width, height: cg.height),
+                byteCost: cg.width * cg.height * 4
+            ))
+        } catch {
+            let message = String(describing: error)
+            if message.localizedCaseInsensitiveContains("unsupported") {
+                return .failed(.unsupported(message))
+            }
+            if message.localizedCaseInsensitiveContains("parse") {
+                return .failed(.parseFailed(message))
+            }
+            if message.localizedCaseInsensitiveContains("layout") {
+                return .failed(.layoutFailed(message))
+            }
+            return .failed(.renderFailed(message))
+        }
+    }
+}

--- a/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
+++ b/Alas/Sources/Code/Mermaid/BeautifulMermaidBackend.swift
@@ -24,13 +24,36 @@ struct BeautifulMermaidBackend: MermaidRenderingBackend {
         width: Int,
         height: Int
     ) -> MermaidRenderFailure? {
-        guard width <= maximumDimension,
+        guard width > 0,
+              height > 0,
+              width <= maximumDimension,
               height <= maximumDimension,
               width * height <= maximumPixels
         else {
             return .rasterTooLarge(width: width, height: height)
         }
         return nil
+    }
+
+    static func preflightRaster(
+        layoutSize: CGSize,
+        scale: Double
+    ) -> MermaidRenderFailure? {
+        let width = layoutSize.width * scale
+        let height = layoutSize.height * scale
+        guard width.isFinite,
+              height.isFinite,
+              width > 0,
+              height > 0,
+              width <= Double(Int.max),
+              height <= Double(Int.max)
+        else {
+            return .rasterTooLarge(
+                width: maximumDimension + 1,
+                height: maximumDimension + 1
+            )
+        }
+        return validateRaster(width: Int(width), height: Int(height))
     }
 
     func render(key: MermaidRenderKey) async -> MermaidRenderOutcome {
@@ -40,6 +63,15 @@ struct BeautifulMermaidBackend: MermaidRenderingBackend {
             return .failed(.sourceTooLarge(actualBytes: bytes))
         }
         do {
+            let layout = try await Task.detached {
+                try MermaidRenderer.layout(key.source)
+            }.value
+            if let failure = Self.preflightRaster(
+                layoutSize: CGSize(width: layout.width, height: layout.height),
+                scale: key.scale
+            ) {
+                return .failed(failure)
+            }
             guard let image = try await MermaidRenderer.renderImageAsync(
                 source: key.source,
                 theme: key.theme.nativeTheme,

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -17,6 +17,14 @@ final class MermaidRenderCancellation {
     }
 }
 
+struct MermaidSourceDisclosureSnapshot: Equatable {
+    fileprivate let sourcesByID: [String: String]
+
+    var isEmpty: Bool {
+        sourcesByID.isEmpty
+    }
+}
+
 @MainActor
 final class MermaidAttachmentCoordinator {
     private let mode: MermaidPresentationProfile
@@ -55,6 +63,37 @@ final class MermaidAttachmentCoordinator {
     func updateViewerTheme(_ theme: Theme) {
         viewerTheme = theme
         MermaidDiagramViewerController.shared.updateTheme(theme)
+    }
+
+    func explicitSourceDisclosureSnapshot(
+        in textView: NSTextView
+    ) -> MermaidSourceDisclosureSnapshot {
+        guard self.textView === textView,
+              let storage = textView.textStorage
+        else {
+            return MermaidSourceDisclosureSnapshot(sourcesByID: [:])
+        }
+        let sourcesByID = references.reduce(into: [String: String]()) { result, entry in
+            let id = entry.key
+            guard !failureDisclosedSourceIDs.contains(id),
+                  sourceRange(id: id, in: storage) != nil
+            else { return }
+            result[id] = entry.value.source
+        }
+        return MermaidSourceDisclosureSnapshot(sourcesByID: sourcesByID)
+    }
+
+    func restoreExplicitSourceDisclosures(
+        _ snapshot: MermaidSourceDisclosureSnapshot,
+        in textView: NSTextView
+    ) {
+        guard !snapshot.isEmpty else { return }
+        for id in snapshot.sourcesByID.keys.sorted() {
+            guard let source = snapshot.sourcesByID[id],
+                  references[id]?.source == source
+            else { continue }
+            showSource(id: id, in: textView)
+        }
     }
 
     func apply(

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -14,15 +14,18 @@ final class MermaidAttachmentCoordinator {
     private var tasks: [String: Task<Void, Never>] = [:]
     private var onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?
     private var viewerTheme: Theme?
+    private let onWillPresentViewer: (() -> Void)?
 
     init(
         mode: MermaidPresentationProfile = .full,
         service: MermaidRenderService = .shared,
-        theme: Theme? = nil
+        theme: Theme? = nil,
+        onWillPresentViewer: (() -> Void)? = nil
     ) {
         self.mode = mode
         self.service = service
         self.viewerTheme = theme
+        self.onWillPresentViewer = onWillPresentViewer
     }
 
     func updateViewerTheme(_ theme: Theme) {
@@ -272,8 +275,14 @@ extension MermaidAttachmentCoordinator: MermaidTextAttachmentCellDelegate {
     ) {
         guard let source = references[cell.id]?.source,
               let viewerTheme,
-              let hostWindow = textView?.window
+              let sourceWindow = textView?.window
         else { return }
+        let hostWindow = mode == .compact
+            ? sourceWindow.parent ?? sourceWindow
+            : sourceWindow
+        if mode == .compact {
+            onWillPresentViewer?()
+        }
         MermaidDiagramViewerController.shared.show(
             source: source,
             theme: viewerTheme,

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -54,6 +54,7 @@ final class MermaidAttachmentCoordinator {
 
     func updateViewerTheme(_ theme: Theme) {
         viewerTheme = theme
+        MermaidDiagramViewerController.shared.updateTheme(theme)
     }
 
     func apply(

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -26,6 +26,7 @@ final class MermaidAttachmentCoordinator {
     private var references: [String: MermaidAttachmentReference] = [:]
     private var tasks: [String: Task<Void, Never>] = [:]
     private var onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?
+    private var backingPropertiesObserver: NSObjectProtocol?
     private var viewerTheme: Theme?
     private let onWillPresentViewer: (() -> Void)?
 
@@ -51,7 +52,11 @@ final class MermaidAttachmentCoordinator {
         to textView: NSTextView,
         onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?
     ) {
-        if self.revision == revision, self.textView === textView {
+        let scale = textView.window?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor
+            ?? 2
+        if self.revision == revision, self.textView === textView,
+           self.backingScale == scale {
             return
         }
         cancelAll()
@@ -59,10 +64,8 @@ final class MermaidAttachmentCoordinator {
         self.textView = textView
         self.references = Dictionary(uniqueKeysWithValues: references.map { ($0.id, $0) })
         self.onTextStorageDelta = onTextStorageDelta
-
-        let scale = textView.window?.backingScaleFactor
-            ?? NSScreen.main?.backingScaleFactor
-            ?? 2
+        self.backingScale = scale
+        observeBackingProperties(of: textView.window)
         for reference in references {
             let cell = reference.attachment.mermaidCell
             cell.delegate = self
@@ -103,6 +106,35 @@ final class MermaidAttachmentCoordinator {
         revision = nil
         textView = nil
         onTextStorageDelta = nil
+        backingScale = nil
+        if let backingPropertiesObserver {
+            NotificationCenter.default.removeObserver(backingPropertiesObserver)
+        }
+        backingPropertiesObserver = nil
+    }
+
+    private var backingScale: CGFloat?
+
+    private func observeBackingProperties(of window: NSWindow?) {
+        guard let window else { return }
+        backingPropertiesObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeBackingPropertiesNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      let revision = self.revision,
+                      let textView = self.textView
+                else { return }
+                self.apply(
+                    Array(self.references.values),
+                    revision: revision,
+                    to: textView,
+                    onTextStorageDelta: self.onTextStorageDelta
+                )
+            }
+        }
     }
 
     func showSource(id: String, in textView: NSTextView) {

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -5,6 +5,19 @@ extension NSAttributedString.Key {
 }
 
 @MainActor
+final class MermaidRenderCancellation {
+    private var action: (() -> Void)?
+
+    func register(_ action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    func cancel() {
+        action?()
+    }
+}
+
+@MainActor
 final class MermaidAttachmentCoordinator {
     private let mode: MermaidPresentationProfile
     private let service: MermaidRenderService

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -28,6 +28,7 @@ final class MermaidAttachmentCoordinator {
     private var onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?
     private var backingPropertiesObserver: NSObjectProtocol?
     private weak var observedBackingWindow: NSWindow?
+    private var failureDisclosedSourceIDs: Set<String> = []
     private var viewerTheme: Theme?
     private let onWillPresentViewer: (() -> Void)?
 
@@ -69,7 +70,9 @@ final class MermaidAttachmentCoordinator {
             observeBackingPropertiesIfNeeded(of: textView.window)
             return
         }
-        cancelAll()
+        let preservesFailureDisclosures = self.revision == revision
+            && self.textView === textView
+        cancelAll(clearFailureDisclosures: !preservesFailureDisclosures)
         self.revision = revision
         self.textView = textView
         self.references = Dictionary(uniqueKeysWithValues: references.map { ($0.id, $0) })
@@ -105,6 +108,10 @@ final class MermaidAttachmentCoordinator {
     }
 
     func cancelAll() {
+        cancelAll(clearFailureDisclosures: true)
+    }
+
+    private func cancelAll(clearFailureDisclosures: Bool) {
         for task in tasks.values {
             task.cancel()
         }
@@ -122,6 +129,9 @@ final class MermaidAttachmentCoordinator {
         }
         backingPropertiesObserver = nil
         observedBackingWindow = nil
+        if clearFailureDisclosures {
+            failureDisclosedSourceIDs.removeAll()
+        }
     }
 
     private var backingScale: CGFloat?
@@ -189,6 +199,7 @@ final class MermaidAttachmentCoordinator {
     }
 
     func hideSource(id: String, in textView: NSTextView) {
+        failureDisclosedSourceIDs.remove(id)
         guard let reference = references[id],
               self.textView === textView,
               let storage = textView.textStorage
@@ -223,6 +234,15 @@ final class MermaidAttachmentCoordinator {
         Clipboard.copy(payload, to: pasteboard)
     }
 
+    func applyOutcomeForTesting(
+        _ outcome: MermaidRenderOutcome,
+        to id: String,
+        revision: UUID,
+        in textView: NSTextView
+    ) {
+        apply(outcome, to: id, revision: revision, in: textView)
+    }
+
     private func apply(
         _ outcome: MermaidRenderOutcome,
         to id: String,
@@ -232,16 +252,23 @@ final class MermaidAttachmentCoordinator {
         guard self.revision == revision,
               self.textView === textView,
               let reference = references[id],
+              let storage = textView.textStorage,
               attachmentRange(
                   for: reference.attachment,
-                  in: textView.textStorage
+                  in: storage
               ) != nil
         else { return }
 
         tasks.removeValue(forKey: id)
         reference.attachment.mermaidCell.apply(outcome)
         if case .failed = outcome {
+            let sourceWasVisible = sourceRange(id: id, in: storage) != nil
             showSource(id: id, in: textView)
+            if !sourceWasVisible {
+                failureDisclosedSourceIDs.insert(id)
+            }
+        } else if failureDisclosedSourceIDs.contains(id) {
+            hideSource(id: id, in: textView)
         }
         invalidate(reference.attachment, in: textView)
     }

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -27,6 +27,7 @@ final class MermaidAttachmentCoordinator {
     private var tasks: [String: Task<Void, Never>] = [:]
     private var onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?
     private var backingPropertiesObserver: NSObjectProtocol?
+    private weak var observedBackingWindow: NSWindow?
     private var viewerTheme: Theme?
     private let onWillPresentViewer: (() -> Void)?
 
@@ -42,6 +43,14 @@ final class MermaidAttachmentCoordinator {
         self.onWillPresentViewer = onWillPresentViewer
     }
 
+    var hasBackingPropertiesObserverForTesting: Bool {
+        backingPropertiesObserver != nil
+    }
+
+    var observedBackingWindowForTesting: NSWindow? {
+        observedBackingWindow
+    }
+
     func updateViewerTheme(_ theme: Theme) {
         viewerTheme = theme
     }
@@ -55,11 +64,9 @@ final class MermaidAttachmentCoordinator {
         let scale = textView.window?.backingScaleFactor
             ?? NSScreen.main?.backingScaleFactor
             ?? 2
-        if backingPropertiesObserver == nil {
-            observeBackingProperties(of: textView.window)
-        }
         if self.revision == revision, self.textView === textView,
            self.backingScale == scale {
+            observeBackingPropertiesIfNeeded(of: textView.window)
             return
         }
         cancelAll()
@@ -68,6 +75,7 @@ final class MermaidAttachmentCoordinator {
         self.references = Dictionary(uniqueKeysWithValues: references.map { ($0.id, $0) })
         self.onTextStorageDelta = onTextStorageDelta
         self.backingScale = scale
+        observeBackingPropertiesIfNeeded(of: textView.window)
         for reference in references {
             let cell = reference.attachment.mermaidCell
             cell.delegate = self
@@ -113,12 +121,20 @@ final class MermaidAttachmentCoordinator {
             NotificationCenter.default.removeObserver(backingPropertiesObserver)
         }
         backingPropertiesObserver = nil
+        observedBackingWindow = nil
     }
 
     private var backingScale: CGFloat?
 
-    private func observeBackingProperties(of window: NSWindow?) {
+    private func observeBackingPropertiesIfNeeded(of window: NSWindow?) {
         guard let window else { return }
+        guard backingPropertiesObserver == nil || observedBackingWindow !== window else {
+            return
+        }
+        if let backingPropertiesObserver {
+            NotificationCenter.default.removeObserver(backingPropertiesObserver)
+        }
+        observedBackingWindow = window
         backingPropertiesObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didChangeBackingPropertiesNotification,
             object: window,

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -88,11 +88,21 @@ final class MermaidAttachmentCoordinator {
         in textView: NSTextView
     ) {
         guard !snapshot.isEmpty else { return }
+        var restoredIDs: Set<String> = []
         for id in snapshot.sourcesByID.keys.sorted() {
             guard let source = snapshot.sourcesByID[id],
                   references[id]?.source == source
             else { continue }
             showSource(id: id, in: textView)
+            restoredIDs.insert(id)
+        }
+        for source in snapshot.sourcesByID.values {
+            guard let id = references.keys.sorted().first(where: { id in
+                !restoredIDs.contains(id)
+                    && references[id]?.source == source
+            }) else { continue }
+            showSource(id: id, in: textView)
+            restoredIDs.insert(id)
         }
     }
 

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -19,6 +19,7 @@ final class MermaidRenderCancellation {
 
 struct MermaidSourceDisclosureSnapshot: Equatable {
     fileprivate let sourcesByID: [String: String]
+    fileprivate let referenceIDsBySource: [String: Set<String>]
 
     var isEmpty: Bool {
         sourcesByID.isEmpty
@@ -71,7 +72,16 @@ final class MermaidAttachmentCoordinator {
         guard self.textView === textView,
               let storage = textView.textStorage
         else {
-            return MermaidSourceDisclosureSnapshot(sourcesByID: [:])
+            return MermaidSourceDisclosureSnapshot(
+                sourcesByID: [:],
+                referenceIDsBySource: [:]
+            )
+        }
+        let referenceIDsBySource = Dictionary(
+            grouping: references.values,
+            by: \.source
+        ).mapValues { references in
+            Set(references.map(\.id))
         }
         let sourcesByID = references.reduce(into: [String: String]()) { result, entry in
             let id = entry.key
@@ -80,7 +90,10 @@ final class MermaidAttachmentCoordinator {
             else { return }
             result[id] = entry.value.source
         }
-        return MermaidSourceDisclosureSnapshot(sourcesByID: sourcesByID)
+        return MermaidSourceDisclosureSnapshot(
+            sourcesByID: sourcesByID,
+            referenceIDsBySource: referenceIDsBySource
+        )
     }
 
     func restoreExplicitSourceDisclosures(
@@ -88,15 +101,28 @@ final class MermaidAttachmentCoordinator {
         in textView: NSTextView
     ) {
         guard !snapshot.isEmpty else { return }
+        let currentIDsBySource = Dictionary(
+            grouping: references.values,
+            by: \.source
+        ).mapValues { references in
+            Set(references.map(\.id))
+        }
         var restoredIDs: Set<String> = []
         for id in snapshot.sourcesByID.keys.sorted() {
             guard let source = snapshot.sourcesByID[id],
-                  references[id]?.source == source
+                  references[id]?.source == source,
+                  canTrustExactDisclosureID(
+                      id,
+                      source: source,
+                      snapshot: snapshot,
+                      currentIDsBySource: currentIDsBySource
+                  )
             else { continue }
             showSource(id: id, in: textView)
             restoredIDs.insert(id)
         }
         for source in snapshot.sourcesByID.values {
+            guard currentIDsBySource[source]?.count == 1 else { continue }
             guard let id = references.keys.sorted().first(where: { id in
                 !restoredIDs.contains(id)
                     && references[id]?.source == source
@@ -104,6 +130,20 @@ final class MermaidAttachmentCoordinator {
             showSource(id: id, in: textView)
             restoredIDs.insert(id)
         }
+    }
+
+    private func canTrustExactDisclosureID(
+        _ id: String,
+        source: String,
+        snapshot: MermaidSourceDisclosureSnapshot,
+        currentIDsBySource: [String: Set<String>]
+    ) -> Bool {
+        let previousIDs = snapshot.referenceIDsBySource[source] ?? []
+        let currentIDs = currentIDsBySource[source] ?? []
+        guard previousIDs.count > 1 || currentIDs.count > 1 else {
+            return true
+        }
+        return previousIDs == currentIDs && currentIDs.contains(id)
     }
 
     func apply(

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -55,6 +55,9 @@ final class MermaidAttachmentCoordinator {
         let scale = textView.window?.backingScaleFactor
             ?? NSScreen.main?.backingScaleFactor
             ?? 2
+        if backingPropertiesObserver == nil {
+            observeBackingProperties(of: textView.window)
+        }
         if self.revision == revision, self.textView === textView,
            self.backingScale == scale {
             return
@@ -65,7 +68,6 @@ final class MermaidAttachmentCoordinator {
         self.references = Dictionary(uniqueKeysWithValues: references.map { ($0.id, $0) })
         self.onTextStorageDelta = onTextStorageDelta
         self.backingScale = scale
-        observeBackingProperties(of: textView.window)
         for reference in references {
             let cell = reference.attachment.mermaidCell
             cell.delegate = self

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -154,8 +154,10 @@ final class MermaidAttachmentCoordinator {
         id: String,
         to pasteboard: NSPasteboard = .general
     ) {
-        guard let source = references[id]?.source else { return }
-        Clipboard.copy(source, to: pasteboard)
+        guard let payload = references[id]?.attachment.copyPayload else {
+            return
+        }
+        Clipboard.copy(payload, to: pasteboard)
     }
 
     private func apply(

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -1,0 +1,283 @@
+import AppKit
+
+extension NSAttributedString.Key {
+    static let mermaidSourceID = NSAttributedString.Key("alas.mermaid.sourceID")
+}
+
+@MainActor
+final class MermaidAttachmentCoordinator {
+    private let mode: MermaidPresentationProfile
+    private let service: MermaidRenderService
+    private weak var textView: NSTextView?
+    private var revision: UUID?
+    private var references: [String: MermaidAttachmentReference] = [:]
+    private var tasks: [String: Task<Void, Never>] = [:]
+    private var onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?
+    private var viewerTheme: Theme?
+
+    init(
+        mode: MermaidPresentationProfile = .full,
+        service: MermaidRenderService = .shared,
+        theme: Theme? = nil
+    ) {
+        self.mode = mode
+        self.service = service
+        self.viewerTheme = theme
+    }
+
+    func updateViewerTheme(_ theme: Theme) {
+        viewerTheme = theme
+    }
+
+    func apply(
+        _ references: [MermaidAttachmentReference],
+        revision: UUID,
+        to textView: NSTextView,
+        onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?
+    ) {
+        if self.revision == revision, self.textView === textView {
+            return
+        }
+        cancelAll()
+        self.revision = revision
+        self.textView = textView
+        self.references = Dictionary(uniqueKeysWithValues: references.map { ($0.id, $0) })
+        self.onTextStorageDelta = onTextStorageDelta
+
+        let scale = textView.window?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor
+            ?? 2
+        for reference in references {
+            let cell = reference.attachment.mermaidCell
+            cell.delegate = self
+            cell.configure(theme: reference.theme)
+            cell.beginLoading()
+            invalidate(reference.attachment, in: textView)
+
+            let key = MermaidRenderKey(
+                source: reference.source,
+                theme: reference.theme,
+                scale: Double(scale),
+                profile: reference.profile
+            )
+            let id = reference.id
+            let service = self.service
+            tasks[id] = Task { [weak self, weak textView] in
+                let outcome = await service.render(key: key)
+                guard !Task.isCancelled, let self, let textView else { return }
+                self.apply(
+                    outcome,
+                    to: id,
+                    revision: revision,
+                    in: textView
+                )
+            }
+        }
+    }
+
+    func cancelAll() {
+        for task in tasks.values {
+            task.cancel()
+        }
+        tasks.removeAll()
+        for reference in references.values {
+            reference.attachment.mermaidCell.delegate = nil
+        }
+        references.removeAll()
+        revision = nil
+        textView = nil
+        onTextStorageDelta = nil
+    }
+
+    func showSource(id: String, in textView: NSTextView) {
+        guard let reference = references[id],
+              self.textView === textView,
+              let storage = textView.textStorage,
+              sourceRange(id: id, in: storage) == nil,
+              let attachmentRange = attachmentRange(
+                  for: reference.attachment,
+                  in: storage
+              )
+        else { return }
+
+        let insertionLocation = NSMaxRange(attachmentRange)
+        let source = NSAttributedString(
+            string: reference.source,
+            attributes: [
+                .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular),
+                .foregroundColor: color(
+                    reference.theme.foreground,
+                    fallback: .labelColor
+                ),
+                .backgroundColor: color(
+                    reference.theme.surface,
+                    fallback: .controlBackgroundColor
+                ),
+                .mermaidSourceID: id
+            ]
+        )
+        storage.insert(source, at: insertionLocation)
+        reference.attachment.mermaidCell.setSourceVisible(true)
+        onTextStorageDelta?(insertionLocation, source.length)
+        invalidate(reference.attachment, in: textView)
+    }
+
+    func hideSource(id: String, in textView: NSTextView) {
+        guard let reference = references[id],
+              self.textView === textView,
+              let storage = textView.textStorage
+        else { return }
+
+        var ranges: [NSRange] = []
+        storage.enumerateAttribute(
+            .mermaidSourceID,
+            in: NSRange(location: 0, length: storage.length)
+        ) { value, range, _ in
+            if value as? String == id {
+                ranges.append(range)
+            }
+        }
+        guard !ranges.isEmpty else { return }
+
+        for range in ranges.reversed() {
+            storage.deleteCharacters(in: range)
+            onTextStorageDelta?(range.location, -range.length)
+        }
+        reference.attachment.mermaidCell.setSourceVisible(false)
+        invalidate(reference.attachment, in: textView)
+    }
+
+    func copySource(
+        id: String,
+        to pasteboard: NSPasteboard = .general
+    ) {
+        guard let source = references[id]?.source else { return }
+        Clipboard.copy(source, to: pasteboard)
+    }
+
+    private func apply(
+        _ outcome: MermaidRenderOutcome,
+        to id: String,
+        revision: UUID,
+        in textView: NSTextView
+    ) {
+        guard self.revision == revision,
+              self.textView === textView,
+              let reference = references[id],
+              attachmentRange(
+                  for: reference.attachment,
+                  in: textView.textStorage
+              ) != nil
+        else { return }
+
+        tasks.removeValue(forKey: id)
+        reference.attachment.mermaidCell.apply(outcome)
+        if case .failed = outcome {
+            showSource(id: id, in: textView)
+        }
+        invalidate(reference.attachment, in: textView)
+    }
+
+    private func sourceRange(
+        id: String,
+        in storage: NSTextStorage
+    ) -> NSRange? {
+        var found: NSRange?
+        storage.enumerateAttribute(
+            .mermaidSourceID,
+            in: NSRange(location: 0, length: storage.length)
+        ) { value, range, stop in
+            guard value as? String == id else { return }
+            found = range
+            stop.pointee = true
+        }
+        return found
+    }
+
+    private func attachmentRange(
+        for attachment: NSTextAttachment,
+        in storage: NSTextStorage?
+    ) -> NSRange? {
+        guard let storage else { return nil }
+        var found: NSRange?
+        storage.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: storage.length)
+        ) { value, range, stop in
+            guard let candidate = value as? NSTextAttachment,
+                  candidate === attachment else { return }
+            found = range
+            stop.pointee = true
+        }
+        return found
+    }
+
+    private func invalidate(
+        _ attachment: NSTextAttachment,
+        in textView: NSTextView
+    ) {
+        guard let storage = textView.textStorage,
+              let range = attachmentRange(for: attachment, in: storage)
+        else { return }
+        storage.edited(
+            .editedAttributes,
+            range: range,
+            changeInLength: 0
+        )
+        for layoutManager in storage.layoutManagers {
+            layoutManager.invalidateLayout(
+                forCharacterRange: range,
+                actualCharacterRange: nil
+            )
+            layoutManager.invalidateDisplay(forCharacterRange: range)
+        }
+    }
+
+    private func color(_ hex: String, fallback: NSColor) -> NSColor {
+        guard hex.count == 7, hex.first == "#",
+              let value = UInt32(hex.dropFirst(), radix: 16)
+        else { return fallback }
+        let red = CGFloat((value >> 16) & 0xFF) / 255
+        let green = CGFloat((value >> 8) & 0xFF) / 255
+        let blue = CGFloat(value & 0xFF) / 255
+        return NSColor(
+            srgbRed: red,
+            green: green,
+            blue: blue,
+            alpha: 1
+        )
+    }
+}
+
+extension MermaidAttachmentCoordinator: MermaidTextAttachmentCellDelegate {
+    func mermaidTextAttachmentCellDidToggleSource(
+        _ cell: MermaidTextAttachmentCell
+    ) {
+        guard let textView else { return }
+        if cell.showsSource {
+            hideSource(id: cell.id, in: textView)
+        } else {
+            showSource(id: cell.id, in: textView)
+        }
+    }
+
+    func mermaidTextAttachmentCellDidRequestCopy(
+        _ cell: MermaidTextAttachmentCell
+    ) {
+        copySource(id: cell.id)
+    }
+
+    func mermaidTextAttachmentCellDidRequestExpansion(
+        _ cell: MermaidTextAttachmentCell
+    ) {
+        guard let source = references[cell.id]?.source,
+              let viewerTheme,
+              let hostWindow = textView?.window
+        else { return }
+        MermaidDiagramViewerController.shared.show(
+            source: source,
+            theme: viewerTheme,
+            from: hostWindow
+        )
+    }
+}

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
@@ -70,6 +70,9 @@ struct MermaidDiagramBlockView: View {
             RoundedRectangle(cornerRadius: 6)
                 .strokeBorder(theme.color("line"), lineWidth: 0.5)
         }
+        .onChange(of: theme) { _, newTheme in
+            MermaidDiagramViewerController.shared.updateTheme(newTheme)
+        }
         .task(id: key) {
             let requestedKey = key
             renderState.begin(requestedKey)

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
@@ -12,8 +12,10 @@ struct MermaidSourceDisclosureState {
 
     mutating func apply(_ outcome: MermaidRenderOutcome) {
         if outcome.failure != nil {
-            showsSource = true
-            failureDisclosure = true
+            if !showsSource {
+                showsSource = true
+                failureDisclosure = true
+            }
         } else if failureDisclosure {
             showsSource = false
             failureDisclosure = false

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
@@ -3,14 +3,21 @@ import SwiftUI
 
 struct MermaidSourceDisclosureState {
     private(set) var showsSource = false
+    private var failureDisclosure = false
 
     mutating func toggle() {
         showsSource.toggle()
+        failureDisclosure = false
     }
 
     mutating func apply(_ outcome: MermaidRenderOutcome) {
-        guard outcome.failure != nil else { return }
-        showsSource = true
+        if outcome.failure != nil {
+            showsSource = true
+            failureDisclosure = true
+        } else if failureDisclosure {
+            showsSource = false
+            failureDisclosure = false
+        }
     }
 
     func visibleSource(_ source: String) -> String? {

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
@@ -1,0 +1,248 @@
+import AppKit
+import SwiftUI
+
+struct MermaidDiagramBlockView: View {
+    let source: String
+    let profile: MermaidPresentationProfile
+    var service: MermaidRenderService = .shared
+
+    @Environment(\.displayScale) private var displayScale
+    @Environment(\.theme) private var theme
+    @State private var outcome: MermaidRenderOutcome?
+    @State private var showsSource = false
+
+    private var key: MermaidRenderKey {
+        MermaidRenderKey(
+            source: source,
+            theme: MermaidDiagramTheme(theme: theme),
+            scale: displayScale,
+            profile: profile
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            MermaidDiagramBlockHeader(
+                showsSource: showsSource,
+                toggleSource: { showsSource.toggle() },
+                copySource: copySource,
+                expand: expand
+            )
+            MermaidDiagramRenderContent(
+                source: source,
+                profile: profile,
+                outcome: outcome
+            )
+            if showsSource {
+                MermaidDiagramSourceView(source: source)
+            }
+        }
+        .background(theme.color("bg-0").opacity(0.6))
+        .compositingGroup()
+        .clipShape(.rect(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        }
+        .task(id: key) {
+            outcome = nil
+            outcome = await service.render(key: key)
+        }
+    }
+
+    private func copySource() {
+        Clipboard.copy(source)
+    }
+
+    private func expand() {
+        guard let hostWindow = NSApp.keyWindow ?? NSApp.mainWindow else { return }
+        MermaidDiagramViewerController.shared.show(
+            source: source,
+            theme: theme,
+            from: hostWindow
+        )
+    }
+}
+
+private struct MermaidDiagramBlockHeader: View {
+    let showsSource: Bool
+    let toggleSource: () -> Void
+    let copySource: () -> Void
+    let expand: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("MERMAID")
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.4)
+                .foregroundStyle(theme.color("fg-faint"))
+            Spacer(minLength: 0)
+            Button(showsSource ? "Hide source" : "Show source", action: toggleSource)
+            Button("Copy", action: copySource)
+            Button("Expand", action: expand)
+        }
+        .font(.system(size: 10, weight: .medium))
+        .buttonStyle(.plain)
+        .foregroundStyle(theme.color("fg-muted"))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .frame(maxWidth: .infinity)
+        .background(theme.color("bg-2").opacity(0.6))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.color("line-soft"))
+                .frame(height: 0.5)
+        }
+    }
+}
+
+private struct MermaidDiagramRenderContent: View {
+    let source: String
+    let profile: MermaidPresentationProfile
+    let outcome: MermaidRenderOutcome?
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        switch outcome {
+        case .rendered(let diagram):
+            MermaidFittedDiagram(
+                diagram: diagram,
+                maxHeight: profile.maxEmbeddedHeight,
+                source: source
+            )
+            .padding(12)
+            .frame(maxWidth: .infinity)
+        case .failed(let failure):
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Couldn't render Mermaid diagram")
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(theme.color("fg"))
+                Text(failure.mermaidDisplayDiagnostic)
+                    .font(.caption)
+                    .foregroundStyle(theme.color("fg-muted"))
+                    .textSelection(.enabled)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        case nil:
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+                .frame(height: profile == .compact ? 72 : 120)
+                .accessibilityLabel("Rendering Mermaid diagram")
+        }
+    }
+}
+
+private struct MermaidFittedDiagram: View {
+    let diagram: MermaidRenderedDiagram
+    let maxHeight: CGFloat
+    let source: String
+
+    var body: some View {
+        MermaidFittedDiagramLayout(
+            intrinsicSize: diagram.image.size,
+            maxHeight: maxHeight
+        ) {
+            Image(nsImage: diagram.image)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(contentMode: .fit)
+                .accessibilityLabel("Mermaid diagram")
+                .accessibilityValue(Text(verbatim: source))
+        }
+    }
+}
+
+private struct MermaidFittedDiagramLayout: Layout {
+    let intrinsicSize: CGSize
+    let maxHeight: CGFloat
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        MermaidDiagramLayout.fittedSize(
+            intrinsic: intrinsicSize,
+            availableWidth: proposal.width ?? intrinsicSize.width,
+            maxHeight: maxHeight
+        )
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        subviews.first?.place(
+            at: CGPoint(x: bounds.midX, y: bounds.midY),
+            anchor: .center,
+            proposal: ProposedViewSize(bounds.size)
+        )
+    }
+}
+
+struct MermaidDiagramSourceView: View {
+    let source: String
+    var maximumHeight: CGFloat = 220
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        ScrollView([.horizontal, .vertical]) {
+            Text(verbatim: source)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(theme.color("fg"))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: true, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+        }
+        .frame(maxHeight: maximumHeight)
+        .background(theme.color("bg-1"))
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(theme.color("line-soft"))
+                .frame(height: 0.5)
+        }
+    }
+}
+
+extension MermaidRenderFailure {
+    var mermaidDisplayDiagnostic: String {
+        switch self {
+        case .empty:
+            return "The diagram source is empty."
+        case .sourceTooLarge(let actualBytes):
+            return "The diagram source is too large (\(actualBytes) bytes)."
+        case .unsupported(let message):
+            return Self.sanitized("Unsupported diagram. \(message)")
+        case .parseFailed(let message):
+            return Self.sanitized("The diagram source could not be parsed. \(message)")
+        case .layoutFailed(let message):
+            return Self.sanitized("The diagram layout failed. \(message)")
+        case .renderFailed(let message):
+            return Self.sanitized("The diagram image could not be generated. \(message)")
+        case .rasterTooLarge(let width, let height):
+            return "The rendered diagram is too large (\(width) × \(height) pixels)."
+        }
+    }
+
+    private static func sanitized(_ message: String) -> String {
+        let oneLine = message
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        let scalars = oneLine.unicodeScalars.filter {
+            !CharacterSet.controlCharacters.contains($0)
+        }
+        let cleaned = String(String.UnicodeScalarView(scalars))
+        guard cleaned.count > 400 else { return cleaned }
+        return "\(cleaned.prefix(399))…"
+    }
+}

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
@@ -1,6 +1,23 @@
 import AppKit
 import SwiftUI
 
+struct MermaidSourceDisclosureState {
+    private(set) var showsSource = false
+
+    mutating func toggle() {
+        showsSource.toggle()
+    }
+
+    mutating func apply(_ outcome: MermaidRenderOutcome) {
+        guard outcome.failure != nil else { return }
+        showsSource = true
+    }
+
+    func visibleSource(_ source: String) -> String? {
+        showsSource ? source : nil
+    }
+}
+
 struct MermaidDiagramBlockView: View {
     let source: String
     let profile: MermaidPresentationProfile
@@ -9,7 +26,7 @@ struct MermaidDiagramBlockView: View {
     @Environment(\.displayScale) private var displayScale
     @Environment(\.theme) private var theme
     @State private var renderState = MermaidRenderRequestState()
-    @State private var showsSource = false
+    @State private var sourceDisclosure = MermaidSourceDisclosureState()
 
     private var key: MermaidRenderKey {
         MermaidRenderKey(
@@ -23,8 +40,8 @@ struct MermaidDiagramBlockView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             MermaidDiagramBlockHeader(
-                showsSource: showsSource,
-                toggleSource: { showsSource.toggle() },
+                showsSource: sourceDisclosure.showsSource,
+                toggleSource: { sourceDisclosure.toggle() },
                 copySource: copySource,
                 expand: expand
             )
@@ -33,8 +50,8 @@ struct MermaidDiagramBlockView: View {
                 profile: profile,
                 outcome: renderState.outcome
             )
-            if showsSource {
-                MermaidDiagramSourceView(source: source)
+            if let visibleSource = sourceDisclosure.visibleSource(source) {
+                MermaidDiagramSourceView(source: visibleSource)
             }
         }
         .background(theme.color("bg-0").opacity(0.6))
@@ -49,7 +66,9 @@ struct MermaidDiagramBlockView: View {
             renderState.begin(requestedKey)
             let rendered = await service.render(key: requestedKey)
             guard !Task.isCancelled else { return }
+            guard renderState.currentKey == requestedKey else { return }
             renderState.apply(rendered, for: requestedKey)
+            sourceDisclosure.apply(rendered)
         }
     }
 

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
@@ -8,7 +8,7 @@ struct MermaidDiagramBlockView: View {
 
     @Environment(\.displayScale) private var displayScale
     @Environment(\.theme) private var theme
-    @State private var outcome: MermaidRenderOutcome?
+    @State private var renderState = MermaidRenderRequestState()
     @State private var showsSource = false
 
     private var key: MermaidRenderKey {
@@ -31,7 +31,7 @@ struct MermaidDiagramBlockView: View {
             MermaidDiagramRenderContent(
                 source: source,
                 profile: profile,
-                outcome: outcome
+                outcome: renderState.outcome
             )
             if showsSource {
                 MermaidDiagramSourceView(source: source)
@@ -45,8 +45,11 @@ struct MermaidDiagramBlockView: View {
                 .strokeBorder(theme.color("line"), lineWidth: 0.5)
         }
         .task(id: key) {
-            outcome = nil
-            outcome = await service.render(key: key)
+            let requestedKey = key
+            renderState.begin(requestedKey)
+            let rendered = await service.render(key: requestedKey)
+            guard !Task.isCancelled else { return }
+            renderState.apply(rendered, for: requestedKey)
         }
     }
 

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
@@ -10,6 +10,20 @@ enum MermaidDiagramLayout {
         let scale = min(1, availableWidth / intrinsic.width, maxHeight / intrinsic.height)
         return CGSize(width: intrinsic.width * scale, height: intrinsic.height * scale)
     }
+
+    static func actualSizeScale(intrinsic: CGSize, fitted: CGSize) -> CGFloat {
+        guard intrinsic.width > 0,
+              intrinsic.height > 0,
+              fitted.width > 0,
+              fitted.height > 0
+        else { return 1 }
+
+        let scale = max(
+            intrinsic.width / fitted.width,
+            intrinsic.height / fitted.height
+        )
+        return scale.isFinite && scale > 0 ? scale : 1
+    }
 }
 
 struct MermaidRenderRequestState {
@@ -42,6 +56,11 @@ struct MermaidZoomState: Equatable {
     mutating func setScale(_ scale: CGFloat) {
         guard scale.isFinite else { return }
         self.scale = Self.clamped(scale)
+    }
+
+    mutating func setActualSize(_ scale: CGFloat) {
+        guard scale.isFinite, scale > 0 else { return }
+        self.scale = max(Self.minimumScale, scale)
     }
 
     mutating func translate(by delta: CGSize) {

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
@@ -12,6 +12,21 @@ enum MermaidDiagramLayout {
     }
 }
 
+struct MermaidRenderRequestState {
+    private(set) var currentKey: MermaidRenderKey?
+    private(set) var outcome: MermaidRenderOutcome?
+
+    mutating func begin(_ key: MermaidRenderKey) {
+        currentKey = key
+        outcome = nil
+    }
+
+    mutating func apply(_ outcome: MermaidRenderOutcome, for key: MermaidRenderKey) {
+        guard key == currentKey else { return }
+        self.outcome = outcome
+    }
+}
+
 struct MermaidZoomState: Equatable {
     static let minimumScale: CGFloat = 0.25
     static let maximumScale: CGFloat = 8

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
@@ -76,7 +76,8 @@ struct MermaidZoomState: Equatable {
 
     func scale(adding factor: CGFloat) -> CGFloat {
         guard factor.isFinite, factor > 0 else { return scale }
-        return Self.clamped(scale * factor)
+        let maximum = max(Self.maximumScale, scale)
+        return min(maximum, max(Self.minimumScale, scale * factor))
     }
 
     private static func clamped(_ scale: CGFloat) -> CGFloat {

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
@@ -30,6 +30,13 @@ struct MermaidRenderRequestState {
     private(set) var currentKey: MermaidRenderKey?
     private(set) var outcome: MermaidRenderOutcome?
 
+    func resetsViewport(for key: MermaidRenderKey) -> Bool {
+        guard let currentKey else { return true }
+        return currentKey.source != key.source
+            || currentKey.theme != key.theme
+            || currentKey.profile != key.profile
+    }
+
     mutating func begin(_ key: MermaidRenderKey) {
         currentKey = key
         outcome = nil
@@ -45,21 +52,47 @@ struct MermaidZoomState: Equatable {
     static let minimumScale: CGFloat = 0.25
     static let maximumScale: CGFloat = 8
 
+    private enum Mode: Equatable {
+        case fit
+        case explicit
+    }
+
     private(set) var scale: CGFloat = 1
     private(set) var translation: CGSize = .zero
+    private var mode: Mode = .fit
 
     mutating func zoom(by factor: CGFloat) {
         scale = scale(adding: factor)
+        mode = .explicit
     }
 
     mutating func setScale(_ scale: CGFloat) {
         guard scale.isFinite else { return }
         self.scale = Self.clamped(scale)
+        mode = .explicit
     }
 
     mutating func setActualSize(_ scale: CGFloat) {
         guard scale.isFinite, scale > 0 else { return }
         self.scale = max(Self.minimumScale, scale)
+        mode = .explicit
+    }
+
+    mutating func preserveIntrinsicZoom(
+        from oldActualSizeScale: CGFloat,
+        to newActualSizeScale: CGFloat
+    ) {
+        guard mode == .explicit,
+              oldActualSizeScale.isFinite,
+              oldActualSizeScale > 0,
+              newActualSizeScale.isFinite,
+              newActualSizeScale > 0
+        else { return }
+
+        let intrinsicScale = scale / oldActualSizeScale
+        let nextScale = intrinsicScale * newActualSizeScale
+        guard nextScale.isFinite else { return }
+        scale = max(Self.minimumScale, nextScale)
     }
 
     mutating func translate(by delta: CGSize) {
@@ -71,6 +104,7 @@ struct MermaidZoomState: Equatable {
     mutating func resetToFit() {
         scale = 1
         translation = .zero
+        mode = .fit
     }
 
     func scale(adding factor: CGFloat) -> CGFloat {

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
@@ -33,7 +33,6 @@ struct MermaidRenderRequestState {
     func resetsViewport(for key: MermaidRenderKey) -> Bool {
         guard let currentKey else { return true }
         return currentKey.source != key.source
-            || currentKey.theme != key.theme
             || currentKey.profile != key.profile
     }
 

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
@@ -1,0 +1,51 @@
+import CoreGraphics
+
+enum MermaidDiagramLayout {
+    static func fittedSize(
+        intrinsic: CGSize,
+        availableWidth: CGFloat,
+        maxHeight: CGFloat
+    ) -> CGSize {
+        guard intrinsic.width > 0, intrinsic.height > 0 else { return .zero }
+        let scale = min(1, availableWidth / intrinsic.width, maxHeight / intrinsic.height)
+        return CGSize(width: intrinsic.width * scale, height: intrinsic.height * scale)
+    }
+}
+
+struct MermaidZoomState: Equatable {
+    static let minimumScale: CGFloat = 0.25
+    static let maximumScale: CGFloat = 8
+
+    private(set) var scale: CGFloat = 1
+    private(set) var translation: CGSize = .zero
+
+    mutating func zoom(by factor: CGFloat) {
+        guard factor.isFinite, factor > 0 else { return }
+        scale = Self.clamped(scale * factor)
+    }
+
+    mutating func setScale(_ scale: CGFloat) {
+        guard scale.isFinite else { return }
+        self.scale = Self.clamped(scale)
+    }
+
+    mutating func translate(by delta: CGSize) {
+        guard delta.width.isFinite, delta.height.isFinite else { return }
+        translation.width += delta.width
+        translation.height += delta.height
+    }
+
+    mutating func resetToFit() {
+        scale = 1
+        translation = .zero
+    }
+
+    func scale(adding factor: CGFloat) -> CGFloat {
+        guard factor.isFinite, factor > 0 else { return scale }
+        return Self.clamped(scale * factor)
+    }
+
+    private static func clamped(_ scale: CGFloat) -> CGFloat {
+        min(maximumScale, max(minimumScale, scale))
+    }
+}

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramLayout.swift
@@ -49,8 +49,7 @@ struct MermaidZoomState: Equatable {
     private(set) var translation: CGSize = .zero
 
     mutating func zoom(by factor: CGFloat) {
-        guard factor.isFinite, factor > 0 else { return }
-        scale = Self.clamped(scale * factor)
+        scale = scale(adding: factor)
     }
 
     mutating func setScale(_ scale: CGFloat) {
@@ -76,8 +75,12 @@ struct MermaidZoomState: Equatable {
 
     func scale(adding factor: CGFloat) -> CGFloat {
         guard factor.isFinite, factor > 0 else { return scale }
-        let maximum = max(Self.maximumScale, scale)
-        return min(maximum, max(Self.minimumScale, scale * factor))
+        let nextScale = scale * factor
+        guard nextScale.isFinite else { return scale }
+        if scale > Self.maximumScale {
+            return max(Self.minimumScale, nextScale)
+        }
+        return Self.clamped(nextScale)
     }
 
     private static func clamped(_ scale: CGFloat) -> CGFloat {

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramTheme.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramTheme.swift
@@ -1,0 +1,40 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+struct MermaidDiagramTheme: Hashable, Sendable {
+    let background: String
+    let foreground: String
+    let line: String
+    let accent: String
+    let muted: String
+    let surface: String
+    let border: String
+
+    @MainActor
+    init(theme: Theme) {
+        background = Self.hex(theme.color("bg-1"))
+        foreground = Self.hex(theme.color("fg"))
+        line = Self.hex(theme.color("line"))
+        accent = Self.hex(theme.color("accent"))
+        muted = Self.hex(theme.color("fg-muted"))
+        surface = Self.hex(theme.color("bg-2"))
+        border = Self.hex(theme.color("line"))
+    }
+
+    var signature: String {
+        [background, foreground, line, accent, muted, surface, border]
+            .joined(separator: "|")
+    }
+
+    @MainActor
+    private static func hex(_ color: Color) -> String {
+        let rgb = NSColor(color).usingColorSpace(.sRGB) ?? .black
+        return String(
+            format: "#%02X%02X%02X",
+            Int(round(rgb.redComponent * 255)),
+            Int(round(rgb.greenComponent * 255)),
+            Int(round(rgb.blueComponent * 255))
+        )
+    }
+}

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
@@ -135,6 +135,7 @@ struct MermaidViewerZoomAccessibilityMetadata: Equatable {
 struct MermaidViewerInteractionState {
     private var zoomState = MermaidZoomState()
     private(set) var showsSource = false
+    private var failureDisclosure = false
 
     var scale: CGFloat {
         zoomState.scale
@@ -170,10 +171,23 @@ struct MermaidViewerInteractionState {
             zoomState.resetToFit()
         case .toggleSource:
             showsSource.toggle()
+            failureDisclosure = false
         case .copySource:
             return .copySource
         }
         return nil
+    }
+
+    mutating func apply(_ outcome: MermaidRenderOutcome) {
+        if outcome.failure != nil {
+            if !showsSource {
+                showsSource = true
+                failureDisclosure = true
+            }
+        } else if failureDisclosure {
+            showsSource = false
+            failureDisclosure = false
+        }
     }
 
     mutating func adjustZoom(_ adjustment: MermaidViewerZoomAdjustment) {
@@ -268,6 +282,7 @@ struct MermaidDiagramViewerView: View {
             let rendered = await service.render(key: requestedKey)
             guard !Task.isCancelled else { return }
             renderState.apply(rendered, for: requestedKey)
+            interactionState.apply(rendered)
         }
     }
 

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
@@ -189,6 +189,16 @@ struct MermaidViewerInteractionState {
         zoomState.zoom(by: factor)
     }
 
+    mutating func preserveIntrinsicZoom(
+        from oldActualSizeScale: CGFloat,
+        to newActualSizeScale: CGFloat
+    ) {
+        zoomState.preserveIntrinsicZoom(
+            from: oldActualSizeScale,
+            to: newActualSizeScale
+        )
+    }
+
     mutating func translate(by delta: CGSize) {
         zoomState.translate(by: delta)
     }
@@ -201,8 +211,7 @@ struct MermaidViewerInteractionState {
 struct MermaidDiagramViewerView: View {
     let source: String
     let diagramTheme: MermaidDiagramTheme
-    let backingScale: CGFloat
-    var service: MermaidRenderService = .shared
+    var service: MermaidRenderService
 
     @Environment(\.theme) private var theme
     @State private var renderState = MermaidRenderRequestState()
@@ -210,14 +219,27 @@ struct MermaidDiagramViewerView: View {
     @GestureState private var dragTranslation: CGSize = .zero
     @GestureState private var magnification: CGFloat = 1
     @State private var actualSizeScale: CGFloat = 1
+    @State private var liveBackingScale: CGFloat
 
     private var key: MermaidRenderKey {
         MermaidRenderKey(
             source: source,
             theme: diagramTheme,
-            scale: backingScale,
+            scale: liveBackingScale,
             profile: .full
         )
+    }
+
+    init(
+        source: String,
+        diagramTheme: MermaidDiagramTheme,
+        backingScale: CGFloat,
+        service: MermaidRenderService = .shared
+    ) {
+        self.source = source
+        self.diagramTheme = diagramTheme
+        self.service = service
+        _liveBackingScale = State(initialValue: backingScale)
     }
 
     var body: some View {
@@ -233,10 +255,16 @@ struct MermaidDiagramViewerView: View {
             viewerContent
         }
         .background(theme.color("bg-1"))
+        .background(
+            MermaidDiagramViewerBackingScaleReader(scale: $liveBackingScale)
+        )
         .task(id: key) {
             let requestedKey = key
+            let resetsViewport = renderState.resetsViewport(for: requestedKey)
             renderState.begin(requestedKey)
-            interactionState.perform(.resetToFit)
+            if resetsViewport {
+                interactionState.perform(.resetToFit)
+            }
             let rendered = await service.render(key: requestedKey)
             guard !Task.isCancelled else { return }
             renderState.apply(rendered, for: requestedKey)
@@ -351,9 +379,15 @@ struct MermaidDiagramViewerView: View {
         intrinsic: CGSize,
         fitted: CGSize
     ) {
-        actualSizeScale = MermaidDiagramLayout.actualSizeScale(
+        let oldActualSizeScale = actualSizeScale
+        let newActualSizeScale = MermaidDiagramLayout.actualSizeScale(
             intrinsic: intrinsic,
             fitted: fitted
+        )
+        actualSizeScale = newActualSizeScale
+        interactionState.preserveIntrinsicZoom(
+            from: oldActualSizeScale,
+            to: newActualSizeScale
         )
     }
 
@@ -365,6 +399,64 @@ struct MermaidDiagramViewerView: View {
             width: committed.width + gesture.width,
             height: committed.height + gesture.height
         )
+    }
+}
+
+private struct MermaidDiagramViewerBackingScaleReader: NSViewRepresentable {
+    @Binding var scale: CGFloat
+
+    func makeNSView(context: Context) -> MermaidDiagramViewerBackingScaleView {
+        let view = MermaidDiagramViewerBackingScaleView()
+        view.onScaleChange = { scale = $0 }
+        return view
+    }
+
+    func updateNSView(
+        _ nsView: MermaidDiagramViewerBackingScaleView,
+        context: Context
+    ) {
+        nsView.onScaleChange = { scale = $0 }
+        nsView.publishScale()
+    }
+}
+
+private final class MermaidDiagramViewerBackingScaleView: NSView {
+    var onScaleChange: ((CGFloat) -> Void)?
+    private var backingPropertiesObserver: NSObjectProtocol?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        observeBackingProperties()
+        publishScale()
+    }
+
+    deinit {
+        if let backingPropertiesObserver {
+            NotificationCenter.default.removeObserver(backingPropertiesObserver)
+        }
+    }
+
+    func publishScale() {
+        guard let scale = window?.backingScaleFactor,
+              scale.isFinite,
+              scale > 0
+        else { return }
+        onScaleChange?(scale)
+    }
+
+    private func observeBackingProperties() {
+        if let backingPropertiesObserver {
+            NotificationCenter.default.removeObserver(backingPropertiesObserver)
+            self.backingPropertiesObserver = nil
+        }
+        guard let window else { return }
+        backingPropertiesObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeBackingPropertiesNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.publishScale()
+        }
     }
 }
 

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
@@ -99,7 +99,7 @@ struct MermaidDiagramViewerView: View {
     var service: MermaidRenderService = .shared
 
     @Environment(\.theme) private var theme
-    @State private var outcome: MermaidRenderOutcome?
+    @State private var renderState = MermaidRenderRequestState()
     @State private var showsSource = false
     @State private var zoomState = MermaidZoomState()
     @GestureState private var dragTranslation: CGSize = .zero
@@ -130,9 +130,12 @@ struct MermaidDiagramViewerView: View {
         }
         .background(theme.color("bg-1"))
         .task(id: key) {
-            outcome = nil
+            let requestedKey = key
+            renderState.begin(requestedKey)
             zoomState.resetToFit()
-            outcome = await service.render(key: key)
+            let rendered = await service.render(key: requestedKey)
+            guard !Task.isCancelled else { return }
+            renderState.apply(rendered, for: requestedKey)
         }
     }
 
@@ -155,7 +158,7 @@ struct MermaidDiagramViewerView: View {
         GeometryReader { proxy in
             ZStack {
                 theme.color("bg-1")
-                switch outcome {
+                switch renderState.outcome {
                 case .rendered(let diagram):
                     let fittedSize = MermaidDiagramLayout.fittedSize(
                         intrinsic: diagram.image.size,

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
@@ -1,0 +1,287 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class MermaidDiagramViewerController: NSObject, NSWindowDelegate {
+    static let shared = MermaidDiagramViewerController()
+
+    private weak var hostWindow: NSWindow?
+    private var sheetWindow: MermaidDiagramSheetWindow?
+
+    func show(source: String, theme: Theme, from hostWindow: NSWindow) {
+        endCurrentViewer()
+
+        let visibleFrame = hostWindow.screen?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 1_280, height: 800)
+        let size = NSSize(
+            width: visibleFrame.width * 0.8,
+            height: visibleFrame.height * 0.8
+        )
+        let backingScale = hostWindow.screen?.backingScaleFactor
+            ?? hostWindow.backingScaleFactor
+        let rootView = MermaidDiagramViewerView(
+            source: source,
+            diagramTheme: MermaidDiagramTheme(theme: theme),
+            backingScale: backingScale
+        )
+        .environment(\.theme, theme)
+
+        let sheet = MermaidDiagramSheetWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        sheet.title = "Mermaid Diagram"
+        sheet.isReleasedWhenClosed = false
+        sheet.contentMinSize = NSSize(
+            width: min(480, size.width),
+            height: min(320, size.height)
+        )
+        sheet.contentView = NSHostingView(rootView: rootView)
+        sheet.delegate = self
+        sheet.onCancel = { [weak self] in
+            self?.dismiss()
+        }
+
+        self.hostWindow = hostWindow
+        sheetWindow = sheet
+        hostWindow.beginSheet(sheet)
+    }
+
+    func dismiss() {
+        endCurrentViewer()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard sender === sheetWindow else { return true }
+        endCurrentViewer()
+        return false
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard let closingWindow = notification.object as? NSWindow,
+              closingWindow === sheetWindow else { return }
+        hostWindow = nil
+        sheetWindow = nil
+    }
+
+    private func endCurrentViewer() {
+        guard let sheet = sheetWindow else { return }
+        let parent = sheet.sheetParent ?? hostWindow
+        sheet.delegate = nil
+        sheet.onCancel = nil
+        sheetWindow = nil
+        hostWindow = nil
+        if let parent {
+            parent.endSheet(sheet)
+            sheet.orderOut(nil)
+        } else {
+            sheet.close()
+        }
+    }
+}
+
+@MainActor
+private final class MermaidDiagramSheetWindow: NSWindow {
+    var onCancel: (() -> Void)?
+
+    override func cancelOperation(_ sender: Any?) {
+        onCancel?()
+    }
+}
+
+struct MermaidDiagramViewerView: View {
+    let source: String
+    let diagramTheme: MermaidDiagramTheme
+    let backingScale: CGFloat
+    var service: MermaidRenderService = .shared
+
+    @Environment(\.theme) private var theme
+    @State private var outcome: MermaidRenderOutcome?
+    @State private var showsSource = false
+    @State private var zoomState = MermaidZoomState()
+    @GestureState private var dragTranslation: CGSize = .zero
+    @GestureState private var magnification: CGFloat = 1
+
+    private var key: MermaidRenderKey {
+        MermaidRenderKey(
+            source: source,
+            theme: diagramTheme,
+            scale: backingScale,
+            profile: .full
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            MermaidDiagramViewerToolbar(
+                scale: zoomState.scale,
+                showsSource: showsSource,
+                zoomOut: { zoomState.zoom(by: 0.8) },
+                zoomIn: { zoomState.zoom(by: 1.25) },
+                resetScale: { zoomState.setScale(1) },
+                reset: { zoomState.resetToFit() },
+                toggleSource: { showsSource.toggle() },
+                copySource: { Clipboard.copy(source) }
+            )
+            viewerContent
+        }
+        .background(theme.color("bg-1"))
+        .task(id: key) {
+            outcome = nil
+            zoomState.resetToFit()
+            outcome = await service.render(key: key)
+        }
+    }
+
+    @ViewBuilder
+    private var viewerContent: some View {
+        if showsSource {
+            HSplitView {
+                canvas
+                    .frame(minWidth: 240, maxWidth: .infinity, maxHeight: .infinity)
+                MermaidDiagramSourceView(source: source, maximumHeight: .infinity)
+                    .frame(minWidth: 220, idealWidth: 360, maxWidth: .infinity)
+                    .frame(maxHeight: .infinity)
+            }
+        } else {
+            canvas
+        }
+    }
+
+    private var canvas: some View {
+        GeometryReader { proxy in
+            ZStack {
+                theme.color("bg-1")
+                switch outcome {
+                case .rendered(let diagram):
+                    let fittedSize = MermaidDiagramLayout.fittedSize(
+                        intrinsic: diagram.image.size,
+                        availableWidth: max(0, proxy.size.width - 40),
+                        maxHeight: max(0, proxy.size.height - 40)
+                    )
+                    Image(nsImage: diagram.image)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: fittedSize.width, height: fittedSize.height)
+                        .scaleEffect(zoomState.scale(adding: magnification))
+                        .offset(Self.displayTranslation(
+                            committed: zoomState.translation,
+                            gesture: dragTranslation
+                        ))
+                        .accessibilityLabel("Mermaid diagram")
+                        .accessibilityValue(Text(verbatim: source))
+                case .failed(let failure):
+                    VStack(spacing: 8) {
+                        Text("Couldn't render Mermaid diagram")
+                            .font(.headline)
+                            .foregroundStyle(theme.color("fg"))
+                        Text(failure.mermaidDisplayDiagnostic)
+                            .font(.callout)
+                            .foregroundStyle(theme.color("fg-muted"))
+                            .textSelection(.enabled)
+                    }
+                    .multilineTextAlignment(.center)
+                    .padding(24)
+                case nil:
+                    ProgressView()
+                        .controlSize(.regular)
+                        .accessibilityLabel("Rendering Mermaid diagram")
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .clipped()
+        }
+        .simultaneousGesture(panGesture)
+        .simultaneousGesture(zoomGesture)
+    }
+
+    private var panGesture: some Gesture {
+        DragGesture(minimumDistance: 1)
+            .updating($dragTranslation) { value, translation, _ in
+                translation = value.translation
+            }
+            .onEnded { value in
+                zoomState.translate(by: value.translation)
+            }
+    }
+
+    private var zoomGesture: some Gesture {
+        MagnifyGesture()
+            .updating($magnification) { value, magnification, _ in
+                magnification = value.magnification
+            }
+            .onEnded { value in
+                zoomState.zoom(by: value.magnification)
+            }
+    }
+
+    nonisolated static func displayTranslation(
+        committed: CGSize,
+        gesture: CGSize
+    ) -> CGSize {
+        CGSize(
+            width: committed.width + gesture.width,
+            height: committed.height + gesture.height
+        )
+    }
+}
+
+private struct MermaidDiagramViewerToolbar: View {
+    let scale: CGFloat
+    let showsSource: Bool
+    let zoomOut: () -> Void
+    let zoomIn: () -> Void
+    let resetScale: () -> Void
+    let reset: () -> Void
+    let toggleSource: () -> Void
+    let copySource: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text("MERMAID")
+                .font(.system(size: 11, weight: .semibold))
+                .tracking(0.4)
+                .foregroundStyle(theme.color("fg-faint"))
+            Spacer(minLength: 0)
+            Button(action: zoomOut) {
+                Label("Zoom out", systemImage: "minus.magnifyingglass")
+                    .labelStyle(.iconOnly)
+            }
+            .help("Zoom out")
+            Button(action: resetScale) {
+                Text("\(Int((scale * 100).rounded()))%")
+                    .monospacedDigit()
+                    .frame(minWidth: 38)
+            }
+            .help("Set zoom to 100%")
+            Button(action: zoomIn) {
+                Label("Zoom in", systemImage: "plus.magnifyingglass")
+                    .labelStyle(.iconOnly)
+            }
+            .help("Zoom in")
+            Button("Reset", action: reset)
+            Divider()
+                .frame(height: 16)
+            Button(showsSource ? "Hide source" : "Show source", action: toggleSource)
+            Button("Copy", action: copySource)
+        }
+        .font(.system(size: 11, weight: .medium))
+        .buttonStyle(.plain)
+        .foregroundStyle(theme.color("fg-muted"))
+        .padding(.horizontal, 14)
+        .frame(height: 40)
+        .background(theme.color("bg-2"))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.color("line"))
+                .frame(height: 0.5)
+        }
+    }
+}

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
@@ -92,6 +92,106 @@ private final class MermaidDiagramSheetWindow: NSWindow {
     }
 }
 
+enum MermaidViewerAction: CaseIterable {
+    case zoomOut
+    case zoomIn
+    case actualSize
+    case resetToFit
+    case toggleSource
+    case copySource
+
+    var shortcut: ShortcutBinding {
+        switch self {
+        case .zoomOut:
+            ShortcutBinding(key: "-", modifiers: [.command])
+        case .zoomIn:
+            ShortcutBinding(key: "=", modifiers: [.command])
+        case .actualSize:
+            ShortcutBinding(key: "0", modifiers: [.command])
+        case .resetToFit:
+            ShortcutBinding(key: "9", modifiers: [.command])
+        case .toggleSource:
+            ShortcutBinding(key: "u", modifiers: [.option, .command])
+        case .copySource:
+            ShortcutBinding(key: "c", modifiers: [.option, .command])
+        }
+    }
+}
+
+enum MermaidViewerEffect: Equatable {
+    case copySource
+}
+
+enum MermaidViewerZoomAdjustment {
+    case increment
+    case decrement
+}
+
+struct MermaidViewerZoomAccessibilityMetadata: Equatable {
+    let label: String
+    let value: String
+}
+
+struct MermaidViewerInteractionState {
+    private var zoomState = MermaidZoomState()
+    private(set) var showsSource = false
+
+    var scale: CGFloat {
+        zoomState.scale
+    }
+
+    var translation: CGSize {
+        zoomState.translation
+    }
+
+    var zoomAccessibilityMetadata: MermaidViewerZoomAccessibilityMetadata {
+        MermaidViewerZoomAccessibilityMetadata(
+            label: "Mermaid diagram zoom",
+            value: "\(Int((scale * 100).rounded()))%"
+        )
+    }
+
+    @discardableResult
+    mutating func perform(_ action: MermaidViewerAction) -> MermaidViewerEffect? {
+        switch action {
+        case .zoomOut:
+            zoomState.zoom(by: 0.8)
+        case .zoomIn:
+            zoomState.zoom(by: 1.25)
+        case .actualSize:
+            zoomState.setScale(1)
+        case .resetToFit:
+            zoomState.resetToFit()
+        case .toggleSource:
+            showsSource.toggle()
+        case .copySource:
+            return .copySource
+        }
+        return nil
+    }
+
+    mutating func adjustZoom(_ adjustment: MermaidViewerZoomAdjustment) {
+        switch adjustment {
+        case .increment:
+            perform(.zoomIn)
+        case .decrement:
+            perform(.zoomOut)
+        }
+    }
+
+    mutating func zoom(by factor: CGFloat) {
+        zoomState.zoom(by: factor)
+    }
+
+    mutating func translate(by delta: CGSize) {
+        zoomState.translate(by: delta)
+    }
+
+    func scale(adding factor: CGFloat) -> CGFloat {
+        zoomState.scale(adding: factor)
+    }
+}
+
 struct MermaidDiagramViewerView: View {
     let source: String
     let diagramTheme: MermaidDiagramTheme
@@ -100,8 +200,7 @@ struct MermaidDiagramViewerView: View {
 
     @Environment(\.theme) private var theme
     @State private var renderState = MermaidRenderRequestState()
-    @State private var showsSource = false
-    @State private var zoomState = MermaidZoomState()
+    @State private var interactionState = MermaidViewerInteractionState()
     @GestureState private var dragTranslation: CGSize = .zero
     @GestureState private var magnification: CGFloat = 1
 
@@ -117,14 +216,10 @@ struct MermaidDiagramViewerView: View {
     var body: some View {
         VStack(spacing: 0) {
             MermaidDiagramViewerToolbar(
-                scale: zoomState.scale,
-                showsSource: showsSource,
-                zoomOut: { zoomState.zoom(by: 0.8) },
-                zoomIn: { zoomState.zoom(by: 1.25) },
-                resetScale: { zoomState.setScale(1) },
-                reset: { zoomState.resetToFit() },
-                toggleSource: { showsSource.toggle() },
-                copySource: { Clipboard.copy(source) }
+                showsSource: interactionState.showsSource,
+                zoomAccessibilityMetadata: interactionState.zoomAccessibilityMetadata,
+                perform: perform,
+                adjustZoom: { interactionState.adjustZoom($0) }
             )
             viewerContent
         }
@@ -132,7 +227,7 @@ struct MermaidDiagramViewerView: View {
         .task(id: key) {
             let requestedKey = key
             renderState.begin(requestedKey)
-            zoomState.resetToFit()
+            interactionState.perform(.resetToFit)
             let rendered = await service.render(key: requestedKey)
             guard !Task.isCancelled else { return }
             renderState.apply(rendered, for: requestedKey)
@@ -141,7 +236,7 @@ struct MermaidDiagramViewerView: View {
 
     @ViewBuilder
     private var viewerContent: some View {
-        if showsSource {
+        if interactionState.showsSource {
             HSplitView {
                 canvas
                     .frame(minWidth: 240, maxWidth: .infinity, maxHeight: .infinity)
@@ -170,9 +265,9 @@ struct MermaidDiagramViewerView: View {
                         .interpolation(.high)
                         .aspectRatio(contentMode: .fit)
                         .frame(width: fittedSize.width, height: fittedSize.height)
-                        .scaleEffect(zoomState.scale(adding: magnification))
+                        .scaleEffect(interactionState.scale(adding: magnification))
                         .offset(Self.displayTranslation(
-                            committed: zoomState.translation,
+                            committed: interactionState.translation,
                             gesture: dragTranslation
                         ))
                         .accessibilityLabel("Mermaid diagram")
@@ -209,7 +304,7 @@ struct MermaidDiagramViewerView: View {
                 translation = value.translation
             }
             .onEnded { value in
-                zoomState.translate(by: value.translation)
+                interactionState.translate(by: value.translation)
             }
     }
 
@@ -219,8 +314,13 @@ struct MermaidDiagramViewerView: View {
                 magnification = value.magnification
             }
             .onEnded { value in
-                zoomState.zoom(by: value.magnification)
+                interactionState.zoom(by: value.magnification)
             }
+    }
+
+    private func perform(_ action: MermaidViewerAction) {
+        guard interactionState.perform(action) == .copySource else { return }
+        Clipboard.copy(source)
     }
 
     nonisolated static func displayTranslation(
@@ -235,14 +335,10 @@ struct MermaidDiagramViewerView: View {
 }
 
 private struct MermaidDiagramViewerToolbar: View {
-    let scale: CGFloat
     let showsSource: Bool
-    let zoomOut: () -> Void
-    let zoomIn: () -> Void
-    let resetScale: () -> Void
-    let reset: () -> Void
-    let toggleSource: () -> Void
-    let copySource: () -> Void
+    let zoomAccessibilityMetadata: MermaidViewerZoomAccessibilityMetadata
+    let perform: (MermaidViewerAction) -> Void
+    let adjustZoom: (MermaidViewerZoomAdjustment) -> Void
 
     @Environment(\.theme) private var theme
 
@@ -253,27 +349,51 @@ private struct MermaidDiagramViewerToolbar: View {
                 .tracking(0.4)
                 .foregroundStyle(theme.color("fg-faint"))
             Spacer(minLength: 0)
-            Button(action: zoomOut) {
+            Button(action: { perform(.zoomOut) }) {
                 Label("Zoom out", systemImage: "minus.magnifyingglass")
                     .labelStyle(.iconOnly)
             }
             .help("Zoom out")
-            Button(action: resetScale) {
-                Text("\(Int((scale * 100).rounded()))%")
+            .keyboardShortcut(MermaidViewerAction.zoomOut.shortcut.asKeyboardShortcut())
+            Button(action: { perform(.actualSize) }) {
+                Text(zoomAccessibilityMetadata.value)
                     .monospacedDigit()
                     .frame(minWidth: 38)
             }
             .help("Set zoom to 100%")
-            Button(action: zoomIn) {
+            .keyboardShortcut(MermaidViewerAction.actualSize.shortcut.asKeyboardShortcut())
+            .accessibilityLabel(zoomAccessibilityMetadata.label)
+            .accessibilityValue(zoomAccessibilityMetadata.value)
+            .accessibilityAdjustableAction { direction in
+                switch direction {
+                case .increment:
+                    adjustZoom(.increment)
+                case .decrement:
+                    adjustZoom(.decrement)
+                @unknown default:
+                    break
+                }
+            }
+            Button(action: { perform(.zoomIn) }) {
                 Label("Zoom in", systemImage: "plus.magnifyingglass")
                     .labelStyle(.iconOnly)
             }
             .help("Zoom in")
-            Button("Reset", action: reset)
+            .keyboardShortcut(MermaidViewerAction.zoomIn.shortcut.asKeyboardShortcut())
+            Button("Reset") {
+                perform(.resetToFit)
+            }
+            .keyboardShortcut(MermaidViewerAction.resetToFit.shortcut.asKeyboardShortcut())
             Divider()
                 .frame(height: 16)
-            Button(showsSource ? "Hide source" : "Show source", action: toggleSource)
-            Button("Copy", action: copySource)
+            Button(showsSource ? "Hide source" : "Show source") {
+                perform(.toggleSource)
+            }
+            .keyboardShortcut(MermaidViewerAction.toggleSource.shortcut.asKeyboardShortcut())
+            Button("Copy") {
+                perform(.copySource)
+            }
+            .keyboardShortcut(MermaidViewerAction.copySource.shortcut.asKeyboardShortcut())
         }
         .font(.system(size: 11, weight: .medium))
         .buttonStyle(.plain)

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
@@ -152,14 +152,17 @@ struct MermaidViewerInteractionState {
     }
 
     @discardableResult
-    mutating func perform(_ action: MermaidViewerAction) -> MermaidViewerEffect? {
+    mutating func perform(
+        _ action: MermaidViewerAction,
+        actualSizeScale: CGFloat = 1
+    ) -> MermaidViewerEffect? {
         switch action {
         case .zoomOut:
             zoomState.zoom(by: 0.8)
         case .zoomIn:
             zoomState.zoom(by: 1.25)
         case .actualSize:
-            zoomState.setScale(1)
+            zoomState.setActualSize(actualSizeScale)
         case .resetToFit:
             zoomState.resetToFit()
         case .toggleSource:
@@ -203,6 +206,7 @@ struct MermaidDiagramViewerView: View {
     @State private var interactionState = MermaidViewerInteractionState()
     @GestureState private var dragTranslation: CGSize = .zero
     @GestureState private var magnification: CGFloat = 1
+    @State private var actualSizeScale: CGFloat = 1
 
     private var key: MermaidRenderKey {
         MermaidRenderKey(
@@ -272,6 +276,18 @@ struct MermaidDiagramViewerView: View {
                         ))
                         .accessibilityLabel("Mermaid diagram")
                         .accessibilityValue(Text(verbatim: source))
+                        .onAppear {
+                            updateActualSizeScale(
+                                intrinsic: diagram.image.size,
+                                fitted: fittedSize
+                            )
+                        }
+                        .onChange(of: proxy.size) { _ in
+                            updateActualSizeScale(
+                                intrinsic: diagram.image.size,
+                                fitted: fittedSize
+                            )
+                        }
                 case .failed(let failure):
                     VStack(spacing: 8) {
                         Text("Couldn't render Mermaid diagram")
@@ -319,8 +335,21 @@ struct MermaidDiagramViewerView: View {
     }
 
     private func perform(_ action: MermaidViewerAction) {
-        guard interactionState.perform(action) == .copySource else { return }
+        guard interactionState.perform(
+            action,
+            actualSizeScale: actualSizeScale
+        ) == .copySource else { return }
         Clipboard.copy(source)
+    }
+
+    private func updateActualSizeScale(
+        intrinsic: CGSize,
+        fitted: CGSize
+    ) {
+        actualSizeScale = MermaidDiagramLayout.actualSizeScale(
+            intrinsic: intrinsic,
+            fitted: fitted
+        )
     }
 
     nonisolated static func displayTranslation(

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Observation
 import SwiftUI
 
 @MainActor
@@ -7,6 +8,7 @@ final class MermaidDiagramViewerController: NSObject, NSWindowDelegate {
 
     private weak var hostWindow: NSWindow?
     private var sheetWindow: MermaidDiagramSheetWindow?
+    private var themeModel: MermaidDiagramViewerThemeModel?
 
     func show(source: String, theme: Theme, from hostWindow: NSWindow) {
         endCurrentViewer()
@@ -20,12 +22,12 @@ final class MermaidDiagramViewerController: NSObject, NSWindowDelegate {
         )
         let backingScale = hostWindow.screen?.backingScaleFactor
             ?? hostWindow.backingScaleFactor
-        let rootView = MermaidDiagramViewerView(
+        let themeModel = MermaidDiagramViewerThemeModel(theme: theme)
+        let rootView = MermaidDiagramViewerRootView(
             source: source,
-            diagramTheme: MermaidDiagramTheme(theme: theme),
-            backingScale: backingScale
+            backingScale: backingScale,
+            themeModel: themeModel
         )
-        .environment(\.theme, theme)
 
         let sheet = MermaidDiagramSheetWindow(
             contentRect: NSRect(origin: .zero, size: size),
@@ -46,8 +48,13 @@ final class MermaidDiagramViewerController: NSObject, NSWindowDelegate {
         }
 
         self.hostWindow = hostWindow
+        self.themeModel = themeModel
         sheetWindow = sheet
         hostWindow.beginSheet(sheet)
+    }
+
+    func updateTheme(_ theme: Theme) {
+        themeModel?.theme = theme
     }
 
     func dismiss() {
@@ -65,6 +72,7 @@ final class MermaidDiagramViewerController: NSObject, NSWindowDelegate {
               closingWindow === sheetWindow else { return }
         hostWindow = nil
         sheetWindow = nil
+        themeModel = nil
     }
 
     private func endCurrentViewer() {
@@ -74,12 +82,23 @@ final class MermaidDiagramViewerController: NSObject, NSWindowDelegate {
         sheet.onCancel = nil
         sheetWindow = nil
         hostWindow = nil
+        themeModel = nil
         if let parent {
             parent.endSheet(sheet)
             sheet.orderOut(nil)
         } else {
             sheet.close()
         }
+    }
+}
+
+@MainActor
+@Observable
+final class MermaidDiagramViewerThemeModel {
+    var theme: Theme
+
+    init(theme: Theme) {
+        self.theme = theme
     }
 }
 
@@ -222,9 +241,36 @@ struct MermaidViewerInteractionState {
     }
 }
 
+private struct MermaidDiagramViewerRootView: View {
+    let source: String
+    let backingScale: CGFloat
+    let service: MermaidRenderService
+    let themeModel: MermaidDiagramViewerThemeModel
+
+    init(
+        source: String,
+        backingScale: CGFloat,
+        service: MermaidRenderService = .shared,
+        themeModel: MermaidDiagramViewerThemeModel
+    ) {
+        self.source = source
+        self.backingScale = backingScale
+        self.service = service
+        self.themeModel = themeModel
+    }
+
+    var body: some View {
+        MermaidDiagramViewerView(
+            source: source,
+            backingScale: backingScale,
+            service: service
+        )
+        .environment(\.theme, themeModel.theme)
+    }
+}
+
 struct MermaidDiagramViewerView: View {
     let source: String
-    let diagramTheme: MermaidDiagramTheme
     var service: MermaidRenderService
 
     @Environment(\.theme) private var theme
@@ -236,22 +282,19 @@ struct MermaidDiagramViewerView: View {
     @State private var liveBackingScale: CGFloat
 
     private var key: MermaidRenderKey {
-        MermaidRenderKey(
+        Self.renderKey(
             source: source,
-            theme: diagramTheme,
-            scale: liveBackingScale,
-            profile: .full
+            theme: theme,
+            backingScale: liveBackingScale
         )
     }
 
     init(
         source: String,
-        diagramTheme: MermaidDiagramTheme,
         backingScale: CGFloat,
         service: MermaidRenderService = .shared
     ) {
         self.source = source
-        self.diagramTheme = diagramTheme
         self.service = service
         _liveBackingScale = State(initialValue: backingScale)
     }
@@ -413,6 +456,20 @@ struct MermaidDiagramViewerView: View {
         CGSize(
             width: committed.width + gesture.width,
             height: committed.height + gesture.height
+        )
+    }
+
+    @MainActor
+    static func renderKey(
+        source: String,
+        theme: Theme,
+        backingScale: CGFloat
+    ) -> MermaidRenderKey {
+        MermaidRenderKey(
+            source: source,
+            theme: MermaidDiagramTheme(theme: theme),
+            scale: backingScale,
+            profile: .full
         )
     }
 }

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramViewer.swift
@@ -144,10 +144,13 @@ struct MermaidViewerInteractionState {
         zoomState.translation
     }
 
-    var zoomAccessibilityMetadata: MermaidViewerZoomAccessibilityMetadata {
-        MermaidViewerZoomAccessibilityMetadata(
+    func zoomAccessibilityMetadata(
+        actualSizeScale: CGFloat = 1
+    ) -> MermaidViewerZoomAccessibilityMetadata {
+        let intrinsicScale = actualSizeScale > 0 ? scale / actualSizeScale : scale
+        return MermaidViewerZoomAccessibilityMetadata(
             label: "Mermaid diagram zoom",
-            value: "\(Int((scale * 100).rounded()))%"
+            value: "\(Int((intrinsicScale * 100).rounded()))%"
         )
     }
 
@@ -221,7 +224,9 @@ struct MermaidDiagramViewerView: View {
         VStack(spacing: 0) {
             MermaidDiagramViewerToolbar(
                 showsSource: interactionState.showsSource,
-                zoomAccessibilityMetadata: interactionState.zoomAccessibilityMetadata,
+                zoomAccessibilityMetadata: interactionState.zoomAccessibilityMetadata(
+                    actualSizeScale: actualSizeScale
+                ),
                 perform: perform,
                 adjustZoom: { interactionState.adjustZoom($0) }
             )

--- a/Alas/Sources/Code/Mermaid/MermaidModels.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidModels.swift
@@ -80,6 +80,13 @@ enum MermaidRenderOutcome: @unchecked Sendable {
         case .failed: 1
         }
     }
+
+    var isCacheable: Bool {
+        if case .failed(.sourceTooLarge) = self {
+            return false
+        }
+        return true
+    }
 }
 
 protocol MermaidRenderingBackend: Sendable {

--- a/Alas/Sources/Code/Mermaid/MermaidModels.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidModels.swift
@@ -35,6 +35,18 @@ struct MermaidRenderKey: Hashable, Sendable {
     let theme: MermaidDiagramTheme
     let scale: Double
     let profile: MermaidPresentationProfile
+
+    static func == (lhs: MermaidRenderKey, rhs: MermaidRenderKey) -> Bool {
+        lhs.source == rhs.source
+            && lhs.theme == rhs.theme
+            && lhs.scale == rhs.scale
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(source)
+        hasher.combine(theme)
+        hasher.combine(scale)
+    }
 }
 
 struct MermaidRenderedDiagram: @unchecked Sendable {

--- a/Alas/Sources/Code/Mermaid/MermaidModels.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidModels.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Foundation
+
+enum MermaidPresentationProfile: String, Hashable, Sendable {
+    case full
+    case transcript
+    case compact
+
+    var maxEmbeddedHeight: CGFloat {
+        switch self {
+        case .full: 640
+        case .transcript: 420
+        case .compact: 180
+        }
+    }
+}
+
+enum MermaidFence {
+    static func isMermaid(language: String?) -> Bool {
+        language?
+            .split(whereSeparator: \.isWhitespace)
+            .first?
+            .lowercased() == "mermaid"
+    }
+}
+
+struct MermaidRenderKey: Hashable, Sendable {
+    let source: String
+    let theme: MermaidDiagramTheme
+    let scale: Double
+    let profile: MermaidPresentationProfile
+}
+
+struct MermaidRenderedDiagram: @unchecked Sendable {
+    let image: NSImage
+    let pixelSize: CGSize
+    let byteCost: Int
+}
+
+enum MermaidRenderFailure: Error, Equatable, Sendable {
+    case empty
+    case sourceTooLarge(actualBytes: Int)
+    case unsupported(String)
+    case parseFailed(String)
+    case layoutFailed(String)
+    case renderFailed(String)
+    case rasterTooLarge(width: Int, height: Int)
+}
+
+enum MermaidRenderOutcome: @unchecked Sendable {
+    case rendered(MermaidRenderedDiagram)
+    case failed(MermaidRenderFailure)
+
+    var cacheCost: Int {
+        switch self {
+        case .rendered(let diagram): diagram.byteCost
+        case .failed: 1
+        }
+    }
+}
+
+protocol MermaidRenderingBackend: Sendable {
+    func render(key: MermaidRenderKey) async -> MermaidRenderOutcome
+}

--- a/Alas/Sources/Code/Mermaid/MermaidModels.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidModels.swift
@@ -24,6 +24,12 @@ enum MermaidFence {
     }
 }
 
+enum MermaidSource {
+    static func copyPayload(for source: String) -> String {
+        source
+    }
+}
+
 struct MermaidRenderKey: Hashable, Sendable {
     let source: String
     let theme: MermaidDiagramTheme
@@ -50,6 +56,11 @@ enum MermaidRenderFailure: Error, Equatable, Sendable {
 enum MermaidRenderOutcome: @unchecked Sendable {
     case rendered(MermaidRenderedDiagram)
     case failed(MermaidRenderFailure)
+
+    var failure: MermaidRenderFailure? {
+        guard case .failed(let failure) = self else { return nil }
+        return failure
+    }
 
     var cacheCost: Int {
         switch self {

--- a/Alas/Sources/Code/Mermaid/MermaidRenderCache.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidRenderCache.swift
@@ -1,0 +1,42 @@
+struct MermaidRenderCache {
+    private struct Entry {
+        let outcome: MermaidRenderOutcome
+        let cost: Int
+    }
+
+    private var entries: [MermaidRenderKey: Entry] = [:]
+    private var recency: [MermaidRenderKey] = []
+    private(set) var totalCost = 0
+    let countLimit: Int
+    let costLimit: Int
+
+    init(countLimit: Int, costLimit: Int) {
+        self.countLimit = countLimit
+        self.costLimit = costLimit
+    }
+
+    mutating func value(for key: MermaidRenderKey) -> MermaidRenderOutcome? {
+        guard let entry = entries[key] else { return nil }
+        recency.removeAll { $0 == key }
+        recency.append(key)
+        return entry.outcome
+    }
+
+    mutating func insert(_ outcome: MermaidRenderOutcome, for key: MermaidRenderKey) {
+        if let old = entries.removeValue(forKey: key) {
+            totalCost -= old.cost
+        }
+        recency.removeAll { $0 == key }
+        entries[key] = Entry(outcome: outcome, cost: outcome.cacheCost)
+        recency.append(key)
+        totalCost += outcome.cacheCost
+
+        while entries.count > countLimit || totalCost > costLimit {
+            guard let victim = recency.first else { break }
+            recency.removeFirst()
+            if let removed = entries.removeValue(forKey: victim) {
+                totalCost -= removed.cost
+            }
+        }
+    }
+}

--- a/Alas/Sources/Code/Mermaid/MermaidRenderService.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidRenderService.swift
@@ -1,0 +1,58 @@
+actor MermaidRenderLimiter {
+    private var permits = 2
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        if permits > 0 {
+            permits -= 1
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            permits += 1
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
+actor MermaidRenderService {
+    static let shared = MermaidRenderService(backend: BeautifulMermaidBackend())
+
+    private let backend: any MermaidRenderingBackend
+    private let limiter = MermaidRenderLimiter()
+    private var cache = MermaidRenderCache(
+        countLimit: 128,
+        costLimit: 64 * 1024 * 1024
+    )
+    private var inFlight: [MermaidRenderKey: Task<MermaidRenderOutcome, Never>] = [:]
+
+    init(backend: any MermaidRenderingBackend) {
+        self.backend = backend
+    }
+
+    func render(key: MermaidRenderKey) async -> MermaidRenderOutcome {
+        if let cached = cache.value(for: key) {
+            return cached
+        }
+        if let task = inFlight[key] {
+            return await task.value
+        }
+
+        let task = Task { [backend, limiter] in
+            await limiter.acquire()
+            let outcome = await backend.render(key: key)
+            await limiter.release()
+            return outcome
+        }
+        inFlight[key] = task
+
+        let outcome = await task.value
+        inFlight.removeValue(forKey: key)
+        cache.insert(outcome, for: key)
+        return outcome
+    }
+}

--- a/Alas/Sources/Code/Mermaid/MermaidRenderService.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidRenderService.swift
@@ -83,7 +83,11 @@ actor MermaidRenderService {
 
         let renderID = UUID()
         let task: Task<MermaidRenderOutcome?, Never> = Task { [backend, limiter] in
-            guard await limiter.acquire(), !Task.isCancelled else {
+            guard await limiter.acquire() else {
+                return nil
+            }
+            if Task.isCancelled {
+                await limiter.release()
                 return nil
             }
             let outcome = await backend.render(key: key)

--- a/Alas/Sources/Code/Mermaid/MermaidRenderService.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidRenderService.swift
@@ -1,21 +1,46 @@
-actor MermaidRenderLimiter {
-    private var permits = 2
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+import Foundation
 
-    func acquire() async {
-        if permits > 0 {
-            permits -= 1
-            return
+actor MermaidRenderLimiter {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var permits = 2
+    private var waiters: [Waiter] = []
+
+    func acquire() async -> Bool {
+        guard !Task.isCancelled else { return false }
+        let id = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else if permits > 0 {
+                    permits -= 1
+                    continuation.resume(returning: true)
+                } else {
+                    waiters.append(Waiter(id: id, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id) }
         }
-        await withCheckedContinuation { waiters.append($0) }
     }
 
     func release() {
         if waiters.isEmpty {
             permits += 1
         } else {
-            waiters.removeFirst().resume()
+            waiters.removeFirst().continuation.resume(returning: true)
         }
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        waiters.remove(at: index).continuation.resume(returning: false)
     }
 }
 
@@ -28,7 +53,13 @@ actor MermaidRenderService {
         countLimit: 128,
         costLimit: 64 * 1024 * 1024
     )
-    private var inFlight: [MermaidRenderKey: Task<MermaidRenderOutcome, Never>] = [:]
+    private struct InFlightRender {
+        let id: UUID
+        let task: Task<MermaidRenderOutcome?, Never>
+        var consumerIDs: Set<UUID>
+    }
+
+    private var inFlight: [MermaidRenderKey: InFlightRender] = [:]
 
     init(backend: any MermaidRenderingBackend) {
         self.backend = backend
@@ -38,21 +69,96 @@ actor MermaidRenderService {
         if let cached = cache.value(for: key) {
             return cached
         }
-        if let task = inFlight[key] {
-            return await task.value
+        let consumerID = UUID()
+        if var render = inFlight[key] {
+            render.consumerIDs.insert(consumerID)
+            inFlight[key] = render
+            return await awaitOutcome(
+                for: key,
+                renderID: render.id,
+                consumerID: consumerID,
+                task: render.task
+            )
         }
 
-        let task = Task { [backend, limiter] in
-            await limiter.acquire()
+        let renderID = UUID()
+        let task: Task<MermaidRenderOutcome?, Never> = Task { [backend, limiter] in
+            guard await limiter.acquire(), !Task.isCancelled else {
+                return nil
+            }
             let outcome = await backend.render(key: key)
             await limiter.release()
-            return outcome
+            return Task.isCancelled ? nil : outcome
         }
-        inFlight[key] = task
+        inFlight[key] = InFlightRender(
+            id: renderID,
+            task: task,
+            consumerIDs: [consumerID]
+        )
 
-        let outcome = await task.value
+        return await awaitOutcome(
+            for: key,
+            renderID: renderID,
+            consumerID: consumerID,
+            task: task
+        )
+    }
+
+    private func awaitOutcome(
+        for key: MermaidRenderKey,
+        renderID: UUID,
+        consumerID: UUID,
+        task: Task<MermaidRenderOutcome?, Never>
+    ) async -> MermaidRenderOutcome {
+        await withTaskCancellationHandler {
+            let outcome = await task.value
+            finish(
+                outcome,
+                for: key,
+                renderID: renderID,
+                consumerID: consumerID
+            )
+            return outcome ?? .failed(.renderFailed("Mermaid rendering cancelled"))
+        } onCancel: {
+            Task {
+                await self.cancelConsumer(
+                    for: key,
+                    renderID: renderID,
+                    consumerID: consumerID
+                )
+            }
+        }
+    }
+
+    private func finish(
+        _ outcome: MermaidRenderOutcome?,
+        for key: MermaidRenderKey,
+        renderID: UUID,
+        consumerID: UUID
+    ) {
+        guard var render = inFlight[key], render.id == renderID,
+              render.consumerIDs.remove(consumerID) != nil
+        else { return }
         inFlight.removeValue(forKey: key)
-        cache.insert(outcome, for: key)
-        return outcome
+        if let outcome {
+            cache.insert(outcome, for: key)
+        }
+    }
+
+    private func cancelConsumer(
+        for key: MermaidRenderKey,
+        renderID: UUID,
+        consumerID: UUID
+    ) {
+        guard var render = inFlight[key], render.id == renderID,
+              render.consumerIDs.remove(consumerID) != nil
+        else { return }
+
+        if render.consumerIDs.isEmpty {
+            render.task.cancel()
+            inFlight.removeValue(forKey: key)
+        } else {
+            inFlight[key] = render
+        }
     }
 }

--- a/Alas/Sources/Code/Mermaid/MermaidRenderService.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidRenderService.swift
@@ -144,7 +144,7 @@ actor MermaidRenderService {
               render.consumerIDs.remove(consumerID) != nil
         else { return }
         inFlight.removeValue(forKey: key)
-        if let outcome {
+        if let outcome, outcome.isCacheable {
             cache.insert(outcome, for: key)
         }
     }

--- a/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
@@ -14,6 +14,14 @@ final class MermaidTextAttachment: NSTextAttachment {
     let profile: MermaidPresentationProfile
     let mermaidCell: MermaidTextAttachmentCell
 
+    var currentOutcome: MermaidRenderOutcome? {
+        mermaidCell.outcome
+    }
+
+    var copyPayload: String {
+        MermaidSource.copyPayload(for: source)
+    }
+
     init(id: String, source: String, profile: MermaidPresentationProfile) {
         self.id = id
         self.source = source
@@ -34,6 +42,11 @@ final class MermaidTextAttachment: NSTextAttachment {
 }
 
 final class MermaidTextAttachmentCell: NSTextAttachmentCell {
+    struct AccessibilityMetadata: Equatable {
+        let label: String?
+        let value: String?
+    }
+
     struct LayoutFrames {
         let header: NSRect?
         let body: NSRect
@@ -55,6 +68,7 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
     private(set) var outcome: MermaidRenderOutcome?
     private(set) var showsSource = false
     private var theme: MermaidDiagramTheme?
+    private var customAccessibilityActions: [NSAccessibilityCustomAction] = []
     nonisolated(unsafe) private var measuredWidth: CGFloat = 600
     nonisolated(unsafe) private var sizingState: SizingState = .loading
 
@@ -78,6 +92,7 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         }
         setAccessibilityLabel("Mermaid diagram")
         setAccessibilityValue(source)
+        updateAccessibilityActions()
     }
 
     required init(coder: NSCoder) {
@@ -106,6 +121,31 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
     func setSourceVisible(_ visible: Bool) {
         showsSource = visible
         updateCompactMenu()
+        updateAccessibilityActions()
+    }
+
+    var accessibilityMetadata: AccessibilityMetadata {
+        AccessibilityMetadata(
+            label: accessibilityLabel(),
+            value: accessibilityValue() as? String
+        )
+    }
+
+    var visibleActionLabels: [String] {
+        guard profile != .compact else { return [] }
+        return [
+            showsSource ? "Hide source" : "Show source",
+            "Copy",
+            "Expand",
+        ]
+    }
+
+    var contextMenuActionLabels: [String] {
+        menu?.items.map(\.title) ?? []
+    }
+
+    var accessibilityActionLabels: [String] {
+        customAccessibilityActions.map(\.name)
     }
 
     private func configureCompactMenu() {
@@ -135,6 +175,56 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         toggleSource.title = showsSource
             ? "Show Mermaid diagram"
             : "Show Mermaid source"
+    }
+
+    private func updateAccessibilityActions() {
+        let actions: [NSAccessibilityCustomAction]
+        if profile == .compact {
+            actions = [
+                accessibilityAction(
+                    named: showsSource
+                        ? "Show Mermaid diagram"
+                        : "Show Mermaid source"
+                ) { cell in
+                    cell.delegate?
+                        .mermaidTextAttachmentCellDidToggleSource(cell)
+                },
+                accessibilityAction(named: "Copy Mermaid source") { cell in
+                    cell.delegate?
+                        .mermaidTextAttachmentCellDidRequestCopy(cell)
+                },
+            ]
+        } else {
+            actions = [
+                accessibilityAction(
+                    named: showsSource ? "Hide source" : "Show source"
+                ) { cell in
+                    cell.delegate?
+                        .mermaidTextAttachmentCellDidToggleSource(cell)
+                },
+                accessibilityAction(named: "Copy") { cell in
+                    cell.delegate?
+                        .mermaidTextAttachmentCellDidRequestCopy(cell)
+                },
+                accessibilityAction(named: "Expand") { cell in
+                    cell.delegate?
+                        .mermaidTextAttachmentCellDidRequestExpansion(cell)
+                },
+            ]
+        }
+        customAccessibilityActions = actions
+        setAccessibilityCustomActions(actions)
+    }
+
+    private func accessibilityAction(
+        named name: String,
+        perform: @escaping (MermaidTextAttachmentCell) -> Void
+    ) -> NSAccessibilityCustomAction {
+        NSAccessibilityCustomAction(name: name) { [weak self] in
+            guard let self, delegate != nil else { return false }
+            perform(self)
+            return true
+        }
     }
 
     @objc private func toggleSourceFromMenu(_ sender: NSMenuItem) {

--- a/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
@@ -330,6 +330,9 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
     }
 
     private nonisolated func size(for width: CGFloat) -> NSSize {
+        if profile == .compact, showsSource {
+            return .zero
+        }
         let bodyWidth = max(1, width - Self.horizontalPadding * 2)
         let bodyHeight: CGFloat
         switch sizingState {

--- a/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
@@ -74,6 +74,7 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
 
     nonisolated private static let horizontalPadding: CGFloat = 12
     nonisolated private static let headerHeight: CGFloat = 31
+    nonisolated private static let compactSourceToggleHeight: CGFloat = 30
     nonisolated private static let fallbackWidth: CGFloat = 600
 
     private enum SizingState: Sendable {
@@ -312,7 +313,11 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         guard event.type == .leftMouseDown, let controlView else { return false }
         let point = controlView.convert(event.locationInWindow, from: nil)
         if profile == .compact {
-            delegate?.mermaidTextAttachmentCellDidRequestExpansion(self)
+            if showsSource {
+                delegate?.mermaidTextAttachmentCellDidToggleSource(self)
+            } else {
+                delegate?.mermaidTextAttachmentCellDidRequestExpansion(self)
+            }
             return true
         }
 
@@ -331,7 +336,7 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
 
     private nonisolated func size(for width: CGFloat) -> NSSize {
         if profile == .compact, showsSource {
-            return .zero
+            return NSSize(width: width, height: Self.compactSourceToggleHeight)
         }
         let bodyWidth = max(1, width - Self.horizontalPadding * 2)
         let bodyHeight: CGFloat
@@ -436,6 +441,10 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
     }
 
     private func drawBody(in frame: NSRect, colors: DrawingColors) {
+        if profile == .compact, showsSource {
+            drawCompactSourceRestore(in: frame, colors: colors)
+            return
+        }
         switch outcome {
         case .rendered(let diagram):
             let available = frame.insetBy(
@@ -466,6 +475,25 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         case nil:
             drawLoading(in: frame, colors: colors)
         }
+    }
+
+    private func drawCompactSourceRestore(
+        in frame: NSRect,
+        colors: DrawingColors
+    ) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 10, weight: .medium),
+            .foregroundColor: colors.muted
+        ]
+        let text = "Show Mermaid diagram" as NSString
+        let size = text.size(withAttributes: attributes)
+        text.draw(
+            at: NSPoint(
+                x: frame.midX - size.width / 2,
+                y: frame.midY - size.height / 2
+            ),
+            withAttributes: attributes
+        )
     }
 
     private func drawLoading(in frame: NSRect, colors: DrawingColors) {

--- a/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
@@ -73,6 +73,9 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         self.source = source
         self.profile = profile
         super.init(textCell: "")
+        if profile == .compact {
+            configureCompactMenu()
+        }
         setAccessibilityLabel("Mermaid diagram")
         setAccessibilityValue(source)
     }
@@ -102,6 +105,44 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
 
     func setSourceVisible(_ visible: Bool) {
         showsSource = visible
+        updateCompactMenu()
+    }
+
+    private func configureCompactMenu() {
+        let menu = NSMenu()
+        let toggleSource = NSMenuItem(
+            title: "Show Mermaid source",
+            action: #selector(toggleSourceFromMenu(_:)),
+            keyEquivalent: ""
+        )
+        toggleSource.target = self
+        menu.addItem(toggleSource)
+
+        let copySource = NSMenuItem(
+            title: "Copy Mermaid source",
+            action: #selector(copySourceFromMenu(_:)),
+            keyEquivalent: ""
+        )
+        copySource.target = self
+        menu.addItem(copySource)
+        self.menu = menu
+    }
+
+    private func updateCompactMenu() {
+        guard profile == .compact, let toggleSource = menu?.items.first else {
+            return
+        }
+        toggleSource.title = showsSource
+            ? "Show Mermaid diagram"
+            : "Show Mermaid source"
+    }
+
+    @objc private func toggleSourceFromMenu(_ sender: NSMenuItem) {
+        delegate?.mermaidTextAttachmentCellDidToggleSource(self)
+    }
+
+    @objc private func copySourceFromMenu(_ sender: NSMenuItem) {
+        delegate?.mermaidTextAttachmentCellDidRequestCopy(self)
     }
 
     override var cellSize: NSSize {
@@ -203,12 +244,16 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         let bodyHeight: CGFloat
         switch sizingState {
         case .rendered(let imageSize):
-            let fitted = MermaidDiagramLayout.fittedSize(
-                intrinsic: imageSize,
-                availableWidth: bodyWidth,
-                maxHeight: profile.maxEmbeddedHeight
-            )
-            bodyHeight = max(44, fitted.height + Self.horizontalPadding * 2)
+            if profile == .compact {
+                bodyHeight = profile.maxEmbeddedHeight
+            } else {
+                let fitted = MermaidDiagramLayout.fittedSize(
+                    intrinsic: imageSize,
+                    availableWidth: bodyWidth,
+                    maxHeight: profile.maxEmbeddedHeight
+                )
+                bodyHeight = max(44, fitted.height + Self.horizontalPadding * 2)
+            }
         case .failed:
             bodyHeight = profile == .compact ? profile.maxEmbeddedHeight : 76
         case .loading:

--- a/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
@@ -1,0 +1,407 @@
+import AppKit
+
+@MainActor
+protocol MermaidTextAttachmentCellDelegate: AnyObject {
+    func mermaidTextAttachmentCellDidToggleSource(_ cell: MermaidTextAttachmentCell)
+    func mermaidTextAttachmentCellDidRequestCopy(_ cell: MermaidTextAttachmentCell)
+    func mermaidTextAttachmentCellDidRequestExpansion(_ cell: MermaidTextAttachmentCell)
+}
+
+@MainActor
+final class MermaidTextAttachment: NSTextAttachment {
+    let id: String
+    let source: String
+    let profile: MermaidPresentationProfile
+    let mermaidCell: MermaidTextAttachmentCell
+
+    init(id: String, source: String, profile: MermaidPresentationProfile) {
+        self.id = id
+        self.source = source
+        self.profile = profile
+        self.mermaidCell = MermaidTextAttachmentCell(
+            id: id,
+            source: source,
+            profile: profile
+        )
+        super.init(data: nil, ofType: nil)
+        allowsTextAttachmentView = false
+        attachmentCell = mermaidCell
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+final class MermaidTextAttachmentCell: NSTextAttachmentCell {
+    let id: String
+    let source: String
+    nonisolated let profile: MermaidPresentationProfile
+    weak var delegate: MermaidTextAttachmentCellDelegate?
+
+    private(set) var outcome: MermaidRenderOutcome?
+    private(set) var showsSource = false
+    private var theme: MermaidDiagramTheme?
+    nonisolated(unsafe) private var measuredWidth: CGFloat = 600
+    nonisolated(unsafe) private var sizingState: SizingState = .loading
+
+    nonisolated private static let horizontalPadding: CGFloat = 12
+    nonisolated private static let headerHeight: CGFloat = 31
+    nonisolated private static let fallbackWidth: CGFloat = 600
+
+    private enum SizingState: Sendable {
+        case loading
+        case rendered(CGSize)
+        case failed
+    }
+
+    init(id: String, source: String, profile: MermaidPresentationProfile) {
+        self.id = id
+        self.source = source
+        self.profile = profile
+        super.init(textCell: "")
+        setAccessibilityLabel("Mermaid diagram")
+        setAccessibilityValue(source)
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(theme: MermaidDiagramTheme) {
+        self.theme = theme
+    }
+
+    func beginLoading() {
+        outcome = nil
+        sizingState = .loading
+    }
+
+    func apply(_ outcome: MermaidRenderOutcome) {
+        self.outcome = outcome
+        switch outcome {
+        case .rendered(let diagram):
+            sizingState = .rendered(diagram.image.size)
+        case .failed:
+            sizingState = .failed
+        }
+    }
+
+    func setSourceVisible(_ visible: Bool) {
+        showsSource = visible
+    }
+
+    override var cellSize: NSSize {
+        size(for: measuredWidth)
+    }
+
+    override func cellFrame(
+        for textContainer: NSTextContainer,
+        proposedLineFragment lineFragment: NSRect,
+        glyphPosition position: NSPoint,
+        characterIndex charIndex: Int
+    ) -> NSRect {
+        let proposedWidth = lineFragment.width
+        let usableWidth: CGFloat
+        if proposedWidth.isFinite, proposedWidth > 0 {
+            usableWidth = proposedWidth
+        } else {
+            usableWidth = Self.fallbackWidth
+        }
+        measuredWidth = usableWidth
+        return NSRect(origin: .zero, size: size(for: usableWidth))
+    }
+
+    override func draw(withFrame frame: NSRect, in controlView: NSView?) {
+        let colors = DrawingColors(theme: theme)
+        let cardPath = NSBezierPath(
+            roundedRect: frame.insetBy(dx: 0.5, dy: 0.5),
+            xRadius: 6,
+            yRadius: 6
+        )
+        colors.background.setFill()
+        cardPath.fill()
+        colors.border.setStroke()
+        cardPath.lineWidth = 0.75
+        cardPath.stroke()
+
+        let bodyFrame: NSRect
+        if profile == .compact {
+            bodyFrame = frame.insetBy(dx: 1, dy: 1)
+        } else {
+            let header = NSRect(
+                x: frame.minX + 1,
+                y: frame.maxY - Self.headerHeight - 1,
+                width: max(0, frame.width - 2),
+                height: Self.headerHeight
+            )
+            colors.surface.setFill()
+            header.fill()
+            colors.border.setFill()
+            NSRect(x: header.minX, y: header.minY, width: header.width, height: 0.5).fill()
+            drawHeader(in: header, colors: colors)
+            bodyFrame = NSRect(
+                x: frame.minX + 1,
+                y: frame.minY + 1,
+                width: max(0, frame.width - 2),
+                height: max(0, frame.height - Self.headerHeight - 2)
+            )
+        }
+        drawBody(in: bodyFrame, colors: colors)
+    }
+
+    override func highlight(
+        _ flag: Bool,
+        withFrame frame: NSRect,
+        in controlView: NSView?
+    ) {
+        draw(withFrame: frame, in: controlView)
+    }
+
+    override func wantsToTrackMouse() -> Bool {
+        true
+    }
+
+    override func trackMouse(
+        with event: NSEvent,
+        in cellFrame: NSRect,
+        of controlView: NSView?,
+        untilMouseUp flag: Bool
+    ) -> Bool {
+        guard event.type == .leftMouseDown, let controlView else { return false }
+        let point = controlView.convert(event.locationInWindow, from: nil)
+        if profile == .compact {
+            delegate?.mermaidTextAttachmentCellDidRequestExpansion(self)
+            return true
+        }
+
+        let buttons = buttonFrames(in: cellFrame)
+        if buttons.source.contains(point) {
+            delegate?.mermaidTextAttachmentCellDidToggleSource(self)
+        } else if buttons.copy.contains(point) {
+            delegate?.mermaidTextAttachmentCellDidRequestCopy(self)
+        } else if buttons.expand.contains(point) {
+            delegate?.mermaidTextAttachmentCellDidRequestExpansion(self)
+        } else {
+            return false
+        }
+        return true
+    }
+
+    private nonisolated func size(for width: CGFloat) -> NSSize {
+        let bodyWidth = max(1, width - Self.horizontalPadding * 2)
+        let bodyHeight: CGFloat
+        switch sizingState {
+        case .rendered(let imageSize):
+            let fitted = MermaidDiagramLayout.fittedSize(
+                intrinsic: imageSize,
+                availableWidth: bodyWidth,
+                maxHeight: profile.maxEmbeddedHeight
+            )
+            bodyHeight = max(44, fitted.height + Self.horizontalPadding * 2)
+        case .failed:
+            bodyHeight = profile == .compact ? profile.maxEmbeddedHeight : 76
+        case .loading:
+            bodyHeight = profile == .compact ? profile.maxEmbeddedHeight : 120
+        }
+        let headerHeight = profile == .compact ? 0 : Self.headerHeight
+        return NSSize(width: width, height: headerHeight + bodyHeight + 2)
+    }
+
+    private func drawHeader(in frame: NSRect, colors: DrawingColors) {
+        let labelAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 10, weight: .semibold),
+            .foregroundColor: colors.muted
+        ]
+        let label = "MERMAID" as NSString
+        let labelSize = label.size(withAttributes: labelAttributes)
+        label.draw(
+            at: NSPoint(
+                x: frame.minX + 10,
+                y: frame.midY - labelSize.height / 2
+            ),
+            withAttributes: labelAttributes
+        )
+
+        let buttons = buttonFrames(in: NSRect(
+            x: frame.minX - 1,
+            y: frame.minY,
+            width: frame.width + 2,
+            height: frame.height
+        ))
+        drawButton(
+            showsSource ? "Hide source" : "Show source",
+            in: buttons.source,
+            color: colors.muted
+        )
+        drawButton("Copy", in: buttons.copy, color: colors.muted)
+        drawButton("Expand", in: buttons.expand, color: colors.muted)
+    }
+
+    private func drawButton(_ title: String, in frame: NSRect, color: NSColor) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 10, weight: .medium),
+            .foregroundColor: color
+        ]
+        let text = title as NSString
+        let size = text.size(withAttributes: attributes)
+        text.draw(
+            at: NSPoint(
+                x: frame.midX - size.width / 2,
+                y: frame.midY - size.height / 2
+            ),
+            withAttributes: attributes
+        )
+    }
+
+    private func drawBody(in frame: NSRect, colors: DrawingColors) {
+        switch outcome {
+        case .rendered(let diagram):
+            let available = frame.insetBy(
+                dx: Self.horizontalPadding,
+                dy: Self.horizontalPadding
+            )
+            let fitted = MermaidDiagramLayout.fittedSize(
+                intrinsic: diagram.image.size,
+                availableWidth: available.width,
+                maxHeight: min(available.height, profile.maxEmbeddedHeight)
+            )
+            let imageFrame = NSRect(
+                x: available.midX - fitted.width / 2,
+                y: available.midY - fitted.height / 2,
+                width: fitted.width,
+                height: fitted.height
+            )
+            diagram.image.draw(
+                in: imageFrame,
+                from: .zero,
+                operation: .sourceOver,
+                fraction: 1,
+                respectFlipped: true,
+                hints: [.interpolation: NSImageInterpolation.high]
+            )
+        case .failed(let failure):
+            drawFailure(failure, in: frame, colors: colors)
+        case nil:
+            drawLoading(in: frame, colors: colors)
+        }
+    }
+
+    private func drawLoading(in frame: NSRect, colors: DrawingColors) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12),
+            .foregroundColor: colors.muted
+        ]
+        let text = "Rendering Mermaid diagram…" as NSString
+        let size = text.size(withAttributes: attributes)
+        text.draw(
+            at: NSPoint(
+                x: frame.midX - size.width / 2,
+                y: frame.midY - size.height / 2
+            ),
+            withAttributes: attributes
+        )
+    }
+
+    private func drawFailure(
+        _ failure: MermaidRenderFailure,
+        in frame: NSRect,
+        colors: DrawingColors
+    ) {
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12, weight: .semibold),
+            .foregroundColor: colors.foreground
+        ]
+        let diagnosticAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 10),
+            .foregroundColor: colors.muted
+        ]
+        let title = "Couldn't render Mermaid diagram" as NSString
+        let diagnostic = failure.mermaidDisplayDiagnostic as NSString
+        let titleSize = title.size(withAttributes: titleAttributes)
+        let diagnosticSize = diagnostic.size(withAttributes: diagnosticAttributes)
+        let contentHeight = titleSize.height + 4 + diagnosticSize.height
+        let startY = frame.midY + contentHeight / 2 - titleSize.height
+        title.draw(
+            at: NSPoint(x: frame.minX + Self.horizontalPadding, y: startY),
+            withAttributes: titleAttributes
+        )
+        diagnostic.draw(
+            in: NSRect(
+                x: frame.minX + Self.horizontalPadding,
+                y: startY - diagnosticSize.height - 4,
+                width: max(0, frame.width - Self.horizontalPadding * 2),
+                height: diagnosticSize.height
+            ),
+            withAttributes: diagnosticAttributes
+        )
+    }
+
+    private func buttonFrames(
+        in frame: NSRect
+    ) -> (source: NSRect, copy: NSRect, expand: NSRect) {
+        let y = frame.maxY - Self.headerHeight
+        let height = Self.headerHeight
+        let expandWidth = buttonWidth(for: "Expand")
+        let copyWidth = buttonWidth(for: "Copy")
+        let sourceWidth = buttonWidth(for: showsSource ? "Hide source" : "Show source")
+        let right = frame.maxX - 6
+        let expand = NSRect(
+            x: right - expandWidth,
+            y: y,
+            width: expandWidth,
+            height: height
+        )
+        let copy = NSRect(
+            x: expand.minX - copyWidth,
+            y: y,
+            width: copyWidth,
+            height: height
+        )
+        let source = NSRect(
+            x: copy.minX - sourceWidth,
+            y: y,
+            width: sourceWidth,
+            height: height
+        )
+        return (source, copy, expand)
+    }
+
+    private func buttonWidth(for title: String) -> CGFloat {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 10, weight: .medium)
+        ]
+        return ceil((title as NSString).size(withAttributes: attributes).width) + 16
+    }
+}
+
+private struct DrawingColors {
+    let background: NSColor
+    let surface: NSColor
+    let foreground: NSColor
+    let muted: NSColor
+    let border: NSColor
+
+    init(theme: MermaidDiagramTheme?) {
+        background = Self.color(theme?.background, fallback: .textBackgroundColor)
+        surface = Self.color(theme?.surface, fallback: .controlBackgroundColor)
+        foreground = Self.color(theme?.foreground, fallback: .labelColor)
+        muted = Self.color(theme?.muted, fallback: .secondaryLabelColor)
+        border = Self.color(theme?.border, fallback: .separatorColor)
+    }
+
+    private static func color(_ hex: String?, fallback: NSColor) -> NSColor {
+        guard let hex, hex.count == 7, hex.first == "#",
+              let value = UInt32(hex.dropFirst(), radix: 16)
+        else { return fallback }
+        let red = CGFloat((value >> 16) & 0xFF) / 255
+        let green = CGFloat((value >> 8) & 0xFF) / 255
+        let blue = CGFloat(value & 0xFF) / 255
+        return NSColor(
+            srgbRed: red,
+            green: green,
+            blue: blue,
+            alpha: 1
+        )
+    }
+}

--- a/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
@@ -194,6 +194,10 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
                     cell.delegate?
                         .mermaidTextAttachmentCellDidRequestCopy(cell)
                 },
+                accessibilityAction(named: "Expand") { cell in
+                    cell.delegate?
+                        .mermaidTextAttachmentCellDidRequestExpansion(cell)
+                },
             ]
         } else {
             actions = [

--- a/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
@@ -34,6 +34,19 @@ final class MermaidTextAttachment: NSTextAttachment {
 }
 
 final class MermaidTextAttachmentCell: NSTextAttachmentCell {
+    struct LayoutFrames {
+        let header: NSRect?
+        let body: NSRect
+        let sourceButton: NSRect
+        let copyButton: NSRect
+        let expandButton: NSRect
+    }
+
+    struct FailureTextFrames {
+        let title: NSRect
+        let diagnostic: NSRect
+    }
+
     let id: String
     let source: String
     nonisolated let profile: MermaidPresentationProfile
@@ -114,6 +127,7 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
 
     override func draw(withFrame frame: NSRect, in controlView: NSView?) {
         let colors = DrawingColors(theme: theme)
+        let layout = layoutFrames(in: frame)
         let cardPath = NSBezierPath(
             roundedRect: frame.insetBy(dx: 0.5, dy: 0.5),
             xRadius: 6,
@@ -125,29 +139,25 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         cardPath.lineWidth = 0.75
         cardPath.stroke()
 
-        let bodyFrame: NSRect
-        if profile == .compact {
-            bodyFrame = frame.insetBy(dx: 1, dy: 1)
-        } else {
-            let header = NSRect(
-                x: frame.minX + 1,
-                y: frame.maxY - Self.headerHeight - 1,
-                width: max(0, frame.width - 2),
-                height: Self.headerHeight
-            )
+        if let header = layout.header {
             colors.surface.setFill()
             header.fill()
             colors.border.setFill()
-            NSRect(x: header.minX, y: header.minY, width: header.width, height: 0.5).fill()
-            drawHeader(in: header, colors: colors)
-            bodyFrame = NSRect(
-                x: frame.minX + 1,
-                y: frame.minY + 1,
-                width: max(0, frame.width - 2),
-                height: max(0, frame.height - Self.headerHeight - 2)
+            NSRect(
+                x: header.minX,
+                y: header.maxY - 0.5,
+                width: header.width,
+                height: 0.5
+            ).fill()
+            drawHeader(
+                in: header,
+                sourceButton: layout.sourceButton,
+                copyButton: layout.copyButton,
+                expandButton: layout.expandButton,
+                colors: colors
             )
         }
-        drawBody(in: bodyFrame, colors: colors)
+        drawBody(in: layout.body, colors: colors)
     }
 
     override func highlight(
@@ -175,12 +185,12 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
             return true
         }
 
-        let buttons = buttonFrames(in: cellFrame)
-        if buttons.source.contains(point) {
+        let layout = layoutFrames(in: cellFrame)
+        if layout.sourceButton.contains(point) {
             delegate?.mermaidTextAttachmentCellDidToggleSource(self)
-        } else if buttons.copy.contains(point) {
+        } else if layout.copyButton.contains(point) {
             delegate?.mermaidTextAttachmentCellDidRequestCopy(self)
-        } else if buttons.expand.contains(point) {
+        } else if layout.expandButton.contains(point) {
             delegate?.mermaidTextAttachmentCellDidRequestExpansion(self)
         } else {
             return false
@@ -208,7 +218,46 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         return NSSize(width: width, height: headerHeight + bodyHeight + 2)
     }
 
-    private func drawHeader(in frame: NSRect, colors: DrawingColors) {
+    func layoutFrames(in frame: NSRect) -> LayoutFrames {
+        guard profile != .compact else {
+            return LayoutFrames(
+                header: nil,
+                body: frame.insetBy(dx: 1, dy: 1),
+                sourceButton: .zero,
+                copyButton: .zero,
+                expandButton: .zero
+            )
+        }
+
+        let header = NSRect(
+            x: frame.minX + 1,
+            y: frame.minY + 1,
+            width: max(0, frame.width - 2),
+            height: min(Self.headerHeight, max(0, frame.height - 2))
+        )
+        let body = NSRect(
+            x: frame.minX + 1,
+            y: header.maxY,
+            width: max(0, frame.width - 2),
+            height: max(0, frame.maxY - header.maxY - 1)
+        )
+        let buttons = buttonFrames(in: frame)
+        return LayoutFrames(
+            header: header,
+            body: body,
+            sourceButton: buttons.source,
+            copyButton: buttons.copy,
+            expandButton: buttons.expand
+        )
+    }
+
+    private func drawHeader(
+        in frame: NSRect,
+        sourceButton: NSRect,
+        copyButton: NSRect,
+        expandButton: NSRect,
+        colors: DrawingColors
+    ) {
         let labelAttributes: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 10, weight: .semibold),
             .foregroundColor: colors.muted
@@ -223,19 +272,13 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
             withAttributes: labelAttributes
         )
 
-        let buttons = buttonFrames(in: NSRect(
-            x: frame.minX - 1,
-            y: frame.minY,
-            width: frame.width + 2,
-            height: frame.height
-        ))
         drawButton(
             showsSource ? "Hide source" : "Show source",
-            in: buttons.source,
+            in: sourceButton,
             color: colors.muted
         )
-        drawButton("Copy", in: buttons.copy, color: colors.muted)
-        drawButton("Expand", in: buttons.expand, color: colors.muted)
+        drawButton("Copy", in: copyButton, color: colors.muted)
+        drawButton("Expand", in: expandButton, color: colors.muted)
     }
 
     private func drawButton(_ title: String, in frame: NSRect, color: NSColor) {
@@ -318,29 +361,56 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         ]
         let title = "Couldn't render Mermaid diagram" as NSString
         let diagnostic = failure.mermaidDisplayDiagnostic as NSString
-        let titleSize = title.size(withAttributes: titleAttributes)
-        let diagnosticSize = diagnostic.size(withAttributes: diagnosticAttributes)
-        let contentHeight = titleSize.height + 4 + diagnosticSize.height
-        let startY = frame.midY + contentHeight / 2 - titleSize.height
+        let frames = failureTextFrames(for: failure, in: frame)
         title.draw(
-            at: NSPoint(x: frame.minX + Self.horizontalPadding, y: startY),
+            at: frames.title.origin,
             withAttributes: titleAttributes
         )
         diagnostic.draw(
-            in: NSRect(
-                x: frame.minX + Self.horizontalPadding,
-                y: startY - diagnosticSize.height - 4,
-                width: max(0, frame.width - Self.horizontalPadding * 2),
-                height: diagnosticSize.height
-            ),
+            in: frames.diagnostic,
             withAttributes: diagnosticAttributes
+        )
+    }
+
+    func failureTextFrames(
+        for failure: MermaidRenderFailure,
+        in frame: NSRect
+    ) -> FailureTextFrames {
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12, weight: .semibold)
+        ]
+        let diagnosticAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 10)
+        ]
+        let title = "Couldn't render Mermaid diagram" as NSString
+        let diagnostic = failure.mermaidDisplayDiagnostic as NSString
+        let titleSize = title.size(withAttributes: titleAttributes)
+        let diagnosticSize = diagnostic.size(withAttributes: diagnosticAttributes)
+        let contentHeight = titleSize.height + 4 + diagnosticSize.height
+        let startY = frame.midY - contentHeight / 2
+        let width = max(0, frame.width - Self.horizontalPadding * 2)
+        let titleFrame = NSRect(
+            x: frame.minX + Self.horizontalPadding,
+            y: startY,
+            width: width,
+            height: titleSize.height
+        )
+        let diagnosticFrame = NSRect(
+            x: frame.minX + Self.horizontalPadding,
+            y: titleFrame.maxY + 4,
+            width: width,
+            height: diagnosticSize.height
+        )
+        return FailureTextFrames(
+            title: titleFrame,
+            diagnostic: diagnosticFrame
         )
     }
 
     private func buttonFrames(
         in frame: NSRect
     ) -> (source: NSRect, copy: NSRect, expand: NSRect) {
-        let y = frame.maxY - Self.headerHeight
+        let y = frame.minY + 1
         let height = Self.headerHeight
         let expandWidth = buttonWidth(for: "Expand")
         let copyWidth = buttonWidth(for: "Copy")

--- a/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidTextAttachment.swift
@@ -80,7 +80,7 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
     private enum SizingState: Sendable {
         case loading
         case rendered(CGSize)
-        case failed
+        case failed(String)
     }
 
     init(id: String, source: String, profile: MermaidPresentationProfile) {
@@ -114,8 +114,8 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         switch outcome {
         case .rendered(let diagram):
             sizingState = .rendered(diagram.image.size)
-        case .failed:
-            sizingState = .failed
+        case .failed(let failure):
+            sizingState = .failed(failure.mermaidDisplayDiagnostic)
         }
     }
 
@@ -356,8 +356,12 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
                 )
                 bodyHeight = max(44, fitted.height + Self.horizontalPadding * 2)
             }
-        case .failed:
-            bodyHeight = profile == .compact ? profile.maxEmbeddedHeight : 76
+        case .failed(let diagnostic):
+            bodyHeight = Self.failureBodyHeight(
+                diagnostic: diagnostic,
+                width: bodyWidth,
+                profile: profile
+            )
         case .loading:
             bodyHeight = profile == .compact ? profile.maxEmbeddedHeight : 120
         }
@@ -555,10 +559,23 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         let title = "Couldn't render Mermaid diagram" as NSString
         let diagnostic = failure.mermaidDisplayDiagnostic as NSString
         let titleSize = title.size(withAttributes: titleAttributes)
-        let diagnosticSize = diagnostic.size(withAttributes: diagnosticAttributes)
-        let contentHeight = titleSize.height + 4 + diagnosticSize.height
-        let startY = frame.midY - contentHeight / 2
         let width = max(0, frame.width - Self.horizontalPadding * 2)
+        let availableContentHeight = max(0, frame.height - Self.horizontalPadding * 2)
+        let availableDiagnosticHeight = max(0, availableContentHeight - titleSize.height - 4)
+        let diagnosticSize = Self.wrappedTextSize(
+            diagnostic,
+            attributes: diagnosticAttributes,
+            width: width,
+            maxHeight: availableDiagnosticHeight
+        )
+        let contentHeight = min(
+            availableContentHeight,
+            titleSize.height + 4 + diagnosticSize.height
+        )
+        let startY = max(
+            frame.minY + Self.horizontalPadding,
+            frame.midY - contentHeight / 2
+        )
         let titleFrame = NSRect(
             x: frame.minX + Self.horizontalPadding,
             y: startY,
@@ -574,6 +591,51 @@ final class MermaidTextAttachmentCell: NSTextAttachmentCell {
         return FailureTextFrames(
             title: titleFrame,
             diagnostic: diagnosticFrame
+        )
+    }
+
+    private nonisolated static func failureBodyHeight(
+        diagnostic: String,
+        width: CGFloat,
+        profile: MermaidPresentationProfile
+    ) -> CGFloat {
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12, weight: .semibold)
+        ]
+        let diagnosticAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 10)
+        ]
+        let titleSize = ("Couldn't render Mermaid diagram" as NSString)
+            .size(withAttributes: titleAttributes)
+        let diagnosticSize = wrappedTextSize(
+            diagnostic as NSString,
+            attributes: diagnosticAttributes,
+            width: width,
+            maxHeight: .greatestFiniteMagnitude
+        )
+        let measuredHeight = titleSize.height
+            + 4
+            + diagnosticSize.height
+            + horizontalPadding * 2
+        let minimumHeight = profile == .compact ? profile.maxEmbeddedHeight : 76
+        return min(profile.maxEmbeddedHeight, max(minimumHeight, measuredHeight))
+    }
+
+    private nonisolated static func wrappedTextSize(
+        _ text: NSString,
+        attributes: [NSAttributedString.Key: Any],
+        width: CGFloat,
+        maxHeight: CGFloat
+    ) -> CGSize {
+        guard width > 0, maxHeight > 0 else { return .zero }
+        let rect = text.boundingRect(
+            with: NSSize(width: width, height: maxHeight),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: attributes
+        )
+        return NSSize(
+            width: min(width, ceil(rect.width)),
+            height: min(maxHeight, ceil(rect.height))
         )
     }
 

--- a/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
@@ -59,6 +59,20 @@ struct ACPMarkdownBlockCacheTests {
         ])
     }
 
+    @Test("closed mermaid fence becomes diagram but open fence stays streaming code")
+    func mermaidFenceLifecycle() {
+        #expect(ACPMarkdownText.parse("""
+        ```mermaid
+        graph TD; A-->B
+        ```
+        """) == [.mermaid(source: "graph TD; A-->B")])
+
+        #expect(ACPMarkdownText.parse("""
+        ```mermaid
+        graph TD; A-->B
+        """) == [.streamingCode(language: "mermaid", body: "graph TD; A-->B")])
+    }
+
     @Test("blank line inside an unclosed tilde fence does NOT promote stable blocks")
     func tildeFenceKeepsUnstable() async {
         let cache = ACPMarkdownBlockCache()

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -5,6 +5,26 @@ import Testing
 
 @Suite("ACPMarkdownText bare URL links")
 struct ACPMarkdownTextBareURLTests {
+    @Test("mermaid recognition uses the first case-insensitive fence token")
+    func mermaidFenceRecognition() {
+        #expect(ACPMarkdownText.parse("""
+        ```MERMAID title=Architecture
+        graph TD; A-->B
+        ```
+        """) == [.mermaid(source: "graph TD; A-->B")])
+
+        #expect(ACPMarkdownText.parse("""
+        ```swift mermaid
+        graph TD; A-->B
+        ```
+        """) == [.code(language: "swift mermaid", body: "graph TD; A-->B")])
+
+        #expect(ACPMarkdownText.parse("""
+        ```mermaid
+        ```
+        """) == [.code(language: "mermaid", body: "")])
+    }
+
     @Test("tilde fenced URL parses as code block")
     func tildeFencedURLParsesAsCodeBlock() {
         let blocks = ACPMarkdownText.parse("""

--- a/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownTextBareURLTests.swift
@@ -23,6 +23,10 @@ struct ACPMarkdownTextBareURLTests {
         ```mermaid
         ```
         """) == [.code(language: "mermaid", body: "")])
+
+        #expect(ACPMarkdownText.parse("```mermaid\n   \n\t\n```") == [
+            .code(language: "mermaid", body: "   \n\t"),
+        ])
     }
 
     @Test("tilde fenced URL parses as code block")

--- a/AlasTests/AppStateTabAvailabilityTests.swift
+++ b/AlasTests/AppStateTabAvailabilityTests.swift
@@ -91,6 +91,29 @@ struct AppStateTabAvailabilityTests {
         #expect(!state.hasActiveCodeEditorTab)
     }
 
+    @Test func hasActiveCodeEditorTabFalseForStandaloneMermaidPreview() async throws {
+        let repo = try await makeRepo(name: "mermaid-preview")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.appendEditor(
+            worktreeId: trees[0].id,
+            title: "architecture.mmd",
+            relativePath: "architecture.mmd"
+        )
+
+        #expect(state.hasActiveEditorTab)
+        #expect(!state.hasActiveCodeEditorTab)
+    }
+
     @Test func openStashDiffTabDoesNotReuseTabForDifferentStashSha() {
         let state = AppState()
         let worktree = Worktree(

--- a/AlasTests/Code/LSP/Features/CompletionDocumentationRendererTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionDocumentationRendererTests.swift
@@ -18,4 +18,15 @@ struct CompletionDocumentationRendererTests {
 
         #expect(color != NSColor(theme.color("fg")))
     }
+
+    @Test func completionMermaidUsesCompactAttachment() throws {
+        let result = CompletionDocumentationRenderer.render(
+            "```mermaid\ngraph TD; A-->B\n```",
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13
+        )
+
+        #expect(result.mermaidAttachments.first?.profile == .compact)
+    }
 }

--- a/AlasTests/Code/LSP/Features/CompletionWindowControllerTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionWindowControllerTests.swift
@@ -9,4 +9,66 @@ struct CompletionWindowControllerTests {
         let controller = CompletionWindowController()
         #expect(controller.isVisible == false)
     }
+
+    @Test func documentationKeepsExistingPopupBounds() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 100, y: 100, width: 800, height: 600),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let storage = NSTextStorage(string: "completion")
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(
+            size: NSSize(width: 800, height: 600)
+        )
+        layoutManager.addTextContainer(textContainer)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 600),
+            textContainer: textContainer
+        )
+        window.contentView = textView
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let documentation = CompletionDocumentationRenderer.render(
+            "```mermaid\ngraph TD; A-->B\n```",
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13
+        )
+        let cell = try #require(
+            documentation.mermaidAttachments.first?.attachment.mermaidCell
+        )
+        let controller = CompletionWindowController()
+        defer {
+            MermaidDiagramViewerController.shared.dismiss()
+            controller.hide()
+        }
+
+        controller.show(
+            rows: [
+                CompletionPopupRow(
+                    id: UUID(),
+                    label: "completion",
+                    detail: nil,
+                    kind: nil,
+                    source: .lsp
+                )
+            ],
+            selection: 0,
+            documentation: documentation,
+            theme: theme,
+            anchor: NSRect(x: 10, y: 10, width: 1, height: 14),
+            in: textView,
+            onChoose: { _ in }
+        )
+
+        #expect(controller.screenFrame?.size == NSSize(width: 640, height: 260))
+        #expect(cell.delegate != nil)
+
+        cell.delegate?.mermaidTextAttachmentCellDidRequestExpansion(cell)
+
+        #expect(!controller.isVisible)
+        #expect(window.attachedSheet?.title == "Mermaid Diagram")
+    }
 }

--- a/AlasTests/Code/Mermaid/BeautifulMermaidBackendTests.swift
+++ b/AlasTests/Code/Mermaid/BeautifulMermaidBackendTests.swift
@@ -21,4 +21,71 @@ struct BeautifulMermaidBackendTests {
         #expect(diagram.pixelSize.width > 0)
         #expect(diagram.pixelSize.height > 0)
     }
+
+    @Test("rejects source over 256 KiB before rendering")
+    func rejectsOversizedSource() async throws {
+        let source = String(
+            repeating: "a",
+            count: BeautifulMermaidBackend.maximumSourceBytes + 1
+        )
+        let key = MermaidRenderKey(
+            source: source,
+            theme: MermaidDiagramTheme(
+                theme: try Theme.loadBundled(id: "cool-slate")
+            ),
+            scale: 2,
+            profile: .full
+        )
+
+        let outcome = await BeautifulMermaidBackend().render(key: key)
+
+        #expect(
+            outcome.failure
+                == .sourceTooLarge(actualBytes: source.utf8.count)
+        )
+    }
+
+    @Test("invalid source retains a renderer diagnostic")
+    func invalidSourceFallsBack() async throws {
+        let outcome = try await render(source: "not a Mermaid diagram")
+
+        switch outcome.failure {
+        case .parseFailed(let diagnostic), .renderFailed(let diagnostic):
+            #expect(!diagnostic.isEmpty)
+        default:
+            Issue.record("expected invalid source to fail parsing or rendering")
+        }
+    }
+
+    @Test("unsupported family retains a renderer diagnostic")
+    func unsupportedFamilyFallsBack() async throws {
+        let outcome = try await render(
+            source: """
+            gantt
+                title Unsupported
+                section Example
+                Item :done, 2026-07-29, 1d
+            """
+        )
+
+        switch outcome.failure {
+        case .unsupported(let diagnostic), .renderFailed(let diagnostic):
+            #expect(!diagnostic.isEmpty)
+        default:
+            Issue.record("expected gantt to be unsupported or fail rendering")
+        }
+    }
+
+    private func render(source: String) async throws -> MermaidRenderOutcome {
+        await BeautifulMermaidBackend().render(
+            key: MermaidRenderKey(
+                source: source,
+                theme: MermaidDiagramTheme(
+                    theme: try Theme.loadBundled(id: "cool-slate")
+                ),
+                scale: 2,
+                profile: .full
+            )
+        )
+    }
 }

--- a/AlasTests/Code/Mermaid/BeautifulMermaidBackendTests.swift
+++ b/AlasTests/Code/Mermaid/BeautifulMermaidBackendTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("Beautiful Mermaid backend")
+struct BeautifulMermaidBackendTests {
+    @Test("renders a native flowchart image")
+    func rendersFlowchart() async throws {
+        let theme = MermaidDiagramTheme(theme: try Theme.loadBundled(id: "cool-slate"))
+        let outcome = await BeautifulMermaidBackend().render(key: MermaidRenderKey(
+            source: "graph TD; A-->B;",
+            theme: theme,
+            scale: 2,
+            profile: .full
+        ))
+
+        guard case .rendered(let diagram) = outcome else {
+            Issue.record("expected a rendered flowchart")
+            return
+        }
+        #expect(diagram.pixelSize.width > 0)
+        #expect(diagram.pixelSize.height > 0)
+    }
+}

--- a/AlasTests/Code/Mermaid/BeautifulMermaidSmokeTests.swift
+++ b/AlasTests/Code/Mermaid/BeautifulMermaidSmokeTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("Beautiful Mermaid smoke")
+struct BeautifulMermaidSmokeTests {
+    @Test(arguments: [
+        "graph TD; A-->B",
+        "stateDiagram-v2\n[*] --> Ready",
+        "sequenceDiagram\nA->>B: Hello",
+        "classDiagram\nAnimal <|-- Cat",
+        "erDiagram\nCUSTOMER ||--o{ ORDER : places",
+        "xychart-beta\nx-axis [a, b]\ny-axis 0 --> 2\nbar [1, 2]",
+    ])
+    func rendersSupportedFamily(_ source: String) async throws {
+        let theme = MermaidDiagramTheme(
+            theme: try Theme.loadBundled(id: "cool-slate")
+        )
+        let outcome = await BeautifulMermaidBackend().render(
+            key: MermaidRenderKey(
+                source: source,
+                theme: theme,
+                scale: 2,
+                profile: .full
+            )
+        )
+
+        guard case .rendered(let diagram) = outcome else {
+            Issue.record("expected rendered diagram for \(source)")
+            return
+        }
+        #expect(diagram.pixelSize.width > 0)
+        #expect(diagram.pixelSize.height > 0)
+    }
+}

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -633,6 +633,32 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(text.diagnostic.maxY <= body.maxY)
     }
 
+    @Test("failure diagnostics measure wrapped text before drawing")
+    func failureDiagnosticsMeasureWrappedText() throws {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let cell = attachment.mermaidCell
+        let failure = MermaidRenderFailure.parseFailed(
+            String(repeating: "unexpected token in Mermaid diagram ", count: 12)
+        )
+        cell.apply(.failed(failure))
+        let frame = cell.cellFrame(
+            for: NSTextContainer(size: NSSize(width: 180, height: 1_000)),
+            proposedLineFragment: NSRect(x: 0, y: 0, width: 180, height: 1_000),
+            glyphPosition: .zero,
+            characterIndex: 0
+        )
+        let body = cell.layoutFrames(in: frame).body
+        let text = cell.failureTextFrames(for: failure, in: body)
+
+        #expect(frame.height > 31 + 76 + 2)
+        #expect(text.diagnostic.height > 24)
+        #expect(text.diagnostic.maxY <= body.maxY)
+    }
+
     private func makeReference(
         attachment: MermaidTextAttachment
     ) throws -> MermaidAttachmentReference {

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -319,6 +319,36 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(attachment.mermaidCell.cellSize.height > 0)
     }
 
+    @Test("backing observer remains installed after a substantive apply")
+    func backingObserverSurvivesSubstantiveApply() throws {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let reference = try makeReference(attachment: attachment)
+        let textView = makeTextView(attachment: attachment)
+        let window = NSWindow(
+            contentRect: textView.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(textView)
+        let coordinator = MermaidAttachmentCoordinator()
+        defer { coordinator.cancelAll() }
+
+        coordinator.apply(
+            [reference],
+            revision: UUID(),
+            to: textView,
+            onTextStorageDelta: nil
+        )
+
+        #expect(coordinator.hasBackingPropertiesObserverForTesting)
+        #expect(coordinator.observedBackingWindowForTesting === window)
+    }
+
     @Test("full attachment header actions hit in the flipped top band")
     func fullAttachmentHeaderHitTargetsUseFlippedCoordinates() throws {
         let attachment = MermaidTextAttachment(

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -145,6 +145,43 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(replacementAttachment.mermaidCell.showsSource)
     }
 
+    @Test("preview replacement can restore disclosure by unchanged source")
+    func previewReplacementRestoresDisclosureBySource() throws {
+        let source = "graph TD; A-->B"
+        let firstAttachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: source,
+            profile: .full
+        )
+        let replacementAttachment = MermaidTextAttachment(
+            id: "mermaid-source-stable",
+            source: source,
+            profile: .full
+        )
+        let controller = MarkdownPreviewController(theme: try Theme.loadBundled(id: "cool-slate"))
+        defer { controller.dismantle() }
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachment: firstAttachment),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [try makeReference(attachment: firstAttachment)]
+        ))
+        controller.showMermaidSourceForTesting(id: firstAttachment.id)
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachment: replacementAttachment),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [try makeReference(attachment: replacementAttachment)]
+        ))
+
+        #expect(controller.textView.string.contains(source))
+        #expect(replacementAttachment.mermaidCell.showsSource)
+    }
+
     @Test("preview replacement does not preserve source for changed diagram body")
     func previewReplacementSkipsDisclosureForChangedSource() throws {
         let oldSource = "graph TD; A-->B"

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -236,7 +236,27 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(cell.accessibilityActionLabels == [
             "Show Mermaid source",
             "Copy Mermaid source",
+            "Expand",
         ])
+    }
+
+    @Test("compact expand accessibility action opens the expanded viewer")
+    func compactExpandAccessibilityAction() throws {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .compact
+        )
+        let cell = attachment.mermaidCell
+        let delegate = MermaidCellDelegateSpy()
+        cell.delegate = delegate
+
+        let action = try #require(
+            cell.accessibilityCustomActions()?.first { $0.name == "Expand" }
+        )
+
+        #expect(action.handler?() == true)
+        #expect(delegate.expansionCount == 1)
     }
 
     @Test("compact source disclosure replaces the diagram card with a restore target")

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -209,7 +209,7 @@ struct MermaidAttachmentCoordinatorTests {
         ])
     }
 
-    @Test("compact source disclosure replaces the diagram card")
+    @Test("compact source disclosure replaces the diagram card with a restore target")
     func compactSourceDisclosureReplacesDiagramCard() throws {
         let attachment = MermaidTextAttachment(
             id: "mermaid-0",
@@ -232,8 +232,36 @@ struct MermaidAttachmentCoordinatorTests {
         coordinator.showSource(id: reference.id, in: textView)
 
         #expect(attachment.mermaidCell.showsSource)
-        #expect(attachment.mermaidCell.cellSize == .zero)
+        #expect(attachment.mermaidCell.cellSize.height > 0)
         #expect(textView.string.contains(reference.source))
+
+        let delegate = MermaidCellDelegateSpy()
+        attachment.mermaidCell.delegate = delegate
+        let window = NSWindow(
+            contentRect: textView.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(textView)
+        let cellFrame = NSRect(
+            x: 20,
+            y: 20,
+            width: 600,
+            height: attachment.mermaidCell.cellSize.height
+        )
+        let event = try mouseDown(
+            at: NSPoint(x: cellFrame.midX, y: cellFrame.midY),
+            in: textView,
+            window: window
+        )
+        #expect(attachment.mermaidCell.trackMouse(
+            with: event,
+            in: cellFrame,
+            of: textView,
+            untilMouseUp: false
+        ))
+        #expect(delegate.sourceToggleCount == 1)
 
         coordinator.hideSource(id: reference.id, in: textView)
 
@@ -451,11 +479,12 @@ struct MermaidAttachmentCoordinatorTests {
 
 @MainActor
 private final class MermaidCellDelegateSpy: MermaidTextAttachmentCellDelegate {
+    private(set) var sourceToggleCount = 0
     private(set) var expansionCount = 0
 
-    func mermaidTextAttachmentCellDidToggleSource(
-        _ cell: MermaidTextAttachmentCell
-    ) {}
+    func mermaidTextAttachmentCellDidToggleSource(_ cell: MermaidTextAttachmentCell) {
+        sourceToggleCount += 1
+    }
 
     func mermaidTextAttachmentCellDidRequestCopy(
         _ cell: MermaidTextAttachmentCell

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -209,6 +209,38 @@ struct MermaidAttachmentCoordinatorTests {
         ])
     }
 
+    @Test("compact source disclosure replaces the diagram card")
+    func compactSourceDisclosureReplacesDiagramCard() throws {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .compact
+        )
+        let reference = try makeReference(attachment: attachment)
+        let textView = makeTextView(attachment: attachment)
+        let coordinator = MermaidAttachmentCoordinator(mode: .compact)
+        defer { coordinator.cancelAll() }
+
+        coordinator.apply(
+            [reference],
+            revision: UUID(),
+            to: textView,
+            onTextStorageDelta: nil
+        )
+        #expect(attachment.mermaidCell.cellSize.height > 0)
+
+        coordinator.showSource(id: reference.id, in: textView)
+
+        #expect(attachment.mermaidCell.showsSource)
+        #expect(attachment.mermaidCell.cellSize == .zero)
+        #expect(textView.string.contains(reference.source))
+
+        coordinator.hideSource(id: reference.id, in: textView)
+
+        #expect(!attachment.mermaidCell.showsSource)
+        #expect(attachment.mermaidCell.cellSize.height > 0)
+    }
+
     @Test("full attachment header actions hit in the flipped top band")
     func fullAttachmentHeaderHitTargetsUseFlippedCoordinates() throws {
         let attachment = MermaidTextAttachment(

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -106,6 +106,84 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(controller.lastAppliedRevision == nextRevision)
     }
 
+    @Test("preview replacement preserves explicitly opened Mermaid source")
+    func previewReplacementPreservesExplicitSourceDisclosure() throws {
+        let source = "graph TD; A-->B"
+        let firstAttachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: source,
+            profile: .full
+        )
+        let replacementAttachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: source,
+            profile: .full
+        )
+        let controller = MarkdownPreviewController(theme: try Theme.loadBundled(id: "cool-slate"))
+        defer { controller.dismantle() }
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachment: firstAttachment),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [try makeReference(attachment: firstAttachment)]
+        ))
+        controller.showMermaidSourceForTesting(id: firstAttachment.id)
+
+        #expect(controller.textView.string.contains(source))
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachment: replacementAttachment),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [try makeReference(attachment: replacementAttachment)]
+        ))
+
+        #expect(controller.textView.string.contains(source))
+        #expect(replacementAttachment.mermaidCell.showsSource)
+    }
+
+    @Test("preview replacement does not preserve source for changed diagram body")
+    func previewReplacementSkipsDisclosureForChangedSource() throws {
+        let oldSource = "graph TD; A-->B"
+        let newSource = "graph TD; A-->C"
+        let firstAttachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: oldSource,
+            profile: .full
+        )
+        let replacementAttachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: newSource,
+            profile: .full
+        )
+        let controller = MarkdownPreviewController(theme: try Theme.loadBundled(id: "cool-slate"))
+        defer { controller.dismantle() }
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachment: firstAttachment),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [try makeReference(attachment: firstAttachment)]
+        ))
+        controller.showMermaidSourceForTesting(id: firstAttachment.id)
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachment: replacementAttachment),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [try makeReference(attachment: replacementAttachment)]
+        ))
+
+        #expect(!controller.textView.string.contains(oldSource))
+        #expect(!controller.textView.string.contains(newSource))
+        #expect(!replacementAttachment.mermaidCell.showsSource)
+    }
+
     @Test("an old revision cannot update a replacement attachment")
     func rejectsStaleAttachmentOutcome() async throws {
         let backend = ControlledMermaidBackend()

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -182,6 +182,74 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(replacementAttachment.mermaidCell.showsSource)
     }
 
+    @Test("preview replacement does not restore onto wrong duplicate source")
+    func previewReplacementSkipsAmbiguousDuplicateSourceDisclosure() throws {
+        let source = "graph TD; Same-->Diagram"
+        let firstOldAttachment = MermaidTextAttachment(
+            id: "mermaid-same-1",
+            source: source,
+            profile: .full
+        )
+        let secondOldAttachment = MermaidTextAttachment(
+            id: "mermaid-same-2",
+            source: source,
+            profile: .full
+        )
+        let insertedAttachment = MermaidTextAttachment(
+            id: "mermaid-same-inserted",
+            source: source,
+            profile: .full
+        )
+        let shiftedFirstAttachment = MermaidTextAttachment(
+            id: "mermaid-same-2",
+            source: source,
+            profile: .full
+        )
+        let shiftedSecondAttachment = MermaidTextAttachment(
+            id: "mermaid-same-3",
+            source: source,
+            profile: .full
+        )
+        let controller = MarkdownPreviewController(theme: try Theme.loadBundled(id: "cool-slate"))
+        defer { controller.dismantle() }
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachments: [
+                firstOldAttachment,
+                secondOldAttachment,
+            ]),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [
+                try makeReference(attachment: firstOldAttachment),
+                try makeReference(attachment: secondOldAttachment),
+            ]
+        ))
+        controller.showMermaidSourceForTesting(id: secondOldAttachment.id)
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachments: [
+                insertedAttachment,
+                shiftedFirstAttachment,
+                shiftedSecondAttachment,
+            ]),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [
+                try makeReference(attachment: insertedAttachment),
+                try makeReference(attachment: shiftedFirstAttachment),
+                try makeReference(attachment: shiftedSecondAttachment),
+            ]
+        ))
+
+        #expect(!insertedAttachment.mermaidCell.showsSource)
+        #expect(!shiftedFirstAttachment.mermaidCell.showsSource)
+        #expect(!shiftedSecondAttachment.mermaidCell.showsSource)
+        #expect(!controller.textView.string.contains(source))
+    }
+
     @Test("preview replacement does not preserve source for changed diagram body")
     func previewReplacementSkipsDisclosureForChangedSource() throws {
         let oldSource = "graph TD; A-->B"
@@ -725,8 +793,21 @@ struct MermaidAttachmentCoordinatorTests {
         attachment: MermaidTextAttachment,
         suffix: String = ""
     ) -> NSAttributedString {
-        let contents = NSMutableAttributedString(attachment: attachment)
-        contents.append(NSAttributedString(string: "\n\(suffix)"))
+        makeContents(attachments: [attachment], suffix: suffix)
+    }
+
+    private func makeContents(
+        attachments: [MermaidTextAttachment],
+        suffix: String = ""
+    ) -> NSAttributedString {
+        let contents = NSMutableAttributedString()
+        for attachment in attachments {
+            contents.append(NSAttributedString(attachment: attachment))
+            contents.append(NSAttributedString(string: "\n"))
+        }
+        if !suffix.isEmpty {
+            contents.append(NSAttributedString(string: suffix))
+        }
         return contents
     }
 

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -106,8 +106,8 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(controller.lastAppliedRevision == nextRevision)
     }
 
-    @Test("a completed render cannot update a replaced revision")
-    func staleRenderCannotUpdateCurrentAttachment() async throws {
+    @Test("an old revision cannot update a replacement attachment")
+    func rejectsStaleAttachmentOutcome() async throws {
         let backend = ControlledMermaidBackend()
         let service = MermaidRenderService(backend: backend)
         let coordinator = MermaidAttachmentCoordinator(service: service)
@@ -152,15 +152,61 @@ struct MermaidAttachmentCoordinatorTests {
         for _ in 0 ..< 20 {
             await Task.yield()
         }
-        #expect(oldAttachment.mermaidCell.outcome == nil)
-        #expect(currentAttachment.mermaidCell.outcome == nil)
+        #expect(oldAttachment.currentOutcome == nil)
+        #expect(currentAttachment.currentOutcome == nil)
 
         await backend.resume(
             source: currentAttachment.source,
             outcome: renderedOutcome()
         )
         #expect(await waitForOutcome(in: currentAttachment))
-        #expect(oldAttachment.mermaidCell.outcome == nil)
+        #expect(oldAttachment.currentOutcome == nil)
+    }
+
+    @Test("full attachment exposes exact accessibility and copy metadata")
+    func fullCellAccessibility() {
+        let source = "graph TD;\n  A-->B"
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: source,
+            profile: .full
+        )
+        let cell = attachment.mermaidCell
+
+        #expect(cell.accessibilityMetadata.label == "Mermaid diagram")
+        #expect(cell.accessibilityMetadata.value == source)
+        #expect(cell.accessibilityActionLabels == [
+            "Show source",
+            "Copy",
+            "Expand",
+        ])
+        #expect(cell.visibleActionLabels == [
+            "Show source",
+            "Copy",
+            "Expand",
+        ])
+        #expect(attachment.copyPayload == source)
+        #expect(!attachment.copyPayload.contains("```"))
+    }
+
+    @Test("compact attachment uses only its source context menu")
+    func compactCellActions() {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .compact
+        )
+        let cell = attachment.mermaidCell
+
+        #expect(cell.visibleActionLabels.isEmpty)
+        #expect(cell.contextMenuActionLabels == [
+            "Show Mermaid source",
+            "Copy Mermaid source",
+        ])
+        #expect(cell.accessibilityActionLabels == [
+            "Show Mermaid source",
+            "Copy Mermaid source",
+        ])
     }
 
     @Test("full attachment header actions hit in the flipped top band")
@@ -334,7 +380,7 @@ struct MermaidAttachmentCoordinatorTests {
         in attachment: MermaidTextAttachment
     ) async -> Bool {
         for _ in 0 ..< 1_000 {
-            if attachment.mermaidCell.outcome != nil {
+            if attachment.currentOutcome != nil {
                 return true
             }
             await Task.yield()

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -193,6 +193,89 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(await backend.waitForCancellation(source: reference.source))
     }
 
+    @Test("failure-disclosed source clears after a successful rerender")
+    func failureDisclosedSourceClearsAfterSuccess() async throws {
+        let backend = ControlledMermaidBackend()
+        let service = MermaidRenderService(backend: backend)
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let reference = try makeReference(attachment: attachment)
+        let textView = makeTextView(attachment: attachment)
+        let revision = UUID()
+        let coordinator = MermaidAttachmentCoordinator(service: service)
+        defer { coordinator.cancelAll() }
+
+        coordinator.apply(
+            [reference],
+            revision: revision,
+            to: textView,
+            onTextStorageDelta: nil
+        )
+        #expect(await backend.waitForRequest(source: reference.source))
+
+        await backend.resume(
+            source: reference.source,
+            outcome: .failed(.rasterTooLarge(width: 8_193, height: 1))
+        )
+        #expect(await waitForOutcome(in: attachment))
+        #expect(textView.string.contains(reference.source))
+        #expect(attachment.mermaidCell.showsSource)
+
+        coordinator.applyOutcomeForTesting(
+            renderedOutcome(),
+            to: reference.id,
+            revision: revision,
+            in: textView
+        )
+
+        #expect(!textView.string.contains(reference.source))
+        #expect(!attachment.mermaidCell.showsSource)
+    }
+
+    @Test("explicitly opened source remains after a successful rerender")
+    func explicitSourceRemainsAfterSuccess() async throws {
+        let backend = ControlledMermaidBackend()
+        let service = MermaidRenderService(backend: backend)
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let reference = try makeReference(attachment: attachment)
+        let textView = makeTextView(attachment: attachment)
+        let revision = UUID()
+        let coordinator = MermaidAttachmentCoordinator(service: service)
+        defer { coordinator.cancelAll() }
+
+        coordinator.apply(
+            [reference],
+            revision: revision,
+            to: textView,
+            onTextStorageDelta: nil
+        )
+        #expect(await backend.waitForRequest(source: reference.source))
+        coordinator.showSource(id: reference.id, in: textView)
+
+        await backend.resume(
+            source: reference.source,
+            outcome: .failed(.rasterTooLarge(width: 8_193, height: 1))
+        )
+        #expect(await waitForOutcome(in: attachment))
+
+        coordinator.applyOutcomeForTesting(
+            renderedOutcome(),
+            to: reference.id,
+            revision: revision,
+            in: textView
+        )
+
+        #expect(textView.string.contains(reference.source))
+        #expect(attachment.mermaidCell.showsSource)
+    }
+
     @Test("full attachment exposes exact accessibility and copy metadata")
     func fullCellAccessibility() {
         let source = "graph TD;\n  A-->B"

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -163,6 +163,36 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(oldAttachment.currentOutcome == nil)
     }
 
+    @Test("dismantling a Markdown preview cancels its Mermaid render")
+    func dismantlingPreviewCancelsMermaidRender() async throws {
+        let backend = ControlledMermaidBackend()
+        let service = MermaidRenderService(backend: backend)
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let reference = try makeReference(attachment: attachment)
+        let controller = MarkdownPreviewController(
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            mermaidService: service
+        )
+        let result = MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachment: attachment),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [reference]
+        )
+
+        controller.apply(result: result)
+        #expect(await backend.waitForRequest(source: reference.source))
+
+        controller.dismantle()
+
+        #expect(await backend.waitForCancellation(source: reference.source))
+    }
+
     @Test("full attachment exposes exact accessibility and copy metadata")
     func fullCellAccessibility() {
         let source = "graph TD;\n  A-->B"
@@ -501,10 +531,15 @@ private actor ControlledMermaidBackend: MermaidRenderingBackend {
     private var continuations: [
         String: CheckedContinuation<MermaidRenderOutcome, Never>
     ] = [:]
+    private var cancelledSources: Set<String> = []
 
     func render(key: MermaidRenderKey) async -> MermaidRenderOutcome {
-        await withCheckedContinuation { continuation in
-            continuations[key.source] = continuation
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                continuations[key.source] = continuation
+            }
+        } onCancel: {
+            Task { await self.recordCancellation(source: key.source) }
         }
     }
 
@@ -520,5 +555,19 @@ private actor ControlledMermaidBackend: MermaidRenderingBackend {
 
     func resume(source: String, outcome: MermaidRenderOutcome) {
         continuations.removeValue(forKey: source)?.resume(returning: outcome)
+    }
+
+    func waitForCancellation(source: String) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if cancelledSources.contains(source) {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
+    }
+
+    private func recordCancellation(source: String) {
+        cancelledSources.insert(source)
     }
 }

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -163,6 +163,129 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(oldAttachment.mermaidCell.outcome == nil)
     }
 
+    @Test("full attachment header actions hit in the flipped top band")
+    func fullAttachmentHeaderHitTargetsUseFlippedCoordinates() throws {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let cell = attachment.mermaidCell
+        let delegate = MermaidCellDelegateSpy()
+        cell.delegate = delegate
+        let textView = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 480)
+        )
+        let window = NSWindow(
+            contentRect: textView.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(textView)
+        let cellFrame = NSRect(
+            x: 20,
+            y: 20,
+            width: 600,
+            height: cell.cellSize.height
+        )
+
+        let topEvent = try mouseDown(
+            at: NSPoint(x: cellFrame.maxX - 18, y: cellFrame.minY + 15),
+            in: textView,
+            window: window
+        )
+        #expect(
+            cell.trackMouse(
+                with: topEvent,
+                in: cellFrame,
+                of: textView,
+                untilMouseUp: false
+            )
+        )
+        #expect(delegate.expansionCount == 1)
+
+        let bottomEvent = try mouseDown(
+            at: NSPoint(x: cellFrame.maxX - 18, y: cellFrame.maxY - 15),
+            in: textView,
+            window: window
+        )
+        #expect(
+            !cell.trackMouse(
+                with: bottomEvent,
+                in: cellFrame,
+                of: textView,
+                untilMouseUp: false
+            )
+        )
+        #expect(delegate.expansionCount == 1)
+    }
+
+    @Test("full attachment geometry is top-to-bottom for every render state")
+    func fullAttachmentGeometryUsesFlippedCoordinates() throws {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let cell = attachment.mermaidCell
+        let states: [MermaidRenderOutcome?] = [
+            nil,
+            renderedOutcome(),
+            .failed(.parseFailed("unexpected token"))
+        ]
+
+        for state in states {
+            if let state {
+                cell.apply(state)
+            } else {
+                cell.beginLoading()
+            }
+            let frame = NSRect(
+                x: 20,
+                y: 40,
+                width: 600,
+                height: cell.cellSize.height
+            )
+            let layout = cell.layoutFrames(in: frame)
+            let header = try #require(layout.header)
+
+            #expect(header.minY == frame.minY + 1)
+            #expect(layout.sourceButton.minY >= frame.minY)
+            #expect(layout.copyButton.minY >= frame.minY)
+            #expect(layout.expandButton.minY >= frame.minY)
+            #expect(layout.sourceButton.maxY <= layout.body.minY)
+            #expect(layout.copyButton.maxY <= layout.body.minY)
+            #expect(layout.expandButton.maxY <= layout.body.minY)
+            #expect(layout.body.minY == header.maxY)
+            #expect(layout.body.maxY == frame.maxY - 1)
+        }
+    }
+
+    @Test("failure title precedes its diagnostic in flipped coordinates")
+    func failureTextGeometryUsesFlippedCoordinates() throws {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let cell = attachment.mermaidCell
+        let failure = MermaidRenderFailure.parseFailed("unexpected token")
+        cell.apply(.failed(failure))
+        let frame = NSRect(
+            x: 20,
+            y: 40,
+            width: 600,
+            height: cell.cellSize.height
+        )
+        let body = cell.layoutFrames(in: frame).body
+        let text = cell.failureTextFrames(for: failure, in: body)
+
+        #expect(text.title.minY >= body.minY)
+        #expect(text.title.maxY < text.diagnostic.minY)
+        #expect(text.diagnostic.maxY <= body.maxY)
+    }
+
     private func makeReference(
         attachment: MermaidTextAttachment
     ) throws -> MermaidAttachmentReference {
@@ -219,6 +342,24 @@ struct MermaidAttachmentCoordinatorTests {
         return false
     }
 
+    private func mouseDown(
+        at point: NSPoint,
+        in view: NSView,
+        window: NSWindow
+    ) throws -> NSEvent {
+        try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: view.convert(point, to: nil),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+
     private func makeResult(revision: UUID, string: String) -> MarkdownRenderResult {
         MarkdownRenderResult(
             revision: revision,
@@ -227,6 +368,25 @@ struct MermaidAttachmentCoordinatorTests {
             remoteImages: [],
             mermaidAttachments: []
         )
+    }
+}
+
+@MainActor
+private final class MermaidCellDelegateSpy: MermaidTextAttachmentCellDelegate {
+    private(set) var expansionCount = 0
+
+    func mermaidTextAttachmentCellDidToggleSource(
+        _ cell: MermaidTextAttachmentCell
+    ) {}
+
+    func mermaidTextAttachmentCellDidRequestCopy(
+        _ cell: MermaidTextAttachmentCell
+    ) {}
+
+    func mermaidTextAttachmentCellDidRequestExpansion(
+        _ cell: MermaidTextAttachmentCell
+    ) {
+        expansionCount += 1
     }
 }
 

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -1,0 +1,257 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("Mermaid attachment coordinator")
+struct MermaidAttachmentCoordinatorTests {
+    @Test("source disclosure preserves exact selectable source and shifts later anchors")
+    func sourceDisclosureMutatesTextStorageByUTF16Delta() throws {
+        let source = "graph TD; A[👋]-->B"
+        let attachment = MermaidTextAttachment(id: "mermaid-0", source: source, profile: .full)
+        let reference = try makeReference(attachment: attachment)
+        let controller = MarkdownPreviewController(theme: try Theme.loadBundled(id: "cool-slate"))
+        let textView = makeTextView(attachment: attachment, suffix: "After")
+        controller.anchorRanges = ["after": NSRange(location: 2, length: 5)]
+        let originalAnchor = try #require(controller.anchorRanges["after"])
+        let coordinator = MermaidAttachmentCoordinator()
+        defer { coordinator.cancelAll() }
+        var deltas: [(location: Int, delta: Int)] = []
+
+        coordinator.apply(
+            [reference],
+            revision: UUID(),
+            to: textView,
+            onTextStorageDelta: { location, delta in
+                deltas.append((location, delta))
+                controller.shiftAnchors(startingAt: location, by: delta)
+            }
+        )
+        coordinator.showSource(id: reference.id, in: textView)
+
+        let insertedRange = (textView.string as NSString).range(of: reference.source)
+        #expect(insertedRange.location != NSNotFound)
+        #expect(
+            textView.textStorage?.attribute(
+                .mermaidSourceID,
+                at: insertedRange.location,
+                effectiveRange: nil
+            ) as? String == reference.id
+        )
+        let font = textView.textStorage?.attribute(
+            .font,
+            at: insertedRange.location,
+            effectiveRange: nil
+        ) as? NSFont
+        #expect(font?.isFixedPitch == true)
+        let sourceLength = (reference.source as NSString).length
+        #expect(deltas.last?.location == 1)
+        #expect(deltas.last?.delta == sourceLength)
+        #expect(controller.anchorRanges["after"]?.location == originalAnchor.location + sourceLength)
+
+        coordinator.hideSource(id: reference.id, in: textView)
+
+        #expect(!textView.string.contains(reference.source))
+        #expect(textView.string == "\u{FFFC}\nAfter")
+        #expect(deltas.last?.delta == -sourceLength)
+        #expect(controller.anchorRanges["after"] == originalAnchor)
+    }
+
+    @Test("hiding one source leaves other text untouched")
+    func hideSourceRemovesOnlyMatchingMarkedRun() throws {
+        let source = "graph TD; A-->B"
+        let attachment = MermaidTextAttachment(id: "mermaid-0", source: source, profile: .full)
+        let reference = try makeReference(attachment: attachment)
+        let textView = makeTextView(attachment: attachment, suffix: "Keep \(source)")
+        let coordinator = MermaidAttachmentCoordinator()
+        defer { coordinator.cancelAll() }
+
+        coordinator.apply([reference], revision: UUID(), to: textView, onTextStorageDelta: nil)
+        coordinator.showSource(id: reference.id, in: textView)
+        coordinator.hideSource(id: reference.id, in: textView)
+
+        #expect(textView.string == "\u{FFFC}\nKeep \(source)")
+    }
+
+    @Test("copy uses exact source without a Markdown fence")
+    func copySourcePreservesExactBody() throws {
+        let source = "graph TD;\n  A-->B"
+        let attachment = MermaidTextAttachment(id: "mermaid-0", source: source, profile: .full)
+        let reference = try makeReference(attachment: attachment)
+        let textView = makeTextView(attachment: attachment)
+        let coordinator = MermaidAttachmentCoordinator()
+        defer { coordinator.cancelAll() }
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("mermaid-test-\(UUID().uuidString)"))
+
+        coordinator.apply([reference], revision: UUID(), to: textView, onTextStorageDelta: nil)
+        coordinator.copySource(id: reference.id, to: pasteboard)
+
+        #expect(pasteboard.string(forType: .string) == source)
+    }
+
+    @Test("preview controller ignores a result whose revision is already applied")
+    func previewControllerRejectsDuplicateRevision() throws {
+        let controller = MarkdownPreviewController(theme: try Theme.loadBundled(id: "cool-slate"))
+        let revision = UUID()
+        controller.apply(result: makeResult(revision: revision, string: "first"))
+
+        controller.apply(result: makeResult(revision: revision, string: "duplicate"))
+
+        #expect(controller.textView.string == "first")
+        #expect(controller.lastAppliedRevision == revision)
+
+        let nextRevision = UUID()
+        controller.apply(result: makeResult(revision: nextRevision, string: "next"))
+        #expect(controller.textView.string == "next")
+        #expect(controller.lastAppliedRevision == nextRevision)
+    }
+
+    @Test("a completed render cannot update a replaced revision")
+    func staleRenderCannotUpdateCurrentAttachment() async throws {
+        let backend = ControlledMermaidBackend()
+        let service = MermaidRenderService(backend: backend)
+        let coordinator = MermaidAttachmentCoordinator(service: service)
+        defer { coordinator.cancelAll() }
+        let oldAttachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; old",
+            profile: .full
+        )
+        let currentAttachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; current",
+            profile: .full
+        )
+        let textView = makeTextView(attachment: oldAttachment)
+        let oldRevision = UUID()
+        let currentRevision = UUID()
+
+        coordinator.apply(
+            [try makeReference(attachment: oldAttachment)],
+            revision: oldRevision,
+            to: textView,
+            onTextStorageDelta: nil
+        )
+        #expect(await backend.waitForRequest(source: oldAttachment.source))
+
+        textView.textStorage?.setAttributedString(
+            makeContents(attachment: currentAttachment)
+        )
+        coordinator.apply(
+            [try makeReference(attachment: currentAttachment)],
+            revision: currentRevision,
+            to: textView,
+            onTextStorageDelta: nil
+        )
+        #expect(await backend.waitForRequest(source: currentAttachment.source))
+
+        await backend.resume(
+            source: oldAttachment.source,
+            outcome: renderedOutcome()
+        )
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        #expect(oldAttachment.mermaidCell.outcome == nil)
+        #expect(currentAttachment.mermaidCell.outcome == nil)
+
+        await backend.resume(
+            source: currentAttachment.source,
+            outcome: renderedOutcome()
+        )
+        #expect(await waitForOutcome(in: currentAttachment))
+        #expect(oldAttachment.mermaidCell.outcome == nil)
+    }
+
+    private func makeReference(
+        attachment: MermaidTextAttachment
+    ) throws -> MermaidAttachmentReference {
+        MermaidAttachmentReference(
+            id: attachment.id,
+            source: attachment.source,
+            profile: attachment.profile,
+            theme: MermaidDiagramTheme(theme: try Theme.loadBundled(id: "cool-slate")),
+            attachment: attachment
+        )
+    }
+
+    private func makeTextView(
+        attachment: MermaidTextAttachment,
+        suffix: String = ""
+    ) -> NSTextView {
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.textStorage?.setAttributedString(
+            makeContents(attachment: attachment, suffix: suffix)
+        )
+        return textView
+    }
+
+    private func makeContents(
+        attachment: MermaidTextAttachment,
+        suffix: String = ""
+    ) -> NSAttributedString {
+        let contents = NSMutableAttributedString(attachment: attachment)
+        contents.append(NSAttributedString(string: "\n\(suffix)"))
+        return contents
+    }
+
+    private func renderedOutcome() -> MermaidRenderOutcome {
+        .rendered(
+            MermaidRenderedDiagram(
+                image: NSImage(size: NSSize(width: 80, height: 40)),
+                pixelSize: CGSize(width: 160, height: 80),
+                byteCost: 160 * 80 * 4
+            )
+        )
+    }
+
+    private func waitForOutcome(
+        in attachment: MermaidTextAttachment
+    ) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if attachment.mermaidCell.outcome != nil {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
+    }
+
+    private func makeResult(revision: UUID, string: String) -> MarkdownRenderResult {
+        MarkdownRenderResult(
+            revision: revision,
+            attributedString: NSAttributedString(string: string),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: []
+        )
+    }
+}
+
+private actor ControlledMermaidBackend: MermaidRenderingBackend {
+    private var continuations: [
+        String: CheckedContinuation<MermaidRenderOutcome, Never>
+    ] = [:]
+
+    func render(key: MermaidRenderKey) async -> MermaidRenderOutcome {
+        await withCheckedContinuation { continuation in
+            continuations[key.source] = continuation
+        }
+    }
+
+    func waitForRequest(source: String) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if continuations[source] != nil {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
+    }
+
+    func resume(source: String, outcome: MermaidRenderOutcome) {
+        continuations.removeValue(forKey: source)?.resume(returning: outcome)
+    }
+}

--- a/AlasTests/Code/Mermaid/MermaidDiagramLayoutTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidDiagramLayoutTests.swift
@@ -1,0 +1,38 @@
+import CoreGraphics
+import Testing
+@testable import Alas
+
+struct MermaidDiagramLayoutTests {
+    @Test("fit preserves ratio, respects height, and never upscales")
+    func fitRules() {
+        #expect(MermaidDiagramLayout.fittedSize(
+            intrinsic: CGSize(width: 1_000, height: 500),
+            availableWidth: 400,
+            maxHeight: 420
+        ) == CGSize(width: 400, height: 200))
+        #expect(MermaidDiagramLayout.fittedSize(
+            intrinsic: CGSize(width: 500, height: 1_000),
+            availableWidth: 400,
+            maxHeight: 420
+        ) == CGSize(width: 210, height: 420))
+        #expect(MermaidDiagramLayout.fittedSize(
+            intrinsic: CGSize(width: 100, height: 50),
+            availableWidth: 400,
+            maxHeight: 420
+        ) == CGSize(width: 100, height: 50))
+    }
+
+    @Test("fit rejects invalid dimensions")
+    func invalidDimensions() {
+        #expect(MermaidDiagramLayout.fittedSize(
+            intrinsic: CGSize(width: 0, height: 100),
+            availableWidth: 400,
+            maxHeight: 420
+        ) == .zero)
+        #expect(MermaidDiagramLayout.fittedSize(
+            intrinsic: CGSize(width: 100, height: 100),
+            availableWidth: 0,
+            maxHeight: 420
+        ) == .zero)
+    }
+}

--- a/AlasTests/Code/Mermaid/MermaidDiagramLayoutTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidDiagramLayoutTests.swift
@@ -35,4 +35,24 @@ struct MermaidDiagramLayoutTests {
             maxHeight: 420
         ) == .zero)
     }
+
+    @Test("rejects either raster safety bound")
+    func rejectsOversizedRaster() {
+        #expect(
+            BeautifulMermaidBackend.validateRaster(width: 8_193, height: 1)
+                == .rasterTooLarge(width: 8_193, height: 1)
+        )
+        #expect(
+            BeautifulMermaidBackend.validateRaster(width: 4_001, height: 4_000)
+                == .rasterTooLarge(width: 4_001, height: 4_000)
+        )
+        #expect(
+            BeautifulMermaidBackend.validateRaster(width: 8_192, height: 1)
+                == nil
+        )
+        #expect(
+            BeautifulMermaidBackend.validateRaster(width: 4_000, height: 4_000)
+                == nil
+        )
+    }
 }

--- a/AlasTests/Code/Mermaid/MermaidDiagramLayoutTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidDiagramLayoutTests.swift
@@ -55,4 +55,20 @@ struct MermaidDiagramLayoutTests {
                 == nil
         )
     }
+
+    @Test("preflight rejects an oversized layout before rasterization")
+    func preflightRejectsOversizedLayout() {
+        #expect(
+            BeautifulMermaidBackend.preflightRaster(
+                layoutSize: CGSize(width: 4_097, height: 1),
+                scale: 2
+            ) == .rasterTooLarge(width: 8_194, height: 2)
+        )
+        #expect(
+            BeautifulMermaidBackend.preflightRaster(
+                layoutSize: CGSize(width: 4_000, height: 4_000),
+                scale: 1
+            ) == nil
+        )
+    }
 }

--- a/AlasTests/Code/Mermaid/MermaidDiagramThemeTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidDiagramThemeTests.swift
@@ -16,4 +16,27 @@ struct MermaidDiagramThemeTests {
         #expect(palette.accent == "#D3A25C")
         #expect(palette.signature.contains("#D3A25C"))
     }
+
+    @Test("effective accent participates in the render key")
+    func accentChangesKey() throws {
+        var firstTheme = try Theme.loadBundled(id: "cool-slate")
+        var secondTheme = firstTheme
+        firstTheme.accentOverrideHex = "#112233"
+        secondTheme.accentOverrideHex = "#445566"
+
+        let firstKey = MermaidRenderKey(
+            source: "graph TD; A-->B",
+            theme: MermaidDiagramTheme(theme: firstTheme),
+            scale: 2,
+            profile: .full
+        )
+        let secondKey = MermaidRenderKey(
+            source: firstKey.source,
+            theme: MermaidDiagramTheme(theme: secondTheme),
+            scale: firstKey.scale,
+            profile: firstKey.profile
+        )
+
+        #expect(firstKey != secondKey)
+    }
 }

--- a/AlasTests/Code/Mermaid/MermaidDiagramThemeTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidDiagramThemeTests.swift
@@ -1,0 +1,19 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("Mermaid diagram theme")
+struct MermaidDiagramThemeTests {
+    @Test("theme palette is stable sRGB hex and includes accent")
+    func stablePalette() throws {
+        var theme = try Theme.loadBundled(id: "cool-slate")
+        theme.accentOverrideHex = "#D3A25C"
+        let palette = MermaidDiagramTheme(theme: theme)
+
+        #expect(palette.background.hasPrefix("#"))
+        #expect(palette.foreground.hasPrefix("#"))
+        #expect(palette.accent == "#D3A25C")
+        #expect(palette.signature.contains("#D3A25C"))
+    }
+}

--- a/AlasTests/Code/Mermaid/MermaidModelsTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidModelsTests.swift
@@ -18,4 +18,14 @@ struct MermaidModelsTests {
         #expect(MermaidPresentationProfile.transcript.maxEmbeddedHeight == 420)
         #expect(MermaidPresentationProfile.compact.maxEmbeddedHeight == 180)
     }
+
+    @Test("copy payload is the exact source without a fence")
+    func copyPayloadHasNoFence() {
+        let source = "graph TD;\n  A-->B\n"
+
+        let payload = MermaidSource.copyPayload(for: source)
+
+        #expect(payload == source)
+        #expect(!payload.contains("```"))
+    }
 }

--- a/AlasTests/Code/Mermaid/MermaidModelsTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidModelsTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import Alas
+
+@Suite("Mermaid models")
+struct MermaidModelsTests {
+    @Test("recognizes only the first mermaid fence token")
+    func fenceRecognition() {
+        #expect(MermaidFence.isMermaid(language: "mermaid"))
+        #expect(MermaidFence.isMermaid(language: "MERMAID title=Architecture"))
+        #expect(!MermaidFence.isMermaid(language: "swift mermaid"))
+        #expect(!MermaidFence.isMermaid(language: nil))
+        #expect(!MermaidFence.isMermaid(language: ""))
+    }
+
+    @Test("profiles lock the approved height caps")
+    func profileHeights() {
+        #expect(MermaidPresentationProfile.full.maxEmbeddedHeight == 640)
+        #expect(MermaidPresentationProfile.transcript.maxEmbeddedHeight == 420)
+        #expect(MermaidPresentationProfile.compact.maxEmbeddedHeight == 180)
+    }
+}

--- a/AlasTests/Code/Mermaid/MermaidRenderCacheTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidRenderCacheTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("Mermaid render cache")
+struct MermaidRenderCacheTests {
+    @Test("cache evicts least-recently-used entries by count")
+    func evictsByCount() {
+        var cache = MermaidRenderCache(countLimit: 2, costLimit: 100)
+        cache.insert(.failed(.empty), for: TestMermaid.key(source: "a"))
+        cache.insert(.failed(.empty), for: TestMermaid.key(source: "b"))
+        _ = cache.value(for: TestMermaid.key(source: "a"))
+        cache.insert(.failed(.empty), for: TestMermaid.key(source: "c"))
+
+        #expect(cache.value(for: TestMermaid.key(source: "a")) != nil)
+        #expect(cache.value(for: TestMermaid.key(source: "b")) == nil)
+    }
+
+    @Test("cache evicts least-recently-used entries by total cost")
+    func evictsByCost() {
+        var cache = MermaidRenderCache(countLimit: 10, costLimit: 3)
+        cache.insert(.failed(.empty), for: TestMermaid.key(source: "a"))
+        cache.insert(.failed(.empty), for: TestMermaid.key(source: "b"))
+        cache.insert(.failed(.empty), for: TestMermaid.key(source: "c"))
+        _ = cache.value(for: TestMermaid.key(source: "a"))
+        cache.insert(.failed(.empty), for: TestMermaid.key(source: "d"))
+
+        #expect(cache.value(for: TestMermaid.key(source: "b")) == nil)
+        #expect(cache.totalCost == 3)
+    }
+}

--- a/AlasTests/Code/Mermaid/MermaidRenderServiceTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidRenderServiceTests.swift
@@ -44,13 +44,24 @@ struct MermaidRenderServiceTests {
         #expect(await backend.maximumActiveCount == 2)
     }
 
-    @Test("render identity changes for source, theme, scale, and profile")
+    @Test("render identity changes for source, theme, and scale")
     func completeKeyIdentity() {
         let base = TestMermaid.key(source: "graph TD; A-->B")
         #expect(base != TestMermaid.key(source: "graph TD; A-->C"))
         #expect(base != TestMermaid.key(source: base.source, accent: "#445566"))
         #expect(base != TestMermaid.key(source: base.source, scale: 1))
-        #expect(base != TestMermaid.key(source: base.source, profile: .compact))
+    }
+
+    @Test("presentation profiles share a render cache identity")
+    func profilesShareRenderIdentity() {
+        let full = TestMermaid.key(source: "graph TD; A-->B", profile: .full)
+        let compact = TestMermaid.key(
+            source: full.source,
+            profile: .compact
+        )
+
+        #expect(full == compact)
+        #expect(Set([full, compact]).count == 1)
     }
 }
 

--- a/AlasTests/Code/Mermaid/MermaidRenderServiceTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidRenderServiceTests.swift
@@ -1,0 +1,94 @@
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("Mermaid render service")
+struct MermaidRenderServiceTests {
+    @Test("same-key requests share one backend render")
+    func coalescesSameKey() async {
+        let backend = FakeMermaidBackend(outcome: .failed(.unsupported("test")))
+        let service = MermaidRenderService(backend: backend)
+        let key = TestMermaid.key(source: "graph TD; A-->B")
+
+        async let first = service.render(key: key)
+        async let second = service.render(key: key)
+        _ = await (first, second)
+
+        #expect(await backend.renderCount == 1)
+    }
+
+    @Test("deterministic failures are cached")
+    func cachesFailures() async {
+        let backend = FakeMermaidBackend(outcome: .failed(.unsupported("test")))
+        let service = MermaidRenderService(backend: backend)
+        let key = TestMermaid.key(source: "graph TD; A-->B")
+
+        _ = await service.render(key: key)
+        _ = await service.render(key: key)
+
+        #expect(await backend.renderCount == 1)
+    }
+
+    @Test("at most two distinct renders use the backend concurrently")
+    func limitsConcurrentRenders() async {
+        let backend = FakeMermaidBackend(outcome: .failed(.unsupported("test")))
+        let service = MermaidRenderService(backend: backend)
+
+        async let first = service.render(key: TestMermaid.key(source: "a"))
+        async let second = service.render(key: TestMermaid.key(source: "b"))
+        async let third = service.render(key: TestMermaid.key(source: "c"))
+        async let fourth = service.render(key: TestMermaid.key(source: "d"))
+        _ = await (first, second, third, fourth)
+
+        #expect(await backend.renderCount == 4)
+        #expect(await backend.maximumActiveCount == 2)
+    }
+
+    @Test("render identity changes for source, theme, scale, and profile")
+    func completeKeyIdentity() {
+        let base = TestMermaid.key(source: "graph TD; A-->B")
+        #expect(base != TestMermaid.key(source: "graph TD; A-->C"))
+        #expect(base != TestMermaid.key(source: base.source, accent: "#445566"))
+        #expect(base != TestMermaid.key(source: base.source, scale: 1))
+        #expect(base != TestMermaid.key(source: base.source, profile: .compact))
+    }
+}
+
+@MainActor
+enum TestMermaid {
+    static func key(
+        source: String,
+        accent: String = "#336699",
+        scale: Double = 2,
+        profile: MermaidPresentationProfile = .full
+    ) -> MermaidRenderKey {
+        var theme = try! Theme.loadBundled(id: "cool-slate")
+        theme.accentOverrideHex = accent
+        return MermaidRenderKey(
+            source: source,
+            theme: MermaidDiagramTheme(theme: theme),
+            scale: scale,
+            profile: profile
+        )
+    }
+}
+
+actor FakeMermaidBackend: MermaidRenderingBackend {
+    private let outcome: MermaidRenderOutcome
+    private(set) var renderCount = 0
+    private var activeCount = 0
+    private(set) var maximumActiveCount = 0
+
+    init(outcome: MermaidRenderOutcome) {
+        self.outcome = outcome
+    }
+
+    func render(key: MermaidRenderKey) async -> MermaidRenderOutcome {
+        renderCount += 1
+        activeCount += 1
+        maximumActiveCount = max(maximumActiveCount, activeCount)
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        activeCount -= 1
+        return outcome
+    }
+}

--- a/AlasTests/Code/Mermaid/MermaidRenderServiceTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidRenderServiceTests.swift
@@ -63,6 +63,48 @@ struct MermaidRenderServiceTests {
         #expect(full == compact)
         #expect(Set([full, compact]).count == 1)
     }
+
+    @Test("cancelling the last consumer cancels its render task")
+    func cancellingLastConsumerCancelsRenderTask() async {
+        let backend = CancellationTrackingMermaidBackend()
+        let service = MermaidRenderService(backend: backend)
+        let task = Task {
+            await service.render(key: TestMermaid.key(source: "graph TD; A-->B"))
+        }
+
+        #expect(await backend.waitForStart())
+        task.cancel()
+        _ = await task.value
+
+        #expect(await backend.observedCancellation)
+    }
+
+    @Test("cancelling one consumer preserves a shared render")
+    func cancellingOneConsumerPreservesSharedRender() async {
+        let backend = CancellationTrackingMermaidBackend()
+        let service = MermaidRenderService(backend: backend)
+        let key = TestMermaid.key(source: "graph TD; A-->B")
+        let first = Task { await service.render(key: key) }
+
+        #expect(await backend.waitForStart())
+        let second = Task { await service.render(key: key) }
+        first.cancel()
+        _ = await (first.value, second.value)
+
+        #expect(!(await backend.observedCancellation))
+    }
+
+    @Test("cancelling a queued render removes its limiter waiter")
+    func cancellingQueuedRenderRemovesLimiterWaiter() async {
+        let limiter = MermaidRenderLimiter()
+        #expect(await limiter.acquire())
+        #expect(await limiter.acquire())
+
+        let waitingTask = Task { await limiter.acquire() }
+        waitingTask.cancel()
+
+        #expect(!(await waitingTask.value))
+    }
 }
 
 @MainActor
@@ -101,5 +143,27 @@ actor FakeMermaidBackend: MermaidRenderingBackend {
         try? await Task.sleep(nanoseconds: 20_000_000)
         activeCount -= 1
         return outcome
+    }
+}
+
+private actor CancellationTrackingMermaidBackend: MermaidRenderingBackend {
+    private(set) var started = false
+    private(set) var observedCancellation = false
+
+    func render(key: MermaidRenderKey) async -> MermaidRenderOutcome {
+        started = true
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        observedCancellation = Task.isCancelled
+        return .failed(.renderFailed("cancelled"))
+    }
+
+    func waitForStart() async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if started {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
     }
 }

--- a/AlasTests/Code/Mermaid/MermaidRenderServiceTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidRenderServiceTests.swift
@@ -29,6 +29,20 @@ struct MermaidRenderServiceTests {
         #expect(await backend.renderCount == 1)
     }
 
+    @Test("oversized-source failures are not cached")
+    func doesNotCacheOversizedSourceFailures() async {
+        let backend = FakeMermaidBackend(
+            outcome: .failed(.sourceTooLarge(actualBytes: 262_145))
+        )
+        let service = MermaidRenderService(backend: backend)
+        let key = TestMermaid.key(source: String(repeating: "a", count: 262_145))
+
+        _ = await service.render(key: key)
+        _ = await service.render(key: key)
+
+        #expect(await backend.renderCount == 2)
+    }
+
     @Test("at most two distinct renders use the backend concurrently")
     func limitsConcurrentRenders() async {
         let backend = FakeMermaidBackend(outcome: .failed(.unsupported("test")))

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -76,6 +76,53 @@ struct MermaidViewerStateTests {
         #expect(state.scale == 1)
     }
 
+    @Test("explicit viewer zoom preserves its intrinsic percentage after resize")
+    func explicitZoomPreservesIntrinsicPercentageAfterResize() {
+        var state = MermaidViewerInteractionState()
+        _ = state.perform(.actualSize, actualSizeScale: 2)
+
+        state.preserveIntrinsicZoom(from: 2, to: 1.5)
+
+        #expect(state.scale == 1.5)
+        #expect(state.zoomAccessibilityMetadata(actualSizeScale: 1.5).value == "100%")
+
+        state.adjustZoom(.increment)
+        state.preserveIntrinsicZoom(from: 1.5, to: 3)
+
+        #expect(state.scale == 3.75)
+        #expect(state.zoomAccessibilityMetadata(actualSizeScale: 3).value == "125%")
+    }
+
+    @Test("fit zoom follows resize without preserving intrinsic percentage")
+    func fitZoomFollowsResize() {
+        var state = MermaidViewerInteractionState()
+        _ = state.perform(.actualSize, actualSizeScale: 2)
+        _ = state.perform(.resetToFit)
+
+        state.preserveIntrinsicZoom(from: 2, to: 1.5)
+
+        #expect(state.scale == 1)
+        #expect(state.zoomAccessibilityMetadata(actualSizeScale: 1.5).value == "67%")
+    }
+
+    @Test("render scale changes do not reset the viewer viewport")
+    func renderScaleChangesDoNotResetViewport() {
+        let original = TestMermaid.key(source: "graph TD; A-->B", scale: 1)
+        let sameDiagramAtNewScale = TestMermaid.key(
+            source: "graph TD; A-->B",
+            scale: 2
+        )
+        let differentDiagram = TestMermaid.key(source: "graph TD; A-->C", scale: 2)
+        var state = MermaidRenderRequestState()
+
+        #expect(state.resetsViewport(for: original))
+
+        state.begin(original)
+
+        #expect(!state.resetsViewport(for: sameDiagramAtNewScale))
+        #expect(state.resetsViewport(for: differentDiagram))
+    }
+
     @Test("actual size remains monotonic through gesture and toolbar zoom")
     func actualSizeScaleAboveGestureMaximumIsPreserved() {
         var state = MermaidZoomState()

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -76,12 +76,14 @@ struct MermaidViewerStateTests {
         #expect(state.scale == 1)
     }
 
-    @Test("actual size is not clamped by gesture display scaling")
+    @Test("actual size remains monotonic through gesture and toolbar zoom")
     func actualSizeScaleAboveGestureMaximumIsPreserved() {
         var state = MermaidZoomState()
         state.setActualSize(12)
 
-        #expect(state.scale(adding: 1) == 12)
+        #expect(state.scale(adding: 1.25) == 15)
+        state.zoom(by: 1.25)
+        #expect(state.scale == 15)
     }
 
     @Test("latest render key wins when an obsolete render completes last")

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import Testing
 @testable import Alas
@@ -28,6 +29,42 @@ struct MermaidViewerStateTests {
         state.toggle()
 
         #expect(state.visibleSource(source) == nil)
+    }
+
+    @Test("user-opened block source stays open across failed and successful renders")
+    func userOpenedBlockSourceStaysOpenAcrossFailureRecovery() {
+        let source = "graph TD;\n  A-->B\n"
+        var state = MermaidSourceDisclosureState()
+
+        state.toggle()
+        state.apply(.failed(.rasterTooLarge(width: 8_193, height: 1)))
+        state.apply(Self.renderedOutcome())
+
+        #expect(state.visibleSource(source) == source)
+    }
+
+    @Test("viewer failure disclosure opens source and closes only failure-driven source")
+    func viewerFailureDisclosureLifecycle() {
+        var state = MermaidViewerInteractionState()
+
+        state.apply(.failed(.parseFailed("unexpected token")))
+
+        #expect(state.showsSource)
+
+        state.apply(Self.renderedOutcome())
+
+        #expect(!state.showsSource)
+    }
+
+    @Test("viewer preserves source explicitly opened before a failure")
+    func viewerPreservesExplicitSourceAcrossFailureRecovery() {
+        var state = MermaidViewerInteractionState()
+
+        _ = state.perform(.toggleSource)
+        state.apply(.failed(.parseFailed("unexpected token")))
+        state.apply(Self.renderedOutcome())
+
+        #expect(state.showsSource)
     }
 
     @Test("zoom clamps and resets")
@@ -225,5 +262,15 @@ struct MermaidViewerStateTests {
 
         #expect(state.scale == 1)
         #expect(state.zoomAccessibilityMetadata().value == "100%")
+    }
+
+    private static func renderedOutcome() -> MermaidRenderOutcome {
+        .rendered(
+            MermaidRenderedDiagram(
+                image: NSImage(size: NSSize(width: 80, height: 40)),
+                pixelSize: CGSize(width: 160, height: 80),
+                byteCost: 160 * 80 * 4
+            )
+        )
     }
 }

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -66,10 +66,22 @@ struct MermaidViewerStateTests {
 
         #expect(actualSizeScale == 2)
         #expect(state.scale == actualSizeScale)
+        #expect(
+            state.zoomAccessibilityMetadata(actualSizeScale: actualSizeScale)
+                .value == "100%"
+        )
 
         _ = state.perform(.resetToFit)
 
         #expect(state.scale == 1)
+    }
+
+    @Test("actual size is not clamped by gesture display scaling")
+    func actualSizeScaleAboveGestureMaximumIsPreserved() {
+        var state = MermaidZoomState()
+        state.setActualSize(12)
+
+        #expect(state.scale(adding: 1) == 12)
     }
 
     @Test("latest render key wins when an obsolete render completes last")
@@ -157,12 +169,12 @@ struct MermaidViewerStateTests {
 
         state.adjustZoom(.increment)
 
-        #expect(state.zoomAccessibilityMetadata.label == "Mermaid diagram zoom")
-        #expect(state.zoomAccessibilityMetadata.value == "125%")
+        #expect(state.zoomAccessibilityMetadata().label == "Mermaid diagram zoom")
+        #expect(state.zoomAccessibilityMetadata().value == "125%")
 
         state.adjustZoom(.decrement)
 
         #expect(state.scale == 1)
-        #expect(state.zoomAccessibilityMetadata.value == "100%")
+        #expect(state.zoomAccessibilityMetadata().value == "100%")
     }
 }

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Testing
 @testable import Alas
 
+@MainActor
 struct MermaidViewerStateTests {
     @Test("zoom clamps and resets")
     func zoomState() {
@@ -25,5 +26,23 @@ struct MermaidViewerStateTests {
         state.zoom(by: 0.001)
 
         #expect(state.scale == MermaidZoomState.minimumScale)
+    }
+
+    @Test("latest render key wins when an obsolete render completes last")
+    func latestRenderKeyWins() {
+        let obsoleteKey = TestMermaid.key(source: "graph TD; obsolete")
+        let latestKey = TestMermaid.key(source: "graph TD; latest")
+        var state = MermaidRenderRequestState()
+        state.begin(obsoleteKey)
+        state.begin(latestKey)
+        state.apply(.failed(.unsupported("latest result")), for: latestKey)
+        state.apply(.failed(.unsupported("obsolete result")), for: obsoleteKey)
+
+        #expect(state.currentKey == latestKey)
+        if case .failed(let failure) = state.outcome {
+            #expect(failure == .unsupported("latest result"))
+        } else {
+            Issue.record("Expected the latest render failure to remain visible")
+        }
     }
 }

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -67,6 +67,40 @@ struct MermaidViewerStateTests {
         #expect(state.showsSource)
     }
 
+    @Test("viewer theme model applies live theme changes")
+    func viewerThemeModelAppliesLiveThemeChanges() throws {
+        let initial = try Theme.loadBundled(id: "cool-slate")
+        let updated = try Theme.loadBundled(id: "light")
+        let model = MermaidDiagramViewerThemeModel(theme: initial)
+
+        model.theme = updated
+
+        #expect(model.theme == updated)
+    }
+
+    @Test("viewer render key follows effective theme")
+    func viewerRenderKeyFollowsEffectiveTheme() throws {
+        let source = "graph TD; A-->B"
+        let dark = try Theme.loadBundled(id: "cool-slate")
+        let light = try Theme.loadBundled(id: "light")
+
+        let darkKey = MermaidDiagramViewerView.renderKey(
+            source: source,
+            theme: dark,
+            backingScale: 2
+        )
+        let lightKey = MermaidDiagramViewerView.renderKey(
+            source: source,
+            theme: light,
+            backingScale: 2
+        )
+
+        #expect(darkKey != lightKey)
+        #expect(darkKey.source == lightKey.source)
+        #expect(darkKey.scale == lightKey.scale)
+        #expect(darkKey.profile == lightKey.profile)
+    }
+
     @Test("zoom clamps and resets")
     func zoomState() {
         var state = MermaidZoomState()

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -176,12 +176,17 @@ struct MermaidViewerStateTests {
         #expect(state.zoomAccessibilityMetadata(actualSizeScale: 1.5).value == "67%")
     }
 
-    @Test("render scale changes do not reset the viewer viewport")
-    func renderScaleChangesDoNotResetViewport() {
+    @Test("render scale and theme changes do not reset the viewer viewport")
+    func renderScaleAndThemeChangesDoNotResetViewport() {
         let original = TestMermaid.key(source: "graph TD; A-->B", scale: 1)
         let sameDiagramAtNewScale = TestMermaid.key(
             source: "graph TD; A-->B",
             scale: 2
+        )
+        let sameDiagramWithNewTheme = TestMermaid.key(
+            source: "graph TD; A-->B",
+            accent: "#D3A25C",
+            scale: 1
         )
         let differentDiagram = TestMermaid.key(source: "graph TD; A-->C", scale: 2)
         var state = MermaidRenderRequestState()
@@ -191,6 +196,7 @@ struct MermaidViewerStateTests {
         state.begin(original)
 
         #expect(!state.resetsViewport(for: sameDiagramAtNewScale))
+        #expect(!state.resetsViewport(for: sameDiagramWithNewTheme))
         #expect(state.resetsViewport(for: differentDiagram))
     }
 

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -1,0 +1,29 @@
+import CoreGraphics
+import Testing
+@testable import Alas
+
+struct MermaidViewerStateTests {
+    @Test("zoom clamps and resets")
+    func zoomState() {
+        var state = MermaidZoomState()
+        state.zoom(by: 100)
+        state.translate(by: CGSize(width: 24, height: -12))
+
+        #expect(state.scale == MermaidZoomState.maximumScale)
+        #expect(state.translation == CGSize(width: 24, height: -12))
+
+        state.resetToFit()
+
+        #expect(state.scale == 1)
+        #expect(state.translation == .zero)
+    }
+
+    @Test("zoom clamps at minimum")
+    func minimumZoom() {
+        var state = MermaidZoomState()
+
+        state.zoom(by: 0.001)
+
+        #expect(state.scale == MermaidZoomState.minimumScale)
+    }
+}

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -4,6 +4,32 @@ import Testing
 
 @MainActor
 struct MermaidViewerStateTests {
+    @Test(arguments: [
+        MermaidRenderFailure.empty,
+        .sourceTooLarge(actualBytes: 262_145),
+        .unsupported("gantt"),
+        .parseFailed("unexpected token"),
+        .layoutFailed("cycle"),
+        .renderFailed("image"),
+        .rasterTooLarge(width: 8_193, height: 1),
+    ])
+    func failureAutomaticallyExposesExactSource(
+        _ failure: MermaidRenderFailure
+    ) {
+        let source = "graph TD;\n  A-->B\n"
+        var state = MermaidSourceDisclosureState()
+
+        #expect(state.visibleSource(source) == nil)
+
+        state.apply(.failed(failure))
+
+        #expect(state.visibleSource(source) == source)
+
+        state.toggle()
+
+        #expect(state.visibleSource(source) == nil)
+    }
+
     @Test("zoom clamps and resets")
     func zoomState() {
         var state = MermaidZoomState()
@@ -44,5 +70,81 @@ struct MermaidViewerStateTests {
         } else {
             Issue.record("Expected the latest render failure to remain visible")
         }
+    }
+
+    @Test("viewer actions declare explicit keyboard shortcuts")
+    func viewerKeyboardShortcuts() {
+        #expect(
+            MermaidViewerAction.zoomIn.shortcut
+                == ShortcutBinding(key: "=", modifiers: [.command])
+        )
+        #expect(
+            MermaidViewerAction.zoomOut.shortcut
+                == ShortcutBinding(key: "-", modifiers: [.command])
+        )
+        #expect(
+            MermaidViewerAction.resetToFit.shortcut
+                == ShortcutBinding(key: "9", modifiers: [.command])
+        )
+        #expect(
+            MermaidViewerAction.actualSize.shortcut
+                == ShortcutBinding(key: "0", modifiers: [.command])
+        )
+        #expect(
+            MermaidViewerAction.toggleSource.shortcut
+                == ShortcutBinding(
+                    key: "u",
+                    modifiers: [.option, .command]
+                )
+        )
+        #expect(
+            MermaidViewerAction.copySource.shortcut
+                == ShortcutBinding(
+                    key: "c",
+                    modifiers: [.option, .command]
+                )
+        )
+    }
+
+    @Test("viewer actions share one state transition contract")
+    func viewerActionWiring() {
+        var state = MermaidViewerInteractionState()
+        state.translate(by: CGSize(width: 24, height: -12))
+
+        let zoomEffect = state.perform(.zoomIn)
+
+        #expect(zoomEffect == nil)
+        #expect(state.scale == 1.25)
+        #expect(state.translation == CGSize(width: 24, height: -12))
+
+        _ = state.perform(.actualSize)
+
+        #expect(state.scale == 1)
+        #expect(state.translation == CGSize(width: 24, height: -12))
+
+        _ = state.perform(.resetToFit)
+
+        #expect(state.scale == 1)
+        #expect(state.translation == .zero)
+
+        _ = state.perform(.toggleSource)
+
+        #expect(state.showsSource)
+        #expect(state.perform(.copySource) == .copySource)
+    }
+
+    @Test("zoom accessibility exposes a named adjustable percentage")
+    func zoomAccessibilityMetadataAndAdjustment() {
+        var state = MermaidViewerInteractionState()
+
+        state.adjustZoom(.increment)
+
+        #expect(state.zoomAccessibilityMetadata.label == "Mermaid diagram zoom")
+        #expect(state.zoomAccessibilityMetadata.value == "125%")
+
+        state.adjustZoom(.decrement)
+
+        #expect(state.scale == 1)
+        #expect(state.zoomAccessibilityMetadata.value == "100%")
     }
 }

--- a/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidViewerStateTests.swift
@@ -54,6 +54,24 @@ struct MermaidViewerStateTests {
         #expect(state.scale == MermaidZoomState.minimumScale)
     }
 
+    @Test("actual size restores the intrinsic diagram dimensions")
+    func actualSizeUsesIntrinsicToFittedScale() {
+        let actualSizeScale = MermaidDiagramLayout.actualSizeScale(
+            intrinsic: CGSize(width: 1_200, height: 600),
+            fitted: CGSize(width: 600, height: 300)
+        )
+        var state = MermaidViewerInteractionState()
+
+        _ = state.perform(.actualSize, actualSizeScale: actualSizeScale)
+
+        #expect(actualSizeScale == 2)
+        #expect(state.scale == actualSizeScale)
+
+        _ = state.perform(.resetToFit)
+
+        #expect(state.scale == 1)
+    }
+
     @Test("latest render key wins when an obsolete render completes last")
     func latestRenderKeyWins() {
         let obsoleteKey = TestMermaid.key(source: "graph TD; obsolete")

--- a/AlasTests/DiffReviewInlineFeedbackMarkdownTests.swift
+++ b/AlasTests/DiffReviewInlineFeedbackMarkdownTests.swift
@@ -1,0 +1,17 @@
+import Testing
+@testable import Alas
+
+@Suite("DiffReviewInlineFeedbackMarkdown")
+struct DiffReviewInlineFeedbackMarkdownTests {
+    @MainActor
+    @Test("review plain text retains Mermaid source")
+    func reviewPlainTextRetainsSource() {
+        let source = """
+        ```mermaid
+        graph TD; A-->B
+        ```
+        """
+
+        #expect(DiffReviewInlineFeedbackMarkdown.plainText(source).contains("graph TD; A-->B"))
+    }
+}

--- a/AlasTests/HoverFeatureBehaviorTests.swift
+++ b/AlasTests/HoverFeatureBehaviorTests.swift
@@ -219,6 +219,52 @@ struct HoverFeatureBehaviorTests {
         #expect(feature.isShowingPopover == false)
     }
 
+    @Test func mermaidExpansionAllowsSameSymbolToReopen() async throws {
+        let textView = makeTextView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 100, y: 100, width: 800, height: 600),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = textView
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.mermaid("graph TD; A-->B"))
+        recorder.queueResponse(.plainText("reopened"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+        defer {
+            MermaidDiagramViewerController.shared.dismiss()
+            feature.tearDown()
+            window.close()
+        }
+        let symbolPoint = point(forCharacterAt: 12, in: textView)
+
+        feature.simulateMouseMoved(at: symbolPoint)
+        feature.simulateOptionPressed()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(await recorder.calls.count == 1)
+        #expect(feature.isShowingPopover)
+        let overlay = try #require(window.childWindows?.first)
+        overlay.contentViewController?.view.layoutSubtreeIfNeeded()
+        let hoverTextView = try #require(
+            firstTextView(in: overlay.contentViewController?.view)
+        )
+        let cell = try #require(firstMermaidCell(in: hoverTextView))
+
+        cell.delegate?.mermaidTextAttachmentCellDidRequestExpansion(cell)
+
+        #expect(!feature.isShowingPopover)
+        #expect(window.attachedSheet?.title == "Mermaid Diagram")
+        MermaidDiagramViewerController.shared.dismiss()
+
+        feature.simulateMouseMoved(at: symbolPoint)
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(await recorder.calls.count == 2)
+        #expect(feature.isShowingPopover)
+    }
+
     @Test func mouseExitsEditorAfterGraceDismisses() async {
         let textView = makeTextView()
         let recorder = HoverRequestRecorder()
@@ -239,6 +285,37 @@ struct HoverFeatureBehaviorTests {
         // will dismiss regardless.)
         try? await Task.sleep(nanoseconds: 700_000_000)
         #expect(feature.isShowingPopover == false)
+    }
+
+    private func firstTextView(in view: NSView?) -> NSTextView? {
+        guard let view else { return nil }
+        if let textView = view as? NSTextView {
+            return textView
+        }
+        for subview in view.subviews {
+            if let textView = firstTextView(in: subview) {
+                return textView
+            }
+        }
+        return nil
+    }
+
+    private func firstMermaidCell(
+        in textView: NSTextView
+    ) -> MermaidTextAttachmentCell? {
+        guard let storage = textView.textStorage else { return nil }
+        var found: MermaidTextAttachmentCell?
+        storage.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: storage.length)
+        ) { value, _, stop in
+            guard let attachment = value as? MermaidTextAttachment else {
+                return
+            }
+            found = attachment.mermaidCell
+            stop.pointee = true
+        }
+        return found
     }
 }
 
@@ -269,5 +346,15 @@ final class HoverRequestRecorder {
 private extension LSPHoverResult {
     static func plainText(_ value: String) -> LSPHoverResult {
         LSPHoverResult(contents: .plain(value), range: nil)
+    }
+
+    static func mermaid(_ source: String) -> LSPHoverResult {
+        LSPHoverResult(
+            contents: .markupContent(
+                kind: "markdown",
+                value: "```mermaid\n\(source)\n```"
+            ),
+            range: nil
+        )
     }
 }

--- a/AlasTests/HoverFeatureRenderingTests.swift
+++ b/AlasTests/HoverFeatureRenderingTests.swift
@@ -118,4 +118,41 @@ struct HoverFeatureRenderingTests {
         #expect(hugeSize.width <= 520)
         #expect(hugeSize.height <= 400)
     }
+
+    @Test func hoverMermaidUsesCompactAttachment() throws {
+        let result = MarkdownRenderer().render(
+            document: Document(parsing: "```mermaid\ngraph TD; A-->B\n```"),
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/"),
+            mermaidProfile: .compact
+        )
+        let attachment = try #require(result.mermaidAttachments.first?.attachment)
+        let cell = attachment.mermaidCell
+        let frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: 500, height: cell.cellSize.height)
+        )
+        let loadingSize = HoverFeatureTesting.computePreferredSize(for: result)
+
+        #expect(attachment.profile == .compact)
+        #expect(cell.layoutFrames(in: frame).body.height == 180)
+        #expect(loadingSize.height <= 400)
+
+        cell.apply(.rendered(
+            MermaidRenderedDiagram(
+                image: NSImage(size: NSSize(width: 80, height: 40)),
+                pixelSize: CGSize(width: 160, height: 80),
+                byteCost: 160 * 80 * 4
+            )
+        ))
+        let renderedFrame = NSRect(
+            origin: .zero,
+            size: NSSize(width: 500, height: cell.cellSize.height)
+        )
+
+        #expect(cell.layoutFrames(in: renderedFrame).body.height == 180)
+        #expect(HoverFeatureTesting.computePreferredSize(for: result) == loadingSize)
+    }
 }

--- a/AlasTests/HoverWindowControllerTests.swift
+++ b/AlasTests/HoverWindowControllerTests.swift
@@ -68,7 +68,10 @@ struct HoverWindowControllerTests {
             size: HoverFeatureTesting.computePreferredSize(for: first),
             theme: theme,
             anchor: NSRect(x: 10, y: 10, width: 1, height: 14),
-            in: editor
+            in: editor,
+            onWillPresentMermaidViewer: { [weak controller] in
+                controller?.hide()
+            }
         )
 
         #expect(firstCell.delegate != nil)
@@ -78,7 +81,10 @@ struct HoverWindowControllerTests {
             size: HoverFeatureTesting.computePreferredSize(for: second),
             theme: theme,
             anchor: NSRect(x: 10, y: 10, width: 1, height: 14),
-            in: editor
+            in: editor,
+            onWillPresentMermaidViewer: { [weak controller] in
+                controller?.hide()
+            }
         )
         hostWindow.childWindows?.forEach {
             $0.contentViewController?.view.layoutSubtreeIfNeeded()

--- a/AlasTests/HoverWindowControllerTests.swift
+++ b/AlasTests/HoverWindowControllerTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Markdown
 import Testing
 @testable import Alas
 
@@ -8,5 +9,106 @@ struct HoverWindowControllerTests {
     @Test func isVisibleStartsFalse() {
         let controller = HoverWindowController()
         #expect(controller.isVisible == false)
+    }
+
+    @Test func compactAttachmentUsesMenuInsteadOfVisibleHeaderActions() {
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .compact
+        )
+        let cell = attachment.mermaidCell
+        let frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: 500, height: cell.cellSize.height)
+        )
+        let layout = cell.layoutFrames(in: frame)
+
+        #expect(layout.header == nil)
+        #expect(layout.sourceButton == .zero)
+        #expect(layout.copyButton == .zero)
+        #expect(layout.expandButton == .zero)
+        #expect(cell.menu?.items.map(\.title) == [
+            "Show Mermaid source",
+            "Copy Mermaid source"
+        ])
+
+        cell.setSourceVisible(true)
+
+        #expect(cell.menu?.items.map(\.title) == [
+            "Show Mermaid diagram",
+            "Copy Mermaid source"
+        ])
+    }
+
+    @Test func hoverReplacesCompactAttachmentWorkAndDismissesBeforeExpansion() throws {
+        let hostWindow = NSWindow(
+            contentRect: NSRect(x: 100, y: 100, width: 800, height: 600),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let editor = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 600)
+        )
+        hostWindow.contentView = editor
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let first = renderMermaid("graph TD; first-->result", theme: theme)
+        let second = renderMermaid("graph TD; second-->result", theme: theme)
+        let firstCell = try #require(first.mermaidAttachments.first?.attachment.mermaidCell)
+        let secondCell = try #require(second.mermaidAttachments.first?.attachment.mermaidCell)
+        let controller = HoverWindowController()
+        defer {
+            MermaidDiagramViewerController.shared.dismiss()
+            controller.hide()
+        }
+
+        controller.show(
+            result: first,
+            size: HoverFeatureTesting.computePreferredSize(for: first),
+            theme: theme,
+            anchor: NSRect(x: 10, y: 10, width: 1, height: 14),
+            in: editor
+        )
+
+        #expect(firstCell.delegate != nil)
+
+        controller.show(
+            result: second,
+            size: HoverFeatureTesting.computePreferredSize(for: second),
+            theme: theme,
+            anchor: NSRect(x: 10, y: 10, width: 1, height: 14),
+            in: editor
+        )
+        hostWindow.childWindows?.forEach {
+            $0.contentViewController?.view.layoutSubtreeIfNeeded()
+        }
+
+        #expect(firstCell.delegate == nil)
+        #expect(secondCell.delegate != nil)
+        #expect(controller.isVisible)
+
+        secondCell.delegate?.mermaidTextAttachmentCellDidRequestExpansion(
+            secondCell
+        )
+
+        #expect(!controller.isVisible)
+        #expect(hostWindow.attachedSheet?.title == "Mermaid Diagram")
+    }
+
+    private func renderMermaid(
+        _ source: String,
+        theme: Theme
+    ) -> MarkdownRenderResult {
+        MarkdownRenderer().render(
+            document: Document(
+                parsing: "```mermaid\n\(source)\n```"
+            ),
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/"),
+            mermaidProfile: .compact
+        )
     }
 }

--- a/AlasTests/MarkdownFileTypeTests.swift
+++ b/AlasTests/MarkdownFileTypeTests.swift
@@ -31,4 +31,11 @@ struct MarkdownFileTypeTests {
         #expect(!MarkdownFileType.isMarkdown(relativePath: "README.txt"))
         #expect(!MarkdownFileType.isMarkdown(relativePath: ""))
     }
+
+    @Test func recognizesStandaloneMermaidFiles() {
+        #expect(MarkdownFileType.isStandaloneMermaid(relativePath: "docs/flow.mmd"))
+        #expect(MarkdownFileType.isStandaloneMermaid(relativePath: "ARCH.MERMAID"))
+        #expect(!MarkdownFileType.isStandaloneMermaid(relativePath: "README.md"))
+        #expect(MarkdownFileType.supportsRichPreview(relativePath: "flow.mmd"))
+    }
 }

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -207,6 +207,33 @@ struct MarkdownRendererTests {
         #expect(font?.isFixedPitch == true)
     }
 
+    @Test func mermaidFenceEmitsAttachmentReference() throws {
+        let result = try Self.render("""
+        ```mermaid
+        graph TD; A-->B
+        ```
+        """)
+
+        #expect(result.mermaidAttachments.count == 1)
+        #expect(result.mermaidAttachments[0].id == "mermaid-0")
+        #expect(result.mermaidAttachments[0].source == "graph TD; A-->B")
+        #expect(result.mermaidAttachments[0].profile == .full)
+        #expect(result.attributedString.string.contains("graph TD") == false)
+    }
+
+    @Test func emptyMermaidFenceRemainsCode() throws {
+        let result = try Self.render("```mermaid\n```")
+
+        #expect(result.mermaidAttachments.isEmpty)
+    }
+
+    @Test func ordinaryFenceRemainsCode() throws {
+        let result = try Self.render("```swift\nlet value = 1\n```")
+
+        #expect(result.mermaidAttachments.isEmpty)
+        #expect(result.attributedString.string.contains("let value = 1"))
+    }
+
     private func tableBlock(at substring: String, in attributed: NSAttributedString) -> NSTextTableBlock? {
         let range = (attributed.string as NSString).range(of: substring)
         guard range.location != NSNotFound else { return nil }

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -215,10 +215,38 @@ struct MarkdownRendererTests {
         """)
 
         #expect(result.mermaidAttachments.count == 1)
-        #expect(result.mermaidAttachments[0].id == "mermaid-0")
+        #expect(
+            result.mermaidAttachments[0].id
+                == "mermaid-\(MarkdownRenderer.stableMermaidSourceKey("graph TD; A-->B"))"
+        )
         #expect(result.mermaidAttachments[0].source == "graph TD; A-->B")
         #expect(result.mermaidAttachments[0].profile == .full)
         #expect(result.attributedString.string.contains("graph TD") == false)
+    }
+
+    @Test func mermaidAttachmentIDSurvivesEarlierDifferentDiagram() throws {
+        let target = "graph TD; Target-->Done"
+        let base = try Self.render("""
+        ```mermaid
+        \(target)
+        ```
+        """)
+        let withEarlierDiagram = try Self.render("""
+        ```mermaid
+        graph TD; Earlier-->Diagram
+        ```
+
+        ```mermaid
+        \(target)
+        ```
+        """)
+
+        let targetID = try #require(base.mermaidAttachments.first?.id)
+        let shiftedTargetID = try #require(
+            withEarlierDiagram.mermaidAttachments.first { $0.source == target }?.id
+        )
+
+        #expect(targetID == shiftedTargetID)
     }
 
     @Test func emptyMermaidFenceRemainsCode() throws {

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -249,6 +249,26 @@ struct MarkdownRendererTests {
         #expect(targetID == shiftedTargetID)
     }
 
+    @Test func duplicateMermaidAttachmentIDsUseSourceLocation() throws {
+        let source = "graph TD; Same-->Diagram"
+        let result = try Self.render("""
+        ```mermaid
+        \(source)
+        ```
+
+        ```mermaid
+        \(source)
+        ```
+        """)
+
+        #expect(result.mermaidAttachments.count == 2)
+        #expect(result.mermaidAttachments[0].source == source)
+        #expect(result.mermaidAttachments[1].source == source)
+        #expect(result.mermaidAttachments[0].id != result.mermaidAttachments[1].id)
+        #expect(result.mermaidAttachments[0].id.contains(MarkdownRenderer.stableMermaidSourceKey(source)))
+        #expect(result.mermaidAttachments[1].id.contains(MarkdownRenderer.stableMermaidSourceKey(source)))
+    }
+
     @Test func emptyMermaidFenceRemainsCode() throws {
         let result = try Self.render("```mermaid\n```")
 

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -390,6 +390,33 @@ struct TabsManagerTests {
         }
     }
 
+    @Test func standaloneMermaidRevealForcesEditorMode() {
+        let manager = TabsManager()
+        let worktreeID = "standalone-mermaid-reveal"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeID)) }
+
+        let first = manager.openEditor(
+            worktreeId: worktreeID,
+            relativePath: "docs/flow.mmd",
+            revealLine: nil,
+            revealCharacter: nil
+        )
+        manager.setMarkdownViewMode(worktreeId: worktreeID, tabId: first.id, mode: .preview)
+
+        let revealed = manager.openEditor(
+            worktreeId: worktreeID,
+            relativePath: "docs/flow.mmd",
+            revealLine: 2,
+            revealCharacter: 0
+        )
+
+        guard case .editor(let state) = revealed else {
+            Issue.record("expected editor tab")
+            return
+        }
+        #expect(state.markdownViewMode == .editor)
+    }
+
     @Test func openExternalEditorAppendsAndActivates() {
         let worktreeId = "tabs-manager-open-external"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }

--- a/docs/superpowers/specs/2026-07-29-mermaid-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-29-mermaid-rendering-design.md
@@ -1,0 +1,444 @@
+# Native Mermaid Rendering Design
+
+**Date:** 2026-07-29  
+**Status:** Approved
+
+## Context
+
+Alas currently has two Markdown rendering paths:
+
+- Markdown files and LSP documentation use `swift-markdown`, `MarkdownRenderer`,
+  `MarkdownRenderResult`, and read-only AppKit text views.
+- ACP messages, queued prompts, and review comments use the block-oriented
+  `ACPMarkdownText` SwiftUI renderer.
+
+Both paths already identify fenced code blocks, but a `mermaid` fence is shown as
+source code. Standalone `.mmd` and `.mermaid` files are not recognized as
+previewable diagrams.
+
+The selected renderer is
+[`beautiful-mermaid-swift`](https://github.com/lukilabs/beautiful-mermaid-swift).
+It is a Swift 5.9 package supporting macOS 12 and later, so it is compatible with
+Alas's Swift 5.9 and macOS 15 baselines. It renders natively without JavaScript or
+WebKit and can produce AppKit images asynchronously.
+
+The package intentionally implements a subset of Mermaid syntax. Its current
+supported families are flowcharts, state diagrams, sequence diagrams, class
+diagrams, ER diagrams, and XY charts. Unsupported Mermaid families and unsupported
+features such as callbacks, links, tooltips, HTML labels, icons, and some styling
+directives must degrade to readable source rather than being presented as fully
+compatible Mermaid.js output.
+
+## Goal
+
+Render supported Mermaid diagrams natively in every existing Alas surface that
+already renders Markdown:
+
+- Markdown file Preview and Split modes,
+- ACP user and agent messages,
+- queued ACP prompt previews,
+- inline review comments, replies, outdated threads, and review summary surfaces,
+- editor LSP hover documentation,
+- diff-pane LSP hover documentation,
+- LSP completion documentation.
+
+Also recognize standalone `.mmd` and `.mermaid` files and provide Editor, Split,
+and Preview modes for them.
+
+The experience must:
+
+- follow the active Alas theme and accent,
+- preserve the original source and make it easy to copy,
+- fit diagrams to their host surface,
+- provide an expanded pan-and-zoom viewer,
+- render asynchronously without blocking transcript or editor updates,
+- avoid repeated work while ACP content is streaming,
+- preserve readable code when rendering fails or is unsupported.
+
+## Non-Goals
+
+- Full Mermaid.js syntax compatibility.
+- Embedding Mermaid.js, JavaScript, WebKit, or remote rendering.
+- Executing Mermaid links, callbacks, tooltips, or external resources.
+- Adding diagram editing beyond the existing source editor.
+- Adding PNG, SVG, or JPEG export in the first version.
+- Replacing or unifying Alas's existing Markdown rendering pipelines.
+- Rendering an unfinished ACP Mermaid fence while it is streaming.
+- Adding settings for renderer choice, themes, cache sizes, or layout tuning.
+
+## Chosen Architecture
+
+Keep both Markdown renderers and connect them to one shared native image-rendering
+service. Each surface uses a thin adapter suited to its existing UI technology.
+
+### MermaidRenderService
+
+Add an actor-isolated `MermaidRenderService` with one shared application instance.
+It wraps `BeautifulMermaid` behind a small internal rendering protocol so tests can
+inject a deterministic backend.
+
+The service accepts:
+
+- exact Mermaid source,
+- an Alas-derived diagram theme,
+- backing scale,
+- a presentation size class.
+
+It returns a structured outcome:
+
+- a rendered `NSImage` and its intrinsic size, or
+- a typed failure describing empty input, excessive input, unsupported syntax,
+  parse failure, layout failure, or rendering failure.
+
+The service owns:
+
+- asynchronous native rendering,
+- in-flight request coalescing for identical keys,
+- a bounded result cache containing both successful and deterministic failed
+  outcomes,
+- concurrency limiting so opening a transcript with many diagrams does not start
+  an unbounded number of layout operations.
+
+The cache key includes the exact source, effective diagram-theme signature, backing
+scale, and presentation size class. The initial cache should be limited to 128
+entries and approximately 64 MiB of image cost. Native rendering should run at no
+more than two operations concurrently. These are internal safety bounds, not user
+settings.
+
+Source larger than 256 KiB should not be passed to the package. Rendered rasters
+must be capped at an 8,192-pixel maximum dimension and 16 million total pixels.
+Exceeding a bound produces a typed fallback outcome and leaves the source readable.
+
+UI mutation remains on the main actor. Consumers carry an identity derived from
+source and theme and ignore outcomes that no longer match their current identity.
+
+### Theme Mapping
+
+Build a `DiagramTheme` from the active Alas theme rather than selecting an
+unrelated package preset:
+
+| BeautifulMermaid role | Alas theme role |
+|---|---|
+| background | `bg-1` |
+| foreground | `fg` |
+| line | `line` |
+| accent | `accent` |
+| muted | `fg-muted` |
+| surface | `bg-2` |
+| border | `line` |
+
+The theme signature used in render keys must change when any mapped color changes.
+Switching theme, system appearance, or accent therefore requests a fresh result,
+while identical content and effective colors reuse the cache.
+
+## Markdown Recognition
+
+### Fenced Markdown
+
+A completed fenced code block is Mermaid when the first whitespace-separated
+language token is `mermaid`, compared case-insensitively. Additional fence metadata
+may follow that token without changing recognition.
+
+Examples that render:
+
+````text
+```mermaid
+```MERMAID
+```mermaid title=Architecture
+````
+
+An empty Mermaid fence remains an ordinary code block.
+
+### ACP Streaming
+
+Extend `ACPMarkdownText.Block` with a completed Mermaid block carrying the original
+source. A closed `mermaid` fence becomes that block. An unclosed fence remains the
+existing `.streamingCode` case and must not invoke `MermaidRenderService`.
+
+This preserves the existing streaming-performance boundary: diagram parsing and
+layout begin only after the closing fence arrives and the block can become stable
+in `ACPMarkdownBlockCache`.
+
+### Standalone Files
+
+Add case-insensitive recognition for `.mmd` and `.mermaid`. These files open in a
+dedicated diagram tab presentation that reuses:
+
+- the normal source editor,
+- `MarkdownViewMode` values and persistence,
+- the configured Markdown default view mode,
+- the existing 200 ms preview debounce behavior.
+
+Editor mode shows source. Split mode shows source and diagram. Preview mode shows
+the diagram. The entire file is the diagram source; it is not parsed as a Markdown
+document.
+
+## Surface Adapters
+
+### SwiftUI Block Adapter
+
+Use a shared `MermaidDiagramBlockView` for ACP, queued prompts, and review Markdown.
+The view owns only transient presentation state:
+
+- loading,
+- rendered image,
+- fallback,
+- source expanded or collapsed,
+- expanded-view presentation.
+
+It delegates rendering and caching to `MermaidRenderService`.
+
+The block displays:
+
+- a compact `MERMAID` header,
+- **Show source** / **Hide source**,
+- **Copy**,
+- **Expand**,
+- the fitted diagram or source fallback.
+
+Review cards and other narrow hosts use the same block with a smaller embedded
+height profile. Existing consumers of `ACPMarkdownText` inherit Mermaid support
+without duplicating parsing or rendering logic.
+
+### Attributed-Text Adapter
+
+Extend `MarkdownRenderResult` with Mermaid attachment references. When
+`MarkdownRenderer` visits a completed Mermaid `CodeBlock`, it emits a stable custom
+text attachment and records:
+
+- source,
+- attachment identity,
+- presentation profile,
+- the source range needed for fallback and source disclosure.
+
+The attributed-text adapter resolves those references asynchronously and updates
+only the matching attachment. It should be reusable by:
+
+- `MarkdownPreviewController`,
+- editor and diff LSP hover content,
+- completion documentation content.
+
+Alas's current text views use the TextKit 1 layout path. A custom
+`NSTextAttachmentCell` should provide the interactive full-surface presentation
+without replacing the Markdown preview renderer. It draws the header, fitted image,
+optional source, and failure state, forwards actions to its controller, and
+invalidates its attachment layout when state changes.
+
+Full Markdown previews expose visible **Show source**, **Copy**, and **Expand**
+controls. Compact LSP attachments omit the visible header to preserve popover
+space:
+
+- clicking the diagram opens the expanded viewer,
+- a context menu offers **Show source** and **Copy Mermaid source**,
+- a failed compact attachment shows the source directly.
+
+Extract only the attachment-loading and action-routing behavior needed to keep the
+three text-view consumers consistent. Do not turn this feature into a broader
+Markdown-view rewrite.
+
+### Standalone-File Adapter
+
+A standalone diagram tab uses the same `MermaidDiagramBlockView` and shared service.
+It supplies the full-surface profile and the raw editor buffer as source.
+
+## Presentation
+
+### Embedded Sizing
+
+Images preserve aspect ratio and never upscale beyond their intrinsic size.
+Otherwise they fit the available width.
+
+Use these initial embedded height caps:
+
+- Markdown and standalone full previews: 640 points,
+- ACP transcript and review surfaces: 420 points,
+- LSP hover and completion documentation: 180 points.
+
+When a fitted diagram exceeds its height cap, crop neither content nor source. The
+embedded presentation remains a fitted overview, and **Expand** opens the full
+viewer. Compact LSP popovers keep their existing outer scrolling bounds rather than
+adding nested diagram scrolling.
+
+### Expanded Viewer
+
+Present a transient Alas viewer sheet from the host window. If expansion starts in
+an LSP popover, dismiss the popover before presenting the viewer.
+
+The viewer provides:
+
+- fit-to-window on open,
+- pan,
+- zoom in and out,
+- reset to fit,
+- 100% scale,
+- source disclosure,
+- source copy,
+- Escape to close.
+
+The viewer rerenders or reuses an appropriately scaled cached image rather than
+pixel-scaling a small compact attachment.
+
+### Source Disclosure and Copying
+
+Successful full-surface diagrams start with source collapsed. **Show source**
+reveals the original fenced body beneath the image in selectable monospaced text.
+The label changes to **Hide source** while expanded.
+
+**Copy** always copies the exact Mermaid source body, without the Markdown fence.
+Standalone files copy the complete file contents.
+
+## Loading, Errors, and Security
+
+A new request displays stable Mermaid chrome with a subdued progress indicator.
+The layout reserves a reasonable minimum height so asynchronous completion does not
+collapse the surrounding transcript or preview.
+
+Failure behavior is content-preserving:
+
+- invalid or unsupported diagrams render through the normal code-block style,
+- a subdued `Couldn't render Mermaid diagram` message appears in the header,
+- a concise package error may appear in help text or the expanded source view,
+- the original source remains selectable and copyable,
+- an error in one diagram does not affect the rest of the document.
+
+Unsupported Mermaid families must be described as unsupported rather than malformed
+when the package makes that distinction available. If it does not, use the general
+rendering-failure message and preserve the package diagnostic for debugging.
+
+Rendering is local and native. Diagram content must not:
+
+- execute JavaScript,
+- open URLs,
+- fetch remote resources,
+- invoke callbacks,
+- interpret HTML as executable content.
+
+## Testing
+
+### Pure Recognition and Routing Tests
+
+Add Swift Testing coverage for:
+
+- case-insensitive `mermaid` fence recognition,
+- fence metadata after the first language token,
+- empty Mermaid fences remaining code,
+- closed ACP fences becoming Mermaid blocks,
+- unclosed ACP fences remaining `.streamingCode`,
+- `.mmd` and `.mermaid` file recognition,
+- Editor, Split, and Preview state persistence for standalone files.
+
+### Service Tests
+
+Use an injected fake backend to verify:
+
+- cache hits for identical render keys,
+- misses after source, theme, scale, or size-class changes,
+- in-flight request coalescing,
+- the two-operation concurrency bound,
+- stale consumer outcomes being rejected,
+- successful and failed outcomes being cached,
+- source and raster safety bounds,
+- cache-cost eviction behavior.
+
+### Renderer and Adapter Tests
+
+Verify:
+
+- `MarkdownRenderer` emits a Mermaid reference instead of syntax-highlighted code
+  for a completed Mermaid fence,
+- ordinary fenced code remains unchanged,
+- a successful image replaces only its matching attachment,
+- an old asynchronous result cannot replace a newer diagram,
+- full and compact attachment profiles expose the correct actions,
+- source disclosure preserves exact source,
+- Copy uses the exact source without fences,
+- ACP and review views use the shared block adapter,
+- failures preserve code and diagnostic chrome.
+
+Keep sizing calculations and menu/action routing in pure helpers where possible so
+tests do not depend on brittle SwiftUI inspection.
+
+### Native Package Smoke Tests
+
+Render one small example of each supported family:
+
+- flowchart,
+- state,
+- sequence,
+- class,
+- ER,
+- XY chart.
+
+Assert a non-empty image and sensible intrinsic size rather than snapshotting exact
+pixels. Also exercise invalid source and one unsupported Mermaid family to lock the
+fallback contract.
+
+### Manual Acceptance
+
+Exercise:
+
+- Markdown Preview and Split modes,
+- ACP user and agent messages,
+- queued ACP prompts,
+- inline review comments and replies,
+- outdated-thread and review-summary surfaces,
+- editor and diff LSP hovers,
+- completion documentation,
+- `.mmd` and `.mermaid` Editor, Split, and Preview modes,
+- light/dark theme and accent changes,
+- host-window resizing,
+- source disclosure and copying,
+- expanded pan/zoom/reset behavior,
+- invalid and unsupported diagrams,
+- multiple identical diagrams in one transcript.
+
+## Risks and Mitigations
+
+### Partial Mermaid Compatibility
+
+The native package is not a drop-in Mermaid.js implementation. Preserve the source,
+name unsupported cases honestly, and keep the package behind an internal protocol
+so its implementation can be upgraded without changing surface code.
+
+### Native View Resizing
+
+The package currently has a reported macOS redraw issue when its SwiftUI view
+changes size. Alas will consume rendered images instead of embedding the package's
+view directly, making resizing an Alas-owned fit calculation.
+
+### Transcript and Popover Performance
+
+Diagram layout can be expensive. Closed-fence gating, asynchronous work, in-flight
+coalescing, cache bounds, render concurrency limits, and stale-result rejection
+keep it out of streaming and repeated-update hot paths.
+
+### TextKit Attachment Complexity
+
+Interactive attachment cells add more state than current image attachments. Keep
+the cell behind the attributed-text adapter, test layout invalidation separately,
+and retain a plain code fallback if a host cannot install the rich attachment.
+
+### Package Maturity
+
+The dependency is young. Add it through `project.yml` with the documented
+`from: 1.0.0` constraint, commit the regenerated Xcode project and package
+resolution, and keep the adapter narrow enough to replace or fork the dependency
+later if necessary.
+
+## Expected Implementation Boundary
+
+Expected additions or modifications include:
+
+- `project.yml` and regenerated `Alas.xcodeproj`,
+- package resolution for `BeautifulMermaid`,
+- shared Mermaid source/theme/result/render-service support,
+- shared SwiftUI diagram block and expanded viewer,
+- attributed-text Mermaid attachment support,
+- `MarkdownRenderer`, `MarkdownRenderResult`, and preview controller integration,
+- ACP Markdown block parsing and rendering,
+- LSP hover and completion attachment integration,
+- standalone Mermaid file detection and tab routing,
+- focused Swift Testing coverage for each boundary.
+
+Do not refactor unrelated Markdown, ACP transcript, review, LSP, or file-tab
+architecture while implementing this design.

--- a/docs/superpowers/specs/2026-07-29-mermaid-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-29-mermaid-rendering-design.md
@@ -100,10 +100,9 @@ The service owns:
   an unbounded number of layout operations.
 
 The cache key includes the exact source, effective diagram-theme signature, backing
-scale, and presentation size class. The initial cache should be limited to 128
-entries and approximately 64 MiB of image cost. Native rendering should run at no
-more than two operations concurrently. These are internal safety bounds, not user
-settings.
+scale, and presentation size class. The initial cache uses a 128-entry count limit
+and a 64 MiB total-cost limit. Native rendering runs at no more than two operations
+concurrently. These are internal safety bounds, not user settings.
 
 Source larger than 256 KiB should not be passed to the package. Rendered rasters
 must be capped at an 8,192-pixel maximum dimension and 16 million total pixels.
@@ -200,6 +199,11 @@ Review cards and other narrow hosts use the same block with a smaller embedded
 height profile. Existing consumers of `ACPMarkdownText` inherit Mermaid support
 without duplicating parsing or rendering logic.
 
+Any exhaustive block consumers, including review-card plain-text flattening and
+height estimation, treat a Mermaid block as its original source. Search,
+accessibility summaries, drag payloads, and collapsed previews therefore remain
+readable even when they do not instantiate the diagram view.
+
 ### Attributed-Text Adapter
 
 Extend `MarkdownRenderResult` with Mermaid attachment references. When
@@ -229,7 +233,10 @@ controls. Compact LSP attachments omit the visible header to preserve popover
 space:
 
 - clicking the diagram opens the expanded viewer,
-- a context menu offers **Show source** and **Copy Mermaid source**,
+- a context menu offers **Show Mermaid source** and **Copy Mermaid source**,
+- **Show Mermaid source** replaces the compact image with selectable monospaced
+  source inside the existing outer scroller; while source is shown, the menu item
+  becomes **Show Mermaid diagram**,
 - a failed compact attachment shows the source directly.
 
 Extract only the attachment-loading and action-routing behavior needed to keep the
@@ -259,6 +266,10 @@ embedded presentation remains a fitted overview, and **Expand** opens the full
 viewer. Compact LSP popovers keep their existing outer scrolling bounds rather than
 adding nested diagram scrolling.
 
+The compact loading attachment reserves the 180-point diagram slot before native
+rendering starts. Completion invalidates text layout inside the existing popover
+but does not grow the popover past its current maximum dimensions.
+
 ### Expanded Viewer
 
 Present a transient Alas viewer sheet from the host window. If expansion starts in
@@ -287,17 +298,28 @@ The label changes to **Hide source** while expanded.
 **Copy** always copies the exact Mermaid source body, without the Markdown fence.
 Standalone files copy the complete file contents.
 
+### Accessibility
+
+Rendered images expose the label `Mermaid diagram` and an accessibility value
+containing the original source. Header and context-menu actions use explicit
+labels, help text, and keyboard focus. Source disclosure remains selectable and
+readable by assistive technologies. The expanded viewer exposes its zoom value and
+provides keyboard equivalents for zoom, reset, source disclosure, copying, and
+closing.
+
 ## Loading, Errors, and Security
 
 A new request displays stable Mermaid chrome with a subdued progress indicator.
-The layout reserves a reasonable minimum height so asynchronous completion does not
-collapse the surrounding transcript or preview.
+Full-surface loading presentations reserve 120 points of height; compact LSP
+presentations reserve the 180-point slot specified above. Completion replaces that
+reservation with the measured success or fallback presentation.
 
 Failure behavior is content-preserving:
 
 - invalid or unsupported diagrams render through the normal code-block style,
 - a subdued `Couldn't render Mermaid diagram` message appears in the header,
-- a concise package error may appear in help text or the expanded source view,
+- a concise sanitized package diagnostic appears in the header's help text and
+  beneath the source in the expanded viewer,
 - the original source remains selectable and copyable,
 - an error in one diagram does not affect the rest of the document.
 
@@ -353,6 +375,8 @@ Verify:
 - source disclosure preserves exact source,
 - Copy uses the exact source without fences,
 - ACP and review views use the shared block adapter,
+- review plain-text flattening and accessibility summaries retain Mermaid source,
+- rendered diagrams and actions expose the specified accessibility labels,
 - failures preserve code and diagnostic chrome.
 
 Keep sizing calculations and menu/action routing in pure helpers where possible so

--- a/project.yml
+++ b/project.yml
@@ -105,6 +105,9 @@ packages:
   Markdown:
     url: https://github.com/apple/swift-markdown
     from: 0.8.0
+  BeautifulMermaidSwift:
+    url: https://github.com/lukilabs/beautiful-mermaid-swift
+    from: 1.0.0
 
 targets:
   Alas:
@@ -195,6 +198,8 @@ targets:
         product: TreeSitterDockerfile
       - package: Markdown
         product: Markdown
+      - package: BeautifulMermaidSwift
+        product: BeautifulMermaid
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.nlopez.alas


### PR DESCRIPTION
## Summary

- Render supported Mermaid diagrams natively across Markdown previews, ACP/review content, LSP hover and completion documentation, and standalone `.mmd`/`.mermaid` files.
- Add bounded asynchronous rendering with theme-aware caching, stale-result protection, TextKit attachments, source fallback/copy controls, and an accessible keyboard-enabled expanded viewer.
- Preserve source for unsupported or invalid diagrams and keep existing Markdown, transcript, and LSP rendering paths intact.

## Validation

- `xcodegen`
- `swiftformat Alas AlasTests --lint --reporter github-actions-log`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -parallel-testing-enabled NO test`
  - 6,649 passed, 12 skipped, 0 failed on the rebased head.

## Manual follow-up

Runtime keyboard and VoiceOver interaction remains to be manually exercised in the app; automated action/state coverage is included.
