### PR TITLE
fix(acp): fix slash-command autocomplete rendering and missed suggestions

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -84,12 +84,12 @@ struct ACPInputField: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         context.coordinator.isFocused = $isFocused
-        // The agent can send `available_commands_update` after the user has
-        // already typed a "/" token (e.g. right after a takeover re-attaches
-        // via session/load) — reconcileSlashPanel only runs on keystrokes, so
-        // without this the panel never appears for that still-active token.
-        let suggestionsArrived = context.coordinator.promptSuggestions.isEmpty
-            && !session.promptSuggestions.isEmpty
+        // The agent can send `available_commands_update` at any time — after
+        // the user has already typed a "/" token (e.g. right after a
+        // takeover re-attaches via session/load), or to replace/clear an
+        // already-open panel's list. reconcileSlashPanel only runs on
+        // keystrokes, so without this the panel would miss all of that.
+        let suggestionsChanged = context.coordinator.promptSuggestions != session.promptSuggestions
         context.coordinator.promptSuggestions = session.promptSuggestions
         context.coordinator.theme = context.environment.theme
         context.coordinator.sendOnEnter = sendOnEnter
@@ -106,7 +106,7 @@ struct ACPInputField: NSViewRepresentable {
             tv.placeholderText = Self.placeholder(for: session.transcript.streamingState, sendOnEnter: sendOnEnter)
             tv.needsDisplay = true
             context.coordinator.syncPersistedDraft(composer.draft, into: tv)
-            if suggestionsArrived {
+            if suggestionsChanged {
                 tv.reconcileSlashPanel()
             }
         }
@@ -741,7 +741,11 @@ final class ACPNSTextView: NSTextView {
             closeSlashPanel()
             return
         }
-        if slashPanel == nil { presentSlashPanel() }
+        if slashPanel == nil {
+            presentSlashPanel()
+        } else {
+            slashPanel?.model.updateSuggestions(coord.promptSuggestions)
+        }
         slashStart = tok.start
         slashPanel?.model.setQuery(tok.query)
         if slashPanel?.model.filtered.isEmpty == true {

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -613,6 +613,17 @@ final class ACPNSTextView: NSTextView {
         needsDisplay = true
     }
 
+    /// A restored draft can already contain an active "/" token before
+    /// this view is attached to a window — `positionAndShow` needs the
+    /// window to place the panel, so `reconcileSlashPanel` is a no-op
+    /// until attachment. Retry once a window exists.
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            reconcileSlashPanel()
+        }
+    }
+
     /// Dismiss any floating picker panel owned by this text view. The
     /// panels are attached as child windows of the host window (not of
     /// this view), so without an explicit close on teardown they outlive
