### PR TITLE
fix(acp): bound broker IPC so one wedged broker cannot hang every session

### DIFF
--- a/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerClient.swift
@@ -788,6 +788,16 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
         }
     }
 
+    /// Answers an adapter's `fs`/`terminal` request, and answers it *somehow*
+    /// even when the intended reply cannot be delivered.
+    ///
+    /// The payload here is whatever the adapter asked for, which for an
+    /// unbounded `fs/read_text_file` is an entire file — so delivery can fail
+    /// on size where nothing else would. Dropping that failure, as this did,
+    /// leaves the adapter waiting on a request that will never be answered and
+    /// the turn stalled with no indication why. A JSON-RPC error is a poor
+    /// answer but an answer: the adapter can report it, retry with `line` and
+    /// `limit`, or give up, none of which it can do while blocked.
     private func respondToRawResult(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
         Task { [weak self] in
             guard let self else { return }
@@ -798,7 +808,14 @@ final class ACPBrokerClient: ACPClient, @unchecked Sendable {
                 case .failure(let error):
                     try await self.respond(id: id, result: nil, error: error)
                 }
-            } catch {}
+            } catch {
+                let undeliverable = JSONRPCError(
+                    code: -32603,
+                    message: "response could not be delivered: \(error.localizedDescription)",
+                    data: nil
+                )
+                try? await self.respond(id: id, result: nil, error: undeliverable)
+            }
         }
     }
 

--- a/Alas/Sources/ACP/Broker/ACPBrokerProtocol.swift
+++ b/Alas/Sources/ACP/Broker/ACPBrokerProtocol.swift
@@ -165,11 +165,15 @@ struct ACPBrokerRPCOutcome: Codable, Equatable, Sendable {
     let error: JSONRPCError?
 }
 
+/// Deliberately carries no `params`. Nothing here reads them — `setSnapshot`
+/// uses only the request id, operation key and terminal outcome — and a
+/// prompt's params can be hundreds of megabytes, which the broker would then
+/// serialize into every attach reply. A broker from an older build still
+/// sends the field; `Codable` ignores it.
 struct ACPBrokerOperationSnapshot: Codable, Equatable, Sendable {
     let operationKey: ACPBrokerOperationKey
     let adapterRequestId: ACPBrokerAdapterRequestID
     let method: String
-    let params: ACPBrokerJSONValue
     let terminalOutcome: ACPBrokerRPCOutcome?
 }
 
