### PR TITLE
fix(editor): keep autocomplete visible

### DIFF
--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -347,6 +347,20 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
     }
 
+    override func deleteBackward(_ sender: Any?) {
+        let wasSuppressing = suppressCompletionSelectionNotifications
+        suppressCompletionSelectionNotifications = true
+        super.deleteBackward(sender)
+        suppressCompletionSelectionNotifications = wasSuppressing
+    }
+
+    override func deleteForward(_ sender: Any?) {
+        let wasSuppressing = suppressCompletionSelectionNotifications
+        suppressCompletionSelectionNotifications = true
+        super.deleteForward(sender)
+        suppressCompletionSelectionNotifications = wasSuppressing
+    }
+
     override func insertNewline(_ sender: Any?) {
         guard isEditable else {
             super.insertNewline(sender)

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -29,7 +29,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var flagsChangedHandler: ((NSEvent) -> Void)?
     var mouseExitedHandler: (() -> Void)?
     var completionManualTriggerHandler: (() -> Void)?
-    var completionChangeHandler: (() -> Void)?
+    var completionChangeHandler: ((NSRange?) -> Void)?
     var completionSelectionChangeHandler: (() -> Void)?
     var escapeHandler: (() -> Bool)?
     var completionKeyHandler: ((CompletionKeyAction) -> Bool)?
@@ -47,6 +47,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     private var possibleColumnSelectionDrag: ColumnSelectionDrag?
     private var suppressCompletionChangeNotifications = false
     private var suppressCompletionSelectionNotifications = false
+    private var pendingCompletionEditRange: NSRange?
     private var isApplyingSelectionChange = false
 
     private struct ColumnSelectionDrag {
@@ -276,6 +277,12 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     override func didChangeText() {
         super.didChangeText()
         notifyCompletionChanged()
+    }
+
+    override func shouldChangeText(in affectedCharRange: NSRange, replacementString: String?) -> Bool {
+        let shouldChange = super.shouldChangeText(in: affectedCharRange, replacementString: replacementString)
+        if shouldChange { pendingCompletionEditRange = affectedCharRange }
+        return shouldChange
     }
 
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
@@ -839,8 +846,10 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     // MARK: - Private helpers
 
     private func notifyCompletionChanged() {
+        let editRange = pendingCompletionEditRange
+        pendingCompletionEditRange = nil
         guard !suppressCompletionChangeNotifications else { return }
-        completionChangeHandler?()
+        completionChangeHandler?(editRange)
     }
 
     private func notifyCompletionSelectionChanged() {

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -102,13 +102,21 @@ enum CompletionEngine {
     }
 
     static func bufferWordCandidates(in text: String, prefix: CompletionPrefix, limit: Int = 24) -> [CompletionCandidate] {
-        bufferWordCandidates(from: bufferWords(in: text), prefix: prefix, limit: limit)
+        bufferWordCandidateCache(in: text, prefix: prefix, limit: limit)[prefix.text] ?? []
     }
 
-    static func bufferWords(in text: String) -> [String] {
+    static func bufferWordCandidateCache(
+        in text: String,
+        prefix: CompletionPrefix,
+        limit: Int = 24
+    ) -> [String: [CompletionCandidate]] {
+        let prefixText = prefix.text as NSString
+        guard prefixText.length >= 3, limit > 0 else { return [:] }
+
+        let prefixes = (3...prefixText.length).map { prefixText.substring(to: $0) }
         let ns = text as NSString
-        var seen = Set<String>()
-        var words: [String] = []
+        var seen = Dictionary(uniqueKeysWithValues: prefixes.map { ($0, Set<String>()) })
+        var words = Dictionary(uniqueKeysWithValues: prefixes.map { ($0, [String]()) })
         var index = 0
 
         while index < ns.length {
@@ -123,36 +131,29 @@ enum CompletionEngine {
             }
 
             let word = ns.substring(with: NSRange(location: start, length: index - start))
-            if seen.insert(word).inserted {
-                words.append(word)
+            for prefix in prefixes where words[prefix, default: []].count < limit {
+                guard word != prefix,
+                      hasCaseInsensitivePrefix(word, prefix),
+                      seen[prefix, default: []].insert(word).inserted else { continue }
+                words[prefix, default: []].append(word)
             }
         }
-        return words
-    }
 
-    static func bufferWordCandidates(
-        from words: [String],
-        prefix: CompletionPrefix,
-        limit: Int = 24
-    ) -> [CompletionCandidate] {
-        guard (prefix.text as NSString).length >= 3, limit > 0 else { return [] }
-
-        return words.lazy
-            .filter { $0 != prefix.text && hasCaseInsensitivePrefix($0, prefix.text) }
-            .prefix(limit)
-            .map { word in
-            CompletionCandidate(
-                label: word,
-                detail: "Current buffer",
-                kind: nil,
-                documentation: nil,
-                sortText: nil,
-                filterText: word,
-                replacementText: word,
-                textEdit: nil,
-                additionalTextEdits: [],
-                source: .buffer
-            )
+        return words.mapValues { words in
+            words.map { word in
+                CompletionCandidate(
+                    label: word,
+                    detail: "Current buffer",
+                    kind: nil,
+                    documentation: nil,
+                    sortText: nil,
+                    filterText: word,
+                    replacementText: word,
+                    textEdit: nil,
+                    additionalTextEdits: [],
+                    source: .buffer
+                )
+            }
         }
     }
 

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -102,8 +102,10 @@ enum CompletionEngine {
     }
 
     static func bufferWordCandidates(in text: String, prefix: CompletionPrefix, limit: Int = 24) -> [CompletionCandidate] {
-        guard (prefix.text as NSString).length >= 3, limit > 0 else { return [] }
+        bufferWordCandidates(from: bufferWords(in: text), prefix: prefix, limit: limit)
+    }
 
+    static func bufferWords(in text: String) -> [String] {
         let ns = text as NSString
         var seen = Set<String>()
         var words: [String] = []
@@ -121,14 +123,24 @@ enum CompletionEngine {
             }
 
             let word = ns.substring(with: NSRange(location: start, length: index - start))
-            if word != prefix.text,
-               hasCaseInsensitivePrefix(word, prefix.text),
-               seen.insert(word).inserted {
+            if seen.insert(word).inserted {
                 words.append(word)
             }
         }
+        return words
+    }
 
-        return words.prefix(limit).map { word in
+    static func bufferWordCandidates(
+        from words: [String],
+        prefix: CompletionPrefix,
+        limit: Int = 24
+    ) -> [CompletionCandidate] {
+        guard (prefix.text as NSString).length >= 3, limit > 0 else { return [] }
+
+        return words.lazy
+            .filter { $0 != prefix.text && hasCaseInsensitivePrefix($0, prefix.text) }
+            .prefix(limit)
+            .map { word in
             CompletionCandidate(
                 label: word,
                 detail: "Current buffer",

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -178,6 +178,7 @@ enum CompletionEngine {
                 for: textEdit.range,
                 originalPrefix: originalPrefix,
                 prefix: prefix,
+                includeInsertedTextAtEnd: true,
                 in: text
             ) else { return nil }
             if shouldReplacePrefix(range: range, replacement: candidate.replacementText, prefix: prefix) {
@@ -197,6 +198,7 @@ enum CompletionEngine {
                 for: additional.range,
                 originalPrefix: originalPrefix,
                 prefix: prefix,
+                includeInsertedTextAtEnd: false,
                 in: text
             ) else { continue }
             let edit = CompletionTextEdit(range: range, replacementText: additional.newText)
@@ -315,6 +317,7 @@ enum CompletionEngine {
         for range: LSPRange,
         originalPrefix: CompletionPrefix?,
         prefix: CompletionPrefix,
+        includeInsertedTextAtEnd: Bool,
         in text: String
     ) -> NSRange? {
         guard let originalPrefix,
@@ -332,14 +335,17 @@ enum CompletionEngine {
         }
         let oldCaretCharacter = prefixStart.character + originalPrefix.range.length
 
-        func shifted(_ position: LSPPosition) -> LSPPosition {
+        func shifted(_ position: LSPPosition, atEnd: Bool) -> LSPPosition {
             guard position.line == prefixStart.line,
-                  position.character >= oldCaretCharacter else { return position }
+                  position.character > oldCaretCharacter ||
+                  (!atEnd || includeInsertedTextAtEnd) && position.character == oldCaretCharacter else {
+                return position
+            }
             return LSPPosition(line: position.line, character: position.character + growth)
         }
 
         return nsRange(
-            for: LSPRange(start: shifted(range.start), end: shifted(range.end)),
+            for: LSPRange(start: shifted(range.start, atEnd: false), end: shifted(range.end, atEnd: true)),
             in: text
         )
     }

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -119,9 +119,10 @@ enum CompletionEngine {
         let ns = text as NSString
         var seen = Dictionary(uniqueKeysWithValues: prefixes.map { ($0, Set<String>()) })
         var words = Dictionary(uniqueKeysWithValues: prefixes.map { ($0, [String]()) })
+        var incompletePrefixCount = prefixes.count
         var index = 0
 
-        while index < ns.length {
+        while index < ns.length, incompletePrefixCount > 0 {
             guard isIdentifierChar(ns.character(at: index)) else {
                 index += 1
                 continue
@@ -133,11 +134,18 @@ enum CompletionEngine {
             }
 
             let word = ns.substring(with: NSRange(location: start, length: index - start))
-            for prefix in prefixes where words[prefix, default: []].count < limit {
-                guard word != prefix,
-                      hasCaseInsensitivePrefix(word, prefix),
+            let wordText = word as NSString
+            let commonLength = caseInsensitiveCommonPrefixLength(wordText, prefixText)
+            guard commonLength >= bufferWordMinimumPrefixLength else { continue }
+            for length in bufferWordMinimumPrefixLength...commonLength {
+                let prefix = prefixes[length - bufferWordMinimumPrefixLength]
+                guard words[prefix, default: []].count < limit,
+                      wordText.length != length,
                       seen[prefix, default: []].insert(word).inserted else { continue }
                 words[prefix, default: []].append(word)
+                if words[prefix]?.count == limit {
+                    incompletePrefixCount -= 1
+                }
             }
         }
 
@@ -395,6 +403,20 @@ enum CompletionEngine {
 
     static func hasCaseInsensitivePrefix(_ text: String, _ prefix: String) -> Bool {
         prefix.isEmpty || text.range(of: prefix, options: [.caseInsensitive, .anchored]) != nil
+    }
+
+    private static func caseInsensitiveCommonPrefixLength(_ lhs: NSString, _ rhs: NSString) -> Int {
+        let maximum = min(lhs.length, rhs.length)
+        var length = 0
+        while length < maximum {
+            let lhsCharacter = lhs.character(at: length)
+            let rhsCharacter = rhs.character(at: length)
+            let foldedLHS = lhsCharacter >= 0x41 && lhsCharacter <= 0x5A ? lhsCharacter + 0x20 : lhsCharacter
+            let foldedRHS = rhsCharacter >= 0x41 && rhsCharacter <= 0x5A ? rhsCharacter + 0x20 : rhsCharacter
+            guard foldedLHS == foldedRHS else { break }
+            length += 1
+        }
+        return length
     }
 
     private static func isIdentifierChar(_ character: unichar) -> Bool {

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -170,7 +170,7 @@ enum CompletionEngine {
         let primaryRange: NSRange
         if let textEdit = candidate.textEdit {
             guard let range = nsRange(for: textEdit.range, in: text) else { return nil }
-            if shouldReplacePrefixForCaretInsertion(range: range, replacement: candidate.replacementText, prefix: prefix) {
+            if shouldReplacePrefix(range: range, replacement: candidate.replacementText, prefix: prefix) {
                 primaryRange = prefix.range
             } else {
                 primaryRange = range
@@ -296,15 +296,16 @@ enum CompletionEngine {
         return NSIntersectionRange(lhs, rhs).length > 0
     }
 
-    private static func shouldReplacePrefixForCaretInsertion(
+    private static func shouldReplacePrefix(
         range: NSRange,
         replacement: String,
         prefix: CompletionPrefix
     ) -> Bool {
-        !prefix.text.isEmpty &&
-            range.length == 0 &&
-            range.location == NSMaxRange(prefix.range) &&
-            hasCaseInsensitivePrefix(replacement, prefix.text)
+        guard !prefix.text.isEmpty,
+              hasCaseInsensitivePrefix(replacement, prefix.text) else { return false }
+
+        return (range.length == 0 && range.location == NSMaxRange(prefix.range)) ||
+            (range.location == prefix.range.location && NSMaxRange(range) < NSMaxRange(prefix.range))
     }
 
     static func hasCaseInsensitivePrefix(_ text: String, _ prefix: String) -> Bool {

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -49,6 +49,8 @@ struct CompletionEditPlan: Hashable, Sendable {
 }
 
 enum CompletionEngine {
+    static let bufferWordMinimumPrefixLength = 3
+
     static func prefix(in text: String, caret: Int) -> CompletionPrefix? {
         let ns = text as NSString
         guard caret >= 0, caret <= ns.length else { return nil }
@@ -111,9 +113,9 @@ enum CompletionEngine {
         limit: Int = 24
     ) -> [String: [CompletionCandidate]] {
         let prefixText = prefix.text as NSString
-        guard prefixText.length >= 3, limit > 0 else { return [:] }
+        guard prefixText.length >= bufferWordMinimumPrefixLength, limit > 0 else { return [:] }
 
-        let prefixes = (3...prefixText.length).map { prefixText.substring(to: $0) }
+        let prefixes = (bufferWordMinimumPrefixLength...prefixText.length).map { prefixText.substring(to: $0) }
         let ns = text as NSString
         var seen = Dictionary(uniqueKeysWithValues: prefixes.map { ($0, Set<String>()) })
         var words = Dictionary(uniqueKeysWithValues: prefixes.map { ($0, [String]()) })

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -334,12 +334,18 @@ enum CompletionEngine {
             return nsRange(for: range, in: text)
         }
         let oldCaretCharacter = prefixStart.character + originalPrefix.range.length
+        let newCaretCharacter = oldCaretCharacter + growth
         let isInsertion = range.start.line == range.end.line &&
             range.start.character == range.end.character
 
         func shifted(_ position: LSPPosition, atEnd: Bool) -> LSPPosition {
-            guard position.line == prefixStart.line,
-                  position.character > oldCaretCharacter ||
+            guard position.line == prefixStart.line else { return position }
+            if growth < 0,
+               position.character > newCaretCharacter,
+               position.character < oldCaretCharacter {
+                return LSPPosition(line: position.line, character: newCaretCharacter)
+            }
+            guard position.character > oldCaretCharacter ||
                   (!atEnd || includeInsertedTextAtEnd || isInsertion || growth < 0) &&
                   position.character == oldCaretCharacter else {
                 return position

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -350,7 +350,7 @@ enum CompletionEngine {
             }
             let shiftsAtCaret = growth < 0 || (atEnd
                 ? includeInsertedTextAtEnd || isInsertion
-                : !includeInsertedTextAtStart)
+                : !includeInsertedTextAtStart || isInsertion)
             guard position.character > oldCaretCharacter ||
                   shiftsAtCaret && position.character == oldCaretCharacter else {
                 return position

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -334,11 +334,13 @@ enum CompletionEngine {
             return nsRange(for: range, in: text)
         }
         let oldCaretCharacter = prefixStart.character + originalPrefix.range.length
+        let isInsertion = range.start.line == range.end.line &&
+            range.start.character == range.end.character
 
         func shifted(_ position: LSPPosition, atEnd: Bool) -> LSPPosition {
             guard position.line == prefixStart.line,
                   position.character > oldCaretCharacter ||
-                  (!atEnd || includeInsertedTextAtEnd || growth < 0) &&
+                  (!atEnd || includeInsertedTextAtEnd || isInsertion || growth < 0) &&
                   position.character == oldCaretCharacter else {
                 return position
             }

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -338,7 +338,8 @@ enum CompletionEngine {
         func shifted(_ position: LSPPosition, atEnd: Bool) -> LSPPosition {
             guard position.line == prefixStart.line,
                   position.character > oldCaretCharacter ||
-                  (!atEnd || includeInsertedTextAtEnd) && position.character == oldCaretCharacter else {
+                  (!atEnd || includeInsertedTextAtEnd || growth < 0) &&
+                  position.character == oldCaretCharacter else {
                 return position
             }
             return LSPPosition(line: position.line, character: position.character + growth)

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -178,6 +178,7 @@ enum CompletionEngine {
                 for: textEdit.range,
                 originalPrefix: originalPrefix,
                 prefix: prefix,
+                includeInsertedTextAtStart: true,
                 includeInsertedTextAtEnd: true,
                 in: text
             ) else { return nil }
@@ -198,6 +199,7 @@ enum CompletionEngine {
                 for: additional.range,
                 originalPrefix: originalPrefix,
                 prefix: prefix,
+                includeInsertedTextAtStart: false,
                 includeInsertedTextAtEnd: false,
                 in: text
             ) else { continue }
@@ -317,6 +319,7 @@ enum CompletionEngine {
         for range: LSPRange,
         originalPrefix: CompletionPrefix?,
         prefix: CompletionPrefix,
+        includeInsertedTextAtStart: Bool,
         includeInsertedTextAtEnd: Bool,
         in text: String
     ) -> NSRange? {
@@ -345,9 +348,11 @@ enum CompletionEngine {
                position.character < oldCaretCharacter {
                 return LSPPosition(line: position.line, character: newCaretCharacter)
             }
+            let shiftsAtCaret = growth < 0 || (atEnd
+                ? includeInsertedTextAtEnd || isInsertion
+                : !includeInsertedTextAtStart)
             guard position.character > oldCaretCharacter ||
-                  (!atEnd || includeInsertedTextAtEnd || isInsertion || growth < 0) &&
-                  position.character == oldCaretCharacter else {
+                  shiftsAtCaret && position.character == oldCaretCharacter else {
                 return position
             }
             return LSPPosition(line: position.line, character: position.character + growth)

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -5,7 +5,7 @@ struct CompletionPrefix: Equatable, Sendable {
     let range: NSRange
 }
 
-enum CompletionCandidateSource: Equatable, Sendable {
+enum CompletionCandidateSource: Hashable, Sendable {
     case lsp
     case buffer
 }
@@ -37,12 +37,12 @@ struct CompletionCandidate: Identifiable, Equatable, Sendable {
     }
 }
 
-struct CompletionTextEdit: Equatable, Sendable {
+struct CompletionTextEdit: Hashable, Sendable {
     let range: NSRange
     let replacementText: String
 }
 
-struct CompletionEditPlan: Equatable, Sendable {
+struct CompletionEditPlan: Hashable, Sendable {
     /// Original-buffer ranges sorted ascending; consumers must apply edits in reverse order.
     let edits: [CompletionTextEdit]
     let finalSelection: NSRange

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -170,8 +170,10 @@ enum CompletionEngine {
         accepting candidate: CompletionCandidate,
         prefix: CompletionPrefix,
         originalPrefix: CompletionPrefix? = nil,
-        in text: String
+        in text: String,
+        coordinateIndex: TextEditCoordinates.LineIndex? = nil
     ) -> CompletionEditPlan? {
+        let coordinateIndex = coordinateIndex ?? TextEditCoordinates.LineIndex(text)
         let primaryRange: NSRange
         if let textEdit = candidate.textEdit {
             guard let range = rebasedRange(
@@ -180,7 +182,7 @@ enum CompletionEngine {
                 prefix: prefix,
                 includeInsertedTextAtStart: true,
                 includeInsertedTextAtEnd: true,
-                in: text
+                coordinateIndex: coordinateIndex
             ) else { return nil }
             if shouldReplacePrefix(range: range, replacement: candidate.replacementText, prefix: prefix) {
                 primaryRange = prefix.range
@@ -201,7 +203,7 @@ enum CompletionEngine {
                 prefix: prefix,
                 includeInsertedTextAtStart: false,
                 includeInsertedTextAtEnd: false,
-                in: text
+                coordinateIndex: coordinateIndex
             ) else { continue }
             let edit = CompletionTextEdit(range: range, replacementText: additional.newText)
             guard !overlaps(edit.range, primary.range),
@@ -293,9 +295,12 @@ enum CompletionEngine {
         }
     }
 
-    private static func nsRange(for range: LSPRange, in text: String) -> NSRange? {
-        guard let start = TextEditCoordinates.utf16Offset(from: range.start, in: text),
-              let end = TextEditCoordinates.utf16Offset(from: range.end, in: text),
+    private static func nsRange(
+        for range: LSPRange,
+        coordinateIndex: TextEditCoordinates.LineIndex
+    ) -> NSRange? {
+        guard let start = coordinateIndex.utf16Offset(from: range.start),
+              let end = coordinateIndex.utf16Offset(from: range.end),
               start <= end else {
             return nil
         }
@@ -321,20 +326,17 @@ enum CompletionEngine {
         prefix: CompletionPrefix,
         includeInsertedTextAtStart: Bool,
         includeInsertedTextAtEnd: Bool,
-        in text: String
+        coordinateIndex: TextEditCoordinates.LineIndex
     ) -> NSRange? {
         guard let originalPrefix,
               originalPrefix.range.location == prefix.range.location else {
-            return nsRange(for: range, in: text)
+            return nsRange(for: range, coordinateIndex: coordinateIndex)
         }
 
         let growth = NSMaxRange(prefix.range) - NSMaxRange(originalPrefix.range)
         guard growth != 0,
-              let prefixStart = TextEditCoordinates.lspPosition(
-                utf16Offset: prefix.range.location,
-                in: text
-              ) else {
-            return nsRange(for: range, in: text)
+              let prefixStart = coordinateIndex.lspPosition(utf16Offset: prefix.range.location) else {
+            return nsRange(for: range, coordinateIndex: coordinateIndex)
         }
         let oldCaretCharacter = prefixStart.character + originalPrefix.range.length
         let newCaretCharacter = oldCaretCharacter + growth
@@ -360,7 +362,7 @@ enum CompletionEngine {
 
         return nsRange(
             for: LSPRange(start: shifted(range.start, atEnd: false), end: shifted(range.end, atEnd: true)),
-            in: text
+            coordinateIndex: coordinateIndex
         )
     }
 

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -166,10 +166,20 @@ enum CompletionEngine {
             }
     }
 
-    static func editPlan(accepting candidate: CompletionCandidate, prefix: CompletionPrefix, in text: String) -> CompletionEditPlan? {
+    static func editPlan(
+        accepting candidate: CompletionCandidate,
+        prefix: CompletionPrefix,
+        originalPrefix: CompletionPrefix? = nil,
+        in text: String
+    ) -> CompletionEditPlan? {
         let primaryRange: NSRange
         if let textEdit = candidate.textEdit {
-            guard let range = nsRange(for: textEdit.range, in: text) else { return nil }
+            guard let range = rebasedRange(
+                for: textEdit.range,
+                originalPrefix: originalPrefix,
+                prefix: prefix,
+                in: text
+            ) else { return nil }
             if shouldReplacePrefix(range: range, replacement: candidate.replacementText, prefix: prefix) {
                 primaryRange = prefix.range
             } else {
@@ -183,7 +193,12 @@ enum CompletionEngine {
         var edits: [CompletionTextEdit] = []
 
         for additional in candidate.additionalTextEdits {
-            guard let range = nsRange(for: additional.range, in: text) else { continue }
+            guard let range = rebasedRange(
+                for: additional.range,
+                originalPrefix: originalPrefix,
+                prefix: prefix,
+                in: text
+            ) else { continue }
             let edit = CompletionTextEdit(range: range, replacementText: additional.newText)
             guard !overlaps(edit.range, primary.range),
                   edits.allSatisfy({ !overlaps($0.range, edit.range) }) else {
@@ -294,6 +309,38 @@ enum CompletionEngine {
             return lhs.location <= rhs.location && rhs.location < NSMaxRange(lhs)
         }
         return NSIntersectionRange(lhs, rhs).length > 0
+    }
+
+    private static func rebasedRange(
+        for range: LSPRange,
+        originalPrefix: CompletionPrefix?,
+        prefix: CompletionPrefix,
+        in text: String
+    ) -> NSRange? {
+        guard let originalPrefix,
+              originalPrefix.range.location == prefix.range.location else {
+            return nsRange(for: range, in: text)
+        }
+
+        let growth = NSMaxRange(prefix.range) - NSMaxRange(originalPrefix.range)
+        guard growth > 0,
+              let oldCaret = TextEditCoordinates.lspPosition(
+                utf16Offset: NSMaxRange(originalPrefix.range),
+                in: text
+              ) else {
+            return nsRange(for: range, in: text)
+        }
+
+        func shifted(_ position: LSPPosition) -> LSPPosition {
+            guard position.line == oldCaret.line,
+                  position.character >= oldCaret.character else { return position }
+            return LSPPosition(line: position.line, character: position.character + growth)
+        }
+
+        return nsRange(
+            for: LSPRange(start: shifted(range.start), end: shifted(range.end)),
+            in: text
+        )
     }
 
     private static func shouldReplacePrefix(

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -307,7 +307,7 @@ enum CompletionEngine {
             hasCaseInsensitivePrefix(replacement, prefix.text)
     }
 
-    private static func hasCaseInsensitivePrefix(_ text: String, _ prefix: String) -> Bool {
+    static func hasCaseInsensitivePrefix(_ text: String, _ prefix: String) -> Bool {
         prefix.isEmpty || text.range(of: prefix, options: [.caseInsensitive, .anchored]) != nil
     }
 

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -323,17 +323,18 @@ enum CompletionEngine {
         }
 
         let growth = NSMaxRange(prefix.range) - NSMaxRange(originalPrefix.range)
-        guard growth > 0,
-              let oldCaret = TextEditCoordinates.lspPosition(
-                utf16Offset: NSMaxRange(originalPrefix.range),
+        guard growth != 0,
+              let prefixStart = TextEditCoordinates.lspPosition(
+                utf16Offset: prefix.range.location,
                 in: text
               ) else {
             return nsRange(for: range, in: text)
         }
+        let oldCaretCharacter = prefixStart.character + originalPrefix.range.length
 
         func shifted(_ position: LSPPosition) -> LSPPosition {
-            guard position.line == oldCaret.line,
-                  position.character >= oldCaret.character else { return position }
+            guard position.line == prefixStart.line,
+                  position.character >= oldCaretCharacter else { return position }
             return LSPPosition(line: position.line, character: position.character + growth)
         }
 

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -134,13 +134,10 @@ enum CompletionEngine {
             }
 
             let word = ns.substring(with: NSRange(location: start, length: index - start))
-            let wordText = word as NSString
-            let commonLength = caseInsensitiveCommonPrefixLength(wordText, prefixText)
-            guard commonLength >= bufferWordMinimumPrefixLength else { continue }
-            for length in bufferWordMinimumPrefixLength...commonLength {
-                let prefix = prefixes[length - bufferWordMinimumPrefixLength]
+            guard let lastMatchingPrefix = lastMatchingPrefixIndex(for: word, prefixes: prefixes) else { continue }
+            for prefix in prefixes[...lastMatchingPrefix] {
                 guard words[prefix, default: []].count < limit,
-                      wordText.length != length,
+                      word != prefix,
                       seen[prefix, default: []].insert(word).inserted else { continue }
                 words[prefix, default: []].append(word)
                 if words[prefix]?.count == limit {
@@ -405,24 +402,28 @@ enum CompletionEngine {
         prefix.isEmpty || text.range(of: prefix, options: [.caseInsensitive, .anchored]) != nil
     }
 
-    private static func caseInsensitiveCommonPrefixLength(_ lhs: NSString, _ rhs: NSString) -> Int {
-        let maximum = min(lhs.length, rhs.length)
-        var length = 0
-        while length < maximum {
-            let lhsCharacter = lhs.character(at: length)
-            let rhsCharacter = rhs.character(at: length)
-            let foldedLHS = lhsCharacter >= 0x41 && lhsCharacter <= 0x5A ? lhsCharacter + 0x20 : lhsCharacter
-            let foldedRHS = rhsCharacter >= 0x41 && rhsCharacter <= 0x5A ? rhsCharacter + 0x20 : rhsCharacter
-            guard foldedLHS == foldedRHS else { break }
-            length += 1
+    private static func lastMatchingPrefixIndex(for word: String, prefixes: [String]) -> Int? {
+        var lowerBound = 0
+        var upperBound = prefixes.count
+        while lowerBound < upperBound {
+            let middle = (lowerBound + upperBound) / 2
+            if hasCaseInsensitivePrefix(word, prefixes[middle]) {
+                lowerBound = middle + 1
+            } else {
+                upperBound = middle
+            }
         }
-        return length
+        return lowerBound > 0 ? lowerBound - 1 : nil
     }
 
     private static func isIdentifierChar(_ character: unichar) -> Bool {
-        (character >= 0x41 && character <= 0x5A) ||
+        if (character >= 0x41 && character <= 0x5A) ||
         (character >= 0x61 && character <= 0x7A) ||
         (character >= 0x30 && character <= 0x39) ||
-        character == 0x5F
+        character == 0x5F {
+            return true
+        }
+        guard let scalar = UnicodeScalar(character) else { return false }
+        return CharacterSet.alphanumerics.contains(scalar)
     }
 }

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -283,15 +283,7 @@ final class CompletionFeature {
             text: bufferText,
             coordinateIndex: coordinateIndex
         )
-        let visible = merged.candidates.filter { candidate in
-            let filter = candidate.filterText ?? candidate.label
-            return CompletionEngine.hasCaseInsensitivePrefix(filter, prefix.text) ||
-                CompletionEngine.hasCaseInsensitivePrefix(candidate.label, prefix.text)
-        }
-        guard !visible.isEmpty else {
-            cancelAndDismiss()
-            return
-        }
+        let visible = merged.candidates.filter { Self.isVisible($0, for: prefix) }
 
         candidates = visible
         candidatePool = merged.candidates
@@ -326,7 +318,11 @@ final class CompletionFeature {
                     ) == selectedEditPlan
             }
         } ?? 0
-        showPopup()
+        if candidates.isEmpty {
+            closeUI()
+        } else {
+            showPopup()
+        }
     }
 
     private static func candidates(
@@ -406,6 +402,16 @@ final class CompletionFeature {
             source: candidate.source,
             editPlan: editPlan
         )
+    }
+
+    private static func isVisible(_ candidate: CompletionCandidate, for prefix: CompletionPrefix) -> Bool {
+        if candidate.source == .buffer,
+           (prefix.text as NSString).length < CompletionEngine.bufferWordMinimumPrefixLength {
+            return false
+        }
+        let filter = candidate.filterText ?? candidate.label
+        return CompletionEngine.hasCaseInsensitivePrefix(filter, prefix.text) ||
+            CompletionEngine.hasCaseInsensitivePrefix(candidate.label, prefix.text)
     }
 
     private func showPopup() {
@@ -575,11 +581,7 @@ final class CompletionFeature {
             candidateOrigins = merged.origins
         }
 
-        candidates = candidatePool.filter { candidate in
-            let filter = candidate.filterText ?? candidate.label
-            return CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) ||
-                CompletionEngine.hasCaseInsensitivePrefix(candidate.label, updatedPrefix.text)
-        }
+        candidates = candidatePool.filter { Self.isVisible($0, for: updatedPrefix) }
         isRefreshing = candidates.isEmpty
         prefix = updatedPrefix
         selection = selectedCandidate.flatMap { selected in

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -28,7 +28,7 @@ final class CompletionFeature {
     private var prefix: CompletionPrefix?
     private var candidatePrefix: CompletionPrefix?
     private var candidateOrigins: [UUID: CompletionPrefix] = [:]
-    private var candidateBufferWords: [String] = []
+    private var candidateBufferCache: [String: [CompletionCandidate]] = [:]
     private var candidateItems: [LSPCompletionItem] = []
     private var candidateAllowsBufferFallback = false
     private var candidateMemberAccessOnly = false
@@ -88,7 +88,7 @@ final class CompletionFeature {
         prefix = nil
         candidatePrefix = nil
         candidateOrigins.removeAll()
-        candidateBufferWords.removeAll()
+        candidateBufferCache.removeAll()
         candidateItems.removeAll()
         candidateAllowsBufferFallback = false
         candidateMemberAccessOnly = false
@@ -251,11 +251,13 @@ final class CompletionFeature {
         let coordinateIndex = TextEditCoordinates.LineIndex(bufferText)
         let retainedMemberAccessOnly = candidateMemberAccessOnly || memberAccessOnly
         let retainedBufferFallback = allowBufferFallback && !retainedMemberAccessOnly
-        let bufferWords = retainedBufferFallback ? CompletionEngine.bufferWords(in: bufferText) : []
+        let bufferCache = retainedBufferFallback
+            ? CompletionEngine.bufferWordCandidateCache(in: bufferText, prefix: prefix)
+            : [:]
         let next = Self.candidates(
             items: items,
             prefix: prefix,
-            bufferWords: bufferWords,
+            bufferCandidates: bufferCache[prefix.text] ?? [],
             allowBufferFallback: retainedBufferFallback,
             memberAccessOnly: retainedMemberAccessOnly
         )
@@ -298,7 +300,7 @@ final class CompletionFeature {
         } ?? false
         if !keepsBroaderResponse {
             candidatePrefix = prefix
-            candidateBufferWords = bufferWords
+            candidateBufferCache = bufferCache
             candidateItems = items
         }
         candidateAllowsBufferFallback = retainedBufferFallback
@@ -327,7 +329,7 @@ final class CompletionFeature {
     private static func candidates(
         items: [LSPCompletionItem],
         prefix: CompletionPrefix,
-        bufferWords: [String],
+        bufferCandidates: [CompletionCandidate],
         allowBufferFallback: Bool,
         memberAccessOnly: Bool
     ) -> [CompletionCandidate] {
@@ -337,8 +339,7 @@ final class CompletionFeature {
             memberAccessOnly: memberAccessOnly
         )
         if allowBufferFallback {
-            let buffer = CompletionEngine.bufferWordCandidates(from: bufferWords, prefix: prefix)
-            candidates.append(contentsOf: buffer.filter { bufferCandidate in
+            candidates.append(contentsOf: bufferCandidates.filter { bufferCandidate in
                 !candidates.contains { $0.label == bufferCandidate.label }
             })
         }
@@ -522,7 +523,7 @@ final class CompletionFeature {
             prefix = nil
             candidatePrefix = nil
             candidateOrigins.removeAll()
-            candidateBufferWords.removeAll()
+            candidateBufferCache.removeAll()
             candidateItems.removeAll()
             candidateAllowsBufferFallback = false
             candidateMemberAccessOnly = false
@@ -550,7 +551,7 @@ final class CompletionFeature {
             let rebuilt = Self.candidates(
                 items: candidateItems,
                 prefix: updatedPrefix,
-                bufferWords: candidateBufferWords,
+                bufferCandidates: candidateBufferCache[updatedPrefix.text] ?? [],
                 allowBufferFallback: candidateAllowsBufferFallback,
                 memberAccessOnly: candidateMemberAccessOnly
             )
@@ -661,7 +662,7 @@ extension CompletionFeature {
         self.prefix = prefix
         candidatePrefix = prefix
         candidateOrigins = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, prefix) })
-        candidateBufferWords.removeAll()
+        candidateBufferCache.removeAll()
         candidateMemberAccessOnly = memberAccessOnly
         candidateAllowsEmptyPrefix = prefix.text.isEmpty
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -444,6 +444,15 @@ final class CompletionFeature {
             return
         }
 
+        let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
+        let selectedEditPlan = selectedCandidate.flatMap { candidate in
+            CompletionEngine.editPlan(
+                accepting: candidate,
+                prefix: updatedPrefix,
+                originalPrefix: candidatePoolPrefix,
+                in: textView.string
+            )
+        }
         if let previousPrefix,
            let candidatePrefix,
            updatedPrefix.range.length < previousPrefix.range.length,
@@ -464,7 +473,6 @@ final class CompletionFeature {
             candidatePoolPrefix = candidatePrefix
         }
 
-        let selectedCandidateID = candidates.indices.contains(selection) ? candidates[selection].id : nil
         candidates = candidatePool.filter { candidate in
             let filter = candidate.filterText ?? candidate.label
             return CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) ||
@@ -472,7 +480,21 @@ final class CompletionFeature {
         }
         isRefreshing = candidates.isEmpty
         prefix = updatedPrefix
-        selection = selectedCandidateID.flatMap { id in candidates.firstIndex { $0.id == id } } ?? 0
+        selection = selectedCandidate.flatMap { selected in
+            candidates.firstIndex {
+                $0.label == selected.label &&
+                    $0.kind == selected.kind &&
+                    $0.detail == selected.detail &&
+                    $0.source == selected.source &&
+                    selectedEditPlan != nil &&
+                    CompletionEngine.editPlan(
+                        accepting: $0,
+                        prefix: updatedPrefix,
+                        originalPrefix: candidatePoolPrefix,
+                        in: textView.string
+                    ) == selectedEditPlan
+            }
+        } ?? 0
 
         if candidates.isEmpty {
             closeUI()

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -19,7 +19,7 @@ final class CompletionFeature {
     private var candidatePool: [CompletionCandidate] = []
     private var prefix: CompletionPrefix?
     private var candidatePrefix: CompletionPrefix?
-    private var candidatePoolPrefix: CompletionPrefix?
+    private var candidateOrigins: [UUID: CompletionPrefix] = [:]
     private var candidateBufferText: String?
     private var candidateItems: [LSPCompletionItem] = []
     private var candidateAllowsBufferFallback = false
@@ -79,7 +79,7 @@ final class CompletionFeature {
         candidatePool.removeAll()
         prefix = nil
         candidatePrefix = nil
-        candidatePoolPrefix = nil
+        candidateOrigins.removeAll()
         candidateBufferText = nil
         candidateItems.removeAll()
         candidateAllowsBufferFallback = false
@@ -260,14 +260,14 @@ final class CompletionFeature {
             CompletionEngine.editPlan(
                 accepting: candidate,
                 prefix: prefix,
-                originalPrefix: candidatePoolPrefix,
+                originalPrefix: candidateOrigins[candidate.id],
                 in: bufferText
             )
         }
         candidates = next
         candidatePool = next
         self.prefix = prefix
-        candidatePoolPrefix = prefix
+        candidateOrigins = Dictionary(uniqueKeysWithValues: next.map { ($0.id, prefix) })
         let keepsBroaderResponse = candidatePrefix.map {
             $0.range.location == prefix.range.location && $0.range.length < prefix.range.length
         } ?? false
@@ -290,7 +290,7 @@ final class CompletionFeature {
                     CompletionEngine.editPlan(
                         accepting: $0,
                         prefix: prefix,
-                        originalPrefix: prefix,
+                        originalPrefix: candidateOrigins[$0.id],
                         in: bufferText
                     ) == selectedEditPlan
             }
@@ -399,7 +399,7 @@ final class CompletionFeature {
         guard let plan = CompletionEngine.editPlan(
             accepting: candidate,
             prefix: prefix,
-            originalPrefix: candidatePoolPrefix,
+            originalPrefix: candidateOrigins[candidate.id],
             in: textView.string
         ) else {
             cancelAndDismiss()
@@ -433,7 +433,7 @@ final class CompletionFeature {
             candidatePool.removeAll()
             prefix = nil
             candidatePrefix = nil
-            candidatePoolPrefix = nil
+            candidateOrigins.removeAll()
             candidateBufferText = nil
             candidateItems.removeAll()
             candidateAllowsBufferFallback = false
@@ -449,7 +449,7 @@ final class CompletionFeature {
             CompletionEngine.editPlan(
                 accepting: candidate,
                 prefix: updatedPrefix,
-                originalPrefix: candidatePoolPrefix,
+                originalPrefix: candidateOrigins[candidate.id],
                 in: textView.string
             )
         }
@@ -465,10 +465,38 @@ final class CompletionFeature {
                 allowBufferFallback: candidateAllowsBufferFallback,
                 memberAccessOnly: candidateMemberAccessOnly
             )
-            candidatePool = rebuilt.map { candidate in
-                candidatePool.first { $0 == candidate } ?? candidate
+            var merged = rebuilt
+            var mergedOrigins = Dictionary(uniqueKeysWithValues: rebuilt.map { ($0.id, candidatePrefix) })
+            for candidate in candidatePool {
+                let filter = candidate.filterText ?? candidate.label
+                guard CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) ||
+                    CompletionEngine.hasCaseInsensitivePrefix(candidate.label, updatedPrefix.text) else { continue }
+                let plan = CompletionEngine.editPlan(
+                    accepting: candidate,
+                    prefix: updatedPrefix,
+                    originalPrefix: candidateOrigins[candidate.id],
+                    in: textView.string
+                )
+                let isDuplicate = merged.contains {
+                    $0.label == candidate.label &&
+                        $0.kind == candidate.kind &&
+                        $0.detail == candidate.detail &&
+                        $0.source == candidate.source &&
+                        plan != nil &&
+                        CompletionEngine.editPlan(
+                            accepting: $0,
+                            prefix: updatedPrefix,
+                            originalPrefix: mergedOrigins[$0.id],
+                            in: textView.string
+                        ) == plan
+                }
+                if !isDuplicate {
+                    merged.append(candidate)
+                    mergedOrigins[candidate.id] = candidateOrigins[candidate.id]
+                }
             }
-            candidatePoolPrefix = candidatePrefix
+            candidatePool = merged
+            candidateOrigins = mergedOrigins
         }
 
         candidates = candidatePool.filter { candidate in
@@ -488,7 +516,7 @@ final class CompletionFeature {
                     CompletionEngine.editPlan(
                         accepting: $0,
                         prefix: updatedPrefix,
-                        originalPrefix: candidatePoolPrefix,
+                        originalPrefix: candidateOrigins[$0.id],
                         in: textView.string
                     ) == selectedEditPlan
             }
@@ -583,7 +611,7 @@ extension CompletionFeature {
         candidatePool = candidates
         self.prefix = prefix
         candidatePrefix = prefix
-        candidatePoolPrefix = prefix
+        candidateOrigins = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, prefix) })
         candidateBufferText = textView?.string
         candidateMemberAccessOnly = memberAccessOnly
         candidateAllowsEmptyPrefix = prefix.text.isEmpty

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -16,6 +16,7 @@ final class CompletionFeature {
     private var requestTask: Task<Void, Never>?
     private var requestID: UInt64 = 0
     private var candidates: [CompletionCandidate] = []
+    private var candidatePool: [CompletionCandidate] = []
     private var prefix: CompletionPrefix?
     private var candidatePrefix: CompletionPrefix?
     private var selection: Int = 0
@@ -69,6 +70,7 @@ final class CompletionFeature {
         requestTask = nil
         requestID &+= 1
         candidates.removeAll()
+        candidatePool.removeAll()
         prefix = nil
         candidatePrefix = nil
         selection = 0
@@ -243,6 +245,7 @@ final class CompletionFeature {
 
         let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
         candidates = next
+        candidatePool = next
         self.prefix = prefix
         candidatePrefix = prefix
         isRefreshing = false
@@ -369,6 +372,7 @@ final class CompletionFeature {
               !updatedPrefix.text.isEmpty,
               previousPrefix?.range.location == updatedPrefix.range.location else {
             candidates.removeAll()
+            candidatePool.removeAll()
             prefix = nil
             candidatePrefix = nil
             selection = 0
@@ -377,10 +381,10 @@ final class CompletionFeature {
         }
 
         let selectedCandidateID = candidates.indices.contains(selection) ? candidates[selection].id : nil
-        candidates.removeAll { candidate in
+        candidates = candidatePool.filter { candidate in
             let filter = candidate.filterText ?? candidate.label
-            return !CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) &&
-                !CompletionEngine.hasCaseInsensitivePrefix(candidate.label, updatedPrefix.text)
+            return CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) ||
+                CompletionEngine.hasCaseInsensitivePrefix(candidate.label, updatedPrefix.text)
         }
         isRefreshing = candidates.isEmpty
         prefix = candidates.isEmpty ? nil : updatedPrefix
@@ -452,6 +456,7 @@ extension CompletionFeature {
                 source: .lsp
             )
         }
+        candidatePool = candidates
         self.prefix = prefix
         candidatePrefix = prefix
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -28,7 +28,7 @@ final class CompletionFeature {
     private var prefix: CompletionPrefix?
     private var candidatePrefix: CompletionPrefix?
     private var candidateOrigins: [UUID: CompletionPrefix] = [:]
-    private var candidateBufferText: String?
+    private var candidateBufferWords: [String] = []
     private var candidateItems: [LSPCompletionItem] = []
     private var candidateAllowsBufferFallback = false
     private var candidateMemberAccessOnly = false
@@ -88,7 +88,7 @@ final class CompletionFeature {
         prefix = nil
         candidatePrefix = nil
         candidateOrigins.removeAll()
-        candidateBufferText = nil
+        candidateBufferWords.removeAll()
         candidateItems.removeAll()
         candidateAllowsBufferFallback = false
         candidateMemberAccessOnly = false
@@ -251,10 +251,11 @@ final class CompletionFeature {
         let coordinateIndex = TextEditCoordinates.LineIndex(bufferText)
         let retainedMemberAccessOnly = candidateMemberAccessOnly || memberAccessOnly
         let retainedBufferFallback = allowBufferFallback && !retainedMemberAccessOnly
+        let bufferWords = retainedBufferFallback ? CompletionEngine.bufferWords(in: bufferText) : []
         let next = Self.candidates(
             items: items,
             prefix: prefix,
-            bufferText: bufferText,
+            bufferWords: bufferWords,
             allowBufferFallback: retainedBufferFallback,
             memberAccessOnly: retainedMemberAccessOnly
         )
@@ -297,7 +298,7 @@ final class CompletionFeature {
         } ?? false
         if !keepsBroaderResponse {
             candidatePrefix = prefix
-            candidateBufferText = bufferText
+            candidateBufferWords = bufferWords
             candidateItems = items
         }
         candidateAllowsBufferFallback = retainedBufferFallback
@@ -326,7 +327,7 @@ final class CompletionFeature {
     private static func candidates(
         items: [LSPCompletionItem],
         prefix: CompletionPrefix,
-        bufferText: String,
+        bufferWords: [String],
         allowBufferFallback: Bool,
         memberAccessOnly: Bool
     ) -> [CompletionCandidate] {
@@ -336,7 +337,7 @@ final class CompletionFeature {
             memberAccessOnly: memberAccessOnly
         )
         if allowBufferFallback {
-            let buffer = CompletionEngine.bufferWordCandidates(in: bufferText, prefix: prefix)
+            let buffer = CompletionEngine.bufferWordCandidates(from: bufferWords, prefix: prefix)
             candidates.append(contentsOf: buffer.filter { bufferCandidate in
                 !candidates.contains { $0.label == bufferCandidate.label }
             })
@@ -521,7 +522,7 @@ final class CompletionFeature {
             prefix = nil
             candidatePrefix = nil
             candidateOrigins.removeAll()
-            candidateBufferText = nil
+            candidateBufferWords.removeAll()
             candidateItems.removeAll()
             candidateAllowsBufferFallback = false
             candidateMemberAccessOnly = false
@@ -545,12 +546,11 @@ final class CompletionFeature {
         }
         if let candidatePrefix,
            updatedPrefix.range.length < previousPrefix.range.length,
-           !candidateItems.isEmpty || candidateAllowsBufferFallback,
-           let candidateBufferText {
+           !candidateItems.isEmpty || candidateAllowsBufferFallback {
             let rebuilt = Self.candidates(
                 items: candidateItems,
                 prefix: updatedPrefix,
-                bufferText: candidateBufferText,
+                bufferWords: candidateBufferWords,
                 allowBufferFallback: candidateAllowsBufferFallback,
                 memberAccessOnly: candidateMemberAccessOnly
             )
@@ -661,7 +661,7 @@ extension CompletionFeature {
         self.prefix = prefix
         candidatePrefix = prefix
         candidateOrigins = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, prefix) })
-        candidateBufferText = textView?.string
+        candidateBufferWords.removeAll()
         candidateMemberAccessOnly = memberAccessOnly
         candidateAllowsEmptyPrefix = prefix.text.isEmpty
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
@@ -681,6 +681,7 @@ extension CompletionFeature {
         prefix: CompletionPrefix,
         bufferText: String,
         allowEmptyPrefix: Bool = false,
+        allowBufferFallback: Bool = false,
         memberAccessOnly: Bool = false
     ) {
         present(
@@ -688,7 +689,7 @@ extension CompletionFeature {
             prefix: prefix,
             bufferText: bufferText,
             allowEmptyPrefix: allowEmptyPrefix,
-            allowBufferFallback: false,
+            allowBufferFallback: allowBufferFallback,
             memberAccessOnly: memberAccessOnly
         )
     }

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -17,6 +17,7 @@ final class CompletionFeature {
     private var requestID: UInt64 = 0
     private var candidates: [CompletionCandidate] = []
     private var prefix: CompletionPrefix?
+    private var candidatePrefix: CompletionPrefix?
     private var selection: Int = 0
     private let suggestionWindow = CompletionWindowController()
     private var isRefreshing = false
@@ -69,6 +70,7 @@ final class CompletionFeature {
         requestID &+= 1
         candidates.removeAll()
         prefix = nil
+        candidatePrefix = nil
         selection = 0
         isRefreshing = false
         closeUI()
@@ -239,10 +241,19 @@ final class CompletionFeature {
             return
         }
 
+        let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
         candidates = next
         self.prefix = prefix
+        candidatePrefix = prefix
         isRefreshing = false
-        selection = min(max(selection, 0), next.count - 1)
+        selection = selectedCandidate.flatMap { selected in
+            next.firstIndex {
+                $0.label == selected.label &&
+                    $0.kind == selected.kind &&
+                    $0.detail == selected.detail &&
+                    $0.source == selected.source
+            }
+        } ?? 0
         showPopup()
     }
 
@@ -323,7 +334,12 @@ final class CompletionFeature {
         }
 
         let candidate = candidates[index]
-        guard let plan = CompletionEngine.editPlan(accepting: candidate, prefix: prefix, in: textView.string) else {
+        guard let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: prefix,
+            originalPrefix: candidatePrefix,
+            in: textView.string
+        ) else {
             cancelAndDismiss()
             return
         }
@@ -352,6 +368,7 @@ final class CompletionFeature {
               previousPrefix?.range.location == updatedPrefix.range.location else {
             candidates.removeAll()
             prefix = nil
+            candidatePrefix = nil
             selection = 0
             closeUI()
             return
@@ -429,12 +446,23 @@ extension CompletionFeature {
             )
         }
         self.prefix = prefix
+        candidatePrefix = prefix
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
         isRefreshing = false
     }
 
     func testingShowPopup() {
         showPopup()
+    }
+
+    func testingPresent(items: [LSPCompletionItem], prefix: CompletionPrefix, bufferText: String) {
+        present(
+            items: items,
+            prefix: prefix,
+            bufferText: bufferText,
+            allowBufferFallback: false,
+            memberAccessOnly: false
+        )
     }
 
     var testingSnapshot: TestingSnapshot {

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -456,7 +456,6 @@ final class CompletionFeature {
         if let previousPrefix,
            let candidatePrefix,
            updatedPrefix.range.length < previousPrefix.range.length,
-           updatedPrefix.range.length <= candidatePrefix.range.length,
            updatedPrefix.range.length < candidatePrefix.range.length ||
            candidatePoolPrefix != candidatePrefix,
            let candidateBufferText {

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -456,8 +456,7 @@ final class CompletionFeature {
         if let previousPrefix,
            let candidatePrefix,
            updatedPrefix.range.length < previousPrefix.range.length,
-           updatedPrefix.range.length < candidatePrefix.range.length ||
-           candidatePoolPrefix != candidatePrefix,
+           !candidateItems.isEmpty || candidateAllowsBufferFallback,
            let candidateBufferText {
             let rebuilt = Self.candidates(
                 items: candidateItems,

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -35,6 +35,7 @@ final class CompletionFeature {
     private var candidateMemberAccessOnly = false
     private var candidateAllowsEmptyPrefix = false
     private var selection: Int = 0
+    private var selectedCandidateID: UUID?
     private let suggestionWindow = CompletionWindowController()
     private var isRefreshing = false
 
@@ -96,6 +97,7 @@ final class CompletionFeature {
         candidateMemberAccessOnly = false
         candidateAllowsEmptyPrefix = false
         selection = 0
+        selectedCandidateID = nil
         isRefreshing = false
         closeUI()
     }
@@ -264,7 +266,9 @@ final class CompletionFeature {
             memberAccessOnly: retainedMemberAccessOnly
         )
 
-        let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
+        let selectedCandidate = candidates.indices.contains(selection)
+            ? candidates[selection]
+            : candidatePool.first { $0.id == selectedCandidateID }
         let selectedEditPlan = selectedCandidate.flatMap { candidate in
             CompletionEngine.editPlan(
                 accepting: candidate,
@@ -318,6 +322,9 @@ final class CompletionFeature {
                     ) == selectedEditPlan
             }
         } ?? 0
+        if candidates.indices.contains(selection) {
+            selectedCandidateID = candidates[selection].id
+        }
         if candidates.isEmpty {
             closeUI()
         } else {
@@ -474,6 +481,7 @@ final class CompletionFeature {
             return true
         case .moveSelection(let delta):
             selection = min(max(0, selection + delta), candidates.count - 1)
+            selectedCandidateID = candidates[selection].id
             showPopup()
             return true
         case .dismiss:
@@ -539,6 +547,7 @@ final class CompletionFeature {
             candidateMemberAccessOnly = false
             candidateAllowsEmptyPrefix = false
             selection = 0
+            selectedCandidateID = nil
             closeUI()
             return
         }
@@ -548,7 +557,9 @@ final class CompletionFeature {
         let coordinateIndex = candidateCoordinateIndex?
             .adjustingOffsets(after: editRange.location, by: prefixDelta) ?? TextEditCoordinates.LineIndex(bufferText)
         candidateCoordinateIndex = coordinateIndex
-        let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
+        let selectedCandidate = candidates.indices.contains(selection)
+            ? candidates[selection]
+            : candidatePool.first { $0.id == selectedCandidateID }
         let selectedEditPlan = selectedCandidate.flatMap { candidate in
             CompletionEngine.editPlan(
                 accepting: candidate,
@@ -600,6 +611,9 @@ final class CompletionFeature {
                     ) == selectedEditPlan
             }
         } ?? 0
+        if candidates.indices.contains(selection) {
+            selectedCandidateID = candidates[selection].id
+        }
 
         if candidates.isEmpty {
             closeUI()
@@ -676,6 +690,7 @@ extension CompletionFeature {
         candidateMemberAccessOnly = memberAccessOnly
         candidateAllowsEmptyPrefix = prefix.text.isEmpty
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
+        selectedCandidateID = candidates.indices.contains(self.selection) ? candidates[self.selection].id : nil
         isRefreshing = false
     }
 
@@ -685,6 +700,7 @@ extension CompletionFeature {
 
     func testingSetSelection(_ selection: Int) {
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
+        selectedCandidateID = candidates.indices.contains(self.selection) ? candidates[self.selection].id : nil
     }
 
     func testingPresent(

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -23,6 +23,7 @@ final class CompletionFeature {
     private var candidateItems: [LSPCompletionItem] = []
     private var candidateAllowsBufferFallback = false
     private var candidateMemberAccessOnly = false
+    private var candidateAllowsEmptyPrefix = false
     private var selection: Int = 0
     private let suggestionWindow = CompletionWindowController()
     private var isRefreshing = false
@@ -81,6 +82,7 @@ final class CompletionFeature {
         candidateItems.removeAll()
         candidateAllowsBufferFallback = false
         candidateMemberAccessOnly = false
+        candidateAllowsEmptyPrefix = false
         selection = 0
         isRefreshing = false
         closeUI()
@@ -198,6 +200,7 @@ final class CompletionFeature {
                     items: lspItems,
                     prefix: prefix,
                     bufferText: activeTextView.string,
+                    allowEmptyPrefix: allowEmptyPrefix,
                     allowBufferFallback: allowBufferFallback,
                     memberAccessOnly: memberAccessOnly
                 )
@@ -231,6 +234,7 @@ final class CompletionFeature {
         items: [LSPCompletionItem],
         prefix: CompletionPrefix,
         bufferText: String,
+        allowEmptyPrefix: Bool,
         allowBufferFallback: Bool,
         memberAccessOnly: Bool
     ) {
@@ -264,6 +268,7 @@ final class CompletionFeature {
         candidateItems = items
         candidateAllowsBufferFallback = allowBufferFallback
         candidateMemberAccessOnly = memberAccessOnly
+        candidateAllowsEmptyPrefix = allowEmptyPrefix
         isRefreshing = false
         selection = selectedCandidate.flatMap { selected in
             next.firstIndex {
@@ -411,6 +416,7 @@ final class CompletionFeature {
                 in: textView.string,
                 caret: textView.selectedRange().location
               ),
+              candidateAllowsEmptyPrefix || !updatedPrefix.text.isEmpty,
               previousPrefix?.range.location == updatedPrefix.range.location,
               textOutsideCandidatePrefixIsUnchanged(in: textView.string, updatedPrefix: updatedPrefix) else {
             candidates.removeAll()
@@ -421,6 +427,7 @@ final class CompletionFeature {
             candidateItems.removeAll()
             candidateAllowsBufferFallback = false
             candidateMemberAccessOnly = false
+            candidateAllowsEmptyPrefix = false
             selection = 0
             closeUI()
             return
@@ -540,6 +547,7 @@ extension CompletionFeature {
         self.prefix = prefix
         candidatePrefix = prefix
         candidateBufferText = textView?.string
+        candidateAllowsEmptyPrefix = prefix.text.isEmpty
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
         isRefreshing = false
     }
@@ -552,11 +560,17 @@ extension CompletionFeature {
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
     }
 
-    func testingPresent(items: [LSPCompletionItem], prefix: CompletionPrefix, bufferText: String) {
+    func testingPresent(
+        items: [LSPCompletionItem],
+        prefix: CompletionPrefix,
+        bufferText: String,
+        allowEmptyPrefix: Bool = false
+    ) {
         present(
             items: items,
             prefix: prefix,
             bufferText: bufferText,
+            allowEmptyPrefix: allowEmptyPrefix,
             allowBufferFallback: false,
             memberAccessOnly: false
         )

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -28,6 +28,7 @@ final class CompletionFeature {
     private var prefix: CompletionPrefix?
     private var candidatePrefix: CompletionPrefix?
     private var candidateOrigins: [UUID: CompletionPrefix] = [:]
+    private var candidateCoordinateIndex: TextEditCoordinates.LineIndex?
     private var candidateBufferCache: [String: [CompletionCandidate]] = [:]
     private var candidateItems: [LSPCompletionItem] = []
     private var candidateAllowsBufferFallback = false
@@ -88,6 +89,7 @@ final class CompletionFeature {
         prefix = nil
         candidatePrefix = nil
         candidateOrigins.removeAll()
+        candidateCoordinateIndex = nil
         candidateBufferCache.removeAll()
         candidateItems.removeAll()
         candidateAllowsBufferFallback = false
@@ -295,6 +297,7 @@ final class CompletionFeature {
         candidatePool = merged.candidates
         self.prefix = prefix
         candidateOrigins = merged.origins
+        candidateCoordinateIndex = coordinateIndex
         let keepsBroaderResponse = candidatePrefix.map {
             $0.range.location == prefix.range.location && $0.range.length < prefix.range.length
         } ?? false
@@ -523,6 +526,7 @@ final class CompletionFeature {
             prefix = nil
             candidatePrefix = nil
             candidateOrigins.removeAll()
+            candidateCoordinateIndex = nil
             candidateBufferCache.removeAll()
             candidateItems.removeAll()
             candidateAllowsBufferFallback = false
@@ -534,7 +538,10 @@ final class CompletionFeature {
         }
 
         let bufferText = textView.string
-        let coordinateIndex = TextEditCoordinates.LineIndex(bufferText)
+        let prefixDelta = updatedPrefix.range.length - previousPrefix.range.length
+        let coordinateIndex = candidateCoordinateIndex?
+            .adjustingOffsets(after: editRange.location, by: prefixDelta) ?? TextEditCoordinates.LineIndex(bufferText)
+        candidateCoordinateIndex = coordinateIndex
         let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
         let selectedEditPlan = selectedCandidate.flatMap { candidate in
             CompletionEngine.editPlan(
@@ -662,6 +669,7 @@ extension CompletionFeature {
         self.prefix = prefix
         candidatePrefix = prefix
         candidateOrigins = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, prefix) })
+        candidateCoordinateIndex = textView.map { TextEditCoordinates.LineIndex($0.string) }
         candidateBufferCache.removeAll()
         candidateMemberAccessOnly = memberAccessOnly
         candidateAllowsEmptyPrefix = prefix.text.isEmpty

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -251,7 +251,9 @@ final class CompletionFeature {
                 $0.label == selected.label &&
                     $0.kind == selected.kind &&
                     $0.detail == selected.detail &&
-                    $0.source == selected.source
+                    $0.source == selected.source &&
+                    $0.replacementText == selected.replacementText &&
+                    $0.additionalTextEdits.map(\.newText) == selected.additionalTextEdits.map(\.newText)
             }
         } ?? 0
         showPopup()
@@ -430,16 +432,21 @@ extension CompletionFeature {
         let isRefreshing: Bool
     }
 
-    func testingSeedVisibleCandidates(labels: [String], prefix: CompletionPrefix, selection: Int = 0) {
-        candidates = labels.map {
+    func testingSeedVisibleCandidates(
+        labels: [String],
+        replacementTexts: [String]? = nil,
+        prefix: CompletionPrefix,
+        selection: Int = 0
+    ) {
+        candidates = labels.enumerated().map { index, label in
             CompletionCandidate(
-                label: $0,
+                label: label,
                 detail: nil,
                 kind: nil,
                 documentation: nil,
                 sortText: nil,
-                filterText: $0,
-                replacementText: $0,
+                filterText: label,
+                replacementText: replacementTexts?[index] ?? label,
                 textEdit: nil,
                 additionalTextEdits: [],
                 source: .lsp

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -361,29 +361,30 @@ final class CompletionFeature {
         text: String,
         coordinateIndex: TextEditCoordinates.LineIndex
     ) -> (candidates: [CompletionCandidate], origins: [UUID: CompletionPrefix]) {
-        var merged = candidates
-        var mergedOrigins = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, originPrefix) })
-        var identities = Set(merged.compactMap {
-            candidateIdentity(
-                for: $0,
-                origin: mergedOrigins[$0.id],
+        var merged: [CompletionCandidate] = []
+        var mergedOrigins: [UUID: CompletionPrefix] = [:]
+        var identities = Set<CandidateIdentity>()
+        for candidate in candidates {
+            guard let identity = candidateIdentity(
+                for: candidate,
+                origin: originPrefix,
                 prefix: prefix,
                 text: text,
                 coordinateIndex: coordinateIndex
-            )
-        })
+            ), identities.insert(identity).inserted else { continue }
+            merged.append(candidate)
+            mergedOrigins[candidate.id] = originPrefix
+        }
         for candidate in retained {
-            let identity = candidateIdentity(
+            guard let identity = candidateIdentity(
                 for: candidate,
                 origin: origins[candidate.id],
                 prefix: prefix,
                 text: text,
                 coordinateIndex: coordinateIndex
-            )
-            guard identity.map({ !identities.contains($0) }) ?? true else { continue }
+            ), identities.insert(identity).inserted else { continue }
             merged.append(candidate)
             mergedOrigins[candidate.id] = origins[candidate.id]
-            if let identity { identities.insert(identity) }
         }
         return (merged, mergedOrigins)
     }

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -19,6 +19,7 @@ final class CompletionFeature {
     private var candidatePool: [CompletionCandidate] = []
     private var prefix: CompletionPrefix?
     private var candidatePrefix: CompletionPrefix?
+    private var candidateBufferText: String?
     private var selection: Int = 0
     private let suggestionWindow = CompletionWindowController()
     private var isRefreshing = false
@@ -73,6 +74,7 @@ final class CompletionFeature {
         candidatePool.removeAll()
         prefix = nil
         candidatePrefix = nil
+        candidateBufferText = nil
         selection = 0
         isRefreshing = false
         closeUI()
@@ -248,6 +250,7 @@ final class CompletionFeature {
         candidatePool = next
         self.prefix = prefix
         candidatePrefix = prefix
+        candidateBufferText = bufferText
         isRefreshing = false
         selection = selectedCandidate.flatMap { selected in
             next.firstIndex {
@@ -370,11 +373,13 @@ final class CompletionFeature {
                 caret: textView.selectedRange().location
               ),
               !updatedPrefix.text.isEmpty,
-              previousPrefix?.range.location == updatedPrefix.range.location else {
+              previousPrefix?.range.location == updatedPrefix.range.location,
+              textOutsideCandidatePrefixIsUnchanged(in: textView.string, updatedPrefix: updatedPrefix) else {
             candidates.removeAll()
             candidatePool.removeAll()
             prefix = nil
             candidatePrefix = nil
+            candidateBufferText = nil
             selection = 0
             closeUI()
             return
@@ -387,14 +392,34 @@ final class CompletionFeature {
                 CompletionEngine.hasCaseInsensitivePrefix(candidate.label, updatedPrefix.text)
         }
         isRefreshing = candidates.isEmpty
-        prefix = candidates.isEmpty ? nil : updatedPrefix
+        prefix = updatedPrefix
         selection = selectedCandidateID.flatMap { id in candidates.firstIndex { $0.id == id } } ?? 0
 
         if candidates.isEmpty {
             closeUI()
-        } else if suggestionWindow.isVisible {
+        } else {
             showPopup()
         }
+    }
+
+    private func textOutsideCandidatePrefixIsUnchanged(
+        in text: String,
+        updatedPrefix: CompletionPrefix
+    ) -> Bool {
+        guard let candidateBufferText,
+              let candidatePrefix else { return false }
+
+        let original = candidateBufferText as NSString
+        let current = text as NSString
+        let start = candidatePrefix.range.location
+        let originalEnd = NSMaxRange(candidatePrefix.range)
+        let currentEnd = NSMaxRange(updatedPrefix.range)
+        guard start >= 0,
+              originalEnd <= original.length,
+              currentEnd <= current.length else { return false }
+
+        return original.substring(to: start) == current.substring(to: start) &&
+            original.substring(from: originalEnd) == current.substring(from: currentEnd)
     }
 
     private func canAcceptCompletion(prefix: CompletionPrefix, in textView: CodeTextView) -> Bool {
@@ -459,6 +484,7 @@ extension CompletionFeature {
         candidatePool = candidates
         self.prefix = prefix
         candidatePrefix = prefix
+        candidateBufferText = textView?.string
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
         isRefreshing = false
     }

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -357,6 +357,7 @@ final class CompletionFeature {
             return
         }
 
+        let selectedCandidateID = candidates.indices.contains(selection) ? candidates[selection].id : nil
         candidates.removeAll { candidate in
             let filter = candidate.filterText ?? candidate.label
             return !CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) &&
@@ -364,7 +365,7 @@ final class CompletionFeature {
         }
         isRefreshing = candidates.isEmpty
         prefix = candidates.isEmpty ? nil : updatedPrefix
-        selection = min(max(selection, 0), max(candidates.count - 1, 0))
+        selection = selectedCandidateID.flatMap { id in candidates.firstIndex { $0.id == id } } ?? 0
 
         if candidates.isEmpty {
             closeUI()

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -19,6 +19,7 @@ final class CompletionFeature {
     private var candidatePool: [CompletionCandidate] = []
     private var prefix: CompletionPrefix?
     private var candidatePrefix: CompletionPrefix?
+    private var candidatePoolPrefix: CompletionPrefix?
     private var candidateBufferText: String?
     private var candidateItems: [LSPCompletionItem] = []
     private var candidateAllowsBufferFallback = false
@@ -78,6 +79,7 @@ final class CompletionFeature {
         candidatePool.removeAll()
         prefix = nil
         candidatePrefix = nil
+        candidatePoolPrefix = nil
         candidateBufferText = nil
         candidateItems.removeAll()
         candidateAllowsBufferFallback = false
@@ -258,16 +260,22 @@ final class CompletionFeature {
             CompletionEngine.editPlan(
                 accepting: candidate,
                 prefix: prefix,
-                originalPrefix: candidatePrefix,
+                originalPrefix: candidatePoolPrefix,
                 in: bufferText
             )
         }
         candidates = next
         candidatePool = next
         self.prefix = prefix
-        candidatePrefix = prefix
-        candidateBufferText = bufferText
-        candidateItems = items
+        candidatePoolPrefix = prefix
+        let keepsBroaderResponse = candidatePrefix.map {
+            $0.range.location == prefix.range.location && $0.range.length < prefix.range.length
+        } ?? false
+        if !keepsBroaderResponse {
+            candidatePrefix = prefix
+            candidateBufferText = bufferText
+            candidateItems = items
+        }
         candidateAllowsBufferFallback = retainedBufferFallback
         candidateMemberAccessOnly = retainedMemberAccessOnly
         candidateAllowsEmptyPrefix = candidateAllowsEmptyPrefix || allowEmptyPrefix
@@ -391,7 +399,7 @@ final class CompletionFeature {
         guard let plan = CompletionEngine.editPlan(
             accepting: candidate,
             prefix: prefix,
-            originalPrefix: candidatePrefix,
+            originalPrefix: candidatePoolPrefix,
             in: textView.string
         ) else {
             cancelAndDismiss()
@@ -425,6 +433,7 @@ final class CompletionFeature {
             candidatePool.removeAll()
             prefix = nil
             candidatePrefix = nil
+            candidatePoolPrefix = nil
             candidateBufferText = nil
             candidateItems.removeAll()
             candidateAllowsBufferFallback = false
@@ -435,8 +444,12 @@ final class CompletionFeature {
             return
         }
 
-        if let candidatePrefix,
-           updatedPrefix.range.length < candidatePrefix.range.length,
+        if let previousPrefix,
+           let candidatePrefix,
+           updatedPrefix.range.length < previousPrefix.range.length,
+           updatedPrefix.range.length <= candidatePrefix.range.length,
+           updatedPrefix.range.length < candidatePrefix.range.length ||
+           candidatePoolPrefix != candidatePrefix,
            let candidateBufferText {
             let rebuilt = Self.candidates(
                 items: candidateItems,
@@ -448,6 +461,7 @@ final class CompletionFeature {
             candidatePool = rebuilt.map { candidate in
                 candidatePool.first { $0 == candidate } ?? candidate
             }
+            candidatePoolPrefix = candidatePrefix
         }
 
         let selectedCandidateID = candidates.indices.contains(selection) ? candidates[selection].id : nil
@@ -549,6 +563,7 @@ extension CompletionFeature {
         candidatePool = candidates
         self.prefix = prefix
         candidatePrefix = prefix
+        candidatePoolPrefix = prefix
         candidateBufferText = textView?.string
         candidateMemberAccessOnly = memberAccessOnly
         candidateAllowsEmptyPrefix = prefix.text.isEmpty
@@ -568,7 +583,8 @@ extension CompletionFeature {
         items: [LSPCompletionItem],
         prefix: CompletionPrefix,
         bufferText: String,
-        allowEmptyPrefix: Bool = false
+        allowEmptyPrefix: Bool = false,
+        memberAccessOnly: Bool = false
     ) {
         present(
             items: items,
@@ -576,7 +592,7 @@ extension CompletionFeature {
             bufferText: bufferText,
             allowEmptyPrefix: allowEmptyPrefix,
             allowBufferFallback: false,
-            memberAccessOnly: false
+            memberAccessOnly: memberAccessOnly
         )
     }
 

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -250,11 +250,6 @@ final class CompletionFeature {
             memberAccessOnly: retainedMemberAccessOnly
         )
 
-        guard !next.isEmpty else {
-            cancelAndDismiss()
-            return
-        }
-
         let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
         let selectedEditPlan = selectedCandidate.flatMap { candidate in
             CompletionEngine.editPlan(
@@ -264,10 +259,28 @@ final class CompletionFeature {
                 in: bufferText
             )
         }
-        candidates = next
-        candidatePool = next
+        let merged = Self.mergingCandidates(
+            next,
+            originPrefix: prefix,
+            with: candidatePool,
+            origins: candidateOrigins,
+            prefix: prefix,
+            text: bufferText
+        )
+        let visible = merged.candidates.filter { candidate in
+            let filter = candidate.filterText ?? candidate.label
+            return CompletionEngine.hasCaseInsensitivePrefix(filter, prefix.text) ||
+                CompletionEngine.hasCaseInsensitivePrefix(candidate.label, prefix.text)
+        }
+        guard !visible.isEmpty else {
+            cancelAndDismiss()
+            return
+        }
+
+        candidates = visible
+        candidatePool = merged.candidates
         self.prefix = prefix
-        candidateOrigins = Dictionary(uniqueKeysWithValues: next.map { ($0.id, prefix) })
+        candidateOrigins = merged.origins
         let keepsBroaderResponse = candidatePrefix.map {
             $0.range.location == prefix.range.location && $0.range.length < prefix.range.length
         } ?? false
@@ -281,7 +294,7 @@ final class CompletionFeature {
         candidateAllowsEmptyPrefix = candidateAllowsEmptyPrefix || allowEmptyPrefix
         isRefreshing = false
         selection = selectedCandidate.flatMap { selected in
-            next.firstIndex {
+            visible.firstIndex {
                 $0.label == selected.label &&
                     $0.kind == selected.kind &&
                     $0.detail == selected.detail &&
@@ -317,6 +330,44 @@ final class CompletionFeature {
             })
         }
         return candidates
+    }
+
+    private static func mergingCandidates(
+        _ candidates: [CompletionCandidate],
+        originPrefix: CompletionPrefix,
+        with retained: [CompletionCandidate],
+        origins: [UUID: CompletionPrefix],
+        prefix: CompletionPrefix,
+        text: String
+    ) -> (candidates: [CompletionCandidate], origins: [UUID: CompletionPrefix]) {
+        var merged = candidates
+        var mergedOrigins = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, originPrefix) })
+        for candidate in retained {
+            let plan = CompletionEngine.editPlan(
+                accepting: candidate,
+                prefix: prefix,
+                originalPrefix: origins[candidate.id],
+                in: text
+            )
+            let isDuplicate = merged.contains {
+                $0.label == candidate.label &&
+                    $0.kind == candidate.kind &&
+                    $0.detail == candidate.detail &&
+                    $0.source == candidate.source &&
+                    plan != nil &&
+                    CompletionEngine.editPlan(
+                        accepting: $0,
+                        prefix: prefix,
+                        originalPrefix: mergedOrigins[$0.id],
+                        in: text
+                    ) == plan
+            }
+            if !isDuplicate {
+                merged.append(candidate)
+                mergedOrigins[candidate.id] = origins[candidate.id]
+            }
+        }
+        return (merged, mergedOrigins)
     }
 
     private func showPopup() {
@@ -465,38 +516,16 @@ final class CompletionFeature {
                 allowBufferFallback: candidateAllowsBufferFallback,
                 memberAccessOnly: candidateMemberAccessOnly
             )
-            var merged = rebuilt
-            var mergedOrigins = Dictionary(uniqueKeysWithValues: rebuilt.map { ($0.id, candidatePrefix) })
-            for candidate in candidatePool {
-                let filter = candidate.filterText ?? candidate.label
-                guard CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) ||
-                    CompletionEngine.hasCaseInsensitivePrefix(candidate.label, updatedPrefix.text) else { continue }
-                let plan = CompletionEngine.editPlan(
-                    accepting: candidate,
-                    prefix: updatedPrefix,
-                    originalPrefix: candidateOrigins[candidate.id],
-                    in: textView.string
-                )
-                let isDuplicate = merged.contains {
-                    $0.label == candidate.label &&
-                        $0.kind == candidate.kind &&
-                        $0.detail == candidate.detail &&
-                        $0.source == candidate.source &&
-                        plan != nil &&
-                        CompletionEngine.editPlan(
-                            accepting: $0,
-                            prefix: updatedPrefix,
-                            originalPrefix: mergedOrigins[$0.id],
-                            in: textView.string
-                        ) == plan
-                }
-                if !isDuplicate {
-                    merged.append(candidate)
-                    mergedOrigins[candidate.id] = candidateOrigins[candidate.id]
-                }
-            }
-            candidatePool = merged
-            candidateOrigins = mergedOrigins
+            let merged = Self.mergingCandidates(
+                rebuilt,
+                originPrefix: candidatePrefix,
+                with: candidatePool,
+                origins: candidateOrigins,
+                prefix: updatedPrefix,
+                text: textView.string
+            )
+            candidatePool = merged.candidates
+            candidateOrigins = merged.origins
         }
 
         candidates = candidatePool.filter { candidate in

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -268,7 +268,7 @@ final class CompletionFeature {
         candidateItems = items
         candidateAllowsBufferFallback = allowBufferFallback
         candidateMemberAccessOnly = memberAccessOnly
-        candidateAllowsEmptyPrefix = allowEmptyPrefix
+        candidateAllowsEmptyPrefix = candidateAllowsEmptyPrefix || allowEmptyPrefix
         isRefreshing = false
         selection = selectedCandidate.flatMap { selected in
             next.firstIndex {

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -293,9 +293,9 @@ final class CompletionFeature {
         let keepsBroaderResponse = candidatePrefix.map {
             $0.range.location == prefix.range.location && $0.range.length < prefix.range.length
         } ?? false
+        candidateBufferCache.merge(bufferCache) { _, latest in latest }
         if !keepsBroaderResponse {
             candidatePrefix = prefix
-            candidateBufferCache = bufferCache
             candidateItems = items
         }
         candidateAllowsBufferFallback = retainedBufferFallback

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -337,14 +337,39 @@ final class CompletionFeature {
     }
 
     private func invalidateActiveSessionForChange() {
+        let previousPrefix = prefix
         requestTask?.cancel()
         requestTask = nil
         requestID &+= 1
-        candidates.removeAll()
-        prefix = nil
-        selection = 0
         isRefreshing = true
-        closeUI()
+
+        guard let textView,
+              let updatedPrefix = CompletionEngine.prefix(
+                in: textView.string,
+                caret: textView.selectedRange().location
+              ),
+              !updatedPrefix.text.isEmpty,
+              previousPrefix?.range.location == updatedPrefix.range.location else {
+            candidates.removeAll()
+            prefix = nil
+            selection = 0
+            closeUI()
+            return
+        }
+
+        candidates.removeAll { candidate in
+            let filter = candidate.filterText ?? candidate.label
+            return !CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) &&
+                !CompletionEngine.hasCaseInsensitivePrefix(candidate.label, updatedPrefix.text)
+        }
+        prefix = candidates.isEmpty ? nil : updatedPrefix
+        selection = min(max(selection, 0), max(candidates.count - 1, 0))
+
+        if candidates.isEmpty {
+            closeUI()
+        } else if suggestionWindow.isVisible {
+            showPopup()
+        }
     }
 
     private func canAcceptCompletion(prefix: CompletionPrefix, in textView: CodeTextView) -> Bool {

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -461,7 +461,8 @@ final class CompletionFeature {
     }
 
     private func handleKey(_ action: CodeTextView.CompletionKeyAction) -> Bool {
-        if case .dismiss = action, suggestionWindow.isVisible || !candidates.isEmpty || isRefreshing {
+        if case .dismiss = action,
+           suggestionWindow.isVisible || !candidates.isEmpty || !candidatePool.isEmpty || isRefreshing {
             cancelAndDismiss()
             return true
         }

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -246,6 +246,14 @@ final class CompletionFeature {
         }
 
         let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
+        let selectedEditPlan = selectedCandidate.flatMap { candidate in
+            CompletionEngine.editPlan(
+                accepting: candidate,
+                prefix: prefix,
+                originalPrefix: candidatePrefix,
+                in: bufferText
+            )
+        }
         candidates = next
         candidatePool = next
         self.prefix = prefix
@@ -258,8 +266,13 @@ final class CompletionFeature {
                     $0.kind == selected.kind &&
                     $0.detail == selected.detail &&
                     $0.source == selected.source &&
-                    $0.replacementText == selected.replacementText &&
-                    $0.additionalTextEdits.map(\.newText) == selected.additionalTextEdits.map(\.newText)
+                    selectedEditPlan != nil &&
+                    CompletionEngine.editPlan(
+                        accepting: $0,
+                        prefix: prefix,
+                        originalPrefix: prefix,
+                        in: bufferText
+                    ) == selectedEditPlan
             }
         } ?? 0
         showPopup()
@@ -463,11 +476,10 @@ extension CompletionFeature {
 
     func testingSeedVisibleCandidates(
         labels: [String],
-        replacementTexts: [String]? = nil,
         prefix: CompletionPrefix,
         selection: Int = 0
     ) {
-        candidates = labels.enumerated().map { index, label in
+        candidates = labels.map { label in
             CompletionCandidate(
                 label: label,
                 detail: nil,
@@ -475,7 +487,7 @@ extension CompletionFeature {
                 documentation: nil,
                 sortText: nil,
                 filterText: label,
-                replacementText: replacementTexts?[index] ?? label,
+                replacementText: label,
                 textEdit: nil,
                 additionalTextEdits: [],
                 source: .lsp
@@ -491,6 +503,10 @@ extension CompletionFeature {
 
     func testingShowPopup() {
         showPopup()
+    }
+
+    func testingSetSelection(_ selection: Int) {
+        self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
     }
 
     func testingPresent(items: [LSPCompletionItem], prefix: CompletionPrefix, bufferText: String) {

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -3,6 +3,14 @@ import SwiftUI
 
 @MainActor
 final class CompletionFeature {
+    private struct CandidateIdentity: Hashable {
+        let label: String
+        let kind: Int?
+        let detail: String?
+        let source: CompletionCandidateSource
+        let editPlan: CompletionEditPlan
+    }
+
     private weak var textView: CodeTextView?
     private let getClient: () -> LSPClient?
     private let getURI: () -> String?
@@ -342,32 +350,48 @@ final class CompletionFeature {
     ) -> (candidates: [CompletionCandidate], origins: [UUID: CompletionPrefix]) {
         var merged = candidates
         var mergedOrigins = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, originPrefix) })
-        for candidate in retained {
-            let plan = CompletionEngine.editPlan(
-                accepting: candidate,
+        var identities = Set(merged.compactMap {
+            candidateIdentity(
+                for: $0,
+                origin: mergedOrigins[$0.id],
                 prefix: prefix,
-                originalPrefix: origins[candidate.id],
-                in: text
+                text: text
             )
-            let isDuplicate = merged.contains {
-                $0.label == candidate.label &&
-                    $0.kind == candidate.kind &&
-                    $0.detail == candidate.detail &&
-                    $0.source == candidate.source &&
-                    plan != nil &&
-                    CompletionEngine.editPlan(
-                        accepting: $0,
-                        prefix: prefix,
-                        originalPrefix: mergedOrigins[$0.id],
-                        in: text
-                    ) == plan
-            }
-            if !isDuplicate {
-                merged.append(candidate)
-                mergedOrigins[candidate.id] = origins[candidate.id]
-            }
+        })
+        for candidate in retained {
+            let identity = candidateIdentity(
+                for: candidate,
+                origin: origins[candidate.id],
+                prefix: prefix,
+                text: text
+            )
+            guard identity.map({ !identities.contains($0) }) ?? true else { continue }
+            merged.append(candidate)
+            mergedOrigins[candidate.id] = origins[candidate.id]
+            if let identity { identities.insert(identity) }
         }
         return (merged, mergedOrigins)
+    }
+
+    private static func candidateIdentity(
+        for candidate: CompletionCandidate,
+        origin: CompletionPrefix?,
+        prefix: CompletionPrefix,
+        text: String
+    ) -> CandidateIdentity? {
+        guard let editPlan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: prefix,
+            originalPrefix: origin,
+            in: text
+        ) else { return nil }
+        return CandidateIdentity(
+            label: candidate.label,
+            kind: candidate.kind,
+            detail: candidate.detail,
+            source: candidate.source,
+            editPlan: editPlan
+        )
     }
 
     private func showPopup() {

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -248,6 +248,7 @@ final class CompletionFeature {
         allowBufferFallback: Bool,
         memberAccessOnly: Bool
     ) {
+        let coordinateIndex = TextEditCoordinates.LineIndex(bufferText)
         let retainedMemberAccessOnly = candidateMemberAccessOnly || memberAccessOnly
         let retainedBufferFallback = allowBufferFallback && !retainedMemberAccessOnly
         let next = Self.candidates(
@@ -264,7 +265,8 @@ final class CompletionFeature {
                 accepting: candidate,
                 prefix: prefix,
                 originalPrefix: candidateOrigins[candidate.id],
-                in: bufferText
+                in: bufferText,
+                coordinateIndex: coordinateIndex
             )
         }
         let merged = Self.mergingCandidates(
@@ -273,7 +275,8 @@ final class CompletionFeature {
             with: candidatePool,
             origins: candidateOrigins,
             prefix: prefix,
-            text: bufferText
+            text: bufferText,
+            coordinateIndex: coordinateIndex
         )
         let visible = merged.candidates.filter { candidate in
             let filter = candidate.filterText ?? candidate.label
@@ -312,7 +315,8 @@ final class CompletionFeature {
                         accepting: $0,
                         prefix: prefix,
                         originalPrefix: candidateOrigins[$0.id],
-                        in: bufferText
+                        in: bufferText,
+                        coordinateIndex: coordinateIndex
                     ) == selectedEditPlan
             }
         } ?? 0
@@ -346,7 +350,8 @@ final class CompletionFeature {
         with retained: [CompletionCandidate],
         origins: [UUID: CompletionPrefix],
         prefix: CompletionPrefix,
-        text: String
+        text: String,
+        coordinateIndex: TextEditCoordinates.LineIndex
     ) -> (candidates: [CompletionCandidate], origins: [UUID: CompletionPrefix]) {
         var merged = candidates
         var mergedOrigins = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, originPrefix) })
@@ -355,7 +360,8 @@ final class CompletionFeature {
                 for: $0,
                 origin: mergedOrigins[$0.id],
                 prefix: prefix,
-                text: text
+                text: text,
+                coordinateIndex: coordinateIndex
             )
         })
         for candidate in retained {
@@ -363,7 +369,8 @@ final class CompletionFeature {
                 for: candidate,
                 origin: origins[candidate.id],
                 prefix: prefix,
-                text: text
+                text: text,
+                coordinateIndex: coordinateIndex
             )
             guard identity.map({ !identities.contains($0) }) ?? true else { continue }
             merged.append(candidate)
@@ -377,13 +384,15 @@ final class CompletionFeature {
         for candidate: CompletionCandidate,
         origin: CompletionPrefix?,
         prefix: CompletionPrefix,
-        text: String
+        text: String,
+        coordinateIndex: TextEditCoordinates.LineIndex
     ) -> CandidateIdentity? {
         guard let editPlan = CompletionEngine.editPlan(
             accepting: candidate,
             prefix: prefix,
             originalPrefix: origin,
-            in: text
+            in: text,
+            coordinateIndex: coordinateIndex
         ) else { return nil }
         return CandidateIdentity(
             label: candidate.label,
@@ -522,13 +531,16 @@ final class CompletionFeature {
             return
         }
 
+        let bufferText = textView.string
+        let coordinateIndex = TextEditCoordinates.LineIndex(bufferText)
         let selectedCandidate = candidates.indices.contains(selection) ? candidates[selection] : nil
         let selectedEditPlan = selectedCandidate.flatMap { candidate in
             CompletionEngine.editPlan(
                 accepting: candidate,
                 prefix: updatedPrefix,
                 originalPrefix: candidateOrigins[candidate.id],
-                in: textView.string
+                in: bufferText,
+                coordinateIndex: coordinateIndex
             )
         }
         if let candidatePrefix,
@@ -548,7 +560,8 @@ final class CompletionFeature {
                 with: candidatePool,
                 origins: candidateOrigins,
                 prefix: updatedPrefix,
-                text: textView.string
+                text: bufferText,
+                coordinateIndex: coordinateIndex
             )
             candidatePool = merged.candidates
             candidateOrigins = merged.origins
@@ -572,7 +585,8 @@ final class CompletionFeature {
                         accepting: $0,
                         prefix: updatedPrefix,
                         originalPrefix: candidateOrigins[$0.id],
-                        in: textView.string
+                        in: bufferText,
+                        coordinateIndex: coordinateIndex
                     ) == selectedEditPlan
             }
         } ?? 0

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -362,6 +362,7 @@ final class CompletionFeature {
             return !CompletionEngine.hasCaseInsensitivePrefix(filter, updatedPrefix.text) &&
                 !CompletionEngine.hasCaseInsensitivePrefix(candidate.label, updatedPrefix.text)
         }
+        isRefreshing = candidates.isEmpty
         prefix = candidates.isEmpty ? nil : updatedPrefix
         selection = min(max(selection, 0), max(candidates.count - 1, 0))
 
@@ -429,6 +430,10 @@ extension CompletionFeature {
         self.prefix = prefix
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
         isRefreshing = false
+    }
+
+    func testingShowPopup() {
+        showPopup()
     }
 
     var testingSnapshot: TestingSnapshot {

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -238,12 +238,14 @@ final class CompletionFeature {
         allowBufferFallback: Bool,
         memberAccessOnly: Bool
     ) {
+        let retainedMemberAccessOnly = candidateMemberAccessOnly || memberAccessOnly
+        let retainedBufferFallback = allowBufferFallback && !retainedMemberAccessOnly
         let next = Self.candidates(
             items: items,
             prefix: prefix,
             bufferText: bufferText,
-            allowBufferFallback: allowBufferFallback,
-            memberAccessOnly: memberAccessOnly
+            allowBufferFallback: retainedBufferFallback,
+            memberAccessOnly: retainedMemberAccessOnly
         )
 
         guard !next.isEmpty else {
@@ -266,8 +268,8 @@ final class CompletionFeature {
         candidatePrefix = prefix
         candidateBufferText = bufferText
         candidateItems = items
-        candidateAllowsBufferFallback = allowBufferFallback
-        candidateMemberAccessOnly = memberAccessOnly
+        candidateAllowsBufferFallback = retainedBufferFallback
+        candidateMemberAccessOnly = retainedMemberAccessOnly
         candidateAllowsEmptyPrefix = candidateAllowsEmptyPrefix || allowEmptyPrefix
         isRefreshing = false
         selection = selectedCandidate.flatMap { selected in
@@ -527,7 +529,8 @@ extension CompletionFeature {
     func testingSeedVisibleCandidates(
         labels: [String],
         prefix: CompletionPrefix,
-        selection: Int = 0
+        selection: Int = 0,
+        memberAccessOnly: Bool = false
     ) {
         candidates = labels.map { label in
             CompletionCandidate(
@@ -547,6 +550,7 @@ extension CompletionFeature {
         self.prefix = prefix
         candidatePrefix = prefix
         candidateBufferText = textView?.string
+        candidateMemberAccessOnly = memberAccessOnly
         candidateAllowsEmptyPrefix = prefix.text.isEmpty
         self.selection = min(max(selection, 0), max(candidates.count - 1, 0))
         isRefreshing = false

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -20,6 +20,9 @@ final class CompletionFeature {
     private var prefix: CompletionPrefix?
     private var candidatePrefix: CompletionPrefix?
     private var candidateBufferText: String?
+    private var candidateItems: [LSPCompletionItem] = []
+    private var candidateAllowsBufferFallback = false
+    private var candidateMemberAccessOnly = false
     private var selection: Int = 0
     private let suggestionWindow = CompletionWindowController()
     private var isRefreshing = false
@@ -75,6 +78,9 @@ final class CompletionFeature {
         prefix = nil
         candidatePrefix = nil
         candidateBufferText = nil
+        candidateItems.removeAll()
+        candidateAllowsBufferFallback = false
+        candidateMemberAccessOnly = false
         selection = 0
         isRefreshing = false
         closeUI()
@@ -228,17 +234,13 @@ final class CompletionFeature {
         allowBufferFallback: Bool,
         memberAccessOnly: Bool
     ) {
-        var next = CompletionEngine.lspCandidates(
-            from: items,
+        let next = Self.candidates(
+            items: items,
             prefix: prefix,
+            bufferText: bufferText,
+            allowBufferFallback: allowBufferFallback,
             memberAccessOnly: memberAccessOnly
         )
-        if allowBufferFallback {
-            let buffer = CompletionEngine.bufferWordCandidates(in: bufferText, prefix: prefix)
-            next.append(contentsOf: buffer.filter { bufferCandidate in
-                !next.contains { $0.label == bufferCandidate.label }
-            })
-        }
 
         guard !next.isEmpty else {
             cancelAndDismiss()
@@ -259,6 +261,9 @@ final class CompletionFeature {
         self.prefix = prefix
         candidatePrefix = prefix
         candidateBufferText = bufferText
+        candidateItems = items
+        candidateAllowsBufferFallback = allowBufferFallback
+        candidateMemberAccessOnly = memberAccessOnly
         isRefreshing = false
         selection = selectedCandidate.flatMap { selected in
             next.firstIndex {
@@ -276,6 +281,27 @@ final class CompletionFeature {
             }
         } ?? 0
         showPopup()
+    }
+
+    private static func candidates(
+        items: [LSPCompletionItem],
+        prefix: CompletionPrefix,
+        bufferText: String,
+        allowBufferFallback: Bool,
+        memberAccessOnly: Bool
+    ) -> [CompletionCandidate] {
+        var candidates = CompletionEngine.lspCandidates(
+            from: items,
+            prefix: prefix,
+            memberAccessOnly: memberAccessOnly
+        )
+        if allowBufferFallback {
+            let buffer = CompletionEngine.bufferWordCandidates(in: bufferText, prefix: prefix)
+            candidates.append(contentsOf: buffer.filter { bufferCandidate in
+                !candidates.contains { $0.label == bufferCandidate.label }
+            })
+        }
+        return candidates
     }
 
     private func showPopup() {
@@ -385,7 +411,6 @@ final class CompletionFeature {
                 in: textView.string,
                 caret: textView.selectedRange().location
               ),
-              !updatedPrefix.text.isEmpty,
               previousPrefix?.range.location == updatedPrefix.range.location,
               textOutsideCandidatePrefixIsUnchanged(in: textView.string, updatedPrefix: updatedPrefix) else {
             candidates.removeAll()
@@ -393,9 +418,27 @@ final class CompletionFeature {
             prefix = nil
             candidatePrefix = nil
             candidateBufferText = nil
+            candidateItems.removeAll()
+            candidateAllowsBufferFallback = false
+            candidateMemberAccessOnly = false
             selection = 0
             closeUI()
             return
+        }
+
+        if let candidatePrefix,
+           updatedPrefix.range.length < candidatePrefix.range.length,
+           let candidateBufferText {
+            let rebuilt = Self.candidates(
+                items: candidateItems,
+                prefix: updatedPrefix,
+                bufferText: candidateBufferText,
+                allowBufferFallback: candidateAllowsBufferFallback,
+                memberAccessOnly: candidateMemberAccessOnly
+            )
+            candidatePool = rebuilt.map { candidate in
+                candidatePool.first { $0 == candidate } ?? candidate
+            }
         }
 
         let selectedCandidateID = candidates.indices.contains(selection) ? candidates[selection].id : nil

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -66,8 +66,8 @@ final class CompletionFeature {
         textView.completionManualTriggerHandler = { [weak self] in
             self?.triggerManual()
         }
-        textView.completionChangeHandler = { [weak self] in
-            self?.scheduleAutomatic()
+        textView.completionChangeHandler = { [weak self] editRange in
+            self?.scheduleAutomatic(editRange: editRange)
         }
         textView.completionSelectionChangeHandler = { [weak self] in
             self?.cancelAndDismiss()
@@ -104,14 +104,14 @@ final class CompletionFeature {
         startCompletion(trigger: .invoked, triggerCharacter: nil, allowEmptyPrefix: true, allowBufferFallback: true)
     }
 
-    private func scheduleAutomatic() {
+    private func scheduleAutomatic(editRange: NSRange?) {
         guard hasSessionPreconditions() else {
             cancelAndDismiss()
             return
         }
 
         debounceTask?.cancel()
-        invalidateActiveSessionForChange()
+        invalidateActiveSessionForChange(editRange: editRange)
         debounceTask = Task { [weak self] in
             guard let self else { return }
             try? await Task.sleep(nanoseconds: automaticDebounceNanos)
@@ -489,7 +489,7 @@ final class CompletionFeature {
         suggestionWindow.hide()
     }
 
-    private func invalidateActiveSessionForChange() {
+    private func invalidateActiveSessionForChange(editRange: NSRange?) {
         let previousPrefix = prefix
         requestTask?.cancel()
         requestTask = nil
@@ -503,7 +503,10 @@ final class CompletionFeature {
               ),
               candidateAllowsEmptyPrefix || !updatedPrefix.text.isEmpty,
               previousPrefix?.range.location == updatedPrefix.range.location,
-              textOutsideCandidatePrefixIsUnchanged(in: textView.string, updatedPrefix: updatedPrefix) else {
+              let previousPrefix,
+              let editRange,
+              editRange.location >= previousPrefix.range.location,
+              NSMaxRange(editRange) <= NSMaxRange(previousPrefix.range) else {
             candidates.removeAll()
             candidatePool.removeAll()
             prefix = nil
@@ -528,8 +531,7 @@ final class CompletionFeature {
                 in: textView.string
             )
         }
-        if let previousPrefix,
-           let candidatePrefix,
+        if let candidatePrefix,
            updatedPrefix.range.length < previousPrefix.range.length,
            !candidateItems.isEmpty || candidateAllowsBufferFallback,
            let candidateBufferText {
@@ -580,26 +582,6 @@ final class CompletionFeature {
         } else {
             showPopup()
         }
-    }
-
-    private func textOutsideCandidatePrefixIsUnchanged(
-        in text: String,
-        updatedPrefix: CompletionPrefix
-    ) -> Bool {
-        guard let candidateBufferText,
-              let candidatePrefix else { return false }
-
-        let original = candidateBufferText as NSString
-        let current = text as NSString
-        let start = candidatePrefix.range.location
-        let originalEnd = NSMaxRange(candidatePrefix.range)
-        let currentEnd = NSMaxRange(updatedPrefix.range)
-        guard start >= 0,
-              originalEnd <= original.length,
-              currentEnd <= current.length else { return false }
-
-        return original.substring(to: start) == current.substring(to: start) &&
-            original.substring(from: originalEnd) == current.substring(from: currentEnd)
     }
 
     private func canAcceptCompletion(prefix: CompletionPrefix, in textView: CodeTextView) -> Bool {

--- a/Alas/Sources/Code/TextEditCoordinates.swift
+++ b/Alas/Sources/Code/TextEditCoordinates.swift
@@ -12,6 +12,44 @@ struct EditorTextEdit: Sendable, Equatable {
 }
 
 enum TextEditCoordinates {
+    struct LineIndex {
+        private let starts: [Int]
+        private let textLength: Int
+
+        init(_ text: String) {
+            let ns = text as NSString
+            var starts = [0]
+            for index in 0..<ns.length where ns.character(at: index) == 10 {
+                starts.append(index + 1)
+            }
+            self.starts = starts
+            textLength = ns.length
+        }
+
+        func utf16Offset(from position: LSPPosition) -> Int? {
+            guard starts.indices.contains(position.line), position.character >= 0 else { return nil }
+            let lineEnd = position.line + 1 < starts.count ? starts[position.line + 1] - 1 : textLength
+            let offset = starts[position.line] + position.character
+            return offset <= lineEnd ? offset : nil
+        }
+
+        func lspPosition(utf16Offset target: Int) -> LSPPosition? {
+            guard target >= 0, target <= textLength else { return nil }
+            var lowerBound = 0
+            var upperBound = starts.count
+            while lowerBound < upperBound {
+                let middle = (lowerBound + upperBound) / 2
+                if starts[middle] <= target {
+                    lowerBound = middle + 1
+                } else {
+                    upperBound = middle
+                }
+            }
+            let line = lowerBound - 1
+            return LSPPosition(line: line, character: target - starts[line])
+        }
+    }
+
     static func apply(_ edit: EditorTextEdit, to text: String) -> String? {
         let ns = text as NSString
         guard edit.location >= 0,
@@ -47,34 +85,11 @@ enum TextEditCoordinates {
     }
 
     static func lspPosition(utf16Offset target: Int, in text: String) -> LSPPosition? {
-        guard let point = point(utf16Offset: target, in: text) else { return nil }
-        return LSPPosition(line: point.line, character: point.character)
+        LineIndex(text).lspPosition(utf16Offset: target)
     }
 
     static func utf16Offset(from position: LSPPosition, in text: String) -> Int? {
-        guard position.line >= 0, position.character >= 0 else { return nil }
-        let ns = text as NSString
-        var line = 0
-        var lineStart = 0
-        var index = 0
-        while index < ns.length {
-            if ns.character(at: index) == 10 {
-                if line == position.line {
-                    let offset = lineStart + position.character
-                    guard offset <= index else { return nil }
-                    return offset
-                }
-                line += 1
-                lineStart = index + 1
-            }
-            index += 1
-        }
-        if line == position.line {
-            let offset = lineStart + position.character
-            guard offset <= ns.length else { return nil }
-            return offset
-        }
-        return nil
+        LineIndex(text).utf16Offset(from: position)
     }
 
     private static func point(utf16Offset target: Int, in text: String) -> (line: Int, character: Int, byteColumn: Int)? {

--- a/Alas/Sources/Code/TextEditCoordinates.swift
+++ b/Alas/Sources/Code/TextEditCoordinates.swift
@@ -14,7 +14,9 @@ struct EditorTextEdit: Sendable, Equatable {
 enum TextEditCoordinates {
     struct LineIndex {
         private let starts: [Int]
-        private let textLength: Int
+        private var textLength: Int
+        private var shiftedAfterLine: Int?
+        private var suffixShift = 0
 
         init(_ text: String) {
             let ns = text as NSString
@@ -26,10 +28,21 @@ enum TextEditCoordinates {
             textLength = ns.length
         }
 
+        func adjustingOffsets(after offset: Int, by delta: Int) -> LineIndex? {
+            guard delta != 0 else { return self }
+            guard let line = lspPosition(utf16Offset: offset)?.line,
+                  shiftedAfterLine == nil || shiftedAfterLine == line else { return nil }
+            var adjusted = self
+            adjusted.shiftedAfterLine = line
+            adjusted.suffixShift += delta
+            adjusted.textLength += delta
+            return adjusted
+        }
+
         func utf16Offset(from position: LSPPosition) -> Int? {
             guard starts.indices.contains(position.line), position.character >= 0 else { return nil }
-            let lineEnd = position.line + 1 < starts.count ? starts[position.line + 1] - 1 : textLength
-            let offset = starts[position.line] + position.character
+            let lineEnd = position.line + 1 < starts.count ? lineStart(position.line + 1) - 1 : textLength
+            let offset = lineStart(position.line) + position.character
             return offset <= lineEnd ? offset : nil
         }
 
@@ -39,14 +52,18 @@ enum TextEditCoordinates {
             var upperBound = starts.count
             while lowerBound < upperBound {
                 let middle = (lowerBound + upperBound) / 2
-                if starts[middle] <= target {
+                if lineStart(middle) <= target {
                     lowerBound = middle + 1
                 } else {
                     upperBound = middle
                 }
             }
             let line = lowerBound - 1
-            return LSPPosition(line: line, character: target - starts[line])
+            return LSPPosition(line: line, character: target - lineStart(line))
+        }
+
+        private func lineStart(_ line: Int) -> Int {
+            starts[line] + (shiftedAfterLine.map { line > $0 } == true ? suffixShift : 0)
         }
     }
 

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -259,6 +259,40 @@ struct CompletionEngineTests {
         #expect(plan.flatMap { apply($0, to: "openXYZ") } == "openAlpha")
     }
 
+    @Test("keeps a retained primary edit start before a grown prefix")
+    func plansRetainedPrimaryEditStartingAtOldCaret() {
+        let candidate = CompletionCandidate(
+            label: "car",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "car",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 4),
+                    end: LSPPosition(line: 0, character: 7)
+                ),
+                newText: "car"
+            ),
+            additionalTextEdits: [],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "c", range: NSRange(location: 4, length: 1)),
+            originalPrefix: CompletionPrefix(text: "", range: NSRange(location: 4, length: 0)),
+            in: "foo.cBar"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 4, length: 4), replacementText: "car")
+        ])
+        #expect(plan.flatMap { apply($0, to: "foo.cBar") } == "foo.car")
+    }
+
     @Test("shifts a retained textEdit when the prefix shrinks")
     func plansRetainedTextEditAfterBackspace() {
         let candidate = CompletionCandidate(

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -37,6 +37,16 @@ struct CompletionEngineTests {
         #expect(candidates.isEmpty)
     }
 
+    @Test("matches Unicode buffer words case-insensitively")
+    func unicodeBufferWordFallback() {
+        let candidates = CompletionEngine.bufferWordCandidates(
+            in: "ÄbcWord",
+            prefix: CompletionPrefix(text: "äbc", range: NSRange(location: 0, length: 3))
+        )
+
+        #expect(candidates.map(\.label) == ["ÄbcWord"])
+    }
+
     @Test("bounds cached buffer words for broadened prefixes")
     func boundedBufferWordCache() {
         let words = (0..<30).map { "openWord\($0)" }.joined(separator: " ")

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -37,6 +37,19 @@ struct CompletionEngineTests {
         #expect(candidates.isEmpty)
     }
 
+    @Test("bounds cached buffer words for broadened prefixes")
+    func boundedBufferWordCache() {
+        let words = (0..<30).map { "openWord\($0)" }.joined(separator: " ")
+        let cache = CompletionEngine.bufferWordCandidateCache(
+            in: words,
+            prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4))
+        )
+
+        #expect(cache["ope"]?.count == 24)
+        #expect(cache["open"]?.count == 24)
+        #expect(cache.values.allSatisfy { $0.count <= 24 })
+    }
+
     @Test("normalizes and ranks LSP items")
     func normalizeLSPItems() {
         let items = [

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -192,6 +192,39 @@ struct CompletionEngineTests {
         #expect(plan.flatMap { apply($0, to: "tabs.op") } == "tabs.openEditor")
     }
 
+    @Test("rebases an older LSP textEdit onto the current prefix")
+    func plansStalePrefixTextEditAsCurrentPrefixReplacement() {
+        let candidate = CompletionCandidate(
+            label: "openAlpha",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openAlpha",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 0),
+                    end: LSPPosition(line: 0, character: 4)
+                ),
+                newText: "openAlpha"
+            ),
+            additionalTextEdits: [],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "openA", range: NSRange(location: 0, length: 5)),
+            in: "openA"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 0, length: 5), replacementText: "openAlpha")
+        ])
+        #expect(plan.flatMap { apply($0, to: "openA") } == "openAlpha")
+    }
+
     @Test("plans textEdit plus non-overlapping additional edits")
     func plansAdditionalTextEdits() {
         let text = "let value = op\n"

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -336,6 +336,49 @@ struct CompletionEngineTests {
         #expect(plan.flatMap { apply($0, to: "foo.c") } == "object.count")
     }
 
+    @Test("moves an adjacent additional edit with a shrinking prefix")
+    func plansAdjacentAdditionalEditAfterBackspace() {
+        let candidate = CompletionCandidate(
+            label: "value",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "value",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 4),
+                    end: LSPPosition(line: 0, character: 4)
+                ),
+                newText: "value"
+            ),
+            additionalTextEdits: [
+                LSPTextEdit(
+                    range: LSPRange(
+                        start: LSPPosition(line: 0, character: 0),
+                        end: LSPPosition(line: 0, character: 4)
+                    ),
+                    newText: "object."
+                )
+            ],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3)),
+            originalPrefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
+            in: "opeX"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 0, length: 3), replacementText: "object."),
+            CompletionTextEdit(range: NSRange(location: 3, length: 0), replacementText: "value")
+        ])
+        #expect(plan.flatMap { apply($0, to: "opeX") } == "object.valueX")
+    }
+
     @Test("plans textEdit plus non-overlapping additional edits")
     func plansAdditionalTextEdits() {
         let text = "let value = op\n"

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -225,6 +225,40 @@ struct CompletionEngineTests {
         #expect(plan.flatMap { apply($0, to: "openA") } == "openAlpha")
     }
 
+    @Test("shifts a retained textEdit that spans the old caret")
+    func plansRetainedTextEditSpanningOldCaret() {
+        let candidate = CompletionCandidate(
+            label: "openAlpha",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openAlpha",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 0),
+                    end: LSPPosition(line: 0, character: 6)
+                ),
+                newText: "openAlpha"
+            ),
+            additionalTextEdits: [],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
+            originalPrefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3)),
+            in: "openXYZ"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 0, length: 7), replacementText: "openAlpha")
+        ])
+        #expect(plan.flatMap { apply($0, to: "openXYZ") } == "openAlpha")
+    }
+
     @Test("plans textEdit plus non-overlapping additional edits")
     func plansAdditionalTextEdits() {
         let text = "let value = op\n"
@@ -380,7 +414,7 @@ private func apply(_ plan: CompletionEditPlan, to text: String) -> String? {
     return storage as String
 }
 
-private extension LSPCompletionItem {
+extension LSPCompletionItem {
     static func testing(
         label: String,
         kind: Int? = nil,

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -190,6 +190,18 @@ struct CompletionEngineTests {
         ])
         #expect(plan?.finalSelection == NSRange(location: 15, length: 0))
         #expect(plan.flatMap { apply($0, to: "tabs.op") } == "tabs.openEditor")
+
+        let retainedPlan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "ope", range: NSRange(location: 5, length: 3)),
+            originalPrefix: CompletionPrefix(text: "op", range: NSRange(location: 5, length: 2)),
+            in: "tabs.ope"
+        )
+
+        #expect(retainedPlan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 5, length: 3), replacementText: "openEditor")
+        ])
+        #expect(retainedPlan.flatMap { apply($0, to: "tabs.ope") } == "tabs.openEditor")
     }
 
     @Test("rebases an older LSP textEdit onto the current prefix")

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -293,6 +293,40 @@ struct CompletionEngineTests {
         #expect(plan.flatMap { apply($0, to: "opeXYZ") } == "openAlphaXYZ")
     }
 
+    @Test("clamps a retained textEdit inside a deleted prefix")
+    func plansRetainedTextEditAfterMultipleBackspaces() {
+        let candidate = CompletionCandidate(
+            label: "openAlpha",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openAlpha",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 3),
+                    end: LSPPosition(line: 0, character: 7)
+                ),
+                newText: "openAlpha"
+            ),
+            additionalTextEdits: [],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2)),
+            originalPrefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
+            in: "opXYZ"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 2, length: 3), replacementText: "openAlpha")
+        ])
+        #expect(plan.flatMap { apply($0, to: "opXYZ") } == "opopenAlpha")
+    }
+
     @Test("keeps an adjacent additional edit before a grown prefix")
     func plansAdjacentAdditionalEditAtOldCaret() {
         let candidate = CompletionCandidate(

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -259,6 +259,40 @@ struct CompletionEngineTests {
         #expect(plan.flatMap { apply($0, to: "openXYZ") } == "openAlpha")
     }
 
+    @Test("shifts a retained textEdit when the prefix shrinks")
+    func plansRetainedTextEditAfterBackspace() {
+        let candidate = CompletionCandidate(
+            label: "openAlpha",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openAlpha",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 0),
+                    end: LSPPosition(line: 0, character: 4)
+                ),
+                newText: "openAlpha"
+            ),
+            additionalTextEdits: [],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3)),
+            originalPrefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
+            in: "opeXYZ"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 0, length: 3), replacementText: "openAlpha")
+        ])
+        #expect(plan.flatMap { apply($0, to: "opeXYZ") } == "openAlphaXYZ")
+    }
+
     @Test("plans textEdit plus non-overlapping additional edits")
     func plansAdditionalTextEdits() {
         let text = "let value = op\n"

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -293,6 +293,49 @@ struct CompletionEngineTests {
         #expect(plan.flatMap { apply($0, to: "opeXYZ") } == "openAlphaXYZ")
     }
 
+    @Test("keeps an adjacent additional edit before a grown prefix")
+    func plansAdjacentAdditionalEditAtOldCaret() {
+        let candidate = CompletionCandidate(
+            label: "count",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "count",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 4),
+                    end: LSPPosition(line: 0, character: 4)
+                ),
+                newText: "count"
+            ),
+            additionalTextEdits: [
+                LSPTextEdit(
+                    range: LSPRange(
+                        start: LSPPosition(line: 0, character: 0),
+                        end: LSPPosition(line: 0, character: 4)
+                    ),
+                    newText: "object."
+                )
+            ],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "c", range: NSRange(location: 4, length: 1)),
+            originalPrefix: CompletionPrefix(text: "", range: NSRange(location: 4, length: 0)),
+            in: "foo.c"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 0, length: 4), replacementText: "object."),
+            CompletionTextEdit(range: NSRange(location: 4, length: 1), replacementText: "count")
+        ])
+        #expect(plan.flatMap { apply($0, to: "foo.c") } == "object.count")
+    }
+
     @Test("plans textEdit plus non-overlapping additional edits")
     func plansAdditionalTextEdits() {
         let text = "let value = op\n"

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -379,6 +379,49 @@ struct CompletionEngineTests {
         #expect(plan.flatMap { apply($0, to: "opeX") } == "object.valueX")
     }
 
+    @Test("moves a zero-length additional edit with a grown prefix")
+    func plansAdditionalInsertionAtOldCaret() {
+        let candidate = CompletionCandidate(
+            label: "openAlpha",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openAlpha",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 0),
+                    end: LSPPosition(line: 0, character: 3)
+                ),
+                newText: "openAlpha"
+            ),
+            additionalTextEdits: [
+                LSPTextEdit(
+                    range: LSPRange(
+                        start: LSPPosition(line: 0, character: 3),
+                        end: LSPPosition(line: 0, character: 3)
+                    ),
+                    newText: "!"
+                )
+            ],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
+            originalPrefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3)),
+            in: "open"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 0, length: 4), replacementText: "openAlpha"),
+            CompletionTextEdit(range: NSRange(location: 4, length: 0), replacementText: "!")
+        ])
+        #expect(plan.flatMap { apply($0, to: "open") } == "openAlpha!")
+    }
+
     @Test("plans textEdit plus non-overlapping additional edits")
     func plansAdditionalTextEdits() {
         let text = "let value = op\n"

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -152,6 +152,28 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("automatic refresh dismisses at an empty prefix")
+    func automaticRefreshDismissesAtEmptyPrefix() {
+        let textView = makeTextView("o")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingSeedVisibleCandidates(
+            labels: ["openAlpha"],
+            prefix: CompletionPrefix(text: "o", range: NSRange(location: 0, length: 1))
+        )
+
+        textView.deleteBackward(nil)
+
+        #expect(textView.string.isEmpty)
+        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
+        #expect(feature.testingSnapshot.prefix == nil)
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh rebuilds candidates when broadening past the response prefix")
     func refreshRebuildsCandidatesPastResponsePrefix() {
         let textView = makeTextView("open")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -154,7 +154,8 @@ struct CompletionFeatureTests {
 
     @Test("refreshed results preserve the selected candidate")
     func refreshedResultsPreserveSelectedCandidate() {
-        let textView = makeTextView("ap")
+        let textView = makeTextView("apTail")
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
         let feature = CompletionFeature(
             textView: textView,
             getClient: { nil },
@@ -162,27 +163,50 @@ struct CompletionFeatureTests {
             isEnabled: { true }
         )
         let prefix = CompletionPrefix(text: "ap", range: NSRange(location: 0, length: 2))
-        feature.testingSeedVisibleCandidates(
-            labels: ["append", "append"],
-            replacementTexts: ["append(_:)", "append(contentsOf:)"],
+        feature.testingPresent(
+            items: [
+                completionItem(label: "append", sortText: "001", replacement: "append", rangeEnd: 6),
+                completionItem(label: "append", sortText: "002", replacement: "append", rangeEnd: 2)
+            ],
             prefix: prefix,
-            selection: 1
+            bufferText: "apTail"
         )
+        feature.testingSetSelection(0)
 
         feature.testingPresent(
             items: [
-                .testing(label: "append", sortText: "001", filterText: nil, insertText: "append(_:)"),
-                .testing(label: "append", sortText: "002", filterText: nil, insertText: "append(contentsOf:)")
+                completionItem(label: "append", sortText: "001", replacement: "append", rangeEnd: 2),
+                completionItem(label: "append", sortText: "002", replacement: "append", rangeEnd: 6)
             ],
             prefix: prefix,
-            bufferText: "ap"
+            bufferText: "apTail"
         )
 
         #expect(feature.testingSnapshot.candidateLabels == ["append", "append"])
         #expect(feature.testingSnapshot.selection == 1)
         #expect(textView.completionKeyHandler?(.acceptSelected) == true)
-        #expect(textView.string == "append(contentsOf:)")
+        #expect(textView.string == "append")
         feature.cancelAndDismiss()
+    }
+
+    private func completionItem(
+        label: String,
+        sortText: String,
+        replacement: String,
+        rangeEnd: Int
+    ) -> LSPCompletionItem {
+        .testing(
+            label: label,
+            sortText: sortText,
+            filterText: nil,
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 0),
+                    end: LSPPosition(line: 0, character: rangeEnd)
+                ),
+                newText: replacement
+            )
+        )
     }
 
     private func waitForCompletionRequest(events: () -> [String]) async throws {

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -141,18 +141,22 @@ struct CompletionFeatureTests {
         )
         feature.testingSeedVisibleCandidates(
             labels: ["count", "copy"],
-            prefix: CompletionPrefix(text: "", range: NSRange(location: 4, length: 0))
+            prefix: CompletionPrefix(text: "", range: NSRange(location: 4, length: 0)),
+            memberAccessOnly: true
         )
 
         textView.insertText("c", replacementRange: NSRange(location: NSNotFound, length: 0))
         feature.testingPresent(
             items: [
-                .testing(label: "count", sortText: "001", filterText: nil),
-                .testing(label: "copy", sortText: "002", filterText: nil)
+                .testing(label: "count", kind: 10, sortText: "001", filterText: nil),
+                .testing(label: "copy", kind: 2, sortText: "002", filterText: nil),
+                .testing(label: "case", kind: 14, sortText: "003", filterText: nil)
             ],
             prefix: CompletionPrefix(text: "c", range: NSRange(location: 4, length: 1)),
             bufferText: "foo.c"
         )
+
+        #expect(feature.testingSnapshot.candidateLabels == ["count", "copy"])
         textView.deleteBackward(nil)
 
         #expect(textView.string == "foo.")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -434,6 +434,37 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("narrow responses extend the retained buffer cache")
+    func narrowResponseExtendsBufferCache() {
+        let text = "operate openEditor\no"
+        let textView = makeTextView(text)
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        let item = LSPCompletionItem.testing(label: "openAlpha", sortText: "001", filterText: nil)
+        feature.testingPresent(
+            items: [item],
+            prefix: CompletionEngine.prefix(in: text, caret: (text as NSString).length)!,
+            bufferText: text,
+            allowBufferFallback: true
+        )
+
+        textView.insertText("pen", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [item],
+            prefix: CompletionEngine.prefix(in: textView.string, caret: textView.selectedRange().location)!,
+            bufferText: textView.string,
+            allowBufferFallback: true
+        )
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels.contains("operate"))
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh preserves the selected matching candidate")
     func refreshPreservesSelectedMatchingCandidate() {
         let textView = makeTextView("a")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -64,8 +64,8 @@ struct CompletionFeatureTests {
         #expect(!CompletionFeature.isMemberAccessTriggerCharacter(nil))
     }
 
-    @Test("refresh clears stale candidates before the next response")
-    func refreshClearsStaleCandidatesBeforeNextResponse() {
+    @Test("refresh keeps matching candidates while awaiting the next response")
+    func refreshKeepsMatchingCandidatesWhileAwaitingNextResponse() {
         let textView = makeTextView("open")
         let feature = CompletionFeature(
             textView: textView,
@@ -78,10 +78,10 @@ struct CompletionFeatureTests {
             prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4))
         )
 
-        textView.completionChangeHandler?()
+        textView.insertText("A", replacementRange: NSRange(location: NSNotFound, length: 0))
 
-        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
-        #expect(feature.testingSnapshot.prefix == nil)
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha"])
+        #expect(feature.testingSnapshot.prefix == CompletionPrefix(text: "openA", range: NSRange(location: 0, length: 5)))
         #expect(feature.testingSnapshot.selection == 0)
         #expect(feature.testingSnapshot.isRefreshing)
         feature.cancelAndDismiss()

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -112,6 +112,37 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("refreshed results preserve the selected candidate")
+    func refreshedResultsPreserveSelectedCandidate() {
+        let textView = makeTextView("ap")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        let prefix = CompletionPrefix(text: "ap", range: NSRange(location: 0, length: 2))
+        feature.testingSeedVisibleCandidates(
+            labels: ["apple", "apricot"],
+            prefix: prefix,
+            selection: 1
+        )
+
+        feature.testingPresent(
+            items: [
+                .testing(label: "apartment", sortText: "001", filterText: nil),
+                .testing(label: "apricot", sortText: "002", filterText: nil),
+                .testing(label: "apple", sortText: "003", filterText: nil)
+            ],
+            prefix: prefix,
+            bufferText: "ap"
+        )
+
+        #expect(feature.testingSnapshot.candidateLabels == ["apartment", "apricot", "apple"])
+        #expect(feature.testingSnapshot.selection == 1)
+        feature.cancelAndDismiss()
+    }
+
     private func waitForCompletionRequest(events: () -> [String]) async throws {
         let deadline = Date().addingTimeInterval(2)
         while !events().contains("completion"), Date() < deadline {

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -158,6 +158,37 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("refresh restores broader candidates at an intermediate prefix")
+    func refreshRestoresBroaderResponseImmediately() {
+        let textView = makeTextView("o")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingPresent(
+            items: [
+                .testing(label: "openAlpha", sortText: "001", filterText: nil),
+                .testing(label: "operate", sortText: "002", filterText: nil)
+            ],
+            prefix: CompletionPrefix(text: "o", range: NSRange(location: 0, length: 1)),
+            bufferText: "o"
+        )
+
+        textView.insertText("pen", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [.testing(label: "openAlpha", sortText: "001", filterText: nil)],
+            prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
+            bufferText: "open"
+        )
+        textView.deleteBackward(nil)
+
+        #expect(textView.string == "ope")
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "operate"])
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh discards candidates when text changes outside the prefix")
     func refreshDiscardsCandidatesAfterForwardDelete() {
         let textView = makeTextView("opeXYZ tail")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -487,6 +487,31 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("empty local filter preserves the selected candidate")
+    func emptyLocalFilterPreservesSelection() {
+        let textView = makeTextView("ap")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingSeedVisibleCandidates(
+            labels: ["apple", "apricot"],
+            prefix: CompletionPrefix(text: "ap", range: NSRange(location: 0, length: 2)),
+            selection: 1
+        )
+
+        textView.insertText("z", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels == ["apple", "apricot"])
+        #expect(feature.testingSnapshot.selection == 1)
+        #expect(textView.completionKeyHandler?(.acceptSelected) == true)
+        #expect(textView.string == "apricot")
+        feature.cancelAndDismiss()
+    }
+
     @Test("refreshed results preserve the selected candidate")
     func refreshedResultsPreserveSelectedCandidate() {
         let textView = makeTextView("apTail")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -91,10 +91,42 @@ struct CompletionFeatureTests {
         #expect(textView.string == "open")
         #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "openBeta"])
 
+        textView.insertText("Z", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
+        #expect(feature.testingSnapshot.prefix == CompletionPrefix(text: "openZ", range: NSRange(location: 0, length: 5)))
+
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "openBeta"])
+
         textView.insertText("A", replacementRange: NSRange(location: NSNotFound, length: 0))
 
         #expect(textView.completionKeyHandler?(.acceptTop) == true)
         #expect(textView.string == "openAlpha")
+        feature.cancelAndDismiss()
+    }
+
+    @Test("refresh discards candidates when text changes outside the prefix")
+    func refreshDiscardsCandidatesAfterForwardDelete() {
+        let textView = makeTextView("opeXYZ tail")
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingSeedVisibleCandidates(
+            labels: ["openAlpha"],
+            prefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3))
+        )
+
+        textView.deleteForward(nil)
+
+        #expect(textView.string == "opeYZ tail")
+        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
+        #expect(feature.testingSnapshot.prefix == nil)
         feature.cancelAndDismiss()
     }
 

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -107,6 +107,36 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("refresh retains candidates from a broader response")
+    func refreshRetainsBroaderResponse() {
+        let textView = makeTextView("ope")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingPresent(
+            items: [
+                .testing(label: "openAlpha", sortText: "001", filterText: nil),
+                .testing(label: "operate", sortText: "002", filterText: nil)
+            ],
+            prefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3)),
+            bufferText: "ope"
+        )
+
+        textView.insertText("n", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [.testing(label: "openAlpha", sortText: "001", filterText: nil)],
+            prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
+            bufferText: "open"
+        )
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "operate"])
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh discards candidates when text changes outside the prefix")
     func refreshDiscardsCandidatesAfterForwardDelete() {
         let textView = makeTextView("opeXYZ tail")
@@ -139,9 +169,14 @@ struct CompletionFeatureTests {
             getURI: { "file:///tmp/foo.swift" },
             isEnabled: { true }
         )
-        feature.testingSeedVisibleCandidates(
-            labels: ["count", "copy"],
+        feature.testingPresent(
+            items: [
+                .testing(label: "count", kind: 10, sortText: "001", filterText: nil),
+                .testing(label: "copy", kind: 2, sortText: "002", filterText: nil)
+            ],
             prefix: CompletionPrefix(text: "", range: NSRange(location: 4, length: 0)),
+            bufferText: "foo.",
+            allowEmptyPrefix: true,
             memberAccessOnly: true
         )
 

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -494,6 +494,43 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("invalid LSP edit candidates are not retained")
+    func invalidEditCandidatesAreDropped() {
+        let textView = makeTextView("a")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        let invalid = LSPCompletionItem.testing(
+            label: "alpha",
+            sortText: "001",
+            filterText: nil,
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 99, character: 0),
+                    end: LSPPosition(line: 99, character: 1)
+                ),
+                newText: "alpha"
+            )
+        )
+
+        feature.testingPresent(
+            items: [invalid],
+            prefix: CompletionPrefix(text: "a", range: NSRange(location: 0, length: 1)),
+            bufferText: "a"
+        )
+        feature.testingPresent(
+            items: [invalid],
+            prefix: CompletionPrefix(text: "a", range: NSRange(location: 0, length: 1)),
+            bufferText: "a"
+        )
+
+        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh preserves the selected matching candidate")
     func refreshPreservesSelectedMatchingCandidate() {
         let textView = makeTextView("a")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -375,6 +375,32 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("refresh filters cached buffer words when broadening the prefix")
+    func refreshFiltersCachedBufferWords() {
+        let text = "openEditor operate\nopen"
+        let textView = makeTextView(text)
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        let prefix = CompletionEngine.prefix(in: text, caret: (text as NSString).length)!
+        feature.testingPresent(
+            items: [],
+            prefix: prefix,
+            bufferText: text,
+            allowBufferFallback: true
+        )
+
+        #expect(feature.testingSnapshot.candidateLabels == ["openEditor"])
+
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels == ["openEditor", "operate", "open"])
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh preserves the selected matching candidate")
     func refreshPreservesSelectedMatchingCandidate() {
         let textView = makeTextView("a")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -398,6 +398,39 @@ struct CompletionFeatureTests {
         textView.deleteBackward(nil)
 
         #expect(feature.testingSnapshot.candidateLabels == ["openEditor", "operate", "open"])
+
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
+        feature.cancelAndDismiss()
+    }
+
+    @Test("empty refresh response retains candidates for backspacing")
+    func emptyRefreshRetainsCandidates() {
+        let textView = makeTextView("op")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingPresent(
+            items: [.testing(label: "openAlpha", sortText: "001", filterText: nil)],
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2)),
+            bufferText: "op"
+        )
+
+        textView.insertText("Z", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [],
+            prefix: CompletionPrefix(text: "opZ", range: NSRange(location: 0, length: 3)),
+            bufferText: "opZ"
+        )
+        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
+
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha"])
         feature.cancelAndDismiss()
     }
 

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -227,6 +227,43 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("refresh retains candidates introduced by an intermediate response")
+    func refreshRetainsIntermediateResponseCandidates() {
+        let textView = makeTextView("o")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingPresent(
+            items: [.testing(label: "openAlpha", sortText: "001", filterText: nil)],
+            prefix: CompletionPrefix(text: "o", range: NSRange(location: 0, length: 1)),
+            bufferText: "o"
+        )
+
+        textView.insertText("p", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [
+                .testing(label: "openAlpha", sortText: "001", filterText: nil),
+                .testing(label: "option", sortText: "002", filterText: nil)
+            ],
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2)),
+            bufferText: "op"
+        )
+
+        textView.insertText("e", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [.testing(label: "openAlpha", sortText: "001", filterText: nil)],
+            prefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3)),
+            bufferText: "ope"
+        )
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "option"])
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh discards candidates when text changes outside the prefix")
     func refreshDiscardsCandidatesAfterForwardDelete() {
         let textView = makeTextView("opeXYZ tail")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -170,7 +170,8 @@ struct CompletionFeatureTests {
         feature.testingPresent(
             items: [
                 .testing(label: "openAlpha", sortText: "001", filterText: nil),
-                .testing(label: "operate", sortText: "002", filterText: nil)
+                .testing(label: "operate", sortText: "002", filterText: nil),
+                .testing(label: "opaque", sortText: "003", filterText: nil)
             ],
             prefix: CompletionPrefix(text: "o", range: NSRange(location: 0, length: 1)),
             bufferText: "o"
@@ -186,6 +187,11 @@ struct CompletionFeatureTests {
 
         #expect(textView.string == "ope")
         #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "operate"])
+
+        textView.deleteBackward(nil)
+
+        #expect(textView.string == "op")
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "operate", "opaque"])
         feature.cancelAndDismiss()
     }
 

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -123,23 +123,25 @@ struct CompletionFeatureTests {
         )
         let prefix = CompletionPrefix(text: "ap", range: NSRange(location: 0, length: 2))
         feature.testingSeedVisibleCandidates(
-            labels: ["apple", "apricot"],
+            labels: ["append", "append"],
+            replacementTexts: ["append(_:)", "append(contentsOf:)"],
             prefix: prefix,
             selection: 1
         )
 
         feature.testingPresent(
             items: [
-                .testing(label: "apartment", sortText: "001", filterText: nil),
-                .testing(label: "apricot", sortText: "002", filterText: nil),
-                .testing(label: "apple", sortText: "003", filterText: nil)
+                .testing(label: "append", sortText: "001", filterText: nil, insertText: "append(_:)"),
+                .testing(label: "append", sortText: "002", filterText: nil, insertText: "append(contentsOf:)")
             ],
             prefix: prefix,
             bufferText: "ap"
         )
 
-        #expect(feature.testingSnapshot.candidateLabels == ["apartment", "apricot", "apple"])
+        #expect(feature.testingSnapshot.candidateLabels == ["append", "append"])
         #expect(feature.testingSnapshot.selection == 1)
+        #expect(textView.completionKeyHandler?(.acceptSelected) == true)
+        #expect(textView.string == "append(contentsOf:)")
         feature.cancelAndDismiss()
     }
 

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -44,7 +44,7 @@ struct CompletionFeatureTests {
             }
         )
 
-        textView.completionChangeHandler?()
+        textView.completionChangeHandler?(nil)
         try await waitForCompletionRequest(events: { events })
 
         #expect(events == ["flush", "completion"])

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -85,6 +85,14 @@ struct CompletionFeatureTests {
         #expect(feature.testingSnapshot.prefix == CompletionPrefix(text: "openA", range: NSRange(location: 0, length: 5)))
         #expect(feature.testingSnapshot.selection == 0)
         #expect(!feature.testingSnapshot.isRefreshing)
+
+        textView.deleteBackward(nil)
+
+        #expect(textView.string == "open")
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "openBeta"])
+
+        textView.insertText("A", replacementRange: NSRange(location: NSNotFound, length: 0))
+
         #expect(textView.completionKeyHandler?(.acceptTop) == true)
         #expect(textView.string == "openAlpha")
         feature.cancelAndDismiss()

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -195,6 +195,38 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("refresh retains matching candidates introduced by a narrow response")
+    func refreshRetainsNarrowResponseCandidates() {
+        let textView = makeTextView("o")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingPresent(
+            items: [.testing(label: "openAlpha", sortText: "001", filterText: nil)],
+            prefix: CompletionPrefix(text: "o", range: NSRange(location: 0, length: 1)),
+            bufferText: "o"
+        )
+
+        textView.insertText("p", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [
+                .testing(label: "openAlpha", sortText: "001", filterText: nil),
+                .testing(label: "operate", sortText: "002", filterText: nil)
+            ],
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2)),
+            bufferText: "op"
+        )
+        feature.testingSetSelection(1)
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "operate"])
+        #expect(feature.testingSnapshot.selection == 1)
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh discards candidates when text changes outside the prefix")
     func refreshDiscardsCandidatesAfterForwardDelete() {
         let textView = makeTextView("opeXYZ tail")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -145,6 +145,14 @@ struct CompletionFeatureTests {
         )
 
         textView.insertText("c", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [
+                .testing(label: "count", sortText: "001", filterText: nil),
+                .testing(label: "copy", sortText: "002", filterText: nil)
+            ],
+            prefix: CompletionPrefix(text: "c", range: NSRange(location: 4, length: 1)),
+            bufferText: "foo.c"
+        )
         textView.deleteBackward(nil)
 
         #expect(textView.string == "foo.")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -434,6 +434,35 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("escape cancels a hidden retained completion session")
+    func escapeCancelsHiddenRetainedSession() {
+        let textView = makeTextView("op")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingPresent(
+            items: [.testing(label: "openAlpha", sortText: "001", filterText: nil)],
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2)),
+            bufferText: "op"
+        )
+        textView.insertText("Z", replacementRange: NSRange(location: NSNotFound, length: 0))
+        feature.testingPresent(
+            items: [],
+            prefix: CompletionPrefix(text: "opZ", range: NSRange(location: 0, length: 3)),
+            bufferText: "opZ"
+        )
+
+        #expect(textView.completionKeyHandler?(.dismiss) == true)
+        textView.deleteBackward(nil)
+
+        #expect(feature.testingSnapshot.candidateLabels.isEmpty)
+        #expect(feature.testingSnapshot.prefix == nil)
+        feature.cancelAndDismiss()
+    }
+
     @Test("narrow responses extend the retained buffer cache")
     func narrowResponseExtendsBufferCache() {
         let text = "operate openEditor\no"

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -90,6 +90,28 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("refresh preserves the selected matching candidate")
+    func refreshPreservesSelectedMatchingCandidate() {
+        let textView = makeTextView("a")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingSeedVisibleCandidates(
+            labels: ["alpha", "apple", "apricot"],
+            prefix: CompletionPrefix(text: "a", range: NSRange(location: 0, length: 1)),
+            selection: 1
+        )
+
+        textView.insertText("p", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(feature.testingSnapshot.candidateLabels == ["apple", "apricot"])
+        #expect(feature.testingSnapshot.selection == 0)
+        feature.cancelAndDismiss()
+    }
+
     private func waitForCompletionRequest(events: () -> [String]) async throws {
         let deadline = Date().addingTimeInterval(2)
         while !events().contains("completion"), Date() < deadline {

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -77,13 +77,16 @@ struct CompletionFeatureTests {
             labels: ["openAlpha", "openBeta"],
             prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4))
         )
+        feature.testingShowPopup()
 
         textView.insertText("A", replacementRange: NSRange(location: NSNotFound, length: 0))
 
         #expect(feature.testingSnapshot.candidateLabels == ["openAlpha"])
         #expect(feature.testingSnapshot.prefix == CompletionPrefix(text: "openA", range: NSRange(location: 0, length: 5)))
         #expect(feature.testingSnapshot.selection == 0)
-        #expect(feature.testingSnapshot.isRefreshing)
+        #expect(!feature.testingSnapshot.isRefreshing)
+        #expect(textView.completionKeyHandler?(.acceptTop) == true)
+        #expect(textView.string == "openAlpha")
         feature.cancelAndDismiss()
     }
 

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -130,6 +130,55 @@ struct CompletionFeatureTests {
         feature.cancelAndDismiss()
     }
 
+    @Test("refresh restores candidates at an empty trigger prefix")
+    func refreshRestoresCandidatesAtEmptyPrefix() {
+        let textView = makeTextView("foo.")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingSeedVisibleCandidates(
+            labels: ["count", "copy"],
+            prefix: CompletionPrefix(text: "", range: NSRange(location: 4, length: 0))
+        )
+
+        textView.insertText("c", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.deleteBackward(nil)
+
+        #expect(textView.string == "foo.")
+        #expect(feature.testingSnapshot.candidateLabels == ["count", "copy"])
+        feature.cancelAndDismiss()
+    }
+
+    @Test("refresh rebuilds candidates when broadening past the response prefix")
+    func refreshRebuildsCandidatesPastResponsePrefix() {
+        let textView = makeTextView("open")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true }
+        )
+        feature.testingPresent(
+            items: [
+                .testing(label: "openAlpha", sortText: "001", filterText: nil),
+                .testing(label: "operate", sortText: "002", filterText: nil)
+            ],
+            prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
+            bufferText: "open"
+        )
+
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha"])
+
+        textView.deleteBackward(nil)
+
+        #expect(textView.string == "ope")
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "operate"])
+        feature.cancelAndDismiss()
+    }
+
     @Test("refresh preserves the selected matching candidate")
     func refreshPreservesSelectedMatchingCandidate() {
         let textView = makeTextView("a")

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -109,7 +109,22 @@ struct CompletionFeatureTests {
 
     @Test("refresh retains candidates from a broader response")
     func refreshRetainsBroaderResponse() {
-        let textView = makeTextView("ope")
+        func item(_ label: String, sortText: String, rangeLength: Int) -> LSPCompletionItem {
+            .testing(
+                label: label,
+                sortText: sortText,
+                filterText: nil,
+                textEdit: LSPTextEdit(
+                    range: LSPRange(
+                        start: LSPPosition(line: 0, character: 0),
+                        end: LSPPosition(line: 0, character: rangeLength)
+                    ),
+                    newText: label
+                )
+            )
+        }
+
+        let textView = makeTextView("o")
         let feature = CompletionFeature(
             textView: textView,
             getClient: { nil },
@@ -118,22 +133,28 @@ struct CompletionFeatureTests {
         )
         feature.testingPresent(
             items: [
-                .testing(label: "openAlpha", sortText: "001", filterText: nil),
-                .testing(label: "operate", sortText: "002", filterText: nil)
+                item("openAlpha", sortText: "001", rangeLength: 1),
+                item("operate", sortText: "002", rangeLength: 1),
+                item("output", sortText: "003", rangeLength: 1)
             ],
-            prefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3)),
-            bufferText: "ope"
+            prefix: CompletionPrefix(text: "o", range: NSRange(location: 0, length: 1)),
+            bufferText: "o"
         )
 
-        textView.insertText("n", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.insertText("p", replacementRange: NSRange(location: NSNotFound, length: 0))
         feature.testingPresent(
-            items: [.testing(label: "openAlpha", sortText: "001", filterText: nil)],
-            prefix: CompletionPrefix(text: "open", range: NSRange(location: 0, length: 4)),
-            bufferText: "open"
+            items: [
+                item("openAlpha", sortText: "001", rangeLength: 2),
+                item("operate", sortText: "002", rangeLength: 2)
+            ],
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2)),
+            bufferText: "op"
         )
+        feature.testingSetSelection(1)
         textView.deleteBackward(nil)
 
-        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "operate"])
+        #expect(feature.testingSnapshot.candidateLabels == ["openAlpha", "operate", "output"])
+        #expect(feature.testingSnapshot.selection == 1)
         feature.cancelAndDismiss()
     }
 

--- a/AlasTests/CodeTextViewCompletionTests.swift
+++ b/AlasTests/CodeTextViewCompletionTests.swift
@@ -97,7 +97,7 @@ struct CodeTextViewCompletionTests {
     @Test func applyCompletionEditsCoalescesCompletionChangeNotification() {
         let textView = makeTextView("let value = op\n")
         var changeCount = 0
-        textView.completionChangeHandler = {
+        textView.completionChangeHandler = { _ in
             changeCount += 1
         }
 
@@ -113,7 +113,7 @@ struct CodeTextViewCompletionTests {
         let textView = makeTextView("let value = open")
         var changeCount = 0
         var selectionChangeCount = 0
-        textView.completionChangeHandler = {
+        textView.completionChangeHandler = { _ in
             changeCount += 1
         }
         textView.completionSelectionChangeHandler = {
@@ -129,9 +129,11 @@ struct CodeTextViewCompletionTests {
     @Test func textEditWithProgrammaticSelectionTriggersOnlyTextChange() {
         let textView = makeTextView()
         var changeCount = 0
+        var editRange: NSRange?
         var selectionChangeCount = 0
-        textView.completionChangeHandler = {
+        textView.completionChangeHandler = { range in
             changeCount += 1
+            editRange = range
         }
         textView.completionSelectionChangeHandler = {
             selectionChangeCount += 1
@@ -141,6 +143,7 @@ struct CodeTextViewCompletionTests {
 
         #expect(textView.string == "()")
         #expect(changeCount == 1)
+        #expect(editRange == NSRange(location: 0, length: 0))
         #expect(selectionChangeCount == 0)
     }
 

--- a/AlasTests/TextEditCoordinatesTests.swift
+++ b/AlasTests/TextEditCoordinatesTests.swift
@@ -98,6 +98,15 @@ struct TextEditCoordinatesTests {
         #expect(index.utf16Offset(from: LSPPosition(line: 1, character: 9)) == nil)
     }
 
+    @Test func lineIndexAdjustsLaterLinesWithoutRebuilding() {
+        let index = TextEditCoordinates.LineIndex("one\ntwo\nthree")
+            .adjustingOffsets(after: 6, by: 2)!
+
+        #expect(index.utf16Offset(from: LSPPosition(line: 1, character: 2)) == 6)
+        #expect(index.utf16Offset(from: LSPPosition(line: 2, character: 0)) == 10)
+        #expect(index.lspPosition(utf16Offset: 10) == LSPPosition(line: 2, character: 0))
+    }
+
     @Test func applyLspTextEditSingleReplacement() {
         let text = "hello"
         let edit = LSPTextEdit(

--- a/AlasTests/TextEditCoordinatesTests.swift
+++ b/AlasTests/TextEditCoordinatesTests.swift
@@ -90,6 +90,14 @@ struct TextEditCoordinatesTests {
         #expect(TextEditCoordinates.utf16Offset(from: LSPPosition(line: 0, character: -1), in: text) == nil)
     }
 
+    @Test func lineIndexReusesUtf16LineStartsForConversions() {
+        let index = TextEditCoordinates.LineIndex("first\n𐍈second\nthird")
+
+        #expect(index.utf16Offset(from: LSPPosition(line: 1, character: 2)) == 8)
+        #expect(index.lspPosition(utf16Offset: 15) == LSPPosition(line: 2, character: 0))
+        #expect(index.utf16Offset(from: LSPPosition(line: 1, character: 9)) == nil)
+    }
+
     @Test func applyLspTextEditSingleReplacement() {
         let text = "hello"
         let edit = LSPTextEdit(


### PR DESCRIPTION
## Summary

- filter existing autocomplete candidates immediately as the prefix changes
- keep the visible completion panel open while matching candidates remain
- dismiss the panel when filtering leaves no candidates

## Root cause

The completion refresh path cleared all current candidates and hid the overlay before the debounced LSP request completed. Each typed character therefore ordered the panel out and presented it again when refreshed results arrived.

## User impact

Typing through an existing completion now updates the list in place without a distracting hide/show cycle.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- focused `CompletionFeatureTests` pass\n- full suite ran 7,074 tests; two unrelated order/timing failures passed when rerun in isolation