### PR TITLE
perf(diff): bound review render tree

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -318,9 +318,11 @@ final class DiffPaneTextDocumentContainerView: NSView {
         oldPane.onContextExpansion = onContextExpansion
         newPane.onContextExpansion = onContextExpansion
         stackedPane.onContextExpansion = onContextExpansion
-        oldPane.activeCommentHighlight = activeCommentHighlight
-        newPane.activeCommentHighlight = activeCommentHighlight
-        stackedPane.activeCommentHighlight = activeCommentHighlight
+        if oldPane.activeCommentHighlight != activeCommentHighlight {
+            oldPane.activeCommentHighlight = activeCommentHighlight
+            newPane.activeCommentHighlight = activeCommentHighlight
+            stackedPane.activeCommentHighlight = activeCommentHighlight
+        }
 
         let signature = UpdateSignature(
             groupID: group.id,
@@ -518,9 +520,11 @@ final class DiffPaneTextDocumentContainerView: NSView {
         oldPane.onContextExpansion = onContextExpansion
         newPane.onContextExpansion = onContextExpansion
         stackedPane.onContextExpansion = onContextExpansion
-        oldPane.activeCommentHighlight = activeCommentHighlight
-        newPane.activeCommentHighlight = activeCommentHighlight
-        stackedPane.activeCommentHighlight = activeCommentHighlight
+        if oldPane.activeCommentHighlight != activeCommentHighlight {
+            oldPane.activeCommentHighlight = activeCommentHighlight
+            newPane.activeCommentHighlight = activeCommentHighlight
+            stackedPane.activeCommentHighlight = activeCommentHighlight
+        }
 
         let signature = RowsUpdateSignature(
             rowsSignature: rowsSignature ?? DiffDisplayRowsSignature(rows),
@@ -666,6 +670,7 @@ final class DiffPaneTextScrollView: NSScrollView {
     private var theme: Theme?
     var activeCommentHighlight: DiffReviewCommentHighlight? {
         didSet {
+            guard activeCommentHighlight != oldValue else { return }
             textView.activeCommentHighlight = activeCommentHighlight
             (verticalRulerView as? DiffPaneLineNumberRulerView)?.activeCommentHighlight = activeCommentHighlight
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -101,6 +101,7 @@ struct DiffReviewFileSection: View {
     let codeFontFamily: String
     let codeFontSize: CGFloat
     let showsSourceBadge: Bool
+    var automaticallyRendersDiff: Bool = true
     var lspContext: DiffPaneLSPContext? = nil
     var inlineFeedbackActions = DiffReviewInlineFeedbackActions()
     var onSelectInlineFeedback: (DiffReviewInlineFeedback) -> Void = { _ in }
@@ -152,8 +153,12 @@ struct DiffReviewFileSection: View {
         return DiffReviewRenderBudget.isOverBudget(displayModel)
     }
 
+    private var isDeferredByAggregateBudget: Bool {
+        file.displayModel != nil && !automaticallyRendersDiff
+    }
+
     private var shouldDeferRender: Bool {
-        isOverRenderBudget && !showFullDiffOverride
+        (isOverRenderBudget || isDeferredByAggregateBudget) && !showFullDiffOverride
     }
 
     var body: some View {
@@ -621,8 +626,11 @@ struct DiffReviewFileSection: View {
     private var renderBudgetPlaceholder: some View {
         let changedLines = file.summary.additions + file.summary.deletions
         let hiddenItems = hiddenReviewItemCount
+        let title = isDeferredByAggregateBudget
+            ? "Large review diff deferred for performance"
+            : "Large diff hidden for performance"
         return VStack(alignment: .leading, spacing: 8) {
-            Text("Large diff hidden for performance")
+            Text(title)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(theme.color("fg"))
             Text("\(changedLines.formatted()) changed lines. Rendering may be slow.")
@@ -656,9 +664,17 @@ struct DiffReviewFileSection: View {
         .background(
             DiffReviewAccessibilityMarker(
                 identifier: "diff-review-render-budget-\(file.id.rawValue)",
-                label: "Large diff hidden for performance"
+                label: title
             )
         )
+        .background {
+            if isDeferredByAggregateBudget {
+                DiffReviewAccessibilityMarker(
+                    identifier: "diff-review-aggregate-budget-\(file.id.rawValue)",
+                    label: "Large review diff deferred for performance"
+                )
+            }
+        }
     }
 
     /// Zero-size anchors carrying the same target IDs the rendered comment views
@@ -1489,6 +1505,7 @@ struct EquatableDiffReviewFileSection: View, Equatable {
             && lhs.section.codeFontFamily == rhs.section.codeFontFamily
             && lhs.section.codeFontSize == rhs.section.codeFontSize
             && lhs.section.showsSourceBadge == rhs.section.showsSourceBadge
+            && lhs.section.automaticallyRendersDiff == rhs.section.automaticallyRendersDiff
             && DiffPaneLSPContext.rendersEqual(lhs.section.lspContext, rhs.section.lspContext)
             && lhs.section.allowsDraftCommentCreation == rhs.section.allowsDraftCommentCreation
             && lhs.section.reviewFeedbackTarget == rhs.section.reviewFeedbackTarget

--- a/Alas/Sources/Center/DiffReview/DiffReviewRenderEligibility.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRenderEligibility.swift
@@ -4,10 +4,11 @@ struct DiffReviewRenderRow: Identifiable, Equatable {
     let index: Int
     let id: DiffReviewFileID
     let showsBottomSpacing: Bool
+    let automaticallyRendersDiff: Bool
 }
 
-/// Keeps the review stream deterministic: every loaded file is render-eligible,
-/// and SwiftUI's `LazyVStack` is the only virtualization layer.
+/// Keeps the review stream deterministic by deciding automatic eligibility in
+/// the loaded-file order.
 enum DiffReviewRenderEligibility {
     static func fileIDs(ordered: [DiffReviewFileID]) -> Set<DiffReviewFileID> {
         Set(ordered)
@@ -19,7 +20,46 @@ enum DiffReviewRenderEligibility {
             DiffReviewRenderRow(
                 index: index,
                 id: fileIDs[index],
-                showsBottomSpacing: index != lastIndex
+                showsBottomSpacing: index != lastIndex,
+                automaticallyRendersDiff: true
+            )
+        }
+    }
+
+    static func renderRows(
+        ordered fileIDs: [DiffReviewFileID],
+        renderedRowCounts: [Int?],
+        maxAutomaticallyRenderedRows: Int
+    ) -> [DiffReviewRenderRow] {
+        precondition(fileIDs.count == renderedRowCounts.count)
+
+        let lastIndex = fileIDs.indices.last
+        var automaticallyRenderedRows = 0
+        var hasExceededAggregateBudget = false
+
+        return fileIDs.indices.map { index in
+            let renderedRowCount = renderedRowCounts[index]
+            let isIndividuallyOverBudget = renderedRowCount.map(DiffReviewRenderBudget.isOverBudget) ?? false
+            let automaticallyRendersDiff: Bool
+
+            if let renderedRowCount, !isIndividuallyOverBudget {
+                let remainingRows = maxAutomaticallyRenderedRows - automaticallyRenderedRows
+                automaticallyRendersDiff = !hasExceededAggregateBudget && renderedRowCount <= remainingRows
+
+                if automaticallyRendersDiff {
+                    automaticallyRenderedRows += renderedRowCount
+                } else {
+                    hasExceededAggregateBudget = true
+                }
+            } else {
+                automaticallyRendersDiff = true
+            }
+
+            return DiffReviewRenderRow(
+                index: index,
+                id: fileIDs[index],
+                showsBottomSpacing: index != lastIndex,
+                automaticallyRendersDiff: automaticallyRendersDiff
             )
         }
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -284,14 +284,20 @@ struct DiffReviewSurface: View {
         ScrollViewReader { scrollProxy in
             ScrollView(.vertical) {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    let renderRows = DiffReviewRenderEligibility.renderRows(ordered: session.files.map(\.id))
+                    let renderRows = DiffReviewRenderEligibility.renderRows(
+                        ordered: session.files.map(\.id),
+                        renderedRowCounts: session.files.map { file in
+                            file.displayModel.map(DiffReviewRenderBudget.renderedRowCount)
+                        },
+                        maxAutomaticallyRenderedRows: DiffReviewRenderBudget.maxRenderedRows
+                    )
                     ForEach(renderRows) { row in
                         let file = session.files[row.index]
                         Color.clear
                             .frame(height: 1)
                             .id(DiffReviewSurfaceSelectionSync.topVisibilityTargetID(for: row.id))
                             .accessibilityHidden(true)
-                        fileSection(file)
+                        fileSection(file, automaticallyRendersDiff: row.automaticallyRendersDiff)
                             .id(DiffReviewSurfaceSelectionSync.sectionVisibilityTargetID(for: row.id))
                         Color.clear
                             .frame(height: row.showsBottomSpacing ? 14 : 0)
@@ -345,7 +351,10 @@ struct DiffReviewSurface: View {
     }
 
     @ViewBuilder
-    private func fileSection(_ file: DiffReviewFileSectionModel) -> some View {
+    private func fileSection(
+        _ file: DiffReviewFileSectionModel,
+        automaticallyRendersDiff: Bool
+    ) -> some View {
         let inlineFeedback = inlineFeedbackByFileID[file.id] ?? []
         let draftComments = draftCommentsByFileID[file.id] ?? []
         EquatableDiffReviewFileSection(
@@ -363,6 +372,7 @@ struct DiffReviewSurface: View {
                 codeFontFamily: codeFontFamily,
                 codeFontSize: codeFontSize,
                 showsSourceBadge: showsSourceBadges,
+                automaticallyRendersDiff: automaticallyRendersDiff,
                 lspContext: lspContextForFile(file),
                 inlineFeedbackActions: inlineFeedbackActions,
                 onSelectInlineFeedback: onSelectInlineFeedback,

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -4162,6 +4162,77 @@ let second = true
         #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
     }
 
+    @Test func unchangedGroupContainerUpdateDoesNotInvalidateCommentHighlightViews() throws {
+        let group = try #require(model().groups.first)
+        let container = DiffPaneTextDocumentContainerView(
+            frame: NSRect(x: 0, y: 0, width: 700, height: 300)
+        )
+        let highlight = DiffReviewCommentHighlight(path: "a.swift", side: .new, line: 2)
+
+        func update() {
+            container.update(
+                group: group,
+                expandedCollapsedRowIDs: [],
+                layoutMode: .split,
+                wrapLines: false,
+                showWhitespace: false,
+                fileExtension: "swift",
+                font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+                theme: theme(),
+                lspContext: nil,
+                activeCommentHighlight: highlight
+            )
+        }
+
+        update()
+        let codeViews = allSubviews(of: container).compactMap { $0 as? DiffPaneCodeTextView }
+        let rulers = allSubviews(of: container).compactMap { $0 as? DiffPaneLineNumberRulerView }
+        #expect(!codeViews.isEmpty)
+        #expect(!rulers.isEmpty)
+        codeViews.forEach { $0.needsDisplay = false }
+        rulers.forEach { $0.needsDisplay = false }
+
+        update()
+
+        #expect(codeViews.allSatisfy { !$0.needsDisplay })
+        #expect(rulers.allSatisfy { !$0.needsDisplay })
+    }
+
+    @Test func unchangedRowsContainerUpdateDoesNotInvalidateCommentHighlightViews() throws {
+        let rows = Array(try #require(model().groups.first).rows)
+        let container = DiffPaneTextDocumentContainerView(
+            frame: NSRect(x: 0, y: 0, width: 700, height: 300)
+        )
+        let highlight = DiffReviewCommentHighlight(path: "a.swift", side: .new, line: 2)
+
+        func update() {
+            container.update(
+                rows: rows,
+                layoutMode: .split,
+                wrapLines: false,
+                showWhitespace: false,
+                fileExtension: "swift",
+                font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+                theme: theme(),
+                lspContext: nil,
+                activeCommentHighlight: highlight
+            )
+        }
+
+        update()
+        let codeViews = allSubviews(of: container).compactMap { $0 as? DiffPaneCodeTextView }
+        let rulers = allSubviews(of: container).compactMap { $0 as? DiffPaneLineNumberRulerView }
+        #expect(!codeViews.isEmpty)
+        #expect(!rulers.isEmpty)
+        codeViews.forEach { $0.needsDisplay = false }
+        rulers.forEach { $0.needsDisplay = false }
+
+        update()
+
+        #expect(codeViews.allSatisfy { !$0.needsDisplay })
+        #expect(rulers.allSatisfy { !$0.needsDisplay })
+    }
+
     @Test func stableWidthLayoutAppliesTextLayoutConfigurationOnce() throws {
         let scrollView = makeLongTextScrollView(width: 220, wraps: true)
 

--- a/AlasTests/DiffReviewFileSectionEqualityTests.swift
+++ b/AlasTests/DiffReviewFileSectionEqualityTests.swift
@@ -39,6 +39,7 @@ struct DiffReviewFileSectionEqualityTests {
         #expect(base != section(file: file, codeFontFamily: "Menlo"))
         #expect(base != section(file: file, codeFontSize: 14))
         #expect(base != section(file: file, showsSourceBadge: true))
+        #expect(base != section(file: file, automaticallyRendersDiff: false))
         #expect(base != section(file: file, allowsDraftCommentCreation: true))
         #expect(base != section(file: file, canReply: true))
         #expect(base != section(file: file, canResolve: true))
@@ -244,6 +245,7 @@ private func section(
     codeFontFamily: String = "SF Mono",
     codeFontSize: CGFloat = 12,
     showsSourceBadge: Bool = false,
+    automaticallyRendersDiff: Bool = true,
     onSelectInlineFeedback: @escaping (DiffReviewInlineFeedback) -> Void = { _ in },
     allowsDraftCommentCreation: Bool = false,
     reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
@@ -270,6 +272,7 @@ private func section(
             codeFontFamily: codeFontFamily,
             codeFontSize: codeFontSize,
             showsSourceBadge: showsSourceBadge,
+            automaticallyRendersDiff: automaticallyRendersDiff,
             onSelectInlineFeedback: onSelectInlineFeedback,
             allowsDraftCommentCreation: allowsDraftCommentCreation,
             reviewFeedbackTarget: reviewFeedbackTarget,

--- a/AlasTests/DiffReviewRenderEligibilityTests.swift
+++ b/AlasTests/DiffReviewRenderEligibilityTests.swift
@@ -31,5 +31,50 @@ struct DiffReviewRenderEligibilityTests {
 
         #expect(rows.map(\.index) == [0, 1, 2])
         #expect(rows.map(\.id) == files)
+        #expect(rows.map(\.showsBottomSpacing) == [true, true, false])
+    }
+
+    @Test func legacyRenderRowsKeepEveryFileAutomaticallyEligible() {
+        let files = [id("A.swift"), id("B.swift")]
+
+        let rows = DiffReviewRenderEligibility.renderRows(ordered: files)
+
+        #expect(rows.map(\.automaticallyRendersDiff) == [true, true])
+    }
+
+    @Test func aggregateEligibilityIncludesRowsThatExactlyFillTheCap() {
+        let files = [id("A.swift"), id("B.swift"), id("C.swift")]
+
+        let rows = DiffReviewRenderEligibility.renderRows(
+            ordered: files,
+            renderedRowCounts: [2, 3, 1],
+            maxAutomaticallyRenderedRows: 5
+        )
+
+        #expect(rows.map(\.automaticallyRendersDiff) == [true, true, false])
+    }
+
+    @Test func aggregateEligibilityDefersTheFirstNormalRowBeyondTheRemainingCapAndLaterNormalRows() {
+        let files = [id("A.swift"), id("B.swift"), id("C.swift")]
+
+        let rows = DiffReviewRenderEligibility.renderRows(
+            ordered: files,
+            renderedRowCounts: [3, 3, 1],
+            maxAutomaticallyRenderedRows: 5
+        )
+
+        #expect(rows.map(\.automaticallyRendersDiff) == [true, false, false])
+    }
+
+    @Test func aggregateEligibilityDoesNotChargeMissingOrOversizedRowsToTheCap() {
+        let files = [id("A.swift"), id("B.swift"), id("C.swift"), id("D.swift"), id("E.swift")]
+
+        let rows = DiffReviewRenderEligibility.renderRows(
+            ordered: files,
+            renderedRowCounts: [2, nil, DiffReviewRenderBudget.maxRenderedRows + 1, 3, 1],
+            maxAutomaticallyRenderedRows: 5
+        )
+
+        #expect(rows.map(\.automaticallyRendersDiff) == [true, true, true, true, false])
     }
 }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -2914,6 +2914,48 @@ struct DiffReviewSurfaceTests {
         #expect(!allSubviews(of: controller.view).contains { $0 is DiffPaneTextScrollView })
     }
 
+    @Test func aggregateBudgetDeferralHidesTextDiffUntilReviewerRequestsIt() {
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Sources/Deferred.swift"),
+            parsedDiff: parsedDiff(),
+            displayModel: displayModel(),
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+
+        let view = DiffReviewFileSection(
+            file: file,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: true,
+            automaticallyRendersDiff: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 260)
+
+        #expect(subview(
+            withAccessibilityIdentifier: "diff-review-aggregate-budget-\(file.id.rawValue)",
+            in: controller.view
+        ) != nil)
+        #expect(!allSubviews(of: controller.view).contains { $0 is DiffPaneTextScrollView })
+
+        #expect(pressAccessibilityElement(
+            withAccessibilityIdentifier: "diff-review-show-full-diff-\(file.id.rawValue)",
+            in: controller.view
+        ))
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(allSubviews(of: controller.view).contains { $0 is DiffPaneTextScrollView })
+    }
+
     @Test func surfaceRepairsInvalidSelectedIDToFirstSessionFile() {
         let first = summary(path: "Sources/App/AlphaView.swift")
         let second = summary(path: "Tests/BetaTests.swift")

--- a/docs/superpowers/specs/2026-07-30-diff-review-aggregate-render-budget-design.md
+++ b/docs/superpowers/specs/2026-07-30-diff-review-aggregate-render-budget-design.md
@@ -1,0 +1,91 @@
+# Diff Review Aggregate Render Budget
+
+## Problem
+
+The diff review surface automatically renders every loaded file inside one
+`LazyVStack`. SwiftUI materializes lazy children as they are visited but does
+not recycle them, so the retained layout tree grows throughout a long review.
+The existing 20,000-row limit applies independently to each file and therefore
+does not bound aggregate layout work.
+
+Captured hangs show the main thread remaining inside one SwiftUI transaction,
+with most samples in recursive stack layout and explicit alignment traversal.
+The same failure exists before the recently added static-height width
+measurement, so that unconfirmed feedback edge is not part of this fix.
+
+## Design
+
+### Aggregate Eligibility
+
+Extend `DiffReviewRenderEligibility` to calculate automatic render eligibility
+from ordered file IDs and their post-collapse row counts. Files remain
+automatically eligible in deterministic review order while their cumulative
+row count fits within a session-wide cap. Once the cap is exhausted, later
+renderable files are deferred.
+
+Non-text files and files without a display model do not consume the row budget.
+The aggregate cap matches the existing per-file cap so any file that is valid
+under the current policy can still render automatically when it fits.
+
+This is a fixed eligibility decision for a loaded session, not a viewport
+window. Scrolling therefore does not replace already laid-out sections or
+change preceding section heights.
+
+### Deferred Sections
+
+Pass aggregate eligibility from `DiffReviewSurface` into
+`DiffReviewFileSection`. A section defers when either:
+
+- its own display model exceeds the per-file budget, or
+- the session-wide automatic render budget excludes it.
+
+The existing placeholder, comment scroll anchors, and per-section "Show full
+diff" override remain the interaction model. Placeholder copy distinguishes an
+individually oversized file from a file deferred because the review is large.
+An explicit user override is allowed to exceed the automatic aggregate cap.
+
+The aggregate eligibility flag participates in the equatable wrapper's render
+identity so a session reload cannot leave stale section content.
+
+### Redundant Highlight Invalidations
+
+`DiffPaneTextDocumentContainerView.update` assigns
+`activeCommentHighlight` to all panes before its content-signature early
+return. Add equality checks at that assignment boundary so unchanged values do
+not propagate into text and ruler views and mark them for display again.
+
+## Out Of Scope
+
+- Changing the static-height width preference or estimator without evidence of
+  width oscillation.
+- Dynamically recycling sections around the viewport.
+- Replacing the SwiftUI stream with an AppKit collection view.
+- Broad stack flattening or alignment changes.
+- Changing intrinsic-content-size invalidation behavior without a confirmed
+  oscillation.
+
+## Testing
+
+Add focused Swift Testing coverage for aggregate eligibility:
+
+- cumulative rows at the cap remain eligible;
+- the first file that exceeds the remaining aggregate budget and later files
+  are deferred;
+- files without renderable text do not consume the cap;
+- ordering and row metadata remain stable.
+
+Add a focused AppKit test showing that assigning the same active highlight
+does not re-invalidate the pane descendants, using a small observable helper if
+direct `needsDisplay` assertions are unreliable.
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+The captured hang is not deterministic, so runtime success is additionally
+defined as preserving ordinary review navigation and allowing deferred files
+to be opened explicitly without automatic tree growth beyond the cap.


### PR DESCRIPTION
## Summary
- Cap automatic diff-review rendering across the loaded session instead of only per file.
- Defer files beyond the cap through the existing placeholder and explicit Show full diff action.
- Skip redundant active-comment highlight redraws in diff text panes.

## Root cause
The review stream retained every materialized LazyVStack section, allowing the SwiftUI layout tree to grow without a session-wide bound.

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build\n- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test