@@ -195,11 +199,13 @@ enum ACPBrokerEventKind: Equatable, Sendable {
     case turnStateChanged(state: ACPBrokerTurnState)
     case pendingRequest(ACPBrokerPendingRequest)
     case pendingRequestResolved(requestId: String, response: ACPBrokerRPCOutcome)
+    /// No `params` for the same reason as `ACPBrokerOperationSnapshot`: they
+    /// are unread, and the replay would otherwise carry a second full copy of
+    /// a prompt that the snapshot already carried once.
     case operationStarted(
         operationKey: ACPBrokerOperationKey,
         adapterRequestId: ACPBrokerAdapterRequestID,
-        method: String,
-        params: ACPBrokerJSONValue
+        method: String
     )
     case operationCompleted(operationKey: ACPBrokerOperationKey, outcome: ACPBrokerRPCOutcome)
     case adapterNotification(method: String, params: ACPBrokerJSONValue)
@@ -243,8 +249,7 @@ extension ACPBrokerEventKind: Codable {
             self = .operationStarted(
                 operationKey: try container.decode(ACPBrokerOperationKey.self, forKey: .operationKey),
                 adapterRequestId: try container.decode(ACPBrokerAdapterRequestID.self, forKey: .adapterRequestId),
-                method: try container.decode(String.self, forKey: .method),
-                params: try container.decode(ACPBrokerJSONValue.self, forKey: .params)
+                method: try container.decode(String.self, forKey: .method)
             )
         case "operationCompleted":
             let outcome = try container.decodeIfPresent(ACPBrokerRPCOutcome.self, forKey: .outcome)
@@ -286,12 +291,11 @@ extension ACPBrokerEventKind: Codable {
             try container.encode("pendingRequestResolved", forKey: .type)
             try container.encode(requestId, forKey: .requestId)
             try container.encode(response, forKey: .response)
-        case .operationStarted(let operationKey, let adapterRequestId, let method, let params):
+        case .operationStarted(let operationKey, let adapterRequestId, let method):
             try container.encode("operationStarted", forKey: .type)
             try container.encode(operationKey, forKey: .operationKey)
             try container.encode(adapterRequestId, forKey: .adapterRequestId)
             try container.encode(method, forKey: .method)
-            try container.encode(params, forKey: .params)
         case .operationCompleted(let operationKey, let outcome):
             try container.encode("operationCompleted", forKey: .type)
             try container.encode(operationKey, forKey: .operationKey)

--- a/AlasHelper/src/acp_broker.rs
+++ b/AlasHelper/src/acp_broker.rs
@@ -193,6 +193,8 @@ pub enum BrokerEventKind {
         operation_key: OperationKey,
         adapter_request_id: AdapterRequestId,
         method: String,
+        /// Always null. See `OperationSnapshot::params`.
+        params: Value,
     },
     OperationCompleted {
         operation_key: OperationKey,
@@ -223,6 +225,16 @@ pub struct OperationSnapshot {
     pub operation_key: OperationKey,
     pub adapter_request_id: AdapterRequestId,
     pub method: String,
+    /// Always null, and deliberately still emitted.
+    ///
+    /// The real params are not sent — nothing reads them, and a prompt's can
+    /// run to hundreds of megabytes that the reply would otherwise carry (see
+    /// `snapshot`). Dropping the key outright is what cannot be done: a
+    /// broker outlives the app that started it, so a client from an earlier
+    /// build can adopt this one, and its decoder requires the key to be
+    /// present. Six bytes buys that; omitting them would leave such a client
+    /// unable to adopt or even close the broker.
+    pub params: Value,
     pub terminal_outcome: Option<AdapterRPCOutcome>,
 }
 
@@ -392,6 +404,7 @@ impl ACPBrokerState {
             operation_key: operation_key.clone(),
             adapter_request_id,
             method: record.fingerprint.method.clone(),
+            params: Value::Null,
         });
         self.operations.insert(operation_key.clone(), record);
 
@@ -558,6 +571,7 @@ impl ACPBrokerState {
                 operation_key: record.key.clone(),
                 adapter_request_id: record.adapter_request_id,
                 method: record.fingerprint.method.clone(),
+                params: Value::Null,
                 terminal_outcome: record.terminal_outcome.clone(),
             })
             .collect();

--- a/AlasHelper/src/acp_broker.rs
+++ b/AlasHelper/src/acp_broker.rs
@@ -193,7 +193,6 @@ pub enum BrokerEventKind {
         operation_key: OperationKey,
         adapter_request_id: AdapterRequestId,
         method: String,
-        params: Value,
     },
     OperationCompleted {
         operation_key: OperationKey,
@@ -224,7 +223,6 @@ pub struct OperationSnapshot {
     pub operation_key: OperationKey,
     pub adapter_request_id: AdapterRequestId,
     pub method: String,
-    pub params: Value,
     pub terminal_outcome: Option<AdapterRPCOutcome>,
 }
 
@@ -394,7 +392,6 @@ impl ACPBrokerState {
             operation_key: operation_key.clone(),
             adapter_request_id,
             method: record.fingerprint.method.clone(),
-            params: record.fingerprint.params.clone(),
         });
         self.operations.insert(operation_key.clone(), record);
 
@@ -561,7 +558,6 @@ impl ACPBrokerState {
                 operation_key: record.key.clone(),
                 adapter_request_id: record.adapter_request_id,
                 method: record.fingerprint.method.clone(),
-                params: record.fingerprint.params.clone(),
                 terminal_outcome: record.terminal_outcome.clone(),
             })
             .collect();

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -33,20 +33,24 @@ use std::os::unix::net::{UnixListener, UnixStream};
 /// caller has declared a length and is held to it instead.
 const IPC_REQUEST_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Ceiling on the whole first line, alongside the silence bound above.
+/// Rate a caller must sustain on the first line once it starts sending.
 ///
-/// Without it a caller can send one byte every 59s forever, and since every
-/// connection owns a thread, repeating that accumulates threads until the
-/// broker cannot spawn any more. Generous next to what the line actually
-/// costs — a legacy caller pauses ~7.4s to encode a maximal prompt and then
-/// writes it in ~0.2s — so this only ever catches a caller that is not really
-/// trying to finish.
-const IPC_REQUEST_TOTAL_TIMEOUT: Duration = Duration::from_secs(180);
+/// A fixed duration cannot work here. Under the legacy encoding this line is
+/// the whole message, and a legacy request is not bounded in size — an
+/// `acp/respond` carries whatever `fs/read_text_file` was asked for, and
+/// `ACPSessionRunner.serveRead` returns a whole file when the adapter sends no
+/// line/limit. Any ceiling on elapsed time is therefore a ceiling on size.
+/// Requiring a rate instead tells a large transfer apart from a trickle
+/// without needing to know how large: this is ~1% of what the socket
+/// measures, so a genuine sender clears it easily, while one byte every 59s
+/// does not — and since every connection owns a thread, that pattern would
+/// otherwise accumulate threads until the broker cannot spawn any more.
+const MIN_IPC_REQUEST_RATE: u64 = 16 * 1024;
 
-/// Bounds on the first line of a request: silence, and total elapsed.
+/// Bounds on the first line of a request: silence, and sustained rate.
 #[cfg(unix)]
 const IPC_REQUEST_HEAD_BUDGET: ReadBudget =
-    ReadBudget::bounded_const(IPC_REQUEST_IDLE_TIMEOUT, IPC_REQUEST_TOTAL_TIMEOUT);
+    ReadBudget::at_least(IPC_REQUEST_IDLE_TIMEOUT, MIN_IPC_REQUEST_RATE);
 
 /// Slowest a caller may deliver a framed body before we stop waiting.
 ///
@@ -78,7 +82,7 @@ fn trusted_body_budget(_len: usize) -> ReadBudget {
 #[cfg(unix)]
 fn framed_body_budget(len: usize) -> ReadBudget {
     let by_rate = Duration::from_secs_f64(len as f64 / MIN_IPC_BODY_THROUGHPUT as f64);
-    ReadBudget::bounded(
+    ReadBudget::within(
         BROKER_IPC_IDLE_TIMEOUT,
         by_rate.max(BROKER_IPC_IDLE_TIMEOUT),
     )
@@ -490,49 +494,76 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
     Ok(json!({ "brokers": brokers }))
 }
 
+/// What is asked of a peer beyond not going silent.
+#[derive(Clone, Copy)]
+enum Pace {
+    /// Finish within this, however fast you go. Right where the sender
+    /// declared a length, since the deadline can then be derived from it.
+    Within(Duration),
+    /// Once you start sending, keep up at least this many bytes per second.
+    /// Right where the length is *not* known — a legacy request is the whole
+    /// message on one line, so there is no size to turn into a deadline, and
+    /// any fixed duration would be a size ceiling in disguise. A rate tells a
+    /// large transfer apart from a trickle without needing to know how large.
+    AtLeast(u64),
+    /// Nothing beyond the idle bound. For a broker this helper spawned: its
+    /// reply has no size we could bound, and one thread per outstanding
+    /// request is limited by how many sessions exist, not by the peer.
+    Unbounded,
+}
+
 /// How a read is bounded in time.
 ///
-/// Two bounds, because either alone has a hole. An idle bound asks only that
-/// the peer keep sending, which a trickle satisfies forever. A total bound
-/// asks the read to finish by a fixed time, which fails a legitimately large
-/// or slow-to-start transfer. Applying both lets a peer be slow *or* large
-/// without letting it be indefinite.
+/// An idle bound alone has a hole — a trickle satisfies it forever — so every
+/// read from an arbitrary peer pairs one with a `Pace`. Which pace depends on
+/// whether the sender told us how much to expect.
 #[derive(Clone, Copy)]
 struct ReadBudget {
     /// Longest run with no bytes arriving.
     idle: Duration,
-    /// Longest the whole read may take, however much progress is made. `None`
-    /// where the peer is a broker this helper spawned and its reply has no
-    /// size we could turn into a deadline — there, one thread per outstanding
-    /// request is bounded by the number of sessions, not by the peer.
-    total: Option<Duration>,
+    pace: Pace,
 }
 
 impl ReadBudget {
     /// For a peer we trust to finish what it starts.
     fn idle(idle: Duration) -> Self {
-        Self { idle, total: None }
-    }
-
-    /// For an arbitrary peer, which must be both making progress and finishing.
-    fn bounded(idle: Duration, total: Duration) -> Self {
-        Self::bounded_const(idle, total)
-    }
-
-    const fn bounded_const(idle: Duration, total: Duration) -> Self {
         Self {
             idle,
-            total: Some(total),
+            pace: Pace::Unbounded,
+        }
+    }
+
+    /// For a sender that declared how much it is about to send.
+    fn within(idle: Duration, total: Duration) -> Self {
+        Self {
+            idle,
+            pace: Pace::Within(total),
+        }
+    }
+
+    /// For a sender whose length we cannot know.
+    const fn at_least(idle: Duration, bytes_per_second: u64) -> Self {
+        Self {
+            idle,
+            pace: Pace::AtLeast(bytes_per_second),
         }
     }
 }
 
-/// Tracks whether a read still has time left under both of its bounds.
+/// Grace before a rate is judged, so a sender is not failed on the strength of
+/// its first few hundred bytes.
+#[cfg(unix)]
+const IPC_RATE_GRACE: Duration = Duration::from_secs(10);
+
+/// Tracks whether a read still has time left under its bounds.
 #[cfg(unix)]
 struct BudgetClock {
     idle: Duration,
+    pace: Pace,
     idle_deadline: std::time::Instant,
     total_deadline: Option<std::time::Instant>,
+    first_byte_at: Option<std::time::Instant>,
+    bytes: u64,
 }
 
 #[cfg(unix)]
@@ -541,20 +572,45 @@ impl BudgetClock {
         let now = std::time::Instant::now();
         Self {
             idle: budget.idle,
+            pace: budget.pace,
             idle_deadline: now + budget.idle,
-            total_deadline: budget.total.map(|total| now + total),
+            total_deadline: match budget.pace {
+                Pace::Within(total) => Some(now + total),
+                _ => None,
+            },
+            first_byte_at: None,
+            bytes: 0,
         }
     }
 
     fn expired(&self) -> bool {
         let now = std::time::Instant::now();
-        now >= self.idle_deadline || self.total_deadline.is_some_and(|deadline| now >= deadline)
+        if now >= self.idle_deadline {
+            return true;
+        }
+        if self.total_deadline.is_some_and(|deadline| now >= deadline) {
+            return true;
+        }
+        let Pace::AtLeast(rate) = self.pace else {
+            return false;
+        };
+        let Some(first_byte_at) = self.first_byte_at else {
+            // Nothing sent yet, so there is no rate to judge — the idle bound
+            // above is what covers a sender still preparing its request.
+            return false;
+        };
+        let elapsed = now.duration_since(first_byte_at);
+        let judged = elapsed.saturating_sub(IPC_RATE_GRACE);
+        self.bytes < rate.saturating_mul(judged.as_secs())
     }
 
-    /// Bytes arrived, so the idle bound starts over. The total bound does not:
-    /// that is the one a trickle cannot renew.
-    fn progressed(&mut self) {
-        self.idle_deadline = std::time::Instant::now() + self.idle;
+    /// `count` bytes arrived, so the idle bound starts over. Neither the total
+    /// nor the required rate does: those are what a trickle cannot renew.
+    fn progressed(&mut self, count: usize) {
+        let now = std::time::Instant::now();
+        self.idle_deadline = now + self.idle;
+        self.first_byte_at.get_or_insert(now);
+        self.bytes = self.bytes.saturating_add(count as u64);
     }
 
     fn timed_out() -> io::Error {
@@ -629,7 +685,7 @@ fn read_line_within(reader: &mut BufReader<&UnixStream>, budget: ReadBudget) -> 
             Err(error) => return Err(error),
         };
         reader.consume(consumed);
-        clock.progressed();
+        clock.progressed(consumed);
         if finished {
             return String::from_utf8(line)
                 .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
@@ -670,7 +726,7 @@ fn read_exact_within(
             Err(error) => return Err(error),
         };
         reader.consume(consumed);
-        clock.progressed();
+        clock.progressed(consumed);
     }
     String::from_utf8(body).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
@@ -1930,7 +1986,7 @@ mod tests {
         let outcome = read_exact_within(
             &mut reader,
             4 * 1024 * 1024,
-            ReadBudget::bounded(Duration::from_secs(2), Duration::from_secs(2)),
+            ReadBudget::within(Duration::from_secs(2), Duration::from_secs(2)),
         );
         *done.lock().expect("drip flag") = true;
 
@@ -1982,6 +2038,56 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A rate bound has to separate the two cases a fixed duration cannot: a
+    /// legacy request whose sender pauses to encode and then delivers a lot,
+    /// and a trickle that never intends to finish. Both look identical to an
+    /// idle bound, and any total that admits the first admits the second.
+    #[cfg(unix)]
+    #[test]
+    fn a_rate_bound_admits_a_slow_start_but_not_a_trickle() {
+        fn read_with(chunk: usize, gap: Duration, chunks: usize) -> io::Result<String> {
+            let (mut writer, reader) = UnixStream::pair().expect("socket pair");
+            std::thread::spawn(move || {
+                // A long pause first, standing in for an older helper encoding
+                // its request before it writes anything at all.
+                std::thread::sleep(Duration::from_secs(1));
+                for _ in 0..chunks {
+                    if writer.write_all(&vec![b'q'; chunk]).is_err() {
+                        return;
+                    }
+                    let _ = writer.flush();
+                    std::thread::sleep(gap);
+                }
+                let _ = writer.write_all(b"\n");
+                let _ = writer.flush();
+            });
+            let mut reader = ipc_reader(&reader).expect("reader");
+            // 64 KiB/s required, judged after a 10s grace.
+            read_line_within(
+                &mut reader,
+                ReadBudget::at_least(Duration::from_secs(30), 64 * 1024),
+            )
+        }
+
+        // Pauses a second, then sends ~2 MiB in bursts: comfortably above the
+        // rate, and a fixed total tuned to reject the trickle below would have
+        // had to reject this too.
+        let delivered = read_with(256 * 1024, Duration::from_millis(50), 8)
+            .expect("a sender that pauses and then delivers must be allowed to finish");
+        assert_eq!(delivered.len(), 8 * 256 * 1024 + 1);
+
+        // A byte every 100ms never approaches the rate, and never ends.
+        let started = std::time::Instant::now();
+        let error = read_with(1, Duration::from_millis(100), usize::MAX)
+            .expect_err("a trickle must not be allowed to run indefinitely");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "the rate bound took too long to notice: {:?}",
+            started.elapsed()
+        );
+    }
+
     /// The two body budgets encode different trust, and mixing them up is easy
     /// to do silently: holding a broker's reply to a throughput floor would
     /// fail a legitimately slow one, while letting an inbound request go
@@ -1990,12 +2096,11 @@ mod tests {
     fn only_arbitrary_peers_are_held_to_a_declared_length() {
         let len = 64 * 1024 * 1024;
         assert!(
-            framed_body_budget(len).total.is_some(),
+            matches!(framed_body_budget(len).pace, Pace::Within(_)),
             "a request body must be bounded by the length its sender declared"
         );
-        assert_eq!(
-            trusted_body_budget(len).total,
-            None,
+        assert!(
+            matches!(trusted_body_budget(len).pace, Pace::Unbounded),
             "a reply from our own broker has no size we can turn into a deadline"
         );
         assert_eq!(trusted_body_budget(len).idle, BROKER_IPC_IDLE_TIMEOUT);
@@ -2014,11 +2119,8 @@ mod tests {
         let one_tib = 1024usize.pow(4);
         let mut budget = framed_body_budget(one_tib);
         assert!(
-            budget
-                .total
-                .is_some_and(|total| total > Duration::from_secs(3600)),
-            "a 1 TiB body should be allowed hours in total: {:?}",
-            budget.total
+            matches!(budget.pace, Pace::Within(total) if total > Duration::from_secs(3600)),
+            "a 1 TiB body should be allowed hours in total"
         );
         // Shorten only the silence bound, so this test does not sit for the
         // full idle budget while proving the total is not what stops it.
@@ -2036,19 +2138,16 @@ mod tests {
     #[test]
     fn the_body_deadline_scales_with_the_length_a_caller_declares() {
         // Small bodies are not held to a stricter rule than large ones.
-        assert_eq!(
-            framed_body_budget(1024).total,
-            Some(BROKER_IPC_IDLE_TIMEOUT)
-        );
+        assert!(matches!(
+            framed_body_budget(1024).pace,
+            Pace::Within(total) if total == BROKER_IPC_IDLE_TIMEOUT
+        ));
         // A maximal image prompt (~267 MiB) gets time proportional to its size.
         let maximal = 267 * 1024 * 1024;
         let budget = framed_body_budget(maximal);
         assert!(
-            budget
-                .total
-                .is_some_and(|total| total >= BROKER_IPC_IDLE_TIMEOUT),
-            "a large body was given less time than a small one: {:?}",
-            budget.total
+            matches!(budget.pace, Pace::Within(total) if total >= BROKER_IPC_IDLE_TIMEOUT),
+            "a large body was given less time than a small one"
         );
         // The silence bound does not scale with the declared length, or a
         // caller could buy quiet by claiming a huge body.
@@ -2079,7 +2178,7 @@ mod tests {
         let mut reader = ipc_reader(&reader).expect("reader");
         let outcome = read_line_within(
             &mut reader,
-            ReadBudget::bounded(Duration::from_secs(2), Duration::from_secs(2)),
+            ReadBudget::within(Duration::from_secs(2), Duration::from_secs(2)),
         );
         let elapsed = started.elapsed();
         *done.lock().expect("drip flag") = true;

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -12,32 +12,35 @@ use std::collections::HashMap;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
 
-/// How long the supervisor waits for an accepted client to deliver a complete
-/// request line. The read happens on the accept thread, so a client that
-/// connects and then goes quiet — a stalled writer, or one killed between
-/// `connect()` and `write()` — would otherwise stop the broker from ever
-/// accepting another connection.
+/// How long the supervisor waits for a caller to deliver the first line of a
+/// request — a framing header, or under the legacy encoding the whole message.
+///
+/// A total rather than an idle budget, because the caller here is arbitrary
+/// and a trickle would otherwise pass for progress indefinitely. That is
+/// affordable only because the length arrives up front under framing: the body
+/// is then read against an idle budget with no ceiling, so this bound applies
+/// to the header, not to the payload.
 const IPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How long a caller gives a broker to send *something* before treating it as
-/// wedged. Idle rather than total, because a legitimate response has no size
-/// we can predict and therefore no duration we can predict either: the reply
-/// to a maximal image prompt carries its params
-/// twice and measures ~15s just to serialize, silently, before a byte is
-/// written. A total budget would have to out-guess that; an idle budget only
-/// has to notice a broker that has stopped.
+/// wedged. Idle rather than total, because a legitimate reply has no size we
+/// can predict and therefore no duration we can predict either; a total budget
+/// would have to out-guess that, while an idle one only has to notice a broker
+/// that has stopped.
 ///
-/// It is still worth keeping tight-ish, because `send_ipc` runs inline on the
-/// helper's single-threaded serve loop, so this is also how long one wedged
-/// broker freezes every other session. Moving `acp/*` dispatch off that thread
-/// would decouple the two and let this be far more generous.
-const BROKER_IPC_IDLE_TIMEOUT: Duration = Duration::from_secs(20);
+/// Generous, because nothing waits behind it any more. `acp/*` runs on its own
+/// thread (see `AcpJob`) and same-broker calls serialize on `broker_lock`, so
+/// this bounds one session's call rather than the whole helper. Erring long is
+/// the right way round: too short fails a healthy broker and, because
+/// `ACPBrokerClient` drops the error, can leave an adapter waiting forever —
+/// too long merely delays reporting a broker that is genuinely stuck.
+const BROKER_IPC_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// How long a single write to a broker may block. Writing even a maximal
 /// request measures ~0.2s, so this only ever fires on a broker that has
@@ -112,7 +115,52 @@ struct PendingOperation {
     method: String,
 }
 
+/// Serializes requests per broker.
+///
+/// These now run on worker threads rather than the helper's serve loop, which
+/// is the point — one slow broker must not hold up the others. Within a single
+/// broker, though, concurrency is not safe: two `acp/open` calls racing would
+/// both find no live supervisor and both spawn one, and the rest mutate broker
+/// state that was written assuming one caller at a time. Holding a per-broker
+/// lock keeps exactly the ordering the single-threaded loop used to provide,
+/// while letting different brokers proceed at once.
+fn broker_lock(broker_id: &str) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut locks = locks.lock().unwrap_or_else(|error| error.into_inner());
+    Arc::clone(
+        locks
+            .entry(broker_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(()))),
+    )
+}
+
+fn with_broker_lock<T>(params: Option<&Value>, body: impl FnOnce() -> T) -> T {
+    let broker_id = params
+        .and_then(|params| params.get("brokerId"))
+        .and_then(Value::as_str);
+    match broker_id {
+        Some(broker_id) => {
+            let lock = broker_lock(broker_id);
+            let _guard = lock.lock().unwrap_or_else(|error| error.into_inner());
+            body()
+        }
+        // `acp/list` names no broker: it sweeps every one of them, so there is
+        // no single lock to take, and it only reads.
+        None => body(),
+    }
+}
+
 pub fn handle_control_request(
+    method: &str,
+    params: Option<Value>,
+) -> Result<Value, AcpBrokerProcessError> {
+    with_broker_lock(params.as_ref(), || {
+        dispatch_control_request(method, params.clone())
+    })
+}
+
+fn dispatch_control_request(
     method: &str,
     params: Option<Value>,
 ) -> Result<Value, AcpBrokerProcessError> {
@@ -403,58 +451,90 @@ enum LineBudget {
     Idle(Duration),
 }
 
-/// Reads one newline-terminated line, bounded in time by `budget`.
-///
-/// `set_read_timeout` on its own bounds neither: it applies to each underlying
-/// read for inactivity, while `read_line` keeps issuing fresh reads until it
-/// finds a newline. A peer that trickles bytes faster than the timeout renews
-/// its budget indefinitely, holding the caller — and growing the buffer —
-/// without limit.
-///
-/// The socket timeout is therefore set once, to a short slice that just wakes
-/// a blocked read periodically; the budget checked on each pass is what
-/// actually bounds the line. (Re-arming the socket per read would express a
-/// deadline more directly, but `setsockopt` starts failing with `EINVAL` once
-/// the peer goes away mid-stream, which would turn an otherwise complete read
-/// into an error.)
-///
-/// There is deliberately no length ceiling in either direction. Neither side
-/// sends a payload whose size we can predict: a request can be an `acp/respond`
-/// carrying a whole file `fs/read_text_file` was asked for, and a reply can be
-/// an attach replay carrying a prompt's params more than once. Every ceiling
-/// picked for those was eventually below something legitimate, and being wrong
-/// is expensive — the Swift side drops the resulting error (`catch {}` in
-/// `ACPBrokerClient.respondToRawResult`), so a rejected response leaves the
-/// adapter waiting forever, which is the very hang this bounding exists to
-/// prevent. `budget` still limits how long a peer can feed us, and so how much
-/// it can feed us.
+/// Tracks whether a read still has time left, under whichever budget applies.
 #[cfg(unix)]
-fn read_line_within(stream: &UnixStream, budget: LineBudget) -> io::Result<String> {
-    /// How long a blocked read waits before the budget is re-checked. Also
-    /// the amount by which a read may overshoot it.
-    const POLL_SLICE: Duration = Duration::from_millis(500);
+struct BudgetClock {
+    budget: LineBudget,
+    deadline: std::time::Instant,
+}
 
-    enum Step {
-        Complete(usize),
-        Partial(usize),
-        Retry,
+#[cfg(unix)]
+impl BudgetClock {
+    fn new(budget: LineBudget) -> Self {
+        let limit = match budget {
+            LineBudget::Total(limit) | LineBudget::Idle(limit) => limit,
+        };
+        Self {
+            budget,
+            deadline: std::time::Instant::now() + limit,
+        }
     }
 
-    stream.set_read_timeout(Some(POLL_SLICE))?;
-    let mut reader = BufReader::new(stream);
-    let mut line: Vec<u8> = Vec::new();
-    // For `Idle`, this is pushed back every time bytes actually arrive.
-    let mut deadline = match budget {
-        LineBudget::Total(limit) | LineBudget::Idle(limit) => std::time::Instant::now() + limit,
-    };
-    loop {
-        if std::time::Instant::now() >= deadline {
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "timed out reading IPC line",
-            ));
+    fn expired(&self) -> bool {
+        std::time::Instant::now() >= self.deadline
+    }
+
+    /// Bytes arrived. An idle budget starts over — the peer is making
+    /// progress, which is the only thing it asks about. A total budget is left
+    /// alone: for an arbitrary peer, progress is exactly what a trickle fakes.
+    fn progressed(&mut self) {
+        if let LineBudget::Idle(limit) = self.budget {
+            self.deadline = std::time::Instant::now() + limit;
         }
-        let step = match reader.fill_buf() {
+    }
+
+    fn timed_out() -> io::Error {
+        io::Error::new(io::ErrorKind::TimedOut, "timed out reading IPC message")
+    }
+}
+
+/// How long a blocked read waits before its budget is re-checked. Also the
+/// amount by which a read may overshoot.
+#[cfg(unix)]
+const IPC_READ_POLL_SLICE: Duration = Duration::from_millis(500);
+
+/// Prepares a stream for the budgeted readers below.
+///
+/// The socket timeout is set once, to a short slice that just wakes a blocked
+/// read periodically; the budget checked on each pass is what actually bounds
+/// the read. (Re-arming the socket per read would express a deadline more
+/// directly, but `setsockopt` starts failing with `EINVAL` once the peer goes
+/// away mid-stream, which would turn an otherwise complete read into an error.)
+///
+/// One reader must be shared across a whole message: `BufReader` reads ahead,
+/// so building a second one to read a frame body would discard bytes the first
+/// had already pulled off the socket.
+#[cfg(unix)]
+fn ipc_reader(stream: &UnixStream) -> io::Result<BufReader<&UnixStream>> {
+    stream.set_read_timeout(Some(IPC_READ_POLL_SLICE))?;
+    Ok(BufReader::new(stream))
+}
+
+/// True when an error means "nothing to read just yet" rather than a failure.
+/// The budget decides when quiet has gone on too long.
+#[cfg(unix)]
+fn is_quiet(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut | io::ErrorKind::Interrupted
+    )
+}
+
+/// Reads one newline-terminated line, bounded in time by `budget`.
+///
+/// `set_read_timeout` on its own would not bound it: that applies to each
+/// underlying read for inactivity, while reading a line keeps issuing fresh
+/// reads until it finds a newline, so a peer trickling bytes faster than the
+/// timeout renews its budget indefinitely.
+#[cfg(unix)]
+fn read_line_within(reader: &mut BufReader<&UnixStream>, budget: LineBudget) -> io::Result<String> {
+    let mut clock = BudgetClock::new(budget);
+    let mut line: Vec<u8> = Vec::new();
+    loop {
+        if clock.expired() {
+            return Err(BudgetClock::timed_out());
+        }
+        let (finished, consumed) = match reader.fill_buf() {
             Ok([]) => {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
@@ -464,45 +544,18 @@ fn read_line_within(stream: &UnixStream, budget: LineBudget) -> io::Result<Strin
             Ok(available) => match available.iter().position(|byte| *byte == b'\n') {
                 Some(index) => {
                     line.extend_from_slice(&available[..=index]);
-                    Step::Complete(index + 1)
+                    (true, index + 1)
                 }
                 None => {
                     line.extend_from_slice(available);
-                    Step::Partial(available.len())
+                    (false, available.len())
                 }
             },
-            // A quiet peer, not a failed one — the deadline above decides
-            // when quiet has gone on too long.
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    io::ErrorKind::WouldBlock
-                        | io::ErrorKind::TimedOut
-                        | io::ErrorKind::Interrupted
-                ) =>
-            {
-                Step::Retry
-            }
+            Err(error) if is_quiet(&error) => continue,
             Err(error) => return Err(error),
         };
-        let finished = match step {
-            Step::Complete(consumed) => {
-                reader.consume(consumed);
-                true
-            }
-            Step::Partial(consumed) => {
-                reader.consume(consumed);
-                false
-            }
-            Step::Retry => continue,
-        };
-        // Bytes arrived, so an idle budget starts over: the peer is making
-        // progress, which is the only thing this bound is asking about. A
-        // total budget is left alone — for an arbitrary peer, progress is
-        // exactly what a slow trickle fakes.
-        if let LineBudget::Idle(limit) = budget {
-            deadline = std::time::Instant::now() + limit;
-        }
+        reader.consume(consumed);
+        clock.progressed();
         if finished {
             return String::from_utf8(line)
                 .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
@@ -510,48 +563,176 @@ fn read_line_within(stream: &UnixStream, budget: LineBudget) -> io::Result<Strin
     }
 }
 
+/// Reads exactly `len` bytes.
+///
+/// Knowing the length up front is the point of framing: there is no ceiling to
+/// guess and no newline to wait for, so an idle budget is enough — a peer that
+/// keeps delivering is making progress no matter how much it has left to send.
+#[cfg(unix)]
+fn read_exact_within(
+    reader: &mut BufReader<&UnixStream>,
+    len: usize,
+    budget: LineBudget,
+) -> io::Result<String> {
+    let mut clock = BudgetClock::new(budget);
+    let mut body: Vec<u8> = Vec::with_capacity(len.min(1024 * 1024));
+    while body.len() < len {
+        if clock.expired() {
+            return Err(BudgetClock::timed_out());
+        }
+        let consumed = match reader.fill_buf() {
+            Ok([]) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "peer closed before completing the IPC frame",
+                ));
+            }
+            Ok(available) => {
+                let take = available.len().min(len - body.len());
+                body.extend_from_slice(&available[..take]);
+                take
+            }
+            Err(error) if is_quiet(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        reader.consume(consumed);
+        clock.progressed();
+    }
+    String::from_utf8(body).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+/// How a message is delimited on the broker socket.
+///
+/// `Framed` prefixes a byte count, so the reader knows the length up front and
+/// needs no ceiling and no total-time budget standing in for one. `Legacy` is
+/// the original newline-delimited JSON, kept because a helper can adopt a
+/// broker that a previous build started and which is still speaking it.
+#[cfg(unix)]
+#[derive(Clone, Copy, PartialEq)]
+enum Framing {
+    Legacy,
+    Framed,
+}
+
+/// Header introducing a framed message: this, a byte count, and a newline.
+/// Chosen so it cannot be confused with the legacy encoding, which always
+/// starts with `{`.
+#[cfg(unix)]
+const IPC_FRAME_HEADER: &str = "ALASIPC1 ";
+
+/// Marker a supervisor writes to advertise that it understands framing.
+/// Callers check for it rather than negotiating, because the answer has to
+/// survive the caller restarting while the broker keeps running.
+#[cfg(unix)]
+const IPC_FRAMING_MARKER: &str = "framing";
+
+#[cfg(unix)]
+fn broker_supports_framing(dir: &Path) -> bool {
+    dir.join(IPC_FRAMING_MARKER).exists()
+}
+
+/// Reads one message, in whichever framing the peer used.
+///
+/// Detection is by prefix rather than by configuration so that both mixed
+/// pairings work: a new caller reaching an old broker, and an old caller
+/// reaching a new one.
+///
+/// `head` bounds the first line, which is either a short framing header or —
+/// under the legacy encoding — the entire message, so the two callers want
+/// different budgets for it: a request arriving from an arbitrary peer gets a
+/// total, while a reply from a broker we spawned gets an idle budget, since
+/// its size is not ours to predict.
+#[cfg(unix)]
+fn read_ipc_message(
+    reader: &mut BufReader<&UnixStream>,
+    head: LineBudget,
+    body_idle: Duration,
+) -> io::Result<(String, Framing)> {
+    let head = read_line_within(reader, head)?;
+    let Some(len) = head.strip_prefix(IPC_FRAME_HEADER) else {
+        return Ok((head, Framing::Legacy));
+    };
+    let len: usize = len.trim().parse().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid IPC frame length: {}", len.trim()),
+        )
+    })?;
+    let body = read_exact_within(reader, len, LineBudget::Idle(body_idle))?;
+    Ok((body, Framing::Framed))
+}
+
+#[cfg(unix)]
+fn write_ipc_message(writer: &mut impl Write, body: &str, framing: Framing) -> io::Result<()> {
+    if framing == Framing::Framed {
+        writeln!(writer, "{IPC_FRAME_HEADER}{}", body.len())?;
+    }
+    writer.write_all(body.as_bytes())?;
+    if framing == Framing::Legacy {
+        writer.write_all(b"\n")?;
+    }
+    writer.flush()
+}
+
 fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProcessError> {
     #[cfg(unix)]
     {
+        /// How long the accept loop sleeps between polls when no client is
+        /// waiting. Also the longest a `close` takes to end the loop.
+        const ACCEPT_POLL: Duration = Duration::from_millis(50);
+        /// How long to let in-flight handlers finish after a `close`, so the
+        /// caller that asked for it still receives its answer.
+        const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
         let socket_path = dir.join("broker.sock");
         let _ = std::fs::remove_file(&socket_path);
+        // Advertise framing before the socket exists, not after: a caller that
+        // connected in between would find no marker and fall back to the
+        // legacy encoding for that request.
+        write_restrictive_bytes(&dir.join(IPC_FRAMING_MARKER), b"1\n")?;
         let listener = UnixListener::bind(&socket_path)
             .map_err(|error| broker_error(-32072, format!("socket bind failed: {error}")))?;
+        // Non-blocking so the loop can notice `close` without waiting for
+        // another connection to arrive. Handling used to run inline for
+        // exactly that reason, which is what let one slow client hold up
+        // everyone else.
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| broker_error(-32072, format!("socket mode failed: {error}")))?;
         write_restrictive_bytes(&dir.join("ready"), b"1\n")?;
-        for stream in listener.incoming() {
-            let stream = match stream {
-                Ok(stream) => stream,
+
+        let inflight = Arc::new(Mutex::new(0usize));
+        while !runtime_is_closing(&runtime) {
+            let stream = match listener.accept() {
+                Ok((stream, _)) => stream,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(ACCEPT_POLL);
+                    continue;
+                }
                 Err(_) => continue,
             };
-            // The request line is read on this thread, so a client that never
-            // completes one would stop `accept()` for every other caller.
-            // `read_line_within` bounds the whole line, not just each read, so
-            // neither silence nor a slow trickle can hold this loop; dropping
-            // the stream afterwards gives that client a clean EOF to fail on
-            // instead of a hang. The write gets the larger budget on purpose:
-            // it guards against a client that stops reading, but an `attach`
-            // replay can be a large response, and cutting one short would
-            // corrupt a legitimate reply rather than rescue a stuck one.
-            if stream
-                .set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))
-                .is_err()
-            {
+            // Accepted sockets do not reliably inherit the listener's mode,
+            // and the readers below want a blocking socket with timeouts.
+            if stream.set_nonblocking(false).is_err() {
                 continue;
             }
-            let Ok(line) = read_line_within(&stream, LineBudget::Total(IPC_REQUEST_TIMEOUT)) else {
-                continue;
-            };
-            if ipc_line_is_close(&line) {
-                let _ = handle_ipc_line(runtime.clone(), stream, line);
-            } else {
-                let request_runtime = runtime.clone();
-                std::thread::spawn(move || {
-                    let _ = handle_ipc_line(request_runtime, stream, line);
-                });
-            }
-            if runtime_is_closing(&runtime) {
+            let request_runtime = runtime.clone();
+            let request_inflight = Arc::clone(&inflight);
+            *request_inflight.lock().unwrap_or_else(|e| e.into_inner()) += 1;
+            std::thread::spawn(move || {
+                let _ = handle_connection(request_runtime, stream);
+                *request_inflight.lock().unwrap_or_else(|e| e.into_inner()) -= 1;
+            });
+        }
+
+        // A `close` handler sets the closing flag before it replies, so the
+        // loop can exit while that reply is still being written. Wait for it.
+        let deadline = std::time::Instant::now() + DRAIN_TIMEOUT;
+        while std::time::Instant::now() < deadline {
+            if *inflight.lock().unwrap_or_else(|e| e.into_inner()) == 0 {
                 break;
             }
+            std::thread::sleep(ACCEPT_POLL);
         }
         Ok(())
     }
@@ -563,8 +744,33 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
     }
 }
 
+/// Reads one request off an accepted connection and answers it, in whichever
+/// framing the caller used. Runs on its own thread, so a caller that is slow
+/// to deliver its request costs only that thread.
 #[cfg(unix)]
-fn handle_ipc_line(runtime: Runtime, stream: UnixStream, line: String) -> io::Result<()> {
+fn handle_connection(runtime: Runtime, stream: UnixStream) -> io::Result<()> {
+    // Guards against a caller that stops reading. Generous, because a reply
+    // can legitimately be large and cutting one short would corrupt it rather
+    // than rescue anything.
+    stream.set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))?;
+    let (line, framing) = {
+        let mut reader = ipc_reader(&stream)?;
+        read_ipc_message(
+            &mut reader,
+            LineBudget::Total(IPC_REQUEST_TIMEOUT),
+            BROKER_IPC_IDLE_TIMEOUT,
+        )?
+    };
+    handle_ipc_line(runtime, stream, line, framing)
+}
+
+#[cfg(unix)]
+fn handle_ipc_line(
+    runtime: Runtime,
+    stream: UnixStream,
+    line: String,
+    framing: Framing,
+) -> io::Result<()> {
     let response = match serde_json::from_str::<BrokerIpcRequest>(&line) {
         Ok(request) => match handle_ipc_request(&runtime, request) {
             Ok(result) => BrokerIpcResponse {
@@ -594,15 +800,23 @@ fn handle_ipc_line(runtime: Runtime, stream: UnixStream, line: String) -> io::Re
     // enough to trip the caller's budget before the reply even starts.
     // Streaming turns that silence into steady progress.
     let mut writer = BufWriter::new(stream);
-    serde_json::to_writer(&mut writer, &response).map_err(io::Error::other)?;
-    writer.write_all(b"\n")?;
-    writer.flush()
-}
-
-fn ipc_line_is_close(line: &str) -> bool {
-    serde_json::from_str::<BrokerIpcRequest>(line)
-        .map(|request| request.method == "close")
-        .unwrap_or(false)
+    match framing {
+        // Framing needs the length before the bytes, so this one has to be
+        // built first. That is the trade for having no size ceiling; it costs
+        // a transient copy of the reply, and replies no longer carry prompt
+        // params (see `OperationSnapshot`), so what is copied is small.
+        Framing::Framed => {
+            let body = serde_json::to_string(&response).map_err(io::Error::other)?;
+            write_ipc_message(&mut writer, &body, framing)
+        }
+        // Nothing downstream needs the length, so stream it: the caller sees
+        // steady progress instead of one silent pause while it is built.
+        Framing::Legacy => {
+            serde_json::to_writer(&mut writer, &response).map_err(io::Error::other)?;
+            writer.write_all(b"\n")?;
+            writer.flush()
+        }
+    }
 }
 
 fn handle_ipc_request(
@@ -1121,27 +1335,34 @@ fn send_ipc_within(
         let mut stream = UnixStream::connect(dir.join("broker.sock"))
             .map_err(|error| broker_error(-32072, format!("broker connect failed: {error}")))?;
         // Without a bound, a broker that accepted the connection but never
-        // answered would block this call forever. That matters more than it
-        // looks: every `acp/*` request is handled inline on the helper's
-        // single-threaded serve loop, so one unresponsive broker would take
-        // down file, watch, search and *every other ACP session* with it.
-        // The response read is bounded below by `read_line_within`.
+        // answered would block this call forever.
         stream
             .set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))
             .map_err(|error| {
                 broker_error(-32072, format!("broker write timeout failed: {error}"))
             })?;
-        writeln!(stream, "{body}")
+        // Frame the request when the broker advertises it. Without framing the
+        // reader has to hunt for a newline, which needs a total budget, which
+        // is a size ceiling wearing a different hat — and this request can be
+        // an `acp/respond` carrying a whole file the adapter asked to read.
+        // A broker started by an earlier build has no marker and still gets
+        // the original encoding.
+        let framing = if broker_supports_framing(dir) {
+            Framing::Framed
+        } else {
+            Framing::Legacy
+        };
+        write_ipc_message(&mut stream, &body, framing)
             .map_err(|error| broker_error(-32072, format!("broker write failed: {error}")))?;
-        stream
-            .flush()
-            .map_err(|error| broker_error(-32072, format!("broker flush failed: {error}")))?;
         // Bounded by inactivity, not total time: a reply's size — and so how
-        // long it legitimately takes — is not a bounded multiple of the
-        // request. What can be asked of a broker is that it keep making
-        // progress.
-        let line = read_line_within(&stream, LineBudget::Idle(idle_timeout))
-            .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?;
+        // long it legitimately takes — is not something we can predict. What
+        // can be asked of a broker is that it keep making progress.
+        let (line, _) = {
+            let mut reader = ipc_reader(&stream)
+                .map_err(|error| broker_error(-32072, format!("broker read setup: {error}")))?;
+            read_ipc_message(&mut reader, LineBudget::Idle(idle_timeout), idle_timeout)
+                .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?
+        };
         let response: BrokerIpcResponse = serde_json::from_str(&line)
             .map_err(|error| broker_error(-32072, format!("broker response failed: {error}")))?;
         if response.ok {
@@ -1208,7 +1429,13 @@ fn read_startup_error(dir: &Path) -> Option<String> {
 }
 
 fn remove_transient_startup_files(dir: &Path) {
-    for name in ["broker.sock", "ready", "startup-error", "pid.json"] {
+    for name in [
+        "broker.sock",
+        "ready",
+        "startup-error",
+        "pid.json",
+        IPC_FRAMING_MARKER,
+    ] {
         let _ = std::fs::remove_file(dir.join(name));
     }
 }
@@ -1584,7 +1811,8 @@ mod tests {
         });
 
         let started = std::time::Instant::now();
-        let line = read_line_within(&reader, LineBudget::Idle(Duration::from_secs(1)))
+        let mut reader = ipc_reader(&reader).expect("reader");
+        let line = read_line_within(&mut reader, LineBudget::Idle(Duration::from_secs(1)))
             .expect("a peer that keeps making progress must not be given up on");
         assert_eq!(line.len(), 6 * 512 + 1);
         assert!(
@@ -1614,7 +1842,8 @@ mod tests {
         });
 
         let started = std::time::Instant::now();
-        let outcome = read_line_within(&reader, LineBudget::Total(Duration::from_secs(2)));
+        let mut reader = ipc_reader(&reader).expect("reader");
+        let outcome = read_line_within(&mut reader, LineBudget::Total(Duration::from_secs(2)));
         let elapsed = started.elapsed();
         *done.lock().expect("drip flag") = true;
 
@@ -1640,7 +1869,8 @@ mod tests {
             let _ = writer.flush();
         });
 
-        let line = read_line_within(&reader, LineBudget::Total(Duration::from_secs(30)))
+        let mut reader = ipc_reader(&reader).expect("reader");
+        let line = read_line_within(&mut reader, LineBudget::Total(Duration::from_secs(30)))
             .expect("large line");
         assert_eq!(line.len(), expected + 1);
     }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -18,6 +18,25 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 #[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
 
+/// How long the supervisor waits for an accepted client to deliver a complete
+/// request line. The read happens on the accept thread, so a client that
+/// connects and then goes quiet — a stalled writer, or one killed between
+/// `connect()` and `write()` — would otherwise stop the broker from ever
+/// accepting another connection.
+const IPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long a caller waits on a single broker IPC round trip. Generous
+/// compared to the work a broker actually does per request (`close` is the
+/// slowest at ~2.5s, and it may queue behind one `IPC_REQUEST_TIMEOUT` read),
+/// but bounded: `send_ipc` runs inline on the helper's single-threaded serve
+/// loop, so an unbounded wait here stalls every session the helper serves.
+const BROKER_IPC_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Floor for a single retried attempt, so a nearly-spent deadline cannot
+/// shrink the per-attempt budget down to something a healthy broker on a busy
+/// machine would miss.
+const BROKER_IPC_MIN_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
+
 #[derive(Debug)]
 pub struct AcpBrokerProcessError {
     pub code: i64,
@@ -336,7 +355,11 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
         if !dir.is_dir() || !broker_is_running(&dir) {
             continue;
         }
-        if let Ok(snapshot) = send_ipc(&dir, "snapshot", json!({})) {
+        // This sweeps every broker dir on disk, including leftovers from
+        // earlier app runs, so it must not pay the full per-request budget
+        // for each unresponsive one. A live broker answers `snapshot` from
+        // memory; anything slower than this is not worth listing.
+        if let Ok(snapshot) = send_ipc_within(&dir, "snapshot", json!({}), Duration::from_secs(2)) {
             if snapshot
                 .get("adapterExited")
                 .and_then(Value::as_bool)
@@ -363,6 +386,19 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
                 Ok(stream) => stream,
                 Err(_) => continue,
             };
+            // Bound both directions before touching the stream. The request
+            // line is read on this thread, so an unbounded read lets a single
+            // silent client wedge `accept()` for every other caller; dropping
+            // the stream on timeout gives that client a clean EOF to fail on
+            // instead of a hang. The write gets the larger budget on purpose:
+            // it guards against a client that stops reading, but an `attach`
+            // replay can be a large response, and cutting one short would
+            // corrupt a legitimate reply rather than rescue a stuck one.
+            if stream.set_read_timeout(Some(IPC_REQUEST_TIMEOUT)).is_err()
+                || stream.set_write_timeout(Some(BROKER_IPC_TIMEOUT)).is_err()
+            {
+                continue;
+            }
             let mut line = String::new();
             {
                 let mut reader = BufReader::new(&stream);
@@ -904,10 +940,30 @@ fn sorted_env_keys(env: &HashMap<String, String>) -> Vec<String> {
 }
 
 fn send_ipc(dir: &Path, method: &str, params: Value) -> Result<Value, AcpBrokerProcessError> {
+    send_ipc_within(dir, method, params, BROKER_IPC_TIMEOUT)
+}
+
+fn send_ipc_within(
+    dir: &Path,
+    method: &str,
+    params: Value,
+    timeout: Duration,
+) -> Result<Value, AcpBrokerProcessError> {
     #[cfg(unix)]
     {
         let mut stream = UnixStream::connect(dir.join("broker.sock"))
             .map_err(|error| broker_error(-32072, format!("broker connect failed: {error}")))?;
+        // Without these, a broker that accepted the connection but never
+        // answered would block this call forever. That matters more than it
+        // looks: every `acp/*` request is handled inline on the helper's
+        // single-threaded serve loop, so one unresponsive broker would take
+        // down file, watch, search and *every other ACP session* with it.
+        stream.set_read_timeout(Some(timeout)).map_err(|error| {
+            broker_error(-32072, format!("broker read timeout failed: {error}"))
+        })?;
+        stream.set_write_timeout(Some(timeout)).map_err(|error| {
+            broker_error(-32072, format!("broker write timeout failed: {error}"))
+        })?;
         let request = BrokerIpcRequest {
             method: method.to_string(),
             params: Some(params),
@@ -958,7 +1014,18 @@ fn send_ipc_with_retry(
         if let Some(message) = read_startup_error(dir) {
             return Err(broker_error(-32072, message));
         }
-        match send_ipc(dir, method, params.clone()) {
+        // Bound each attempt, not just the gaps between attempts. A broker
+        // that accepts and then never answers never produces the error this
+        // loop checks the deadline on, so a per-attempt bound is the only
+        // thing that makes `timeout` mean anything for a wedged broker.
+        // The floor keeps a slow-but-healthy broker on a loaded machine from
+        // being declared dead just because the deadline is nearly spent — it
+        // can overshoot `timeout`, which is the right trade: this bound
+        // exists to rule out hangs, not to hit a precise deadline.
+        let remaining = deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .max(BROKER_IPC_MIN_ATTEMPT_TIMEOUT);
+        match send_ipc_within(dir, method, params.clone(), remaining) {
             Ok(value) => return Ok(value),
             Err(error) if std::time::Instant::now() < deadline => {
                 let _ = error;

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -33,6 +33,21 @@ use std::os::unix::net::{UnixListener, UnixStream};
 /// caller has declared a length and is held to it instead.
 const IPC_REQUEST_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Ceiling on the whole first line, alongside the silence bound above.
+///
+/// Without it a caller can send one byte every 59s forever, and since every
+/// connection owns a thread, repeating that accumulates threads until the
+/// broker cannot spawn any more. Generous next to what the line actually
+/// costs — a legacy caller pauses ~7.4s to encode a maximal prompt and then
+/// writes it in ~0.2s — so this only ever catches a caller that is not really
+/// trying to finish.
+const IPC_REQUEST_TOTAL_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Bounds on the first line of a request: silence, and total elapsed.
+#[cfg(unix)]
+const IPC_REQUEST_HEAD_BUDGET: ReadBudget =
+    ReadBudget::bounded_const(IPC_REQUEST_IDLE_TIMEOUT, IPC_REQUEST_TOTAL_TIMEOUT);
+
 /// Slowest a caller may deliver a framed body before we stop waiting.
 ///
 /// An idle budget alone is not enough once a length is known: a caller can
@@ -42,13 +57,20 @@ const IPC_REQUEST_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 /// so a legitimate transfer clears it by two orders of magnitude.
 const MIN_IPC_BODY_THROUGHPUT: u64 = 10 * 1024 * 1024;
 
-/// Deadline for a framed body of `len` bytes: whatever the throughput floor
-/// allows, but never less than the ordinary idle budget, so a small body is
-/// not held to a stricter rule than a large one.
+/// Budget for a framed body of `len` bytes.
+///
+/// The total scales with the length the caller declared — never below the
+/// ordinary idle budget, so a small body is not held to a stricter rule than a
+/// large one. The idle bound is kept alongside it and does not scale: a caller
+/// that declares 1 TiB and then says nothing would otherwise have bought
+/// itself about 29 hours of silence, and a thread to spend it in.
 #[cfg(unix)]
-fn framed_body_budget(len: usize) -> LineBudget {
+fn framed_body_budget(len: usize) -> ReadBudget {
     let by_rate = Duration::from_secs_f64(len as f64 / MIN_IPC_BODY_THROUGHPUT as f64);
-    LineBudget::Total(by_rate.max(BROKER_IPC_IDLE_TIMEOUT))
+    ReadBudget::bounded(
+        BROKER_IPC_IDLE_TIMEOUT,
+        by_rate.max(BROKER_IPC_IDLE_TIMEOUT),
+    )
 }
 
 /// How long a caller gives a broker to send *something* before treating it as
@@ -457,53 +479,71 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
     Ok(json!({ "brokers": brokers }))
 }
 
-/// How a line read is bounded in time.
+/// How a read is bounded in time.
 ///
-/// Which variant is right depends on whether the peer is one we trust to
-/// finish what it starts.
+/// Two bounds, because either alone has a hole. An idle bound asks only that
+/// the peer keep sending, which a trickle satisfies forever. A total bound
+/// asks the read to finish by a fixed time, which fails a legitimately large
+/// or slow-to-start transfer. Applying both lets a peer be slow *or* large
+/// without letting it be indefinite.
 #[derive(Clone, Copy)]
-enum LineBudget {
-    /// Wall-clock for the whole line. Correct where the peer is arbitrary,
-    /// since only a total bound stops a slow trickle that keeps looking like
-    /// progress.
-    Total(Duration),
-    /// Longest run with no bytes arriving. Correct where a legitimate payload
-    /// can be arbitrarily large, which makes any total a guess that eventually
-    /// fails a valid transfer: the real failure being guarded against is a peer
-    /// that has stopped making progress, not one that is merely big.
-    Idle(Duration),
+struct ReadBudget {
+    /// Longest run with no bytes arriving.
+    idle: Duration,
+    /// Longest the whole read may take, however much progress is made. `None`
+    /// where the peer is a broker this helper spawned and its reply has no
+    /// size we could turn into a deadline — there, one thread per outstanding
+    /// request is bounded by the number of sessions, not by the peer.
+    total: Option<Duration>,
 }
 
-/// Tracks whether a read still has time left, under whichever budget applies.
+impl ReadBudget {
+    /// For a peer we trust to finish what it starts.
+    fn idle(idle: Duration) -> Self {
+        Self { idle, total: None }
+    }
+
+    /// For an arbitrary peer, which must be both making progress and finishing.
+    fn bounded(idle: Duration, total: Duration) -> Self {
+        Self::bounded_const(idle, total)
+    }
+
+    const fn bounded_const(idle: Duration, total: Duration) -> Self {
+        Self {
+            idle,
+            total: Some(total),
+        }
+    }
+}
+
+/// Tracks whether a read still has time left under both of its bounds.
 #[cfg(unix)]
 struct BudgetClock {
-    budget: LineBudget,
-    deadline: std::time::Instant,
+    idle: Duration,
+    idle_deadline: std::time::Instant,
+    total_deadline: Option<std::time::Instant>,
 }
 
 #[cfg(unix)]
 impl BudgetClock {
-    fn new(budget: LineBudget) -> Self {
-        let limit = match budget {
-            LineBudget::Total(limit) | LineBudget::Idle(limit) => limit,
-        };
+    fn new(budget: ReadBudget) -> Self {
+        let now = std::time::Instant::now();
         Self {
-            budget,
-            deadline: std::time::Instant::now() + limit,
+            idle: budget.idle,
+            idle_deadline: now + budget.idle,
+            total_deadline: budget.total.map(|total| now + total),
         }
     }
 
     fn expired(&self) -> bool {
-        std::time::Instant::now() >= self.deadline
+        let now = std::time::Instant::now();
+        now >= self.idle_deadline || self.total_deadline.is_some_and(|deadline| now >= deadline)
     }
 
-    /// Bytes arrived. An idle budget starts over — the peer is making
-    /// progress, which is the only thing it asks about. A total budget is left
-    /// alone: for an arbitrary peer, progress is exactly what a trickle fakes.
+    /// Bytes arrived, so the idle bound starts over. The total bound does not:
+    /// that is the one a trickle cannot renew.
     fn progressed(&mut self) {
-        if let LineBudget::Idle(limit) = self.budget {
-            self.deadline = std::time::Instant::now() + limit;
-        }
+        self.idle_deadline = std::time::Instant::now() + self.idle;
     }
 
     fn timed_out() -> io::Error {
@@ -550,7 +590,7 @@ fn is_quiet(error: &io::Error) -> bool {
 /// reads until it finds a newline, so a peer trickling bytes faster than the
 /// timeout renews its budget indefinitely.
 #[cfg(unix)]
-fn read_line_within(reader: &mut BufReader<&UnixStream>, budget: LineBudget) -> io::Result<String> {
+fn read_line_within(reader: &mut BufReader<&UnixStream>, budget: ReadBudget) -> io::Result<String> {
     let mut clock = BudgetClock::new(budget);
     let mut line: Vec<u8> = Vec::new();
     loop {
@@ -595,7 +635,7 @@ fn read_line_within(reader: &mut BufReader<&UnixStream>, budget: LineBudget) -> 
 fn read_exact_within(
     reader: &mut BufReader<&UnixStream>,
     len: usize,
-    budget: LineBudget,
+    budget: ReadBudget,
 ) -> io::Result<String> {
     let mut clock = BudgetClock::new(budget);
     let mut body: Vec<u8> = Vec::with_capacity(len.min(1024 * 1024));
@@ -649,9 +689,25 @@ const IPC_FRAME_HEADER: &str = "ALASIPC1 ";
 #[cfg(unix)]
 const IPC_FRAMING_MARKER: &str = "framing";
 
+/// True when the broker *currently* running in `dir` wrote the marker.
+///
+/// Presence alone is not enough. A supervisor from an earlier build can
+/// replace one from this build in the same directory, and its cleanup does not
+/// know to remove a file it has never heard of — so the marker outlives the
+/// broker that meant it. Framed requests would then go to a broker that only
+/// understands newlines, which rejects them, and `acp/open` will not replace it
+/// because its pid is live: the session cannot be reopened at all. Recording
+/// the pid the marker was written for makes it expire with its broker, since
+/// any replacement writes a new `pid.json`.
 #[cfg(unix)]
 fn broker_supports_framing(dir: &Path) -> bool {
-    dir.join(IPC_FRAMING_MARKER).exists()
+    let Ok(marker) = std::fs::read_to_string(dir.join(IPC_FRAMING_MARKER)) else {
+        return false;
+    };
+    let Ok(marked_pid) = marker.trim().parse::<u32>() else {
+        return false;
+    };
+    read_broker_pid_metadata(dir).is_some_and(|metadata| metadata.pid == marked_pid)
 }
 
 /// Reads one message, in whichever framing the peer used.
@@ -660,16 +716,16 @@ fn broker_supports_framing(dir: &Path) -> bool {
 /// pairings work: a new caller reaching an old broker, and an old caller
 /// reaching a new one.
 ///
-/// `head_idle` bounds silence on the first line, which is a short framing
-/// header or — under the legacy encoding — the entire message. The framed body
-/// is then bounded by the length the caller declared, so an advertised size
-/// cannot be used to hold resources indefinitely.
+/// `head` bounds the first line, which is a short framing header or — under
+/// the legacy encoding — the entire message. The framed body is then bounded
+/// by the length the caller declared, so an advertised size cannot be used to
+/// hold resources indefinitely.
 #[cfg(unix)]
 fn read_ipc_message(
     reader: &mut BufReader<&UnixStream>,
-    head_idle: Duration,
+    head: ReadBudget,
 ) -> io::Result<(String, Framing)> {
-    let head = read_line_within(reader, LineBudget::Idle(head_idle))?;
+    let head = read_line_within(reader, head)?;
     let Some(len) = head.strip_prefix(IPC_FRAME_HEADER) else {
         return Ok((head, Framing::Legacy));
     };
@@ -709,8 +765,12 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
         let _ = std::fs::remove_file(&socket_path);
         // Advertise framing before the socket exists, not after: a caller that
         // connected in between would find no marker and fall back to the
-        // legacy encoding for that request.
-        write_restrictive_bytes(&dir.join(IPC_FRAMING_MARKER), b"1\n")?;
+        // legacy encoding for that request. Stamped with this process's pid so
+        // it cannot outlive this broker — see `broker_supports_framing`.
+        write_restrictive_bytes(
+            &dir.join(IPC_FRAMING_MARKER),
+            format!("{}\n", std::process::id()).as_bytes(),
+        )?;
         let listener = UnixListener::bind(&socket_path)
             .map_err(|error| broker_error(-32072, format!("socket bind failed: {error}")))?;
         // Non-blocking so the loop can notice `close` without waiting for
@@ -776,7 +836,7 @@ fn handle_connection(runtime: Runtime, stream: UnixStream) -> io::Result<()> {
     stream.set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))?;
     let (line, framing) = {
         let mut reader = ipc_reader(&stream)?;
-        read_ipc_message(&mut reader, IPC_REQUEST_IDLE_TIMEOUT)?
+        read_ipc_message(&mut reader, IPC_REQUEST_HEAD_BUDGET)?
     };
     handle_ipc_line(runtime, stream, line, framing)
 }
@@ -1377,7 +1437,7 @@ fn send_ipc_within(
         let (line, _) = {
             let mut reader = ipc_reader(&stream)
                 .map_err(|error| broker_error(-32072, format!("broker read setup: {error}")))?;
-            read_ipc_message(&mut reader, idle_timeout)
+            read_ipc_message(&mut reader, ReadBudget::idle(idle_timeout))
                 .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?
         };
         let response: BrokerIpcResponse = serde_json::from_str(&line)
@@ -1829,7 +1889,7 @@ mod tests {
 
         let started = std::time::Instant::now();
         let mut reader = ipc_reader(&reader).expect("reader");
-        let line = read_line_within(&mut reader, LineBudget::Idle(Duration::from_secs(1)))
+        let line = read_line_within(&mut reader, ReadBudget::idle(Duration::from_secs(1)))
             .expect("a peer that keeps making progress must not be given up on");
         assert_eq!(line.len(), 6 * 512 + 1);
         assert!(
@@ -1864,7 +1924,7 @@ mod tests {
         let outcome = read_exact_within(
             &mut reader,
             4 * 1024 * 1024,
-            LineBudget::Total(Duration::from_secs(2)),
+            ReadBudget::bounded(Duration::from_secs(2), Duration::from_secs(2)),
         );
         *done.lock().expect("drip flag") = true;
 
@@ -1873,24 +1933,101 @@ mod tests {
         assert!(started.elapsed() < Duration::from_secs(10));
     }
 
+    /// A framing marker must expire with the broker that wrote it.
+    ///
+    /// A supervisor from an earlier build can replace this one in the same
+    /// directory, and its cleanup does not know to remove a file it has never
+    /// heard of — so the marker outlives the broker that meant it. Trusting it
+    /// then sends framed requests to a broker that only speaks newlines, which
+    /// rejects them, and `acp/open` will not replace it while its pid is live.
+    ///
+    /// Tested here rather than end-to-end because reproducing it for real
+    /// needs a supervisor built before framing existed; what can be pinned is
+    /// that presence alone is not taken as consent.
+    #[cfg(unix)]
+    #[test]
+    fn a_framing_marker_is_only_trusted_for_the_live_broker() {
+        let dir = PathBuf::from(format!("/tmp/alas-marker-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("marker dir");
+        write_broker_pid(&dir).expect("pid metadata");
+        let live = std::process::id();
+
+        assert!(
+            !broker_supports_framing(&dir),
+            "no marker should mean no framing"
+        );
+
+        std::fs::write(dir.join(IPC_FRAMING_MARKER), format!("{live}\n")).expect("marker");
+        assert!(
+            broker_supports_framing(&dir),
+            "a marker written by the live broker should be trusted"
+        );
+
+        // Stands in for a marker left behind by a broker that has since been
+        // replaced: present, but naming a process that is no longer the one
+        // serving this directory.
+        std::fs::write(dir.join(IPC_FRAMING_MARKER), format!("{}\n", live + 1)).expect("marker");
+        assert!(
+            !broker_supports_framing(&dir),
+            "a marker from a replaced broker must not be trusted"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A declared length buys time proportional to itself, and nothing else.
+    /// Deriving the only deadline from it would let a caller claim 1 TiB and
+    /// then say nothing for the ~29 hours that implies, parking a thread per
+    /// such connection.
+    #[cfg(unix)]
+    #[test]
+    fn a_huge_declared_length_does_not_buy_silence() {
+        let (_writer, reader) = UnixStream::pair().expect("socket pair");
+        let mut reader = ipc_reader(&reader).expect("reader");
+
+        let one_tib = 1024usize.pow(4);
+        let mut budget = framed_body_budget(one_tib);
+        assert!(
+            budget
+                .total
+                .is_some_and(|total| total > Duration::from_secs(3600)),
+            "a 1 TiB body should be allowed hours in total: {:?}",
+            budget.total
+        );
+        // Shorten only the silence bound, so this test does not sit for the
+        // full idle budget while proving the total is not what stops it.
+        budget.idle = Duration::from_millis(300);
+
+        let started = std::time::Instant::now();
+        let error = read_exact_within(&mut reader, one_tib, budget)
+            .expect_err("a silent caller must be cut by the idle bound, not its own claim");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(started.elapsed() < Duration::from_secs(30));
+    }
+
     /// The rate floor must not turn into a ceiling on legitimate payloads: a
     /// body large enough to take real time still has to be allowed to arrive.
     #[test]
     fn the_body_deadline_scales_with_the_length_a_caller_declares() {
         // Small bodies are not held to a stricter rule than large ones.
-        assert!(matches!(
-            framed_body_budget(1024),
-            LineBudget::Total(budget) if budget == BROKER_IPC_IDLE_TIMEOUT
-        ));
+        assert_eq!(
+            framed_body_budget(1024).total,
+            Some(BROKER_IPC_IDLE_TIMEOUT)
+        );
         // A maximal image prompt (~267 MiB) gets time proportional to its size.
         let maximal = 267 * 1024 * 1024;
-        let LineBudget::Total(budget) = framed_body_budget(maximal) else {
-            panic!("a framed body should be bounded in total, not by inactivity");
-        };
+        let budget = framed_body_budget(maximal);
         assert!(
-            budget >= BROKER_IPC_IDLE_TIMEOUT,
-            "a large body was given less time than a small one: {budget:?}"
+            budget
+                .total
+                .is_some_and(|total| total >= BROKER_IPC_IDLE_TIMEOUT),
+            "a large body was given less time than a small one: {:?}",
+            budget.total
         );
+        // The silence bound does not scale with the declared length, or a
+        // caller could buy quiet by claiming a huge body.
+        assert_eq!(budget.idle, BROKER_IPC_IDLE_TIMEOUT);
     }
 
     /// The whole fix rests on this: a peer that keeps the connection alive and
@@ -1915,7 +2052,10 @@ mod tests {
 
         let started = std::time::Instant::now();
         let mut reader = ipc_reader(&reader).expect("reader");
-        let outcome = read_line_within(&mut reader, LineBudget::Total(Duration::from_secs(2)));
+        let outcome = read_line_within(
+            &mut reader,
+            ReadBudget::bounded(Duration::from_secs(2), Duration::from_secs(2)),
+        );
         let elapsed = started.elapsed();
         *done.lock().expect("drip flag") = true;
 
@@ -1942,7 +2082,7 @@ mod tests {
         });
 
         let mut reader = ipc_reader(&reader).expect("reader");
-        let line = read_line_within(&mut reader, LineBudget::Total(Duration::from_secs(30)))
+        let line = read_line_within(&mut reader, ReadBudget::idle(Duration::from_secs(30)))
             .expect("large line");
         assert_eq!(line.len(), expected + 1);
     }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1074,6 +1074,20 @@ fn send_ipc_within(
 ) -> Result<Value, AcpBrokerProcessError> {
     #[cfg(unix)]
     {
+        // Serialize BEFORE connecting. The broker starts its request deadline
+        // the moment `accept()` returns, so any work done between connecting
+        // and writing is spent out of the broker's budget rather than ours.
+        // That is not a small effect at the sizes the UI permits: encoding a
+        // maximal image prompt (~267 MiB, see `MAX_IPC_LINE_BYTES`) measures
+        // ~7.4s on an idle machine, against an `IPC_REQUEST_TIMEOUT` of 5s —
+        // so connecting first would drop a perfectly valid prompt every time,
+        // not merely under load. Writing the bytes, by contrast, takes ~0.2s,
+        // which is what the broker's deadline should actually be covering.
+        let body = serde_json::to_string(&BrokerIpcRequest {
+            method: method.to_string(),
+            params: Some(params),
+        })
+        .expect("IPC request serialization");
         // This connect is blocking and deliberately left that way. On Darwin
         // — the only platform that reaches this code, since the ACP broker is
         // spawned for local sessions only — a full listen backlog fails the
@@ -1097,16 +1111,8 @@ fn send_ipc_within(
         stream.set_write_timeout(Some(timeout)).map_err(|error| {
             broker_error(-32072, format!("broker write timeout failed: {error}"))
         })?;
-        let request = BrokerIpcRequest {
-            method: method.to_string(),
-            params: Some(params),
-        };
-        writeln!(
-            stream,
-            "{}",
-            serde_json::to_string(&request).expect("IPC request serialization")
-        )
-        .map_err(|error| broker_error(-32072, format!("broker write failed: {error}")))?;
+        writeln!(stream, "{body}")
+            .map_err(|error| broker_error(-32072, format!("broker write failed: {error}")))?;
         stream
             .flush()
             .map_err(|error| broker_error(-32072, format!("broker flush failed: {error}")))?;

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -18,15 +18,38 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 #[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
 
-/// How long the supervisor waits for a caller to deliver the first line of a
-/// request — a framing header, or under the legacy encoding the whole message.
+/// How long the supervisor waits on a silent caller before giving up on the
+/// first line of a request.
 ///
-/// A total rather than an idle budget, because the caller here is arbitrary
-/// and a trickle would otherwise pass for progress indefinitely. That is
-/// affordable only because the length arrives up front under framing: the body
-/// is then read against an idle budget with no ceiling, so this bound applies
-/// to the header, not to the payload.
-const IPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// Idle, not total, and that is forced by the legacy encoding: under framing
+/// this line is a short header, but a legacy caller sends the whole message
+/// here — and an older helper serializes *after* connecting, so it can
+/// legitimately say nothing at all for the ~7.4s a maximal image prompt takes
+/// to encode. A total budget would drop that request, breaking the very
+/// callers the legacy path exists to keep working.
+///
+/// Shorter than `BROKER_IPC_IDLE_TIMEOUT` because it is the one bound a caller
+/// can hold without having promised anything yet; past this line a framed
+/// caller has declared a length and is held to it instead.
+const IPC_REQUEST_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Slowest a caller may deliver a framed body before we stop waiting.
+///
+/// An idle budget alone is not enough once a length is known: a caller can
+/// advertise an enormous frame and dribble it, renewing the budget forever
+/// while the buffer grows. Holding it to a rate turns the promise into a
+/// deadline — and the floor is generous, since this socket measures ~1.3 GB/s,
+/// so a legitimate transfer clears it by two orders of magnitude.
+const MIN_IPC_BODY_THROUGHPUT: u64 = 10 * 1024 * 1024;
+
+/// Deadline for a framed body of `len` bytes: whatever the throughput floor
+/// allows, but never less than the ordinary idle budget, so a small body is
+/// not held to a stricter rule than a large one.
+#[cfg(unix)]
+fn framed_body_budget(len: usize) -> LineBudget {
+    let by_rate = Duration::from_secs_f64(len as f64 / MIN_IPC_BODY_THROUGHPUT as f64);
+    LineBudget::Total(by_rate.max(BROKER_IPC_IDLE_TIMEOUT))
+}
 
 /// How long a caller gives a broker to send *something* before treating it as
 /// wedged. Idle rather than total, because a legitimate reply has no size we
@@ -637,18 +660,16 @@ fn broker_supports_framing(dir: &Path) -> bool {
 /// pairings work: a new caller reaching an old broker, and an old caller
 /// reaching a new one.
 ///
-/// `head` bounds the first line, which is either a short framing header or —
-/// under the legacy encoding — the entire message, so the two callers want
-/// different budgets for it: a request arriving from an arbitrary peer gets a
-/// total, while a reply from a broker we spawned gets an idle budget, since
-/// its size is not ours to predict.
+/// `head_idle` bounds silence on the first line, which is a short framing
+/// header or — under the legacy encoding — the entire message. The framed body
+/// is then bounded by the length the caller declared, so an advertised size
+/// cannot be used to hold resources indefinitely.
 #[cfg(unix)]
 fn read_ipc_message(
     reader: &mut BufReader<&UnixStream>,
-    head: LineBudget,
-    body_idle: Duration,
+    head_idle: Duration,
 ) -> io::Result<(String, Framing)> {
-    let head = read_line_within(reader, head)?;
+    let head = read_line_within(reader, LineBudget::Idle(head_idle))?;
     let Some(len) = head.strip_prefix(IPC_FRAME_HEADER) else {
         return Ok((head, Framing::Legacy));
     };
@@ -658,7 +679,7 @@ fn read_ipc_message(
             format!("invalid IPC frame length: {}", len.trim()),
         )
     })?;
-    let body = read_exact_within(reader, len, LineBudget::Idle(body_idle))?;
+    let body = read_exact_within(reader, len, framed_body_budget(len))?;
     Ok((body, Framing::Framed))
 }
 
@@ -755,11 +776,7 @@ fn handle_connection(runtime: Runtime, stream: UnixStream) -> io::Result<()> {
     stream.set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))?;
     let (line, framing) = {
         let mut reader = ipc_reader(&stream)?;
-        read_ipc_message(
-            &mut reader,
-            LineBudget::Total(IPC_REQUEST_TIMEOUT),
-            BROKER_IPC_IDLE_TIMEOUT,
-        )?
+        read_ipc_message(&mut reader, IPC_REQUEST_IDLE_TIMEOUT)?
     };
     handle_ipc_line(runtime, stream, line, framing)
 }
@@ -1360,7 +1377,7 @@ fn send_ipc_within(
         let (line, _) = {
             let mut reader = ipc_reader(&stream)
                 .map_err(|error| broker_error(-32072, format!("broker read setup: {error}")))?;
-            read_ipc_message(&mut reader, LineBudget::Idle(idle_timeout), idle_timeout)
+            read_ipc_message(&mut reader, idle_timeout)
                 .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?
         };
         let response: BrokerIpcResponse = serde_json::from_str(&line)
@@ -1818,6 +1835,61 @@ mod tests {
         assert!(
             started.elapsed() > Duration::from_secs(1),
             "transfer finished too fast to prove the budget was exceeded in total"
+        );
+    }
+
+    /// A framed caller declares a length, and is then held to delivering it.
+    /// Without that, an idle budget alone lets a caller advertise an enormous
+    /// body and dribble it, renewing its budget forever while the buffer
+    /// grows — the trickle path framing was supposed to close, not reopen.
+    #[cfg(unix)]
+    #[test]
+    fn a_framed_body_must_be_delivered_at_a_minimum_rate() {
+        let (mut writer, reader) = UnixStream::pair().expect("socket pair");
+        let done = Arc::new(Mutex::new(false));
+        let writer_done = done.clone();
+        std::thread::spawn(move || {
+            while !*writer_done.lock().expect("drip flag") {
+                if writer.write_all(b"z").is_err() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        });
+
+        // Claims 4 MiB, which the floor allows well under the 2s asked for
+        // here, then delivers a byte at a time.
+        let mut reader = ipc_reader(&reader).expect("reader");
+        let started = std::time::Instant::now();
+        let outcome = read_exact_within(
+            &mut reader,
+            4 * 1024 * 1024,
+            LineBudget::Total(Duration::from_secs(2)),
+        );
+        *done.lock().expect("drip flag") = true;
+
+        let error = outcome.expect_err("a dribbled body must not be waited on forever");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(started.elapsed() < Duration::from_secs(10));
+    }
+
+    /// The rate floor must not turn into a ceiling on legitimate payloads: a
+    /// body large enough to take real time still has to be allowed to arrive.
+    #[test]
+    fn the_body_deadline_scales_with_the_length_a_caller_declares() {
+        // Small bodies are not held to a stricter rule than large ones.
+        assert!(matches!(
+            framed_body_budget(1024),
+            LineBudget::Total(budget) if budget == BROKER_IPC_IDLE_TIMEOUT
+        ));
+        // A maximal image prompt (~267 MiB) gets time proportional to its size.
+        let maximal = 267 * 1024 * 1024;
+        let LineBudget::Total(budget) = framed_body_budget(maximal) else {
+            panic!("a framed body should be bounded in total, not by inactivity");
+        };
+        assert!(
+            budget >= BROKER_IPC_IDLE_TIMEOUT,
+            "a large body was given less time than a small one: {budget:?}"
         );
     }
 

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -27,8 +27,8 @@ const IPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How long a caller gives a broker to send *something* before treating it as
 /// wedged. Idle rather than total, because a legitimate response has no size
-/// we can predict (see `MAX_IPC_LINE_BYTES`) and therefore no duration we can
-/// predict either: the reply to a maximal image prompt carries its params
+/// we can predict and therefore no duration we can predict either: the reply
+/// to a maximal image prompt carries its params
 /// twice and measures ~15s just to serialize, silently, before a byte is
 /// written. A total budget would have to out-guess that; an idle budget only
 /// has to notice a broker that has stopped.
@@ -43,32 +43,6 @@ const BROKER_IPC_IDLE_TIMEOUT: Duration = Duration::from_secs(20);
 /// request measures ~0.2s, so this only ever fires on a broker that has
 /// stopped reading.
 const BROKER_IPC_WRITE_TIMEOUT: Duration = Duration::from_secs(20);
-
-/// Upper bound on a *request* line arriving at a broker, so a peer that never
-/// sends a newline cannot grow the buffer without limit.
-///
-/// It has to clear the largest request the UI can legitimately produce, or it
-/// rejects valid input instead of catching abuse. The composer allows
-/// `ACPComposer.maxImagesPerMessage` (10) images of `ACPImageStaging.maxBytes`
-/// (20 MiB) each, and ACP embeds images as base64 inside `session/prompt`,
-/// which travels this socket as one `acp/send` line — 200 MiB of image
-/// becoming ~267 MiB on the wire, before prompt text and the JSON envelope.
-/// `ipc_line_cap_admits_the_largest_composer_payload` fails if those UI limits
-/// ever outgrow the value below.
-///
-/// Deliberately NOT applied to responses read back from a broker. A response
-/// is not a bounded multiple of the request: `broker_attach` returns the
-/// snapshot *and* the replayed events, and a prompt's params appear in both
-/// (`ACPBrokerState::snapshot` carries `operations[*].params`, while
-/// `OperationStarted` carries them again), while the snapshot also retains
-/// every operation not yet acknowledged. Any fixed ceiling there is a guess
-/// that eventually rejects a legitimate reply — and it would do so *after*
-/// the prompt was already dispatched, failing the send with nothing to retry.
-/// The peer on that side is a broker this helper spawned, and
-/// `BROKER_IPC_IDLE_TIMEOUT` still bounds how long it can hold the caller
-/// without sending anything — progress is what can be asked of it, size is
-/// not.
-const MAX_IPC_LINE_BYTES: usize = 512 * 1024 * 1024;
 
 #[derive(Debug)]
 pub struct AcpBrokerProcessError {
@@ -414,14 +388,13 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
 
 /// How a line read is bounded in time.
 ///
-/// The two variants exist for the same reason `max_len` is optional: whether a
-/// fixed ceiling is meaningful depends entirely on whether we can predict what
-/// the peer legitimately sends.
+/// Which variant is right depends on whether the peer is one we trust to
+/// finish what it starts.
 #[derive(Clone, Copy)]
 enum LineBudget {
-    /// Wall-clock for the whole line. Correct where the payload size is one we
-    /// bound ourselves, so the time it can take is bounded too — and where the
-    /// peer is arbitrary, since only a total bound stops a slow trickle.
+    /// Wall-clock for the whole line. Correct where the peer is arbitrary,
+    /// since only a total bound stops a slow trickle that keeps looking like
+    /// progress.
     Total(Duration),
     /// Longest run with no bytes arriving. Correct where a legitimate payload
     /// can be arbitrarily large, which makes any total a guess that eventually
@@ -430,8 +403,7 @@ enum LineBudget {
     Idle(Duration),
 }
 
-/// Reads one newline-terminated line, bounded in time by `budget` and, when
-/// given, in length by `max_len`.
+/// Reads one newline-terminated line, bounded in time by `budget`.
 ///
 /// `set_read_timeout` on its own bounds neither: it applies to each underlying
 /// read for inactivity, while `read_line` keeps issuing fresh reads until it
@@ -446,14 +418,18 @@ enum LineBudget {
 /// the peer goes away mid-stream, which would turn an otherwise complete read
 /// into an error.)
 ///
-/// `max_len` is `None` where the peer is our own broker and the size of what
-/// it sends is not ours to predict — see `MAX_IPC_LINE_BYTES`.
+/// There is deliberately no length ceiling in either direction. Neither side
+/// sends a payload whose size we can predict: a request can be an `acp/respond`
+/// carrying a whole file `fs/read_text_file` was asked for, and a reply can be
+/// an attach replay carrying a prompt's params more than once. Every ceiling
+/// picked for those was eventually below something legitimate, and being wrong
+/// is expensive — the Swift side drops the resulting error (`catch {}` in
+/// `ACPBrokerClient.respondToRawResult`), so a rejected response leaves the
+/// adapter waiting forever, which is the very hang this bounding exists to
+/// prevent. `budget` still limits how long a peer can feed us, and so how much
+/// it can feed us.
 #[cfg(unix)]
-fn read_line_within(
-    stream: &UnixStream,
-    budget: LineBudget,
-    max_len: Option<usize>,
-) -> io::Result<String> {
+fn read_line_within(stream: &UnixStream, budget: LineBudget) -> io::Result<String> {
     /// How long a blocked read waits before the budget is re-checked. Also
     /// the amount by which a read may overshoot it.
     const POLL_SLICE: Duration = Duration::from_millis(500);
@@ -527,15 +503,6 @@ fn read_line_within(
         if let LineBudget::Idle(limit) = budget {
             deadline = std::time::Instant::now() + limit;
         }
-        // Checked on every pass, including the one that completes the line: a
-        // line that arrives inside a single buffer fill is over the cap just
-        // as much as one that took several.
-        if max_len.is_some_and(|max| line.len() > max) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "IPC line exceeded the maximum length",
-            ));
-        }
         if finished {
             return String::from_utf8(line)
                 .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
@@ -571,11 +538,7 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
             {
                 continue;
             }
-            let Ok(line) = read_line_within(
-                &stream,
-                LineBudget::Total(IPC_REQUEST_TIMEOUT),
-                Some(MAX_IPC_LINE_BYTES),
-            ) else {
+            let Ok(line) = read_line_within(&stream, LineBudget::Total(IPC_REQUEST_TIMEOUT)) else {
                 continue;
             };
             if ipc_line_is_close(&line) {
@@ -1134,7 +1097,7 @@ fn send_ipc_within(
         // the moment `accept()` returns, so any work done between connecting
         // and writing is spent out of the broker's budget rather than ours.
         // That is not a small effect at the sizes the UI permits: encoding a
-        // maximal image prompt (~267 MiB, see `MAX_IPC_LINE_BYTES`) measures
+        // maximal image prompt (~267 MiB) measures
         // ~7.4s on an idle machine, against an `IPC_REQUEST_TIMEOUT` of 5s —
         // so connecting first would drop a perfectly valid prompt every time,
         // not merely under load. Writing the bytes, by contrast, takes ~0.2s,
@@ -1173,12 +1136,11 @@ fn send_ipc_within(
         stream
             .flush()
             .map_err(|error| broker_error(-32072, format!("broker flush failed: {error}")))?;
-        // Neither a length cap nor a total time budget here: this is a
-        // response from a broker this helper spawned, and its size — and so
-        // the time it legitimately takes — is not a bounded multiple of the
-        // request (see `MAX_IPC_LINE_BYTES`). What can be asked of it is that
-        // it keep making progress.
-        let line = read_line_within(&stream, LineBudget::Idle(idle_timeout), None)
+        // Bounded by inactivity, not total time: a reply's size — and so how
+        // long it legitimately takes — is not a bounded multiple of the
+        // request. What can be asked of a broker is that it keep making
+        // progress.
+        let line = read_line_within(&stream, LineBudget::Idle(idle_timeout))
             .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?;
         let response: BrokerIpcResponse = serde_json::from_str(&line)
             .map_err(|error| broker_error(-32072, format!("broker response failed: {error}")))?;
@@ -1509,61 +1471,6 @@ mod tests {
         ));
     }
 
-    /// The IPC line cap is a guard against abuse, so it must sit above what
-    /// the composer legitimately produces — otherwise a user attaching the
-    /// permitted number of full-size images has their prompt dropped at the
-    /// socket with a broker read error. Raising the UI limits without raising
-    /// this cap should fail here rather than in someone's chat.
-    #[test]
-    fn ipc_line_cap_admits_the_largest_composer_payload() {
-        // Alas/Sources/ACP/UI/ACPImageStaging.swift: maxBytes = 20 MiB
-        // Alas/Sources/ACP/UI/ACPComposer.swift: maxImagesPerMessage = 10
-        const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
-        const MAX_IMAGES_PER_MESSAGE: usize = 10;
-        let raw = MAX_IMAGE_BYTES * MAX_IMAGES_PER_MESSAGE;
-        let base64 = raw.div_ceil(3) * 4;
-        assert!(
-            MAX_IPC_LINE_BYTES > base64,
-            "IPC line cap {MAX_IPC_LINE_BYTES} would reject a permitted \
-             {MAX_IMAGES_PER_MESSAGE}-image prompt ({base64} base64 bytes)"
-        );
-    }
-
-    /// The whole fix rests on this: a peer that keeps the connection alive and
-    /// keeps sending, but never ends the line, must still hit the deadline.
-    /// A per-read inactivity timeout never would.
-    #[cfg(unix)]
-    #[test]
-    fn read_line_within_stops_a_peer_that_drips_without_ever_ending_the_line() {
-        let (mut writer, reader) = UnixStream::pair().expect("socket pair");
-        let done = Arc::new(Mutex::new(false));
-        let writer_done = done.clone();
-        std::thread::spawn(move || {
-            while !*writer_done.lock().expect("drip flag") {
-                if writer.write_all(b" ").is_err() {
-                    return;
-                }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-        });
-
-        let started = std::time::Instant::now();
-        let outcome = read_line_within(
-            &reader,
-            LineBudget::Total(Duration::from_secs(2)),
-            Some(MAX_IPC_LINE_BYTES),
-        );
-        let elapsed = started.elapsed();
-        *done.lock().expect("drip flag") = true;
-
-        let error = outcome.expect_err("a line that never ends must not read forever");
-        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-        assert!(
-            elapsed < Duration::from_secs(10),
-            "deadline overshot badly: {elapsed:?}"
-        );
-    }
-
     /// The retry budget governs how long to keep retrying a broker that is not
     /// answering *yet* — its socket may not exist while it starts up. It must
     /// not double as the deadline for a single legitimate response, which can
@@ -1677,7 +1584,7 @@ mod tests {
         });
 
         let started = std::time::Instant::now();
-        let line = read_line_within(&reader, LineBudget::Idle(Duration::from_secs(1)), None)
+        let line = read_line_within(&reader, LineBudget::Idle(Duration::from_secs(1)))
             .expect("a peer that keeps making progress must not be given up on");
         assert_eq!(line.len(), 6 * 512 + 1);
         assert!(
@@ -1686,31 +1593,41 @@ mod tests {
         );
     }
 
-    /// Requests get a length cap; responses from our own broker do not, and
-    /// that difference is load-bearing — an attach reply can legitimately
-    /// carry a prompt's params more than once. Exercised with a tiny cap so
-    /// the distinction is testable without allocating hundreds of megabytes.
+    /// The whole fix rests on this: a peer that keeps the connection alive and
+    /// keeps sending, but never ends the line, must still hit the deadline.
+    /// A per-read inactivity timeout never would — and with no length ceiling
+    /// left, this total budget is the only thing standing between a trickling
+    /// peer and an unbounded read.
     #[cfg(unix)]
     #[test]
-    fn read_line_within_enforces_a_length_cap_only_when_given_one() {
-        fn read_with(max_len: Option<usize>) -> io::Result<String> {
-            let (mut writer, reader) = UnixStream::pair().expect("socket pair");
-            std::thread::spawn(move || {
-                let _ = writer.write_all(&vec![b'y'; 4096]);
-                let _ = writer.write_all(b"\n");
-                let _ = writer.flush();
-            });
-            read_line_within(&reader, LineBudget::Total(Duration::from_secs(10)), max_len)
-        }
+    fn read_line_within_stops_a_peer_that_drips_without_ever_ending_the_line() {
+        let (mut writer, reader) = UnixStream::pair().expect("socket pair");
+        let done = Arc::new(Mutex::new(false));
+        let writer_done = done.clone();
+        std::thread::spawn(move || {
+            while !*writer_done.lock().expect("drip flag") {
+                if writer.write_all(b" ").is_err() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
 
-        let capped = read_with(Some(1024)).expect_err("a line past the cap must be rejected");
-        assert_eq!(capped.kind(), io::ErrorKind::InvalidData);
-        assert_eq!(read_with(None).expect("uncapped read").len(), 4097);
+        let started = std::time::Instant::now();
+        let outcome = read_line_within(&reader, LineBudget::Total(Duration::from_secs(2)));
+        let elapsed = started.elapsed();
+        *done.lock().expect("drip flag") = true;
+
+        let error = outcome.expect_err("a line that never ends must not read forever");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "deadline overshot badly: {elapsed:?}"
+        );
     }
 
-    /// Guards the cap against the read path itself: a line well past the
-    /// previous 32 MiB limit must still arrive intact rather than being cut
-    /// short mid-request.
+    /// A large line must arrive intact rather than being cut short mid-way:
+    /// an `acp/respond` can carry a whole file the adapter asked to read.
     #[cfg(unix)]
     #[test]
     fn read_line_within_accepts_a_line_larger_than_a_typical_request() {
@@ -1723,12 +1640,8 @@ mod tests {
             let _ = writer.flush();
         });
 
-        let line = read_line_within(
-            &reader,
-            LineBudget::Total(Duration::from_secs(30)),
-            Some(MAX_IPC_LINE_BYTES),
-        )
-        .expect("large line");
+        let line = read_line_within(&reader, LineBudget::Total(Duration::from_secs(30)))
+            .expect("large line");
         assert_eq!(line.len(), expected + 1);
     }
 }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -9,7 +9,7 @@ use crate::acp_broker_protocol::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::HashMap;
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Condvar, Mutex};
@@ -601,7 +601,7 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
 }
 
 #[cfg(unix)]
-fn handle_ipc_line(runtime: Runtime, mut stream: UnixStream, line: String) -> io::Result<()> {
+fn handle_ipc_line(runtime: Runtime, stream: UnixStream, line: String) -> io::Result<()> {
     let response = match serde_json::from_str::<BrokerIpcRequest>(&line) {
         Ok(request) => match handle_ipc_request(&runtime, request) {
             Ok(result) => BrokerIpcResponse {
@@ -621,12 +621,19 @@ fn handle_ipc_line(runtime: Runtime, mut stream: UnixStream, line: String) -> io
             error: Some(format!("invalid IPC request: {error}")),
         },
     };
-    writeln!(
-        stream,
-        "{}",
-        serde_json::to_string(&response).expect("IPC response serialization")
-    )?;
-    stream.flush()
+    // Serialize straight into the socket rather than building the whole
+    // response first. Two reasons, both about large replies: a maximal attach
+    // reply is ~533 MiB, so `to_string` would materialize that entire String
+    // in this process before a byte moved — on exactly the memory-pressured
+    // machine where it is most likely to happen. And the caller bounds this
+    // read by inactivity, which only works if the expensive phase produces
+    // bytes: encoding to a String first means ~15s of complete silence, long
+    // enough to trip the caller's budget before the reply even starts.
+    // Streaming turns that silence into steady progress.
+    let mut writer = BufWriter::new(stream);
+    serde_json::to_writer(&mut writer, &response).map_err(io::Error::other)?;
+    writer.write_all(b"\n")?;
+    writer.flush()
 }
 
 fn ipc_line_is_close(line: &str) -> bool {

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -37,17 +37,29 @@ const BROKER_IPC_TIMEOUT: Duration = Duration::from_secs(20);
 /// machine would miss.
 const BROKER_IPC_MIN_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Upper bound on one broker IPC line, so a peer that never sends a newline
-/// cannot grow the buffer without limit.
+/// Upper bound on a *request* line arriving at a broker, so a peer that never
+/// sends a newline cannot grow the buffer without limit.
 ///
-/// This has to clear the largest payload the UI actually permits, or it
+/// It has to clear the largest request the UI can legitimately produce, or it
 /// rejects valid input instead of catching abuse. The composer allows
 /// `ACPComposer.maxImagesPerMessage` (10) images of `ACPImageStaging.maxBytes`
 /// (20 MiB) each, and ACP embeds images as base64 inside `session/prompt`,
 /// which travels this socket as one `acp/send` line — 200 MiB of image
 /// becoming ~267 MiB on the wire, before prompt text and the JSON envelope.
-/// The value below leaves room above that; `ipc_line_cap_admits_the_largest_
-/// composer_payload` fails if those UI limits ever outgrow it.
+/// `ipc_line_cap_admits_the_largest_composer_payload` fails if those UI limits
+/// ever outgrow the value below.
+///
+/// Deliberately NOT applied to responses read back from a broker. A response
+/// is not a bounded multiple of the request: `broker_attach` returns the
+/// snapshot *and* the replayed events, and a prompt's params appear in both
+/// (`ACPBrokerState::snapshot` carries `operations[*].params`, while
+/// `OperationStarted` carries them again), while the snapshot also retains
+/// every operation not yet acknowledged. Any fixed ceiling there is a guess
+/// that eventually rejects a legitimate reply — and it would do so *after*
+/// the prompt was already dispatched, failing the send with nothing to retry.
+/// The peer on that side is a broker this helper spawned, and the deadline
+/// still bounds how long it can hold the caller, so time is the right bound
+/// there and length is not.
 const MAX_IPC_LINE_BYTES: usize = 512 * 1024 * 1024;
 
 #[derive(Debug)]
@@ -401,11 +413,14 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
 /// deadline more directly, but `setsockopt` starts failing with `EINVAL` once
 /// the peer goes away mid-stream, which would turn an otherwise complete read
 /// into an error.)
+///
+/// `max_len` is `None` where the peer is our own broker and the size of what
+/// it sends is not ours to predict — see `MAX_IPC_LINE_BYTES`.
 #[cfg(unix)]
 fn read_line_within(
     stream: &UnixStream,
     deadline: std::time::Instant,
-    max_len: usize,
+    max_len: Option<usize>,
 ) -> io::Result<String> {
     /// How long a blocked read waits before the deadline is re-checked. Also
     /// the amount by which a read may overshoot its deadline.
@@ -458,22 +473,29 @@ fn read_line_within(
             }
             Err(error) => return Err(error),
         };
-        match step {
+        let finished = match step {
             Step::Complete(consumed) => {
                 reader.consume(consumed);
-                return String::from_utf8(line)
-                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+                true
             }
             Step::Partial(consumed) => {
                 reader.consume(consumed);
-                if line.len() > max_len {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "IPC line exceeded the maximum length",
-                    ));
-                }
+                false
             }
-            Step::Retry => {}
+            Step::Retry => continue,
+        };
+        // Checked on every pass, including the one that completes the line: a
+        // line that arrives inside a single buffer fill is over the cap just
+        // as much as one that took several.
+        if max_len.is_some_and(|max| line.len() > max) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "IPC line exceeded the maximum length",
+            ));
+        }
+        if finished {
+            return String::from_utf8(line)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
         }
     }
 }
@@ -504,7 +526,7 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
                 continue;
             }
             let deadline = std::time::Instant::now() + IPC_REQUEST_TIMEOUT;
-            let Ok(line) = read_line_within(&stream, deadline, MAX_IPC_LINE_BYTES) else {
+            let Ok(line) = read_line_within(&stream, deadline, Some(MAX_IPC_LINE_BYTES)) else {
                 continue;
             };
             if ipc_line_is_close(&line) {
@@ -1078,7 +1100,10 @@ fn send_ipc_within(
         stream
             .flush()
             .map_err(|error| broker_error(-32072, format!("broker flush failed: {error}")))?;
-        let line = read_line_within(&stream, deadline, MAX_IPC_LINE_BYTES)
+        // No length cap here: this is a response from a broker this helper
+        // spawned, and its size is not a bounded multiple of the request (see
+        // `MAX_IPC_LINE_BYTES`). The deadline above is the bound that matters.
+        let line = read_line_within(&stream, deadline, None)
             .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?;
         let response: BrokerIpcResponse = serde_json::from_str(&line)
             .map_err(|error| broker_error(-32072, format!("broker response failed: {error}")))?;
@@ -1451,7 +1476,7 @@ mod tests {
         let outcome = read_line_within(
             &reader,
             started + Duration::from_secs(2),
-            MAX_IPC_LINE_BYTES,
+            Some(MAX_IPC_LINE_BYTES),
         );
         let elapsed = started.elapsed();
         *done.lock().expect("drip flag") = true;
@@ -1462,6 +1487,32 @@ mod tests {
             elapsed < Duration::from_secs(10),
             "deadline overshot badly: {elapsed:?}"
         );
+    }
+
+    /// Requests get a length cap; responses from our own broker do not, and
+    /// that difference is load-bearing — an attach reply can legitimately
+    /// carry a prompt's params more than once. Exercised with a tiny cap so
+    /// the distinction is testable without allocating hundreds of megabytes.
+    #[cfg(unix)]
+    #[test]
+    fn read_line_within_enforces_a_length_cap_only_when_given_one() {
+        fn read_with(max_len: Option<usize>) -> io::Result<String> {
+            let (mut writer, reader) = UnixStream::pair().expect("socket pair");
+            std::thread::spawn(move || {
+                let _ = writer.write_all(&vec![b'y'; 4096]);
+                let _ = writer.write_all(b"\n");
+                let _ = writer.flush();
+            });
+            read_line_within(
+                &reader,
+                std::time::Instant::now() + Duration::from_secs(10),
+                max_len,
+            )
+        }
+
+        let capped = read_with(Some(1024)).expect_err("a line past the cap must be rejected");
+        assert_eq!(capped.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(read_with(None).expect("uncapped read").len(), 4097);
     }
 
     /// Guards the cap against the read path itself: a line well past the
@@ -1480,7 +1531,8 @@ mod tests {
         });
 
         let deadline = std::time::Instant::now() + Duration::from_secs(30);
-        let line = read_line_within(&reader, deadline, MAX_IPC_LINE_BYTES).expect("large line");
+        let line =
+            read_line_within(&reader, deadline, Some(MAX_IPC_LINE_BYTES)).expect("large line");
         assert_eq!(line.len(), expected + 1);
     }
 }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1095,9 +1095,10 @@ fn send_ipc_within(
         // so a wedged supervisor cannot stall the caller here; the retry
         // deadline in `send_ipc_with_retry` handles the refusal. Linux instead
         // *blocks* until backlog space frees up, so if brokers ever run on a
-        // remote helper this needs a non-blocking, deadline-aware connect
-        // before it can be trusted. `connect_does_not_block_on_a_full_backlog`
-        // fails rather than hangs if that assumption ever stops holding.
+        // remote helper — this binary is built for Linux too — this needs a
+        // non-blocking, deadline-aware connect before it can be trusted.
+        // `connect_does_not_block_on_a_full_backlog` pins the Darwin
+        // behaviour this relies on.
         let mut stream = UnixStream::connect(dir.join("broker.sock"))
             .map_err(|error| broker_error(-32072, format!("broker connect failed: {error}")))?;
         // Without a bound, a broker that accepted the connection but never
@@ -1509,9 +1510,16 @@ mod tests {
     /// because Darwin refuses a connect to a full listen backlog instead of
     /// waiting for room — otherwise a wedged supervisor could stall the
     /// helper's single-threaded loop before any timeout is installed. Pin that
-    /// assumption: on a platform that blocks instead (Linux does), this fails
-    /// rather than hanging, and points at the connect that needs rewriting.
-    #[cfg(unix)]
+    /// behaviour so a future Darwin that starts blocking is caught here.
+    ///
+    /// Darwin-only on purpose. This helper is also built for Linux (see
+    /// `scripts/build-alas-helper.sh`), where a full backlog *does* block —
+    /// but Linux never reaches the code this guards, because brokers are
+    /// spawned for local sessions only. Running it there would fail for an
+    /// assumption that platform does not need to hold. What Linux would need
+    /// if brokers ever ran on a remote helper is documented at the connect
+    /// itself, which is the thing that would have to change.
+    #[cfg(target_os = "macos")]
     #[test]
     fn connect_does_not_block_on_a_full_backlog() {
         use std::sync::mpsc;

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -25,12 +25,24 @@ use std::os::unix::net::{UnixListener, UnixStream};
 /// accepting another connection.
 const IPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// How long a caller waits on a single broker IPC round trip. Generous
-/// compared to the work a broker actually does per request (`close` is the
-/// slowest at ~2.5s, and it may queue behind one `IPC_REQUEST_TIMEOUT` read),
-/// but bounded: `send_ipc` runs inline on the helper's single-threaded serve
-/// loop, so an unbounded wait here stalls every session the helper serves.
-const BROKER_IPC_TIMEOUT: Duration = Duration::from_secs(20);
+/// How long a caller gives a broker to send *something* before treating it as
+/// wedged. Idle rather than total, because a legitimate response has no size
+/// we can predict (see `MAX_IPC_LINE_BYTES`) and therefore no duration we can
+/// predict either: the reply to a maximal image prompt carries its params
+/// twice and measures ~15s just to serialize, silently, before a byte is
+/// written. A total budget would have to out-guess that; an idle budget only
+/// has to notice a broker that has stopped.
+///
+/// It is still worth keeping tight-ish, because `send_ipc` runs inline on the
+/// helper's single-threaded serve loop, so this is also how long one wedged
+/// broker freezes every other session. Moving `acp/*` dispatch off that thread
+/// would decouple the two and let this be far more generous.
+const BROKER_IPC_IDLE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long a single write to a broker may block. Writing even a maximal
+/// request measures ~0.2s, so this only ever fires on a broker that has
+/// stopped reading.
+const BROKER_IPC_WRITE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Upper bound on a *request* line arriving at a broker, so a peer that never
 /// sends a newline cannot grow the buffer without limit.
@@ -52,9 +64,10 @@ const BROKER_IPC_TIMEOUT: Duration = Duration::from_secs(20);
 /// every operation not yet acknowledged. Any fixed ceiling there is a guess
 /// that eventually rejects a legitimate reply — and it would do so *after*
 /// the prompt was already dispatched, failing the send with nothing to retry.
-/// The peer on that side is a broker this helper spawned, and the deadline
-/// still bounds how long it can hold the caller, so time is the right bound
-/// there and length is not.
+/// The peer on that side is a broker this helper spawned, and
+/// `BROKER_IPC_IDLE_TIMEOUT` still bounds how long it can hold the caller
+/// without sending anything — progress is what can be asked of it, size is
+/// not.
 const MAX_IPC_LINE_BYTES: usize = 512 * 1024 * 1024;
 
 #[derive(Debug)]
@@ -393,18 +406,36 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
     Ok(json!({ "brokers": brokers }))
 }
 
-/// Reads one newline-terminated line, bounded by a deadline covering the whole
-/// line and by a maximum length.
+/// How a line read is bounded in time.
 ///
-/// `set_read_timeout` on its own does not give that: it bounds each underlying
-/// read for *inactivity*, while `read_line` keeps issuing fresh reads until it
+/// The two variants exist for the same reason `max_len` is optional: whether a
+/// fixed ceiling is meaningful depends entirely on whether we can predict what
+/// the peer legitimately sends.
+#[derive(Clone, Copy)]
+enum LineBudget {
+    /// Wall-clock for the whole line. Correct where the payload size is one we
+    /// bound ourselves, so the time it can take is bounded too — and where the
+    /// peer is arbitrary, since only a total bound stops a slow trickle.
+    Total(Duration),
+    /// Longest run with no bytes arriving. Correct where a legitimate payload
+    /// can be arbitrarily large, which makes any total a guess that eventually
+    /// fails a valid transfer: the real failure being guarded against is a peer
+    /// that has stopped making progress, not one that is merely big.
+    Idle(Duration),
+}
+
+/// Reads one newline-terminated line, bounded in time by `budget` and, when
+/// given, in length by `max_len`.
+///
+/// `set_read_timeout` on its own bounds neither: it applies to each underlying
+/// read for inactivity, while `read_line` keeps issuing fresh reads until it
 /// finds a newline. A peer that trickles bytes faster than the timeout renews
 /// its budget indefinitely, holding the caller — and growing the buffer —
 /// without limit.
 ///
 /// The socket timeout is therefore set once, to a short slice that just wakes
-/// a blocked read periodically; the deadline checked on each pass is what
-/// actually bounds the line. (Re-arming the socket per read would express the
+/// a blocked read periodically; the budget checked on each pass is what
+/// actually bounds the line. (Re-arming the socket per read would express a
 /// deadline more directly, but `setsockopt` starts failing with `EINVAL` once
 /// the peer goes away mid-stream, which would turn an otherwise complete read
 /// into an error.)
@@ -414,11 +445,11 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
 #[cfg(unix)]
 fn read_line_within(
     stream: &UnixStream,
-    deadline: std::time::Instant,
+    budget: LineBudget,
     max_len: Option<usize>,
 ) -> io::Result<String> {
-    /// How long a blocked read waits before the deadline is re-checked. Also
-    /// the amount by which a read may overshoot its deadline.
+    /// How long a blocked read waits before the budget is re-checked. Also
+    /// the amount by which a read may overshoot it.
     const POLL_SLICE: Duration = Duration::from_millis(500);
 
     enum Step {
@@ -430,6 +461,10 @@ fn read_line_within(
     stream.set_read_timeout(Some(POLL_SLICE))?;
     let mut reader = BufReader::new(stream);
     let mut line: Vec<u8> = Vec::new();
+    // For `Idle`, this is pushed back every time bytes actually arrive.
+    let mut deadline = match budget {
+        LineBudget::Total(limit) | LineBudget::Idle(limit) => std::time::Instant::now() + limit,
+    };
     loop {
         if std::time::Instant::now() >= deadline {
             return Err(io::Error::new(
@@ -479,6 +514,13 @@ fn read_line_within(
             }
             Step::Retry => continue,
         };
+        // Bytes arrived, so an idle budget starts over: the peer is making
+        // progress, which is the only thing this bound is asking about. A
+        // total budget is left alone — for an arbitrary peer, progress is
+        // exactly what a slow trickle fakes.
+        if let LineBudget::Idle(limit) = budget {
+            deadline = std::time::Instant::now() + limit;
+        }
         // Checked on every pass, including the one that completes the line: a
         // line that arrives inside a single buffer fill is over the cap just
         // as much as one that took several.
@@ -517,11 +559,17 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
             // it guards against a client that stops reading, but an `attach`
             // replay can be a large response, and cutting one short would
             // corrupt a legitimate reply rather than rescue a stuck one.
-            if stream.set_write_timeout(Some(BROKER_IPC_TIMEOUT)).is_err() {
+            if stream
+                .set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))
+                .is_err()
+            {
                 continue;
             }
-            let deadline = std::time::Instant::now() + IPC_REQUEST_TIMEOUT;
-            let Ok(line) = read_line_within(&stream, deadline, Some(MAX_IPC_LINE_BYTES)) else {
+            let Ok(line) = read_line_within(
+                &stream,
+                LineBudget::Total(IPC_REQUEST_TIMEOUT),
+                Some(MAX_IPC_LINE_BYTES),
+            ) else {
                 continue;
             };
             if ipc_line_is_close(&line) {
@@ -1058,14 +1106,14 @@ fn sorted_env_keys(env: &HashMap<String, String>) -> Vec<String> {
 }
 
 fn send_ipc(dir: &Path, method: &str, params: Value) -> Result<Value, AcpBrokerProcessError> {
-    send_ipc_within(dir, method, params, BROKER_IPC_TIMEOUT)
+    send_ipc_within(dir, method, params, BROKER_IPC_IDLE_TIMEOUT)
 }
 
 fn send_ipc_within(
     dir: &Path,
     method: &str,
     params: Value,
-    timeout: Duration,
+    idle_timeout: Duration,
 ) -> Result<Value, AcpBrokerProcessError> {
     #[cfg(unix)]
     {
@@ -1101,21 +1149,23 @@ fn send_ipc_within(
         // looks: every `acp/*` request is handled inline on the helper's
         // single-threaded serve loop, so one unresponsive broker would take
         // down file, watch, search and *every other ACP session* with it.
-        // The response read is bounded below by `read_line_within`, whose
-        // deadline covers the whole line rather than each read.
-        let deadline = std::time::Instant::now() + timeout;
-        stream.set_write_timeout(Some(timeout)).map_err(|error| {
-            broker_error(-32072, format!("broker write timeout failed: {error}"))
-        })?;
+        // The response read is bounded below by `read_line_within`.
+        stream
+            .set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))
+            .map_err(|error| {
+                broker_error(-32072, format!("broker write timeout failed: {error}"))
+            })?;
         writeln!(stream, "{body}")
             .map_err(|error| broker_error(-32072, format!("broker write failed: {error}")))?;
         stream
             .flush()
             .map_err(|error| broker_error(-32072, format!("broker flush failed: {error}")))?;
-        // No length cap here: this is a response from a broker this helper
-        // spawned, and its size is not a bounded multiple of the request (see
-        // `MAX_IPC_LINE_BYTES`). The deadline above is the bound that matters.
-        let line = read_line_within(&stream, deadline, None)
+        // Neither a length cap nor a total time budget here: this is a
+        // response from a broker this helper spawned, and its size — and so
+        // the time it legitimately takes — is not a bounded multiple of the
+        // request (see `MAX_IPC_LINE_BYTES`). What can be asked of it is that
+        // it keep making progress.
+        let line = read_line_within(&stream, LineBudget::Idle(idle_timeout), None)
             .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?;
         let response: BrokerIpcResponse = serde_json::from_str(&line)
             .map_err(|error| broker_error(-32072, format!("broker response failed: {error}")))?;
@@ -1154,14 +1204,14 @@ fn send_ipc_with_retry(
         // `retry_budget`. The two measure different things: `retry_budget` is
         // how long to keep re-trying a broker that is not answering *yet* —
         // typically one still starting up, whose socket does not exist — while
-        // `BROKER_IPC_TIMEOUT` is how long a single legitimate response may
+        // `BROKER_IPC_IDLE_TIMEOUT` is how long a single legitimate response may
         // take once the broker does answer. Those are far apart: `acp_open`
         // adopts a live broker on a 2s retry budget, and a snapshot carrying a
         // retained large-image prompt takes ~7.4s just to serialize on the
         // broker side. Deriving the response deadline from the retry budget
         // makes adopting such a broker fail permanently, since every retry
         // hits the same wall.
-        match send_ipc_within(dir, method, params.clone(), BROKER_IPC_TIMEOUT) {
+        match send_ipc_within(dir, method, params.clone(), BROKER_IPC_IDLE_TIMEOUT) {
             Ok(value) => return Ok(value),
             Err(error) if std::time::Instant::now() < deadline => {
                 let _ = error;
@@ -1487,7 +1537,7 @@ mod tests {
         let started = std::time::Instant::now();
         let outcome = read_line_within(
             &reader,
-            started + Duration::from_secs(2),
+            LineBudget::Total(Duration::from_secs(2)),
             Some(MAX_IPC_LINE_BYTES),
         );
         let elapsed = started.elapsed();
@@ -1589,6 +1639,40 @@ mod tests {
         assert_eq!(kind, io::ErrorKind::ConnectionRefused);
     }
 
+    /// An idle budget must survive a transfer that runs well past it in total,
+    /// which is the whole reason responses use one: a maximal attach reply
+    /// carries its prompt params twice and takes ~15s to serialize before a
+    /// byte is written, and there is no total we could pick that a larger
+    /// legitimate reply would not eventually exceed. A total budget of the
+    /// same size would fail this.
+    #[cfg(unix)]
+    #[test]
+    fn an_idle_budget_survives_a_transfer_longer_than_the_budget_itself() {
+        let (mut writer, reader) = UnixStream::pair().expect("socket pair");
+        std::thread::spawn(move || {
+            // Six chunks over ~3s, none more than 0.5s apart: never idle for
+            // long, but comfortably past a 1s total.
+            for _ in 0..6 {
+                if writer.write_all(&[b'z'; 512]).is_err() {
+                    return;
+                }
+                let _ = writer.flush();
+                std::thread::sleep(Duration::from_millis(500));
+            }
+            let _ = writer.write_all(b"\n");
+            let _ = writer.flush();
+        });
+
+        let started = std::time::Instant::now();
+        let line = read_line_within(&reader, LineBudget::Idle(Duration::from_secs(1)), None)
+            .expect("a peer that keeps making progress must not be given up on");
+        assert_eq!(line.len(), 6 * 512 + 1);
+        assert!(
+            started.elapsed() > Duration::from_secs(1),
+            "transfer finished too fast to prove the budget was exceeded in total"
+        );
+    }
+
     /// Requests get a length cap; responses from our own broker do not, and
     /// that difference is load-bearing — an attach reply can legitimately
     /// carry a prompt's params more than once. Exercised with a tiny cap so
@@ -1603,11 +1687,7 @@ mod tests {
                 let _ = writer.write_all(b"\n");
                 let _ = writer.flush();
             });
-            read_line_within(
-                &reader,
-                std::time::Instant::now() + Duration::from_secs(10),
-                max_len,
-            )
+            read_line_within(&reader, LineBudget::Total(Duration::from_secs(10)), max_len)
         }
 
         let capped = read_with(Some(1024)).expect_err("a line past the cap must be rejected");
@@ -1630,9 +1710,12 @@ mod tests {
             let _ = writer.flush();
         });
 
-        let deadline = std::time::Instant::now() + Duration::from_secs(30);
-        let line =
-            read_line_within(&reader, deadline, Some(MAX_IPC_LINE_BYTES)).expect("large line");
+        let line = read_line_within(
+            &reader,
+            LineBudget::Total(Duration::from_secs(30)),
+            Some(MAX_IPC_LINE_BYTES),
+        )
+        .expect("large line");
         assert_eq!(line.len(), expected + 1);
     }
 }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -37,6 +37,11 @@ const BROKER_IPC_TIMEOUT: Duration = Duration::from_secs(20);
 /// machine would miss.
 const BROKER_IPC_MIN_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Upper bound on one broker IPC line. Far above any real request or response
+/// — a prompt carrying an embedded image is the large case — while stopping a
+/// peer that never sends a newline from growing the buffer without limit.
+const MAX_IPC_LINE_BYTES: usize = 32 * 1024 * 1024;
+
 #[derive(Debug)]
 pub struct AcpBrokerProcessError {
     pub code: i64,
@@ -373,6 +378,65 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
     Ok(json!({ "brokers": brokers }))
 }
 
+/// Reads one newline-terminated line, bounded by a deadline covering the whole
+/// line and by a maximum length.
+///
+/// `set_read_timeout` on its own does not give that: it bounds each underlying
+/// read for *inactivity*, while `read_line` keeps issuing fresh reads until it
+/// finds a newline. A peer that trickles bytes faster than the timeout renews
+/// its budget indefinitely, holding the caller — and growing the buffer —
+/// without limit. Re-arming the socket timeout with the remaining budget
+/// before each read is what makes the deadline apply to the line as a whole.
+#[cfg(unix)]
+fn read_line_within(
+    stream: &UnixStream,
+    deadline: std::time::Instant,
+    max_len: usize,
+) -> io::Result<String> {
+    let mut reader = BufReader::new(stream);
+    let mut line: Vec<u8> = Vec::new();
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out reading IPC line",
+            ));
+        }
+        reader.get_ref().set_read_timeout(Some(remaining))?;
+        let (finished, consumed) = {
+            let available = reader.fill_buf()?;
+            if available.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "peer closed before completing the IPC line",
+                ));
+            }
+            match available.iter().position(|byte| *byte == b'\n') {
+                Some(index) => {
+                    line.extend_from_slice(&available[..=index]);
+                    (true, index + 1)
+                }
+                None => {
+                    line.extend_from_slice(available);
+                    (false, available.len())
+                }
+            }
+        };
+        reader.consume(consumed);
+        if finished {
+            return String::from_utf8(line)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+        }
+        if line.len() > max_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "IPC line exceeded the maximum length",
+            ));
+        }
+    }
+}
+
 fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProcessError> {
     #[cfg(unix)]
     {
@@ -386,26 +450,22 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
                 Ok(stream) => stream,
                 Err(_) => continue,
             };
-            // Bound both directions before touching the stream. The request
-            // line is read on this thread, so an unbounded read lets a single
-            // silent client wedge `accept()` for every other caller; dropping
-            // the stream on timeout gives that client a clean EOF to fail on
+            // The request line is read on this thread, so a client that never
+            // completes one would stop `accept()` for every other caller.
+            // `read_line_within` bounds the whole line, not just each read, so
+            // neither silence nor a slow trickle can hold this loop; dropping
+            // the stream afterwards gives that client a clean EOF to fail on
             // instead of a hang. The write gets the larger budget on purpose:
             // it guards against a client that stops reading, but an `attach`
             // replay can be a large response, and cutting one short would
             // corrupt a legitimate reply rather than rescue a stuck one.
-            if stream.set_read_timeout(Some(IPC_REQUEST_TIMEOUT)).is_err()
-                || stream.set_write_timeout(Some(BROKER_IPC_TIMEOUT)).is_err()
-            {
+            if stream.set_write_timeout(Some(BROKER_IPC_TIMEOUT)).is_err() {
                 continue;
             }
-            let mut line = String::new();
-            {
-                let mut reader = BufReader::new(&stream);
-                if reader.read_line(&mut line).is_err() {
-                    continue;
-                }
-            }
+            let deadline = std::time::Instant::now() + IPC_REQUEST_TIMEOUT;
+            let Ok(line) = read_line_within(&stream, deadline, MAX_IPC_LINE_BYTES) else {
+                continue;
+            };
             if ipc_line_is_close(&line) {
                 let _ = handle_ipc_line(runtime.clone(), stream, line);
             } else {
@@ -953,14 +1013,14 @@ fn send_ipc_within(
     {
         let mut stream = UnixStream::connect(dir.join("broker.sock"))
             .map_err(|error| broker_error(-32072, format!("broker connect failed: {error}")))?;
-        // Without these, a broker that accepted the connection but never
+        // Without a bound, a broker that accepted the connection but never
         // answered would block this call forever. That matters more than it
         // looks: every `acp/*` request is handled inline on the helper's
         // single-threaded serve loop, so one unresponsive broker would take
         // down file, watch, search and *every other ACP session* with it.
-        stream.set_read_timeout(Some(timeout)).map_err(|error| {
-            broker_error(-32072, format!("broker read timeout failed: {error}"))
-        })?;
+        // The response read is bounded below by `read_line_within`, whose
+        // deadline covers the whole line rather than each read.
+        let deadline = std::time::Instant::now() + timeout;
         stream.set_write_timeout(Some(timeout)).map_err(|error| {
             broker_error(-32072, format!("broker write timeout failed: {error}"))
         })?;
@@ -977,9 +1037,7 @@ fn send_ipc_within(
         stream
             .flush()
             .map_err(|error| broker_error(-32072, format!("broker flush failed: {error}")))?;
-        let mut line = String::new();
-        BufReader::new(stream)
-            .read_line(&mut line)
+        let line = read_line_within(&stream, deadline, MAX_IPC_LINE_BYTES)
             .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?;
         let response: BrokerIpcResponse = serde_json::from_str(&line)
             .map_err(|error| broker_error(-32072, format!("broker response failed: {error}")))?;

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1074,6 +1074,16 @@ fn send_ipc_within(
 ) -> Result<Value, AcpBrokerProcessError> {
     #[cfg(unix)]
     {
+        // This connect is blocking and deliberately left that way. On Darwin
+        // — the only platform that reaches this code, since the ACP broker is
+        // spawned for local sessions only — a full listen backlog fails the
+        // connect with ECONNREFUSED immediately rather than waiting for room,
+        // so a wedged supervisor cannot stall the caller here; the retry
+        // deadline in `send_ipc_with_retry` handles the refusal. Linux instead
+        // *blocks* until backlog space frees up, so if brokers ever run on a
+        // remote helper this needs a non-blocking, deadline-aware connect
+        // before it can be trusted. `connect_does_not_block_on_a_full_backlog`
+        // fails rather than hangs if that assumption ever stops holding.
         let mut stream = UnixStream::connect(dir.join("broker.sock"))
             .map_err(|error| broker_error(-32072, format!("broker connect failed: {error}")))?;
         // Without a bound, a broker that accepted the connection but never
@@ -1487,6 +1497,50 @@ mod tests {
             elapsed < Duration::from_secs(10),
             "deadline overshot badly: {elapsed:?}"
         );
+    }
+
+    /// `send_ipc_within` connects with a blocking socket, which is only safe
+    /// because Darwin refuses a connect to a full listen backlog instead of
+    /// waiting for room — otherwise a wedged supervisor could stall the
+    /// helper's single-threaded loop before any timeout is installed. Pin that
+    /// assumption: on a platform that blocks instead (Linux does), this fails
+    /// rather than hanging, and points at the connect that needs rewriting.
+    #[cfg(unix)]
+    #[test]
+    fn connect_does_not_block_on_a_full_backlog() {
+        use std::sync::mpsc;
+
+        let path = std::env::temp_dir().join(format!("alas-backlog-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        // Bound to a listener that never accepts, so the backlog fills and
+        // stays full.
+        let listener = UnixListener::bind(&path).expect("listener binds");
+
+        let (sender, receiver) = mpsc::channel();
+        let connect_path = path.clone();
+        std::thread::spawn(move || {
+            let mut held = Vec::new();
+            // Comfortably past the default backlog on any platform we target.
+            for _ in 0..1024 {
+                match UnixStream::connect(&connect_path) {
+                    Ok(stream) => held.push(stream),
+                    Err(error) => {
+                        let _ = sender.send(Some(error.kind()));
+                        return;
+                    }
+                }
+            }
+            let _ = sender.send(None);
+        });
+
+        let outcome = receiver.recv_timeout(Duration::from_secs(20));
+        drop(listener);
+        let _ = std::fs::remove_file(&path);
+
+        let kind = outcome
+            .expect("connect blocked on a full backlog — send_ipc_within needs a bounded connect")
+            .expect("expected the backlog to fill within 1024 connects");
+        assert_eq!(kind, io::ErrorKind::ConnectionRefused);
     }
 
     /// Requests get a length cap; responses from our own broker do not, and

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -195,10 +196,7 @@ fn broker_lock(broker_id: &str) -> Arc<Mutex<()>> {
     )
 }
 
-fn with_broker_lock<T>(params: Option<&Value>, body: impl FnOnce() -> T) -> T {
-    let broker_id = params
-        .and_then(|params| params.get("brokerId"))
-        .and_then(Value::as_str);
+fn with_broker_lock<T>(broker_id: Option<&str>, body: impl FnOnce() -> T) -> T {
     match broker_id {
         Some(broker_id) => {
             let lock = broker_lock(broker_id);
@@ -215,8 +213,17 @@ pub fn handle_control_request(
     method: &str,
     params: Option<Value>,
 ) -> Result<Value, AcpBrokerProcessError> {
-    with_broker_lock(params.as_ref(), || {
-        dispatch_control_request(method, params.clone())
+    // The id is copied out before locking so `params` can be *moved* into the
+    // dispatch below. Borrowing it across the lock instead would force a clone,
+    // and these payloads are the large ones — a maximal image prompt is ~267
+    // MiB, and an `acp/respond` carrying a file read is unbounded.
+    let broker_id = params
+        .as_ref()
+        .and_then(|params| params.get("brokerId"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    with_broker_lock(broker_id.as_deref(), || {
+        dispatch_control_request(method, params)
     })
 }
 
@@ -830,6 +837,14 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
         /// How long to let in-flight handlers finish after a `close`, so the
         /// caller that asked for it still receives its answer.
         const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+        /// Most connections served at once. See the accept loop below.
+        ///
+        /// Set for headroom rather than thrift: a helper serializes its calls
+        /// per broker, so real use is a handful, while thread exhaustion needs
+        /// thousands. Sitting between the two means a flood has to be
+        /// deliberate to be felt, and even then it costs availability rather
+        /// than the process.
+        const MAX_BROKER_CONNECTION_WORKERS: usize = 256;
 
         let socket_path = dir.join("broker.sock");
         let _ = std::fs::remove_file(&socket_path);
@@ -852,8 +867,31 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
             .map_err(|error| broker_error(-32072, format!("socket mode failed: {error}")))?;
         write_restrictive_bytes(&dir.join("ready"), b"1\n")?;
 
-        let inflight = Arc::new(Mutex::new(0usize));
+        let inflight = Arc::new(AtomicUsize::new(0));
         while !runtime_is_closing(&runtime) {
+            // Stop accepting rather than spawning without limit. Every
+            // connection owns a thread that can sit for the whole head
+            // timeout, so a peer opening sockets faster than they retire would
+            // otherwise exhaust threads until `spawn` panics and takes the
+            // supervisor with it. Leaving them in the kernel's backlog is
+            // better than a bespoke rejection: a caller that cannot connect
+            // sees the same refusal it already handles, and one that is merely
+            // queued is served as soon as a worker frees up.
+            //
+            // Worth being clear about what this does and does not buy. A local
+            // peer holding sockets open can still starve this broker for as
+            // long as it keeps them, because a connection that has sent
+            // nothing yet is indistinguishable from an older helper still
+            // encoding its request — that is what the head's idle bound is
+            // for. What the ceiling changes is the consequence: a bounded,
+            // self-healing stall instead of a dead supervisor and every
+            // session on it lost. Fixing the rest means not dedicating a
+            // thread to a connection before it has said anything, which is a
+            // different I/O model than this file uses.
+            if inflight.load(Ordering::Acquire) >= MAX_BROKER_CONNECTION_WORKERS {
+                std::thread::sleep(ACCEPT_POLL);
+                continue;
+            }
             let stream = match listener.accept() {
                 Ok((stream, _)) => stream,
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
@@ -869,18 +907,26 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
             }
             let request_runtime = runtime.clone();
             let request_inflight = Arc::clone(&inflight);
-            *request_inflight.lock().unwrap_or_else(|e| e.into_inner()) += 1;
-            std::thread::spawn(move || {
-                let _ = handle_connection(request_runtime, stream);
-                *request_inflight.lock().unwrap_or_else(|e| e.into_inner()) -= 1;
-            });
+            request_inflight.fetch_add(1, Ordering::AcqRel);
+            if std::thread::Builder::new()
+                .spawn(move || {
+                    let _ = handle_connection(request_runtime, stream);
+                    request_inflight.fetch_sub(1, Ordering::AcqRel);
+                })
+                .is_err()
+            {
+                // Out of threads despite the ceiling. Drop the connection
+                // rather than propagating: the caller retries, and the
+                // supervisor stays up for the sessions it already has.
+                inflight.fetch_sub(1, Ordering::AcqRel);
+            }
         }
 
         // A `close` handler sets the closing flag before it replies, so the
         // loop can exit while that reply is still being written. Wait for it.
         let deadline = std::time::Instant::now() + DRAIN_TIMEOUT;
         while std::time::Instant::now() < deadline {
-            if *inflight.lock().unwrap_or_else(|e| e.into_inner()) == 0 {
+            if inflight.load(Ordering::Acquire) == 0 {
                 break;
             }
             std::thread::sleep(ACCEPT_POLL);

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -37,10 +37,18 @@ const BROKER_IPC_TIMEOUT: Duration = Duration::from_secs(20);
 /// machine would miss.
 const BROKER_IPC_MIN_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Upper bound on one broker IPC line. Far above any real request or response
-/// — a prompt carrying an embedded image is the large case — while stopping a
-/// peer that never sends a newline from growing the buffer without limit.
-const MAX_IPC_LINE_BYTES: usize = 32 * 1024 * 1024;
+/// Upper bound on one broker IPC line, so a peer that never sends a newline
+/// cannot grow the buffer without limit.
+///
+/// This has to clear the largest payload the UI actually permits, or it
+/// rejects valid input instead of catching abuse. The composer allows
+/// `ACPComposer.maxImagesPerMessage` (10) images of `ACPImageStaging.maxBytes`
+/// (20 MiB) each, and ACP embeds images as base64 inside `session/prompt`,
+/// which travels this socket as one `acp/send` line — 200 MiB of image
+/// becoming ~267 MiB on the wire, before prompt text and the JSON envelope.
+/// The value below leaves room above that; `ipc_line_cap_admits_the_largest_
+/// composer_payload` fails if those UI limits ever outgrow it.
+const MAX_IPC_LINE_BYTES: usize = 512 * 1024 * 1024;
 
 #[derive(Debug)]
 pub struct AcpBrokerProcessError {
@@ -385,54 +393,87 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
 /// read for *inactivity*, while `read_line` keeps issuing fresh reads until it
 /// finds a newline. A peer that trickles bytes faster than the timeout renews
 /// its budget indefinitely, holding the caller — and growing the buffer —
-/// without limit. Re-arming the socket timeout with the remaining budget
-/// before each read is what makes the deadline apply to the line as a whole.
+/// without limit.
+///
+/// The socket timeout is therefore set once, to a short slice that just wakes
+/// a blocked read periodically; the deadline checked on each pass is what
+/// actually bounds the line. (Re-arming the socket per read would express the
+/// deadline more directly, but `setsockopt` starts failing with `EINVAL` once
+/// the peer goes away mid-stream, which would turn an otherwise complete read
+/// into an error.)
 #[cfg(unix)]
 fn read_line_within(
     stream: &UnixStream,
     deadline: std::time::Instant,
     max_len: usize,
 ) -> io::Result<String> {
+    /// How long a blocked read waits before the deadline is re-checked. Also
+    /// the amount by which a read may overshoot its deadline.
+    const POLL_SLICE: Duration = Duration::from_millis(500);
+
+    enum Step {
+        Complete(usize),
+        Partial(usize),
+        Retry,
+    }
+
+    stream.set_read_timeout(Some(POLL_SLICE))?;
     let mut reader = BufReader::new(stream);
     let mut line: Vec<u8> = Vec::new();
     loop {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        if remaining.is_zero() {
+        if std::time::Instant::now() >= deadline {
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "timed out reading IPC line",
             ));
         }
-        reader.get_ref().set_read_timeout(Some(remaining))?;
-        let (finished, consumed) = {
-            let available = reader.fill_buf()?;
-            if available.is_empty() {
+        let step = match reader.fill_buf() {
+            Ok([]) => {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
                     "peer closed before completing the IPC line",
                 ));
             }
-            match available.iter().position(|byte| *byte == b'\n') {
+            Ok(available) => match available.iter().position(|byte| *byte == b'\n') {
                 Some(index) => {
                     line.extend_from_slice(&available[..=index]);
-                    (true, index + 1)
+                    Step::Complete(index + 1)
                 }
                 None => {
                     line.extend_from_slice(available);
-                    (false, available.len())
+                    Step::Partial(available.len())
+                }
+            },
+            // A quiet peer, not a failed one — the deadline above decides
+            // when quiet has gone on too long.
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::WouldBlock
+                        | io::ErrorKind::TimedOut
+                        | io::ErrorKind::Interrupted
+                ) =>
+            {
+                Step::Retry
+            }
+            Err(error) => return Err(error),
+        };
+        match step {
+            Step::Complete(consumed) => {
+                reader.consume(consumed);
+                return String::from_utf8(line)
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+            }
+            Step::Partial(consumed) => {
+                reader.consume(consumed);
+                if line.len() > max_len {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "IPC line exceeded the maximum length",
+                    ));
                 }
             }
-        };
-        reader.consume(consumed);
-        if finished {
-            return String::from_utf8(line)
-                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
-        }
-        if line.len() > max_len {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "IPC line exceeded the maximum length",
-            ));
+            Step::Retry => {}
         }
     }
 }
@@ -1366,5 +1407,80 @@ mod tests {
         assert!(!pending_kind_awaits_user(
             PendingClientRequestKind::Terminal
         ));
+    }
+
+    /// The IPC line cap is a guard against abuse, so it must sit above what
+    /// the composer legitimately produces — otherwise a user attaching the
+    /// permitted number of full-size images has their prompt dropped at the
+    /// socket with a broker read error. Raising the UI limits without raising
+    /// this cap should fail here rather than in someone's chat.
+    #[test]
+    fn ipc_line_cap_admits_the_largest_composer_payload() {
+        // Alas/Sources/ACP/UI/ACPImageStaging.swift: maxBytes = 20 MiB
+        // Alas/Sources/ACP/UI/ACPComposer.swift: maxImagesPerMessage = 10
+        const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+        const MAX_IMAGES_PER_MESSAGE: usize = 10;
+        let raw = MAX_IMAGE_BYTES * MAX_IMAGES_PER_MESSAGE;
+        let base64 = raw.div_ceil(3) * 4;
+        assert!(
+            MAX_IPC_LINE_BYTES > base64,
+            "IPC line cap {MAX_IPC_LINE_BYTES} would reject a permitted \
+             {MAX_IMAGES_PER_MESSAGE}-image prompt ({base64} base64 bytes)"
+        );
+    }
+
+    /// The whole fix rests on this: a peer that keeps the connection alive and
+    /// keeps sending, but never ends the line, must still hit the deadline.
+    /// A per-read inactivity timeout never would.
+    #[cfg(unix)]
+    #[test]
+    fn read_line_within_stops_a_peer_that_drips_without_ever_ending_the_line() {
+        let (mut writer, reader) = UnixStream::pair().expect("socket pair");
+        let done = Arc::new(Mutex::new(false));
+        let writer_done = done.clone();
+        std::thread::spawn(move || {
+            while !*writer_done.lock().expect("drip flag") {
+                if writer.write_all(b" ").is_err() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
+
+        let started = std::time::Instant::now();
+        let outcome = read_line_within(
+            &reader,
+            started + Duration::from_secs(2),
+            MAX_IPC_LINE_BYTES,
+        );
+        let elapsed = started.elapsed();
+        *done.lock().expect("drip flag") = true;
+
+        let error = outcome.expect_err("a line that never ends must not read forever");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "deadline overshot badly: {elapsed:?}"
+        );
+    }
+
+    /// Guards the cap against the read path itself: a line well past the
+    /// previous 32 MiB limit must still arrive intact rather than being cut
+    /// short mid-request.
+    #[cfg(unix)]
+    #[test]
+    fn read_line_within_accepts_a_line_larger_than_a_typical_request() {
+        let (mut writer, reader) = UnixStream::pair().expect("socket pair");
+        let payload = vec![b'x'; 40 * 1024 * 1024];
+        let expected = payload.len();
+        std::thread::spawn(move || {
+            let _ = writer.write_all(&payload);
+            let _ = writer.write_all(b"\n");
+            let _ = writer.flush();
+        });
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        let line = read_line_within(&reader, deadline, MAX_IPC_LINE_BYTES).expect("large line");
+        assert_eq!(line.len(), expected + 1);
     }
 }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -1115,8 +1115,15 @@ impl Write for BudgetedWriter<'_> {
         }
     }
 
+    /// Flushing is the last thing either caller does, so a successful one
+    /// means the reply is out and the watchdog must stop considering this
+    /// socket — see the `done` check there.
     fn flush(&mut self) -> io::Result<()> {
-        (&mut &*self.stream).flush()
+        let flushed = (&mut &*self.stream).flush();
+        if flushed.is_ok() {
+            self._watch.done.store(true, Ordering::Release);
+        }
+        flushed
     }
 }
 
@@ -1124,6 +1131,7 @@ impl Write for BudgetedWriter<'_> {
 #[cfg(unix)]
 struct WriteWatch {
     id: u64,
+    done: Arc<AtomicBool>,
 }
 
 #[cfg(unix)]
@@ -1131,6 +1139,7 @@ struct WatchedWrite {
     id: u64,
     stream: UnixStream,
     clock: Arc<Mutex<BudgetClock>>,
+    done: Arc<AtomicBool>,
 }
 
 /// The watched set, and the single thread that polices it.
@@ -1145,6 +1154,13 @@ fn watched_writes() -> &'static Mutex<Vec<WatchedWrite>> {
                     .lock()
                     .unwrap_or_else(|error| error.into_inner());
                 for write in watched.iter() {
+                    // Finished writes are still registered for the moment it
+                    // takes their guard to drop. Cutting one then would
+                    // discard a reply that was already delivered in full,
+                    // which is the opposite of the point.
+                    if write.done.load(Ordering::Acquire) {
+                        continue;
+                    }
                     let expired = write
                         .clock
                         .lock()
@@ -1173,11 +1189,17 @@ impl WriteWatch {
         static NEXT_ID: AtomicU64 = AtomicU64::new(0);
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
         let stream = stream.try_clone()?;
+        let done = Arc::new(AtomicBool::new(false));
         watched_writes()
             .lock()
             .unwrap_or_else(|error| error.into_inner())
-            .push(WatchedWrite { id, stream, clock });
-        Ok(Self { id })
+            .push(WatchedWrite {
+                id,
+                stream,
+                clock,
+                done: Arc::clone(&done),
+            });
+        Ok(Self { id, done })
     }
 }
 

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -281,6 +281,13 @@ fn run_broker_supervisor_inner(dir: PathBuf) -> Result<(), AcpBrokerProcessError
         created_at_millis: current_millis(),
     };
     write_restrictive_json(&dir.join("metadata.json"), &metadata)?;
+    // Advertise framing here, before anything can connect, and stamp it with
+    // this generation so it cannot be mistaken for a later broker's — see
+    // `broker_supports_framing`.
+    write_restrictive_bytes(
+        &dir.join(IPC_FRAMING_MARKER),
+        format!("{}\n", metadata.generation.value()).as_bytes(),
+    )?;
     write_broker_pid(&dir)?;
 
     let mut command = Command::new(&launch.command);
@@ -775,18 +782,28 @@ const IPC_FRAMING_MARKER: &str = "framing";
 /// know to remove a file it has never heard of — so the marker outlives the
 /// broker that meant it. Framed requests would then go to a broker that only
 /// understands newlines, which rejects them, and `acp/open` will not replace it
-/// because its pid is live: the session cannot be reopened at all. Recording
-/// the pid the marker was written for makes it expire with its broker, since
-/// any replacement writes a new `pid.json`.
+/// because its pid is live: the session cannot be reopened at all.
+///
+/// Matched against the generation rather than the pid. A pid is recycled, so a
+/// replacement can be handed the very number a stale marker names — unlikely,
+/// but the failure it produces is an unreopenable session, and the generation
+/// is a nanosecond stamp written by every build into `metadata.json`, so there
+/// is nothing to trade for using it.
 #[cfg(unix)]
 fn broker_supports_framing(dir: &Path) -> bool {
     let Ok(marker) = std::fs::read_to_string(dir.join(IPC_FRAMING_MARKER)) else {
         return false;
     };
-    let Ok(marked_pid) = marker.trim().parse::<u32>() else {
+    let Ok(marked_generation) = marker.trim().parse::<u64>() else {
         return false;
     };
-    read_broker_pid_metadata(dir).is_some_and(|metadata| metadata.pid == marked_pid)
+    read_broker_metadata(dir)
+        .is_some_and(|metadata| metadata.generation.value() == marked_generation)
+}
+
+#[cfg(unix)]
+fn read_broker_metadata(dir: &Path) -> Option<ACPBrokerMetadata> {
+    serde_json::from_slice(&std::fs::read(dir.join("metadata.json")).ok()?).ok()
 }
 
 /// Reads one message, in whichever framing the peer used.
@@ -853,14 +870,6 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
 
         let socket_path = dir.join("broker.sock");
         let _ = std::fs::remove_file(&socket_path);
-        // Advertise framing before the socket exists, not after: a caller that
-        // connected in between would find no marker and fall back to the
-        // legacy encoding for that request. Stamped with this process's pid so
-        // it cannot outlive this broker — see `broker_supports_framing`.
-        write_restrictive_bytes(
-            &dir.join(IPC_FRAMING_MARKER),
-            format!("{}\n", std::process::id()).as_bytes(),
-        )?;
         let listener = UnixListener::bind(&socket_path)
             .map_err(|error| broker_error(-32072, format!("socket bind failed: {error}")))?;
         // Non-blocking so the loop can notice `close` without waiting for
@@ -2060,27 +2069,41 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn a_framing_marker_is_only_trusted_for_the_live_broker() {
+        fn write_metadata(dir: &Path, generation: u64) {
+            let metadata = ACPBrokerMetadata {
+                broker_id: BrokerId::new("marker-broker"),
+                generation: BrokerGeneration::new(generation),
+                alas_session_id: "marker-session".to_string(),
+                adapter_program: "adapter".to_string(),
+                adapter_args: vec![],
+                cwd: "/tmp".to_string(),
+                env_keys: vec![],
+                created_at_millis: 0,
+            };
+            write_restrictive_json(&dir.join("metadata.json"), &metadata).expect("metadata");
+        }
+
         let dir = PathBuf::from(format!("/tmp/alas-marker-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("marker dir");
-        write_broker_pid(&dir).expect("pid metadata");
-        let live = std::process::id();
+        write_metadata(&dir, 1_000);
 
         assert!(
             !broker_supports_framing(&dir),
             "no marker should mean no framing"
         );
 
-        std::fs::write(dir.join(IPC_FRAMING_MARKER), format!("{live}\n")).expect("marker");
+        std::fs::write(dir.join(IPC_FRAMING_MARKER), "1000\n").expect("marker");
         assert!(
             broker_supports_framing(&dir),
             "a marker written by the live broker should be trusted"
         );
 
-        // Stands in for a marker left behind by a broker that has since been
-        // replaced: present, but naming a process that is no longer the one
-        // serving this directory.
-        std::fs::write(dir.join(IPC_FRAMING_MARKER), format!("{}\n", live + 1)).expect("marker");
+        // Stands in for a broker replaced by one from an earlier build: the
+        // marker survives its cleanup, but the generation moved on. Matching
+        // on the pid instead would let this through whenever the replacement
+        // happened to be handed the same pid.
+        write_metadata(&dir, 2_000);
         assert!(
             !broker_supports_framing(&dir),
             "a marker from a replaced broker must not be trusted"

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -57,7 +57,18 @@ const IPC_REQUEST_HEAD_BUDGET: ReadBudget =
 /// so a legitimate transfer clears it by two orders of magnitude.
 const MIN_IPC_BODY_THROUGHPUT: u64 = 10 * 1024 * 1024;
 
-/// Budget for a framed body of `len` bytes.
+/// Budget for a framed body from a broker this helper spawned.
+///
+/// Progress only. A reply's size is not something we can turn into a deadline,
+/// and the exposure differs in kind from an inbound request: one thread per
+/// outstanding request, bounded by how many sessions exist rather than by
+/// anything the peer chooses.
+#[cfg(unix)]
+fn trusted_body_budget(_len: usize) -> ReadBudget {
+    ReadBudget::idle(BROKER_IPC_IDLE_TIMEOUT)
+}
+
+/// Budget for a framed body of `len` bytes arriving from an arbitrary peer.
 ///
 /// The total scales with the length the caller declared — never below the
 /// ordinary idle budget, so a small body is not held to a stricter rule than a
@@ -717,13 +728,16 @@ fn broker_supports_framing(dir: &Path) -> bool {
 /// reaching a new one.
 ///
 /// `head` bounds the first line, which is a short framing header or — under
-/// the legacy encoding — the entire message. The framed body is then bounded
-/// by the length the caller declared, so an advertised size cannot be used to
-/// hold resources indefinitely.
+/// the legacy encoding — the entire message. `body_for_len` then bounds the
+/// framed body, and the two callers differ on it: a request comes from an
+/// arbitrary peer and is held to the length it declared, while a reply comes
+/// from a broker this helper spawned and is only asked to keep making
+/// progress.
 #[cfg(unix)]
 fn read_ipc_message(
     reader: &mut BufReader<&UnixStream>,
     head: ReadBudget,
+    body_for_len: fn(usize) -> ReadBudget,
 ) -> io::Result<(String, Framing)> {
     let head = read_line_within(reader, head)?;
     let Some(len) = head.strip_prefix(IPC_FRAME_HEADER) else {
@@ -735,7 +749,7 @@ fn read_ipc_message(
             format!("invalid IPC frame length: {}", len.trim()),
         )
     })?;
-    let body = read_exact_within(reader, len, framed_body_budget(len))?;
+    let body = read_exact_within(reader, len, body_for_len(len))?;
     Ok((body, Framing::Framed))
 }
 
@@ -834,20 +848,15 @@ fn handle_connection(runtime: Runtime, stream: UnixStream) -> io::Result<()> {
     // can legitimately be large and cutting one short would corrupt it rather
     // than rescue anything.
     stream.set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))?;
-    let (line, framing) = {
+    let (line, _framing) = {
         let mut reader = ipc_reader(&stream)?;
-        read_ipc_message(&mut reader, IPC_REQUEST_HEAD_BUDGET)?
+        read_ipc_message(&mut reader, IPC_REQUEST_HEAD_BUDGET, framed_body_budget)?
     };
-    handle_ipc_line(runtime, stream, line, framing)
+    handle_ipc_line(runtime, stream, line)
 }
 
 #[cfg(unix)]
-fn handle_ipc_line(
-    runtime: Runtime,
-    stream: UnixStream,
-    line: String,
-    framing: Framing,
-) -> io::Result<()> {
+fn handle_ipc_line(runtime: Runtime, stream: UnixStream, line: String) -> io::Result<()> {
     let response = match serde_json::from_str::<BrokerIpcRequest>(&line) {
         Ok(request) => match handle_ipc_request(&runtime, request) {
             Ok(result) => BrokerIpcResponse {
@@ -867,33 +876,26 @@ fn handle_ipc_line(
             error: Some(format!("invalid IPC request: {error}")),
         },
     };
-    // Serialize straight into the socket rather than building the whole
-    // response first. Two reasons, both about large replies: a maximal attach
-    // reply is ~533 MiB, so `to_string` would materialize that entire String
-    // in this process before a byte moved — on exactly the memory-pressured
-    // machine where it is most likely to happen. And the caller bounds this
-    // read by inactivity, which only works if the expensive phase produces
-    // bytes: encoding to a String first means ~15s of complete silence, long
-    // enough to trip the caller's budget before the reply even starts.
-    // Streaming turns that silence into steady progress.
+    // Replies are never framed, whichever encoding the request used.
+    //
+    // Framing earns its keep on the request path: the peer is arbitrary, so
+    // the read needs a total budget, and a total budget without a declared
+    // length is a size ceiling in disguise. None of that applies here. The
+    // caller is a helper that spawned this process and reads replies against
+    // an idle budget with no ceiling, so a newline is all the delimiter it
+    // needs — and it lets the reply be *streamed*.
+    //
+    // That matters because a reply is not small. `pendingRequests` carries the
+    // payload of every unanswered client request, which for an
+    // `fs/write_text_file` is the file content, and the replayed
+    // `PendingRequest` event carries it a second time. Framing would mean
+    // serializing all of that into memory before writing a byte: an extra copy
+    // of an unbounded payload, and a silent stretch long enough to trip the
+    // caller's idle budget before the reply even begins.
     let mut writer = BufWriter::new(stream);
-    match framing {
-        // Framing needs the length before the bytes, so this one has to be
-        // built first. That is the trade for having no size ceiling; it costs
-        // a transient copy of the reply, and replies no longer carry prompt
-        // params (see `OperationSnapshot`), so what is copied is small.
-        Framing::Framed => {
-            let body = serde_json::to_string(&response).map_err(io::Error::other)?;
-            write_ipc_message(&mut writer, &body, framing)
-        }
-        // Nothing downstream needs the length, so stream it: the caller sees
-        // steady progress instead of one silent pause while it is built.
-        Framing::Legacy => {
-            serde_json::to_writer(&mut writer, &response).map_err(io::Error::other)?;
-            writer.write_all(b"\n")?;
-            writer.flush()
-        }
-    }
+    serde_json::to_writer(&mut writer, &response).map_err(io::Error::other)?;
+    writer.write_all(b"\n")?;
+    writer.flush()
 }
 
 fn handle_ipc_request(
@@ -1437,8 +1439,12 @@ fn send_ipc_within(
         let (line, _) = {
             let mut reader = ipc_reader(&stream)
                 .map_err(|error| broker_error(-32072, format!("broker read setup: {error}")))?;
-            read_ipc_message(&mut reader, ReadBudget::idle(idle_timeout))
-                .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?
+            read_ipc_message(
+                &mut reader,
+                ReadBudget::idle(idle_timeout),
+                trusted_body_budget,
+            )
+            .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?
         };
         let response: BrokerIpcResponse = serde_json::from_str(&line)
             .map_err(|error| broker_error(-32072, format!("broker response failed: {error}")))?;
@@ -1974,6 +1980,25 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The two body budgets encode different trust, and mixing them up is easy
+    /// to do silently: holding a broker's reply to a throughput floor would
+    /// fail a legitimately slow one, while letting an inbound request go
+    /// unbounded is the trickle path this all exists to close.
+    #[test]
+    fn only_arbitrary_peers_are_held_to_a_declared_length() {
+        let len = 64 * 1024 * 1024;
+        assert!(
+            framed_body_budget(len).total.is_some(),
+            "a request body must be bounded by the length its sender declared"
+        );
+        assert_eq!(
+            trusted_body_budget(len).total,
+            None,
+            "a reply from our own broker has no size we can turn into a deadline"
+        );
+        assert_eq!(trusted_body_budget(len).idle, BROKER_IPC_IDLE_TIMEOUT);
     }
 
     /// A declared length buys time proportional to itself, and nothing else.

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -658,11 +658,9 @@ impl BudgetClock {
     }
 }
 
-/// How many times a write retries on a yield before it starts sleeping. Sized
-/// so a reader that is keeping up never reaches the sleep — see the write loop
-/// in `BudgetedWriter`.
+/// Largest amount handed to a single write. See `BudgetedWriter::write`.
 #[cfg(unix)]
-const IPC_WRITE_SPIN_LIMIT: u32 = 128;
+const IPC_WRITE_CHUNK_BYTES: usize = 64 * 1024;
 
 /// How long a blocked read or write waits before its budget is re-checked.
 /// Also the amount by which a transfer may overshoot.
@@ -1042,86 +1040,154 @@ fn handle_ipc_line(runtime: Runtime, stream: UnixStream, line: String) -> io::Re
 
 /// Applies an `IoBudget` to a stream of writes.
 ///
-/// The socket's own write timeout resets on every partial write, so it cannot
-/// bound a reply as a whole — a peer draining a byte at a time satisfies it
-/// indefinitely. This carries the budget across writes instead, the same way
-/// `BudgetClock` does for reads.
+/// Writes stay **blocking**, and the budget is enforced from outside by a
+/// watchdog. That indirection is not for elegance — the two obvious
+/// alternatives were both measured and both fail:
 ///
-/// It puts the socket in non-blocking mode rather than setting a write
-/// timeout, because **`SO_SNDTIMEO` is not honoured for AF_UNIX sockets on
-/// Darwin**. Measured: `set_write_timeout(300ms)` returns `Ok`, reads back as
-/// `Some(300ms)`, and a write to a socket whose peer is draining slowly still
-/// does not return after twelve seconds. Every write timeout set on these
-/// sockets was therefore doing nothing at all, which is worse than a bound
-/// that merely resets too often. Polling gives the budget something real to
-/// act on.
+/// - A write timeout does nothing. `SO_SNDTIMEO` is not honoured for AF_UNIX
+///   on Darwin: `set_write_timeout(300ms)` returns `Ok`, reads back as
+///   `Some(300ms)`, and a write to a peer draining slowly has still not
+///   returned twelve seconds later.
+/// - Polling a non-blocking socket is correct but slow in a way that depends
+///   on the machine. A 267 MiB reply fills the socket buffer ~34,000 times
+///   even when the reader keeps up, and every fill has to be noticed:
+///   sleeping on them measured 5.5s against 0.2s blocking, and yielding —
+///   fast when the machine is quiet — degraded to tens of seconds under CPU
+///   load, which is exactly when a broker can least afford it.
 ///
-/// Blocking mode is restored on drop, since the same socket is read from
-/// afterwards on the request side and `SO_RCVTIMEO` *is* honoured.
+/// So the write blocks, the kernel does the waiting, and a watchdog closes the
+/// socket under a write that has outstayed its budget.
 #[cfg(unix)]
 struct BudgetedWriter<'a> {
     stream: &'a UnixStream,
-    clock: BudgetClock,
+    clock: Arc<Mutex<BudgetClock>>,
+    _watch: WriteWatch,
 }
 
 #[cfg(unix)]
 impl<'a> BudgetedWriter<'a> {
     fn new(stream: &'a UnixStream, budget: IoBudget) -> io::Result<Self> {
-        stream.set_nonblocking(true)?;
+        let clock = Arc::new(Mutex::new(BudgetClock::new(budget)));
+        let watch = WriteWatch::arm(stream, Arc::clone(&clock))?;
         Ok(Self {
             stream,
-            clock: BudgetClock::new(budget),
+            clock,
+            _watch: watch,
         })
-    }
-}
-
-#[cfg(unix)]
-impl Drop for BudgetedWriter<'_> {
-    fn drop(&mut self) {
-        let _ = self.stream.set_nonblocking(false);
     }
 }
 
 #[cfg(unix)]
 impl Write for BudgetedWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut stalls = 0u32;
-        loop {
-            if self.clock.expired() {
-                return Err(BudgetClock::timed_out());
+        // Chunked, because a blocking AF_UNIX write on Darwin does not return
+        // a partial count — it waits until the whole buffer is accepted.
+        // Handing it a large reply in one call means no progress is reported
+        // until the entire thing is through, so the budget sees `bytes = 0`
+        // for as long as the peer cares to take, and only the idle bound ever
+        // fires. Capping each call keeps progress observable without costing
+        // anything measurable: a 267 MiB reply becomes ~4,200 writes.
+        let buf = &buf[..buf.len().min(IPC_WRITE_CHUNK_BYTES)];
+        match (&mut &*self.stream).write(buf) {
+            Ok(written) => {
+                self.clock
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .progressed(written);
+                Ok(written)
             }
-            match (&mut &*self.stream).write(buf) {
-                Ok(written) => {
-                    self.clock.progressed(written);
-                    return Ok(written);
+            // The watchdog unblocks a stalled write by closing the socket, so
+            // the failure surfaces as a broken pipe. Reporting that verbatim
+            // would send whoever reads the log looking for a peer that
+            // disconnected, when what happened is that this peer stopped
+            // reading. Say which it was.
+            Err(error) => {
+                if self
+                    .clock
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .expired()
+                {
+                    return Err(BudgetClock::timed_out());
                 }
-                // The peer is not reading yet. Not a failure — the budget
-                // above decides when that has gone on too long.
-                //
-                // Yield before sleeping, and the difference is not small. A
-                // 267 MiB reply to a reader that is keeping up still fills the
-                // socket buffer ~34k times; sleeping even 100us on each costs
-                // 5.5s against 0.2s for a blocking write, and sleeping a whole
-                // poll slice would cost hours. Yielding first measures ~0.12s
-                // — at or better than blocking — because a keeping-up reader
-                // frees space within a few scheduler passes. A peer that is
-                // genuinely stalled blows through the spins in microseconds
-                // and lands on the sleep, where it belongs.
-                Err(error) if is_quiet(&error) => {
-                    stalls += 1;
-                    if stalls <= IPC_WRITE_SPIN_LIMIT {
-                        std::thread::yield_now();
-                    } else {
-                        std::thread::sleep(IPC_IO_POLL_SLICE);
-                    }
-                }
-                Err(error) => return Err(error),
+                Err(error)
             }
         }
     }
 
     fn flush(&mut self) -> io::Result<()> {
         (&mut &*self.stream).flush()
+    }
+}
+
+/// A write currently being watched. Dropping it stops the watching.
+#[cfg(unix)]
+struct WriteWatch {
+    id: u64,
+}
+
+#[cfg(unix)]
+struct WatchedWrite {
+    id: u64,
+    stream: UnixStream,
+    clock: Arc<Mutex<BudgetClock>>,
+}
+
+/// The watched set, and the single thread that polices it.
+#[cfg(unix)]
+fn watched_writes() -> &'static Mutex<Vec<WatchedWrite>> {
+    static WATCHED: OnceLock<Mutex<Vec<WatchedWrite>>> = OnceLock::new();
+    WATCHED.get_or_init(|| {
+        let spawned = std::thread::Builder::new().spawn(|| {
+            loop {
+                std::thread::sleep(IPC_IO_POLL_SLICE);
+                let watched = watched_writes()
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner());
+                for write in watched.iter() {
+                    let expired = write
+                        .clock
+                        .lock()
+                        .unwrap_or_else(|error| error.into_inner())
+                        .expired();
+                    if expired {
+                        // Closing the socket is what unblocks the write: it
+                        // returns an error and the handler unwinds. The peer
+                        // sees the connection drop, which is the truthful
+                        // thing to tell it.
+                        let _ = write.stream.shutdown(std::net::Shutdown::Both);
+                    }
+                }
+            }
+        });
+        // Without the thread nothing enforces the budget, but refusing to
+        // write at all would be a worse answer than writing unpoliced.
+        let _ = spawned;
+        Mutex::new(Vec::new())
+    })
+}
+
+#[cfg(unix)]
+impl WriteWatch {
+    fn arm(stream: &UnixStream, clock: Arc<Mutex<BudgetClock>>) -> io::Result<Self> {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let stream = stream.try_clone()?;
+        watched_writes()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(WatchedWrite { id, stream, clock });
+        Ok(Self { id })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for WriteWatch {
+    fn drop(&mut self) {
+        watched_writes()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .retain(|write| write.id != self.id);
     }
 }
 
@@ -2277,10 +2343,13 @@ mod tests {
     }
 
     /// A peer that drains a reply slowly must not be able to hold its handler
-    /// open indefinitely. The socket's write timeout cannot stop it — that
-    /// resets on every partial write — and this direction is worse than the
-    /// read side: a flood of idle connections lapses on its own, while peers
-    /// that keep trickling never do, so the broker would not recover.
+    /// open indefinitely. Enough such peers hold every connection worker, and
+    /// unlike a flood of idle connections — which lapses on its own — these
+    /// never do, so the broker would not recover.
+    ///
+    /// The peer here keeps reading, just far below the rate asked of it, which
+    /// is the case neither an idle bound nor a socket write timeout can catch:
+    /// it is always making progress, and every partial write looks healthy.
     #[cfg(unix)]
     #[test]
     fn a_peer_that_drains_a_reply_slowly_does_not_hold_its_handler_open() {
@@ -2288,31 +2357,35 @@ mod tests {
         let done = Arc::new(Mutex::new(false));
         let reader_done = done.clone();
         std::thread::spawn(move || {
-            // Reads just enough to keep each write making progress, forever.
-            let mut byte = [0u8; 1];
+            // ~320 KiB/s: fast enough that writes keep completing, far short
+            // of the megabytes per second demanded below.
+            let mut chunk = vec![0u8; 32 * 1024];
             while !*reader_done.lock().expect("drain flag") {
-                if std::io::Read::read(&mut reader, &mut byte).is_err() {
+                if std::io::Read::read(&mut reader, &mut chunk).is_err() {
                     return;
                 }
-                std::thread::sleep(Duration::from_millis(20));
+                std::thread::sleep(Duration::from_millis(100));
             }
         });
 
-        // 1 MiB/s demanded, delivered at ~50 B/s.
         let mut budgeted = BudgetedWriter::new(
             &writer,
-            IoBudget::at_least(Duration::from_secs(30), 1024 * 1024),
+            IoBudget::at_least(Duration::from_secs(120), 4 * 1024 * 1024),
         )
         .expect("budgeted writer");
-        let payload = vec![b'r'; 8 * 1024 * 1024];
+        let payload = vec![b'r'; 64 * 1024 * 1024];
         let started = std::time::Instant::now();
         let outcome = budgeted.write_all(&payload);
         *done.lock().expect("drain flag") = true;
 
-        let error = outcome.expect_err("a reply drained at a trickle must not be waited on");
-        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        let error = outcome.expect_err("a reply drained below the required rate must be cut");
+        assert_eq!(
+            error.kind(),
+            io::ErrorKind::TimedOut,
+            "the cause should say the peer was too slow, not that the pipe broke"
+        );
         assert!(
-            started.elapsed() < Duration::from_secs(30),
+            started.elapsed() < Duration::from_secs(60),
             "the rate bound took too long to notice: {:?}",
             started.elapsed()
         );

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -32,11 +32,6 @@ const IPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 /// loop, so an unbounded wait here stalls every session the helper serves.
 const BROKER_IPC_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Floor for a single retried attempt, so a nearly-spent deadline cannot
-/// shrink the per-attempt budget down to something a healthy broker on a busy
-/// machine would miss.
-const BROKER_IPC_MIN_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
-
 /// Upper bound on a *request* line arriving at a broker, so a peer that never
 /// sends a newline cannot grow the buffer without limit.
 ///
@@ -1148,25 +1143,25 @@ fn send_ipc_with_retry(
     dir: &Path,
     method: &str,
     params: Value,
-    timeout: Duration,
+    retry_budget: Duration,
 ) -> Result<Value, AcpBrokerProcessError> {
-    let deadline = std::time::Instant::now() + timeout;
+    let deadline = std::time::Instant::now() + retry_budget;
     loop {
         if let Some(message) = read_startup_error(dir) {
             return Err(broker_error(-32072, message));
         }
-        // Bound each attempt, not just the gaps between attempts. A broker
-        // that accepts and then never answers never produces the error this
-        // loop checks the deadline on, so a per-attempt bound is the only
-        // thing that makes `timeout` mean anything for a wedged broker.
-        // The floor keeps a slow-but-healthy broker on a loaded machine from
-        // being declared dead just because the deadline is nearly spent — it
-        // can overshoot `timeout`, which is the right trade: this bound
-        // exists to rule out hangs, not to hit a precise deadline.
-        let remaining = deadline
-            .saturating_duration_since(std::time::Instant::now())
-            .max(BROKER_IPC_MIN_ATTEMPT_TIMEOUT);
-        match send_ipc_within(dir, method, params.clone(), remaining) {
+        // Each attempt gets the ordinary response budget, NOT what is left of
+        // `retry_budget`. The two measure different things: `retry_budget` is
+        // how long to keep re-trying a broker that is not answering *yet* —
+        // typically one still starting up, whose socket does not exist — while
+        // `BROKER_IPC_TIMEOUT` is how long a single legitimate response may
+        // take once the broker does answer. Those are far apart: `acp_open`
+        // adopts a live broker on a 2s retry budget, and a snapshot carrying a
+        // retained large-image prompt takes ~7.4s just to serialize on the
+        // broker side. Deriving the response deadline from the retry budget
+        // makes adopting such a broker fail permanently, since every retry
+        // hits the same wall.
+        match send_ipc_within(dir, method, params.clone(), BROKER_IPC_TIMEOUT) {
             Ok(value) => return Ok(value),
             Err(error) if std::time::Instant::now() < deadline => {
                 let _ = error;
@@ -1504,6 +1499,43 @@ mod tests {
             elapsed < Duration::from_secs(10),
             "deadline overshot badly: {elapsed:?}"
         );
+    }
+
+    /// The retry budget governs how long to keep retrying a broker that is not
+    /// answering *yet* — its socket may not exist while it starts up. It must
+    /// not double as the deadline for a single legitimate response, which can
+    /// take far longer: `acp_open` adopts with a 2s retry budget, while a
+    /// snapshot carrying a retained large-image prompt takes ~7.4s just to
+    /// serialize broker-side. Conflating the two makes adoption of a live
+    /// broker fail permanently, every retry hitting the same wall.
+    #[cfg(unix)]
+    #[test]
+    fn a_retry_budget_does_not_cap_how_long_one_response_may_take() {
+        let dir = PathBuf::from(format!("/tmp/alas-slow-broker-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("broker dir");
+        let listener = UnixListener::bind(dir.join("broker.sock")).expect("listener binds");
+
+        let responder = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut line = String::new();
+            BufReader::new(&stream)
+                .read_line(&mut line)
+                .expect("request");
+            // Stands in for a broker serializing a large snapshot: answers
+            // correctly, just well past the caller's retry budget.
+            std::thread::sleep(Duration::from_secs(4));
+            let mut stream = stream;
+            writeln!(stream, r#"{{"ok":true,"result":{{"slow":true}}}}"#).expect("response");
+            stream.flush().expect("flush");
+        });
+
+        let outcome = send_ipc_with_retry(&dir, "snapshot", json!({}), Duration::from_secs(2));
+        let _ = responder.join();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let value = outcome.expect("a slow but healthy broker must not be given up on");
+        assert_eq!(value["slow"], json!(true));
     }
 
     /// `send_ipc_within` connects with a blocking socket, which is only safe

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -73,6 +73,21 @@ const MIN_IPC_REQUEST_RATE: u64 = 16 * 1024;
 const IPC_REQUEST_HEAD_BUDGET: IoBudget =
     IoBudget::at_least(IPC_REQUEST_IDLE_TIMEOUT, MIN_IPC_REQUEST_RATE);
 
+/// Largest framed body accepted.
+///
+/// A rate bound limits how long a body may take, not how much of it is held:
+/// a peer declaring a hundred gigabytes and delivering at the required rate is
+/// retained byte for byte until the broker dies. Time was never the dimension
+/// that ran out.
+///
+/// So there is a ceiling again — chosen the way the pre-first-byte bound is,
+/// from what a sender can physically produce rather than from what feels
+/// large. The biggest legitimate request is an `acp/respond` carrying a whole
+/// file, which `ACPSessionRunner.serveRead` builds holding the file, a
+/// `String` copy and the encoded JSON at once; a maximal image prompt is
+/// ~267 MiB by comparison.
+const MAX_IPC_FRAME_BYTES: usize = 8 * 1024 * 1024 * 1024;
+
 /// Slowest a caller may deliver a framed body before we stop waiting.
 ///
 /// An idle budget alone is not enough once a length is known: a caller can
@@ -782,7 +797,7 @@ fn read_exact_within(
 /// the original newline-delimited JSON, kept because a helper can adopt a
 /// broker that a previous build started and which is still speaking it.
 #[cfg(unix)]
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum Framing {
     Legacy,
     Framed,
@@ -859,6 +874,14 @@ fn read_ipc_message(
             format!("invalid IPC frame length: {}", len.trim()),
         )
     })?;
+    // Refused before a byte of the body is read, so an outsized claim costs
+    // nothing to turn away.
+    if len > MAX_IPC_FRAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("IPC frame length {len} exceeds {MAX_IPC_FRAME_BYTES}"),
+        ));
+    }
     let body = read_exact_within(reader, len, body_for_len(len))?;
     Ok((body, Framing::Framed))
 }
@@ -907,6 +930,7 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
         write_restrictive_bytes(&dir.join("ready"), b"1\n")?;
 
         let inflight = Arc::new(AtomicUsize::new(0));
+        let order = Arc::new(RequestOrder::default());
         while !runtime_is_closing(&runtime) {
             // Stop accepting rather than spawning without limit. Every
             // connection owns a thread that can sit for the whole head
@@ -945,11 +969,12 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
                 continue;
             }
             let request_runtime = runtime.clone();
+            let request_order = Arc::clone(&order);
             let request_inflight = Arc::clone(&inflight);
             request_inflight.fetch_add(1, Ordering::AcqRel);
             if std::thread::Builder::new()
                 .spawn(move || {
-                    let _ = handle_connection(request_runtime, stream);
+                    let _ = handle_connection(request_runtime, stream, request_order);
                     request_inflight.fetch_sub(1, Ordering::AcqRel);
                 })
                 .is_err()
@@ -980,15 +1005,85 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
     }
 }
 
+/// Hands out turns so requests are dispatched in the order they finished
+/// arriving, rather than in whatever order the scheduler wakes their threads.
+///
+/// One helper already orders its own calls per broker, but a broker outlives
+/// the app that started it and more than one helper can adopt the same one —
+/// two Alas builds side by side is ordinary here. Their requests arrive on
+/// separate connections, and without this a later `session/cancel` can be
+/// applied before the `session/prompt` it was sent to stop, the same silent
+/// failure the helper's queue prevents within one process.
+///
+/// The turn is taken once a request has finished arriving, not at accept.
+/// Ordering by acceptance would mean holding it across a read allowed to take
+/// minutes for a legacy sender still encoding, letting one slow caller stall
+/// every other client of the broker — reintroducing at the supervisor exactly
+/// what moving dispatch off the serve loop removed at the helper.
+#[cfg(unix)]
+#[derive(Default)]
+struct RequestOrder {
+    state: Mutex<(u64, u64)>,
+    turn: Condvar,
+}
+
+#[cfg(unix)]
+impl RequestOrder {
+    /// Claims the next place in line and waits for it. The returned guard
+    /// advances the queue on drop, including on panic — otherwise one failed
+    /// handler would stall every later request for this broker for good.
+    fn take_turn(&self) -> RequestTurn<'_> {
+        let ticket = {
+            let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+            let ticket = state.0;
+            state.0 += 1;
+            ticket
+        };
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        while state.1 != ticket {
+            state = self
+                .turn
+                .wait(state)
+                .unwrap_or_else(|error| error.into_inner());
+        }
+        RequestTurn { order: self }
+    }
+}
+
+#[cfg(unix)]
+struct RequestTurn<'a> {
+    order: &'a RequestOrder,
+}
+
+#[cfg(unix)]
+impl Drop for RequestTurn<'_> {
+    fn drop(&mut self) {
+        let mut state = self
+            .order
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        state.1 += 1;
+        self.order.turn.notify_all();
+    }
+}
+
 /// Reads one request off an accepted connection and answers it, in whichever
 /// framing the caller used. Runs on its own thread, so a caller that is slow
 /// to deliver its request costs only that thread.
 #[cfg(unix)]
-fn handle_connection(runtime: Runtime, stream: UnixStream) -> io::Result<()> {
+fn handle_connection(
+    runtime: Runtime,
+    stream: UnixStream,
+    order: Arc<RequestOrder>,
+) -> io::Result<()> {
     let (line, _framing) = {
         let mut reader = ipc_reader(&stream)?;
         read_ipc_message(&mut reader, IPC_REQUEST_HEAD_BUDGET, framed_body_budget)?
     };
+    // Ticketed here, not before the read: a caller allowed minutes to finish
+    // arriving must not hold the turn of one that already has.
+    let _turn = order.take_turn();
     handle_ipc_line(runtime, stream, line)
 }
 
@@ -2362,6 +2457,77 @@ mod tests {
             elapsed < Duration::from_secs(10),
             "budgeted writes collapsed throughput: 64 MiB took {elapsed:?}"
         );
+    }
+
+    /// An advertised length is refused before any of the body is read, so a
+    /// peer cannot make the broker hold gigabytes simply by claiming them.
+    /// The rate bound does not cover this: a peer delivering at the required
+    /// rate is retained byte for byte, and time was never what ran out.
+    #[cfg(unix)]
+    #[test]
+    fn an_oversized_declared_frame_is_refused_before_its_body_is_read() {
+        let (mut writer, reader) = UnixStream::pair().expect("socket pair");
+        let oversized = MAX_IPC_FRAME_BYTES + 1;
+        std::thread::spawn(move || {
+            // Header only. If the length were accepted this would block
+            // forever waiting for a body that never comes.
+            let _ = writeln!(writer, "{IPC_FRAME_HEADER}{oversized}");
+            let _ = writer.flush();
+            std::thread::sleep(Duration::from_secs(30));
+        });
+
+        let mut reader = ipc_reader(&reader).expect("reader");
+        let started = std::time::Instant::now();
+        let error = read_ipc_message(&mut reader, IPC_REQUEST_HEAD_BUDGET, framed_body_budget)
+            .expect_err("an outsized declared length must be refused");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "refusal should not wait on the body: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// Turns are handed out in the order they are claimed, not in whatever
+    /// order the scheduler wakes the waiters. A mutex would satisfy the
+    /// mutual-exclusion half of this and still let a `session/cancel` overtake
+    /// the `session/prompt` it was sent to stop.
+    ///
+    /// Each worker holds its turn for a spell that *shrinks* with its ticket,
+    /// so the two behaviours produce different answers: granted in order, the
+    /// holds are serial and the record comes out ascending; granted freely,
+    /// they overlap and the shortest holds finish first.
+    #[cfg(unix)]
+    #[test]
+    fn request_turns_are_granted_in_the_order_they_are_claimed() {
+        const WORKERS: u64 = 8;
+        let order = Arc::new(RequestOrder::default());
+        let observed = Arc::new(Mutex::new(Vec::new()));
+
+        // Held so every worker is queued behind it before any can proceed.
+        let first = order.take_turn();
+        let mut workers = Vec::new();
+        for index in 0..WORKERS {
+            let order = Arc::clone(&order);
+            let observed = Arc::clone(&observed);
+            workers.push(std::thread::spawn(move || {
+                let _turn = order.take_turn();
+                std::thread::sleep(Duration::from_millis(30 * (WORKERS - index)));
+                observed
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .push(index);
+            }));
+            // Sequences the claims only; it does not sequence the grants.
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        drop(first);
+        for worker in workers {
+            worker.join().expect("worker");
+        }
+
+        let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
+        assert_eq!(*observed, (0..WORKERS).collect::<Vec<_>>());
     }
 
     /// A peer that drains a reply slowly must not be able to hold its handler

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -34,6 +34,16 @@ use std::os::unix::net::{UnixListener, UnixStream};
 /// caller has declared a length and is held to it instead.
 const IPC_REQUEST_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Rate a peer must sustain while reading a response.
+///
+/// `SO_SNDTIMEO` bounds each write, not the whole reply, so a peer that reads
+/// a little every nineteen seconds renews it forever and keeps its handler
+/// alive. Enough such peers hold every connection worker, and unlike a flood
+/// of idle connections this one never lapses, so the broker does not recover
+/// on its own. Requiring a rate ends it. Lenient by design: the only real
+/// reader is a helper already blocked on the reply.
+const MIN_IPC_RESPONSE_RATE: u64 = 16 * 1024;
+
 /// Rate a caller must sustain on the first line once it starts sending.
 ///
 /// A fixed duration cannot work here. Under the legacy encoding this line is
@@ -50,8 +60,8 @@ const MIN_IPC_REQUEST_RATE: u64 = 16 * 1024;
 
 /// Bounds on the first line of a request: silence, and sustained rate.
 #[cfg(unix)]
-const IPC_REQUEST_HEAD_BUDGET: ReadBudget =
-    ReadBudget::at_least(IPC_REQUEST_IDLE_TIMEOUT, MIN_IPC_REQUEST_RATE);
+const IPC_REQUEST_HEAD_BUDGET: IoBudget =
+    IoBudget::at_least(IPC_REQUEST_IDLE_TIMEOUT, MIN_IPC_REQUEST_RATE);
 
 /// Slowest a caller may deliver a framed body before we stop waiting.
 ///
@@ -69,8 +79,8 @@ const MIN_IPC_BODY_THROUGHPUT: u64 = 10 * 1024 * 1024;
 /// outstanding request, bounded by how many sessions exist rather than by
 /// anything the peer chooses.
 #[cfg(unix)]
-fn trusted_body_budget(_len: usize) -> ReadBudget {
-    ReadBudget::idle(BROKER_IPC_IDLE_TIMEOUT)
+fn trusted_body_budget(_len: usize) -> IoBudget {
+    IoBudget::idle(BROKER_IPC_IDLE_TIMEOUT)
 }
 
 /// Budget for a framed body of `len` bytes arriving from an arbitrary peer.
@@ -81,9 +91,9 @@ fn trusted_body_budget(_len: usize) -> ReadBudget {
 /// that declares 1 TiB and then says nothing would otherwise have bought
 /// itself about 29 hours of silence, and a thread to spend it in.
 #[cfg(unix)]
-fn framed_body_budget(len: usize) -> ReadBudget {
+fn framed_body_budget(len: usize) -> IoBudget {
     let by_rate = Duration::from_secs_f64(len as f64 / MIN_IPC_BODY_THROUGHPUT as f64);
-    ReadBudget::within(
+    IoBudget::within(
         BROKER_IPC_IDLE_TIMEOUT,
         by_rate.max(BROKER_IPC_IDLE_TIMEOUT),
     )
@@ -103,9 +113,10 @@ fn framed_body_budget(len: usize) -> ReadBudget {
 /// too long merely delays reporting a broker that is genuinely stuck.
 const BROKER_IPC_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// How long a single write to a broker may block. Writing even a maximal
-/// request measures ~0.2s, so this only ever fires on a broker that has
-/// stopped reading.
+/// How long a transfer may stall with the peer reading nothing at all.
+/// Paired with `MIN_IPC_RESPONSE_RATE`, which is what stops a peer reading
+/// just enough to look alive. Writing even a maximal request measures ~0.2s,
+/// so neither bound is near what real traffic needs.
 const BROKER_IPC_WRITE_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug)]
@@ -531,19 +542,19 @@ enum Pace {
     Unbounded,
 }
 
-/// How a read is bounded in time.
+/// How a transfer is bounded in time, in either direction.
 ///
 /// An idle bound alone has a hole — a trickle satisfies it forever — so every
-/// read from an arbitrary peer pairs one with a `Pace`. Which pace depends on
-/// whether the sender told us how much to expect.
+/// transfer with an arbitrary peer pairs one with a `Pace`. Which pace depends
+/// on whether the amount is known in advance.
 #[derive(Clone, Copy)]
-struct ReadBudget {
+struct IoBudget {
     /// Longest run with no bytes arriving.
     idle: Duration,
     pace: Pace,
 }
 
-impl ReadBudget {
+impl IoBudget {
     /// For a peer we trust to finish what it starts.
     fn idle(idle: Duration) -> Self {
         Self {
@@ -587,7 +598,7 @@ struct BudgetClock {
 
 #[cfg(unix)]
 impl BudgetClock {
-    fn new(budget: ReadBudget) -> Self {
+    fn new(budget: IoBudget) -> Self {
         let now = std::time::Instant::now();
         Self {
             idle: budget.idle,
@@ -637,10 +648,10 @@ impl BudgetClock {
     }
 }
 
-/// How long a blocked read waits before its budget is re-checked. Also the
-/// amount by which a read may overshoot.
+/// How long a blocked read or write waits before its budget is re-checked.
+/// Also the amount by which a transfer may overshoot.
 #[cfg(unix)]
-const IPC_READ_POLL_SLICE: Duration = Duration::from_millis(500);
+const IPC_IO_POLL_SLICE: Duration = Duration::from_millis(500);
 
 /// Prepares a stream for the budgeted readers below.
 ///
@@ -655,7 +666,7 @@ const IPC_READ_POLL_SLICE: Duration = Duration::from_millis(500);
 /// had already pulled off the socket.
 #[cfg(unix)]
 fn ipc_reader(stream: &UnixStream) -> io::Result<BufReader<&UnixStream>> {
-    stream.set_read_timeout(Some(IPC_READ_POLL_SLICE))?;
+    stream.set_read_timeout(Some(IPC_IO_POLL_SLICE))?;
     Ok(BufReader::new(stream))
 }
 
@@ -676,7 +687,7 @@ fn is_quiet(error: &io::Error) -> bool {
 /// reads until it finds a newline, so a peer trickling bytes faster than the
 /// timeout renews its budget indefinitely.
 #[cfg(unix)]
-fn read_line_within(reader: &mut BufReader<&UnixStream>, budget: ReadBudget) -> io::Result<String> {
+fn read_line_within(reader: &mut BufReader<&UnixStream>, budget: IoBudget) -> io::Result<String> {
     let mut clock = BudgetClock::new(budget);
     let mut line: Vec<u8> = Vec::new();
     loop {
@@ -721,7 +732,7 @@ fn read_line_within(reader: &mut BufReader<&UnixStream>, budget: ReadBudget) -> 
 fn read_exact_within(
     reader: &mut BufReader<&UnixStream>,
     len: usize,
-    budget: ReadBudget,
+    budget: IoBudget,
 ) -> io::Result<String> {
     let mut clock = BudgetClock::new(budget);
     let mut body: Vec<u8> = Vec::with_capacity(len.min(1024 * 1024));
@@ -821,8 +832,8 @@ fn read_broker_metadata(dir: &Path) -> Option<ACPBrokerMetadata> {
 #[cfg(unix)]
 fn read_ipc_message(
     reader: &mut BufReader<&UnixStream>,
-    head: ReadBudget,
-    body_for_len: fn(usize) -> ReadBudget,
+    head: IoBudget,
+    body_for_len: fn(usize) -> IoBudget,
 ) -> io::Result<(String, Framing)> {
     let head = read_line_within(reader, head)?;
     let Some(len) = head.strip_prefix(IPC_FRAME_HEADER) else {
@@ -960,10 +971,6 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
 /// to deliver its request costs only that thread.
 #[cfg(unix)]
 fn handle_connection(runtime: Runtime, stream: UnixStream) -> io::Result<()> {
-    // Guards against a caller that stops reading. Generous, because a reply
-    // can legitimately be large and cutting one short would corrupt it rather
-    // than rescue anything.
-    stream.set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))?;
     let (line, _framing) = {
         let mut reader = ipc_reader(&stream)?;
         read_ipc_message(&mut reader, IPC_REQUEST_HEAD_BUDGET, framed_body_budget)?
@@ -1008,10 +1015,82 @@ fn handle_ipc_line(runtime: Runtime, stream: UnixStream, line: String) -> io::Re
     // serializing all of that into memory before writing a byte: an extra copy
     // of an unbounded payload, and a silent stretch long enough to trip the
     // caller's idle budget before the reply even begins.
-    let mut writer = BufWriter::new(stream);
+    let mut writer = BufWriter::new(BudgetedWriter::new(
+        &stream,
+        IoBudget::at_least(BROKER_IPC_WRITE_TIMEOUT, MIN_IPC_RESPONSE_RATE),
+    )?);
     serde_json::to_writer(&mut writer, &response).map_err(io::Error::other)?;
     writer.write_all(b"\n")?;
     writer.flush()
+}
+
+/// Applies an `IoBudget` to a stream of writes.
+///
+/// The socket's own write timeout resets on every partial write, so it cannot
+/// bound a reply as a whole — a peer draining a byte at a time satisfies it
+/// indefinitely. This carries the budget across writes instead, the same way
+/// `BudgetClock` does for reads.
+///
+/// It puts the socket in non-blocking mode rather than setting a write
+/// timeout, because **`SO_SNDTIMEO` is not honoured for AF_UNIX sockets on
+/// Darwin**. Measured: `set_write_timeout(300ms)` returns `Ok`, reads back as
+/// `Some(300ms)`, and a write to a socket whose peer is draining slowly still
+/// does not return after twelve seconds. Every write timeout set on these
+/// sockets was therefore doing nothing at all, which is worse than a bound
+/// that merely resets too often. Polling gives the budget something real to
+/// act on.
+///
+/// Blocking mode is restored on drop, since the same socket is read from
+/// afterwards on the request side and `SO_RCVTIMEO` *is* honoured.
+#[cfg(unix)]
+struct BudgetedWriter<'a> {
+    stream: &'a UnixStream,
+    clock: BudgetClock,
+}
+
+#[cfg(unix)]
+impl<'a> BudgetedWriter<'a> {
+    fn new(stream: &'a UnixStream, budget: IoBudget) -> io::Result<Self> {
+        stream.set_nonblocking(true)?;
+        Ok(Self {
+            stream,
+            clock: BudgetClock::new(budget),
+        })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for BudgetedWriter<'_> {
+    fn drop(&mut self) {
+        let _ = self.stream.set_nonblocking(false);
+    }
+}
+
+#[cfg(unix)]
+impl Write for BudgetedWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        loop {
+            if self.clock.expired() {
+                return Err(BudgetClock::timed_out());
+            }
+            match (&mut &*self.stream).write(buf) {
+                Ok(written) => {
+                    self.clock.progressed(written);
+                    return Ok(written);
+                }
+                // The peer is not reading yet. Not a failure — the budget
+                // above decides when that has gone on too long.
+                Err(error) if is_quiet(&error) => {
+                    std::thread::sleep(IPC_IO_POLL_SLICE);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        (&mut &*self.stream).flush()
+    }
 }
 
 fn handle_ipc_request(
@@ -1527,15 +1606,11 @@ fn send_ipc_within(
         // non-blocking, deadline-aware connect before it can be trusted.
         // `connect_does_not_block_on_a_full_backlog` pins the Darwin
         // behaviour this relies on.
-        let mut stream = UnixStream::connect(dir.join("broker.sock"))
+        let stream = UnixStream::connect(dir.join("broker.sock"))
             .map_err(|error| broker_error(-32072, format!("broker connect failed: {error}")))?;
         // Without a bound, a broker that accepted the connection but never
         // answered would block this call forever.
-        stream
-            .set_write_timeout(Some(BROKER_IPC_WRITE_TIMEOUT))
-            .map_err(|error| {
-                broker_error(-32072, format!("broker write timeout failed: {error}"))
-            })?;
+
         // Frame the request when the broker advertises it. Without framing the
         // reader has to hunt for a newline, which needs a total budget, which
         // is a size ceiling wearing a different hat — and this request can be
@@ -1547,8 +1622,19 @@ fn send_ipc_within(
         } else {
             Framing::Legacy
         };
-        write_ipc_message(&mut stream, &body, framing)
-            .map_err(|error| broker_error(-32072, format!("broker write failed: {error}")))?;
+        // Budgeted rather than relying on a socket write timeout, which Darwin
+        // ignores for AF_UNIX (see `BudgetedWriter`). A broker that stopped
+        // reading would otherwise hold this queue's thread forever, and with
+        // it every later request for that broker.
+        {
+            let mut writer = BudgetedWriter::new(
+                &stream,
+                IoBudget::at_least(BROKER_IPC_WRITE_TIMEOUT, MIN_IPC_RESPONSE_RATE),
+            )
+            .map_err(|error| broker_error(-32072, format!("broker write setup: {error}")))?;
+            write_ipc_message(&mut writer, &body, framing)
+                .map_err(|error| broker_error(-32072, format!("broker write failed: {error}")))?;
+        }
         // Bounded by inactivity, not total time: a reply's size — and so how
         // long it legitimately takes — is not something we can predict. What
         // can be asked of a broker is that it keep making progress.
@@ -1557,7 +1643,7 @@ fn send_ipc_within(
                 .map_err(|error| broker_error(-32072, format!("broker read setup: {error}")))?;
             read_ipc_message(
                 &mut reader,
-                ReadBudget::idle(idle_timeout),
+                IoBudget::idle(idle_timeout),
                 trusted_body_budget,
             )
             .map_err(|error| broker_error(-32072, format!("broker read failed: {error}")))?
@@ -2011,7 +2097,7 @@ mod tests {
 
         let started = std::time::Instant::now();
         let mut reader = ipc_reader(&reader).expect("reader");
-        let line = read_line_within(&mut reader, ReadBudget::idle(Duration::from_secs(1)))
+        let line = read_line_within(&mut reader, IoBudget::idle(Duration::from_secs(1)))
             .expect("a peer that keeps making progress must not be given up on");
         assert_eq!(line.len(), 6 * 512 + 1);
         assert!(
@@ -2046,7 +2132,7 @@ mod tests {
         let outcome = read_exact_within(
             &mut reader,
             4 * 1024 * 1024,
-            ReadBudget::within(Duration::from_secs(2), Duration::from_secs(2)),
+            IoBudget::within(Duration::from_secs(2), Duration::from_secs(2)),
         );
         *done.lock().expect("drip flag") = true;
 
@@ -2112,6 +2198,48 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A peer that drains a reply slowly must not be able to hold its handler
+    /// open indefinitely. The socket's write timeout cannot stop it — that
+    /// resets on every partial write — and this direction is worse than the
+    /// read side: a flood of idle connections lapses on its own, while peers
+    /// that keep trickling never do, so the broker would not recover.
+    #[cfg(unix)]
+    #[test]
+    fn a_peer_that_drains_a_reply_slowly_does_not_hold_its_handler_open() {
+        let (writer, mut reader) = UnixStream::pair().expect("socket pair");
+        let done = Arc::new(Mutex::new(false));
+        let reader_done = done.clone();
+        std::thread::spawn(move || {
+            // Reads just enough to keep each write making progress, forever.
+            let mut byte = [0u8; 1];
+            while !*reader_done.lock().expect("drain flag") {
+                if std::io::Read::read(&mut reader, &mut byte).is_err() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        });
+
+        // 1 MiB/s demanded, delivered at ~50 B/s.
+        let mut budgeted = BudgetedWriter::new(
+            &writer,
+            IoBudget::at_least(Duration::from_secs(30), 1024 * 1024),
+        )
+        .expect("budgeted writer");
+        let payload = vec![b'r'; 8 * 1024 * 1024];
+        let started = std::time::Instant::now();
+        let outcome = budgeted.write_all(&payload);
+        *done.lock().expect("drain flag") = true;
+
+        let error = outcome.expect_err("a reply drained at a trickle must not be waited on");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "the rate bound took too long to notice: {:?}",
+            started.elapsed()
+        );
+    }
+
     /// A rate bound has to separate the two cases a fixed duration cannot: a
     /// legacy request whose sender pauses to encode and then delivers a lot,
     /// and a trickle that never intends to finish. Both look identical to an
@@ -2139,7 +2267,7 @@ mod tests {
             // 64 KiB/s required, judged after a 10s grace.
             read_line_within(
                 &mut reader,
-                ReadBudget::at_least(Duration::from_secs(30), 64 * 1024),
+                IoBudget::at_least(Duration::from_secs(30), 64 * 1024),
             )
         }
 
@@ -2252,7 +2380,7 @@ mod tests {
         let mut reader = ipc_reader(&reader).expect("reader");
         let outcome = read_line_within(
             &mut reader,
-            ReadBudget::within(Duration::from_secs(2), Duration::from_secs(2)),
+            IoBudget::within(Duration::from_secs(2), Duration::from_secs(2)),
         );
         let elapsed = started.elapsed();
         *done.lock().expect("drip flag") = true;
@@ -2280,7 +2408,7 @@ mod tests {
         });
 
         let mut reader = ipc_reader(&reader).expect("reader");
-        let line = read_line_within(&mut reader, ReadBudget::idle(Duration::from_secs(30)))
+        let line = read_line_within(&mut reader, IoBudget::idle(Duration::from_secs(30)))
             .expect("large line");
         assert_eq!(line.len(), expected + 1);
     }

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -388,11 +388,17 @@ fn acp_list() -> Result<Value, AcpBrokerProcessError> {
         if !dir.is_dir() || !broker_is_running(&dir) {
             continue;
         }
-        // This sweeps every broker dir on disk, including leftovers from
-        // earlier app runs, so it must not pay the full per-request budget
-        // for each unresponsive one. A live broker answers `snapshot` from
-        // memory; anything slower than this is not worth listing.
-        if let Ok(snapshot) = send_ipc_within(&dir, "snapshot", json!({}), Duration::from_secs(2)) {
+        // The ordinary budget, deliberately. A shorter one was tempting here
+        // — this sweeps every broker dir on disk, including leftovers from
+        // earlier runs — but it silently drops healthy brokers: a snapshot
+        // carrying a retained large-image prompt takes ~7.4s to serialize,
+        // all of it silent, so any budget below that omits a live broker from
+        // the list rather than reporting it. The cheap exclusions are already
+        // handled above by `broker_is_running`, and a dead socket fails the
+        // connect immediately; what is left is a broker that is live but
+        // wedged, which is exactly what an idle budget is for.
+        if let Ok(snapshot) = send_ipc_within(&dir, "snapshot", json!({}), BROKER_IPC_IDLE_TIMEOUT)
+        {
             if snapshot
                 .get("adapterExited")
                 .and_then(Value::as_bool)

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -648,6 +648,12 @@ impl BudgetClock {
     }
 }
 
+/// How many times a write retries on a yield before it starts sleeping. Sized
+/// so a reader that is keeping up never reaches the sleep — see the write loop
+/// in `BudgetedWriter`.
+#[cfg(unix)]
+const IPC_WRITE_SPIN_LIMIT: u32 = 128;
+
 /// How long a blocked read or write waits before its budget is re-checked.
 /// Also the amount by which a transfer may overshoot.
 #[cfg(unix)]
@@ -1069,6 +1075,7 @@ impl Drop for BudgetedWriter<'_> {
 #[cfg(unix)]
 impl Write for BudgetedWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut stalls = 0u32;
         loop {
             if self.clock.expired() {
                 return Err(BudgetClock::timed_out());
@@ -1080,8 +1087,23 @@ impl Write for BudgetedWriter<'_> {
                 }
                 // The peer is not reading yet. Not a failure — the budget
                 // above decides when that has gone on too long.
+                //
+                // Yield before sleeping, and the difference is not small. A
+                // 267 MiB reply to a reader that is keeping up still fills the
+                // socket buffer ~34k times; sleeping even 100us on each costs
+                // 5.5s against 0.2s for a blocking write, and sleeping a whole
+                // poll slice would cost hours. Yielding first measures ~0.12s
+                // — at or better than blocking — because a keeping-up reader
+                // frees space within a few scheduler passes. A peer that is
+                // genuinely stalled blows through the spins in microseconds
+                // and lands on the sleep, where it belongs.
                 Err(error) if is_quiet(&error) => {
-                    std::thread::sleep(IPC_IO_POLL_SLICE);
+                    stalls += 1;
+                    if stalls <= IPC_WRITE_SPIN_LIMIT {
+                        std::thread::yield_now();
+                    } else {
+                        std::thread::sleep(IPC_IO_POLL_SLICE);
+                    }
                 }
                 Err(error) => return Err(error),
             }
@@ -2196,6 +2218,52 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Bounding writes must not cost throughput on the writes that matter.
+    ///
+    /// Polling a non-blocking socket means noticing every time the buffer
+    /// fills, which for a large reply to a reader that is keeping up happens
+    /// tens of thousands of times. Sleeping on each is ruinous — measured at
+    /// 5.5s for 267 MiB against 0.2s blocking, and hours at a full poll slice
+    /// — so the loop yields before it sleeps. The bound here is loose on
+    /// purpose: it is meant to catch that class of regression, not to police
+    /// timing on a shared machine.
+    #[cfg(unix)]
+    #[test]
+    fn a_large_reply_to_a_keeping_up_reader_is_not_slowed_by_the_budget() {
+        let (writer, mut reader) = UnixStream::pair().expect("socket pair");
+        let payload = vec![b'w'; 64 * 1024 * 1024];
+        let expected = payload.len();
+        let drain = std::thread::spawn(move || {
+            let mut buf = vec![0u8; 256 * 1024];
+            let mut total = 0usize;
+            while total < expected {
+                match std::io::Read::read(&mut reader, &mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(read) => total += read,
+                }
+            }
+            total
+        });
+
+        let mut budgeted = BudgetedWriter::new(
+            &writer,
+            IoBudget::at_least(BROKER_IPC_WRITE_TIMEOUT, MIN_IPC_RESPONSE_RATE),
+        )
+        .expect("budgeted writer");
+        let started = std::time::Instant::now();
+        budgeted.write_all(&payload).expect("large reply");
+        budgeted.flush().expect("flush");
+        let elapsed = started.elapsed();
+        drop(budgeted);
+        drop(writer);
+        assert_eq!(drain.join().expect("drain"), expected);
+
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "budgeted writes collapsed throughput: 64 MiB took {elapsed:?}"
+        );
     }
 
     /// A peer that drains a reply slowly must not be able to hold its handler

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -25,14 +25,24 @@ use std::os::unix::net::{UnixListener, UnixStream};
 /// Idle, not total, and that is forced by the legacy encoding: under framing
 /// this line is a short header, but a legacy caller sends the whole message
 /// here — and an older helper serializes *after* connecting, so it can
-/// legitimately say nothing at all for the ~7.4s a maximal image prompt takes
-/// to encode. A total budget would drop that request, breaking the very
-/// callers the legacy path exists to keep working.
+/// legitimately say nothing at all while it encodes. A total budget would drop
+/// that request, breaking the very callers the legacy path exists to serve.
 ///
-/// Shorter than `BROKER_IPC_IDLE_TIMEOUT` because it is the one bound a caller
-/// can hold without having promised anything yet; past this line a framed
-/// caller has declared a length and is held to it instead.
-const IPC_REQUEST_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+/// This is the one bound that has to be a fixed duration rather than a rate,
+/// because before a single byte arrives there is nothing to measure a rate
+/// against: a peer part-way through encoding two gigabytes and a peer that
+/// connected and died look identical. Since it cannot be derived, it is sized
+/// against what a sender can physically produce. Serialization measures
+/// ~36 MB/s, so this covers something over ten gigabytes of encoding — and the
+/// largest legacy request is an `acp/respond` carrying a whole file, which
+/// `ACPSessionRunner.serveRead` builds by holding the file, a `String` copy
+/// and the encoded JSON in memory at once. A sender that needs longer than
+/// this has already failed on its own side.
+///
+/// The cost of being generous is bounded too: a silent connection holds one
+/// worker, there are `MAX_BROKER_CONNECTION_WORKERS` of them, and the listen
+/// backlog caps how many a peer can hold at once regardless.
+const IPC_REQUEST_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Rate a peer must sustain while reading a response.
 ///

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -178,13 +178,18 @@ struct PendingOperation {
 
 /// Serializes requests per broker.
 ///
-/// These now run on worker threads rather than the helper's serve loop, which
-/// is the point — one slow broker must not hold up the others. Within a single
+/// These run on worker threads rather than the helper's serve loop, which is
+/// the point — one slow broker must not hold up the others. Within a single
 /// broker, though, concurrency is not safe: two `acp/open` calls racing would
 /// both find no live supervisor and both spawn one, and the rest mutate broker
-/// state that was written assuming one caller at a time. Holding a per-broker
-/// lock keeps exactly the ordering the single-threaded loop used to provide,
-/// while letting different brokers proceed at once.
+/// state written assuming one caller at a time.
+///
+/// Mutual exclusion only. This does **not** order anything: a mutex is not
+/// FIFO, so it says nothing about which of two waiting callers goes first.
+/// Ordering comes from the per-broker queue in `dispatch_acp_job`, which is
+/// what keeps a `session/cancel` from overtaking the `session/prompt` it was
+/// sent to stop. This lock is the backstop for any path that reaches here
+/// without going through that queue.
 fn broker_lock(broker_id: &str) -> Arc<Mutex<()>> {
     static LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
     let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -210,6 +210,9 @@ pub(crate) enum ProcNotification {
 #[derive(Debug)]
 pub(crate) enum ServerMessage {
     Request(String),
+    /// A fully-formed JSON-RPC response produced off the serve loop, waiting
+    /// to be written. See `AcpJob`.
+    Response(String),
     Watch(WatchNotification),
     Search(SearchNotification),
     Proc(ProcNotification),
@@ -335,9 +338,34 @@ fn serve() -> io::Result<()> {
                 if line.trim().is_empty() {
                     continue;
                 }
-                if let Some(response) = handle_line(&mut state, &line) {
-                    write_json_line(&mut stdout, &response)?;
+                // ACP requests talk to broker processes and wait as long as a
+                // broker takes to answer. Handling one here would put that
+                // wait in front of everything else this helper serves — every
+                // other ACP session, and every fs, watch, search and proc
+                // request — so a single slow or wedged broker would stall the
+                // whole app. Run them off this thread and let the response
+                // come back through the same channel the watchers use.
+                match AcpJob::from_line(&line) {
+                    Some(job) => match state.event_sender.clone() {
+                        Some(sender) => {
+                            std::thread::spawn(move || {
+                                let _ = sender.send(ServerMessage::Response(job.run()));
+                            });
+                        }
+                        // No channel to answer on (only reachable outside the
+                        // serve loop); fall back to answering inline.
+                        None => write_json_line(&mut stdout, &job.run())?,
+                    },
+                    None => {
+                        if let Some(response) = handle_line(&mut state, &line) {
+                            write_json_line(&mut stdout, &response)?;
+                        }
+                    }
                 }
+            }
+            Some(ServerMessage::Response(line)) => {
+                flush_due_watch_events(&mut stdout, &state, &mut pending_events, &mut flush_at)?;
+                write_json_line(&mut stdout, &line)?;
             }
             Some(ServerMessage::Watch(notification)) => {
                 pending_events
@@ -487,6 +515,39 @@ fn flush_watch_events(
         write_json_line(stdout, &notification.to_string())?;
     }
     Ok(())
+}
+
+/// An `acp/*` request lifted out of the serve loop so it can block on a
+/// broker without blocking anything else.
+///
+/// Only requests with an id qualify: a notification has nothing to send back,
+/// so there is no response to route through the channel.
+struct AcpJob {
+    id: Value,
+    method: String,
+    params: Option<Value>,
+}
+
+impl AcpJob {
+    fn from_line(line: &str) -> Option<Self> {
+        let request: JsonRpcRequest = serde_json::from_str(line).ok()?;
+        let method = request.method?;
+        if !method.starts_with("acp/") {
+            return None;
+        }
+        Some(Self {
+            id: request.id?,
+            method,
+            params: request.params,
+        })
+    }
+
+    fn run(self) -> String {
+        match acp_broker_process::handle_control_request(&self.method, self.params) {
+            Ok(result) => success_response(self.id, result),
+            Err(error) => error_response(self.id, error.code, error.message),
+        }
+    }
 }
 
 fn handle_line(state: &mut HelperState, line: &str) -> Option<String> {

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -522,6 +522,15 @@ fn flush_watch_events(
 ///
 /// Only requests with an id qualify: a notification has nothing to send back,
 /// so there is no response to route through the channel.
+///
+/// A thread per request, with no pool, is deliberate. It reads alarming next
+/// to `ACPBrokerClient`'s 50ms active poll — 20 requests a second per live
+/// session — but that loop awaits each `attachAndReplay` before sleeping
+/// again, so a session has at most one attach outstanding. Concurrency
+/// therefore tracks the number of sessions, not the poll rate, and a wedged
+/// broker parks one thread per session rather than accumulating them. What is
+/// left is churn: ~20 spawns a second per active session, tens of microseconds
+/// each. A pool would buy that back and cost a queue that could itself stall.
 struct AcpJob {
     id: Value,
     method: String,

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -574,6 +574,15 @@ impl AcpJob {
 /// the queue rather than from which worker happens to win a mutex. A job that
 /// names no broker (`acp/list`) has nothing to order against and runs on its
 /// own thread.
+///
+/// Queues are not reaped, and that is deliberate rather than overlooked.
+/// Dropping one when its broker closes would let a later `acp/open` for the
+/// same id build a fresh queue that runs ahead of the close still draining on
+/// the old one — reintroducing exactly the reordering this exists to prevent.
+/// The cost of keeping them is one thread per distinct broker seen during this
+/// helper's life, each parked on `recv` using no CPU, which is bounded by how
+/// many sessions the user opens and is strictly cheaper than the
+/// thread-per-request it replaced.
 fn dispatch_acp_job(
     job: AcpJob,
     responses: &Sender<ServerMessage>,

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -588,36 +588,69 @@ fn dispatch_acp_job(
     responses: &Sender<ServerMessage>,
     queues: &mut HashMap<String, Sender<AcpJob>>,
 ) {
+    // Every spawn below goes through `Builder`, never `thread::spawn`, which
+    // panics when threads run out. A panic here is raised on the serve loop
+    // and takes the helper down — every session, and every fs, watch and
+    // search caller with it. Answering one request with an error is the
+    // smaller failure by a wide margin.
+    fn answer_off_thread(job: AcpJob, responses: &Sender<ServerMessage>) {
+        // Kept back so the caller can still be answered if no thread is
+        // available: a failed spawn drops the closure, and the job with it.
+        let id = job.id.clone();
+        let worker_responses = responses.clone();
+        if std::thread::Builder::new()
+            .spawn(move || {
+                let _ = worker_responses.send(ServerMessage::Response(job.run()));
+            })
+            .is_err()
+        {
+            let _ = responses.send(ServerMessage::Response(error_response(
+                id,
+                -32000,
+                "helper could not start a worker for this request",
+            )));
+        }
+    }
+
     let Some(broker_id) = job.broker_id() else {
-        let responses = responses.clone();
-        std::thread::spawn(move || {
-            let _ = responses.send(ServerMessage::Response(job.run()));
-        });
+        answer_off_thread(job, responses);
         return;
     };
 
-    let queue = queues.entry(broker_id.clone()).or_insert_with(|| {
-        let (sender, receiver) = mpsc::channel::<AcpJob>();
-        let responses = responses.clone();
-        std::thread::spawn(move || {
-            for job in receiver {
-                if responses.send(ServerMessage::Response(job.run())).is_err() {
-                    return;
-                }
+    let queue = match queues.entry(broker_id.clone()) {
+        std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            let (sender, receiver) = mpsc::channel::<AcpJob>();
+            let worker_responses = responses.clone();
+            if std::thread::Builder::new()
+                .spawn(move || {
+                    for job in receiver {
+                        if worker_responses
+                            .send(ServerMessage::Response(job.run()))
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                })
+                .is_err()
+            {
+                // No queue means no ordering guarantee, but refusing to answer
+                // is worse: the caller would wait forever on a reply that is
+                // never coming.
+                answer_off_thread(job, responses);
+                return;
             }
-        });
-        sender
-    });
+            entry.insert(sender)
+        }
+    };
 
     // A queue only fails if its thread is gone, which it should not be. Drop
-    // the entry and answer on a fresh thread rather than losing the request:
+    // the entry and answer separately rather than losing the request:
     // ordering is worth less than a reply.
     if let Err(returned) = queue.send(job) {
         queues.remove(&broker_id);
-        let responses = responses.clone();
-        std::thread::spawn(move || {
-            let _ = responses.send(ServerMessage::Response(returned.0.run()));
-        });
+        answer_off_thread(returned.0, responses);
     }
 }
 

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -315,6 +315,9 @@ fn serve() -> io::Result<()> {
     };
     let mut pending_events: HashMap<(String, WatchKind), HashSet<String>> = HashMap::new();
     let mut flush_at: Option<Instant> = None;
+    // One queue per broker, fed in the order requests arrive here. See
+    // `dispatch_acp_job`.
+    let mut acp_queues: HashMap<String, Sender<AcpJob>> = HashMap::new();
 
     loop {
         let message = match flush_at {
@@ -347,11 +350,7 @@ fn serve() -> io::Result<()> {
                 // come back through the same channel the watchers use.
                 match AcpJob::from_line(&line) {
                     Some(job) => match state.event_sender.clone() {
-                        Some(sender) => {
-                            std::thread::spawn(move || {
-                                let _ = sender.send(ServerMessage::Response(job.run()));
-                            });
-                        }
+                        Some(sender) => dispatch_acp_job(job, &sender, &mut acp_queues),
                         // No channel to answer on (only reachable outside the
                         // serve loop); fall back to answering inline.
                         None => write_json_line(&mut stdout, &job.run())?,
@@ -523,14 +522,13 @@ fn flush_watch_events(
 /// Only requests with an id qualify: a notification has nothing to send back,
 /// so there is no response to route through the channel.
 ///
-/// A thread per request, with no pool, is deliberate. It reads alarming next
-/// to `ACPBrokerClient`'s 50ms active poll — 20 requests a second per live
-/// session — but that loop awaits each `attachAndReplay` before sleeping
-/// again, so a session has at most one attach outstanding. Concurrency
-/// therefore tracks the number of sessions, not the poll rate, and a wedged
-/// broker parks one thread per session rather than accumulating them. What is
-/// left is churn: ~20 spawns a second per active session, tens of microseconds
-/// each. A pool would buy that back and cost a queue that could itself stall.
+/// Jobs naming a broker go to that broker's queue, and are run by one thread
+/// in the order they arrived. Mutual exclusion is not enough on its own: a
+/// mutex does not hand out the lock in arrival order, so two jobs racing for
+/// it can be applied backwards. `session/cancel` overtaking the
+/// `session/prompt` it was meant to stop is the case that matters — the
+/// cancel finds no turn to cancel, and the prompt then runs to completion
+/// with the user believing they stopped it.
 struct AcpJob {
     id: Value,
     method: String,
@@ -538,6 +536,16 @@ struct AcpJob {
 }
 
 impl AcpJob {
+    /// The broker this job acts on, if it names one. `acp/list` does not: it
+    /// sweeps every broker and only reads, so it has no queue to join.
+    fn broker_id(&self) -> Option<String> {
+        self.params
+            .as_ref()
+            .and_then(|params| params.get("brokerId"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    }
+
     fn from_line(line: &str) -> Option<Self> {
         let request: JsonRpcRequest = serde_json::from_str(line).ok()?;
         let method = request.method?;
@@ -556,6 +564,51 @@ impl AcpJob {
             Ok(result) => success_response(self.id, result),
             Err(error) => error_response(self.id, error.code, error.message),
         }
+    }
+}
+
+/// Routes an ACP job so that same-broker work stays in arrival order while
+/// different brokers proceed independently.
+///
+/// Each broker gets a queue and one thread draining it, so ordering comes from
+/// the queue rather than from which worker happens to win a mutex. A job that
+/// names no broker (`acp/list`) has nothing to order against and runs on its
+/// own thread.
+fn dispatch_acp_job(
+    job: AcpJob,
+    responses: &Sender<ServerMessage>,
+    queues: &mut HashMap<String, Sender<AcpJob>>,
+) {
+    let Some(broker_id) = job.broker_id() else {
+        let responses = responses.clone();
+        std::thread::spawn(move || {
+            let _ = responses.send(ServerMessage::Response(job.run()));
+        });
+        return;
+    };
+
+    let queue = queues.entry(broker_id.clone()).or_insert_with(|| {
+        let (sender, receiver) = mpsc::channel::<AcpJob>();
+        let responses = responses.clone();
+        std::thread::spawn(move || {
+            for job in receiver {
+                if responses.send(ServerMessage::Response(job.run())).is_err() {
+                    return;
+                }
+            }
+        });
+        sender
+    });
+
+    // A queue only fails if its thread is gone, which it should not be. Drop
+    // the entry and answer on a fresh thread rather than losing the request:
+    // ordering is worth less than a reply.
+    if let Err(returned) = queue.send(job) {
+        queues.remove(&broker_id);
+        let responses = responses.clone();
+        std::thread::spawn(move || {
+            let _ = responses.send(ServerMessage::Response(returned.0.run()));
+        });
     }
 }
 

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -76,6 +76,24 @@ impl Helper {
         serde_json::from_str(&line).expect("helper response JSON")
     }
 
+    /// Like `raw_request`, but skips past responses to other requests instead
+    /// of assuming the next line is ours. `acp/*` requests are answered on
+    /// worker threads now, so a later request can legitimately finish first.
+    fn raw_request_matching(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.write_request_without_reading(method, params);
+        loop {
+            let mut line = String::new();
+            self.stdout
+                .read_line(&mut line)
+                .expect("read helper response");
+            let value: Value = serde_json::from_str(&line).expect("helper response JSON");
+            if value["id"] == json!(id) {
+                return value;
+            }
+        }
+    }
+
     fn write_request_without_reading(&mut self, method: &str, params: Value) {
         let id = self.next_id;
         self.next_id += 1;
@@ -1017,6 +1035,166 @@ fn attached_has_pending_request(attached: &Value) -> bool {
 }
 
 /// A client that connects to a broker's socket and then goes quiet — killed
+/// Sends a raw request straight to a broker socket, bypassing the helper, and
+/// returns the reply plus whether it came back framed. `framed` picks the
+/// request encoding, so the same broker can be driven both ways — and the
+/// caller can assert the reply mirrored it rather than silently downgrading.
+#[cfg(unix)]
+fn broker_roundtrip(socket: &Path, request: &str, framed: bool) -> (String, bool) {
+    use std::os::unix::net::UnixStream;
+
+    let mut stream = UnixStream::connect(socket).expect("broker socket connects");
+    if framed {
+        write!(stream, "ALASIPC1 {}\n{}", request.len(), request).expect("framed request");
+    } else {
+        writeln!(stream, "{request}").expect("legacy request");
+    }
+    stream.flush().expect("flush request");
+
+    let mut reader = BufReader::new(&stream);
+    let mut head = String::new();
+    reader.read_line(&mut head).expect("reply head");
+    match head.strip_prefix("ALASIPC1 ") {
+        Some(len) => {
+            let len: usize = len.trim().parse().expect("frame length");
+            let mut body = vec![0u8; len];
+            std::io::Read::read_exact(&mut reader, &mut body).expect("framed reply body");
+            (String::from_utf8(body).expect("reply utf8"), true)
+        }
+        None => (head, false),
+    }
+}
+
+/// A broker built after framing landed must still understand a caller that
+/// does not use it. This is not hypothetical: a helper from an earlier build
+/// can be the one talking to it, and it only knows the newline encoding.
+#[cfg(unix)]
+#[test]
+fn a_broker_answers_a_legacy_caller_in_the_legacy_encoding() {
+    let fixture = Fixture::new("legacy-caller");
+    let mut helper = Helper::start(&fixture.home);
+    helper.request("acp/open", fixture.open_params("broker-legacy-in", 0));
+    let socket = fixture
+        .home
+        .join(".alas/acp-brokers/broker-legacy-in/broker.sock");
+
+    let (reply, reply_framed) =
+        broker_roundtrip(&socket, r#"{"method":"snapshot","params":{}}"#, false);
+
+    assert!(
+        !reply_framed,
+        "a legacy caller must not be answered with a framed reply it cannot parse"
+    );
+    let value: Value = serde_json::from_str(reply.trim()).expect("legacy reply JSON");
+    assert_eq!(value["ok"], true);
+    assert_eq!(
+        value["result"]["metadata"]["brokerId"], "broker-legacy-in",
+        "legacy caller did not get a usable snapshot: {value}"
+    );
+}
+
+/// The point of framing: the reader is told the length up front, so a request
+/// carries whatever it carries. An `acp/respond` returning a whole file has no
+/// size the caller could have predicted, and under the newline encoding the
+/// only bound available was a total time budget standing in for a size cap.
+#[cfg(unix)]
+#[test]
+fn a_framed_request_carries_a_payload_far_past_any_line_budget() {
+    let fixture = Fixture::new("framed-payload");
+    let mut helper = Helper::start(&fixture.home);
+    helper.request("acp/open", fixture.open_params("broker-framed", 0));
+    let socket = fixture
+        .home
+        .join(".alas/acp-brokers/broker-framed/broker.sock");
+
+    // `snapshot` ignores its params, so this exercises the framed read path
+    // with a large body without involving the adapter.
+    let filler = "x".repeat(40 * 1024 * 1024);
+    let request = json!({"method": "snapshot", "params": {"filler": filler}}).to_string();
+    assert!(request.len() > 40 * 1024 * 1024);
+
+    let (reply, reply_framed) = broker_roundtrip(&socket, &request, true);
+
+    assert!(reply_framed, "a framed request should be answered framed");
+    let value: Value = serde_json::from_str(&reply).expect("framed reply JSON");
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["result"]["metadata"]["brokerId"], "broker-framed");
+}
+
+/// The mirror case: a helper built after framing landed can adopt a broker
+/// that a previous build started, which advertises nothing and speaks only the
+/// newline encoding. Removing the marker stands in for that broker.
+#[test]
+fn the_helper_falls_back_to_the_legacy_encoding_for_an_older_broker() {
+    let fixture = Fixture::new("legacy-broker");
+    let mut helper = Helper::start(&fixture.home);
+    let opened = helper.request("acp/open", fixture.open_params("broker-legacy-out", 0));
+    assert_eq!(opened["adopted"], false);
+
+    let marker = fixture
+        .home
+        .join(".alas/acp-brokers/broker-legacy-out/framing");
+    assert!(marker.exists(), "a fresh broker should advertise framing");
+    std::fs::remove_file(&marker).expect("remove framing marker");
+
+    let adopted = helper.request("acp/open", fixture.open_params("broker-legacy-out", 0));
+    assert_eq!(
+        adopted["adopted"], true,
+        "helper could not talk to a broker that does not advertise framing: {adopted}"
+    );
+}
+
+/// One broker going quiet must not stop a different one being used. Every
+/// `acp/*` request used to be handled inline on the helper's single serve
+/// loop, so a call waiting on a wedged broker held up every other session
+/// behind it — the reason a single bad broker could take the whole app down
+/// rather than one chat.
+#[cfg(unix)]
+#[test]
+fn a_wedged_broker_does_not_block_a_different_broker() {
+    use std::os::unix::net::UnixStream;
+    use std::sync::mpsc;
+
+    let fixture = Fixture::new("independent-brokers");
+    let mut helper = Helper::start(&fixture.home);
+    helper.request("acp/open", fixture.open_params("broker-wedged", 0));
+    let healthy = helper.request("acp/open", fixture.open_params("broker-healthy", 0));
+    assert_eq!(healthy["adopted"], false);
+
+    // Hold the first broker's accept loop with clients that never complete a
+    // request line. Each costs the broker one request-read timeout, so enough
+    // of them keep it unavailable for far longer than this test waits — a
+    // single one would lapse and let the broker recover, and the test would
+    // then pass whether or not dispatch is concurrent.
+    let socket = fixture
+        .home
+        .join(".alas/acp-brokers/broker-wedged/broker.sock");
+    let silent: Vec<UnixStream> = (0..10)
+        .map(|_| UnixStream::connect(&socket).expect("silent client connects"))
+        .collect();
+
+    let (sender, receiver) = mpsc::channel();
+    let wedged_params = fixture.open_params("broker-wedged", 0);
+    let healthy_params = fixture.open_params("broker-healthy", 0);
+    std::thread::spawn(move || {
+        // Issued first, and expected to be the slow one.
+        helper.write_request_without_reading("acp/open", wedged_params);
+        // The interesting call: a different broker, behind the slow one in
+        // arrival order, which must not have to wait for it.
+        let adopted = helper.raw_request_matching("acp/open", healthy_params);
+        let _ = sender.send(adopted);
+    });
+
+    let adopted = receiver
+        .recv_timeout(Duration::from_secs(20))
+        .expect("a healthy broker must be usable while another is wedged");
+    drop(silent);
+    assert_eq!(
+        adopted["result"]["adopted"], true,
+        "healthy broker did not answer while another was wedged: {adopted}"
+    );
+}
+
 /// A socket read timeout is an *inactivity* timeout on each underlying read,
 /// and `read_line` keeps issuing reads until it sees a newline. So a client
 /// that dribbles a byte at a time, faster than the timeout but never ending

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -7,6 +7,18 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 static NEXT_FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
 
+/// Budget for the polling helpers below. These waits used to be bounded by
+/// iteration count, which measures round trips rather than time: the suite
+/// runs its integration tests in parallel, each driving its own helper,
+/// broker and adapter processes, so on a loaded machine a healthy-but-slow
+/// broker could exhaust the count and fail the test. A wall-clock budget
+/// still catches a genuinely stuck broker, without failing a slow one.
+const POLL_BUDGET: Duration = Duration::from_secs(20);
+
+fn poll_deadline() -> std::time::Instant {
+    std::time::Instant::now() + POLL_BUDGET
+}
+
 struct Helper {
     child: Child,
     stdin: ChildStdin,
@@ -368,7 +380,8 @@ fn load_updates_do_not_mark_turn_as_streaming() {
     let generation = open["snapshot"]["metadata"]["generation"].clone();
 
     let mut loaded = Value::Null;
-    for _ in 0..20 {
+    let deadline = poll_deadline();
+    while std::time::Instant::now() < deadline {
         let result = send(
             &mut helper,
             "broker-load-update",
@@ -864,7 +877,8 @@ fn drive_until_operation_completed(
     operation_key: &str,
     params: Value,
 ) -> Value {
-    for _ in 0..60 {
+    let deadline = poll_deadline();
+    while std::time::Instant::now() < deadline {
         let result = send(
             helper,
             broker_id,
@@ -891,7 +905,8 @@ fn drive_until_pending_request(
 ) -> Value {
     let mut acknowledged_cursor = 0;
     let mut last_attached = Value::Null;
-    for _ in 0..60 {
+    let deadline = poll_deadline();
+    while std::time::Instant::now() < deadline {
         let progress = send(
             helper,
             broker_id,
@@ -940,7 +955,8 @@ fn wait_for_pending_request_visible(
     request_id: Value,
 ) -> Value {
     let mut last_attached = Value::Null;
-    for _ in 0..60 {
+    let deadline = poll_deadline();
+    while std::time::Instant::now() < deadline {
         last_attached = helper.request(
             "acp/attach",
             json!({
@@ -971,7 +987,8 @@ fn drive_until_prompt_completed(
     operation_key: &str,
     params: Value,
 ) -> Value {
-    for _ in 0..20 {
+    let deadline = poll_deadline();
+    while std::time::Instant::now() < deadline {
         let result = send(
             helper,
             broker_id,
@@ -997,6 +1014,71 @@ fn attached_has_pending_request(attached: &Value) -> bool {
     }) || attached["snapshot"]["pendingRequests"]
         .as_array()
         .is_some_and(|requests| !requests.is_empty())
+}
+
+/// A client that connects to a broker's socket and then goes quiet — killed
+/// between `connect()` and `write()`, or just slow — used to stall the
+/// supervisor's accept loop forever, because the request line is read on that
+/// thread with no timeout. The helper then blocked forever too: it talks to
+/// brokers over the same unbounded socket, inline on its single-threaded serve
+/// loop, so every other ACP session (and every file, watch and search request)
+/// died with it. Both reads are bounded now, so one silent client costs a
+/// bounded stall and the broker recovers on its own.
+#[cfg(unix)]
+#[test]
+fn a_silent_client_on_the_broker_socket_does_not_wedge_the_helper() {
+    use std::os::unix::net::UnixStream;
+    use std::sync::mpsc;
+
+    let fixture = Fixture::new("silent-ipc-client");
+    let mut helper = Helper::start(&fixture.home);
+    let opened = helper.request("acp/open", fixture.open_params("broker-silent", 0));
+    assert_eq!(opened["adopted"], false);
+
+    let socket = fixture
+        .home
+        .join(".alas/acp-brokers/broker-silent/broker.sock");
+    let silent = UnixStream::connect(&socket).expect("silent client connects");
+
+    let (sender, receiver) = mpsc::channel();
+    let params = fixture.open_params("broker-silent", 0);
+    let probe = std::thread::spawn(move || {
+        // Whatever this answers, it must answer: an error is a recoverable
+        // outcome the UI can surface and retry, a hang is not.
+        let contested = helper.raw_request("acp/open", params.clone());
+        // The decisive check. `ping` never touches a broker, so if it stops
+        // being served, one bad broker has taken the whole helper down.
+        let ping = helper.request("ping", json!({}));
+        let _ = sender.send((contested, ping));
+        // Once the broker times out the silent reader it accepts again, with
+        // no restart and no intervention. Poll for that rather than sleeping
+        // out the timeout, so this test costs only as long as recovery
+        // actually takes.
+        let deadline = poll_deadline();
+        loop {
+            let attempt = helper.raw_request("acp/open", params.clone());
+            if attempt["result"]["adopted"] == true || std::time::Instant::now() >= deadline {
+                return attempt;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    });
+
+    let (contested, ping) = receiver
+        .recv_timeout(Duration::from_secs(30))
+        .expect("helper keeps answering while a silent client holds the broker socket");
+    assert!(
+        contested.get("result").is_some() || contested.get("error").is_some(),
+        "contested acp/open produced neither result nor error: {contested}"
+    );
+    assert_eq!(ping["ok"], true);
+
+    let recovered = probe.join().expect("probe thread");
+    assert_eq!(
+        recovered["result"]["adopted"], true,
+        "broker did not recover after the silent client timed out: {recovered}"
+    );
+    drop(silent);
 }
 
 struct Fixture {
@@ -1044,7 +1126,7 @@ impl Fixture {
     }
 
     fn wait_for_log(&self, needle: &str) {
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let deadline = poll_deadline();
         while std::time::Instant::now() < deadline {
             if std::fs::read_to_string(&self.log)
                 .map(|log| log.contains(needle))

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -1103,6 +1103,51 @@ fn a_broker_answers_a_legacy_caller_in_the_legacy_encoding() {
     );
 }
 
+/// A broker must outlive a peer that opens connections faster than they
+/// retire. Every accepted socket owns a thread that can sit for the whole head
+/// timeout, so spawning one per connection without a ceiling exhausts threads
+/// until `spawn` panics and takes the supervisor down — and with it every
+/// session using that broker.
+///
+/// Note what is asserted and what is not. While the connections are held the
+/// broker can legitimately be starved: one that has sent nothing is
+/// indistinguishable from an older helper still encoding its request. The
+/// property that matters is that the stall is survivable and self-healing, not
+/// that service continues throughout.
+#[cfg(unix)]
+#[test]
+fn a_flood_of_idle_connections_does_not_take_the_broker_down() {
+    use std::os::unix::net::UnixStream;
+
+    let fixture = Fixture::new("connection-flood");
+    let mut helper = Helper::start(&fixture.home);
+    helper.request("acp/open", fixture.open_params("broker-flood", 0));
+    let socket = fixture
+        .home
+        .join(".alas/acp-brokers/broker-flood/broker.sock");
+
+    // The listen backlog refuses connections past ~128, so this saturates
+    // what a peer can hold at once rather than reaching 400.
+    let flood: Vec<UnixStream> = (0..400)
+        .filter_map(|_| UnixStream::connect(&socket).ok())
+        .collect();
+    assert!(
+        flood.len() >= 100,
+        "expected to saturate the broker with connections, got {}",
+        flood.len()
+    );
+    drop(flood);
+
+    // Closing them frees the workers immediately — each read ends on EOF
+    // rather than waiting out its budget — so the broker should serve again
+    // without needing to be restarted.
+    let adopted = helper.request("acp/open", fixture.open_params("broker-flood", 0));
+    assert_eq!(
+        adopted["adopted"], true,
+        "broker did not recover after a flood of connections: {adopted}"
+    );
+}
+
 /// A helper from an earlier build serializes its request *after* connecting,
 /// so it can legitimately say nothing for as long as encoding takes — ~7.4s
 /// for a maximal image prompt. A broker that bounded the first line by total

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -1017,6 +1017,74 @@ fn attached_has_pending_request(attached: &Value) -> bool {
 }
 
 /// A client that connects to a broker's socket and then goes quiet — killed
+/// A socket read timeout is an *inactivity* timeout on each underlying read,
+/// and `read_line` keeps issuing reads until it sees a newline. So a client
+/// that dribbles a byte at a time, faster than the timeout but never ending
+/// the line, renews its budget forever and holds the accept thread just as
+/// effectively as one that sends nothing — while growing the line buffer
+/// without limit. Only a deadline across the whole line catches this.
+#[cfg(unix)]
+#[test]
+fn a_client_dripping_bytes_cannot_renew_the_request_read_forever() {
+    use std::io::Write as _;
+    use std::os::unix::net::UnixStream;
+    use std::sync::mpsc;
+
+    let fixture = Fixture::new("dripping-ipc-client");
+    let mut helper = Helper::start(&fixture.home);
+    let opened = helper.request("acp/open", fixture.open_params("broker-drip", 0));
+    assert_eq!(opened["adopted"], false);
+
+    let socket = fixture
+        .home
+        .join(".alas/acp-brokers/broker-drip/broker.sock");
+    let mut drip = UnixStream::connect(&socket).expect("dripping client connects");
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let dripper_stop = stop.clone();
+    let dripper = std::thread::spawn(move || {
+        // Never a newline: valid JSON padding, one byte at a time, well
+        // inside any per-read inactivity window.
+        while !dripper_stop.load(Ordering::Relaxed) {
+            if drip.write_all(b" ").is_err() || drip.flush().is_err() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+    });
+
+    // The helper survives either way — its own socket reads are bounded, so
+    // it answers with an error rather than hanging. What is at stake here is
+    // the broker: its accept loop is stuck mid-line, so until that read is
+    // bounded in total it never serves anyone again and this session is
+    // permanently dead. Recovery must happen while the client is STILL
+    // dripping, which is what a per-read timeout can never deliver.
+    let (sender, receiver) = mpsc::channel();
+    let params = fixture.open_params("broker-drip", 0);
+    std::thread::spawn(move || {
+        let deadline = poll_deadline();
+        loop {
+            let attempt = helper.raw_request("acp/open", params.clone());
+            if attempt["result"]["adopted"] == true || std::time::Instant::now() >= deadline {
+                let ping = helper.request("ping", json!({}));
+                let _ = sender.send((attempt, ping));
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(250));
+        }
+    });
+
+    let result = receiver.recv_timeout(Duration::from_secs(60));
+    stop.store(true, Ordering::Relaxed);
+    let _ = dripper.join();
+
+    let (recovered, ping) = result.expect("probe finished");
+    assert_eq!(
+        recovered["result"]["adopted"], true,
+        "broker never accepted again while a client dripped bytes without a newline: {recovered}"
+    );
+    assert_eq!(ping["ok"], true);
+}
+
 /// between `connect()` and `write()`, or just slow — used to stall the
 /// supervisor's accept loop forever, because the request line is read on that
 /// thread with no timeout. The helper then blocked forever too: it talks to

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -1114,7 +1114,13 @@ fn a_broker_answers_a_legacy_caller_in_the_legacy_encoding() {
 /// indistinguishable from an older helper still encoding its request. The
 /// property that matters is that the stall is survivable and self-healing, not
 /// that service continues throughout.
-#[cfg(unix)]
+///
+/// Darwin-only, for the same reason as
+/// `connect_does_not_block_on_a_full_backlog`: saturating the listen backlog
+/// is how this test bounds itself, and that only returns an error here. On
+/// Linux the connects would block instead, and the loop would sit for a head
+/// timeout rather than reaching `drop`.
+#[cfg(target_os = "macos")]
 #[test]
 fn a_flood_of_idle_connections_does_not_take_the_broker_down() {
     use std::os::unix::net::UnixStream;

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -1246,6 +1246,70 @@ fn the_helper_falls_back_to_the_legacy_encoding_for_an_older_broker() {
     );
 }
 
+/// Requests to one broker must reach it in the order they were sent.
+///
+/// Running them on independent threads and relying on a mutex for safety is
+/// not enough: a mutex is not FIFO, so whichever worker the scheduler favours
+/// goes first. The case that bites is `session/cancel` overtaking the
+/// `session/prompt` it was sent to stop — the cancel finds no turn to cancel,
+/// and the prompt then runs to completion while the user believes they
+/// stopped it.
+///
+/// The broker's journal records the order it actually processed things, so
+/// `operationStarted` cursors are the observable.
+#[test]
+fn requests_to_one_broker_are_processed_in_the_order_they_arrive() {
+    let fixture = Fixture::new("request-ordering");
+    let mut helper = Helper::start(&fixture.home);
+    let open = helper.request("acp/open", fixture.open_params("broker-ordering", 0));
+    let generation = open["snapshot"]["metadata"]["generation"].clone();
+
+    // Enough that a scheduler-dependent order would almost certainly invert
+    // somewhere, and issued back-to-back so they are genuinely in flight
+    // together rather than serialized by waiting for each reply.
+    let sent: Vec<String> = (0..24).map(|index| format!("op-{index:02}")).collect();
+    for key in &sent {
+        helper.write_request_without_reading(
+            "acp/send",
+            json!({
+                "brokerId": "broker-ordering",
+                "generation": generation,
+                "operationKey": key,
+                "method": "noop/order",
+                "params": {}
+            }),
+        );
+    }
+    for _ in &sent {
+        let mut line = String::new();
+        helper
+            .stdout
+            .read_line(&mut line)
+            .expect("read helper response");
+    }
+
+    let attached = helper.request(
+        "acp/attach",
+        json!({
+            "brokerId": "broker-ordering",
+            "generation": generation,
+            "acknowledgedCursor": 0
+        }),
+    );
+    let started: Vec<String> = attached["events"]
+        .as_array()
+        .expect("events")
+        .iter()
+        .filter(|event| event["kind"]["type"] == "operationStarted")
+        .map(|event| event["kind"]["operationKey"].as_str().unwrap().to_string())
+        .collect();
+
+    assert_eq!(
+        started, sent,
+        "broker processed same-broker requests out of order"
+    );
+}
+
 /// One broker going quiet must not stop a different one being used. Every
 /// `acp/*` request used to be handled inline on the helper's single serve
 /// loop, so a call waiting on a wedged broker held up every other session

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -387,7 +387,17 @@ fn attach_with_stale_persisted_cursor_does_not_move_ack_back() {
         stale_attach["snapshot"]["acknowledgedCursor"],
         json!(journal_tail)
     );
-    assert_eq!(stale_attach["events"], json!([]), "{stale_attach}");
+    // The property is that a stale cursor cannot resurrect acknowledged
+    // events — not that the journal is quiet. Asserting an empty list assumed
+    // nothing was recorded between reading `journal_tail` and acknowledging
+    // it, which is a race the test does not control and does not care about.
+    let events = stale_attach["events"].as_array().expect("events array");
+    assert!(
+        events
+            .iter()
+            .all(|event| event["cursor"].as_u64().is_some_and(|c| c > journal_tail)),
+        "a stale cursor replayed events at or below the acknowledged tail: {stale_attach}"
+    );
 }
 
 #[test]
@@ -1090,6 +1100,40 @@ fn a_broker_answers_a_legacy_caller_in_the_legacy_encoding() {
     assert_eq!(
         value["result"]["metadata"]["brokerId"], "broker-legacy-in",
         "legacy caller did not get a usable snapshot: {value}"
+    );
+}
+
+/// A helper from an earlier build serializes its request *after* connecting,
+/// so it can legitimately say nothing for as long as encoding takes — ~7.4s
+/// for a maximal image prompt. A broker that bounded the first line by total
+/// time would drop that request, breaking exactly the callers the legacy path
+/// exists to support.
+#[cfg(unix)]
+#[test]
+fn a_legacy_caller_may_pause_before_writing_its_request() {
+    use std::os::unix::net::UnixStream;
+
+    let fixture = Fixture::new("legacy-slow-writer");
+    let mut helper = Helper::start(&fixture.home);
+    helper.request("acp/open", fixture.open_params("broker-slow-writer", 0));
+    let socket = fixture
+        .home
+        .join(".alas/acp-brokers/broker-slow-writer/broker.sock");
+
+    let mut stream = UnixStream::connect(&socket).expect("broker socket connects");
+    // Stands in for an older helper encoding a large prompt before it writes.
+    std::thread::sleep(Duration::from_secs(8));
+    writeln!(stream, r#"{{"method":"snapshot","params":{{}}}}"#).expect("legacy request");
+    stream.flush().expect("flush");
+
+    let mut reply = String::new();
+    BufReader::new(&stream)
+        .read_line(&mut reply)
+        .expect("broker still answered after the pause");
+    let value: Value = serde_json::from_str(reply.trim()).expect("legacy reply JSON");
+    assert_eq!(
+        value["result"]["metadata"]["brokerId"], "broker-slow-writer",
+        "broker dropped a legacy request whose sender paused to serialize: {value}"
     );
 }
 

--- a/AlasHelper/tests/acp_broker_crash_recovery.rs
+++ b/AlasHelper/tests/acp_broker_crash_recovery.rs
@@ -1159,8 +1159,15 @@ fn a_framed_request_carries_a_payload_far_past_any_line_budget() {
 
     let (reply, reply_framed) = broker_roundtrip(&socket, &request, true);
 
-    assert!(reply_framed, "a framed request should be answered framed");
-    let value: Value = serde_json::from_str(&reply).expect("framed reply JSON");
+    // Replies are never framed, whichever encoding the request used: framing
+    // buys nothing on a path the caller reads against an idle budget, and it
+    // would force the whole reply — including every unanswered request's
+    // payload — to be built in memory before a byte could be written.
+    assert!(
+        !reply_framed,
+        "replies should stream, not be framed, so a large one needs no buffering"
+    );
+    let value: Value = serde_json::from_str(reply.trim()).expect("reply JSON");
     assert_eq!(value["ok"], true);
     assert_eq!(value["result"]["metadata"]["brokerId"], "broker-framed");
 }

--- a/AlasHelper/tests/acp_broker_protocol.rs
+++ b/AlasHelper/tests/acp_broker_protocol.rs
@@ -440,6 +440,45 @@ fn duplicate_pending_request_ids_are_rejected() {
     );
 }
 
+/// A broker outlives the app build that started it, so a client from an
+/// earlier build can adopt this one — and that client's decoder requires
+/// `params` to be present on both wire shapes. The value is deliberately
+/// null (the real params are hundreds of megabytes and nothing reads them),
+/// but the key has to stay, or such a client cannot adopt or even close the
+/// broker. Tidying the null away would be silently breaking.
+#[test]
+fn operation_params_stay_on_the_wire_as_a_null_placeholder() {
+    let mut broker = broker();
+    broker
+        .begin_operation(
+            OperationKey::new("prompt-1"),
+            "session/prompt".to_string(),
+            json!({"prompt": "hello"}),
+        )
+        .unwrap();
+
+    let snapshot = serde_json::to_value(broker.snapshot()).unwrap();
+    let operation = &snapshot["operations"][0];
+    assert!(
+        operation.get("params").is_some(),
+        "snapshot operation dropped the params key: {operation}"
+    );
+    assert_eq!(operation["params"], Value::Null);
+
+    let events = serde_json::to_value(broker.replay_after(EventCursor::new(0)).unwrap()).unwrap();
+    let started = events
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|event| event["kind"]["type"] == "operationStarted")
+        .expect("operationStarted event");
+    assert!(
+        started["kind"].get("params").is_some(),
+        "operationStarted dropped the params key: {started}"
+    );
+    assert_eq!(started["kind"]["params"], Value::Null);
+}
+
 #[test]
 fn snapshot_round_trip_excludes_secret_environment_values() {
     let mut broker = broker();

--- a/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
+++ b/AlasTests/ACP/Broker/ACPBrokerClientTests.swift
@@ -708,7 +708,6 @@ struct ACPBrokerClientTests {
                     operationKey: ACPBrokerOperationKey(rawValue: "queued-prompt:item:0:session/prompt"),
                     adapterRequestId: ACPBrokerAdapterRequestID(rawValue: 7),
                     method: "session/prompt",
-                    params: .object(["prompt": .string("hi")]),
                     terminalOutcome: nil
                 )
             ]

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -1261,9 +1261,6 @@ private actor ForkRelaunchBrokerService: ACPBrokerServicing {
                     operationKey: Self.forkOperationKey,
                     adapterRequestId: ACPBrokerAdapterRequestID(rawValue: 1),
                     method: "session/fork",
-                    params: .object([
-                        "sessionId": .string("source-remote")
-                    ]),
                     terminalOutcome: forkOutcome
                 )
             ]
@@ -1558,7 +1555,6 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
                     operationKey: operationKey,
                     adapterRequestId: ACPBrokerAdapterRequestID(rawValue: event.cursor.rawValue),
                     method: sentOperationKeys.first == operationKey ? "session/fork" : "unknown",
-                    params: .object([:]),
                     terminalOutcome: outcome
                 )
             }


### PR DESCRIPTION
## Problem

ACP chats could get stuck on **"Launching adapter"** forever — no error, no timeout, no recovery. Restarting the app was the only way out.

## Root cause

Three unbounded blocking reads chain together:

1. **Broker supervisor** (`serve_broker_ipc`) reads a client's request line **on the accept-loop thread** with no read timeout. A client that connects and never delivers a complete line stops the broker from ever accepting another connection.
2. **`send_ipc`** sets no socket timeouts, so the helper's call into that broker blocks forever.
3. **The helper's `serve()` loop is single-threaded** and dispatches every `acp/*` request inline, so that one blocked call takes down `fs`, `watch`, `search`, `proc` and **every other ACP session** with it — even `ping` stops answering.

`send_ipc_with_retry`'s `Duration::from_secs(2)` looks like a timeout but only bounds the gaps *between failed attempts*. A blocked read never returns the error the deadline is checked on, so the deadline was never evaluated.

On the Swift side there is nothing to catch this: `RemoteHelperClient.request` awaits a continuation with no timeout, and it is only failed on transport *exit*. A helper that is alive but wedged waits forever — which is exactly the "Launching adapter" symptom.

## Reproduction

Connect to a live `broker.sock` and send nothing. Before this change:

```
+   31ms acp/open -> adopted:true          # healthy
+   32ms silent client connects, sends nothing
+  334ms acp/open ...
+10334ms HANG: acp/open no response in 10000ms
+15336ms HANG: ping no response in 5000ms
         ==> ENTIRE HELPER IS WEDGED
```

After: the helper answers in ~2.5s with a real error, and the broker recovers on its own once the silent reader times out.

## Fix

- Bound the request-line read on the broker's accept thread (`IPC_REQUEST_TIMEOUT`, 5s) with a deadline covering the **whole line**, not each read. A socket read timeout is only an inactivity timeout, and `read_line` keeps issuing fresh reads until it sees a newline — so a peer trickling bytes below the timeout renews its budget forever. `read_line_within` re-arms the timeout from the remaining budget before each read, and caps **request** lines so the buffer cannot grow without limit either. The cap is 512 MiB, set above what the composer legitimately produces: `ACPComposer.maxImagesPerMessage` (10) images of `ACPImageStaging.maxBytes` (20 MiB), embedded as base64 in `session/prompt`, is ~267 MiB on the wire. A unit test derives that worst case from those two constants and fails if they ever outgrow the cap.
- Deliberately **no** length cap on responses read back from a broker. A response is not a bounded multiple of its request — `broker_attach` returns the snapshot *and* the replayed events, and a prompt's params appear in both (`snapshot` carries `operations[*].params`, `OperationStarted` carries them again), while the snapshot also retains every operation not yet acknowledged. Any fixed ceiling there is a guess that eventually rejects a legitimate reply, and it would do so *after* the prompt was dispatched, failing the send with nothing to retry. That peer is a broker this helper spawned, and the deadline still bounds how long it can hold the caller, so time is the right bound there and length is not. Neither silence nor a slow drip can hold the loop now, and the stream is dropped afterwards so the client gets a clean EOF rather than a hang.
- Bound both directions of the helper's broker socket (`BROKER_IPC_TIMEOUT`, 20s). The response write keeps the larger budget on purpose — an `attach` replay can be large, and truncating one would corrupt a legitimate reply rather than rescue a stuck one.
- Give each `send_ipc_with_retry` attempt its own budget derived from the remaining deadline, with a floor so a slow-but-healthy broker on a loaded machine is not declared dead.
- `acp/list` sweeps every broker dir on disk, including leftovers from earlier runs, so it uses a tighter 2s per-broker budget.

## Tests

`a_silent_client_on_the_broker_socket_does_not_wedge_the_helper` — verified to **fail on the unfixed code** (30s timeout, exactly the wedge) and pass with the fix.

`a_client_dripping_bytes_cannot_renew_the_request_read_forever` — drips a byte every 200ms with no newline and asserts the broker accepts again **while the client is still dripping**, which a per-read timeout can never satisfy. Verified failing before the deadline fix (broker never recovered in 20s) and passing after.

`read_line_within_stops_a_peer_that_drips_without_ever_ending_the_line`, `read_line_within_accepts_a_line_larger_than_a_typical_request` (40 MiB) and `ipc_line_cap_admits_the_largest_composer_payload` cover the reader directly — the deadline fires, a large legitimate line survives, and the cap stays above the UI limits. It asserts the helper keeps serving `ping` while a silent client holds the broker socket, and that the broker recovers with no restart.

The suite's polling helpers were bounded by iteration count, which measures round trips rather than time and expired under parallel load. They now use a wall-clock budget. This also fixes pre-existing flakiness: `main` failed 1/6 full runs; this branch is 11/11 green.

## Scope note

This bounds the hang but does not remove the head-of-line blocking itself — `acp/*` is still handled inline on the helper's single serve thread, so a slow broker still stalls other sessions for the duration of a bounded timeout. Moving ACP dispatch onto worker threads (with per-broker serialization, since concurrent `acp/open` for one broker would race the supervisor spawn) is the follow-up, kept out of this change deliberately per the repo's "no large architectural changes without an explicit plan" rule.

## Verification

- `cargo test` (AlasHelper) — green, 11 consecutive full runs
- `cargo fmt --check` — clean; no new clippy warnings
- `xcodebuild -scheme Alas -destination 'platform=macOS' build` — **BUILD SUCCEEDED**
- No Swift sources changed; CI is the authority for the Swift suite