@@ -754,7 +765,11 @@ final class ACPNSTextView: NSTextView {
     }
 
     private func presentSlashPanel() {
-        guard let coord = coordinator, !coord.promptSuggestions.isEmpty,
+        // `positionAndShow` needs `window` to place the panel; bail out
+        // rather than recording a `slashPanel` that was never actually
+        // shown — reconcileSlashPanel would then skip re-presenting it
+        // on later calls, leaving it permanently invisible.
+        guard window != nil, let coord = coordinator, !coord.promptSuggestions.isEmpty,
               let theme = coord.theme else { return }
         let panel = ACPSlashPickerPanel(
             suggestions: coord.promptSuggestions,

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -84,6 +84,12 @@ struct ACPInputField: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         context.coordinator.isFocused = $isFocused
+        // The agent can send `available_commands_update` after the user has
+        // already typed a "/" token (e.g. right after a takeover re-attaches
+        // via session/load) — reconcileSlashPanel only runs on keystrokes, so
+        // without this the panel never appears for that still-active token.
+        let suggestionsArrived = context.coordinator.promptSuggestions.isEmpty
+            && !session.promptSuggestions.isEmpty
         context.coordinator.promptSuggestions = session.promptSuggestions
         context.coordinator.theme = context.environment.theme
         context.coordinator.sendOnEnter = sendOnEnter
@@ -100,6 +106,9 @@ struct ACPInputField: NSViewRepresentable {
             tv.placeholderText = Self.placeholder(for: session.transcript.streamingState, sendOnEnter: sendOnEnter)
             tv.needsDisplay = true
             context.coordinator.syncPersistedDraft(composer.draft, into: tv)
+            if suggestionsArrived {
+                tv.reconcileSlashPanel()
+            }
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPSlashPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPSlashPicker.swift
@@ -148,7 +148,8 @@ struct ACPSlashPickerView: View {
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(theme.color("fg-faint"))
                     .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
+                    .truncationMode(.tail)
+                    .layoutPriority(-1)
             }
             if let d = s.description, !d.isEmpty {
                 MarqueeText(

--- a/Alas/Sources/ACP/UI/ACPSlashPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPSlashPicker.swift
@@ -10,17 +10,29 @@ import SwiftUI
 final class ACPSlashPickerModel: ObservableObject {
     @Published var query: String = ""
     @Published private(set) var selectedIndex: Int = 0
-    let allSuggestions: [ACPPromptSuggestion]
+    @Published private(set) var allSuggestions: [ACPPromptSuggestion]
 
     init(suggestions: [ACPPromptSuggestion]) {
-        // De-duplicate by `command` (case-sensitive) keeping the first
-        // occurrence in original order. Some agents emit the same slash
-        // command more than once (e.g. across re-sent
-        // `available_commands_update` payloads); duplicates would otherwise
-        // render as repeated rows and, with element-based ForEach identity,
-        // as blank phantom rows.
+        self.allSuggestions = Self.deduplicated(suggestions)
+    }
+
+    /// Replaces the suggestion list in place (e.g. a live
+    /// `available_commands_update` while the panel is already open)
+    /// instead of requiring the panel to be closed and reopened.
+    func updateSuggestions(_ suggestions: [ACPPromptSuggestion]) {
+        allSuggestions = Self.deduplicated(suggestions)
+        selectedIndex = 0
+    }
+
+    /// De-duplicates by `command` (case-sensitive) keeping the first
+    /// occurrence in original order. Some agents emit the same slash
+    /// command more than once (e.g. across re-sent
+    /// `available_commands_update` payloads); duplicates would otherwise
+    /// render as repeated rows and, with element-based ForEach identity,
+    /// as blank phantom rows.
+    private static func deduplicated(_ suggestions: [ACPPromptSuggestion]) -> [ACPPromptSuggestion] {
         var seen = Set<String>()
-        self.allSuggestions = suggestions.filter { seen.insert($0.command).inserted }
+        return suggestions.filter { seen.insert($0.command).inserted }
     }
 
     /// Score each suggestion by how well it matches the (lowercased)

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -877,6 +877,9 @@ struct ACPComposerDraftBridgeTests {
 
     private func makeSlashTextView() -> (ACPNSTextView, ACPInputField.Coordinator) {
         let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 40))
+        // presentSlashPanel() needs a window to position the panel against.
+        let window = NSWindow(contentRect: textView.frame, styleMask: [], backing: .buffered, defer: false)
+        window.contentView?.addSubview(textView)
         let coordinator = makeCoordinator(sendOnEnter: true) { _, _, _, _, _ in true }
         coordinator.promptSuggestions = [
             ACPPromptSuggestion(command: "/init", description: "Initialize"),

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -446,8 +446,8 @@ struct ACPComposerDraftBridgeTests {
 
     @Test("slash panel closes when filtering has no command matches")
     func slashPanelClosesWhenFilteringHasNoMatches() {
-        let (textView, coordinator) = makeSlashTextView()
-        _ = coordinator
+        let (textView, coordinator, window) = makeSlashTextView()
+        _ = (coordinator, window)
         textView.string = "/"
         textView.setSelectedRange(NSRange(location: 1, length: 0))
 
@@ -463,8 +463,8 @@ struct ACPComposerDraftBridgeTests {
 
     @Test("slash panel closes when input is cleared outside keyDown")
     func slashPanelClosesWhenInputIsClearedOutsideKeyDown() {
-        let (textView, coordinator) = makeSlashTextView()
-        _ = coordinator
+        let (textView, coordinator, window) = makeSlashTextView()
+        _ = (coordinator, window)
         textView.string = "/"
         textView.setSelectedRange(NSRange(location: 1, length: 0))
         textView.reconcileSlashPanel()
@@ -479,7 +479,8 @@ struct ACPComposerDraftBridgeTests {
 
     @Test("slash panel closes when composer editing ends")
     func slashPanelClosesOnEditingEnd() {
-        let (textView, coordinator) = makeSlashTextView()
+        let (textView, coordinator, window) = makeSlashTextView()
+        _ = window
         textView.string = "/"
         textView.setSelectedRange(NSRange(location: 1, length: 0))
         textView.reconcileSlashPanel()
@@ -875,9 +876,11 @@ struct ACPComposerDraftBridgeTests {
         )
     }
 
-    private func makeSlashTextView() -> (ACPNSTextView, ACPInputField.Coordinator) {
+    private func makeSlashTextView() -> (ACPNSTextView, ACPInputField.Coordinator, NSWindow) {
         let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 40))
         // presentSlashPanel() needs a window to position the panel against.
+        // `textView.window` is unowned, so the caller must keep the returned
+        // window alive for as long as the text view is used.
         let window = NSWindow(contentRect: textView.frame, styleMask: [], backing: .buffered, defer: false)
         window.contentView?.addSubview(textView)
         let coordinator = makeCoordinator(sendOnEnter: true) { _, _, _, _, _ in true }
@@ -896,7 +899,7 @@ struct ACPComposerDraftBridgeTests {
         )
         coordinator.textView = textView
         textView.coordinator = coordinator
-        return (textView, coordinator)
+        return (textView, coordinator, window)
     }
 
     @Test("⌥⏎ (insertNewlineIgnoringFieldEditor:) submits with .steer")


### PR DESCRIPTION
## Summary
- Long usage hints (e.g. `release-manager`'s bracketed argument list) forced their full intrinsic width via `fixedSize`, overflowing the picker panel instead of truncating with an ellipsis.
- `promptSuggestions` arriving after the user already typed `/` (e.g. right after a session takeover re-attaches) never re-opened the panel, since the panel only reconciled on keystrokes — now it also reconciles when suggestions transition from empty to populated.

## Test plan
- [x] Built and ran the app; typed `/release-manager` and confirmed the hint truncates instead of overflowing the panel
- [x] Reproduced the missed-panel case with a session whose suggestions arrived after typing `/`, confirmed the panel now opens