### PR TITLE
feat(gg): stream progressive inbox refresh

### DIFF
--- a/Alas/Sources/Integrations/GG/GGInboxModels.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxModels.swift
@@ -9,6 +9,13 @@ struct GGInboxSnapshot: Equatable, Decodable {
     let buckets: GGInboxBuckets
     let stackErrors: [GGInboxStackError]
 
+    init(version: Int = 1, totalItems: Int, buckets: GGInboxBuckets, stackErrors: [GGInboxStackError]) {
+        self.version = version
+        self.totalItems = totalItems
+        self.buckets = buckets
+        self.stackErrors = stackErrors
+    }
+
     static func decode(fromJSON data: Data) throws -> GGInboxSnapshot {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
@@ -21,21 +28,43 @@ struct GGInboxSnapshot: Equatable, Decodable {
 }
 
 struct GGInboxBuckets: Equatable, Decodable {
-    let readyToLand: [GGInboxEntry]
-    let changesRequested: [GGInboxEntry]
-    let blockedOnCi: [GGInboxEntry]
-    let awaitingReview: [GGInboxEntry]
-    let behindBase: [GGInboxEntry]
-    let draft: [GGInboxEntry]
+    var refreshFailed: [GGInboxEntry]
+    var readyToLand: [GGInboxEntry]
+    var changesRequested: [GGInboxEntry]
+    var blockedOnCi: [GGInboxEntry]
+    var awaitingReview: [GGInboxEntry]
+    var behindBase: [GGInboxEntry]
+    var draft: [GGInboxEntry]
     /// Only serialized by gg with `--all`; absent in the default invocation.
-    var merged: [GGInboxEntry] = []
+    var merged: [GGInboxEntry]
+
+    init(
+        refreshFailed: [GGInboxEntry] = [],
+        readyToLand: [GGInboxEntry] = [],
+        changesRequested: [GGInboxEntry] = [],
+        blockedOnCi: [GGInboxEntry] = [],
+        awaitingReview: [GGInboxEntry] = [],
+        behindBase: [GGInboxEntry] = [],
+        draft: [GGInboxEntry] = [],
+        merged: [GGInboxEntry] = []
+    ) {
+        self.refreshFailed = refreshFailed
+        self.readyToLand = readyToLand
+        self.changesRequested = changesRequested
+        self.blockedOnCi = blockedOnCi
+        self.awaitingReview = awaitingReview
+        self.behindBase = behindBase
+        self.draft = draft
+        self.merged = merged
+    }
 
     private enum CodingKeys: String, CodingKey {
-        case readyToLand, changesRequested, blockedOnCi, awaitingReview, behindBase, draft, merged
+        case refreshFailed, readyToLand, changesRequested, blockedOnCi, awaitingReview, behindBase, draft, merged
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        refreshFailed = try c.decode([GGInboxEntry].self, forKey: .refreshFailed)
         readyToLand = try c.decode([GGInboxEntry].self, forKey: .readyToLand)
         changesRequested = try c.decode([GGInboxEntry].self, forKey: .changesRequested)
         blockedOnCi = try c.decode([GGInboxEntry].self, forKey: .blockedOnCi)
@@ -43,6 +72,26 @@ struct GGInboxBuckets: Equatable, Decodable {
         behindBase = try c.decode([GGInboxEntry].self, forKey: .behindBase)
         draft = try c.decode([GGInboxEntry].self, forKey: .draft)
         merged = try c.decodeIfPresent([GGInboxEntry].self, forKey: .merged) ?? []
+    }
+
+    mutating func insert(_ entry: GGInboxEntry, into bucket: GGInboxBucket) {
+        var entries = bucket.entries(in: self)
+        let identity = (entry.stackName, entry.position, entry.prNumber)
+        if let index = entries.firstIndex(where: { ($0.stackName, $0.position, $0.prNumber) == identity }) {
+            entries[index] = entry
+        } else {
+            entries.append(entry)
+        }
+        entries.sort { ($0.stackName, $0.position, $0.sha) < ($1.stackName, $1.position, $1.sha) }
+        switch bucket {
+        case .refreshFailed: refreshFailed = entries
+        case .readyToLand: readyToLand = entries
+        case .changesRequested: changesRequested = entries
+        case .blockedOnCi: blockedOnCi = entries
+        case .awaitingReview: awaitingReview = entries
+        case .behindBase: behindBase = entries
+        case .draft: draft = entries
+        }
     }
 }
 
@@ -52,9 +101,49 @@ struct GGInboxEntry: Equatable, Decodable {
     let sha: String
     let title: String
     let prNumber: Int
-    let prUrl: String
+    let prUrl: String?
     let ciStatus: String?
     let behindBase: Int?
+    let refreshError: String?
+
+    init(
+        stackName: String,
+        position: Int,
+        sha: String,
+        title: String,
+        prNumber: Int,
+        prUrl: String? = nil,
+        ciStatus: String? = nil,
+        behindBase: Int? = nil,
+        refreshError: String? = nil
+    ) {
+        self.stackName = stackName
+        self.position = position
+        self.sha = sha
+        self.title = title
+        self.prNumber = prNumber
+        self.prUrl = prUrl?.nilIfEmpty
+        self.ciStatus = ciStatus
+        self.behindBase = behindBase
+        self.refreshError = refreshError
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case stackName, position, sha, title, prNumber, prUrl, ciStatus, behindBase, refreshError
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        stackName = try c.decode(String.self, forKey: .stackName)
+        position = try c.decode(Int.self, forKey: .position)
+        sha = try c.decode(String.self, forKey: .sha)
+        title = try c.decode(String.self, forKey: .title)
+        prNumber = try c.decode(Int.self, forKey: .prNumber)
+        prUrl = try c.decodeIfPresent(String.self, forKey: .prUrl)?.nilIfEmpty
+        ciStatus = try c.decodeIfPresent(String.self, forKey: .ciStatus)
+        behindBase = try c.decodeIfPresent(Int.self, forKey: .behindBase)
+        refreshError = try c.decodeIfPresent(String.self, forKey: .refreshError)
+    }
 }
 
 struct GGInboxStackError: Equatable, Decodable {
@@ -62,38 +151,185 @@ struct GGInboxStackError: Equatable, Decodable {
     let error: String
 }
 
-/// Presentation metadata for the six rendered buckets, in gg's priority
-/// order. `merged` is decodable but intentionally not rendered (no --all in v1).
-enum GGInboxBucket: CaseIterable, Equatable {
-    case readyToLand, changesRequested, blockedOnCi, awaitingReview, behindBase, draft
+/// Presentation metadata for the rendered buckets, in gg's priority order.
+enum GGInboxBucket: String, CaseIterable, Equatable, Decodable {
+    case refreshFailed = "refresh_failed"
+    case readyToLand = "ready_to_land"
+    case changesRequested = "changes_requested"
+    case blockedOnCi = "blocked_on_ci"
+    case awaitingReview = "awaiting_review"
+    case behindBase = "behind_base"
+    case draft
 
     var title: String {
         switch self {
-        case .readyToLand:      return "Ready to land"
+        case .refreshFailed: return "Refresh failed"
+        case .readyToLand: return "Ready to land"
         case .changesRequested: return "Changes requested"
-        case .blockedOnCi:      return "Blocked on CI"
-        case .awaitingReview:   return "Awaiting review"
-        case .behindBase:       return "Behind base"
-        case .draft:            return "Draft"
+        case .blockedOnCi: return "Blocked on CI"
+        case .awaitingReview: return "Awaiting review"
+        case .behindBase: return "Behind base"
+        case .draft: return "Draft"
         }
     }
 
     var themeToken: String {
         switch self {
-        case .readyToLand:                    return "add"
-        case .changesRequested, .blockedOnCi: return "warn"
+        case .readyToLand: return "add"
+        case .refreshFailed, .changesRequested, .blockedOnCi: return "warn"
         case .awaitingReview, .behindBase, .draft: return "fg-dim"
         }
     }
 
     func entries(in buckets: GGInboxBuckets) -> [GGInboxEntry] {
         switch self {
-        case .readyToLand:      return buckets.readyToLand
+        case .refreshFailed: return buckets.refreshFailed
+        case .readyToLand: return buckets.readyToLand
         case .changesRequested: return buckets.changesRequested
-        case .blockedOnCi:      return buckets.blockedOnCi
-        case .awaitingReview:   return buckets.awaitingReview
-        case .behindBase:       return buckets.behindBase
-        case .draft:            return buckets.draft
+        case .blockedOnCi: return buckets.blockedOnCi
+        case .awaitingReview: return buckets.awaitingReview
+        case .behindBase: return buckets.behindBase
+        case .draft: return buckets.draft
         }
     }
+}
+
+struct GGInboxEntryEvent: Equatable {
+    let completed: Int
+    let totalCandidates: Int
+    let included: Bool
+    let bucket: GGInboxBucket?
+    let remoteState: String
+    let entry: GGInboxEntry
+}
+
+struct GGInboxEntryErrorEvent: Equatable {
+    let completed: Int
+    let totalCandidates: Int
+    let included: Bool
+    let bucket: GGInboxBucket
+    let failedEntry: GGInboxEntry
+}
+
+enum GGInboxEvent: Equatable {
+    case start(totalCandidates: Int, totalStackErrors: Int)
+    case stackError(GGInboxStackError)
+    case entry(GGInboxEntryEvent)
+    case entryError(GGInboxEntryErrorEvent)
+    case summary(GGInboxSnapshot)
+    case error(message: String)
+
+    static func decode(line: String) throws -> GGInboxEvent {
+        let data = Data(line.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+            let envelope = try decoder.decode(GGInboxEventEnvelope.self, from: data)
+            guard envelope.version == 1 else {
+                throw GGServiceError.unsupportedSchema(envelope.version)
+            }
+            guard envelope.command == "inbox" else {
+                throw GGServiceError.malformedOutput("Expected gg inbox event, got \(envelope.command).")
+            }
+            switch envelope.event {
+            case "start": return try decoder.decode(GGInboxStartPayload.self, from: data).event
+            case "stack_error": return try decoder.decode(GGInboxStackErrorPayload.self, from: data).event
+            case "entry": return try decoder.decode(GGInboxEntryPayload.self, from: data).event
+            case "entry_error": return try decoder.decode(GGInboxEntryErrorPayload.self, from: data).event
+            case "summary": return .summary(try decoder.decode(GGInboxSnapshot.self, from: data))
+            case "error": return .error(message: try decoder.decode(GGInboxFatalPayload.self, from: data).message)
+            default: throw GGServiceError.malformedOutput("Unknown gg inbox event: \(envelope.event)")
+            }
+        } catch let error as GGServiceError {
+            throw error
+        } catch {
+            throw GGServiceError.malformedOutput(String(describing: error))
+        }
+    }
+}
+
+enum GGInboxSupport {
+    static let minimumVersion = SemanticVersion(major: 0, minor: 9, patch: 12)
+
+    static func isSupported(version: String?) -> Bool {
+        guard let version, let parsed = SemanticVersion(parsing: version) else { return false }
+        return parsed >= minimumVersion
+    }
+}
+
+private struct GGInboxEventEnvelope: Decodable {
+    let event: String
+    let version: Int
+    let command: String
+}
+
+private struct GGInboxStartPayload: Decodable {
+    let totalCandidates: Int
+    let totalStackErrors: Int
+
+    var event: GGInboxEvent { .start(totalCandidates: totalCandidates, totalStackErrors: totalStackErrors) }
+}
+
+private struct GGInboxStackErrorPayload: Decodable {
+    let stackName: String
+    let error: String
+
+    var event: GGInboxEvent { .stackError(GGInboxStackError(stackName: stackName, error: error)) }
+}
+
+private struct GGInboxEntryPayload: Decodable {
+    let completed: Int
+    let totalCandidates: Int
+    let included: Bool
+    let bucket: GGInboxBucket?
+    let remoteState: String
+    let entry: GGInboxEntry
+
+    var event: GGInboxEvent {
+        .entry(GGInboxEntryEvent(
+            completed: completed,
+            totalCandidates: totalCandidates,
+            included: included,
+            bucket: bucket,
+            remoteState: remoteState,
+            entry: entry
+        ))
+    }
+}
+
+private struct GGInboxEntryErrorPayload: Decodable {
+    let completed: Int
+    let totalCandidates: Int
+    let included: Bool
+    let bucket: GGInboxBucket
+    let entry: GGInboxEntry
+    let error: String
+
+    var event: GGInboxEvent {
+        .entryError(GGInboxEntryErrorEvent(
+            completed: completed,
+            totalCandidates: totalCandidates,
+            included: included,
+            bucket: bucket,
+            failedEntry: GGInboxEntry(
+                stackName: entry.stackName,
+                position: entry.position,
+                sha: entry.sha,
+                title: entry.title,
+                prNumber: entry.prNumber,
+                prUrl: nil,
+                ciStatus: nil,
+                behindBase: entry.behindBase,
+                refreshError: error
+            )
+        ))
+    }
+}
+
+private struct GGInboxFatalPayload: Decodable {
+    let message: String
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
 }

--- a/Alas/Sources/Integrations/GG/GGInboxStore.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxStore.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Observation
 
+struct GGInboxRefreshProgress: Equatable {
+    let completed: Int
+    let total: Int
+}
+
 /// Project id → gg inbox triage state. One `gg inbox` round-trip per
 /// project. Snapshots are retained across refresh failures so the view can
 /// show stale data alongside the error. All writes are value-diffed.
@@ -13,6 +18,7 @@ final class GGInboxStore {
         var snapshot: GGInboxSnapshot? = nil
         var fetchedAt: Date? = nil
         var isRefreshing: Bool = false
+        var refreshProgress: GGInboxRefreshProgress? = nil
         var lastError: String? = nil
     }
 
@@ -35,24 +41,86 @@ final class GGInboxStore {
         if states[projectId]?.isRefreshing == true { return }
         let generation = invalidationGenerations[projectId, default: 0]
         var state = states[projectId] ?? State()
+        let rollbackSnapshot = state.snapshot
+        let rollbackFetchedAt = state.fetchedAt
+        var partialBuckets = GGInboxBuckets()
+        var partialStackErrors: [GGInboxStackError] = []
+        var sawSummary = false
         state.isRefreshing = true
+        state.refreshProgress = nil
         write(projectId, state)
         do {
-            let snapshot = try await service.inbox(repoPath: repoPath)
-            state.snapshot = snapshot
-            state.fetchedAt = now()
-            state.lastError = nil
+            for try await event in service.inboxStream(repoPath: repoPath) {
+                guard invalidationGenerations[projectId, default: 0] == generation else {
+                    continue
+                }
+
+                var publishPartial = false
+                switch event {
+                case .start(let total, _):
+                    state.refreshProgress = .init(completed: 0, total: total)
+                case .stackError(let error):
+                    partialStackErrors.append(error)
+                case .entry(let payload):
+                    state.refreshProgress = .init(completed: payload.completed, total: payload.totalCandidates)
+                    if payload.included, let bucket = payload.bucket {
+                        partialBuckets.insert(payload.entry, into: bucket)
+                    }
+                    publishPartial = true
+                case .entryError(let payload):
+                    state.refreshProgress = .init(completed: payload.completed, total: payload.totalCandidates)
+                    partialBuckets.insert(payload.failedEntry, into: .refreshFailed)
+                    publishPartial = true
+                case .summary(let snapshot):
+                    state.snapshot = snapshot
+                    state.fetchedAt = now()
+                    state.refreshProgress = nil
+                    state.lastError = nil
+                    sawSummary = true
+                case .error:
+                    preconditionFailure("GGService intercepts fatal inbox events")
+                }
+
+                if publishPartial {
+                    state.snapshot = GGInboxSnapshot(
+                        totalItems: GGInboxBucket.allCases.reduce(0) { $0 + $1.entries(in: partialBuckets).count },
+                        buckets: partialBuckets,
+                        stackErrors: partialStackErrors
+                    )
+                }
+                guard invalidationGenerations[projectId, default: 0] == generation else {
+                    continue
+                }
+                write(projectId, state)
+            }
         } catch let error as GGServiceError {
+            guard invalidationGenerations[projectId, default: 0] == generation else {
+                finishInvalidatedRefresh(projectId: projectId, rollbackSnapshot: rollbackSnapshot)
+                return
+            }
+            state.snapshot = rollbackSnapshot
+            state.fetchedAt = rollbackFetchedAt
+            state.refreshProgress = nil
             state.lastError = error.userMessage
         } catch {
+            guard invalidationGenerations[projectId, default: 0] == generation else {
+                finishInvalidatedRefresh(projectId: projectId, rollbackSnapshot: rollbackSnapshot)
+                return
+            }
+            state.snapshot = rollbackSnapshot
+            state.fetchedAt = rollbackFetchedAt
+            state.refreshProgress = nil
             state.lastError = error.localizedDescription
         }
         guard invalidationGenerations[projectId, default: 0] == generation else {
-            var invalidated = states[projectId] ?? State()
-            invalidated.isRefreshing = false
-            invalidated.fetchedAt = nil
-            write(projectId, invalidated)
+            finishInvalidatedRefresh(projectId: projectId, rollbackSnapshot: rollbackSnapshot)
             return
+        }
+        if !sawSummary && state.lastError == nil {
+            state.snapshot = rollbackSnapshot
+            state.fetchedAt = rollbackFetchedAt
+            state.refreshProgress = nil
+            state.lastError = "gg inbox ended without a summary event."
         }
         state.isRefreshing = false
         write(projectId, state)
@@ -74,5 +142,14 @@ final class GGInboxStore {
 
     private func write(_ projectId: String, _ new: State) {
         if states[projectId] != new { states[projectId] = new }
+    }
+
+    private func finishInvalidatedRefresh(projectId: String, rollbackSnapshot: GGInboxSnapshot?) {
+        var state = states[projectId] ?? State()
+        state.snapshot = rollbackSnapshot
+        state.fetchedAt = nil
+        state.isRefreshing = false
+        state.refreshProgress = nil
+        write(projectId, state)
     }
 }

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -91,12 +91,24 @@ struct GGInboxTabView: View {
     }
 
     static func shouldShowClearInbox(
-        snapshot: GGInboxSnapshot,
+        snapshot: GGInboxSnapshot?,
         isRefreshing: Bool,
         lastError: String?
     ) -> Bool {
-        snapshot.totalItems == 0 && snapshot.stackErrors.isEmpty
+        guard let snapshot else { return false }
+        return snapshot.totalItems == 0 && snapshot.stackErrors.isEmpty
             && !isRefreshing && lastError == nil
+    }
+
+    static func shouldRefreshAfterSupportTransition(
+        wasSupported: Bool,
+        isSupported: Bool,
+        snapshot: GGInboxSnapshot?,
+        fetchedAt: Date?,
+        now: Date
+    ) -> Bool {
+        guard !wasSupported, isSupported else { return false }
+        return snapshot == nil || GGInboxStore.isStale(fetchedAt: fetchedAt, now: now)
     }
 
     static func validPRURL(_ rawValue: String?) -> URL? {
@@ -137,6 +149,16 @@ struct GGInboxTabView: View {
         .onAppear { refreshIfStale() }
         .onChange(of: ggUpgrade.phase) { _, phase in
             guard phase == .succeeded, supportsStreamingInbox else { return }
+            refresh()
+        }
+        .onChange(of: supportsStreamingInbox) { wasSupported, isSupported in
+            guard Self.shouldRefreshAfterSupportTransition(
+                wasSupported: wasSupported,
+                isSupported: isSupported,
+                snapshot: inboxState.snapshot,
+                fetchedAt: inboxState.fetchedAt,
+                now: Date()
+            ) else { return }
             refresh()
         }
     }
@@ -190,8 +212,6 @@ struct GGInboxTabView: View {
                 } else {
                     bucketList(snapshot)
                 }
-            } else if !inboxState.isRefreshing && inboxState.lastError == nil {
-                emptyState
             } else {
                 Spacer()
             }

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -81,6 +81,17 @@ struct GGInboxTabView: View {
         return "Updated \(Int(seconds / 3_600))h ago"
     }
 
+    static func refreshLabel(_ progress: GGInboxRefreshProgress?) -> String? {
+        guard let progress else { return nil }
+        return "Refreshing \(progress.completed)/\(progress.total)"
+    }
+
+    static func validPRURL(_ rawValue: String?) -> URL? {
+        guard let rawValue, let url = URL(string: rawValue),
+              url.scheme == "https" || url.scheme == "http" else { return nil }
+        return url
+    }
+
     static func ciIconName(_ status: String?) -> String? {
         switch GGCIStatus(rawValue: status ?? "") {
         case .success:            return "checkmark.circle"

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -237,7 +237,7 @@ struct GGInboxTabView: View {
                 Icon(name: icon, size: 11, color: theme.color(Self.ciIconColorToken(entry.ciStatus)))
             }
             Button {
-                if let url = URL(string: entry.prUrl) { NSWorkspace.shared.open(url) }
+                if let prUrl = entry.prUrl, let url = URL(string: prUrl) { NSWorkspace.shared.open(url) }
             } label: {
                 Text("#\(entry.prNumber)")
                     .font(.system(size: 11, weight: .medium, design: .monospaced))

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -111,6 +111,10 @@ struct GGInboxTabView: View {
         return snapshot == nil || GGInboxStore.isStale(fetchedAt: fetchedAt, now: now)
     }
 
+    static func shouldShowUpgradeRequired(hasProbed: Bool, supportsStreamingInbox: Bool) -> Bool {
+        hasProbed && !supportsStreamingInbox
+    }
+
     static func validPRURL(_ rawValue: String?) -> URL? {
         guard let rawValue, let url = URL(string: rawValue),
               url.scheme == "https" || url.scheme == "http" else { return nil }
@@ -196,7 +200,12 @@ struct GGInboxTabView: View {
 
     @ViewBuilder
     private var content: some View {
-        if !supportsStreamingInbox {
+        if !GGAvailability.shared.hasProbed {
+            probingState
+        } else if Self.shouldShowUpgradeRequired(
+            hasProbed: GGAvailability.shared.hasProbed,
+            supportsStreamingInbox: supportsStreamingInbox
+        ) {
             upgradeRequiredState
         } else {
             if let error = inboxState.lastError {
@@ -216,6 +225,18 @@ struct GGInboxTabView: View {
                 Spacer()
             }
         }
+    }
+
+    private var probingState: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 12, height: 12)
+            Text("Checking gg version…")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-dim"))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
     }
 
     private var upgradeRequiredState: some View {

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -65,11 +65,15 @@ struct GGInboxTabView: View {
     let tabState: GGInboxTabState
 
     @Environment(\.theme) private var theme
+    @State private var ggUpgrade = GGInstallController()
     private let store = GGInboxStore.shared
     private let service = GGService()
 
     private var inboxState: GGInboxStore.State { store.states[tabState.projectId] ?? .init() }
     private var project: ProjectConfig? { state.projects.first { $0.id == tabState.projectId } }
+    private var supportsStreamingInbox: Bool {
+        GGInboxSupport.isSupported(version: GGAvailability.shared.version)
+    }
 
     // MARK: pure helpers (tested)
 
@@ -84,6 +88,15 @@ struct GGInboxTabView: View {
     static func refreshLabel(_ progress: GGInboxRefreshProgress?) -> String? {
         guard let progress else { return nil }
         return "Refreshing \(progress.completed)/\(progress.total)"
+    }
+
+    static func shouldShowClearInbox(
+        snapshot: GGInboxSnapshot,
+        isRefreshing: Bool,
+        lastError: String?
+    ) -> Bool {
+        snapshot.totalItems == 0 && snapshot.stackErrors.isEmpty
+            && !isRefreshing && lastError == nil
     }
 
     static func validPRURL(_ rawValue: String?) -> URL? {
@@ -122,6 +135,10 @@ struct GGInboxTabView: View {
         }
         .background(theme.color("bg-1"))
         .onAppear { refreshIfStale() }
+        .onChange(of: ggUpgrade.phase) { _, phase in
+            guard phase == .succeeded, supportsStreamingInbox else { return }
+            refresh()
+        }
     }
 
     private var header: some View {
@@ -135,12 +152,15 @@ struct GGInboxTabView: View {
                     .foregroundColor(theme.color("fg-dim"))
             }
             Spacer()
-            if let label = Self.updatedLabel(fetchedAt: inboxState.fetchedAt, now: Date()) {
-                Text(label).font(.system(size: 11)).foregroundColor(theme.color("fg-faint"))
-            }
             if inboxState.isRefreshing {
                 Spinner(lineWidth: 1.4, duration: 0.8).frame(width: 11, height: 11)
+                if let label = Self.refreshLabel(inboxState.refreshProgress) {
+                    Text(label).font(.system(size: 11)).foregroundColor(theme.color("fg-faint"))
+                }
             } else {
+                if let label = Self.updatedLabel(fetchedAt: inboxState.fetchedAt, now: Date()) {
+                    Text(label).font(.system(size: 11)).foregroundColor(theme.color("fg-faint"))
+                }
                 Button { refresh() } label: {
                     Icon(name: "arrow.clockwise", size: 11, color: theme.color("fg-faint"))
                 }
@@ -154,19 +174,70 @@ struct GGInboxTabView: View {
 
     @ViewBuilder
     private var content: some View {
-        if let error = inboxState.lastError {
-            errorBanner(error)
-        }
-        if let snapshot = inboxState.snapshot {
-            if snapshot.totalItems == 0 && snapshot.stackErrors.isEmpty && inboxState.lastError == nil {
+        if !supportsStreamingInbox {
+            upgradeRequiredState
+        } else {
+            if let error = inboxState.lastError {
+                errorBanner(error)
+            }
+            if let snapshot = inboxState.snapshot {
+                if Self.shouldShowClearInbox(
+                    snapshot: snapshot,
+                    isRefreshing: inboxState.isRefreshing,
+                    lastError: inboxState.lastError
+                ) {
+                    emptyState
+                } else {
+                    bucketList(snapshot)
+                }
+            } else if !inboxState.isRefreshing && inboxState.lastError == nil {
                 emptyState
             } else {
-                bucketList(snapshot)
+                Spacer()
             }
-        } else if !inboxState.isRefreshing && inboxState.lastError == nil {
-            emptyState
-        } else {
+        }
+    }
+
+    private var upgradeRequiredState: some View {
+        VStack(alignment: .leading, spacing: 8) {
             Spacer()
+            Text("Inbox needs a newer gg version.")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            if let version = GGAvailability.shared.version {
+                Text("gg \(version)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg-muted"))
+            }
+            Text("gg Inbox requires gg 0.9.12 or newer.")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-dim"))
+            upgradeStatus
+            AlasButton(title: "Upgrade gg…", style: .normal) { ggUpgrade.upgrade() }
+                .disabled(ggUpgrade.phase == .running)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(14)
+    }
+
+    @ViewBuilder
+    private var upgradeStatus: some View {
+        switch ggUpgrade.phase {
+        case .idle, .succeeded:
+            EmptyView()
+        case .running:
+            HStack(spacing: 6) {
+                Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
+                Text("Upgrading…")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+        case .failed(let message):
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("warn"))
+                .lineLimit(2)
         }
     }
 
@@ -247,16 +318,22 @@ struct GGInboxTabView: View {
             if let icon = Self.ciIconName(entry.ciStatus) {
                 Icon(name: icon, size: 11, color: theme.color(Self.ciIconColorToken(entry.ciStatus)))
             }
-            Button {
-                if let prUrl = entry.prUrl, let url = URL(string: prUrl) { NSWorkspace.shared.open(url) }
-            } label: {
-                Text("#\(entry.prNumber)")
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundColor(theme.color("accent"))
+            if let refreshError = entry.refreshError {
+                Text(refreshError)
+                    .font(.system(size: 10.5))
+                    .foregroundColor(theme.color("warn"))
+                    .lineLimit(2)
             }
-            .buttonStyle(.plain)
-            .focusEffectDisabled()
-            .help("Open PR in browser")
+            if let url = Self.validPRURL(entry.prUrl) {
+                Button { NSWorkspace.shared.open(url) } label: {
+                    prNumberLabel(entry.prNumber)
+                }
+                .buttonStyle(.plain)
+                .focusEffectDisabled()
+                .help("Open PR in browser")
+            } else {
+                prNumberLabel(entry.prNumber)
+            }
         }
         .padding(.horizontal, 14).padding(.vertical, 5)
         .contentShape(Rectangle())
@@ -297,6 +374,12 @@ struct GGInboxTabView: View {
         }
     }
 
+    private func prNumberLabel(_ number: Int) -> some View {
+        Text("#\(number)")
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .foregroundColor(theme.color("accent"))
+    }
+
     // MARK: actions
 
     private func resolveWorktreeId(_ entry: GGInboxEntry) -> String? {
@@ -311,13 +394,14 @@ struct GGInboxTabView: View {
     }
 
     private func refreshIfStale() {
+        guard supportsStreamingInbox else { return }
         guard inboxState.snapshot == nil
             || GGInboxStore.isStale(fetchedAt: inboxState.fetchedAt, now: Date()) else { return }
         refresh()
     }
 
     private func refresh() {
-        guard let project, state.ggInboxAvailable(projectId: project.id) else { return }
+        guard supportsStreamingInbox, let project, state.ggInboxAvailable(projectId: project.id) else { return }
         Task { @MainActor in
             await store.refresh(projectId: project.id, repoPath: project.path, service: service)
         }

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -115,6 +115,10 @@ struct GGInboxTabView: View {
         hasProbed && !supportsStreamingInbox
     }
 
+    static func shouldInstallGG(version: String?) -> Bool {
+        version == nil
+    }
+
     static func validPRURL(_ rawValue: String?) -> URL? {
         guard let rawValue, let url = URL(string: rawValue),
               url.scheme == "https" || url.scheme == "http" else { return nil }
@@ -240,9 +244,10 @@ struct GGInboxTabView: View {
     }
 
     private var upgradeRequiredState: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        let needsInstall = Self.shouldInstallGG(version: GGAvailability.shared.version)
+        return VStack(alignment: .leading, spacing: 8) {
             Spacer()
-            Text("Inbox needs a newer gg version.")
+            Text(needsInstall ? "Inbox needs gg installed." : "Inbox needs a newer gg version.")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(theme.color("fg"))
             if let version = GGAvailability.shared.version {
@@ -250,11 +255,17 @@ struct GGInboxTabView: View {
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(theme.color("fg-muted"))
             }
-            Text("gg Inbox requires gg 0.9.12 or newer.")
+            Text(needsInstall ? "Install gg to use Inbox." : "gg Inbox requires gg 0.9.12 or newer.")
                 .font(.system(size: 11))
                 .foregroundColor(theme.color("fg-dim"))
             upgradeStatus
-            AlasButton(title: "Upgrade gg…", style: .normal) { ggUpgrade.upgrade() }
+            AlasButton(title: needsInstall ? "Install gg…" : "Upgrade gg…", style: .normal) {
+                if needsInstall {
+                    ggUpgrade.install()
+                } else {
+                    ggUpgrade.upgrade()
+                }
+            }
                 .disabled(ggUpgrade.phase == .running)
             Spacer()
         }
@@ -264,13 +275,14 @@ struct GGInboxTabView: View {
 
     @ViewBuilder
     private var upgradeStatus: some View {
+        let needsInstall = Self.shouldInstallGG(version: GGAvailability.shared.version)
         switch ggUpgrade.phase {
         case .idle, .succeeded:
             EmptyView()
         case .running:
             HStack(spacing: 6) {
                 Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
-                Text("Upgrading…")
+                Text(needsInstall ? "Installing…" : "Upgrading…")
                     .font(.system(size: 11))
                     .foregroundColor(theme.color("fg-dim"))
             }

--- a/Alas/Sources/Integrations/GG/GGInstallController.swift
+++ b/Alas/Sources/Integrations/GG/GGInstallController.swift
@@ -15,6 +15,7 @@ final class GGInstallController {
     private(set) var phase: Phase = .idle
 
     private let runInstall: @Sendable () async throws -> ProcessResult
+    private let runUpgrade: @Sendable () async throws -> ProcessResult
     /// Returns whether gg is on PATH after the install. Injectable for tests.
     private let reprobe: @MainActor () async -> Bool
 
@@ -27,12 +28,21 @@ final class GGInstallController {
                 timeout: 600
             )
         },
+        runUpgrade: @escaping @Sendable () async throws -> ProcessResult = {
+            try await Process.run(
+                "/usr/bin/env",
+                args: ["brew", "upgrade", "mrmans0n/tap/gg-stack"],
+                env: Process.gitEnv(),
+                timeout: 600
+            )
+        },
         reprobe: @escaping @MainActor () async -> Bool = {
             await GGAvailability.shared.probe(force: true)
             return GGAvailability.shared.isInstalled
         }
     ) {
         self.runInstall = runInstall
+        self.runUpgrade = runUpgrade
         self.reprobe = reprobe
     }
 
@@ -41,16 +51,31 @@ final class GGInstallController {
     }
 
     func installAndWait() async {
+        await perform(runInstall, missingMessage: "gg is still not on PATH after install.")
+    }
+
+    func upgrade() {
+        Task { await upgradeAndWait() }
+    }
+
+    func upgradeAndWait() async {
+        await perform(runUpgrade, missingMessage: "gg is still not on PATH after upgrade.")
+    }
+
+    private func perform(
+        _ operation: @Sendable () async throws -> ProcessResult,
+        missingMessage: String
+    ) async {
         guard phase != .running else { return }
         phase = .running
         do {
-            let result = try await runInstall()
+            let result = try await operation()
             guard result.exitCode == 0 else {
                 let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
                 phase = .failed(stderr.isEmpty ? "brew exited with code \(result.exitCode)." : stderr)
                 return
             }
-            phase = await reprobe() ? .succeeded : .failed("gg is still not on PATH after install.")
+            phase = await reprobe() ? .succeeded : .failed(missingMessage)
         } catch {
             phase = .failed(error.localizedDescription)
         }

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -363,9 +363,6 @@ struct GGService {
                             let event = try GGInboxEvent.decode(line: line)
                             switch event {
                             case .error(let message):
-                                guard !sawStart else {
-                                    throw GGServiceError.malformedOutput("gg inbox emitted error after discovery.")
-                                }
                                 fatalMessage = message
                             case .start(let count, _):
                                 guard !sawStart else {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -335,12 +335,88 @@ struct GGService {
         return try GGStackSnapshot.decode(fromJSON: Data(result.stdout.utf8))
     }
 
-    /// Cross-stack triage snapshot from `gg inbox --json`. Runs at the
+    /// Streams cross-stack triage events from `gg inbox --jsonl`. Runs at the
     /// project root — one forge round-trip per project, never per worktree.
     /// Per-stack failures arrive in-band as `stackErrors`, not as thrown errors.
-    func inbox(repoPath: String) async throws -> GGInboxSnapshot {
-        let result = try await runChecked(args: ["inbox", "--json"], worktreePath: repoPath)
-        return try GGInboxSnapshot.decode(fromJSON: Data(result.stdout.utf8))
+    func inboxStream(repoPath: String) -> AsyncThrowingStream<GGInboxEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                var sawStart = false
+                var sawSummary = false
+                var fatalMessage: String?
+                var totalCandidates: Int?
+                var lastCompleted = 0
+
+                do {
+                    do {
+                        for try await line in runner.runStreaming(
+                            args: ["inbox", "--jsonl"],
+                            cwd: URL(fileURLWithPath: repoPath)
+                        ) {
+                            guard !sawSummary, fatalMessage == nil else {
+                                throw GGServiceError.malformedOutput("gg inbox emitted data after a terminal event.")
+                            }
+                            let event = try GGInboxEvent.decode(line: line)
+                            switch event {
+                            case .error(let message):
+                                fatalMessage = message
+                            case .start(let count, _):
+                                guard !sawStart else {
+                                    throw GGServiceError.malformedOutput("gg inbox emitted duplicate start events.")
+                                }
+                                sawStart = true
+                                totalCandidates = count
+                                continuation.yield(event)
+                            case .entry(let payload):
+                                try Self.validateInboxProgress(
+                                    started: sawStart,
+                                    expectedTotal: totalCandidates,
+                                    completed: payload.completed,
+                                    eventTotal: payload.totalCandidates,
+                                    lastCompleted: &lastCompleted
+                                )
+                                continuation.yield(event)
+                            case .entryError(let payload):
+                                try Self.validateInboxProgress(
+                                    started: sawStart,
+                                    expectedTotal: totalCandidates,
+                                    completed: payload.completed,
+                                    eventTotal: payload.totalCandidates,
+                                    lastCompleted: &lastCompleted
+                                )
+                                continuation.yield(event)
+                            case .stackError:
+                                guard sawStart else {
+                                    throw GGServiceError.malformedOutput("gg inbox emitted stack_error before start.")
+                                }
+                                continuation.yield(event)
+                            case .summary:
+                                guard sawStart else {
+                                    throw GGServiceError.malformedOutput("gg inbox emitted summary before start.")
+                                }
+                                sawSummary = true
+                                continuation.yield(event)
+                            }
+                        }
+                    } catch {
+                        if let fatalMessage {
+                            throw GGServiceError.commandFailed(stderr: fatalMessage)
+                        }
+                        throw error
+                    }
+
+                    if let fatalMessage {
+                        throw GGServiceError.commandFailed(stderr: fatalMessage)
+                    }
+                    guard sawStart, sawSummary else {
+                        throw GGServiceError.malformedOutput("gg inbox ended without a summary event.")
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
     }
 
     /// Streams sync events when `gg sync --jsonl` is supported; older gg
@@ -548,6 +624,25 @@ struct GGService {
 
     func checkout(worktreePath: String, target: String) async throws {
         _ = try await runChecked(args: ["mv", target], worktreePath: worktreePath)
+    }
+
+    private static func validateInboxProgress(
+        started: Bool,
+        expectedTotal: Int?,
+        completed: Int,
+        eventTotal: Int,
+        lastCompleted: inout Int
+    ) throws {
+        guard started, let expectedTotal else {
+            throw GGServiceError.malformedOutput("gg inbox emitted an entry before start.")
+        }
+        guard eventTotal == expectedTotal else {
+            throw GGServiceError.malformedOutput("gg inbox entry total did not match start total.")
+        }
+        guard lastCompleted < completed, completed <= eventTotal else {
+            throw GGServiceError.malformedOutput("gg inbox emitted invalid entry progress.")
+        }
+        lastCompleted = completed
     }
 
     /// Runs a gg command and maps a non-zero exit to `GGServiceError`, the

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -353,12 +353,19 @@ struct GGService {
                             args: ["inbox", "--jsonl"],
                             cwd: URL(fileURLWithPath: repoPath)
                         ) {
-                            guard !sawSummary, fatalMessage == nil else {
+                            guard !sawSummary else {
+                                throw GGServiceError.malformedOutput("gg inbox emitted data after a terminal event.")
+                            }
+                            guard fatalMessage == nil else {
+                                fatalMessage = nil
                                 throw GGServiceError.malformedOutput("gg inbox emitted data after a terminal event.")
                             }
                             let event = try GGInboxEvent.decode(line: line)
                             switch event {
                             case .error(let message):
+                                guard !sawStart else {
+                                    throw GGServiceError.malformedOutput("gg inbox emitted error after discovery.")
+                                }
                                 fatalMessage = message
                             case .start(let count, _):
                                 guard !sawStart else {

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -100,6 +100,28 @@ struct GGInboxHelpersTests {
         #expect(GGInboxTabView.ciIconColorToken(nil) == "fg-dim")
     }
 
+    @Test(arguments: ["0.9.12", "0.9.13", "0.10.0", "1.0.0"])
+    func supportedInboxVersions(_ version: String) {
+        #expect(GGInboxSupport.isSupported(version: version))
+    }
+
+    @Test(arguments: [nil, "", "abc", "0.9.11", "0.8.99"] as [String?])
+    func unsupportedInboxVersions(_ version: String?) {
+        #expect(!GGInboxSupport.isSupported(version: version))
+    }
+
+    @Test func refreshProgressLabel() {
+        #expect(GGInboxTabView.refreshLabel(nil) == nil)
+        #expect(GGInboxTabView.refreshLabel(.init(completed: 2, total: 5)) == "Refreshing 2/5")
+    }
+
+    @Test func validPRURLRequiresHTTPOrHTTPS() {
+        #expect(GGInboxTabView.validPRURL("https://example.test/42") != nil)
+        #expect(GGInboxTabView.validPRURL("") == nil)
+        #expect(GGInboxTabView.validPRURL(nil) == nil)
+        #expect(GGInboxTabView.validPRURL("file:///tmp/secret") == nil)
+    }
+
     @Test func tabStateIdentityAndCodableRoundTrip() throws {
         let state = GGInboxTabState(projectId: "p1", projectName: "alas")
         #expect(state.id == "gg-inbox:p1")

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -157,6 +157,21 @@ struct GGInboxHelpersTests {
         ))
     }
 
+    @Test func upgradeGateWaitsForAvailabilityProbe() {
+        #expect(!GGInboxTabView.shouldShowUpgradeRequired(
+            hasProbed: false,
+            supportsStreamingInbox: false
+        ))
+        #expect(GGInboxTabView.shouldShowUpgradeRequired(
+            hasProbed: true,
+            supportsStreamingInbox: false
+        ))
+        #expect(!GGInboxTabView.shouldShowUpgradeRequired(
+            hasProbed: true,
+            supportsStreamingInbox: true
+        ))
+    }
+
     @Test func validPRURLRequiresHTTPOrHTTPS() {
         #expect(GGInboxTabView.validPRURL("https://example.test/42") != nil)
         #expect(GGInboxTabView.validPRURL("") == nil)

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -118,8 +118,43 @@ struct GGInboxHelpersTests {
     @Test func clearInboxRequiresCompletedNonErrorState() {
         let empty = GGInboxSnapshot(totalItems: 0, buckets: GGInboxBuckets(), stackErrors: [])
         #expect(GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: false, lastError: nil))
+        #expect(!GGInboxTabView.shouldShowClearInbox(snapshot: nil, isRefreshing: false, lastError: nil))
         #expect(!GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: true, lastError: nil))
         #expect(!GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: false, lastError: "failed"))
+    }
+
+    @Test func becomingSupportedRefreshesMissingOrStaleSnapshot() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let snapshot = GGInboxSnapshot(totalItems: 1, buckets: GGInboxBuckets(), stackErrors: [])
+
+        #expect(GGInboxTabView.shouldRefreshAfterSupportTransition(
+            wasSupported: false,
+            isSupported: true,
+            snapshot: nil,
+            fetchedAt: nil,
+            now: now
+        ))
+        #expect(GGInboxTabView.shouldRefreshAfterSupportTransition(
+            wasSupported: false,
+            isSupported: true,
+            snapshot: snapshot,
+            fetchedAt: now.addingTimeInterval(-120),
+            now: now
+        ))
+        #expect(!GGInboxTabView.shouldRefreshAfterSupportTransition(
+            wasSupported: false,
+            isSupported: true,
+            snapshot: snapshot,
+            fetchedAt: now,
+            now: now
+        ))
+        #expect(!GGInboxTabView.shouldRefreshAfterSupportTransition(
+            wasSupported: true,
+            isSupported: true,
+            snapshot: nil,
+            fetchedAt: nil,
+            now: now
+        ))
     }
 
     @Test func validPRURLRequiresHTTPOrHTTPS() {

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -115,6 +115,13 @@ struct GGInboxHelpersTests {
         #expect(GGInboxTabView.refreshLabel(.init(completed: 2, total: 5)) == "Refreshing 2/5")
     }
 
+    @Test func clearInboxRequiresCompletedNonErrorState() {
+        let empty = GGInboxSnapshot(totalItems: 0, buckets: GGInboxBuckets(), stackErrors: [])
+        #expect(GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: false, lastError: nil))
+        #expect(!GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: true, lastError: nil))
+        #expect(!GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: false, lastError: "failed"))
+    }
+
     @Test func validPRURLRequiresHTTPOrHTTPS() {
         #expect(GGInboxTabView.validPRURL("https://example.test/42") != nil)
         #expect(GGInboxTabView.validPRURL("") == nil)

--- a/AlasTests/Integrations/GGInboxHelpersTests.swift
+++ b/AlasTests/Integrations/GGInboxHelpersTests.swift
@@ -172,6 +172,12 @@ struct GGInboxHelpersTests {
         ))
     }
 
+    @Test func missingGGUsesInstallFlow() {
+        #expect(GGInboxTabView.shouldInstallGG(version: nil))
+        #expect(!GGInboxTabView.shouldInstallGG(version: "0.9.11"))
+        #expect(!GGInboxTabView.shouldInstallGG(version: "0.9.12"))
+    }
+
     @Test func validPRURLRequiresHTTPOrHTTPS() {
         #expect(GGInboxTabView.validPRURL("https://example.test/42") != nil)
         #expect(GGInboxTabView.validPRURL("") == nil)

--- a/AlasTests/Integrations/GGInboxModelsTests.swift
+++ b/AlasTests/Integrations/GGInboxModelsTests.swift
@@ -51,9 +51,12 @@ struct GGInboxModelsTests {
     }
 
     @Test func bucketMetadataPriorityOrderAndAccessors() throws {
-        #expect(GGInboxBucket.allCases == [.refreshFailed, .readyToLand, .changesRequested, .blockedOnCi, .awaitingReview, .behindBase, .draft])
-        #expect(GGInboxBucket.readyToLand.title == "Ready to land")
-        #expect(GGInboxBucket.readyToLand.themeToken == "add")
+        #expect(GGInboxBucket.allCases == [
+            .refreshFailed, .readyToLand, .changesRequested, .blockedOnCi,
+            .awaitingReview, .behindBase, .draft,
+        ])
+        #expect(GGInboxBucket.refreshFailed.title == "Refresh failed")
+        #expect(GGInboxBucket.refreshFailed.themeToken == "warn")
         #expect(GGInboxBucket.changesRequested.themeToken == "warn")
         #expect(GGInboxBucket.blockedOnCi.themeToken == "warn")
         #expect(GGInboxBucket.draft.themeToken == "fg-dim")

--- a/AlasTests/Integrations/GGInboxModelsTests.swift
+++ b/AlasTests/Integrations/GGInboxModelsTests.swift
@@ -6,6 +6,7 @@ struct GGInboxModelsTests {
     static let fullSample = #"""
     {"version":1,"total_items":2,
      "buckets":{
+       "refresh_failed":[],
        "ready_to_land":[{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login flow","pr_number":42,"pr_url":"https://example.test/42","ci_status":"passed","behind_base":2}],
        "changes_requested":[],
        "blocked_on_ci":[],
@@ -35,7 +36,7 @@ struct GGInboxModelsTests {
     }
 
     @Test func decodesMergedBucketWhenPresent() throws {
-        let json = #"{"version":1,"total_items":0,"buckets":{"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[],"merged":[{"stack_name":"done","position":1,"sha":"aaa","title":"Shipped","pr_number":7,"pr_url":"https://example.test/7"}]},"stack_errors":[]}"#
+        let json = #"{"version":1,"total_items":0,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[],"merged":[{"stack_name":"done","position":1,"sha":"aaa","title":"Shipped","pr_number":7,"pr_url":"https://example.test/7"}]},"stack_errors":[]}"#
         let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
         #expect(snapshot.buckets.merged.count == 1)
     }
@@ -50,7 +51,7 @@ struct GGInboxModelsTests {
     }
 
     @Test func bucketMetadataPriorityOrderAndAccessors() throws {
-        #expect(GGInboxBucket.allCases == [.readyToLand, .changesRequested, .blockedOnCi, .awaitingReview, .behindBase, .draft])
+        #expect(GGInboxBucket.allCases == [.refreshFailed, .readyToLand, .changesRequested, .blockedOnCi, .awaitingReview, .behindBase, .draft])
         #expect(GGInboxBucket.readyToLand.title == "Ready to land")
         #expect(GGInboxBucket.readyToLand.themeToken == "add")
         #expect(GGInboxBucket.changesRequested.themeToken == "warn")
@@ -60,5 +61,79 @@ struct GGInboxModelsTests {
         #expect(GGInboxBucket.readyToLand.entries(in: snapshot.buckets).count == 1)
         #expect(GGInboxBucket.awaitingReview.entries(in: snapshot.buckets).count == 1)
         #expect(GGInboxBucket.draft.entries(in: snapshot.buckets).isEmpty)
+    }
+
+    @Test func decodesRefreshFailedEntryAndNormalizesEmptyURL() throws {
+        let json = #"{"version":1,"total_items":1,"buckets":{"refresh_failed":[{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"","ci_status":null,"behind_base":2,"refresh_error":"provider unavailable"}],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[]}"#
+
+        let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
+        let entry = try #require(snapshot.buckets.refreshFailed.first)
+        #expect(entry.prUrl == nil)
+        #expect(entry.refreshError == "provider unavailable")
+        #expect(GGInboxBucket.allCases.first == .refreshFailed)
+    }
+
+    @Test func decodesInboxJSONLEvents() throws {
+        #expect(try GGInboxEvent.decode(line: #"{"event":"start","total_candidates":2,"total_stack_errors":1,"version":1,"command":"inbox"}"#)
+            == .start(totalCandidates: 2, totalStackErrors: 1))
+
+        #expect(try GGInboxEvent.decode(line: #"{"event":"stack_error","stack_name":"stale","error":"missing base","version":1,"command":"inbox"}"#)
+            == .stackError(GGInboxStackError(stackName: "stale", error: "missing base")))
+
+        let entry = try GGInboxEvent.decode(line: #"{"event":"entry","completed":1,"total_candidates":2,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#)
+        guard case .entry(let payload) = entry else {
+            Issue.record("Expected entry event")
+            return
+        }
+        #expect(payload.completed == 1)
+        #expect(payload.bucket == .readyToLand)
+        #expect(payload.entry.prUrl == "https://example.test/42")
+
+        let failed = try GGInboxEvent.decode(line: #"{"event":"entry_error","completed":2,"total_candidates":2,"included":true,"bucket":"refresh_failed","entry":{"stack_name":"perf","position":2,"sha":"def456","title":"Cache layer","pr_number":43,"behind_base":3},"error":"provider unavailable","version":1,"command":"inbox"}"#)
+        guard case .entryError(let payload) = failed else {
+            Issue.record("Expected entry_error event")
+            return
+        }
+        #expect(payload.failedEntry.refreshError == "provider unavailable")
+        #expect(payload.failedEntry.prUrl == nil)
+
+        let summary = try GGInboxEvent.decode(line: #"{"event":"summary","total_items":0,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[],"version":1,"command":"inbox"}"#)
+        guard case .summary(let snapshot) = summary else {
+            Issue.record("Expected summary event")
+            return
+        }
+        #expect(snapshot.totalItems == 0)
+
+        #expect(try GGInboxEvent.decode(line: #"{"version":1,"command":"inbox","status":"error","event":"error","message":"Not in a git repository"}"#)
+            == .error(message: "Not in a git repository"))
+    }
+
+    @Test(arguments: [
+        #"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":2,"command":"inbox"}"#,
+        #"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"sync"}"#,
+        #"{"event":"future_event","version":1,"command":"inbox"}"#,
+        "not json",
+    ])
+    func rejectsInvalidInboxJSONLEnvelopes(_ line: String) {
+        #expect(throws: GGServiceError.self) {
+            _ = try GGInboxEvent.decode(line: line)
+        }
+    }
+
+    @Test func supportsGGVersionZeroNineTwelveAndLater() {
+        #expect(GGInboxSupport.isSupported(version: "0.9.12"))
+        #expect(GGInboxSupport.isSupported(version: "0.10.0"))
+        #expect(!GGInboxSupport.isSupported(version: "0.9.11"))
+        #expect(!GGInboxSupport.isSupported(version: nil))
+    }
+
+    @Test func insertsInboxEntriesInDisplayOrderAndUpsertsIdentity() {
+        var buckets = GGInboxBuckets()
+        buckets.insert(GGInboxEntry(stackName: "zebra", position: 1, sha: "aaa", title: "First", prNumber: 1), into: .refreshFailed)
+        buckets.insert(GGInboxEntry(stackName: "alpha", position: 2, sha: "bbb", title: "Second", prNumber: 2), into: .refreshFailed)
+        buckets.insert(GGInboxEntry(stackName: "alpha", position: 2, sha: "ccc", title: "Updated", prNumber: 2), into: .refreshFailed)
+
+        #expect(buckets.refreshFailed.map(\.stackName) == ["alpha", "zebra"])
+        #expect(buckets.refreshFailed.first?.title == "Updated")
     }
 }

--- a/AlasTests/Integrations/GGInboxStoreTests.swift
+++ b/AlasTests/Integrations/GGInboxStoreTests.swift
@@ -17,34 +17,30 @@ private final class FakeGGRunner: GGCommandRunning, @unchecked Sendable {
 private final class ControlledInboxRunner: GGCommandRunning, @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: AsyncThrowingStream<String, Error>.Continuation?
-    private(set) var lastArgs: [String] = []
+    private var _lastArgs: [String] = []
+
+    var lastArgs: [String] {
+        lock.withLock { _lastArgs }
+    }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         ProcessResult(exitCode: 0, stdout: "", stderr: "")
     }
 
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
-        lock.lock()
-        lastArgs = args
-        lock.unlock()
+        lock.withLock { _lastArgs = args }
         return AsyncThrowingStream { continuation in
-            self.lock.lock()
-            self.continuation = continuation
-            self.lock.unlock()
+            self.lock.withLock { self.continuation = continuation }
         }
     }
 
     func yield(_ line: String) {
-        lock.lock()
-        let continuation = continuation
-        lock.unlock()
+        let continuation = lock.withLock { self.continuation }
         continuation?.yield(line)
     }
 
     func finish(throwing error: Error? = nil) {
-        lock.lock()
-        let continuation = continuation
-        lock.unlock()
+        let continuation = lock.withLock { self.continuation }
         if let error { continuation?.finish(throwing: error) } else { continuation?.finish() }
     }
 }

--- a/AlasTests/Integrations/GGInboxStoreTests.swift
+++ b/AlasTests/Integrations/GGInboxStoreTests.swift
@@ -14,20 +14,38 @@ private final class FakeGGRunner: GGCommandRunning, @unchecked Sendable {
     }
 }
 
-private actor SuspendedInboxRunner: GGCommandRunning {
-    private var started = false
-    private var continuation: CheckedContinuation<ProcessResult, Never>?
+private final class ControlledInboxRunner: GGCommandRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: AsyncThrowingStream<String, Error>.Continuation?
+    private(set) var lastArgs: [String] = []
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
-        started = true
-        return await withCheckedContinuation { continuation = $0 }
+        ProcessResult(exitCode: 0, stdout: "", stderr: "")
     }
 
-    func hasStarted() -> Bool { started }
+    func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
+        lock.lock()
+        lastArgs = args
+        lock.unlock()
+        return AsyncThrowingStream { continuation in
+            self.lock.lock()
+            self.continuation = continuation
+            self.lock.unlock()
+        }
+    }
 
-    func finish(with result: ProcessResult) {
-        continuation?.resume(returning: result)
-        continuation = nil
+    func yield(_ line: String) {
+        lock.lock()
+        let continuation = continuation
+        lock.unlock()
+        continuation?.yield(line)
+    }
+
+    func finish(throwing error: Error? = nil) {
+        lock.lock()
+        let continuation = continuation
+        lock.unlock()
+        if let error { continuation?.finish(throwing: error) } else { continuation?.finish() }
     }
 }
 
@@ -49,11 +67,12 @@ private func waitUntil(
 
 @MainActor
 struct GGInboxStoreTests {
-    private static let emptyJSON = #"{"version":1,"total_items":0,"buckets":{"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[]}"#
+    private static let emptySummary = #"{"event":"summary","total_items":0,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[],"version":1,"command":"inbox"}"#
+    private static let emptyJSONL = #"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"inbox"}"# + "\n" + emptySummary
 
     @Test func refreshStoresSnapshotAndTimestamp() async throws {
         let store = GGInboxStore()
-        let runner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        let runner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSONL, stderr: ""))
         let fixed = Date(timeIntervalSince1970: 1_000)
         await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner), now: { fixed })
         let state = try #require(store.states["p1"])
@@ -65,7 +84,7 @@ struct GGInboxStoreTests {
 
     @Test func refreshFailureKeepsStaleSnapshotAndSetsError() async throws {
         let store = GGInboxStore()
-        let okRunner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        let okRunner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSONL, stderr: ""))
         await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: okRunner))
         let failRunner = FakeGGRunner(result: ProcessResult(exitCode: 1, stdout: "", stderr: "forge unreachable"))
         await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: failRunner))
@@ -75,13 +94,23 @@ struct GGInboxStoreTests {
         #expect(state.isRefreshing == false)
     }
 
-    @Test func refreshDedupesWhileInFlight() async {
+    @Test func refreshDedupesWhileInFlight() async throws {
         let store = GGInboxStore()
-        store.states["p1"] = .init(isRefreshing: true)
-        let runner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        let runner = ControlledInboxRunner()
+        let task = Task { @MainActor in
+            await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
         await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
-        // Guard returned before running: no snapshot was written.
+        #expect(store.states["p1"]?.isRefreshing == true)
         #expect(store.states["p1"]?.snapshot == nil)
+
+        runner.yield(#"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"inbox"}"#)
+        try await waitUntil { store.states["p1"]?.refreshProgress?.total == 0 }
+        runner.yield(Self.emptySummary)
+        runner.finish()
+        await task.value
     }
 
     @Test func staleness() {
@@ -93,7 +122,7 @@ struct GGInboxStoreTests {
 
     @Test func invalidateExpiresFreshnessWithoutDiscardingVisibleSnapshot() async throws {
         let store = GGInboxStore()
-        let runner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        let runner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSONL, stderr: ""))
         let fetchedAt = Date(timeIntervalSince1970: 1_000)
         await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner), now: { fetchedAt })
 
@@ -107,7 +136,7 @@ struct GGInboxStoreTests {
 
     @Test func invalidateDuringRefreshPreventsOlderCompletionFromPublishing() async throws {
         let store = GGInboxStore()
-        let runner = SuspendedInboxRunner()
+        let runner = ControlledInboxRunner()
         let refresh = Task { @MainActor in
             await store.refresh(
                 projectId: "p1",
@@ -116,10 +145,12 @@ struct GGInboxStoreTests {
                 now: { Date(timeIntervalSince1970: 2_000) }
             )
         }
-        try await waitUntil { await runner.hasStarted() }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
 
         store.invalidate(projectId: "p1")
-        await runner.finish(with: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        runner.yield(#"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"inbox"}"#)
+        runner.yield(Self.emptySummary)
+        runner.finish()
         await refresh.value
 
         let state = try #require(store.states["p1"])
@@ -130,7 +161,7 @@ struct GGInboxStoreTests {
 
     @Test func invalidateDuringRefreshRetainsPreviouslyVisibleSnapshot() async throws {
         let store = GGInboxStore()
-        let oldRunner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSON, stderr: ""))
+        let oldRunner = FakeGGRunner(result: ProcessResult(exitCode: 0, stdout: Self.emptyJSONL, stderr: ""))
         await store.refresh(
             projectId: "p1",
             repoPath: "/repo",
@@ -139,7 +170,7 @@ struct GGInboxStoreTests {
         )
         let previousSnapshot = try #require(store.states["p1"]?.snapshot)
 
-        let runner = SuspendedInboxRunner()
+        let runner = ControlledInboxRunner()
         let refresh = Task { @MainActor in
             await store.refresh(
                 projectId: "p1",
@@ -148,17 +179,181 @@ struct GGInboxStoreTests {
                 now: { Date(timeIntervalSince1970: 2_000) }
             )
         }
-        try await waitUntil { await runner.hasStarted() }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
 
         store.invalidate(projectId: "p1")
-        let replacementJSON = Self.emptyJSON.replacingOccurrences(of: #""total_items":0"#, with: #""total_items":9"#)
-        await runner.finish(with: ProcessResult(exitCode: 0, stdout: replacementJSON, stderr: ""))
+        let replacementSummary = Self.emptySummary.replacingOccurrences(of: #""total_items":0"#, with: #""total_items":9"#)
+        runner.yield(#"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"inbox"}"#)
+        runner.yield(replacementSummary)
+        runner.finish()
         await refresh.value
 
         let state = try #require(store.states["p1"])
         #expect(state.snapshot == previousSnapshot)
         #expect(state.fetchedAt == nil)
         #expect(state.isRefreshing == false)
+    }
+
+    @Test func refreshKeepsOldSnapshotUntilFirstCompletionThenPublishesPartialState() async throws {
+        let store = GGInboxStore()
+        let old = GGInboxSnapshot(totalItems: 9, buckets: GGInboxBuckets(), stackErrors: [])
+        store.states["p1"] = .init(snapshot: old, fetchedAt: Date(timeIntervalSince1970: 100))
+        let runner = ControlledInboxRunner()
+        let task = Task { @MainActor in
+            await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner), now: { Date(timeIntervalSince1970: 200) })
+        }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
+        runner.yield(#"{"event":"start","total_candidates":2,"total_stack_errors":0,"version":1,"command":"inbox"}"#)
+        try await waitUntil { store.states["p1"]?.refreshProgress?.total == 2 }
+        #expect(store.states["p1"]?.snapshot == old)
+
+        runner.yield(Self.readyEntryEvent(completed: 1, total: 2))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.completed == 1 }
+        #expect(store.states["p1"]?.snapshot?.totalItems == 1)
+        #expect(store.states["p1"]?.snapshot != old)
+
+        runner.yield(Self.emptySummary)
+        runner.finish()
+        await task.value
+        #expect(store.states["p1"]?.snapshot?.totalItems == 0)
+        #expect(store.states["p1"]?.fetchedAt == Date(timeIntervalSince1970: 200))
+        #expect(store.states["p1"]?.refreshProgress == nil)
+    }
+
+    @Test func entryErrorPublishesRefreshFailureWithoutPRURL() async throws {
+        let store = GGInboxStore()
+        let runner = ControlledInboxRunner()
+        let task = Task { @MainActor in
+            await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
+        runner.yield(Self.start(total: 2))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.total == 2 }
+        runner.yield(Self.entryErrorEvent(completed: 1, total: 2))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.completed == 1 }
+        let entry = try #require(store.states["p1"]?.snapshot?.buckets.refreshFailed.first)
+        #expect(entry.prUrl == nil)
+        #expect(entry.refreshError == "provider unavailable")
+
+        runner.yield(Self.emptySummary)
+        runner.finish()
+        await task.value
+    }
+
+    @Test func excludedEntryPublishesEmptyPartialStateAndAdvancesProgress() async throws {
+        let store = GGInboxStore()
+        let old = GGInboxSnapshot(totalItems: 9, buckets: GGInboxBuckets(), stackErrors: [])
+        store.states["p1"] = .init(snapshot: old, fetchedAt: Date(timeIntervalSince1970: 100))
+        let runner = ControlledInboxRunner()
+        let task = Task { @MainActor in
+            await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
+        runner.yield(Self.start(total: 2))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.total == 2 }
+        runner.yield(Self.excludedEntryEvent(completed: 1, total: 2))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.completed == 1 }
+        #expect(store.states["p1"]?.snapshot?.totalItems == 0)
+        #expect(store.states["p1"]?.snapshot != old)
+
+        runner.yield(Self.emptySummary)
+        runner.finish()
+        await task.value
+    }
+
+    @Test func partialEntriesRemainInStableDisplayOrderWhenCompletionOrderDiffers() async throws {
+        let store = GGInboxStore()
+        let runner = ControlledInboxRunner()
+        let task = Task { @MainActor in
+            await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
+        runner.yield(Self.start(total: 2))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.total == 2 }
+        runner.yield(Self.readyEntryEvent(stackName: "perf", position: 2, completed: 1, total: 2))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.completed == 1 }
+        runner.yield(Self.readyEntryEvent(stackName: "auth", position: 1, completed: 2, total: 2))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.completed == 2 }
+        #expect(store.states["p1"]?.snapshot?.buckets.readyToLand.map(\.stackName) == ["auth", "perf"])
+
+        runner.yield(Self.emptySummary)
+        runner.finish()
+        await task.value
+    }
+
+    @Test func stackErrorsPublishWithFirstPartialSnapshot() async throws {
+        let store = GGInboxStore()
+        let runner = ControlledInboxRunner()
+        let task = Task { @MainActor in
+            await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
+        runner.yield(Self.start(total: 1))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.total == 1 }
+        runner.yield(#"{"event":"stack_error","stack_name":"broken","error":"missing base","version":1,"command":"inbox"}"#)
+        runner.yield(Self.readyEntryEvent(completed: 1, total: 1))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.completed == 1 }
+        #expect(store.states["p1"]?.snapshot?.stackErrors == [GGInboxStackError(stackName: "broken", error: "missing base")])
+
+        runner.yield(Self.emptySummary)
+        runner.finish()
+        await task.value
+    }
+
+    @Test func fatalEOFBeforeSummaryRestoresOldSnapshotAndFetchedAt() async throws {
+        let store = GGInboxStore()
+        let old = GGInboxSnapshot(totalItems: 9, buckets: GGInboxBuckets(), stackErrors: [])
+        let oldFetchedAt = Date(timeIntervalSince1970: 100)
+        store.states["p1"] = .init(snapshot: old, fetchedAt: oldFetchedAt)
+        let runner = ControlledInboxRunner()
+        let task = Task { @MainActor in
+            await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
+        runner.yield(Self.start(total: 1))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.total == 1 }
+        runner.yield(Self.readyEntryEvent(completed: 1, total: 1))
+        try await waitUntil { store.states["p1"]?.snapshot?.totalItems == 1 }
+        runner.finish()
+        await task.value
+
+        let state = try #require(store.states["p1"])
+        #expect(state.snapshot == old)
+        #expect(state.fetchedAt == oldFetchedAt)
+        #expect(state.refreshProgress == nil)
+        #expect(state.lastError != nil)
+    }
+
+    @Test func invalidationAfterPartialPublicationRestoresOldSnapshotAndIgnoresSummary() async throws {
+        let store = GGInboxStore()
+        let old = GGInboxSnapshot(totalItems: 9, buckets: GGInboxBuckets(), stackErrors: [])
+        store.states["p1"] = .init(snapshot: old, fetchedAt: Date(timeIntervalSince1970: 100))
+        let runner = ControlledInboxRunner()
+        let task = Task { @MainActor in
+            await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner), now: { Date(timeIntervalSince1970: 200) })
+        }
+        try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
+        runner.yield(Self.start(total: 1))
+        try await waitUntil { store.states["p1"]?.refreshProgress?.total == 1 }
+        runner.yield(Self.readyEntryEvent(completed: 1, total: 1))
+        try await waitUntil { store.states["p1"]?.snapshot?.totalItems == 1 }
+        store.invalidate(projectId: "p1")
+        runner.yield(Self.emptySummary)
+        runner.finish()
+        await task.value
+
+        let state = try #require(store.states["p1"])
+        #expect(state.snapshot == old)
+        #expect(state.fetchedAt == nil)
+        #expect(state.isRefreshing == false)
+        #expect(state.refreshProgress == nil)
     }
 
     @Test func pruneDropsRemovedProjectsAndIsValueDiffed() {
@@ -168,5 +363,26 @@ struct GGInboxStoreTests {
         #expect(Array(store.states.keys) == ["keep"])
         store.prune(keepingProjectIds: ["keep"]) // no-op prune
         #expect(Array(store.states.keys) == ["keep"])
+    }
+
+    private static func start(total: Int) -> String {
+        #"{"event":"start","total_candidates":\#(total),"total_stack_errors":0,"version":1,"command":"inbox"}"#
+    }
+
+    private static func readyEntryEvent(
+        stackName: String = "auth",
+        position: Int = 1,
+        completed: Int,
+        total: Int
+    ) -> String {
+        #"{"event":"entry","completed":\#(completed),"total_candidates":\#(total),"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"\#(stackName)","position":\#(position),"sha":"abc\#(position)","title":"Add \#(stackName)","pr_number":\#(40 + position),"pr_url":"https://example.test/\#(40 + position)","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
+    }
+
+    private static func excludedEntryEvent(completed: Int, total: Int) -> String {
+        #"{"event":"entry","completed":\#(completed),"total_candidates":\#(total),"included":false,"bucket":null,"remote_state":"closed","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
+    }
+
+    private static func entryErrorEvent(completed: Int, total: Int) -> String {
+        #"{"event":"entry_error","completed":\#(completed),"total_candidates":\#(total),"included":true,"bucket":"refresh_failed","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"error":"provider unavailable","version":1,"command":"inbox"}"#
     }
 }

--- a/AlasTests/Integrations/GGInstallControllerTests.swift
+++ b/AlasTests/Integrations/GGInstallControllerTests.swift
@@ -34,4 +34,41 @@ struct GGInstallControllerTests {
         await controller.installAndWait()
         #expect(controller.phase == .failed("gg is still not on PATH after install."))
     }
+
+    @Test func successfulUpgradeReachesSucceededAndReprobes() async {
+        var upgraded = false
+        var probed = false
+        let controller = GGInstallController(
+            runInstall: { ProcessResult(exitCode: 0, stdout: "", stderr: "") },
+            runUpgrade: {
+                upgraded = true
+                return ProcessResult(exitCode: 0, stdout: "upgraded", stderr: "")
+            },
+            reprobe: {
+                probed = true
+                return true
+            }
+        )
+
+        await controller.upgradeAndWait()
+        #expect(controller.phase == .succeeded)
+        #expect(upgraded)
+        #expect(probed)
+    }
+
+    @Test func upgradeFailureSurfacesStderrWithoutReprobe() async {
+        var probed = false
+        let controller = GGInstallController(
+            runInstall: { ProcessResult(exitCode: 0, stdout: "", stderr: "") },
+            runUpgrade: { ProcessResult(exitCode: 1, stdout: "", stderr: "formula unavailable") },
+            reprobe: {
+                probed = true
+                return true
+            }
+        )
+
+        await controller.upgradeAndWait()
+        #expect(controller.phase == .failed("formula unavailable"))
+        #expect(!probed)
+    }
 }

--- a/AlasTests/Integrations/GGInstallControllerTests.swift
+++ b/AlasTests/Integrations/GGInstallControllerTests.swift
@@ -1,6 +1,25 @@
 import Testing
 @testable import Alas
 
+private actor ControlledUpgradeOperation {
+    private var calls = 0
+    private var continuation: CheckedContinuation<ProcessResult, Never>?
+
+    func run() async -> ProcessResult {
+        calls += 1
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func callCount() -> Int { calls }
+
+    func finish() {
+        continuation?.resume(returning: ProcessResult(exitCode: 0, stdout: "upgraded", stderr: ""))
+        continuation = nil
+    }
+}
+
 @MainActor
 struct GGInstallControllerTests {
     @Test func successfulInstallReachesSucceededAndReprobes() async {
@@ -70,5 +89,26 @@ struct GGInstallControllerTests {
         await controller.upgradeAndWait()
         #expect(controller.phase == .failed("formula unavailable"))
         #expect(!probed)
+    }
+
+    @Test func concurrentUpgradeCallsDeduplicateWhileRunning() async throws {
+        let operation = ControlledUpgradeOperation()
+        let controller = GGInstallController(
+            runUpgrade: { await operation.run() },
+            reprobe: { true }
+        )
+
+        let first = Task { await controller.upgradeAndWait() }
+        while await operation.callCount() == 0 {
+            await Task.yield()
+        }
+        #expect(controller.phase == .running)
+
+        await controller.upgradeAndWait()
+        #expect(await operation.callCount() == 1)
+
+        await operation.finish()
+        await first.value
+        #expect(controller.phase == .succeeded)
     }
 }

--- a/AlasTests/Integrations/GGServiceInboxTests.swift
+++ b/AlasTests/Integrations/GGServiceInboxTests.swift
@@ -55,51 +55,51 @@ struct GGServiceInboxTests {
     @Test(arguments: [
         InboxSequenceFailure(
             name: "summary without start",
-            lines: [summaryLine]
+            lines: [Self.summaryLine]
         ),
         InboxSequenceFailure(
             name: "duplicate start",
-            lines: [startLine, startLine, summaryLine]
+            lines: [Self.startLine, Self.startLine, Self.summaryLine]
         ),
         InboxSequenceFailure(
             name: "duplicate summary",
-            lines: [startLine, summaryLine, summaryLine]
+            lines: [Self.startLine, Self.summaryLine, Self.summaryLine]
         ),
         InboxSequenceFailure(
             name: "entry after summary",
-            lines: [startLine, summaryLine, entryLine]
+            lines: [Self.startLine, Self.summaryLine, Self.entryLine]
         ),
         InboxSequenceFailure(
             name: "clean EOF after start without summary",
-            lines: [startLine]
+            lines: [Self.startLine]
         ),
         InboxSequenceFailure(
             name: "malformed line",
-            lines: [startLine, "not json"]
+            lines: [Self.startLine, "not json"]
         ),
         InboxSequenceFailure(
             name: "entry total differs from start",
-            lines: [startLine, entryWithDifferentTotalLine]
+            lines: [Self.startLine, Self.entryWithDifferentTotalLine]
         ),
         InboxSequenceFailure(
             name: "entry before start",
-            lines: [entryLine]
+            lines: [Self.entryLine]
         ),
         InboxSequenceFailure(
             name: "repeated entry completion",
-            lines: [startTotalTwoLine, entryTotalTwoCompletedOneLine, entryTotalTwoCompletedOneLine]
+            lines: [Self.startTotalTwoLine, Self.entryTotalTwoCompletedOneLine, Self.entryTotalTwoCompletedOneLine]
         ),
         InboxSequenceFailure(
             name: "decreasing entry completion",
-            lines: [startTotalTwoLine, entryTotalTwoCompletedTwoLine, entryTotalTwoCompletedOneLine]
+            lines: [Self.startTotalTwoLine, Self.entryTotalTwoCompletedTwoLine, Self.entryTotalTwoCompletedOneLine]
         ),
         InboxSequenceFailure(
             name: "entry completion above total",
-            lines: [startLine, entryAboveTotalLine]
+            lines: [Self.startLine, Self.entryAboveTotalLine]
         ),
         InboxSequenceFailure(
             name: "entry error progress validation",
-            lines: [startLine, entryErrorAboveTotalLine]
+            lines: [Self.startLine, Self.entryErrorAboveTotalLine]
         ),
     ])
     func inboxRejectsInvalidSequence(_ fixture: InboxSequenceFailure) async {
@@ -126,7 +126,7 @@ struct GGServiceInboxTests {
     @Test func inboxRejectsFatalEventAfterDiscovery() async {
         let runner = InboxRecordingGGRunner(result: ProcessResult(
             exitCode: 1,
-            stdout: [startLine, fatalLine].joined(separator: "\n"),
+            stdout: [Self.startLine, Self.fatalLine].joined(separator: "\n"),
             stderr: "fallback stderr"
         ))
 
@@ -138,7 +138,7 @@ struct GGServiceInboxTests {
     @Test func inboxRejectsDataAfterFatalEvent() async {
         let runner = InboxRecordingGGRunner(result: ProcessResult(
             exitCode: 1,
-            stdout: [fatalLine, startLine].joined(separator: "\n"),
+            stdout: [Self.fatalLine, Self.startLine].joined(separator: "\n"),
             stderr: "fallback stderr"
         ))
 

--- a/AlasTests/Integrations/GGServiceInboxTests.swift
+++ b/AlasTests/Integrations/GGServiceInboxTests.swift
@@ -123,14 +123,14 @@ struct GGServiceInboxTests {
         }
     }
 
-    @Test func inboxRejectsFatalEventAfterDiscovery() async {
+    @Test func inboxAcceptsFatalEventAfterDiscoveryAndSurfacesItsMessage() async {
         let runner = InboxRecordingGGRunner(result: ProcessResult(
             exitCode: 1,
             stdout: [Self.startLine, Self.fatalLine].joined(separator: "\n"),
             stderr: "fallback stderr"
         ))
 
-        await #expect(throws: GGServiceError.malformedOutput("gg inbox emitted error after discovery.")) {
+        await #expect(throws: GGServiceError.commandFailed(stderr: "Not in a git repository")) {
             for try await _ in GGService(runner: runner).inboxStream(repoPath: "/repo/root") {}
         }
     }
@@ -138,7 +138,7 @@ struct GGServiceInboxTests {
     @Test func inboxRejectsDataAfterFatalEvent() async {
         let runner = InboxRecordingGGRunner(result: ProcessResult(
             exitCode: 1,
-            stdout: [Self.fatalLine, Self.startLine].joined(separator: "\n"),
+            stdout: [Self.startLine, Self.fatalLine, Self.entryLine].joined(separator: "\n"),
             stderr: "fallback stderr"
         ))
 

--- a/AlasTests/Integrations/GGServiceInboxTests.swift
+++ b/AlasTests/Integrations/GGServiceInboxTests.swift
@@ -18,7 +18,7 @@ private final class InboxRecordingGGRunner: GGCommandRunning, @unchecked Sendabl
     }
 }
 
-private struct InboxSequenceFailure: Sendable {
+struct InboxSequenceFailure: Sendable {
     let name: String
     let lines: [String]
 }

--- a/AlasTests/Integrations/GGServiceInboxTests.swift
+++ b/AlasTests/Integrations/GGServiceInboxTests.swift
@@ -39,6 +39,17 @@ struct GGServiceInboxTests {
         #expect(runner.lastArgs == ["inbox", "--jsonl"])
         #expect(runner.lastCwd?.path == "/repo/root")
         #expect(events.count == 2)
+        guard case .start(let totalCandidates, let totalStackErrors) = events[0] else {
+            Issue.record("Expected start event")
+            return
+        }
+        #expect(totalCandidates == 0)
+        #expect(totalStackErrors == 0)
+        guard case .summary(let snapshot) = events[1] else {
+            Issue.record("Expected summary event")
+            return
+        }
+        #expect(snapshot.totalItems == 0)
     }
 
     @Test(arguments: [
@@ -70,6 +81,26 @@ struct GGServiceInboxTests {
             name: "entry total differs from start",
             lines: [startLine, entryWithDifferentTotalLine]
         ),
+        InboxSequenceFailure(
+            name: "entry before start",
+            lines: [entryLine]
+        ),
+        InboxSequenceFailure(
+            name: "repeated entry completion",
+            lines: [startTotalTwoLine, entryTotalTwoCompletedOneLine, entryTotalTwoCompletedOneLine]
+        ),
+        InboxSequenceFailure(
+            name: "decreasing entry completion",
+            lines: [startTotalTwoLine, entryTotalTwoCompletedTwoLine, entryTotalTwoCompletedOneLine]
+        ),
+        InboxSequenceFailure(
+            name: "entry completion above total",
+            lines: [startLine, entryAboveTotalLine]
+        ),
+        InboxSequenceFailure(
+            name: "entry error progress validation",
+            lines: [startLine, entryErrorAboveTotalLine]
+        ),
     ])
     func inboxRejectsInvalidSequence(_ fixture: InboxSequenceFailure) async {
         let runner = InboxRecordingGGRunner(result: ProcessResult(
@@ -92,8 +123,38 @@ struct GGServiceInboxTests {
         }
     }
 
+    @Test func inboxRejectsFatalEventAfterDiscovery() async {
+        let runner = InboxRecordingGGRunner(result: ProcessResult(
+            exitCode: 1,
+            stdout: [startLine, fatalLine].joined(separator: "\n"),
+            stderr: "fallback stderr"
+        ))
+
+        await #expect(throws: GGServiceError.malformedOutput("gg inbox emitted error after discovery.")) {
+            for try await _ in GGService(runner: runner).inboxStream(repoPath: "/repo/root") {}
+        }
+    }
+
+    @Test func inboxRejectsDataAfterFatalEvent() async {
+        let runner = InboxRecordingGGRunner(result: ProcessResult(
+            exitCode: 1,
+            stdout: [fatalLine, startLine].joined(separator: "\n"),
+            stderr: "fallback stderr"
+        ))
+
+        await #expect(throws: GGServiceError.malformedOutput("gg inbox emitted data after a terminal event.")) {
+            for try await _ in GGService(runner: runner).inboxStream(repoPath: "/repo/root") {}
+        }
+    }
+
     private static let startLine = #"{"event":"start","total_candidates":1,"total_stack_errors":0,"version":1,"command":"inbox"}"#
+    private static let startTotalTwoLine = #"{"event":"start","total_candidates":2,"total_stack_errors":0,"version":1,"command":"inbox"}"#
     private static let summaryLine = #"{"event":"summary","total_items":0,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[],"version":1,"command":"inbox"}"#
     private static let entryLine = #"{"event":"entry","completed":1,"total_candidates":1,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
     private static let entryWithDifferentTotalLine = #"{"event":"entry","completed":1,"total_candidates":2,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
+    private static let entryTotalTwoCompletedOneLine = #"{"event":"entry","completed":1,"total_candidates":2,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
+    private static let entryTotalTwoCompletedTwoLine = #"{"event":"entry","completed":2,"total_candidates":2,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
+    private static let entryAboveTotalLine = #"{"event":"entry","completed":2,"total_candidates":1,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
+    private static let entryErrorAboveTotalLine = #"{"event":"entry_error","completed":2,"total_candidates":1,"included":true,"bucket":"refresh_failed","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"error":"provider unavailable","version":1,"command":"inbox"}"#
+    private static let fatalLine = #"{"version":1,"command":"inbox","status":"error","event":"error","message":"Not in a git repository"}"#
 }

--- a/AlasTests/Integrations/GGServiceInboxTests.swift
+++ b/AlasTests/Integrations/GGServiceInboxTests.swift
@@ -18,30 +18,82 @@ private final class InboxRecordingGGRunner: GGCommandRunning, @unchecked Sendabl
     }
 }
 
+private struct InboxSequenceFailure: Sendable {
+    let name: String
+    let lines: [String]
+}
+
 struct GGServiceInboxTests {
-    @Test func inboxRunsAtRepoPathAndDecodes() async throws {
-        let json = #"{"version":1,"total_items":0,"buckets":{"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[]}"#
-        let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 0, stdout: json, stderr: ""))
-        let service = GGService(runner: runner)
-        let snapshot = try await service.inbox(repoPath: "/repo/root")
-        #expect(runner.lastArgs == ["inbox", "--json"])
+    @Test func inboxStreamsAtRepoPathAndDecodes() async throws {
+        let ndjson = [
+            #"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"inbox"}"#,
+            #"{"event":"summary","total_items":0,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[],"version":1,"command":"inbox"}"#,
+        ].joined(separator: "\n")
+        let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 0, stdout: ndjson, stderr: ""))
+
+        var events: [GGInboxEvent] = []
+        for try await event in GGService(runner: runner).inboxStream(repoPath: "/repo/root") {
+            events.append(event)
+        }
+
+        #expect(runner.lastArgs == ["inbox", "--jsonl"])
         #expect(runner.lastCwd?.path == "/repo/root")
-        #expect(snapshot.totalItems == 0)
+        #expect(events.count == 2)
     }
 
-    @Test func inboxMapsExitCode127ToCLIMissing() async {
-        let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 127, stdout: "", stderr: "not found"))
-        let service = GGService(runner: runner)
-        await #expect(throws: GGServiceError.self) {
-            _ = try await service.inbox(repoPath: "/repo/root")
+    @Test(arguments: [
+        InboxSequenceFailure(
+            name: "summary without start",
+            lines: [summaryLine]
+        ),
+        InboxSequenceFailure(
+            name: "duplicate start",
+            lines: [startLine, startLine, summaryLine]
+        ),
+        InboxSequenceFailure(
+            name: "duplicate summary",
+            lines: [startLine, summaryLine, summaryLine]
+        ),
+        InboxSequenceFailure(
+            name: "entry after summary",
+            lines: [startLine, summaryLine, entryLine]
+        ),
+        InboxSequenceFailure(
+            name: "clean EOF after start without summary",
+            lines: [startLine]
+        ),
+        InboxSequenceFailure(
+            name: "malformed line",
+            lines: [startLine, "not json"]
+        ),
+        InboxSequenceFailure(
+            name: "entry total differs from start",
+            lines: [startLine, entryWithDifferentTotalLine]
+        ),
+    ])
+    func inboxRejectsInvalidSequence(_ fixture: InboxSequenceFailure) async {
+        let runner = InboxRecordingGGRunner(result: ProcessResult(
+            exitCode: 0,
+            stdout: fixture.lines.joined(separator: "\n"),
+            stderr: ""
+        ))
+
+        await #expect(throws: GGServiceError.self, "Expected \(fixture.name) to be rejected.") {
+            for try await _ in GGService(runner: runner).inboxStream(repoPath: "/repo/root") {}
         }
     }
 
-    @Test func inboxThrowsOnMalformedStdout() async {
-        let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 0, stdout: "garbage", stderr: ""))
-        let service = GGService(runner: runner)
-        await #expect(throws: GGServiceError.self) {
-            _ = try await service.inbox(repoPath: "/repo/root")
+    @Test func inboxAcceptsSoleFatalEventAndSurfacesItsMessage() async {
+        let line = #"{"version":1,"command":"inbox","status":"error","event":"error","message":"Not in a git repository"}"#
+        let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 1, stdout: line, stderr: "fallback stderr"))
+
+        await #expect(throws: GGServiceError.commandFailed(stderr: "Not in a git repository")) {
+            for try await _ in GGService(runner: runner).inboxStream(repoPath: "/repo/root") {}
         }
     }
+
+    private static let startLine = #"{"event":"start","total_candidates":1,"total_stack_errors":0,"version":1,"command":"inbox"}"#
+    private static let summaryLine = #"{"event":"summary","total_items":0,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[],"version":1,"command":"inbox"}"#
+    private static let entryLine = #"{"event":"entry","completed":1,"total_candidates":1,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
+    private static let entryWithDifferentTotalLine = #"{"event":"entry","completed":1,"total_candidates":2,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#
 }

--- a/docs/superpowers/plans/2026-07-31-progressive-gg-inbox.md
+++ b/docs/superpowers/plans/2026-07-31-progressive-gg-inbox.md
@@ -1,0 +1,1013 @@
+# Progressive gg Inbox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stream `gg inbox --jsonl` results into the Alas Inbox tab as each candidate completes, with a hard gg 0.9.12 minimum and an inline Homebrew upgrade path.
+
+**Architecture:** `GGInboxModels` owns the versioned JSONL event contract, `GGService` turns the process line stream into a validated typed stream, and `GGInboxStore` reduces one isolated refresh generation into observable partial state before reconciling the final summary. `GGInboxTabView` remains a state renderer and gates refreshes through the existing session-cached gg version probe.
+
+**Tech Stack:** Swift 5.9+, SwiftUI/Observation, `AsyncThrowingStream`, Foundation `Process`, Swift Testing, XcodeGen.
+
+## Global Constraints
+
+- Inbox requires gg 0.9.12 or newer; there is no `gg inbox --json` fallback.
+- The minimum applies only to Inbox; do not change other gg capability gates.
+- Keep `gg Inbox` discoverable for otherwise-qualified projects with an older installed gg.
+- Preserve project-scoped caching, refresh deduplication, invalidation generations, and stale-snapshot rollback.
+- Do not mix entries from different refresh generations.
+- Treat only the final `summary` as complete and timestampable.
+- Keep all code, comments, logs, and UI copy in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Do not add a new source file; keep the event contract in `GGInboxModels.swift`, so Xcode project membership does not change.
+- Prefix repository commands with `rtk`.
+
+---
+
+## File Map
+
+- `Alas/Sources/Integrations/GG/GGInboxModels.swift`: atomic snapshot additions, JSONL event types/decoder, bucket mutation helpers, optional URL normalization.
+- `Alas/Sources/Integrations/GG/GGService.swift`: validated `inboxStream(repoPath:)` orchestration over the existing incremental runner.
+- `Alas/Sources/Integrations/GG/GGInboxStore.swift`: generation-scoped progressive reducer, progress state, rollback, and final-summary publication.
+- `Alas/Sources/Integrations/GG/GGInstallController.swift`: Homebrew upgrade operation while preserving the Settings install API.
+- `Alas/Sources/Integrations/GG/GGInboxTabView.swift`: version gate, upgrade screen, progress label, Refresh failed rows, and optional PR link.
+- `AlasTests/Integrations/GGInboxModelsTests.swift`: snapshot and event-decoder contract tests.
+- `AlasTests/Integrations/GGServiceInboxTests.swift`: stream sequencing, invocation, and failure tests.
+- `AlasTests/Integrations/GGInboxStoreTests.swift`: progressive-generation and rollback tests.
+- `AlasTests/Integrations/GGInstallControllerTests.swift`: upgrade execution/reprobe tests.
+- `AlasTests/Integrations/GGInboxHelpersTests.swift`: minimum-version and presentation-helper tests.
+
+---
+
+### Task 1: Model the gg 0.9.12 snapshot and JSONL event contract
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/GG/GGInboxModels.swift:3-99`
+- Test: `AlasTests/Integrations/GGInboxModelsTests.swift:5-64`
+
+**Interfaces:**
+- Consumes: `GGServiceError.malformedOutput`, gg JSONL schema version 1.
+- Produces: `GGInboxEvent.decode(line:) throws -> GGInboxEvent`, `GGInboxSnapshot`, `GGInboxBuckets`, `GGInboxEntry`, `GGInboxBucket`, and `GGInboxSupport.isSupported(version:)` for Tasks 2-5.
+
+- [ ] **Step 1: Write failing snapshot-addition tests**
+
+Update `fullSample` to include an empty `refresh_failed` array. Add a refresh-failed fixture that proves the additive fields and empty URL normalization:
+
+```swift
+@Test func decodesRefreshFailedEntryAndNormalizesEmptyURL() throws {
+    let json = #"{"version":1,"total_items":1,"buckets":{"refresh_failed":[{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"","ci_status":null,"behind_base":2,"refresh_error":"provider unavailable"}],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[]}"#
+
+    let snapshot = try GGInboxSnapshot.decode(fromJSON: Data(json.utf8))
+    let entry = try #require(snapshot.buckets.refreshFailed.first)
+    #expect(entry.prUrl == nil)
+    #expect(entry.refreshError == "provider unavailable")
+    #expect(GGInboxBucket.allCases.first == .refreshFailed)
+}
+```
+
+- [ ] **Step 2: Write failing JSONL event tests**
+
+Add one test per event shape, using the exact 0.9.12 field names. The core assertions are:
+
+```swift
+@Test func decodesInboxJSONLEvents() throws {
+    #expect(try GGInboxEvent.decode(line: #"{"event":"start","total_candidates":2,"total_stack_errors":1,"version":1,"command":"inbox"}"#)
+        == .start(totalCandidates: 2, totalStackErrors: 1))
+
+    #expect(try GGInboxEvent.decode(line: #"{"event":"stack_error","stack_name":"stale","error":"missing base","version":1,"command":"inbox"}"#)
+        == .stackError(GGInboxStackError(stackName: "stale", error: "missing base")))
+
+    let entry = try GGInboxEvent.decode(line: #"{"event":"entry","completed":1,"total_candidates":2,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc123","title":"Add login","pr_number":42,"pr_url":"https://example.test/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}"#)
+    guard case .entry(let payload) = entry else {
+        Issue.record("Expected entry event")
+        return
+    }
+    #expect(payload.completed == 1)
+    #expect(payload.bucket == .readyToLand)
+    #expect(payload.entry.prUrl == "https://example.test/42")
+
+    let failed = try GGInboxEvent.decode(line: #"{"event":"entry_error","completed":2,"total_candidates":2,"included":true,"bucket":"refresh_failed","entry":{"stack_name":"perf","position":2,"sha":"def456","title":"Cache layer","pr_number":43,"behind_base":3},"error":"provider unavailable","version":1,"command":"inbox"}"#)
+    guard case .entryError(let payload) = failed else {
+        Issue.record("Expected entry_error event")
+        return
+    }
+    #expect(payload.failedEntry.refreshError == "provider unavailable")
+    #expect(payload.failedEntry.prUrl == nil)
+
+    let summary = try GGInboxEvent.decode(line: #"{"event":"summary","total_items":0,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[],"version":1,"command":"inbox"}"#)
+    guard case .summary(let snapshot) = summary else {
+        Issue.record("Expected summary event")
+        return
+    }
+    #expect(snapshot.totalItems == 0)
+
+    #expect(try GGInboxEvent.decode(line: #"{"version":1,"command":"inbox","status":"error","event":"error","message":"Not in a git repository"}"#)
+        == .error(message: "Not in a git repository"))
+}
+```
+
+Add rejection cases:
+
+```swift
+@Test(arguments: [
+    #"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":2,"command":"inbox"}"#,
+    #"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"sync"}"#,
+    #"{"event":"future_event","version":1,"command":"inbox"}"#,
+    "not json",
+])
+func rejectsInvalidInboxJSONLEnvelopes(_ line: String) {
+    #expect(throws: GGServiceError.self) {
+        _ = try GGInboxEvent.decode(line: line)
+    }
+}
+```
+
+- [ ] **Step 3: Run the model tests and confirm they fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GGInboxModelsTests test
+```
+
+Expected: compilation failures for missing `refreshFailed`, `refreshError`, `GGInboxEvent`, and `GGInboxSupport` APIs.
+
+- [ ] **Step 4: Implement the additive snapshot model**
+
+Make bucket properties mutable for progressive insertion, add explicit initializers, and decode `refresh_failed` as required in the 0.9.12 schema:
+
+```swift
+struct GGInboxSnapshot: Equatable, Decodable {
+    let version: Int
+    let totalItems: Int
+    let buckets: GGInboxBuckets
+    let stackErrors: [GGInboxStackError]
+
+    init(version: Int = 1, totalItems: Int, buckets: GGInboxBuckets, stackErrors: [GGInboxStackError]) {
+        self.version = version
+        self.totalItems = totalItems
+        self.buckets = buckets
+        self.stackErrors = stackErrors
+    }
+}
+
+struct GGInboxBuckets: Equatable, Decodable {
+    var refreshFailed: [GGInboxEntry]
+    var readyToLand: [GGInboxEntry]
+    var changesRequested: [GGInboxEntry]
+    var blockedOnCi: [GGInboxEntry]
+    var awaitingReview: [GGInboxEntry]
+    var behindBase: [GGInboxEntry]
+    var draft: [GGInboxEntry]
+    var merged: [GGInboxEntry]
+
+    init(
+        refreshFailed: [GGInboxEntry] = [],
+        readyToLand: [GGInboxEntry] = [],
+        changesRequested: [GGInboxEntry] = [],
+        blockedOnCi: [GGInboxEntry] = [],
+        awaitingReview: [GGInboxEntry] = [],
+        behindBase: [GGInboxEntry] = [],
+        draft: [GGInboxEntry] = [],
+        merged: [GGInboxEntry] = []
+    ) {
+        self.refreshFailed = refreshFailed
+        self.readyToLand = readyToLand
+        self.changesRequested = changesRequested
+        self.blockedOnCi = blockedOnCi
+        self.awaitingReview = awaitingReview
+        self.behindBase = behindBase
+        self.draft = draft
+        self.merged = merged
+    }
+}
+```
+
+Give `GGInboxEntry` an explicit memberwise initializer and custom decoder. Decode `pr_url` as `String?`, normalize `""` to `nil`, and decode `refresh_error` with `decodeIfPresent`:
+
+```swift
+struct GGInboxEntry: Equatable, Decodable {
+    let stackName: String
+    let position: Int
+    let sha: String
+    let title: String
+    let prNumber: Int
+    let prUrl: String?
+    let ciStatus: String?
+    let behindBase: Int?
+    let refreshError: String?
+}
+```
+
+Make `GGInboxBucket` raw-string backed and put `.refreshFailed` first. Add `mutating func insert(_ entry: GGInboxEntry, into bucket: GGInboxBucket)` on `GGInboxBuckets`; upsert by `(stackName, position, prNumber)` and sort by `stackName`, then `position`, then `sha`.
+
+- [ ] **Step 5: Implement the typed event decoder and version helper**
+
+Add exact payload types and decode through a shallow envelope before switching on `event`:
+
+```swift
+struct GGInboxEntryEvent: Equatable {
+    let completed: Int
+    let totalCandidates: Int
+    let included: Bool
+    let bucket: GGInboxBucket?
+    let remoteState: String
+    let entry: GGInboxEntry
+}
+
+struct GGInboxEntryErrorEvent: Equatable {
+    let completed: Int
+    let totalCandidates: Int
+    let included: Bool
+    let bucket: GGInboxBucket
+    let failedEntry: GGInboxEntry
+}
+
+enum GGInboxEvent: Equatable {
+    case start(totalCandidates: Int, totalStackErrors: Int)
+    case stackError(GGInboxStackError)
+    case entry(GGInboxEntryEvent)
+    case entryError(GGInboxEntryErrorEvent)
+    case summary(GGInboxSnapshot)
+    case error(message: String)
+
+    static func decode(line: String) throws -> GGInboxEvent {
+        let data = Data(line.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+            let envelope = try decoder.decode(GGInboxEventEnvelope.self, from: data)
+            guard envelope.version == 1 else {
+                throw GGServiceError.unsupportedSchema(envelope.version)
+            }
+            guard envelope.command == "inbox" else {
+                throw GGServiceError.malformedOutput("Expected gg inbox event, got \(envelope.command).")
+            }
+            switch envelope.event {
+            case "start": return try decoder.decode(GGInboxStartPayload.self, from: data).event
+            case "stack_error": return try decoder.decode(GGInboxStackErrorPayload.self, from: data).event
+            case "entry": return try decoder.decode(GGInboxEntryPayload.self, from: data).event
+            case "entry_error": return try decoder.decode(GGInboxEntryErrorPayload.self, from: data).event
+            case "summary": return .summary(try decoder.decode(GGInboxSnapshot.self, from: data))
+            case "error": return .error(message: try decoder.decode(GGInboxFatalPayload.self, from: data).message)
+            default: throw GGServiceError.malformedOutput("Unknown gg inbox event: \(envelope.event)")
+            }
+        } catch let error as GGServiceError {
+            throw error
+        } catch {
+            throw GGServiceError.malformedOutput(String(describing: error))
+        }
+    }
+}
+
+enum GGInboxSupport {
+    static let minimumVersion = SemanticVersion(major: 0, minor: 9, patch: 12)
+
+    static func isSupported(version: String?) -> Bool {
+        guard let version, let parsed = SemanticVersion(parsing: version) else { return false }
+        return parsed >= minimumVersion
+    }
+}
+```
+
+The private payload structs must decode all fields named in the event tests. `GGInboxEntryErrorPayload.event` constructs `failedEntry` with `prUrl: nil`, `ciStatus: nil`, and `refreshError: error`.
+
+- [ ] **Step 6: Run model tests and commit**
+
+Run the focused command from Step 3. Expected: all `GGInboxModelsTests` pass.
+
+```bash
+rtk git add Alas/Sources/Integrations/GG/GGInboxModels.swift AlasTests/Integrations/GGInboxModelsTests.swift
+rtk git commit -m "feat(gg): model streaming inbox events"
+```
+
+---
+
+### Task 2: Stream and validate the Inbox protocol in GGService
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/GG/GGService.swift:338-345`
+- Modify: `AlasTests/Integrations/GGServiceInboxTests.swift:5-47`
+
+**Interfaces:**
+- Consumes: `GGInboxEvent.decode(line:)` from Task 1 and `GGCommandRunning.runStreaming(args:cwd:)`.
+- Produces: `GGService.inboxStream(repoPath:) -> AsyncThrowingStream<GGInboxEvent, Error>` for Task 3.
+
+- [ ] **Step 1: Replace atomic service tests with failing stream tests**
+
+Keep `InboxRecordingGGRunner`, but assert the default buffered `runStreaming` path now calls JSONL and yields typed events:
+
+```swift
+@Test func inboxStreamsAtRepoPathAndDecodes() async throws {
+    let ndjson = [
+        #"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"inbox"}"#,
+        #"{"event":"summary","total_items":0,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[],"version":1,"command":"inbox"}"#,
+    ].joined(separator: "\n")
+    let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 0, stdout: ndjson, stderr: ""))
+
+    var events: [GGInboxEvent] = []
+    for try await event in GGService(runner: runner).inboxStream(repoPath: "/repo/root") {
+        events.append(event)
+    }
+
+    #expect(runner.lastArgs == ["inbox", "--jsonl"])
+    #expect(runner.lastCwd?.path == "/repo/root")
+    #expect(events.count == 2)
+}
+```
+
+Add table-driven sequence failures for: summary without start, duplicate start,
+duplicate summary, an entry after summary, clean EOF after start without summary,
+malformed line, and an event whose `total_candidates` differs from start. Assert
+each stream iteration throws `GGServiceError`.
+
+Add the fatal exception test:
+
+```swift
+@Test func inboxAcceptsSoleFatalEventAndSurfacesItsMessage() async {
+    let line = #"{"version":1,"command":"inbox","status":"error","event":"error","message":"Not in a git repository"}"#
+    let runner = InboxRecordingGGRunner(result: ProcessResult(exitCode: 1, stdout: line, stderr: "fallback stderr"))
+
+    await #expect(throws: GGServiceError.commandFailed(stderr: "Not in a git repository")) {
+        for try await _ in GGService(runner: runner).inboxStream(repoPath: "/repo/root") {}
+    }
+}
+```
+
+- [ ] **Step 2: Run service tests and confirm they fail**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GGServiceInboxTests test
+```
+
+Expected: compilation failure because `inboxStream(repoPath:)` does not exist and the old method still invokes `--json`.
+
+- [ ] **Step 3: Implement stream sequencing and fatal-message precedence**
+
+Replace the atomic Inbox method with a typed stream. Keep the raw process stream alive until EOF, even after receiving a fatal event:
+
+```swift
+func inboxStream(repoPath: String) -> AsyncThrowingStream<GGInboxEvent, Error> {
+    AsyncThrowingStream { continuation in
+        Task {
+            var sawStart = false
+            var sawSummary = false
+            var fatalMessage: String?
+            var totalCandidates: Int?
+            var lastCompleted = 0
+
+            do {
+                do {
+                    for try await line in runner.runStreaming(
+                        args: ["inbox", "--jsonl"],
+                        cwd: URL(fileURLWithPath: repoPath)
+                    ) {
+                        guard !sawSummary, fatalMessage == nil else {
+                            throw GGServiceError.malformedOutput("gg inbox emitted data after a terminal event.")
+                        }
+                        let event = try GGInboxEvent.decode(line: line)
+                        switch event {
+                        case .error(let message):
+                            fatalMessage = message
+                        case .start(let count, _):
+                            guard !sawStart else {
+                                throw GGServiceError.malformedOutput("gg inbox emitted duplicate start events.")
+                            }
+                            sawStart = true
+                            totalCandidates = count
+                            continuation.yield(event)
+                        case .entry(let payload):
+                            try Self.validateInboxProgress(
+                                started: sawStart,
+                                expectedTotal: totalCandidates,
+                                completed: payload.completed,
+                                eventTotal: payload.totalCandidates,
+                                lastCompleted: &lastCompleted
+                            )
+                            continuation.yield(event)
+                        case .entryError(let payload):
+                            try Self.validateInboxProgress(
+                                started: sawStart,
+                                expectedTotal: totalCandidates,
+                                completed: payload.completed,
+                                eventTotal: payload.totalCandidates,
+                                lastCompleted: &lastCompleted
+                            )
+                            continuation.yield(event)
+                        case .stackError:
+                            guard sawStart else {
+                                throw GGServiceError.malformedOutput("gg inbox emitted stack_error before start.")
+                            }
+                            continuation.yield(event)
+                        case .summary:
+                            guard sawStart else {
+                                throw GGServiceError.malformedOutput("gg inbox emitted summary before start.")
+                            }
+                            sawSummary = true
+                            continuation.yield(event)
+                        }
+                    }
+                } catch {
+                    if let fatalMessage {
+                        throw GGServiceError.commandFailed(stderr: fatalMessage)
+                    }
+                    throw error
+                }
+
+                if let fatalMessage {
+                    throw GGServiceError.commandFailed(stderr: fatalMessage)
+                }
+                guard sawStart, sawSummary else {
+                    throw GGServiceError.malformedOutput("gg inbox ended without a summary event.")
+                }
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+}
+```
+
+Implement `validateInboxProgress` as a private static helper. It must require a
+start event, require `eventTotal == expectedTotal`, require
+`lastCompleted < completed && completed <= eventTotal`, then assign
+`lastCompleted = completed`. The 0.9.12 contract increments once per candidate,
+so repeated or decreasing values are malformed output.
+
+- [ ] **Step 4: Run service and low-level streaming tests**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GGServiceInboxTests -only-testing:AlasTests/GGCommandRunningStreamingTests test
+```
+
+Expected: all selected tests pass, including existing proof that
+`ProcessGGCommandRunner.streamProcess` yields before process completion.
+
+- [ ] **Step 5: Commit the service boundary**
+
+```bash
+rtk git add Alas/Sources/Integrations/GG/GGService.swift AlasTests/Integrations/GGServiceInboxTests.swift
+rtk git commit -m "feat(gg): stream inbox jsonl events"
+```
+
+---
+
+### Task 3: Reduce progressive events in one isolated store generation
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/GG/GGInboxStore.swift:4-78`
+- Modify: `AlasTests/Integrations/GGInboxStoreTests.swift:5-176`
+
+**Interfaces:**
+- Consumes: `GGService.inboxStream(repoPath:)` and the Task 1 event/snapshot types.
+- Produces: `GGInboxStore.State.refreshProgress: GGInboxRefreshProgress?` and progressively updated `State.snapshot` for Task 5.
+
+- [ ] **Step 1: Add a controllable streaming runner to store tests**
+
+Replace atomic-only suspended fixtures with a runner that exposes its
+continuation and records invocation:
+
+```swift
+private final class ControlledInboxRunner: GGCommandRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: AsyncThrowingStream<String, Error>.Continuation?
+    private(set) var lastArgs: [String] = []
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        ProcessResult(exitCode: 0, stdout: "", stderr: "")
+    }
+
+    func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
+        lock.lock()
+        lastArgs = args
+        lock.unlock()
+        return AsyncThrowingStream { continuation in
+            self.lock.lock()
+            self.continuation = continuation
+            self.lock.unlock()
+        }
+    }
+
+    func yield(_ line: String) {
+        lock.lock()
+        let continuation = continuation
+        lock.unlock()
+        continuation?.yield(line)
+    }
+
+    func finish(throwing error: Error? = nil) {
+        lock.lock()
+        let continuation = continuation
+        lock.unlock()
+        if let error { continuation?.finish(throwing: error) } else { continuation?.finish() }
+    }
+}
+```
+
+Retain `waitUntil` and use it after every yielded event so assertions observe
+the MainActor write before sending the next line. Replace `emptyJSON` with an
+`emptyJSONL` fixture containing a `start` line followed by an empty `summary`,
+and update every pre-existing success runner to return that fixture. Update the
+invalidation replacement fixture by changing `summary.total_items` instead of
+the removed atomic document.
+
+- [ ] **Step 2: Write failing progressive-generation tests**
+
+Add a test that seeds a complete snapshot, starts a two-candidate stream, and
+asserts the exact state transitions:
+
+```swift
+@Test func refreshKeepsOldSnapshotUntilFirstCompletionThenPublishesPartialState() async throws {
+    let store = GGInboxStore()
+    let old = GGInboxSnapshot(totalItems: 9, buckets: GGInboxBuckets(), stackErrors: [])
+    store.states["p1"] = .init(snapshot: old, fetchedAt: Date(timeIntervalSince1970: 100))
+    let runner = ControlledInboxRunner()
+    let task = Task { @MainActor in
+        await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner), now: { Date(timeIntervalSince1970: 200) })
+    }
+    try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
+
+    runner.yield(#"{"event":"start","total_candidates":2,"total_stack_errors":0,"version":1,"command":"inbox"}"#)
+    try await waitUntil { store.states["p1"]?.refreshProgress?.total == 2 }
+    #expect(store.states["p1"]?.snapshot == old)
+
+    runner.yield(Self.readyEntryEvent(completed: 1, total: 2))
+    try await waitUntil { store.states["p1"]?.refreshProgress?.completed == 1 }
+    #expect(store.states["p1"]?.snapshot?.totalItems == 1)
+    #expect(store.states["p1"]?.snapshot != old)
+
+    runner.yield(Self.emptySummary)
+    runner.finish()
+    await task.value
+    #expect(store.states["p1"]?.snapshot?.totalItems == 0)
+    #expect(store.states["p1"]?.fetchedAt == Date(timeIntervalSince1970: 200))
+    #expect(store.states["p1"]?.refreshProgress == nil)
+}
+```
+
+Add focused tests with concrete two-event fixtures for:
+
+- `entry_error` immediately populating `refreshFailed` with no PR URL.
+- an excluded `entry` switching generations and advancing progress without adding a row.
+- fast `perf #2` then slow `auth #1` ending in stable `auth`, `perf` order.
+- `stack_error` accumulating before the first completion and appearing when partial state publishes.
+- fatal EOF before summary restoring the old snapshot and preserving its old `fetchedAt`.
+- invalidation after first partial publication restoring the old snapshot, setting `fetchedAt` to `nil`, and ignoring the later summary.
+- a second refresh call returning while `isRefreshing` is true.
+
+- [ ] **Step 3: Run store tests and confirm failures**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GGInboxStoreTests test
+```
+
+Expected: compilation failures for `refreshProgress` and failures from the old atomic reducer.
+
+- [ ] **Step 4: Add progress state and implement the event reducer**
+
+Add the state value:
+
+```swift
+struct GGInboxRefreshProgress: Equatable {
+    let completed: Int
+    let total: Int
+}
+
+struct State: Equatable {
+    var snapshot: GGInboxSnapshot? = nil
+    var fetchedAt: Date? = nil
+    var isRefreshing: Bool = false
+    var refreshProgress: GGInboxRefreshProgress? = nil
+    var lastError: String? = nil
+}
+```
+
+In `refresh`, capture `rollbackSnapshot` and `rollbackFetchedAt`, create empty
+`partialBuckets`/`partialStackErrors`, and drain `service.inboxStream`. Before
+every write, compare the captured invalidation generation. Continue draining
+after invalidation but skip publication.
+
+Use this reduction shape:
+
+```swift
+switch event {
+case .start(let total, _):
+    state.refreshProgress = .init(completed: 0, total: total)
+case .stackError(let error):
+    partialStackErrors.append(error)
+case .entry(let payload):
+    state.refreshProgress = .init(completed: payload.completed, total: payload.totalCandidates)
+    if payload.included, let bucket = payload.bucket {
+        partialBuckets.insert(payload.entry, into: bucket)
+    }
+    publishPartial = true
+case .entryError(let payload):
+    state.refreshProgress = .init(completed: payload.completed, total: payload.totalCandidates)
+    partialBuckets.insert(payload.failedEntry, into: .refreshFailed)
+    publishPartial = true
+case .summary(let snapshot):
+    state.snapshot = snapshot
+    state.fetchedAt = now()
+    state.refreshProgress = nil
+    state.lastError = nil
+    sawSummary = true
+case .error:
+    preconditionFailure("GGService intercepts fatal inbox events")
+}
+
+if publishPartial {
+    state.snapshot = GGInboxSnapshot(
+        totalItems: GGInboxBucket.allCases.reduce(0) { $0 + $1.entries(in: partialBuckets).count },
+        buckets: partialBuckets,
+        stackErrors: partialStackErrors
+    )
+}
+```
+
+On a command-level catch, restore both rollback values, clear progress, and set
+`lastError`. On invalidation, restore `rollbackSnapshot`, force `fetchedAt = nil`,
+clear refresh/progress, and do not publish any later event. On normal summary,
+clear `isRefreshing` only after stream completion.
+
+- [ ] **Step 5: Run store and model tests**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GGInboxStoreTests -only-testing:AlasTests/GGInboxModelsTests test
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Commit progressive store state**
+
+```bash
+rtk git add Alas/Sources/Integrations/GG/GGInboxStore.swift AlasTests/Integrations/GGInboxStoreTests.swift
+rtk git commit -m "feat(gg): publish progressive inbox state"
+```
+
+---
+
+### Task 4: Add the Homebrew upgrade operation and minimum-version helpers
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/GG/GGInstallController.swift:4-58`
+- Modify: `AlasTests/Integrations/GGInstallControllerTests.swift:5-37`
+- Modify: `AlasTests/Integrations/GGInboxHelpersTests.swift:74-110`
+
+**Interfaces:**
+- Consumes: `GGInboxSupport.isSupported(version:)` from Task 1 and `GGAvailability.probe(force:)` through the existing injected reprobe closure.
+- Produces: `GGInstallController.upgrade()` / `upgradeAndWait()` and tested version/progress helpers for Task 5.
+
+- [ ] **Step 1: Write failing controller upgrade tests**
+
+Add an injected `runUpgrade` closure and verify execution, reprobe, errors, and
+the running-phase dedupe:
+
+```swift
+@Test func successfulUpgradeReachesSucceededAndReprobes() async {
+    var upgraded = false
+    var probed = false
+    let controller = GGInstallController(
+        runInstall: { ProcessResult(exitCode: 0, stdout: "", stderr: "") },
+        runUpgrade: {
+            upgraded = true
+            return ProcessResult(exitCode: 0, stdout: "upgraded", stderr: "")
+        },
+        reprobe: {
+            probed = true
+            return true
+        }
+    )
+
+    await controller.upgradeAndWait()
+    #expect(controller.phase == .succeeded)
+    #expect(upgraded)
+    #expect(probed)
+}
+
+@Test func upgradeFailureSurfacesStderrWithoutReprobe() async {
+    var probed = false
+    let controller = GGInstallController(
+        runInstall: { ProcessResult(exitCode: 0, stdout: "", stderr: "") },
+        runUpgrade: { ProcessResult(exitCode: 1, stdout: "", stderr: "formula unavailable") },
+        reprobe: {
+            probed = true
+            return true
+        }
+    )
+
+    await controller.upgradeAndWait()
+    #expect(controller.phase == .failed("formula unavailable"))
+    #expect(!probed)
+}
+```
+
+Retain all install tests unchanged to prove Settings compatibility.
+
+- [ ] **Step 2: Write failing version and presentation-helper tests**
+
+Add:
+
+```swift
+@Test(arguments: ["0.9.12", "0.9.13", "0.10.0", "1.0.0"])
+func supportedInboxVersions(_ version: String) {
+    #expect(GGInboxSupport.isSupported(version: version))
+}
+
+@Test(arguments: [nil, "", "abc", "0.9.11", "0.8.99"] as [String?])
+func unsupportedInboxVersions(_ version: String?) {
+    #expect(!GGInboxSupport.isSupported(version: version))
+}
+
+@Test func refreshProgressLabel() {
+    #expect(GGInboxTabView.refreshLabel(nil) == nil)
+    #expect(GGInboxTabView.refreshLabel(.init(completed: 2, total: 5)) == "Refreshing 2/5")
+}
+
+@Test func validPRURLRequiresHTTPOrHTTPS() {
+    #expect(GGInboxTabView.validPRURL("https://example.test/42") != nil)
+    #expect(GGInboxTabView.validPRURL("") == nil)
+    #expect(GGInboxTabView.validPRURL(nil) == nil)
+    #expect(GGInboxTabView.validPRURL("file:///tmp/secret") == nil)
+}
+```
+
+- [ ] **Step 3: Run focused tests and confirm failures**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GGInstallControllerTests -only-testing:AlasTests/GGInboxHelpersTests test
+```
+
+Expected: compilation failures for the upgrade API and the two view helpers.
+
+- [ ] **Step 4: Implement the upgrade operation without changing install callers**
+
+Add a second injected command with the exact Homebrew invocation:
+
+```swift
+private let runUpgrade: @Sendable () async throws -> ProcessResult
+
+init(
+    runInstall: @escaping @Sendable () async throws -> ProcessResult = {
+        try await Process.run(
+            "/usr/bin/env",
+            args: ["brew", "install", "mrmans0n/tap/gg-stack"],
+            env: Process.gitEnv(),
+            timeout: 600
+        )
+    },
+    runUpgrade: @escaping @Sendable () async throws -> ProcessResult = {
+        try await Process.run(
+            "/usr/bin/env",
+            args: ["brew", "upgrade", "mrmans0n/tap/gg-stack"],
+            env: Process.gitEnv(),
+            timeout: 600
+        )
+    },
+    reprobe: @escaping @MainActor () async -> Bool = {
+        await GGAvailability.shared.probe(force: true)
+        return GGAvailability.shared.isInstalled
+    }
+) {
+    self.runInstall = runInstall
+    self.runUpgrade = runUpgrade
+    self.reprobe = reprobe
+}
+
+func upgrade() {
+    Task { await upgradeAndWait() }
+}
+
+func upgradeAndWait() async {
+    await perform(runUpgrade, missingMessage: "gg is still not on PATH after upgrade.")
+}
+```
+
+Extract the existing phase/exit/stderr/reprobe flow into
+`perform(_:missingMessage:)`. Keep `install()` and `installAndWait()` source
+compatible and pass the existing install-specific missing message.
+
+- [ ] **Step 5: Add the pure view helpers**
+
+In `GGInboxTabView`, add:
+
+```swift
+static func refreshLabel(_ progress: GGInboxRefreshProgress?) -> String? {
+    guard let progress else { return nil }
+    return "Refreshing \(progress.completed)/\(progress.total)"
+}
+
+static func validPRURL(_ rawValue: String?) -> URL? {
+    guard let rawValue, let url = URL(string: rawValue),
+          url.scheme == "https" || url.scheme == "http" else { return nil }
+    return url
+}
+```
+
+- [ ] **Step 6: Run focused tests and commit**
+
+Run the command from Step 3. Expected: all selected tests pass.
+
+```bash
+rtk git add Alas/Sources/Integrations/GG/GGInstallController.swift Alas/Sources/Integrations/GG/GGInboxTabView.swift AlasTests/Integrations/GGInstallControllerTests.swift AlasTests/Integrations/GGInboxHelpersTests.swift
+rtk git commit -m "feat(gg): add inbox upgrade gate support"
+```
+
+---
+
+### Task 5: Render progressive Inbox state and the upgrade-required screen
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/GG/GGInboxTabView.swift:60-310`
+- Modify: `AlasTests/Integrations/GGInboxHelpersTests.swift:74-110`
+- Modify: `AlasTests/Integrations/GGInboxModelsTests.swift:52-63`
+
+**Interfaces:**
+- Consumes: `GGInboxSupport`, `GGInboxStore.State.refreshProgress`, `GGInstallController.upgrade()`, optional `GGInboxEntry.prUrl`, and `.refreshFailed`.
+- Produces: the complete user-facing progressive Inbox behavior.
+
+- [ ] **Step 1: Extend failing presentation metadata assertions**
+
+Make the bucket-order test assert the complete new order and styling:
+
+```swift
+#expect(GGInboxBucket.allCases == [
+    .refreshFailed, .readyToLand, .changesRequested, .blockedOnCi,
+    .awaitingReview, .behindBase, .draft,
+])
+#expect(GGInboxBucket.refreshFailed.title == "Refresh failed")
+#expect(GGInboxBucket.refreshFailed.themeToken == "warn")
+```
+
+Add a pure empty-state helper and test so partial zero-item state cannot claim
+success:
+
+```swift
+@Test func clearInboxRequiresCompletedNonErrorState() {
+    let empty = GGInboxSnapshot(totalItems: 0, buckets: GGInboxBuckets(), stackErrors: [])
+    #expect(GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: false, lastError: nil))
+    #expect(!GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: true, lastError: nil))
+    #expect(!GGInboxTabView.shouldShowClearInbox(snapshot: empty, isRefreshing: false, lastError: "failed"))
+}
+```
+
+- [ ] **Step 2: Run model/helper tests and confirm failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GGInboxModelsTests -only-testing:AlasTests/GGInboxHelpersTests test
+```
+
+Expected: failure until the new bucket metadata and clear-state helper exist.
+
+- [ ] **Step 3: Add the version-gated content state and upgrade controller**
+
+Add observable upgrade state:
+
+```swift
+@State private var ggUpgrade = GGInstallController()
+
+private var supportsStreamingInbox: Bool {
+    GGInboxSupport.isSupported(version: GGAvailability.shared.version)
+}
+```
+
+At the top of `content`, render `upgradeRequiredState` when unsupported. The
+state must show `gg <detected>` when a raw version exists, the exact requirement
+copy `gg Inbox requires gg 0.9.12 or newer.`, the controller's running/error
+phase, and an `AlasButton(title: "Upgrade gg…", style: .normal)` that calls
+`ggUpgrade.upgrade()`.
+
+Observe `ggUpgrade.phase`. When it becomes `.succeeded`, force no second probe
+(the controller already did it); if `supportsStreamingInbox` is true, call
+`refresh()`. If it remains unsupported, leave the upgrade-required state visible
+with the newly probed raw version.
+
+- [ ] **Step 4: Render progress and partial/failure rows**
+
+In the header, when `isRefreshing` is true, show
+`refreshLabel(inboxState.refreshProgress)` beside the spinner. Keep the previous
+updated timestamp hidden during refresh and restore it afterward.
+
+Use the tested helper for empty-state selection:
+
+```swift
+static func shouldShowClearInbox(
+    snapshot: GGInboxSnapshot,
+    isRefreshing: Bool,
+    lastError: String?
+) -> Bool {
+    snapshot.totalItems == 0 && snapshot.stackErrors.isEmpty
+        && !isRefreshing && lastError == nil
+}
+```
+
+In `row`, replace unconditional URL creation with:
+
+```swift
+if let url = Self.validPRURL(entry.prUrl) {
+    Button { NSWorkspace.shared.open(url) } label: { prNumberLabel(entry.prNumber) }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .help("Open PR in browser")
+} else {
+    prNumberLabel(entry.prNumber)
+}
+```
+
+Extract the existing styled number text into the helper used above:
+
+```swift
+private func prNumberLabel(_ number: Int) -> some View {
+    Text("#\(number)")
+        .font(.system(size: 11, weight: .medium, design: .monospaced))
+        .foregroundColor(theme.color("accent"))
+}
+```
+
+For `entry.refreshError`, add a trailing warning-colored, two-line-limited error
+label before the PR number. Preserve the existing row navigation behavior.
+
+- [ ] **Step 5: Prevent unsupported refresh launches**
+
+Make both automatic and manual refresh paths require
+`supportsStreamingInbox`. `refreshIfStale()` returns without changing store
+state when unsupported; `refresh()` keeps the existing project and
+`ggInboxAvailable` guards and adds the version guard.
+
+- [ ] **Step 6: Run all focused Inbox and installer tests**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/GGInboxModelsTests \
+  -only-testing:AlasTests/GGServiceInboxTests \
+  -only-testing:AlasTests/GGInboxStoreTests \
+  -only-testing:AlasTests/GGInboxHelpersTests \
+  -only-testing:AlasTests/GGInstallControllerTests test
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 7: Format, lint, inspect, and commit the UI integration**
+
+Run SwiftFormat in lint mode on the changed source and test files, matching CI's
+formatter configuration. Inspect the diff and tracked file set:
+
+```bash
+rtk swiftformat Alas/Sources/Integrations/GG/GGInboxModels.swift Alas/Sources/Integrations/GG/GGService.swift Alas/Sources/Integrations/GG/GGInboxStore.swift Alas/Sources/Integrations/GG/GGInstallController.swift Alas/Sources/Integrations/GG/GGInboxTabView.swift AlasTests/Integrations/GGInboxModelsTests.swift AlasTests/Integrations/GGServiceInboxTests.swift AlasTests/Integrations/GGInboxStoreTests.swift AlasTests/Integrations/GGInstallControllerTests.swift AlasTests/Integrations/GGInboxHelpersTests.swift --lint
+rtk git diff --check
+rtk git status --short
+rtk git diff -- Alas/Sources/Integrations/GG AlasTests/Integrations
+rtk git ls-files Alas/Sources/Integrations/GG AlasTests/Integrations
+```
+
+Commit only the Task 5 files:
+
+```bash
+rtk git add Alas/Sources/Integrations/GG/GGInboxTabView.swift AlasTests/Integrations/GGInboxHelpersTests.swift AlasTests/Integrations/GGInboxModelsTests.swift
+rtk git commit -m "feat(gg): render progressive inbox refresh"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run XcodeGen even though no source-membership change is expected, and inspect whether it changes the project:
+
+```bash
+rtk xcodegen
+rtk git status --short
+```
+
+If `Alas.xcodeproj/project.pbxproj` changes, verify the change is solely the
+result of the repository generator, commit `project.yml` only if intentionally
+edited, and commit both generator inputs/outputs together. Otherwise leave the
+project file untouched.
+
+- [ ] Run the required build:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0 with no compiler errors.
+
+- [ ] Run the required full test suite:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exit 0 with all tests passing. A stalled run without an `xctest`
+process is incomplete, not passing; capture the last output and report that
+boundary truthfully.
+
+- [ ] Verify final scope and history:
+
+```bash
+rtk git diff origin/main...HEAD --check
+rtk git status --short --branch
+rtk git log --oneline origin/main..HEAD
+rtk git ls-files docs/superpowers/specs/2026-07-31-progressive-gg-inbox-design.md docs/superpowers/plans/2026-07-31-progressive-gg-inbox.md
+```
+
+Expected: clean worktree, only the intended spec/plan and implementation commits,
+and both ignored design artifacts explicitly tracked.

--- a/docs/superpowers/specs/2026-07-31-progressive-gg-inbox-design.md
+++ b/docs/superpowers/specs/2026-07-31-progressive-gg-inbox-design.md
@@ -1,0 +1,271 @@
+# Progressive gg Inbox Design
+
+## Summary
+
+Use the streaming inbox output added in gg 0.9.12 so Alas can show entries as
+their remote refreshes complete instead of waiting for the entire inbox command.
+Alas will require gg 0.9.12 or newer for its Inbox tab, expose an inline Homebrew
+upgrade action for older installations, and treat the final JSONL `summary` as
+the authoritative complete snapshot.
+
+## Problem
+
+Alas currently runs `gg inbox --json` and publishes the decoded snapshot only
+after the process exits. Even though gg 0.9.12 refreshes candidates concurrently
+and can flush each completion through `--jsonl`, Alas does not consume that
+stream. One slow provider request therefore keeps the entire Inbox tab waiting.
+
+The desired behavior is to make completed results useful immediately without
+mixing entries from different refresh generations or weakening the correctness
+of the final inbox.
+
+## Goals
+
+- Render included inbox entries as their JSONL completion events arrive.
+- Show monotonic `Refreshing N/M` progress during a refresh.
+- Keep stale and fresh refresh generations isolated.
+- Reconcile progressive state with gg's final deterministic `summary`.
+- Support gg 0.9.12's `refresh_failed` bucket and per-entry refresh errors.
+- Keep a previously completed snapshot available if a refresh fails fatally.
+- Require gg 0.9.12 or newer and offer a one-click Homebrew upgrade.
+- Preserve the existing project-scoped cache, invalidation, and refresh deduplication behavior.
+
+## Non-goals
+
+- Do not fall back to `gg inbox --json` for older gg versions.
+- Do not change gg itself or its JSONL schema.
+- Do not add persistent inbox caching.
+- Do not add an Inbox `--all` mode or display merged entries.
+- Do not generalize this work into a new application-wide streaming framework.
+- Do not change remote-project support or the existing gg project/worktree gates.
+
+## Version Gate and Upgrade UX
+
+The existing `GGAvailability` probe remains the source of the installed version.
+Alas compares its raw version string with `0.9.12` using the existing
+`SemanticVersion` type. Any parsed version greater than or equal to `0.9.12` is
+supported.
+
+The `gg Inbox` action remains discoverable whenever the project otherwise
+qualifies for Inbox. Opening it with an older or unparseable installed version
+shows an upgrade-required state instead of starting a command. The state shows
+the detected version, states that gg 0.9.12 or newer is required, and provides
+an `Upgrade gg…` action.
+
+The upgrade action extends the existing Homebrew-backed gg install controller
+with an upgrade operation that runs:
+
+```text
+brew upgrade mrmans0n/tap/gg-stack
+```
+
+After a successful command, Alas force-reprobes `GGAvailability`. If the new
+version is supported, the tab automatically starts its Inbox refresh. Command
+or reprobe failures remain visible inline and can be retried. This version gate
+applies only to Inbox; older gg installations can continue using other Alas gg
+features according to their existing capability gates.
+
+## Architecture
+
+The integration has three boundaries: typed event decoding in the model layer,
+process streaming in `GGService`, and generation-scoped reduction in
+`GGInboxStore`. `GGInboxTabView` only renders the resulting observable state.
+
+### Typed Inbox Events
+
+Add a `GGInboxEvent` model for the exact gg 0.9.12 event set:
+
+- `start(totalCandidates, totalStackErrors)`
+- `stackError(GGInboxStackError)`
+- `entry(completed, totalCandidates, included, bucket, remoteState, entry)`
+- `entryError(completed, totalCandidates, included, bucket, candidate, error)`
+- `summary(GGInboxSnapshot)`
+- `error(message)`
+
+Every decoded line must have schema `version: 1` and `command: "inbox"`.
+Unknown events, malformed event payloads, unsupported schema versions, or a
+wrong command envelope are malformed output rather than ignorable progress.
+This prevents a newer or damaged stream from being presented as a complete
+inbox.
+
+`GGInboxSnapshot` gains a `refreshFailed` bucket. `GGInboxEntry` gains an
+optional `refreshError`, and its PR URL is represented as optional at the Alas
+model boundary so an `entry_error` candidate can be presented before the final
+summary. Empty URLs in summary entries normalize to `nil`.
+
+### Streaming Service
+
+`GGService.inboxStream(repoPath:)` launches:
+
+```text
+gg inbox --jsonl
+```
+
+at the project repository path through the existing true incremental
+`GGCommandRunning.runStreaming` implementation. It decodes and yields one typed
+event per flushed line.
+
+The service validates stream-level completion in addition to individual lines:
+
+- `start` must be the first event for a non-fatal run. A fatal `error` may be
+  the sole event when the command fails before discovery.
+- At most one `summary` may occur.
+- A successful stream must contain a final `summary`.
+- No data events may follow `summary`.
+- An explicit `error` event is terminal and fatal; no later event is accepted.
+  The process stream is still drained to termination before the refresh
+  completes.
+- A nonzero exit, malformed line, or clean exit without `summary` fails the
+  stream.
+
+The store does not need to understand process exit codes or raw JSONL.
+
+### Generation-scoped Store Reduction
+
+`GGInboxStore.refresh` continues to deduplicate concurrent refresh requests and
+uses the existing invalidation generation as its publication guard. At refresh
+start it captures the current completed snapshot as the rollback snapshot and
+initializes a separate empty progressive generation. The existing snapshot
+stays visible while gg performs local discovery.
+
+Events reduce as follows:
+
+1. `start` records `totalCandidates` and resets completed progress to zero.
+2. `stackError` appends a discovery error to the progressive generation.
+3. Every `entry` records gg's `completed` value. Included entries with a bucket
+   are inserted into that progressive bucket. Excluded merged or closed entries
+   advance progress but are not displayed.
+4. `entryError` records progress and inserts an immediately visible entry into
+   the `refreshFailed` bucket with its error text.
+5. The first candidate completion (`entry` or `entryError`, including an
+   excluded entry) switches the visible snapshot from the old generation to the
+   new progressive generation. The two generations are never merged.
+6. `summary` atomically replaces all progressive content with gg's authoritative
+   snapshot, sets `fetchedAt`, clears refresh state and errors, and discards the
+   rollback snapshot.
+
+Partial bucket contents use stable stack-name and position ordering rather than
+network completion order. gg's final summary supplies the authoritative bucket
+and entry order.
+
+If there are no candidate completions, the existing snapshot remains visible
+until `summary` arrives. This covers an empty inbox and discovery-only stack
+errors without a needless blank transition.
+
+If an invalidation occurs during the stream, the old generation is prevented
+from publishing any further partial or final state, matching the store's current
+stale-completion protection.
+
+## Presentation
+
+During a supported refresh, the header keeps the existing spinner and adds
+`Refreshing N/M` after the `start` event. Before `start`, it shows the spinner
+without a count. The normal updated timestamp returns only after the final
+summary succeeds.
+
+The bucket order becomes:
+
+1. Refresh failed
+2. Ready to land
+3. Changes requested
+4. Blocked on CI
+5. Awaiting review
+6. Behind base
+7. Draft
+
+Progressive entries appear in these existing grouped sections as they arrive.
+A refresh-failed row shows its stack, position, title, PR number, and concise
+error text. The PR number is a browser action only when a valid URL is
+available; otherwise it is non-interactive text.
+
+The final summary remains the only state that updates `fetchedAt` or supports an
+"Inbox is clear" claim. Partial state with zero currently included entries does
+not show the clear-inbox empty state while refresh is active.
+
+## Failure Semantics
+
+Per-stack discovery errors and per-entry provider refresh errors are in-band
+partial results. They do not fail the overall refresh:
+
+- `stack_error` values appear in the existing Stack Errors section.
+- `entry_error` values appear in Refresh failed.
+- The final `summary` reconciles both collections.
+
+A malformed event, unsupported schema, explicit fatal error event, nonzero
+process exit, or missing final summary is a command-level failure. On such a
+failure the store restores the last completed snapshot, if one existed, clears
+progress, and shows the existing error banner. If no completed snapshot existed,
+the content area remains empty beneath the error rather than claiming the inbox
+is clear.
+
+## Component Changes
+
+- `GGInboxModels.swift`: event envelopes, event decoding, `refreshFailed`,
+  optional URL, and refresh-error modeling.
+- `GGService.swift`: `inboxStream(repoPath:)`, stream protocol validation, and
+  removal of the Inbox dependency on atomic `--json`.
+- `GGInboxStore.swift`: progressive generation state, progress, reduction,
+  rollback, final reconciliation, and invalidation guards.
+- `GGInboxTabView.swift`: minimum-version state, progressive header, Refresh
+  failed presentation, optional PR link, and upgrade action.
+- `GGInstallController.swift`: explicit Homebrew upgrade operation plus forced
+  reprobe.
+- Focused tests for each boundary above.
+
+No project membership changes are expected unless implementation places the
+event model in a new source file. If it does, `xcodegen` must regenerate and
+commit the project file as required by the repository.
+
+## Testing
+
+### Event and Service Tests
+
+- Decode every gg 0.9.12 Inbox JSONL event shape.
+- Reject wrong versions, wrong commands, unknown events, and malformed payloads.
+- Verify `gg inbox --jsonl` arguments and the project-root working directory.
+- Prove lines are yielded before process completion with the incremental runner.
+- Reject missing or duplicate `start`/`summary`, events after summary, explicit
+  fatal errors, nonzero exits, malformed lines, and clean EOF without summary.
+
+### Store Tests
+
+- Retain the old snapshot through discovery and switch on the first candidate
+  completion.
+- Never mix stale and fresh generations.
+- Insert successful and failed entries into the reported buckets immediately.
+- Advance progress for included and excluded entries.
+- Keep partial entries stably ordered despite out-of-order completions.
+- Reconcile partial state with the final summary and timestamp only then.
+- Restore the completed snapshot after fatal failure.
+- Preserve invalidation-during-refresh and refresh-deduplication behavior.
+
+### Version, Upgrade, and Presentation Tests
+
+- Accept 0.9.12, later patch versions, 0.10.0, and later major versions.
+- Reject 0.9.11, older versions, and unparseable versions for Inbox only.
+- Keep the Inbox action discoverable while showing the upgrade-required state.
+- Verify upgrade command success, failure, forced reprobe, retry, and automatic
+  refresh after reaching a supported version.
+- Verify progress-label formatting, Refresh failed bucket metadata, optional PR
+  link behavior, and suppression of the clear-inbox state during partial refresh.
+
+### Verification
+
+Run focused Swift Testing cases while implementing. Before finishing the change,
+run the repository-required verification:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Also run SwiftFormat lint on the changed Swift files before publication.
+
+## Rollout and Compatibility
+
+The feature intentionally raises only the Alas Inbox minimum to gg 0.9.12.
+There is no migration or persisted-state change. Existing complete snapshots
+remain usable as rollback state within the running app, but every new Inbox
+refresh uses JSONL. Other gg integrations retain their existing availability
+and capability behavior.


### PR DESCRIPTION
## Summary
- stream gg inbox JSONL results into Inbox as each stack completes
- require gg 0.9.12+ and offer an in-app upgrade path
- preserve cached results during refresh and surface actionable refresh errors

## Testing
- xcodegen
- xcodebuild build
- focused Inbox and installer tests
- full suite: 6,710 passed; one existing flaky DiffReviewSurface accessibility test failed twice, and its isolated rerun passed