### PR TITLE
fix(gg): preserve input across availability probe

### DIFF
--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -192,6 +192,16 @@ struct NewWorktreeDialog: View {
                 if let pinned = stackPinnedBase { base = pinned }
             }
         }
+        .onChange(of: GGAvailability.shared.isInstalled) { wasInstalled, isInstalled in
+            guard !wasInstalled, isInstalled, stackedDiffsRequested else { return }
+            // The startup probe can resolve after this field has accepted input.
+            // Carry that input forward without coupling later manual mode toggles.
+            stackName = Self.stackNameAfterGGAvailabilityProbe(
+                branch: branch,
+                branchPrefix: state.config.worktrees.branchPrefix,
+                currentStackName: stackName
+            )
+        }
     }
 
     private var presetProject: ProjectConfig? {
@@ -246,6 +256,18 @@ struct NewWorktreeDialog: View {
         return GGStackCreateMode.createsStack(
             masterEnabled: state.config.changes.stackedDiffsEnabled,
             ggInstalled: GGAvailability.shared.isInstalled,
+            isRemoteProject: project.host != nil,
+            projectMode: project.ggMode,
+            worktreeMode: ggMode,
+            repoHasGGConfig: GGStackGate.repoHasGGConfig(repoPath: project.path)
+        )
+    }
+
+    private var stackedDiffsRequested: Bool {
+        guard let project = state.projects.first(where: { $0.id == projectId }) else { return false }
+        return GGStackCreateMode.createsStack(
+            masterEnabled: state.config.changes.stackedDiffsEnabled,
+            ggInstalled: true,
             isRemoteProject: project.host != nil,
             projectMode: project.ggMode,
             worktreeMode: ggMode,
@@ -503,6 +525,16 @@ struct NewWorktreeDialog: View {
         stackName: String
     ) -> String {
         createsGGStack ? stackName : branch
+    }
+
+    nonisolated static func stackNameAfterGGAvailabilityProbe(
+        branch: String,
+        branchPrefix: String,
+        currentStackName: String
+    ) -> String {
+        guard currentStackName.isEmpty else { return currentStackName }
+        guard branch.hasPrefix(branchPrefix) else { return branch }
+        return String(branch.dropFirst(branchPrefix.count))
     }
 
     nonisolated static func resolvedPresetProject(

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -113,6 +113,26 @@ struct NewWorktreeDialogTests {
         #expect(selection.ggMode == .off)
     }
 
+    @Test func completedGGProbeCarriesImmediateBranchInputIntoEmptyStackDraft() {
+        let stackName = NewWorktreeDialog.stackNameAfterGGAvailabilityProbe(
+            branch: "nacho/feature",
+            branchPrefix: "nacho/",
+            currentStackName: ""
+        )
+
+        #expect(stackName == "feature")
+    }
+
+    @Test func completedGGProbePreservesExistingStackDraft() {
+        let stackName = NewWorktreeDialog.stackNameAfterGGAvailabilityProbe(
+            branch: "nacho/regular-draft",
+            branchPrefix: "nacho/",
+            currentStackName: "stack-draft"
+        )
+
+        #expect(stackName == "stack-draft")
+    }
+
     @Test func initialProjectIdUsesValidPreset() {
         let projects = [Self.project(id: "repo-a"), Self.project(id: "repo-b")]
 


### PR DESCRIPTION
## Summary

- preserve the first New Worktree name character when GG availability resolves after the dialog appears
- transfer only startup-probe input into an empty stack draft while preserving independent manual drafts
- add focused regression coverage

## Root cause

PR #926 seeded the project and Stacked Diffs Mode before the first render, but `GGAvailability.shared.isInstalled` still begins as `false` until the startup probe completes. Input could land in the regular branch draft before availability switched the field to the empty stack draft.

## Verification

- `rtk swiftformat Alas AlasTests --lint --reporter github-actions-log`
- `rtk xcodegen`
- macOS app build with isolated DerivedData
- focused `NewWorktreeDialogTests`
- adjacent `GGAvailabilityTests`, `GGStackCreateModeTests`, and `GGWorktreeContextTests`
- `rtk git diff --check`

The broad local test suite was attempted, but the build stalled before spawning `xctest`; GitHub Actions remains the exhaustive suite gate.