### PR TITLE
perf(acp): AppKit transcript scroller with jump-free pagination

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		330D198F38767801994BF84C /* RemoteHostCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */; };
 		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
 		33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */; };
+		3347BAC4410B740D67FAEE1A /* ACPMessageListSwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BE86A981CD5741B1F7A6E2 /* ACPMessageListSwitchTests.swift */; };
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
 		33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */; };
 		342C28B197D5048F78D2E8D6 /* RemotePairingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F77AE52695B7B19A9F11B89 /* RemotePairingService.swift */; };
@@ -1759,6 +1760,7 @@
 		3111744632DAC342A40DB62A /* ACPAdapterUpdateBannerDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDecider.swift; sourceTree = "<group>"; };
 		311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIWorktreeResolverTests.swift; sourceTree = "<group>"; };
 		312DC027D433B496FD010F85 /* DiffReviewSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewSurfaceTests.swift; sourceTree = "<group>"; };
+		31BE86A981CD5741B1F7A6E2 /* ACPMessageListSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageListSwitchTests.swift; sourceTree = "<group>"; };
 		31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryDetectionTests.swift; sourceTree = "<group>"; };
 		31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowController.swift; sourceTree = "<group>"; };
 		321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessage.swift; sourceTree = "<group>"; };
@@ -3977,6 +3979,7 @@
 				E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */,
 				E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */,
 				9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */,
+				31BE86A981CD5741B1F7A6E2 /* ACPMessageListSwitchTests.swift */,
 				D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */,
@@ -6527,6 +6530,7 @@
 				162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */,
 				26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */,
 				FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */,
+				3347BAC4410B740D67FAEE1A /* ACPMessageListSwitchTests.swift in Sources */,
 				9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */,
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,
 				BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1381,6 +1381,7 @@
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F09324E122712405CCB0389A /* RunScriptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15CFDEF63A656129A3EFEEB /* RunScriptStoreTests.swift */; };
 		F098EBE9088B2EE1DAAF1BFD /* WorktreePathTemplateRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */; };
+		F0F6D9795D96C41F97B6B6BA /* ACPTranscriptTilingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D536FED92C1F59BDA8924C3 /* ACPTranscriptTilingControllerTests.swift */; };
 		F11A596534EEDD3C678DF196 /* MCPRegistrationDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56FED43600BDE5BFE38BF221 /* MCPRegistrationDecision.swift */; };
 		F1299CAAD4DBF766CC56CB8F /* OpenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */; };
 		F134F6DD4EE36865522FF52A /* AlasMCPHTTPSupervisorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3201ACD757677A7F42A8AE /* AlasMCPHTTPSupervisorTests.swift */; };
@@ -1449,6 +1450,7 @@
 		FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */; };
 		FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
+		FD9F0F14E4EA5ACF408211A7 /* ACPTranscriptTilingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A981A28B0FED8C3D95B107 /* ACPTranscriptTilingController.swift */; };
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
 		FDE59101CBC2CA8CD6FFF91B /* ACPMCPExternalStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01291607F0A46E4A50104BB /* ACPMCPExternalStatus.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
@@ -1553,6 +1555,7 @@
 		0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteMCPFilter.swift; sourceTree = "<group>"; };
 		0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAvailableSheet.swift; sourceTree = "<group>"; };
 		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
+		0D536FED92C1F59BDA8924C3 /* ACPTranscriptTilingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptTilingControllerTests.swift; sourceTree = "<group>"; };
 		0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationStateTests.swift; sourceTree = "<group>"; };
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E1B5714AB51C0D1E7B6DB66 /* GGWorktreeContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGWorktreeContextTests.swift; sourceTree = "<group>"; };
@@ -2387,6 +2390,7 @@
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
 		A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageStagingTests.swift; sourceTree = "<group>"; };
 		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
+		A5A981A28B0FED8C3D95B107 /* ACPTranscriptTilingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptTilingController.swift; sourceTree = "<group>"; };
 		A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdateTests.swift; sourceTree = "<group>"; };
 		A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageThumbnail.swift; sourceTree = "<group>"; };
 		A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitTabsManagerTests.swift; sourceTree = "<group>"; };
@@ -3969,6 +3973,7 @@
 				E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */,
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
 				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
+				0D536FED92C1F59BDA8924C3 /* ACPTranscriptTilingControllerTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
 				CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
@@ -4302,6 +4307,7 @@
 			children = (
 				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
 				BA4100A0DBE8B4B1A029EF7A /* ACPTranscriptScrollerFlag.swift */,
+				A5A981A28B0FED8C3D95B107 /* ACPTranscriptTilingController.swift */,
 			);
 			path = Scroller;
 			sourceTree = "<group>";
@@ -5804,6 +5810,7 @@
 				C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */,
 				62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */,
 				26F9DF83A000219C233FE237 /* ACPTranscriptScrollerFlag.swift in Sources */,
+				FD9F0F14E4EA5ACF408211A7 /* ACPTranscriptTilingController.swift in Sources */,
 				05AD50E71FED22187F67D33F /* ACPUserInput.swift in Sources */,
 				64DD701281B8BF9468C50C58 /* ACPUserInputFormState.swift in Sources */,
 				971F93A8880B095537B9A2A8 /* ACPUserInputPrompt.swift in Sources */,
@@ -6573,6 +6580,7 @@
 				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
 				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
+				F0F6D9795D96C41F97B6B6BA /* ACPTranscriptTilingControllerTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
 				441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */,
 				FD5AC98DEE4448EB95C49485 /* ACPUserInputFormStateTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		0722316C2ADB93575221246D /* ACPBareURLLinkifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */; };
 		07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */; };
 		074B2BB17D428AE20AB482AA /* ACPThumbnailImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45952C734DFE7E7F02B047E7 /* ACPThumbnailImageCache.swift */; };
+		0789F98721389570E0C3F942 /* ACPTranscriptRowHostingPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */; };
 		07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */; };
 		082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */; };
 		084E0061691FD9F495E8209B /* GGSplitCommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E189D66411992DFC659CBF /* GGSplitCommitTabView.swift */; };
@@ -171,6 +172,7 @@
 		1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */; };
 		1D66F354E7488D0CDAC39BE2 /* TreeSitterRuby in Frameworks */ = {isa = PBXBuildFile; productRef = 352A452EE3387A4D9C8DBAD9 /* TreeSitterRuby */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
+		1DD03B5760B7FCDF5E1B13A2 /* ACPTranscriptRowSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */; };
 		1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */; };
 		1E5EA96E9798649521CE1427 /* ACPAdapterInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */; };
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
@@ -835,6 +837,7 @@
 		9547580C9DFECD838C120B90 /* DiffReviewRenderEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */; };
 		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
 		95DAB9F9E361DFD0395CC4C2 /* GGStackSummaryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4FE9500B277A3921C8AB2 /* GGStackSummaryStoreTests.swift */; };
+		95E01DC5A933FCC077399762 /* ACPTranscriptRowHostingPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */; };
 		960593EAB0380436038D1400 /* ACPSessionToolCallTruncationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */; };
 		962361DC40B0707AB7CA6E75 /* session-update-tool-call-update-no-meta.json in Resources */ = {isa = PBXBuildFile; fileRef = 30BAC172C16C360F917B6EED /* session-update-tool-call-update-no-meta.json */; };
 		9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */; };
@@ -2384,6 +2387,7 @@
 		A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
 		A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChevronStabilityTests.swift; sourceTree = "<group>"; };
 		A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDirectionTests.swift; sourceTree = "<group>"; };
+		A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowHostingPool.swift; sourceTree = "<group>"; };
 		A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraft.swift; sourceTree = "<group>"; };
 		A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdownTests.swift; sourceTree = "<group>"; };
 		A526016296D5A07C2422BC19 /* FileHistoryTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHistoryTabView.swift; sourceTree = "<group>"; };
@@ -2422,6 +2426,7 @@
 		AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentAgentModelTests.swift; sourceTree = "<group>"; };
 		AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModelsTests.swift; sourceTree = "<group>"; };
 		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
+		ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowSpec.swift; sourceTree = "<group>"; };
 		ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackGate.swift; sourceTree = "<group>"; };
 		ACAF0D9BAB4658B356FBBBAA /* RunScriptPaletteModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptPaletteModelTests.swift; sourceTree = "<group>"; };
 		ACAFC463DDFFF41E0E1B52A9 /* MissionPromptBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionPromptBuilder.swift; sourceTree = "<group>"; };
@@ -2766,6 +2771,7 @@
 		E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPicker.swift; sourceTree = "<group>"; };
 		E4A54DD8080E3395C8E7049E /* RemoteProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProtocol.swift; sourceTree = "<group>"; };
 		E4C4BEC7F392AF938F468B1F /* ACPConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnection.swift; sourceTree = "<group>"; };
+		E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowHostingPoolTests.swift; sourceTree = "<group>"; };
 		E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibilityTests.swift; sourceTree = "<group>"; };
 		E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHost.swift; sourceTree = "<group>"; };
 		E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictMinimap.swift; sourceTree = "<group>"; };
@@ -3971,6 +3977,7 @@
 				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
 				E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */,
+				E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */,
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
 				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
 				0D536FED92C1F59BDA8924C3 /* ACPTranscriptTilingControllerTests.swift */,
@@ -4305,7 +4312,9 @@
 		7AED40BA76EA092B0B29D83D /* Scroller */ = {
 			isa = PBXGroup;
 			children = (
+				A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */,
 				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
+				ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */,
 				BA4100A0DBE8B4B1A029EF7A /* ACPTranscriptScrollerFlag.swift */,
 				A5A981A28B0FED8C3D95B107 /* ACPTranscriptTilingController.swift */,
 			);
@@ -5808,7 +5817,9 @@
 				8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */,
 				9983414D08DCAB87919FB804 /* ACPTranscriptChangeLog.swift in Sources */,
 				C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */,
+				95E01DC5A933FCC077399762 /* ACPTranscriptRowHostingPool.swift in Sources */,
 				62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */,
+				1DD03B5760B7FCDF5E1B13A2 /* ACPTranscriptRowSpec.swift in Sources */,
 				26F9DF83A000219C233FE237 /* ACPTranscriptScrollerFlag.swift in Sources */,
 				FD9F0F14E4EA5ACF408211A7 /* ACPTranscriptTilingController.swift in Sources */,
 				05AD50E71FED22187F67D33F /* ACPUserInput.swift in Sources */,
@@ -6577,6 +6588,7 @@
 				6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */,
 				F22A776D791ABA7A584B4C18 /* ACPTranscriptMessageIndexTests.swift in Sources */,
 				2F1165AE6FD339D03943C182 /* ACPTranscriptRowContentTests.swift in Sources */,
+				0789F98721389570E0C3F942 /* ACPTranscriptRowHostingPoolTests.swift in Sources */,
 				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
 				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -572,6 +572,7 @@
 		6291072E82FC282625FD1617 /* GitServiceCommitEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */; };
 		6294D44BE2DC7F96933F7C4B /* ACPMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */; };
 		629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */; };
+		62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */; };
 		63327D1ACC38C6559F2FDA99 /* CodeHostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B1108F04B06EAC224AB5B /* CodeHostProvider.swift */; };
 		636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */; };
 		63B3A5BB582C8C7ACE51E9E5 /* MermaidDiagramThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */; };
@@ -854,6 +855,7 @@
 		9831EFFF98FCEC663309D8A9 /* ACPMarkdownInlineTextViewHeightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF73DAD392176A774ABA67 /* ACPMarkdownInlineTextViewHeightTests.swift */; };
 		985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */; };
 		98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */; };
+		98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */; };
 		98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */; };
 		98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */; };
 		9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */; };
@@ -1844,6 +1846,7 @@
 		4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPrompt.swift; sourceTree = "<group>"; };
 		430FCE70CDAB35CB0594CF44 /* AlasCLIReviewTargetResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIReviewTargetResolver.swift; sourceTree = "<group>"; };
 		431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowIndentationTests.swift; sourceTree = "<group>"; };
+		434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowHostingViewTests.swift; sourceTree = "<group>"; };
 		435D9E527A76820947F426A8 /* ACPFilesystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFilesystem.swift; sourceTree = "<group>"; };
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteContentSearch.swift; sourceTree = "<group>"; };
@@ -2161,6 +2164,7 @@
 		7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitReviewLoader.swift; sourceTree = "<group>"; };
 		7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAvatarPresetProvider.swift; sourceTree = "<group>"; };
 		7B22D5EBE7EDAC07C943C91D /* WebSocketFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrame.swift; sourceTree = "<group>"; };
+		7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowHostingView.swift; sourceTree = "<group>"; };
 		7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerButton.swift; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionsButton.swift; sourceTree = "<group>"; };
@@ -3959,6 +3963,7 @@
 				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
 				E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */,
+				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
 				CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
@@ -4287,6 +4292,14 @@
 			path = Theme;
 			sourceTree = "<group>";
 		};
+		7AED40BA76EA092B0B29D83D /* Scroller */ = {
+			isa = PBXGroup;
+			children = (
+				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
+			);
+			path = Scroller;
+			sourceTree = "<group>";
+		};
 		8050E4DD79EA4EEE490BC1F1 /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -4357,6 +4370,7 @@
 				4D974BDA7FAE214495278557 /* ACPUserInputPrompt.swift */,
 				FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */,
 				531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */,
+				7AED40BA76EA092B0B29D83D /* Scroller */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -5782,6 +5796,7 @@
 				8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */,
 				9983414D08DCAB87919FB804 /* ACPTranscriptChangeLog.swift in Sources */,
 				C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */,
+				62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */,
 				05AD50E71FED22187F67D33F /* ACPUserInput.swift in Sources */,
 				64DD701281B8BF9468C50C58 /* ACPUserInputFormState.swift in Sources */,
 				971F93A8880B095537B9A2A8 /* ACPUserInputPrompt.swift in Sources */,
@@ -6548,6 +6563,7 @@
 				6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */,
 				F22A776D791ABA7A584B4C18 /* ACPTranscriptMessageIndexTests.swift in Sources */,
 				2F1165AE6FD339D03943C182 /* ACPTranscriptRowContentTests.swift in Sources */,
+				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
 				441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		15378467EC7C0D413FF094D2 /* RunScriptLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7097AF3FAAB8D3FB80151A8B /* RunScriptLaunchTests.swift */; };
 		159525C0A1B6C8E0B7C9FA9D /* ProjectMCPServerEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD456A92D66BA31E0E74B836 /* ProjectMCPServerEditor.swift */; };
 		15BAFAC3EC3613E406024EFD /* RemoteLSPLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACA7839782B71490BFD3A6F /* RemoteLSPLauncher.swift */; };
+		15D264B7D73244CABCC5D22B /* ACPTranscriptScrollBookkeepingResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133BC58A28C72EA330CDCCA5 /* ACPTranscriptScrollBookkeepingResetTests.swift */; };
 		162363BDA6BC54B372C77B91 /* ACPMarkdownTextBareURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */; };
 		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
@@ -1594,6 +1595,7 @@
 		1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTests.swift; sourceTree = "<group>"; };
 		12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewTabView.swift; sourceTree = "<group>"; };
 		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
+		133BC58A28C72EA330CDCCA5 /* ACPTranscriptScrollBookkeepingResetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollBookkeepingResetTests.swift; sourceTree = "<group>"; };
 		134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeResolverTests.swift; sourceTree = "<group>"; };
 		136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookEvent.swift; sourceTree = "<group>"; };
 		137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessorTests.swift; sourceTree = "<group>"; };
@@ -3994,6 +3996,7 @@
 				E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */,
 				E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */,
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
+				133BC58A28C72EA330CDCCA5 /* ACPTranscriptScrollBookkeepingResetTests.swift */,
 				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
 				B24F24D2FFBBC49868AC84B3 /* ACPTranscriptScrollerPolicyTests.swift */,
 				F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */,
@@ -6615,6 +6618,7 @@
 				2F1165AE6FD339D03943C182 /* ACPTranscriptRowContentTests.swift in Sources */,
 				0789F98721389570E0C3F942 /* ACPTranscriptRowHostingPoolTests.swift in Sources */,
 				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
+				15D264B7D73244CABCC5D22B /* ACPTranscriptScrollBookkeepingResetTests.swift in Sources */,
 				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
 				57C95148FA2594979E1B2583 /* ACPTranscriptScrollerPolicyTests.swift in Sources */,
 				7C5139851C6CA3CB4292B5B2 /* ACPTranscriptScrollerReconcilerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */; };
 		551C15188490062DFC77A479 /* MemorySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */; };
 		552EBB79C20E7D939C7015A1 /* ACPMockClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074A17527610230DCFBEA13C /* ACPMockClient.swift */; };
+		555AA9EB427B45EEE1C05488 /* ACPTranscriptScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F849F92835C6A4EEA765B7 /* ACPTranscriptScroller.swift */; };
 		5585C223E2CB23CD8650A5DC /* MergeActionGutter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */; };
 		559D6091E849B5D61F4FA8D0 /* DiffReviewInlineFeedbackMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3BB27D40FCCB5D76C622DA /* DiffReviewInlineFeedbackMarkdownTests.swift */; };
 		55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */; };
@@ -519,6 +520,7 @@
 		57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */; };
 		57BE6CDE03CD3CD20C5430D8 /* ACPSessionForkDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A43599B405E7E263CE825 /* ACPSessionForkDivider.swift */; };
 		57C5E087A453B384485B4EE2 /* ChatFontCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF72CF0EA2F684D6ED3B43F5 /* ChatFontCatalogTests.swift */; };
+		57C95148FA2594979E1B2583 /* ACPTranscriptScrollerPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24F24D2FFBBC49868AC84B3 /* ACPTranscriptScrollerPolicyTests.swift */; };
 		57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */; };
 		5806E3E41DA735380E33BF76 /* DiffReviewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D1ECA099BBDCB5BB2EEC67 /* DiffReviewModels.swift */; };
 		584066607B7E7E97A736213A /* AppQuitAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942B0DCA09E1297D9380C58C /* AppQuitAction.swift */; };
@@ -2468,6 +2470,7 @@
 		B16BDCBFE4C1EB1C8EA6D4D5 /* RemoteDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDevice.swift; sourceTree = "<group>"; };
 		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
+		B24F24D2FFBBC49868AC84B3 /* ACPTranscriptScrollerPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerPolicyTests.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalogTests.swift; sourceTree = "<group>"; };
 		B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifier.swift; sourceTree = "<group>"; };
@@ -2804,6 +2807,7 @@
 		E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeSymlinkTests.swift; sourceTree = "<group>"; };
 		E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPickerTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
+		E9F849F92835C6A4EEA765B7 /* ACPTranscriptScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScroller.swift; sourceTree = "<group>"; };
 		EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionVisibleQueueTests.swift; sourceTree = "<group>"; };
 		EAD81CB1D751F983C64191FF /* ACPRemoteAdapterManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterManagementTests.swift; sourceTree = "<group>"; };
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
@@ -3988,6 +3992,7 @@
 				E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */,
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
 				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
+				B24F24D2FFBBC49868AC84B3 /* ACPTranscriptScrollerPolicyTests.swift */,
 				F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */,
 				009B1616C60DB50E1CC11264 /* ACPTranscriptScrollerViewTests.swift */,
 				0D536FED92C1F59BDA8924C3 /* ACPTranscriptTilingControllerTests.swift */,
@@ -4325,6 +4330,7 @@
 				A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */,
 				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
 				ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */,
+				E9F849F92835C6A4EEA765B7 /* ACPTranscriptScroller.swift */,
 				BA4100A0DBE8B4B1A029EF7A /* ACPTranscriptScrollerFlag.swift */,
 				81D94695C26A2270165EC820 /* ACPTranscriptScrollerReconciler.swift */,
 				447EEDD6DBF9822B25A56CD7 /* ACPTranscriptScrollerView.swift */,
@@ -5832,6 +5838,7 @@
 				95E01DC5A933FCC077399762 /* ACPTranscriptRowHostingPool.swift in Sources */,
 				62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */,
 				1DD03B5760B7FCDF5E1B13A2 /* ACPTranscriptRowSpec.swift in Sources */,
+				555AA9EB427B45EEE1C05488 /* ACPTranscriptScroller.swift in Sources */,
 				26F9DF83A000219C233FE237 /* ACPTranscriptScrollerFlag.swift in Sources */,
 				E982387DB4C0EF18291C68FB /* ACPTranscriptScrollerReconciler.swift in Sources */,
 				39D5D6A30C7232D090066A89 /* ACPTranscriptScrollerView.swift in Sources */,
@@ -6605,6 +6612,7 @@
 				0789F98721389570E0C3F942 /* ACPTranscriptRowHostingPoolTests.swift in Sources */,
 				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
 				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
+				57C95148FA2594979E1B2583 /* ACPTranscriptScrollerPolicyTests.swift in Sources */,
 				7C5139851C6CA3CB4292B5B2 /* ACPTranscriptScrollerReconcilerTests.swift in Sources */,
 				D7AEA4BEFB96EF86A83D6C16 /* ACPTranscriptScrollerViewTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -699,6 +699,7 @@
 		7BBF0BCBD3121E1C20EF93CA /* ReviewReadinessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467E833E3CE05D82DB88C5C5 /* ReviewReadinessModel.swift */; };
 		7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */; };
 		7C286DF876CD8F71D07B6A93 /* WebSocketFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B22D5EBE7EDAC07C943C91D /* WebSocketFrame.swift */; };
+		7C5139851C6CA3CB4292B5B2 /* ACPTranscriptScrollerReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */; };
 		7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */; };
 		7C9647376FCA2B7E9F424FB8 /* ImageDiffDecodedCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAADD6619C81C4B17710B31F /* ImageDiffDecodedCacheTests.swift */; };
 		7C9B1B7376FE5F651D9127D1 /* TreeSitterLua in Frameworks */ = {isa = PBXBuildFile; productRef = 46C4CD399F2A124F7A038D7C /* TreeSitterLua */; };
@@ -1354,6 +1355,7 @@
 		E8CD4B9C918E2A9A83FA637A /* ProjectIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56C7878101DA7532B9850D13 /* ProjectIconView.swift */; };
 		E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */; };
 		E9507AB389CE47A6A48C049B /* ACPProcessLiveness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */; };
+		E982387DB4C0EF18291C68FB /* ACPTranscriptScrollerReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D94695C26A2270165EC820 /* ACPTranscriptScrollerReconciler.swift */; };
 		E99E4DB46496707E7A3F044A /* PiACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */; };
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EA2BAFA70ED22F6085EB1971 /* GitLabCLIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */; };
@@ -2214,6 +2216,7 @@
 		817DF0174BF04CF5DA288E99 /* ACPRemoteFileServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteFileServer.swift; sourceTree = "<group>"; };
 		8182DA33443DD22A370892B7 /* BinaryFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryFileType.swift; sourceTree = "<group>"; };
 		818B29F6B58D4FFC80603AAD /* ACPAdapterTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterTarget.swift; sourceTree = "<group>"; };
+		81D94695C26A2270165EC820 /* ACPTranscriptScrollerReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerReconciler.swift; sourceTree = "<group>"; };
 		81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServer.swift; sourceTree = "<group>"; };
 		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
 		8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateContentFingerprintTests.swift; sourceTree = "<group>"; };
@@ -2881,6 +2884,7 @@
 		F83370751580C42D5DE93F80 /* GitInvocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInvocation.swift; sourceTree = "<group>"; };
 		F84BC1A10866A165EA321719 /* ACPTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptTests.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
+		F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerReconcilerTests.swift; sourceTree = "<group>"; };
 		F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerAttachRestoreTests.swift; sourceTree = "<group>"; };
 		F90F265EBA9431630D56836C /* MissionTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionTestFixtures.swift; sourceTree = "<group>"; };
 		F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceDiscardTests.swift; sourceTree = "<group>"; };
@@ -3984,6 +3988,7 @@
 				E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */,
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
 				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
+				F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */,
 				009B1616C60DB50E1CC11264 /* ACPTranscriptScrollerViewTests.swift */,
 				0D536FED92C1F59BDA8924C3 /* ACPTranscriptTilingControllerTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
@@ -4321,6 +4326,7 @@
 				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
 				ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */,
 				BA4100A0DBE8B4B1A029EF7A /* ACPTranscriptScrollerFlag.swift */,
+				81D94695C26A2270165EC820 /* ACPTranscriptScrollerReconciler.swift */,
 				447EEDD6DBF9822B25A56CD7 /* ACPTranscriptScrollerView.swift */,
 				A5A981A28B0FED8C3D95B107 /* ACPTranscriptTilingController.swift */,
 			);
@@ -5827,6 +5833,7 @@
 				62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */,
 				1DD03B5760B7FCDF5E1B13A2 /* ACPTranscriptRowSpec.swift in Sources */,
 				26F9DF83A000219C233FE237 /* ACPTranscriptScrollerFlag.swift in Sources */,
+				E982387DB4C0EF18291C68FB /* ACPTranscriptScrollerReconciler.swift in Sources */,
 				39D5D6A30C7232D090066A89 /* ACPTranscriptScrollerView.swift in Sources */,
 				FD9F0F14E4EA5ACF408211A7 /* ACPTranscriptTilingController.swift in Sources */,
 				05AD50E71FED22187F67D33F /* ACPUserInput.swift in Sources */,
@@ -6598,6 +6605,7 @@
 				0789F98721389570E0C3F942 /* ACPTranscriptRowHostingPoolTests.swift in Sources */,
 				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
 				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
+				7C5139851C6CA3CB4292B5B2 /* ACPTranscriptScrollerReconcilerTests.swift in Sources */,
 				D7AEA4BEFB96EF86A83D6C16 /* ACPTranscriptScrollerViewTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
 				F0F6D9795D96C41F97B6B6BA /* ACPTranscriptTilingControllerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		2659BA65A6CABBE800A06AB3 /* tool-call-content-diff.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */; };
 		2661C51A093174D940CB5733 /* ProviderReviewActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9F77CC231E1131962F5A43 /* ProviderReviewActions.swift */; };
 		26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */; };
+		26F9DF83A000219C233FE237 /* ACPTranscriptScrollerFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4100A0DBE8B4B1A029EF7A /* ACPTranscriptScrollerFlag.swift */; };
 		270146424B271EBDB8886DD2 /* GGUnstackSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02E6B12C5EC8FAA50202EEA /* GGUnstackSheet.swift */; };
 		272EE1BE3B1A4A3BFA7B2703 /* ACPManagedAdapterDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA89D4C70102BCF7B6B2450B /* ACPManagedAdapterDescriptor.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
@@ -406,6 +407,7 @@
 		439761195191FAC857E78705 /* PaneDragMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD359E5712BE30FF37251EE /* PaneDragMathTests.swift */; };
 		43CB2A054DED7568A583822E /* ACPGeminiE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C204307EE573512D731B8307 /* ACPGeminiE2ETests.swift */; };
 		43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */; };
+		43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */; };
 		441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE51418F7A0C3D24A60464C7 /* ACPUsageUpdateDecodeTests.swift */; };
 		4421A9D1E7481B49701B3131 /* mason-lsps.json in Resources */ = {isa = PBXBuildFile; fileRef = F0D567F7F894902AD192D220 /* mason-lsps.json */; };
 		443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */; };
@@ -2498,6 +2500,7 @@
 		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
 		B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitCommitModel.swift; sourceTree = "<group>"; };
 		B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileAccessTests.swift; sourceTree = "<group>"; };
+		BA4100A0DBE8B4B1A029EF7A /* ACPTranscriptScrollerFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerFlag.swift; sourceTree = "<group>"; };
 		BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneGGStackTests.swift; sourceTree = "<group>"; };
 		BA59378FB8733DBAC67592A3 /* RemotePairingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingServiceTests.swift; sourceTree = "<group>"; };
 		BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileChip.swift; sourceTree = "<group>"; };
@@ -2531,6 +2534,7 @@
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
 		BF72CF0EA2F684D6ED3B43F5 /* ChatFontCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalogTests.swift; sourceTree = "<group>"; };
 		BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequest.swift; sourceTree = "<group>"; };
+		BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerFlagTests.swift; sourceTree = "<group>"; };
 		BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftModels.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPrompt.swift; sourceTree = "<group>"; };
@@ -3964,6 +3968,7 @@
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
 				E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */,
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
+				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
 				CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
@@ -4296,6 +4301,7 @@
 			isa = PBXGroup;
 			children = (
 				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
+				BA4100A0DBE8B4B1A029EF7A /* ACPTranscriptScrollerFlag.swift */,
 			);
 			path = Scroller;
 			sourceTree = "<group>";
@@ -5797,6 +5803,7 @@
 				9983414D08DCAB87919FB804 /* ACPTranscriptChangeLog.swift in Sources */,
 				C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */,
 				62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */,
+				26F9DF83A000219C233FE237 /* ACPTranscriptScrollerFlag.swift in Sources */,
 				05AD50E71FED22187F67D33F /* ACPUserInput.swift in Sources */,
 				64DD701281B8BF9468C50C58 /* ACPUserInputFormState.swift in Sources */,
 				971F93A8880B095537B9A2A8 /* ACPUserInputPrompt.swift in Sources */,
@@ -6564,6 +6571,7 @@
 				F22A776D791ABA7A584B4C18 /* ACPTranscriptMessageIndexTests.swift in Sources */,
 				2F1165AE6FD339D03943C182 /* ACPTranscriptRowContentTests.swift in Sources */,
 				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
+				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
 				441EC5990D107F1059F377F3 /* ACPUsageUpdateDecodeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */; };
 		396AF154C56F4B5061756366 /* ProjectAvatarPresetProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */; };
 		397FADBCCF3211504DAEDC35 /* ZmxEnvTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DFDC1BD30B1D1CC469D54C /* ZmxEnvTests.swift */; };
+		39D5D6A30C7232D090066A89 /* ACPTranscriptScrollerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447EEDD6DBF9822B25A56CD7 /* ACPTranscriptScrollerView.swift */; };
 		39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */; };
 		3A108152BB33EF9B00FC2F1B /* EditorLSPStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */; };
 		3A222D407DC170E065771C56 /* CodeHostRemoteDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */; };
@@ -1235,6 +1236,7 @@
 		D7201A9F55E26C033F188DE8 /* ACPRemoteAdapterInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E0789D49881A17137010D0 /* ACPRemoteAdapterInstallerTests.swift */; };
 		D76AE9874386832FF4C89E6E /* initialize-request.json in Resources */ = {isa = PBXBuildFile; fileRef = 3253B229B757C725B7747249 /* initialize-request.json */; };
 		D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */; };
+		D7AEA4BEFB96EF86A83D6C16 /* ACPTranscriptScrollerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009B1616C60DB50E1CC11264 /* ACPTranscriptScrollerViewTests.swift */; };
 		D7C0F02B7A62097E3EF21160 /* FileSearchRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FABF9037326B7EE23FCC040 /* FileSearchRanker.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
 		D8254D678C89FC54678A1A88 /* RemoteHelperInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB9832AA15DF6888553C7E /* RemoteHelperInstallerTests.swift */; };
@@ -1487,6 +1489,7 @@
 		005F92E45C7D391D8BD5A3FD /* AlasActionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasActionService.swift; sourceTree = "<group>"; };
 		00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPickerTests.swift; sourceTree = "<group>"; };
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
+		009B1616C60DB50E1CC11264 /* ACPTranscriptScrollerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerViewTests.swift; sourceTree = "<group>"; };
 		00B894D92F014C2ADB3CCC9B /* TreeSitterPython */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterPython; path = ThirdParty/TreeSitterPython; sourceTree = SOURCE_ROOT; };
 		00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModelBuilder.swift; sourceTree = "<group>"; };
 		00F9D4F91573E92AE4964353 /* ACPSessionForkRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkRunnerTests.swift; sourceTree = "<group>"; };
@@ -1863,6 +1866,7 @@
 		442D62D5E8B59845EB9494D3 /* RemoteProjectCollisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProjectCollisionTests.swift; sourceTree = "<group>"; };
 		4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionScope.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
+		447EEDD6DBF9822B25A56CD7 /* ACPTranscriptScrollerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerView.swift; sourceTree = "<group>"; };
 		44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPromptTests.swift; sourceTree = "<group>"; };
 		44E26C51ACE48A35EB4CD463 /* ACPTranscriptMessageIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMessageIndexTests.swift; sourceTree = "<group>"; };
 		44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextBuilder.swift; sourceTree = "<group>"; };
@@ -3980,6 +3984,7 @@
 				E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */,
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
 				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
+				009B1616C60DB50E1CC11264 /* ACPTranscriptScrollerViewTests.swift */,
 				0D536FED92C1F59BDA8924C3 /* ACPTranscriptTilingControllerTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
 				CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */,
@@ -4316,6 +4321,7 @@
 				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
 				ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */,
 				BA4100A0DBE8B4B1A029EF7A /* ACPTranscriptScrollerFlag.swift */,
+				447EEDD6DBF9822B25A56CD7 /* ACPTranscriptScrollerView.swift */,
 				A5A981A28B0FED8C3D95B107 /* ACPTranscriptTilingController.swift */,
 			);
 			path = Scroller;
@@ -5821,6 +5827,7 @@
 				62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */,
 				1DD03B5760B7FCDF5E1B13A2 /* ACPTranscriptRowSpec.swift in Sources */,
 				26F9DF83A000219C233FE237 /* ACPTranscriptScrollerFlag.swift in Sources */,
+				39D5D6A30C7232D090066A89 /* ACPTranscriptScrollerView.swift in Sources */,
 				FD9F0F14E4EA5ACF408211A7 /* ACPTranscriptTilingController.swift in Sources */,
 				05AD50E71FED22187F67D33F /* ACPUserInput.swift in Sources */,
 				64DD701281B8BF9468C50C58 /* ACPUserInputFormState.swift in Sources */,
@@ -6591,6 +6598,7 @@
 				0789F98721389570E0C3F942 /* ACPTranscriptRowHostingPoolTests.swift in Sources */,
 				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
 				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
+				D7AEA4BEFB96EF86A83D6C16 /* ACPTranscriptScrollerViewTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
 				F0F6D9795D96C41F97B6B6BA /* ACPTranscriptTilingControllerTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -462,16 +462,27 @@ final class ACPTranscript: ObservableObject {
 
     /// Reveal one more `tailWindow`-sized chunk of older messages.
     /// Clamps at zero. Idempotent at the head.
-    func stepHeadBack() {
+    ///
+    /// `boundTail: false` (AppKit scroller) keeps the current tail so the
+    /// window grows monotonically while the user browses history — the
+    /// mounted-view cap lives in the tiling controller, not the window model.
+    func stepHeadBack(boundTail: Bool = true) {
         let currentTail = visibleTailBound
         let newHead = max(0, visibleHead - Self.tailWindow)
-        let boundedTail = min(messages.count, newHead + Self.maxVisibleRows)
-        setVisibleWindow(head: newHead, tail: min(currentTail, boundedTail))
+        if boundTail {
+            let boundedTail = min(messages.count, newHead + Self.maxVisibleRows)
+            setVisibleWindow(head: newHead, tail: min(currentTail, boundedTail))
+        } else {
+            setVisibleWindow(head: newHead, tail: visibleTail)
+        }
     }
 
     /// Reveal one more chunk of newer messages while keeping the row currently
     /// near the viewport top inside the bounded window when possible.
-    func stepTailForward(preserving preservedIndex: Int?) {
+    ///
+    /// `boundHead: false` (AppKit scroller) keeps the current head so newer
+    /// rows extend the grown window instead of trimming the top.
+    func stepTailForward(preserving preservedIndex: Int?, boundHead: Bool = true) {
         let currentTail = visibleTailBound
         guard currentTail < messages.count else { return }
         var newTail = min(messages.count, currentTail + Self.tailWindow)
@@ -484,7 +495,7 @@ final class ACPTranscript: ObservableObject {
             }
         }
         guard newTail > currentTail else { return }
-        let boundedHead = max(0, newTail - Self.maxVisibleRows)
+        let boundedHead = boundHead ? max(0, newTail - Self.maxVisibleRows) : visibleHead
         setVisibleWindow(head: boundedHead, tail: newTail)
     }
 

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -163,7 +163,20 @@ struct ACPMessageList: View {
         .onReceive(
             NotificationCenter.default.publisher(for: ACPTranscriptScrollerFlag.overrideDidChangeNotification)
         ) { _ in
-            scrollerFlagState = ACPTranscriptScrollerFlag.isEnabled
+            let flagEnabled = ACPTranscriptScrollerFlag.isEnabled
+            guard flagEnabled != scrollerFlagState else { return }
+            // `.id(scrollerFlagState)` rebuilds the transcript subtree, but
+            // this view's own `@State` sits OUTSIDE that subtree and
+            // survives the identity change. Reset the scroll bookkeeping
+            // and per-row caches explicitly so the incoming implementation
+            // starts clean instead of inheriting the outgoing one's
+            // restore state and cached geometry.
+            scrollBook.reset()
+            scrollViewRef = ACPWeakScrollViewRef()
+            latestTopVisibleAnchor = ACPMutableScrollAnchor()
+            modernRowFrameCache = ACPRowFrameCache()
+            visibleRowsCache = ACPVisibleRowsCache()
+            scrollerFlagState = flagEnabled
         }
         .background(
             LinearGradient(
@@ -1784,7 +1797,10 @@ enum ACPContentShrinkBookmarkResetState {
 /// on every write — which is exactly the transaction-feedback edge behind
 /// the transcript live-lock. See docs/plans/2026-07-17-acp-transcript-livelock-fix.md.
 @MainActor
-private final class ACPTranscriptScrollBookkeeping {
+/// Internal rather than file-private so a test can drive `reset()` directly:
+/// the flag-flip path that needs it lives in a SwiftUI `onReceive` closure,
+/// which is not reachable from a unit test.
+final class ACPTranscriptScrollBookkeeping {
     var isRestoringTail = false
     var restoredRememberedAnchor: String?
     var latestRememberedScrollAnchorIndex: Int?
@@ -1810,6 +1826,38 @@ private final class ACPTranscriptScrollBookkeeping {
     /// estimate flip.
     var lastContentGrowthTailRestoreSourceHeight: CGFloat?
     var lastContentGrowthTailRestoreHeight: CGFloat?
+
+    /// Returns every field to its initial value, cancelling any scheduled
+    /// work first so a task queued against the outgoing scroll view cannot
+    /// land on the incoming one.
+    ///
+    /// Needed when the transcript switches between the legacy and AppKit
+    /// scrollers. That switch rebuilds the transcript subtree via
+    /// `.id(scrollerFlagState)`, but this object is `@State` on
+    /// `ACPMessageList` itself — outside the subtree the id replaces — so it
+    /// survives. `restoredRememberedAnchor` surviving is the sharp edge: the
+    /// rebuilt scroll view would see the current anchor as already restored,
+    /// skip `restoreRememberedAnchorIfNeeded`, and leave a paused chat at
+    /// the new scroll view's default position.
+    func reset() {
+        pendingTailScrollTask?.cancel()
+        pendingContentShrinkResetTask?.cancel()
+        isRestoringTail = false
+        restoredRememberedAnchor = nil
+        latestRememberedScrollAnchorIndex = nil
+        lastHeadStepAt = .distantPast
+        lastTailStepAt = .distantPast
+        pendingTailScrollTask = nil
+        pendingTailScrollGeneration = 0
+        pendingContentGrowthTailRestore = nil
+        pendingContentShrinkResetTask = nil
+        pendingContentShrinkResetGeneration = 0
+        contentShrinkBookmarkResetState = .none
+        scrollGeometryGeneration = 0
+        lastScrollProbe = nil
+        lastContentGrowthTailRestoreSourceHeight = nil
+        lastContentGrowthTailRestoreHeight = nil
+    }
 }
 
 /// Non-observed cache for the modern per-row geometry callbacks. SwiftUI's
@@ -1993,7 +2041,10 @@ private struct ACPTranscriptScrollTracking: ViewModifier {
 /// Version-agnostic so `ACPTranscriptScrollTracking` doesn't require blanket
 /// macOS 15 availability — the `ScrollGeometry` reference is confined to the
 /// `#available` branch above.
-private struct ACPScrollProbe: Equatable {
+/// Internal rather than file-private only because it appears in
+/// `ACPTranscriptScrollBookkeeping`'s stored properties, and that type is
+/// internal so its `reset()` can be unit-tested.
+struct ACPScrollProbe: Equatable {
     var generation: UInt64
     var minY: CGFloat
     var viewportHeight: CGFloat

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -35,6 +35,16 @@ struct ACPMessageList: View {
     let onOpenForkSource: (String) -> Void
     let agentDisplayName: (String) -> String
     @Environment(\.theme) private var theme
+    // Cached rather than read fresh from `ACPTranscriptScrollerFlag.isEnabled`
+    // on every body evaluation (which happens per streamed chunk) so that a
+    // flag flip is the ONLY thing that changes it. `.id(scrollerFlagState)`
+    // below then forces SwiftUI to tear down and rebuild the whole transcript
+    // subtree when it changes — switching between the AppKit scroller and the
+    // legacy ScrollView mid-flight, sharing this view's scroll bookkeeping
+    // `@State`, is not something either implementation is designed to
+    // tolerate, so a full identity change (losing scroll position, as
+    // documented in the settings row) is the deliberate, safe behavior.
+    @State private var scrollerFlagState = ACPTranscriptScrollerFlag.isEnabled
     @State private var scrollViewRef = ACPWeakScrollViewRef()
     @State private var latestTopVisibleAnchor = ACPMutableScrollAnchor()
     @State private var scrollBook = ACPTranscriptScrollBookkeeping()
@@ -143,11 +153,17 @@ struct ACPMessageList: View {
 
     var body: some View {
         Group {
-            if Self.usesAppKitScroller(flagEnabled: ACPTranscriptScrollerFlag.isEnabled) {
+            if Self.usesAppKitScroller(flagEnabled: scrollerFlagState) {
                 appKitScrollerBody
             } else {
                 legacyScrollViewBody
             }
+        }
+        .id(scrollerFlagState)
+        .onReceive(
+            NotificationCenter.default.publisher(for: ACPTranscriptScrollerFlag.overrideDidChangeNotification)
+        ) { _ in
+            scrollerFlagState = ACPTranscriptScrollerFlag.isEnabled
         }
         .background(
             LinearGradient(

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -137,7 +137,68 @@ struct ACPMessageList: View {
         }
     }
 
+    nonisolated static func usesAppKitScroller(flagEnabled: Bool) -> Bool {
+        flagEnabled
+    }
+
     var body: some View {
+        Group {
+            if Self.usesAppKitScroller(flagEnabled: ACPTranscriptScrollerFlag.isEnabled) {
+                appKitScrollerBody
+            } else {
+                legacyScrollViewBody
+            }
+        }
+        .background(
+            LinearGradient(
+                colors: [theme.color("bg-1"), theme.color("bg-0")],
+                startPoint: .top, endPoint: .bottom
+            )
+        )
+    }
+
+    private var appKitScrollerBody: some View {
+        ZStack(alignment: .bottomTrailing) {
+            ACPTranscriptScroller(
+                session: session,
+                transcript: transcript,
+                contentMaxWidth: contentMaxWidth,
+                typography: typography,
+                trustedImageRoot: trustedImageRoot,
+                onOpenDiff: onOpenDiff,
+                onLoadFullToolCallContent: onLoadFullToolCallContent,
+                forkTargets: forkTargets,
+                onFork: onFork,
+                rememberedScrollAnchor: rememberedScrollAnchor,
+                onRememberScrollAnchor: onRememberScrollAnchor,
+                onOpenTranscriptLink: onOpenTranscriptLink,
+                policy: policy,
+                scopeKey: scopeKey,
+                onUserInputResponse: onUserInputResponse,
+                onOpenElicitationURL: onOpenElicitationURL,
+                onDismissElicitationURLWait: onDismissElicitationURLWait,
+                onQueueEdit: onQueueEdit,
+                onQueueForceSend: onQueueForceSend,
+                onQueueRemove: onQueueRemove,
+                onQueueRetry: onQueueRetry,
+                onQueueReorder: onQueueReorder,
+                onQueueClearAll: onQueueClearAll,
+                onRetryContextRecovery: onRetryContextRecovery,
+                onOpenForkSource: onOpenForkSource,
+                agentDisplayName: agentDisplayName
+            )
+            if Self.shouldShowGoToNewestAffordance(
+                followsTranscriptTail: session.followsTranscriptTail
+            ) {
+                goToNewestButton {
+                    session.followsTranscriptTail = true
+                    transcript.resetWindowToTail()
+                }
+            }
+        }
+    }
+
+    private var legacyScrollViewBody: some View {
         ScrollViewReader { proxy in
             GeometryReader { viewport in
                 ZStack(alignment: .bottomTrailing) {
@@ -349,42 +410,42 @@ struct ACPMessageList: View {
                     if Self.shouldShowGoToNewestAffordance(
                         followsTranscriptTail: session.followsTranscriptTail
                     ) {
-                        Button {
+                        goToNewestButton {
                             goToNewestMessage(proxy: proxy)
-                        } label: {
-                            Image(systemName: "arrow.down")
-                                .font(.system(size: 14, weight: .semibold))
-                                .frame(width: goToNewestButtonSize, height: goToNewestButtonSize)
                         }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(theme.color("fg"))
-                        .background(
-                            Circle()
-                                .fill(theme.color("bg-1").opacity(0.95))
-                                .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
-                        )
-                        .overlay(
-                            Circle()
-                                .strokeBorder(theme.color("line").opacity(0.9), lineWidth: 0.5)
-                        )
-                        .accessibilityLabel("Go to newest message")
-                        .help("Go to newest message")
-                        .padding(.trailing, 20)
-                        .padding(.bottom, Self.goToNewestAffordanceBottomPadding(
-                            composerSpacerHeight: composerSpacerHeight,
-                            gap: goToNewestButtonComposerGap
-                        ))
-                        .transition(.opacity.combined(with: .scale(scale: 0.94)))
                     }
                 }
             }
         }
+    }
+
+    private func goToNewestButton(action: @escaping () -> Void) -> some View {
+        Button {
+            action()
+        } label: {
+            Image(systemName: "arrow.down")
+                .font(.system(size: 14, weight: .semibold))
+                .frame(width: goToNewestButtonSize, height: goToNewestButtonSize)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(theme.color("fg"))
         .background(
-            LinearGradient(
-                colors: [theme.color("bg-1"), theme.color("bg-0")],
-                startPoint: .top, endPoint: .bottom
-            )
+            Circle()
+                .fill(theme.color("bg-1").opacity(0.95))
+                .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
         )
+        .overlay(
+            Circle()
+                .strokeBorder(theme.color("line").opacity(0.9), lineWidth: 0.5)
+        )
+        .accessibilityLabel("Go to newest message")
+        .help("Go to newest message")
+        .padding(.trailing, 20)
+        .padding(.bottom, Self.goToNewestAffordanceBottomPadding(
+            composerSpacerHeight: composerSpacerHeight,
+            gap: goToNewestButtonComposerGap
+        ))
+        .transition(.opacity.combined(with: .scale(scale: 0.94)))
     }
 
     private func restoreTailIfNeeded(proxy: ScrollViewProxy, animated: Bool) {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -193,6 +193,7 @@ struct ACPMessageList: View {
                 goToNewestButton {
                     session.followsTranscriptTail = true
                     transcript.resetWindowToTail()
+                    onRememberScrollAnchor(nil, nil, true)
                 }
             }
         }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingPool.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingPool.swift
@@ -1,0 +1,48 @@
+import AppKit
+import SwiftUI
+
+/// Owns the live `ACPTranscriptRowHostingView`s, keyed by row id. Views are
+/// reused across layout passes; rootView is only replaced when the row's
+/// equality token changes, mirroring the legacy `.equatable()` gating.
+@MainActor
+final class ACPTranscriptRowHostingPool {
+    var onRowIntrinsicSizeInvalidated: ((String) -> Void)?
+
+    private struct Entry {
+        let view: ACPTranscriptRowHostingView
+        var token: ACPRowEqualityToken
+    }
+
+    private var entries: [String: Entry] = [:]
+
+    var mountedIds: Set<String> { Set(entries.keys) }
+
+    func view(for spec: ACPTranscriptRowSpec) -> (view: ACPTranscriptRowHostingView, contentChanged: Bool) {
+        if var entry = entries[spec.id] {
+            if entry.token.isEqual(to: spec.equalityToken) {
+                return (entry.view, false)
+            }
+            entry.view.updateRootView(spec.build())
+            entry.token = spec.equalityToken
+            entries[spec.id] = entry
+            return (entry.view, true)
+        }
+        let view = ACPTranscriptRowHostingView(rootView: spec.build())
+        let id = spec.id
+        view.onIntrinsicSizeInvalidated = { [weak self] in
+            self?.onRowIntrinsicSizeInvalidated?(id)
+        }
+        entries[id] = Entry(view: view, token: spec.equalityToken)
+        return (view, true)
+    }
+
+    func release(id: String) {
+        entries.removeValue(forKey: id)?.view.removeFromSuperview()
+    }
+
+    func releaseAll(except keep: Set<String> = []) {
+        for id in entries.keys where !keep.contains(id) {
+            release(id: id)
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingPool.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingPool.swift
@@ -17,6 +17,14 @@ final class ACPTranscriptRowHostingPool {
 
     var mountedIds: Set<String> { Set(entries.keys) }
 
+    /// The live hosting view for `id`, or nil when the row currently has
+    /// none. Unlike `view(for:)` this never CREATES one, so callers can ask
+    /// "is this row's content already measured at the current width?"
+    /// without paying for a hosting view they may not need.
+    func mountedView(id: String) -> ACPTranscriptRowHostingView? {
+        entries[id]?.view
+    }
+
     func view(for spec: ACPTranscriptRowSpec) -> (view: ACPTranscriptRowHostingView, contentChanged: Bool) {
         if var entry = entries[spec.id] {
             if entry.token.isEqual(to: spec.equalityToken) {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingView.swift
@@ -16,6 +16,20 @@ final class ACPTranscriptRowHostingView: NSHostingView<AnyView> {
     /// width directly on the root view does.
     private let baseRootView: AnyView
 
+    /// The width this view's displayed content is currently pinned to, i.e.
+    /// the argument of the last successful `measuredHeight(forWidth:)` call.
+    /// `nil` if `measuredHeight(forWidth:)` has never been called with a
+    /// positive width. `measuredHeight(forWidth:)` mutates the view's live
+    /// `rootView` as a side effect of measuring it (see that method's doc
+    /// comment), so callers that place this view at a frame must assert
+    /// `lastMeasuredWidth == placementWidth` before trusting the view's
+    /// current content/height to match that frame. This is the hook later
+    /// tasks (the tiling reconciler) use to catch a stale or mismatched
+    /// pin — e.g. a width probed during a binary search that was never
+    /// followed by a final `measuredHeight(forWidth:)` call at the width the
+    /// view actually ends up placed at.
+    private(set) var lastMeasuredWidth: CGFloat?
+
     required init(rootView: AnyView) {
         baseRootView = rootView
         super.init(rootView: rootView)
@@ -35,9 +49,20 @@ final class ACPTranscriptRowHostingView: NSHostingView<AnyView> {
     /// fixed-width frame pinned to `width` and reads the resulting intrinsic
     /// content size, which SwiftUI recomputes synchronously. The pinned-width
     /// wrapper becomes the view's displayed content, matching the frame the
-    /// tiling layout will place the view at.
+    /// tiling layout will place the view at; `lastMeasuredWidth` is updated to
+    /// `width` so callers can later verify the view is still pinned to the
+    /// width they expect.
+    ///
+    /// A non-positive `width` is degenerate (e.g. a transient 0 during a
+    /// window resize) and is rejected: this method returns `0` without
+    /// touching `rootView` or `lastMeasuredWidth`, leaving the view pinned to
+    /// whatever width (if any) it was last successfully measured at, rather
+    /// than silently corrupting its displayed content by pinning it to a
+    /// zero/negative-width frame.
     func measuredHeight(forWidth width: CGFloat) -> CGFloat {
+        guard width > 0 else { return 0 }
         rootView = AnyView(baseRootView.frame(width: width, alignment: .topLeading))
+        lastMeasuredWidth = width
         return intrinsicContentSize.height
     }
 }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingView.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+
+/// NSHostingView wrapper for a single transcript row. Adds:
+/// - a callback when SwiftUI invalidates the content's intrinsic size
+///   (streaming rows growing), so the tiling controller can re-measure;
+/// - fixed-width height measurement for the tiling layout.
+@MainActor
+final class ACPTranscriptRowHostingView: NSHostingView<AnyView> {
+    var onIntrinsicSizeInvalidated: (() -> Void)?
+
+    /// The row content as originally supplied, before the `.frame(width:)`
+    /// wrapper `measuredHeight(forWidth:)` applies for measurement. Kept
+    /// separately because `fittingSize`/constraint-based measurement does not
+    /// pick up SwiftUI's text-wrapping width dependency reliably; pinning the
+    /// width directly on the root view does.
+    private let baseRootView: AnyView
+
+    required init(rootView: AnyView) {
+        baseRootView = rootView
+        super.init(rootView: rootView)
+        translatesAutoresizingMaskIntoConstraints = false
+        sizingOptions = [.intrinsicContentSize]
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    override func invalidateIntrinsicContentSize() {
+        super.invalidateIntrinsicContentSize()
+        onIntrinsicSizeInvalidated?()
+    }
+
+    /// Height the row wants at `width`. Re-wraps the root view in a
+    /// fixed-width frame pinned to `width` and reads the resulting intrinsic
+    /// content size, which SwiftUI recomputes synchronously. The pinned-width
+    /// wrapper becomes the view's displayed content, matching the frame the
+    /// tiling layout will place the view at.
+    func measuredHeight(forWidth width: CGFloat) -> CGFloat {
+        rootView = AnyView(baseRootView.frame(width: width, alignment: .topLeading))
+        return intrinsicContentSize.height
+    }
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingView.swift
@@ -33,6 +33,26 @@ final class ACPTranscriptRowHostingView: NSHostingView<AnyView> {
     /// view actually ends up placed at.
     private(set) var lastMeasuredWidth: CGFloat?
 
+    /// `translatesAutoresizingMaskIntoConstraints = false` alongside
+    /// `sizingOptions = [.intrinsicContentSize]` is NSHostingView's
+    /// "the container decides my frame, I only report a size" configuration,
+    /// which is exactly the contract the tiling reconciler wants: it reads
+    /// `measuredHeight(forWidth:)` and then assigns `frame` directly.
+    ///
+    /// Opting a view out of the autoresizing bridge normally hands its frame
+    /// to the constraint engine, which — with no constraints describing this
+    /// view — would be the classic "every row collapses to the origin"
+    /// failure. It does not happen here, and not by luck: the entire
+    /// ancestor chain (`ACPTranscriptDocumentView`, the clip view, the
+    /// scroll view) keeps `translatesAutoresizingMaskIntoConstraints ==
+    /// true` and holds no constraints, so nothing ever runs a constraint
+    /// solve over this subtree. Measured inside a real key window after
+    /// `layoutIfNeeded()`: these views report `hasAmbiguousLayout == false`
+    /// and zero constraints, and their assigned frames survive repeated
+    /// layout passes untouched. `ACPTranscriptScrollerReconcilerWindowLayoutTests`
+    /// pins that down, so a future change that does introduce constraints
+    /// into this subtree fails a test instead of silently blanking the
+    /// transcript.
     required init(rootView: AnyView) {
         baseRootView = rootView
         super.init(rootView: rootView)

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowHostingView.swift
@@ -13,8 +13,11 @@ final class ACPTranscriptRowHostingView: NSHostingView<AnyView> {
     /// wrapper `measuredHeight(forWidth:)` applies for measurement. Kept
     /// separately because `fittingSize`/constraint-based measurement does not
     /// pick up SwiftUI's text-wrapping width dependency reliably; pinning the
-    /// width directly on the root view does.
-    private let baseRootView: AnyView
+    /// width directly on the root view does. Mutable so `updateRootView(_:)`
+    /// can replace it: callers MUST go through that method rather than
+    /// assigning `rootView` directly, or this pristine copy goes stale and
+    /// the next `measuredHeight(forWidth:)` call re-pins the OLD content.
+    private var baseRootView: AnyView
 
     /// The width this view's displayed content is currently pinned to, i.e.
     /// the argument of the last successful `measuredHeight(forWidth:)` call.
@@ -43,6 +46,25 @@ final class ACPTranscriptRowHostingView: NSHostingView<AnyView> {
     override func invalidateIntrinsicContentSize() {
         super.invalidateIntrinsicContentSize()
         onIntrinsicSizeInvalidated?()
+    }
+
+    /// Replaces the row's content. This is the ONLY correct way to swap in
+    /// new SwiftUI content on an already-mounted row: assigning `rootView`
+    /// directly (AppKit's own setter) leaves `baseRootView` stale, so the
+    /// next `measuredHeight(forWidth:)` call would re-pin the OLD content,
+    /// silently reverting the update.
+    ///
+    /// If the view has already been measured at some width, the new content
+    /// is immediately re-pinned to that same width so the displayed view
+    /// stays consistent with `lastMeasuredWidth` until the next measurement;
+    /// otherwise the new content is shown unpinned.
+    func updateRootView(_ newRootView: AnyView) {
+        baseRootView = newRootView
+        if let width = lastMeasuredWidth {
+            rootView = AnyView(newRootView.frame(width: width, alignment: .topLeading))
+        } else {
+            rootView = newRootView
+        }
     }
 
     /// Height the row wants at `width`. Re-wraps the root view in a

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowSpec.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowSpec.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Type-erased Equatable. Replaces the legacy `.equatable()` row gating:
+/// the hosting pool skips a rootView update (and re-measure) when the new
+/// token equals the old one.
+struct ACPRowEqualityToken {
+    private let base: Any
+    private let equalsBase: (Any) -> Bool
+
+    init<T: Equatable>(_ value: T) {
+        base = value
+        equalsBase = { ($0 as? T) == value }
+    }
+
+    func isEqual(to other: ACPRowEqualityToken) -> Bool {
+        equalsBase(other.base)
+    }
+}
+
+/// One row the AppKit scroller should display: a stable identity, an
+/// equality token deciding whether hosted content must be rebuilt, and a
+/// deferred SwiftUI builder (only invoked when the row is actually mounted).
+struct ACPTranscriptRowSpec {
+    let id: String
+    let equalityToken: ACPRowEqualityToken
+    let build: () -> AnyView
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowSpec.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptRowSpec.swift
@@ -24,4 +24,17 @@ struct ACPTranscriptRowSpec {
     let id: String
     let equalityToken: ACPRowEqualityToken
     let build: () -> AnyView
+
+    /// Whether this row's hosting view must stay mounted even while entirely
+    /// outside the reconciler's mount band. Message rows are stateless
+    /// renderings of transcript data — releasing their hosting view and
+    /// rebuilding it later is harmless. A handful of synthetic rows are not:
+    /// they carry view-local `@State`/`@FocusState` (an in-progress form,
+    /// most notably `ACPUserInputPrompt`'s `formState`) that a fresh
+    /// `NSHostingView` would silently discard. Set `true` only for rows that
+    /// actually hold such state; the reconciler unions these into the mount
+    /// band's `keep` set without expanding the band itself, so the exemption
+    /// stays small and bounded (at most a handful of live prompts) rather
+    /// than defeating the mount band's memory bound.
+    var keepsMountedOffscreen: Bool = false
 }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -168,22 +168,44 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             )
         }
 
-        /// Folds `host.theme` into an equality token so a live theme switch
-        /// forces every mounted row to rebuild — and thus re-run `wrapRow`'s
-        /// `.environment(\.theme, host.theme)` with the NEW value — instead
-        /// of leaving already-mounted rows on the old palette until some
+        /// Folds `host.theme` and `host.contentMaxWidth` into an equality
+        /// token so a live theme switch or column-width change forces every
+        /// mounted row to rebuild — and thus re-run `wrapRow`'s
+        /// `.environment(\.theme, host.theme)` and `.frame(maxWidth:
+        /// host.contentMaxWidth, ...)` with the NEW values — instead of
+        /// leaving already-mounted rows on the old palette/width until some
         /// other part of their content happens to change. `wrapRow` bakes
-        /// `host.theme` into the built view at construction time; without
-        /// this, `ACPTranscriptRowHostingPool.view(for:)` only rebuilds a
-        /// row when its token changes, so a bare theme switch (no other
-        /// content change) would never be observed by already-mounted rows.
+        /// both values into the built view at construction time for EVERY
+        /// row that goes through it (every synthetic spec below, plus
+        /// message rows); without this, `ACPTranscriptRowHostingPool.view(
+        /// for:)` only rebuilds a row when its token changes, so a bare
+        /// theme switch or window resize (no other content change) would
+        /// never be observed by already-mounted rows. Message rows already
+        /// fold `contentMaxWidth` a second time via `equalityKey`'s own
+        /// field — harmless duplication, not a correctness issue.
+        /// `host.typography` is deliberately NOT folded in here: unlike
+        /// `contentMaxWidth`, `wrapRow` never reads it, and most synthetic
+        /// rows below never capture it either, so folding it generically
+        /// would rebuild rows that don't use it on every typography change.
+        /// Specs whose build closures do capture it (the queue bubble) fold
+        /// it into their own token explicitly instead.
         private static func token<T: Equatable>(_ base: T, host: ACPTranscriptScroller) -> ACPRowEqualityToken {
-            ACPRowEqualityToken(ThemedToken(theme: host.theme, base: base))
+            ACPRowEqualityToken(ThemedToken(theme: host.theme, contentMaxWidth: host.contentMaxWidth, base: base))
         }
 
         private struct ThemedToken<Base: Equatable>: Equatable {
             let theme: Theme
+            let contentMaxWidth: CGFloat
             let base: Base
+        }
+
+        /// See the queue-bubble spec below: folds the rendering/behavior
+        /// inputs its build closure captures beyond what `token(_:host:)`
+        /// already covers generically (theme, contentMaxWidth).
+        private struct QueueBubbleTokenInputs: Equatable {
+            let item: QueuedPrompt
+            let idx: Int
+            let typography: ACPChatTypography
         }
 
         /// Message rows from the render window + synthetic tail rows, in the
@@ -378,7 +400,20 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             where ACPMessageList.shouldRenderQueueBubble(status: item.status) {
                 specs.append(ACPTranscriptRowSpec(
                     id: "__queue_\(item.id)",
-                    equalityToken: token(item, host: host),
+                    // Beyond `item` (and theme/contentMaxWidth folded by
+                    // `token(_:host:)`), this row's build closure also
+                    // captures `host.typography` (passed straight into
+                    // `ACPQueuedBubble`) and `idx` (captured by the
+                    // `.dropDestination` handler below as the reorder
+                    // target). Both must be in the token: a typography
+                    // change would otherwise leave the mounted bubble
+                    // measured with stale text metrics, and a stale `idx`
+                    // after the queue reorders would send a subsequent drag
+                    // on this retained bubble to the wrong slot.
+                    equalityToken: token(
+                        QueueBubbleTokenInputs(item: item, idx: idx, typography: host.typography),
+                        host: host
+                    ),
                     build: {
                         wrapRow(host: host) {
                             ACPQueuedBubble(

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -514,7 +514,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 visibleTail: host.transcript.visibleTailBound,
                 messageCount: host.transcript.messages.count,
                 distanceFromBottom: scroller.distanceFromBottom,
-                isUserDriven: isUserDriven, threshold: threshold
+                isUserDriven: isUserDriven, threshold: threshold,
+                previousScrollY: previousY, newScrollY: newY
             ) {
                 host.transcript.stepTailForward(preserving: nil, boundHead: false)
             }
@@ -632,11 +633,27 @@ extension ACPTranscriptScroller {
         visibleHead > 0 && isUserDriven && scrollY < threshold && !hasPendingHeadStep
     }
 
+    /// Mirrors `ACPMessageList.shouldStepTailForwardFromBottomGeometry`: a
+    /// bounds change within the bottom threshold only pages the hidden tail
+    /// while the viewport is actually moving DOWN through the document (in
+    /// this flipped, top-down coordinate space, that means `newScrollY`
+    /// increasing past `previousScrollY`). Without this, browsing upward
+    /// while near the bottom threshold — e.g. a non-tail-following session
+    /// with hidden newer messages — would advance `visibleTail` and
+    /// synchronously measure another chunk of rows on every tick, which is
+    /// exactly the unnecessary synchronous work this scroller exists to
+    /// avoid. `previousScrollY` is `nil` only before the first reported
+    /// scroll offset, in which case direction is unknown and paging is
+    /// withheld.
     nonisolated static func shouldStepTailForward(
         visibleTail: Int, messageCount: Int, distanceFromBottom: CGFloat,
-        isUserDriven: Bool, threshold: CGFloat
+        isUserDriven: Bool, threshold: CGFloat,
+        previousScrollY: CGFloat?, newScrollY: CGFloat
     ) -> Bool {
-        visibleTail < messageCount && isUserDriven && distanceFromBottom < threshold
+        guard visibleTail < messageCount, isUserDriven, distanceFromBottom < threshold,
+              let previousScrollY
+        else { return false }
+        return newScrollY > previousScrollY + ACPScrollDirectionClassifier.upwardEpsilon
     }
 }
 

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -200,6 +200,18 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// doc comment for the full argument).
         private func reconcileForViewportHeightChange() {
             guard let reconciler, !reconciler.isApplyingSpecs else { return }
+            // Re-tiling alone is not enough while following the tail. A
+            // height-only resize leaves `contentHeight` untouched but moves
+            // the maximum legal offset: shrinking the viewport pushes the
+            // bottom further down, so the unchanged `scrollY` stays legal
+            // while no longer sitting at the end. Without this the newest
+            // content drifts below the viewport, with tail-follow still
+            // reporting true, until some unrelated model update calls
+            // `apply()` and re-pins as a side effect. The legacy path's
+            // height-change handler scrolls to the tail for the same reason.
+            if reconciler.followsTail {
+                scroller?.scrollToBottom()
+            }
             reconciler.layoutMountedRows()
         }
 
@@ -212,7 +224,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // empty once a real width does arrive.
             guard let reconciler, let scroller else { return }
             let specs = Self.rowSpecs(host: host)
-            hasNonSyntheticRow = specs.contains { !$0.id.hasPrefix("__") }
+            hasNonSyntheticRow = specs.contains {
+                !$0.id.hasPrefix(ACPTranscriptScrollerReconciler.syntheticIdPrefix)
+            }
             reconciler.apply(
                 specs: specs,
                 contentWidth: scroller.contentView.bounds.width,
@@ -729,9 +743,17 @@ struct ACPTranscriptScroller: NSViewRepresentable {
 
         private func rememberCurrentAnchor() {
             guard let host, let scroller else { return }
-            guard let anchorId = tiling.topVisibleRowId(viewportMinY: scroller.scrollY),
-                  !anchorId.hasPrefix("__")   // synthetic rows are not anchors
-            else { return }
+            // Scans past synthetic rows rather than discarding the update
+            // when one is on top. The sharp case is the first scroll away
+            // from the tail landing at the head of a paginated transcript:
+            // the pagination spinner is the top row, and recording nothing
+            // there pauses tail-follow with no anchor at all — which
+            // restoration later resolves as "go to the bottom", undoing the
+            // scroll that caused it.
+            guard let anchorId = tiling.firstNonSyntheticRowId(
+                atOrBelow: scroller.scrollY,
+                syntheticIdPrefix: ACPTranscriptScrollerReconciler.syntheticIdPrefix
+            ) else { return }
             // O(1) per tick: the row list is rebuilt only when the window
             // itself changes, and the id → index map is derived once per
             // rebuild. Same rows, same builder, same lookup the legacy list

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -351,7 +351,13 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                                 onOpenURL: host.onOpenElicitationURL
                             )
                         }
-                    }
+                    },
+                    // `ACPUserInputPrompt` holds live `@State`/`@FocusState`
+                    // form data (see `ACPTranscriptRowSpec.keepsMountedOffscreen`).
+                    // Scrolling this prompt out of the mount band must not
+                    // destroy its hosting view — that would silently discard
+                    // whatever the user has already typed.
+                    keepsMountedOffscreen: true
                 ))
             }
 

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -83,6 +83,10 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         private let pool = ACPTranscriptRowHostingPool()
         private var host: ACPTranscriptScroller?
         private var didRestoreInitialPosition = false
+        /// Whether the most recently built spec list contained at least one
+        /// non-synthetic (message) row id — i.e. an id not prefixed `__`.
+        /// See `restoreInitialPositionIfNeeded`'s doc comment.
+        private var hasNonSyntheticRow = false
 
         static let composerSpacerHeight: CGFloat = 220
 
@@ -110,6 +114,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // empty once a real width does arrive.
             guard let reconciler, let scroller else { return }
             let specs = Self.rowSpecs(host: host)
+            hasNonSyntheticRow = specs.contains { !$0.id.hasPrefix("__") }
             reconciler.apply(
                 specs: specs,
                 contentWidth: scroller.contentView.bounds.width,
@@ -120,23 +125,49 @@ struct ACPTranscriptScroller: NSViewRepresentable {
 
         // MARK: row specs
 
-        /// Wraps a row's content with the environment values that would
-        /// otherwise reach it "for free" through normal SwiftUI ancestry in
-        /// the legacy single-ScrollView tree. Each row here is hosted in its
-        /// own, independently-created `NSHostingView` (see
-        /// `ACPTranscriptRowHostingPool`), which SwiftUI's environment
-        /// propagation does not reach automatically — so `\.theme` and
-        /// `\.openURL` (both set once at the legacy VStack root) must be
-        /// re-applied per row.
+        /// Wraps a row's content with the layout and environment values that
+        /// would otherwise reach it "for free" as a child of the legacy
+        /// VStack. In the legacy list, `.frame(maxWidth: contentMaxWidth,
+        /// alignment: .leading).padding(.horizontal: 28 +
+        /// laneWidth).frame(maxWidth: .infinity, alignment: .center)` sits
+        /// on the WHOLE VStack (ACPMessageList.swift:267-270), constraining
+        /// every child — including synthetic rows — into one centered
+        /// content column. `\.theme` and `\.openURL` are likewise set once
+        /// at that same root. Each row here is instead hosted in its own,
+        /// independently-created `NSHostingView` (see
+        /// `ACPTranscriptRowHostingPool`), which SwiftUI's layout/environment
+        /// propagation does not reach automatically — so both the column
+        /// framing and the environment values must be re-applied per row.
         private static func wrapRow<Content: View>(
             host: ACPTranscriptScroller,
             @ViewBuilder _ content: () -> Content
         ) -> AnyView {
             AnyView(
                 content()
+                    .frame(maxWidth: host.contentMaxWidth, alignment: .leading)
+                    .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
+                    .frame(maxWidth: .infinity, alignment: .center)
                     .environment(\.theme, host.theme)
                     .environment(\.openURL, host.openTranscriptURLAction)
             )
+        }
+
+        /// Folds `host.theme` into an equality token so a live theme switch
+        /// forces every mounted row to rebuild — and thus re-run `wrapRow`'s
+        /// `.environment(\.theme, host.theme)` with the NEW value — instead
+        /// of leaving already-mounted rows on the old palette until some
+        /// other part of their content happens to change. `wrapRow` bakes
+        /// `host.theme` into the built view at construction time; without
+        /// this, `ACPTranscriptRowHostingPool.view(for:)` only rebuilds a
+        /// row when its token changes, so a bare theme switch (no other
+        /// content change) would never be observed by already-mounted rows.
+        private static func token<T: Equatable>(_ base: T, host: ACPTranscriptScroller) -> ACPRowEqualityToken {
+            ACPRowEqualityToken(ThemedToken(theme: host.theme, base: base))
+        }
+
+        private struct ThemedToken<Base: Equatable>: Equatable {
+            let theme: Theme
+            let base: Base
         }
 
         /// Message rows from the render window + synthetic tail rows, in the
@@ -148,7 +179,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             if transcript.isBackfillingOlderMessages || transcript.visibleHead > 0 {
                 specs.append(ACPTranscriptRowSpec(
                     id: "__top_pagination__",
-                    equalityToken: ACPRowEqualityToken(transcript.isBackfillingOlderMessages),
+                    equalityToken: token(transcript.isBackfillingOlderMessages, host: host),
                     build: {
                         wrapRow(host: host) {
                             Spinner(lineWidth: 1.5)
@@ -168,16 +199,16 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             )
             for row in rows where transcript.messages.indices.contains(row.index) {
                 let message = transcript.messages[row.index]
-                let token = ACPRowEqualityToken(ACPTranscriptRowContent.equalityKey(
+                let rowToken = token(ACPTranscriptRowContent.equalityKey(
                     stableId: row.stableId, message: message,
                     contentMaxWidth: host.contentMaxWidth, typography: host.typography,
                     trustedImageRoot: host.trustedImageRoot,
                     isForkEligible: host.session.canForkMessage(at: row.index),
                     forkTargets: host.forkTargets
-                ))
+                ), host: host)
                 specs.append(ACPTranscriptRowSpec(
                     id: row.stableId,
-                    equalityToken: token,
+                    equalityToken: rowToken,
                     build: { wrapRow(host: host) { Self.messageRow(host: host, row: row, message: message) } }
                 ))
                 // Fork divider follows its boundary row, as in the legacy list.
@@ -213,9 +244,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 forkTargets: host.forkTargets,
                 onFork: host.onFork
             )
-            .frame(maxWidth: host.contentMaxWidth, alignment: .leading)
-            .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
-            .frame(maxWidth: .infinity, alignment: .center)
+            // Column framing (max width / horizontal padding / centering)
+            // is applied uniformly to every row by `wrapRow`, not here —
+            // see its doc comment.
         }
 
         /// Verbatim port of the fork divider inserted right after the fork
@@ -226,7 +257,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         ) -> ACPTranscriptRowSpec {
             ACPTranscriptRowSpec(
                 id: "__fork_divider__",
-                equalityToken: ACPRowEqualityToken(fork),
+                equalityToken: token(fork, host: host),
                 build: {
                     wrapRow(host: host) {
                         Group {
@@ -261,7 +292,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 let pendingPermission = transcript.pendingPermission
                 specs.append(ACPTranscriptRowSpec(
                     id: "__pending_perm__",
-                    equalityToken: ACPRowEqualityToken(pendingPermission),
+                    equalityToken: token(pendingPermission, host: host),
                     build: {
                         wrapRow(host: host) {
                             ACPPermissionPrompt(session: session, policy: policy, scopeKey: host.scopeKey)
@@ -273,7 +304,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             if let request = transcript.pendingUserInputs.first {
                 specs.append(ACPTranscriptRowSpec(
                     id: "__pending_user_input_\(request.id)",
-                    equalityToken: ACPRowEqualityToken(request.id),
+                    equalityToken: token(request.id, host: host),
                     build: {
                         wrapRow(host: host) {
                             ACPUserInputPrompt(
@@ -289,7 +320,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             for wait in transcript.urlElicitationWaits {
                 specs.append(ACPTranscriptRowSpec(
                     id: "__elicitation_wait_\(wait.id)",
-                    equalityToken: ACPRowEqualityToken(wait),
+                    equalityToken: token(wait, host: host),
                     build: {
                         wrapRow(host: host) {
                             ACPURLElicitationWaitView(
@@ -305,7 +336,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             if transcript.streamingState == .streaming {
                 specs.append(ACPTranscriptRowSpec(
                     id: "__streaming_caret__",
-                    equalityToken: ACPRowEqualityToken(transcript.streamingState),
+                    equalityToken: token(transcript.streamingState, host: host),
                     build: {
                         wrapRow(host: host) {
                             StreamingCaret().frame(width: 8, height: 14)
@@ -318,7 +349,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             if queueHeaderCount > 1 {
                 specs.append(ACPTranscriptRowSpec(
                     id: "__queue_header__",
-                    equalityToken: ACPRowEqualityToken(queueHeaderCount),
+                    equalityToken: token(queueHeaderCount, host: host),
                     build: {
                         wrapRow(host: host) {
                             ACPQueueHeader(count: queueHeaderCount, onClear: host.onQueueClearAll)
@@ -331,7 +362,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             where ACPMessageList.shouldRenderQueueBubble(status: item.status) {
                 specs.append(ACPTranscriptRowSpec(
                     id: "__queue_\(item.id)",
-                    equalityToken: ACPRowEqualityToken(item),
+                    equalityToken: token(item, host: host),
                     build: {
                         wrapRow(host: host) {
                             ACPQueuedBubble(
@@ -363,7 +394,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             if let status = session.contextRecoveryStatus {
                 specs.append(ACPTranscriptRowSpec(
                     id: "__context_recovery__",
-                    equalityToken: ACPRowEqualityToken(status),
+                    equalityToken: token(status, host: host),
                     build: {
                         wrapRow(host: host) {
                             ContextRecoveryRow(status: status, onRetry: host.onRetryContextRecovery)
@@ -374,15 +405,20 @@ struct ACPTranscriptScroller: NSViewRepresentable {
 
             // Invisible tail spacer the tail-follow scroll pins to the
             // viewport bottom; guarantees the streaming caret / last
-            // message sits above the composer pill. Content never changes,
-            // so a constant equality token is correct (never rebuilds).
+            // message sits above the composer pill. Its content is a
+            // fixed-height `Color.clear` that reads neither theme nor
+            // openURL, so — unlike every other row — a constant equality
+            // token is correct here: nothing about it ever needs to rebuild.
+            // Still routed through `wrapRow` for the same column framing
+            // every other row gets, matching the legacy VStack where this
+            // spacer was a plain child of the same constrained stack.
             specs.append(ACPTranscriptRowSpec(
                 id: "__composer_spacer__",
                 equalityToken: ACPRowEqualityToken(true),
                 build: {
-                    AnyView(
+                    wrapRow(host: host) {
                         Color.clear.frame(height: composerSpacerHeight)
-                    )
+                    }
                 }
             ))
 
@@ -397,7 +433,20 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             isProgrammatic: Bool
         ) {
             guard let host, let scroller, let reconciler else { return }
-            reconciler.layoutMountedRows()
+            // `apply()` issues its own programmatic scrolls synchronously
+            // (`applyPrepend`, `scrollToBottom`) while `specsById`/
+            // `orderedIds` are mid-mutation; running a layout pass here
+            // against that stale state would mount views from the previous
+            // update instead of the one `apply()` is still installing.
+            // `apply()`'s own trailing `layoutMountedRows()` call covers
+            // this once it's safe — see `isApplyingSpecs`'s doc comment.
+            // Other programmatic scrolls that happen OUTSIDE of `apply()`
+            // (`resumeTailFollow`, `restoreInitialPositionIfNeeded`) are not
+            // covered by that trailing call, so they invoke
+            // `layoutMountedRows()` explicitly themselves.
+            if !reconciler.isApplyingSpecs {
+                reconciler.layoutMountedRows()
+            }
             guard !isProgrammatic else { return }
 
             let event = NSApp.currentEvent
@@ -479,19 +528,43 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             host.onRememberScrollAnchor(anchorId, index, false)
         }
 
+        /// Runs once per Coordinator lifetime, but only actually latches
+        /// (`didRestoreInitialPosition = true`) once the outcome is
+        /// definite. `__composer_spacer__` and other synthetic rows are
+        /// unconditionally present in `rowSpecs`, so `tiling.rowCount > 0`
+        /// alone is true on the very first `apply()` even with zero
+        /// messages — gating on `hasNonSyntheticRow` instead avoids latching
+        /// before there's any real content to restore a position within.
+        /// Beyond that: tail-follow and "no remembered anchor" are definite
+        /// outcomes (latch immediately); a remembered anchor that isn't yet
+        /// in the tiling map (e.g. the render window hasn't reached it yet)
+        /// is NOT definite — don't latch, so the next `update(host:)` (which
+        /// runs on every relevant transcript/session change, mirroring the
+        /// legacy path's retries on appear / viewport change / scroll
+        /// signature / visibleHead) gets another chance to resolve it,
+        /// instead of permanently falling back to `scrollToBottom()`.
         private func restoreInitialPositionIfNeeded() {
             guard !didRestoreInitialPosition, let host, let scroller,
-                  tiling.rowCount > 0
+                  hasNonSyntheticRow
             else { return }
-            didRestoreInitialPosition = true
             if host.session.followsTranscriptTail {
+                didRestoreInitialPosition = true
                 scroller.scrollToBottom()
-            } else if let anchor = host.rememberedScrollAnchor(),
-                      let row = tiling.row(withId: anchor) {
-                scroller.setScrollY(row.minY)
-            } else {
-                scroller.scrollToBottom()
+                return
             }
+            guard let anchor = host.rememberedScrollAnchor() else {
+                // Nothing to restore — this is a definite final state.
+                didRestoreInitialPosition = true
+                scroller.scrollToBottom()
+                return
+            }
+            guard let row = tiling.row(withId: anchor) else {
+                // Anchor exists but isn't resolvable yet; retry later
+                // instead of latching onto a wrong fallback.
+                return
+            }
+            didRestoreInitialPosition = true
+            scroller.setScrollY(row.minY)
         }
     }
 }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -87,6 +87,18 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// non-synthetic (message) row id — i.e. an id not prefixed `__`.
         /// See `restoreInitialPositionIfNeeded`'s doc comment.
         private var hasNonSyntheticRow = false
+        /// Set when a head step has been requested and cleared by the next
+        /// `update(host:)`. See `handleScroll`'s head-step block.
+        private var pendingHeadStep = false
+        /// Memoizes the window-sliced row list + its id → message-index
+        /// lookup, keyed on (messages generation, window bounds) — the same
+        /// cache the legacy list uses. `rememberCurrentAnchor` runs on every
+        /// non-programmatic scroll tick while browsing history, i.e. at
+        /// display refresh rate over a window that can hold thousands of
+        /// rows; rebuilding that array per tick just to map one anchor id to
+        /// its message index is O(window) work in exactly the state where
+        /// scrolling must stay smooth.
+        private let visibleRowsCache = ACPVisibleRowsCache()
 
         static let composerSpacerHeight: CGFloat = 220
 
@@ -120,6 +132,10 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 contentWidth: scroller.contentView.bounds.width,
                 followsTail: host.session.followsTranscriptTail
             )
+            // This update carries whatever `visibleHead` currently is, so a
+            // head step requested since the last one has now been applied
+            // (or, at width 0, will be re-requested by the next scroll tick).
+            pendingHeadStep = false
             restoreInitialPositionIfNeeded()
         }
 
@@ -480,11 +496,19 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             let threshold = ACPTranscriptScroller.headStepThreshold(viewportHeight: viewportHeight)
             if ACPTranscriptScroller.shouldStepHeadBack(
                 visibleHead: host.transcript.visibleHead,
-                scrollY: newY, isUserDriven: isUserDriven, threshold: threshold
+                scrollY: newY, isUserDriven: isUserDriven, threshold: threshold,
+                hasPendingHeadStep: pendingHeadStep
             ) {
+                // `stepHeadBack` mutates `visibleHead` synchronously, but the
+                // rows it exposes — and the compensating prepend that keeps
+                // them from shoving the reading position down — only arrive
+                // on the NEXT SwiftUI update. Until then every scroll tick
+                // still sees a positive `visibleHead` and a `scrollY` under
+                // threshold, so without this latch one flick near the head
+                // queues several steps that land together as a single
+                // 60-150 row insertion measured in one synchronous pass.
+                pendingHeadStep = true
                 host.transcript.stepHeadBack(boundTail: false)
-                // SwiftUI observes visibleHead; updateNSView re-runs and the
-                // reconciler prepends with compensation in that same pass.
             }
             if ACPTranscriptScroller.shouldStepTailForward(
                 visibleTail: host.transcript.visibleTailBound,
@@ -520,14 +544,24 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             guard let anchorId = tiling.topVisibleRowId(viewportMinY: scroller.scrollY),
                   !anchorId.hasPrefix("__")   // synthetic rows are not anchors
             else { return }
-            let rows = ACPMessageList.visibleRows(
-                messages: host.transcript.messages,
-                visibleHead: host.transcript.visibleHead,
-                visibleTail: host.transcript.visibleTailBound,
-                stableId: { host.transcript.stableId(for: $0) }
+            // O(1) per tick: the row list is rebuilt only when the window
+            // itself changes, and the id → index map is derived once per
+            // rebuild. Same rows, same builder, same lookup the legacy list
+            // uses.
+            let lookup = visibleRowsCache.lookup(
+                generation: host.transcript.messagesGeneration,
+                head: host.transcript.visibleHead,
+                tail: host.transcript.visibleTailBound,
+                build: {
+                    ACPMessageList.visibleRows(
+                        messages: host.transcript.messages,
+                        visibleHead: host.transcript.visibleHead,
+                        visibleTail: host.transcript.visibleTailBound,
+                        stableId: { host.transcript.stableId(for: $0) }
+                    )
+                }
             )
-            let index = rows.first(where: { $0.stableId == anchorId })?.index
-            host.onRememberScrollAnchor(anchorId, index, false)
+            host.onRememberScrollAnchor(anchorId, lookup.transcriptIndex(for: anchorId), false)
         }
 
         /// Runs once per Coordinator lifetime, but only actually latches
@@ -588,10 +622,14 @@ extension ACPTranscriptScroller {
         max(1500, viewportHeight * 2)
     }
 
+    /// `hasPendingHeadStep` is the caller's latch for "a step was already
+    /// requested and its compensating update hasn't landed yet" — see the
+    /// call site in `Coordinator.handleScroll`.
     nonisolated static func shouldStepHeadBack(
-        visibleHead: Int, scrollY: CGFloat, isUserDriven: Bool, threshold: CGFloat
+        visibleHead: Int, scrollY: CGFloat, isUserDriven: Bool, threshold: CGFloat,
+        hasPendingHeadStep: Bool = false
     ) -> Bool {
-        visibleHead > 0 && isUserDriven && scrollY < threshold
+        visibleHead > 0 && isUserDriven && scrollY < threshold && !hasPendingHeadStep
     }
 
     nonisolated static func shouldStepTailForward(

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -1,0 +1,591 @@
+import AppKit
+import SwiftUI
+
+/// AppKit-backed transcript scroller (feature-flagged replacement for the
+/// SwiftUI ScrollView in ACPMessageList). SwiftUI remains the reconciliation
+/// driver: every updateNSView builds the ordered row-spec list from the
+/// transcript's render window and hands it to the reconciler; AppKit owns
+/// scrolling, tiling, and offset compensation.
+struct ACPTranscriptScroller: NSViewRepresentable {
+    @ObservedObject var session: ACPSession
+    @ObservedObject var transcript: ACPTranscript
+    let contentMaxWidth: CGFloat
+    let typography: ACPChatTypography
+    let trustedImageRoot: URL?
+    let onOpenDiff: (String) -> Void
+    let onLoadFullToolCallContent: (String) async -> String?
+    let forkTargets: [ACPSessionForkTarget]
+    let onFork: (ACPForkMessageBoundary, String) -> Void
+    let rememberedScrollAnchor: () -> String?
+    let onRememberScrollAnchor: (String?, Int?, Bool) -> Void
+    // Remaining ACPMessageList host inputs (ACPMessageList.swift:5-36),
+    // carried through with identical names/types so Task 11 can pass this
+    // struct's init the same arguments it already builds for ACPMessageList.
+    let onOpenTranscriptLink: (URL) -> Bool
+    let policy: ACPPermissionPolicy?
+    let scopeKey: String
+    let onUserInputResponse: (UUID, ACPUserInputAction) -> Void
+    let onOpenElicitationURL: (UUID) async -> Bool
+    let onDismissElicitationURLWait: (String) -> Void
+    let onQueueEdit: (QueuedPrompt) -> Void
+    let onQueueForceSend: (UUID) -> Void
+    let onQueueRemove: (UUID) -> Void
+    let onQueueRetry: (UUID) -> Void
+    let onQueueReorder: (Int, Int) -> Void
+    let onQueueClearAll: () -> Void
+    let onRetryContextRecovery: () -> Void
+    let onOpenForkSource: (String) -> Void
+    let agentDisplayName: (String) -> String
+
+    /// Ambient theme at the point this representable sits in the SwiftUI
+    /// tree. Individual rows are hosted in their own, otherwise-disconnected
+    /// `NSHostingView`s (see `ACPTranscriptRowHostingPool`), so SwiftUI's
+    /// normal environment inheritance — which would carry `\.theme` down
+    /// from `RootView`'s `.environment(\.theme, ...)` for free in the legacy
+    /// single-ScrollView tree — does not reach them automatically. Every row
+    /// spec re-applies this value explicitly (see `wrapRow`).
+    @Environment(\.theme) private var theme
+
+    /// Mirrors `ACPMessageList.openTranscriptURLAction`: routes markdown
+    /// link taps inside message rows back through the host callback.
+    private var openTranscriptURLAction: OpenURLAction {
+        OpenURLAction { url in
+            onOpenTranscriptLink(url) ? .handled : .systemAction
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> ACPTranscriptScrollerView {
+        let scroller = ACPTranscriptScrollerView(frame: .zero)
+        context.coordinator.attach(scroller: scroller, host: self)
+        return scroller
+    }
+
+    func updateNSView(_ nsView: ACPTranscriptScrollerView, context: Context) {
+        context.coordinator.update(host: self)
+    }
+
+    @MainActor
+    final class Coordinator {
+        // The Coordinator is the sole strong owner of both `scroller` and
+        // `reconciler`. `reconciler` holds `unowned let scroller`: nothing
+        // outside this Coordinator keeps `reconciler` alive (its callback
+        // closures capture `self` weakly, never `scroller` directly), so
+        // when the Coordinator is deallocated both references are released
+        // together and the unowned pointer is never dereferenced after
+        // `scroller` is gone. SwiftUI's own strong reference to the NSView
+        // it placed in the AppKit hierarchy only extends `scroller`'s
+        // lifetime further, which cannot violate the invariant.
+        private var scroller: ACPTranscriptScrollerView?
+        private var reconciler: ACPTranscriptScrollerReconciler?
+        private let tiling = ACPTranscriptTilingController()
+        private let pool = ACPTranscriptRowHostingPool()
+        private var host: ACPTranscriptScroller?
+        private var didRestoreInitialPosition = false
+
+        static let composerSpacerHeight: CGFloat = 220
+
+        func attach(scroller: ACPTranscriptScrollerView, host: ACPTranscriptScroller) {
+            self.scroller = scroller
+            self.reconciler = ACPTranscriptScrollerReconciler(
+                tiling: tiling, pool: pool, scroller: scroller
+            )
+            scroller.onScroll = { [weak self] previousY, newY, viewportH, contentH, isProgrammatic in
+                self?.handleScroll(
+                    previousY: previousY, newY: newY,
+                    viewportHeight: viewportH, contentHeight: contentH,
+                    isProgrammatic: isProgrammatic
+                )
+            }
+            update(host: host)
+        }
+
+        func update(host: ACPTranscriptScroller) {
+            self.host = host
+            // Re-apply unconditionally: `reconciler.apply` itself early-
+            // returns and records nothing for a non-positive width (host
+            // view not yet laid out), so skipping this call based on any
+            // "already applied" memo would leave the transcript permanently
+            // empty once a real width does arrive.
+            guard let reconciler, let scroller else { return }
+            let specs = Self.rowSpecs(host: host)
+            reconciler.apply(
+                specs: specs,
+                contentWidth: scroller.contentView.bounds.width,
+                followsTail: host.session.followsTranscriptTail
+            )
+            restoreInitialPositionIfNeeded()
+        }
+
+        // MARK: row specs
+
+        /// Wraps a row's content with the environment values that would
+        /// otherwise reach it "for free" through normal SwiftUI ancestry in
+        /// the legacy single-ScrollView tree. Each row here is hosted in its
+        /// own, independently-created `NSHostingView` (see
+        /// `ACPTranscriptRowHostingPool`), which SwiftUI's environment
+        /// propagation does not reach automatically — so `\.theme` and
+        /// `\.openURL` (both set once at the legacy VStack root) must be
+        /// re-applied per row.
+        private static func wrapRow<Content: View>(
+            host: ACPTranscriptScroller,
+            @ViewBuilder _ content: () -> Content
+        ) -> AnyView {
+            AnyView(
+                content()
+                    .environment(\.theme, host.theme)
+                    .environment(\.openURL, host.openTranscriptURLAction)
+            )
+        }
+
+        /// Message rows from the render window + synthetic tail rows, in the
+        /// same order the legacy VStack rendered them.
+        static func rowSpecs(host: ACPTranscriptScroller) -> [ACPTranscriptRowSpec] {
+            let transcript = host.transcript
+            var specs: [ACPTranscriptRowSpec] = []
+
+            if transcript.isBackfillingOlderMessages || transcript.visibleHead > 0 {
+                specs.append(ACPTranscriptRowSpec(
+                    id: "__top_pagination__",
+                    equalityToken: ACPRowEqualityToken(transcript.isBackfillingOlderMessages),
+                    build: {
+                        wrapRow(host: host) {
+                            Spinner(lineWidth: 1.5)
+                                .frame(width: 14, height: 14)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .opacity(transcript.isBackfillingOlderMessages ? 1 : 0)
+                        }
+                    }
+                ))
+            }
+
+            let rows = ACPMessageList.visibleRows(
+                messages: transcript.messages,
+                visibleHead: transcript.visibleHead,
+                visibleTail: transcript.visibleTailBound,
+                stableId: { transcript.stableId(for: $0) }
+            )
+            for row in rows where transcript.messages.indices.contains(row.index) {
+                let message = transcript.messages[row.index]
+                let token = ACPRowEqualityToken(ACPTranscriptRowContent.equalityKey(
+                    stableId: row.stableId, message: message,
+                    contentMaxWidth: host.contentMaxWidth, typography: host.typography,
+                    trustedImageRoot: host.trustedImageRoot,
+                    isForkEligible: host.session.canForkMessage(at: row.index),
+                    forkTargets: host.forkTargets
+                ))
+                specs.append(ACPTranscriptRowSpec(
+                    id: row.stableId,
+                    equalityToken: token,
+                    build: { wrapRow(host: host) { Self.messageRow(host: host, row: row, message: message) } }
+                ))
+                // Fork divider follows its boundary row, as in the legacy list.
+                if let fork = host.session.forkRecord,
+                   fork.phase == .ready,
+                   row.index == fork.inheritedMessageCount - 1,
+                   fork.mechanism != nil {
+                    specs.append(Self.forkDividerSpec(host: host, fork: fork))
+                }
+            }
+
+            specs.append(contentsOf: Self.syntheticTailSpecs(host: host))
+            return specs
+        }
+
+        static func messageRow(
+            host: ACPTranscriptScroller,
+            row: ACPMessageList.VisibleRow,
+            message: ACPMessage
+        ) -> some View {
+            ACPTranscriptRowContent(
+                stableId: row.stableId,
+                messageIndex: row.index,
+                message: message,
+                contentMaxWidth: host.contentMaxWidth,
+                typography: host.typography,
+                trustedImageRoot: host.trustedImageRoot,
+                transcript: host.transcript,
+                session: host.session,
+                onOpenDiff: host.onOpenDiff,
+                onLoadFullToolCallContent: host.onLoadFullToolCallContent,
+                isForkEligible: host.session.canForkMessage(at: row.index),
+                forkTargets: host.forkTargets,
+                onFork: host.onFork
+            )
+            .frame(maxWidth: host.contentMaxWidth, alignment: .leading)
+            .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+
+        /// Verbatim port of the fork divider inserted right after the fork
+        /// boundary row in the legacy VStack (ACPMessageList.swift:179-191).
+        static func forkDividerSpec(
+            host: ACPTranscriptScroller,
+            fork: ACPSessionForkRecord
+        ) -> ACPTranscriptRowSpec {
+            ACPTranscriptRowSpec(
+                id: "__fork_divider__",
+                equalityToken: ACPRowEqualityToken(fork),
+                build: {
+                    wrapRow(host: host) {
+                        Group {
+                            if let mechanism = fork.mechanism {
+                                ACPSessionForkDivider(
+                                    presentation: .init(
+                                        sourceAgentName: host.agentDisplayName(fork.sourceAgentID),
+                                        mechanism: mechanism
+                                    ),
+                                    onOpenSource: { host.onOpenForkSource(fork.sourceSessionID) }
+                                )
+                            }
+                        }
+                    }
+                }
+            )
+        }
+
+        /// Verbatim ports of the trailing elements of the legacy VStack
+        /// (ACPMessageList.swift:199-265): pending permission prompt,
+        /// pending user-input prompt, URL-elicitation waits, streaming
+        /// caret, queue header, queued bubbles, context-recovery row, and
+        /// the invisible composer spacer. Same ids the legacy list used.
+        /// Equality tokens carry the same values `scrollSignature` hashed
+        /// for each element.
+        static func syntheticTailSpecs(host: ACPTranscriptScroller) -> [ACPTranscriptRowSpec] {
+            let transcript = host.transcript
+            let session = host.session
+            var specs: [ACPTranscriptRowSpec] = []
+
+            if transcript.pendingPermission != nil, let policy = host.policy {
+                let pendingPermission = transcript.pendingPermission
+                specs.append(ACPTranscriptRowSpec(
+                    id: "__pending_perm__",
+                    equalityToken: ACPRowEqualityToken(pendingPermission),
+                    build: {
+                        wrapRow(host: host) {
+                            ACPPermissionPrompt(session: session, policy: policy, scopeKey: host.scopeKey)
+                        }
+                    }
+                ))
+            }
+
+            if let request = transcript.pendingUserInputs.first {
+                specs.append(ACPTranscriptRowSpec(
+                    id: "__pending_user_input_\(request.id)",
+                    equalityToken: ACPRowEqualityToken(request.id),
+                    build: {
+                        wrapRow(host: host) {
+                            ACPUserInputPrompt(
+                                request: request,
+                                onRespond: host.onUserInputResponse,
+                                onOpenURL: host.onOpenElicitationURL
+                            )
+                        }
+                    }
+                ))
+            }
+
+            for wait in transcript.urlElicitationWaits {
+                specs.append(ACPTranscriptRowSpec(
+                    id: "__elicitation_wait_\(wait.id)",
+                    equalityToken: ACPRowEqualityToken(wait),
+                    build: {
+                        wrapRow(host: host) {
+                            ACPURLElicitationWaitView(
+                                wait: wait,
+                                onOpenAgain: { NSWorkspace.shared.open($0) },
+                                onDismiss: host.onDismissElicitationURLWait
+                            )
+                        }
+                    }
+                ))
+            }
+
+            if transcript.streamingState == .streaming {
+                specs.append(ACPTranscriptRowSpec(
+                    id: "__streaming_caret__",
+                    equalityToken: ACPRowEqualityToken(transcript.streamingState),
+                    build: {
+                        wrapRow(host: host) {
+                            StreamingCaret().frame(width: 8, height: 14)
+                        }
+                    }
+                ))
+            }
+
+            let queueHeaderCount = ACPMessageList.queueHeaderCount(statuses: session.queue.map(\.status))
+            if queueHeaderCount > 1 {
+                specs.append(ACPTranscriptRowSpec(
+                    id: "__queue_header__",
+                    equalityToken: ACPRowEqualityToken(queueHeaderCount),
+                    build: {
+                        wrapRow(host: host) {
+                            ACPQueueHeader(count: queueHeaderCount, onClear: host.onQueueClearAll)
+                        }
+                    }
+                ))
+            }
+
+            for (idx, item) in session.queue.enumerated()
+            where ACPMessageList.shouldRenderQueueBubble(status: item.status) {
+                specs.append(ACPTranscriptRowSpec(
+                    id: "__queue_\(item.id)",
+                    equalityToken: ACPRowEqualityToken(item),
+                    build: {
+                        wrapRow(host: host) {
+                            ACPQueuedBubble(
+                                item: item,
+                                contentMaxWidth: host.contentMaxWidth,
+                                typography: host.typography,
+                                onForceSend: { host.onQueueForceSend(item.id) },
+                                onEdit: { host.onQueueEdit(item) },
+                                onRemove: { host.onQueueRemove(item.id) },
+                                onRetry: { host.onQueueRetry(item.id) }
+                            )
+                            .dropDestination(for: String.self) { items, _ in
+                                guard let s = items.first,
+                                      let uuid = UUID(uuidString: s),
+                                      let src = session.queue.firstIndex(where: { $0.id == uuid })
+                                else { return false }
+                                guard ACPMessageList.canDropQueuedItem(
+                                    sourceStatus: session.queue[src].status,
+                                    targetStatus: item.status
+                                ) else { return false }
+                                host.onQueueReorder(src, idx)
+                                return true
+                            }
+                        }
+                    }
+                ))
+            }
+
+            if let status = session.contextRecoveryStatus {
+                specs.append(ACPTranscriptRowSpec(
+                    id: "__context_recovery__",
+                    equalityToken: ACPRowEqualityToken(status),
+                    build: {
+                        wrapRow(host: host) {
+                            ContextRecoveryRow(status: status, onRetry: host.onRetryContextRecovery)
+                        }
+                    }
+                ))
+            }
+
+            // Invisible tail spacer the tail-follow scroll pins to the
+            // viewport bottom; guarantees the streaming caret / last
+            // message sits above the composer pill. Content never changes,
+            // so a constant equality token is correct (never rebuilds).
+            specs.append(ACPTranscriptRowSpec(
+                id: "__composer_spacer__",
+                equalityToken: ACPRowEqualityToken(true),
+                build: {
+                    AnyView(
+                        Color.clear.frame(height: composerSpacerHeight)
+                    )
+                }
+            ))
+
+            return specs
+        }
+
+        // MARK: scroll handling
+
+        private func handleScroll(
+            previousY: CGFloat?, newY: CGFloat,
+            viewportHeight: CGFloat, contentHeight: CGFloat,
+            isProgrammatic: Bool
+        ) {
+            guard let host, let scroller, let reconciler else { return }
+            reconciler.layoutMountedRows()
+            guard !isProgrammatic else { return }
+
+            let event = NSApp.currentEvent
+            let eventIsFresh = ACPUserScrollEvent.isFresh(
+                eventTimestamp: event?.timestamp,
+                now: ProcessInfo.processInfo.systemUptime
+            )
+            let isUserDriven = eventIsFresh && ACPUserScrollEvent.isUserDriven(event?.type)
+
+            let decision = ACPScrollDirectionClassifier.decide(
+                previousOffsetY: previousY,
+                newOffsetY: newY,
+                viewportHeight: viewportHeight,
+                contentHeight: contentHeight,
+                isRestoring: false,
+                isUserDriven: isUserDriven
+            )
+            switch decision {
+            case .userScrolledUp:
+                pauseTailFollow()
+            case .userAtBottom:
+                if host.transcript.visibleTailBound >= host.transcript.messages.count {
+                    resumeTailFollow()
+                }
+            case .noChange:
+                break
+            }
+
+            let threshold = ACPTranscriptScroller.headStepThreshold(viewportHeight: viewportHeight)
+            if ACPTranscriptScroller.shouldStepHeadBack(
+                visibleHead: host.transcript.visibleHead,
+                scrollY: newY, isUserDriven: isUserDriven, threshold: threshold
+            ) {
+                host.transcript.stepHeadBack(boundTail: false)
+                // SwiftUI observes visibleHead; updateNSView re-runs and the
+                // reconciler prepends with compensation in that same pass.
+            }
+            if ACPTranscriptScroller.shouldStepTailForward(
+                visibleTail: host.transcript.visibleTailBound,
+                messageCount: host.transcript.messages.count,
+                distanceFromBottom: scroller.distanceFromBottom,
+                isUserDriven: isUserDriven, threshold: threshold
+            ) {
+                host.transcript.stepTailForward(preserving: nil, boundHead: false)
+            }
+
+            if !host.session.followsTranscriptTail {
+                rememberCurrentAnchor()
+            }
+        }
+
+        private func pauseTailFollow() {
+            guard let host, host.session.followsTranscriptTail else { return }
+            host.session.followsTranscriptTail = false
+            host.transcript.freezeVisibleTail()
+            rememberCurrentAnchor()
+        }
+
+        private func resumeTailFollow() {
+            guard let host, !host.session.followsTranscriptTail else { return }
+            host.session.followsTranscriptTail = true
+            host.transcript.resetWindowToTail()
+            host.onRememberScrollAnchor(nil, nil, true)
+            scroller?.scrollToBottom()
+        }
+
+        private func rememberCurrentAnchor() {
+            guard let host, let scroller else { return }
+            guard let anchorId = tiling.topVisibleRowId(viewportMinY: scroller.scrollY),
+                  !anchorId.hasPrefix("__")   // synthetic rows are not anchors
+            else { return }
+            let rows = ACPMessageList.visibleRows(
+                messages: host.transcript.messages,
+                visibleHead: host.transcript.visibleHead,
+                visibleTail: host.transcript.visibleTailBound,
+                stableId: { host.transcript.stableId(for: $0) }
+            )
+            let index = rows.first(where: { $0.stableId == anchorId })?.index
+            host.onRememberScrollAnchor(anchorId, index, false)
+        }
+
+        private func restoreInitialPositionIfNeeded() {
+            guard !didRestoreInitialPosition, let host, let scroller,
+                  tiling.rowCount > 0
+            else { return }
+            didRestoreInitialPosition = true
+            if host.session.followsTranscriptTail {
+                scroller.scrollToBottom()
+            } else if let anchor = host.rememberedScrollAnchor(),
+                      let row = tiling.row(withId: anchor) {
+                scroller.setScrollY(row.minY)
+            } else {
+                scroller.scrollToBottom()
+            }
+        }
+    }
+}
+
+extension ACPTranscriptScroller {
+    nonisolated static func headStepThreshold(viewportHeight: CGFloat) -> CGFloat {
+        max(1500, viewportHeight * 2)
+    }
+
+    nonisolated static func shouldStepHeadBack(
+        visibleHead: Int, scrollY: CGFloat, isUserDriven: Bool, threshold: CGFloat
+    ) -> Bool {
+        visibleHead > 0 && isUserDriven && scrollY < threshold
+    }
+
+    nonisolated static func shouldStepTailForward(
+        visibleTail: Int, messageCount: Int, distanceFromBottom: CGFloat,
+        isUserDriven: Bool, threshold: CGFloat
+    ) -> Bool {
+        visibleTail < messageCount && isUserDriven && distanceFromBottom < threshold
+    }
+}
+
+// MARK: - Synthetic row content
+
+/// Verbatim port of `ACPMessageList.StreamingCaret` (private to that file).
+private struct StreamingCaret: View {
+    @State private var on = false
+    @Environment(\.theme) private var theme
+    var body: some View {
+        RoundedRectangle(cornerRadius: 1)
+            .fill(theme.color("accent"))
+            .opacity(on ? 1 : 0)
+            .animation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true), value: on)
+            .onAppear { on = true }
+    }
+}
+
+/// Verbatim port of `ACPMessageList.contextRecoveryRow(_:)` +
+/// `contextRecoveryText(_:)` (private to that file).
+private struct ContextRecoveryRow: View {
+    let status: ACPSession.ContextRecoveryStatus
+    let onRetry: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            switch status {
+            case .restoring, .sendingTranscript:
+                Spinner(lineWidth: 1.5)
+                    .frame(width: 12, height: 12)
+            case .restored:
+                Image(systemName: "checkmark.circle")
+                    .foregroundStyle(theme.color("accent"))
+            case .failed:
+                Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                    .foregroundStyle(theme.color("warn"))
+            }
+
+            Text(Self.text(for: status))
+                .font(.system(size: 12))
+                .foregroundStyle(theme.color("fg-muted"))
+
+            if case .failed = status {
+                Button("Retry") {
+                    onRetry()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(theme.color("bg-1").opacity(0.65))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(theme.color("line").opacity(0.8), lineWidth: 0.5)
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private static func text(for status: ACPSession.ContextRecoveryStatus) -> String {
+        switch status {
+        case .restoring:
+            return "Restoring model context..."
+        case .sendingTranscript:
+            return "Restoring model context from transcript..."
+        case .restored:
+            return "Transcript restored as model context."
+        case .failed(let message):
+            return message
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -507,7 +507,25 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 eventTimestamp: event?.timestamp,
                 now: ProcessInfo.processInfo.systemUptime
             )
-            let isUserDriven = eventIsFresh && ACPUserScrollEvent.isUserDriven(event?.type)
+            let currentEventType = eventIsFresh ? event?.type : nil
+            let isUserDriven = ACPUserScrollEvent.isUserDriven(currentEventType)
+            // Mirrors `ACPMessageList.handleScrollGeometry`: a click on the
+            // scrollbar track arrives as a plain `.leftMouseDown`, which
+            // `isUserDriven` alone rejects (a bare click can't be told apart
+            // from clicking a transcript control by event type). Widen to
+            // `isHeadPaginationDriven`, which additionally accepts that
+            // click when it actually hit the scrollbar track AND the
+            // geometry genuinely moved upward — so a track click both
+            // pauses tail-follow and can step the head window back, the
+            // same as a trackpad gesture or scroller-knob drag would,
+            // without misclassifying clicks on transcript controls (which
+            // aren't scrollbar hits) as scrolling.
+            let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
+                currentEventType,
+                previousMinY: previousY,
+                newMinY: newY,
+                isScrollbarTrackHit: ACPUserScrollEvent.isScrollbarTrackMouseDown(eventIsFresh ? event : nil)
+            )
 
             let decision = ACPScrollDirectionClassifier.decide(
                 previousOffsetY: previousY,
@@ -515,7 +533,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 viewportHeight: viewportHeight,
                 contentHeight: contentHeight,
                 isRestoring: false,
-                isUserDriven: isUserDriven
+                isUserDriven: isHeadPaginationDriven
             )
             switch decision {
             case .userScrolledUp:
@@ -531,7 +549,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             let threshold = ACPTranscriptScroller.headStepThreshold(viewportHeight: viewportHeight)
             if ACPTranscriptScroller.shouldStepHeadBack(
                 visibleHead: host.transcript.visibleHead,
-                scrollY: newY, isUserDriven: isUserDriven, threshold: threshold,
+                scrollY: newY, isUserDriven: isHeadPaginationDriven, threshold: threshold,
                 hasPendingHeadStep: pendingHeadStep
             ) {
                 // `stepHeadBack` mutates `visibleHead` synchronously, but the

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -442,8 +442,10 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // this once it's safe — see `isApplyingSpecs`'s doc comment.
             // Other programmatic scrolls that happen OUTSIDE of `apply()`
             // (`resumeTailFollow`, `restoreInitialPositionIfNeeded`) are not
-            // covered by that trailing call, so they invoke
-            // `layoutMountedRows()` explicitly themselves.
+            // covered by that trailing call, but `isApplyingSpecs` is false
+            // at those sites too, so this same guard still lets their
+            // `onScroll` callback run `layoutMountedRows()` normally — no
+            // explicit call is needed at either site.
             if !reconciler.isApplyingSpecs {
                 reconciler.layoutMountedRows()
             }
@@ -533,8 +535,20 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// definite. `__composer_spacer__` and other synthetic rows are
         /// unconditionally present in `rowSpecs`, so `tiling.rowCount > 0`
         /// alone is true on the very first `apply()` even with zero
-        /// messages — gating on `hasNonSyntheticRow` instead avoids latching
+        /// messages — gating on `hasNonSyntheticRow` too avoids latching
         /// before there's any real content to restore a position within.
+        /// Both checks are required: `hasNonSyntheticRow` alone is not
+        /// enough, because `makeNSView` builds the scroller at `frame:
+        /// .zero` and `attach` calls `update(host:)` immediately, so the
+        /// very first `update` always runs with `contentWidth == 0` — a
+        /// width `reconciler.apply` deliberately defers on, leaving the
+        /// tiling map empty even though `hasNonSyntheticRow` is already
+        /// true from the spec list. Without also requiring
+        /// `tiling.rowCount > 0`, a non-tail-following session with no
+        /// remembered anchor would hit the "nothing to restore" branch
+        /// below on that width-0 pass, latch, and call `scrollToBottom()`
+        /// on an empty (zero-height) document — a no-op — permanently
+        /// skipping the real restore once actual rows exist.
         /// Beyond that: tail-follow and "no remembered anchor" are definite
         /// outcomes (latch immediately); a remembered anchor that isn't yet
         /// in the tiling map (e.g. the render window hasn't reached it yet)
@@ -545,7 +559,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// instead of permanently falling back to `scrollToBottom()`.
         private func restoreInitialPositionIfNeeded() {
             guard !didRestoreInitialPosition, let host, let scroller,
-                  hasNonSyntheticRow
+                  hasNonSyntheticRow, tiling.rowCount > 0
             else { return }
             if host.session.followsTranscriptTail {
                 didRestoreInitialPosition = true

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -743,15 +743,17 @@ struct ACPTranscriptScroller: NSViewRepresentable {
 
         private func rememberCurrentAnchor() {
             guard let host, let scroller else { return }
-            // Scans past synthetic rows rather than discarding the update
-            // when one is on top. The sharp case is the first scroll away
-            // from the tail landing at the head of a paginated transcript:
-            // the pagination spinner is the top row, and recording nothing
-            // there pauses tail-follow with no anchor at all — which
-            // restoration later resolves as "go to the bottom", undoing the
-            // scroll that caused it.
-            guard let anchorId = tiling.firstNonSyntheticRowId(
-                atOrBelow: scroller.scrollY,
+            // Finds the nearest real message rather than discarding the
+            // update when a synthetic row is on top. Both directions matter:
+            // scrolling to the head of a paginated transcript puts the
+            // pagination spinner on top, and stopping inside the synthetic
+            // tail (queued prompts, composer spacer) has nothing but
+            // synthetic rows below. Recording nothing in either case pauses
+            // tail-follow with no anchor at all, and restoration reads a
+            // missing anchor as "go to the bottom" — undoing the very scroll
+            // that caused it.
+            guard let anchorId = tiling.nearestNonSyntheticRowId(
+                to: scroller.scrollY,
                 syntheticIdPrefix: ACPTranscriptScrollerReconciler.syntheticIdPrefix
             ) else { return }
             // O(1) per tick: the row list is rebuilt only when the window

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -117,6 +117,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             scroller.onContentWidthChange = { [weak self] in
                 self?.reconcileForContentWidthChange()
             }
+            scroller.onViewportHeightChange = { [weak self] in
+                self?.reconcileForViewportHeightChange()
+            }
             update(host: host)
         }
 
@@ -165,6 +168,39 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         private func reconcileForContentWidthChange() {
             guard let host, let reconciler, !reconciler.isApplyingSpecs else { return }
             update(host: host)
+        }
+
+        /// Re-runs the reconciler's mount/relayout pass — NOT a full
+        /// `update(host:)` — when the scroller's own AppKit layout pass
+        /// reports a viewport-HEIGHT change with no accompanying width
+        /// change; see `ACPTranscriptScrollerView.onViewportHeightChange`'s
+        /// doc comment for why the scroller only fires this hook on a
+        /// height-only change.
+        ///
+        /// This is deliberately the cheap response, unlike
+        /// `reconcileForContentWidthChange`: the mount band
+        /// (`ACPTranscriptScrollerReconciler.performLayoutPass`) is derived
+        /// from `scroller.viewportHeight`, so growing or shrinking the
+        /// window without a width change reveals or hides mountable rows
+        /// that nothing else would recompute — but a height change never
+        /// invalidates any row's MEASURED content (nothing reflows
+        /// vertically because the viewport got taller or shorter). Routing
+        /// this through `update(host:)`/`reconciler.apply` instead would
+        /// rebuild the whole row-spec list and re-run the (cheap but O(n))
+        /// unchanged-token diff on every vertical resize tick — exactly the
+        /// per-tick cost the width-settle debounce exists to keep off of
+        /// live resizes, just for the wrong dimension.
+        ///
+        /// Guarded by `reconciler.isApplyingSpecs` for the same reason
+        /// `reconcileForContentWidthChange` is: it spans the ENTIRE
+        /// `apply()` call, including the row-mounting mutations
+        /// `layoutMountedRows()` itself performs, whereas the scroller's own
+        /// `programmaticAdjustmentDepth` only brackets its narrower
+        /// scroll/height primitives (see `reconcileForContentWidthChange`'s
+        /// doc comment for the full argument).
+        private func reconcileForViewportHeightChange() {
+            guard let reconciler, !reconciler.isApplyingSpecs else { return }
+            reconciler.layoutMountedRows()
         }
 
         func update(host: ACPTranscriptScroller) {
@@ -337,6 +373,23 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // see its doc comment.
         }
 
+        /// Beyond `fork` (and theme/contentMaxWidth folded by
+        /// `token(_:host:)`), the fork divider's build closure also derives
+        /// `sourceAgentName` by CALLING `host.agentDisplayName(fork
+        /// .sourceAgentID)` — a resolved `String`, not the closure itself,
+        /// baked into the built view at construction time. Unlike a direct
+        /// host property (`contentMaxWidth`, `typography`), this value isn't
+        /// anywhere in `fork` or `host`'s stored properties for `token(_:
+        /// host:)` to pick up automatically: a live rename of the source
+        /// agent's display name — with the `fork` record and every other
+        /// input unchanged — must still be folded in explicitly, or the
+        /// pool's token comparison stays equal and an already-mounted
+        /// divider keeps showing the stale name forever.
+        private struct ForkDividerTokenInputs: Equatable {
+            let fork: ACPSessionForkRecord
+            let sourceAgentDisplayName: String
+        }
+
         /// Verbatim port of the fork divider inserted right after the fork
         /// boundary row in the legacy VStack (ACPMessageList.swift:179-191).
         static func forkDividerSpec(
@@ -345,7 +398,13 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         ) -> ACPTranscriptRowSpec {
             ACPTranscriptRowSpec(
                 id: "__fork_divider__",
-                equalityToken: token(fork, host: host),
+                equalityToken: token(
+                    ForkDividerTokenInputs(
+                        fork: fork,
+                        sourceAgentDisplayName: host.agentDisplayName(fork.sourceAgentID)
+                    ),
+                    host: host
+                ),
                 build: {
                     wrapRow(host: host) {
                         Group {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -612,10 +612,12 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // at those sites too, so this same guard still lets their
             // `onScroll` callback run `layoutMountedRows()` normally — no
             // explicit call is needed at either site.
-            if !reconciler.isApplyingSpecs {
-                reconciler.layoutMountedRows()
+            guard !isProgrammatic else {
+                if !reconciler.isApplyingSpecs {
+                    reconciler.layoutMountedRows()
+                }
+                return
             }
-            guard !isProgrammatic else { return }
 
             let event = NSApp.currentEvent
             let eventIsFresh = ACPUserScrollEvent.isFresh(
@@ -661,6 +663,16 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 break
             }
 
+            // Deliberately after the classification above. Mounting a newly
+            // exposed row can synchronously invalidate its intrinsic size,
+            // which lands in `remeasureRow` and re-pins to the bottom while
+            // the reconciler still believes tail-follow is on. Pausing
+            // first means that belief is already correct by the time any
+            // row is mounted.
+            if !reconciler.isApplyingSpecs {
+                reconciler.layoutMountedRows()
+            }
+
             let threshold = ACPTranscriptScroller.headStepThreshold(viewportHeight: viewportHeight)
             if ACPTranscriptScroller.shouldStepHeadBack(
                 visibleHead: host.transcript.visibleHead,
@@ -696,6 +708,12 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         private func pauseTailFollow() {
             guard let host, host.session.followsTranscriptTail else { return }
             host.session.followsTranscriptTail = false
+            // Mirror the pause into the reconciler now rather than waiting
+            // for the `apply()` one update later. Between those two points
+            // the scroll handler mounts newly exposed rows, and a row whose
+            // intrinsic size invalidates on mount would otherwise re-pin
+            // this user to the bottom — see `remeasureRow`'s doc comment.
+            reconciler?.setFollowsTail(false)
             host.transcript.freezeVisibleTail()
             rememberCurrentAnchor()
         }
@@ -703,6 +721,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         private func resumeTailFollow() {
             guard let host, !host.session.followsTranscriptTail else { return }
             host.session.followsTranscriptTail = true
+            reconciler?.setFollowsTail(true)
             host.transcript.resetWindowToTail()
             host.onRememberScrollAnchor(nil, nil, true)
             scroller?.scrollToBottom()

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -114,6 +114,56 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                     isProgrammatic: isProgrammatic
                 )
             }
+            scroller.onContentWidthChange = { [weak self] in
+                self?.reconcileForContentWidthChange()
+            }
+            update(host: host)
+        }
+
+        /// Re-runs `update(host:)` against the retained host when the
+        /// scroller's own AppKit layout pass reports a content-width change
+        /// with no accompanying SwiftUI model update — see
+        /// `ACPTranscriptScrollerView.onContentWidthChange`'s doc comment.
+        /// This closes the gap where `attach()`'s first `update(host:)`
+        /// always runs at `contentWidth == 0` (the scroller starts at
+        /// `frame: .zero`), which `reconciler.apply` defers on: without
+        /// this, a fully hydrated but otherwise idle transcript could stay
+        /// empty until some UNRELATED SwiftUI update happened to call
+        /// `updateNSView` again. The same gap could also leave row
+        /// measurements stale after a resize with no model update.
+        ///
+        /// Guarded by `reconciler.isApplyingSpecs`, which is true for the
+        /// ENTIRE duration of `apply()` — every mutation it makes (document
+        /// height, prepend/removal offset compensation, and the per-row
+        /// `addSubview`/`.frame` assignments `layoutMountedRows()` performs
+        /// while mounting rows) is covered, not just the scroller's own
+        /// programmatic scroll/height adjustments (`performProgrammatic`'s
+        /// narrower `programmaticAdjustmentDepth`, which only brackets
+        /// `setScrollY`/`setDocumentHeight`/`applyPrepend`). If any of
+        /// `apply()`'s mutations were to re-trigger AppKit's layout pass on
+        /// the scroll view itself, the reentrant call would land here
+        /// mid-`apply()`, before `orderedIds`/`specsById` finish being
+        /// rewritten — recursing into `update(host:)` at that point would
+        /// call `apply()` again against inconsistent reconciler state.
+        /// `isApplyingSpecs` is therefore the guard that matters here, not
+        /// the scroller's programmatic-adjustment counter (which doesn't
+        /// span the whole call and so wouldn't catch a layout storm
+        /// triggered by the row-mounting mutations specifically).
+        ///
+        /// In practice `ACPTranscriptScrollerView.setFrameSize` only marks
+        /// `needsLayout` when the SCROLL VIEW's own outer frame changes —
+        /// `apply()`'s mutations only ever touch the document view's frame
+        /// and its row subviews, several levels down, which does not bubble
+        /// `needsLayout` back up in this plain (non-Auto-Layout) view tree —
+        /// so this reentrant path is not expected to fire under normal
+        /// (overlay-scroller) conditions. The guard exists to make that
+        /// true by construction rather than by accident of AppKit's
+        /// internals, and covers even a legacy (non-overlay) scroller style
+        /// where showing/hiding the vertical scroller in response to a
+        /// document-height change could, in principle, force a width
+        /// recompute.
+        private func reconcileForContentWidthChange() {
+            guard let host, let reconciler, !reconciler.isApplyingSpecs else { return }
             update(host: host)
         }
 

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerFlag.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerFlag.swift
@@ -8,7 +8,17 @@ enum ACPTranscriptScrollerFlag {
     static let defaultsKey = "alas.transcript.appkitScroller"
 
     static var isEnabled: Bool {
-        let override = UserDefaults.standard.object(forKey: defaultsKey) as? Bool
+        isEnabledWithDefaults(UserDefaults.standard)
+    }
+
+    /// Internal seam for testing: reads the override from the given UserDefaults instance.
+    nonisolated static func readOverride(from defaults: UserDefaults) -> Bool? {
+        defaults.object(forKey: defaultsKey) as? Bool
+    }
+
+    /// Internal seam for testing: computes isEnabled given a UserDefaults instance.
+    nonisolated static func isEnabledWithDefaults(_ defaults: UserDefaults) -> Bool {
+        let override = readOverride(from: defaults)
         #if DEBUG
         return resolve(override: override, isDebugBuild: true)
         #else

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerFlag.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerFlag.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Runtime switch between the legacy SwiftUI transcript ScrollView and the
+/// AppKit-backed scroller. Defaults on for dev builds, off for release,
+/// overridable either way with:
+///   defaults write io.nlopez.alas alas.transcript.appkitScroller -bool NO
+enum ACPTranscriptScrollerFlag {
+    static let defaultsKey = "alas.transcript.appkitScroller"
+
+    static var isEnabled: Bool {
+        let override = UserDefaults.standard.object(forKey: defaultsKey) as? Bool
+        #if DEBUG
+        return resolve(override: override, isDebugBuild: true)
+        #else
+        return resolve(override: override, isDebugBuild: false)
+        #endif
+    }
+
+    nonisolated static func resolve(override: Bool?, isDebugBuild: Bool) -> Bool {
+        override ?? isDebugBuild
+    }
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerFlag.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerFlag.swift
@@ -4,8 +4,17 @@ import Foundation
 /// AppKit-backed scroller. Defaults on for dev builds, off for release,
 /// overridable either way with:
 ///   defaults write io.nlopez.alas alas.transcript.appkitScroller -bool NO
+/// or from Settings > Debug > Experiments.
 enum ACPTranscriptScrollerFlag {
     static let defaultsKey = "alas.transcript.appkitScroller"
+
+    /// Posted by `setOverride` after writing a new override. Open
+    /// `ACPMessageList` instances observe this to re-evaluate `isEnabled`
+    /// and rebuild their transcript subtree without requiring an app
+    /// restart.
+    static let overrideDidChangeNotification = Notification.Name(
+        "io.nlopez.alas.ACPTranscriptScrollerFlag.overrideDidChange"
+    )
 
     static var isEnabled: Bool {
         isEnabledWithDefaults(UserDefaults.standard)
@@ -28,5 +37,20 @@ enum ACPTranscriptScrollerFlag {
 
     nonisolated static func resolve(override: Bool?, isDebugBuild: Bool) -> Bool {
         override ?? isDebugBuild
+    }
+
+    /// Writes an explicit override (e.g. from the Debug settings toggle) and
+    /// broadcasts `overrideDidChangeNotification` so any already-open
+    /// transcripts can pick up the change. `isEnabled` itself is a plain
+    /// UserDefaults read with no observation of its own, so without this
+    /// notification a flipped toggle would only take effect after the
+    /// transcript view happened to re-render for an unrelated reason.
+    nonisolated static func setOverride(
+        _ override: Bool,
+        in defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        defaults.set(override, forKey: defaultsKey)
+        notificationCenter.post(name: overrideDidChangeNotification, object: nil)
     }
 }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -262,11 +262,12 @@ final class ACPTranscriptScrollerReconciler {
         restoreScrollAnchor(anchor)
     }
 
-    /// The scroll offset expressed relative to a row rather than to the
-    /// document, so it survives a wholesale geometry replacement.
-    private struct ScrollAnchor {
-        let id: String
-        let offsetWithinRow: CGFloat
+    /// The scroll offset expressed relative to a row (so it survives a
+    /// wholesale geometry replacement), or — for the synthetic tail region,
+    /// where no such row exists — relative to the document's bottom edge.
+    private enum ScrollAnchor {
+        case row(id: String, offsetWithinRow: CGFloat)
+        case bottomRelative(distance: CGFloat)
     }
 
     /// Anchors to the first NON-synthetic row at or below the viewport top,
@@ -287,31 +288,67 @@ final class ACPTranscriptScrollerReconciler {
     /// screen and the first message begins under it). Restoration
     /// reproduces the same relationship either way, so a negative offset is
     /// exact rather than approximate.
+    ///
+    /// The forward walk can run off the end of the document without ever
+    /// finding a non-synthetic row: when the viewport top is already inside
+    /// the synthetic TAIL region (a queued prompt, the context-recovery row,
+    /// the composer spacer — everything after the last message row), every
+    /// remaining row is synthetic too. Falling back to `nil` there (as this
+    /// used to) skips restoration entirely, so a width-settled reset that
+    /// reflows message heights ABOVE the viewport moves the synthetic
+    /// content the user was looking at even though nothing at or below the
+    /// viewport itself changed. Anchor to the distance from the document's
+    /// bottom edge instead: a reset always re-measures the SAME spec list
+    /// (`performReset` never adds or removes rows — only `resetHeights`
+    /// dimensions change), so nothing in this window can move the document's
+    /// end for reasons other than the very reflow being compensated for,
+    /// which makes a bottom-relative anchor exact here — and, unlike
+    /// anchoring to the nearest preceding message row, it reproduces the
+    /// user's actual depth into the tail rather than snapping to the top of
+    /// it. (A preceding-message anchor was considered — it reuses the `.row`
+    /// case outright — but `offsetWithinRow` for a row the viewport has
+    /// scrolled past is always at or beyond that row's height, so restoring
+    /// through it would always land on the clamp in `restoreScrollAnchor`
+    /// below, i.e. the top of the tail, not the user's actual position
+    /// within it.)
     private func captureScrollAnchor() -> ScrollAnchor? {
         let viewportMinY = scroller.scrollY
         guard var index = tiling.firstRowIndex(intersectingY: viewportMinY) else { return nil }
         while index < tiling.rowCount, tiling.rowId(at: index).hasPrefix(Self.syntheticIdPrefix) {
             index += 1
         }
-        guard index < tiling.rowCount else { return nil }
+        guard index < tiling.rowCount else {
+            return .bottomRelative(distance: scroller.distanceFromBottom)
+        }
         let row = tiling.rowLayout(at: index)
-        return ScrollAnchor(id: row.id, offsetWithinRow: viewportMinY - row.minY)
+        return .row(id: row.id, offsetWithinRow: viewportMinY - row.minY)
     }
 
-    /// Puts the anchored row back where it was on screen. A nil anchor, or
-    /// one whose row no longer exists in the new geometry, leaves the offset
-    /// alone — there is nothing better to aim at, and `setScrollY`'s clamp
-    /// still keeps it inside the new document.
+    /// Puts the anchored position back where it was on screen. A nil
+    /// anchor, or a `.row` anchor whose row no longer exists in the new
+    /// geometry, leaves the offset alone — there is nothing better to aim
+    /// at, and `setScrollY`'s clamp still keeps it inside the new document.
     ///
-    /// The offset is capped at the anchor row's NEW height: a row that
-    /// shrank across the reset (a tall tool-output row collapsing, say)
-    /// would otherwise place the viewport top past its own end by
+    /// For `.row`, the offset is capped at the anchor row's NEW height: a
+    /// row that shrank across the reset (a tall tool-output row collapsing,
+    /// say) would otherwise place the viewport top past its own end by
     /// `oldHeight - newHeight`. The viewport top can be at most the anchor
     /// row's bottom edge. No lower cap — see `captureScrollAnchor` on why
     /// negative offsets are legitimate.
+    ///
+    /// For `.bottomRelative`, `setScrollY` re-derives the offset from the
+    /// NEW `documentHeight` (already installed by the caller before this
+    /// runs) and the captured distance, reproducing the same visual gap
+    /// from the bottom edge.
     private func restoreScrollAnchor(_ anchor: ScrollAnchor?) {
-        guard let anchor, let row = tiling.row(withId: anchor.id) else { return }
-        scroller.setScrollY(row.minY + min(anchor.offsetWithinRow, row.height))
+        guard let anchor else { return }
+        switch anchor {
+        case .row(let id, let offsetWithinRow):
+            guard let row = tiling.row(withId: id) else { return }
+            scroller.setScrollY(row.minY + min(offsetWithinRow, row.height))
+        case .bottomRelative(let distance):
+            scroller.setScrollY(tiling.documentHeight - scroller.viewportHeight - distance)
+        }
     }
 
     /// Heights for a wholesale geometry replacement. Rows whose recorded

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -1,0 +1,181 @@
+import AppKit
+import SwiftUI
+
+/// Applies each SwiftUI update (a fresh ordered list of row specs) onto the
+/// tiling controller + scroller + hosting pool:
+///   - classifies the change (prepend / append / reset / in-place),
+///   - measures new or content-changed rows at the current width,
+///   - applies prepend offset compensation synchronously,
+///   - mounts/unmounts hosting views around the viewport's mount band,
+///   - pins the viewport to the bottom while tail-following.
+@MainActor
+final class ACPTranscriptScrollerReconciler {
+    /// How far beyond the viewport rows stay mounted, in points. Roughly
+    /// 1.5 viewport-heights on a typical window; tuned by feel in QA.
+    static let overscan: CGFloat = 1200
+
+    private let tiling: ACPTranscriptTilingController
+    private let pool: ACPTranscriptRowHostingPool
+    private unowned let scroller: ACPTranscriptScrollerView
+    private var specsById: [String: ACPTranscriptRowSpec] = [:]
+    private var orderedIds: [String] = []
+    private var contentWidth: CGFloat = 0
+
+    init(
+        tiling: ACPTranscriptTilingController,
+        pool: ACPTranscriptRowHostingPool,
+        scroller: ACPTranscriptScrollerView
+    ) {
+        self.tiling = tiling
+        self.pool = pool
+        self.scroller = scroller
+        pool.onRowIntrinsicSizeInvalidated = { [weak self] id in
+            self?.remeasureRow(id: id)
+        }
+    }
+
+    enum Diff: Equatable {
+        case unchanged
+        case prepended(count: Int)
+        case appended(count: Int)
+        case prependedAndAppended(prepended: Int, appended: Int)
+        case reset
+    }
+
+    /// Old ids must appear as a contiguous run inside new ids for an
+    /// incremental classification; anything else is a reset.
+    nonisolated static func diff(oldIds: [String], newIds: [String]) -> Diff {
+        if oldIds == newIds { return .unchanged }
+        guard let oldFirst = oldIds.first else { return newIds.isEmpty ? .unchanged : .reset }
+        guard let start = newIds.firstIndex(of: oldFirst) else { return .reset }
+        let end = start + oldIds.count
+        guard end <= newIds.count, Array(newIds[start..<end]) == oldIds else { return .reset }
+        let prepended = start
+        let appended = newIds.count - end
+        switch (prepended > 0, appended > 0) {
+        case (true, true): return .prependedAndAppended(prepended: prepended, appended: appended)
+        case (true, false): return .prepended(count: prepended)
+        case (false, true): return .appended(count: appended)
+        case (false, false): return .unchanged
+        }
+    }
+
+    func apply(specs: [ACPTranscriptRowSpec], contentWidth width: CGFloat, followsTail: Bool) {
+        let widthChanged = width != contentWidth
+        contentWidth = width
+        let newIds = specs.map(\.id)
+        var newSpecs: [String: ACPTranscriptRowSpec] = [:]
+        newSpecs.reserveCapacity(specs.count)
+        for spec in specs { newSpecs[spec.id] = spec }
+
+        let change: Diff = widthChanged ? .reset : Self.diff(oldIds: orderedIds, newIds: newIds)
+        switch change {
+        case .unchanged:
+            updateChangedContent(specs: specs)
+        case .prepended(let count):
+            let delta = tiling.prepend(rows: measure(specs[0..<count]))
+            scroller.applyPrepend(delta: delta, newDocumentHeight: tiling.documentHeight)
+            updateChangedContent(specs: specs)
+        case .appended(let count):
+            tiling.append(rows: measure(specs[(specs.count - count)...]))
+            scroller.setDocumentHeight(tiling.documentHeight)
+            updateChangedContent(specs: specs)
+        case .prependedAndAppended(let prepended, let appended):
+            let delta = tiling.prepend(rows: measure(specs[0..<prepended]))
+            tiling.append(rows: measure(specs[(specs.count - appended)...]))
+            scroller.applyPrepend(delta: delta, newDocumentHeight: tiling.documentHeight)
+            updateChangedContent(specs: specs)
+        case .reset:
+            pool.releaseAll()
+            tiling.replaceAll(rows: measure(specs[...]))
+            scroller.setDocumentHeight(tiling.documentHeight)
+        }
+
+        orderedIds = newIds
+        specsById = newSpecs
+        if followsTail {
+            scroller.scrollToBottom()
+        }
+        layoutMountedRows()
+    }
+
+    /// Re-apply specs whose equality token changed; re-measure those rows and
+    /// compensate the viewport when the change happened above it.
+    private func updateChangedContent(specs: [ACPTranscriptRowSpec]) {
+        for spec in specs {
+            guard let old = specsById[spec.id],
+                  !old.equalityToken.isEqual(to: spec.equalityToken)
+            else { continue }
+            specsById[spec.id] = spec
+            guard pool.mountedIds.contains(spec.id) else { continue }
+            let (view, contentChanged) = pool.view(for: spec)
+            if contentChanged {
+                applyMeasuredHeight(id: spec.id, view: view)
+            }
+        }
+    }
+
+    func remeasureRow(id: String) {
+        guard let spec = specsById[id] else { return }
+        let (view, _) = pool.view(for: spec)
+        applyMeasuredHeight(id: id, view: view)
+    }
+
+    private func applyMeasuredHeight(id: String, view: ACPTranscriptRowHostingView) {
+        let height = view.measuredHeight(forWidth: contentWidth)
+        let compensation = tiling.updateHeight(
+            id: id, to: height, viewportMinY: scroller.scrollY
+        )
+        scroller.setDocumentHeight(tiling.documentHeight)
+        if compensation != 0 {
+            scroller.setScrollY(scroller.scrollY + compensation)
+        }
+        layoutMountedRows()
+    }
+
+    private func measure<S: Sequence>(_ specs: S) -> [(id: String, height: CGFloat)]
+    where S.Element == ACPTranscriptRowSpec {
+        specs.map { spec in
+            let (view, _) = pool.view(for: spec)
+            return (spec.id, view.measuredHeight(forWidth: contentWidth))
+        }
+    }
+
+    /// Mount hosting views for rows in the band, position them, unmount the
+    /// rest. Called after every apply and on every scroll tick.
+    func layoutMountedRows() {
+        guard tiling.rowCount > 0 else {
+            pool.releaseAll()
+            return
+        }
+        let band = tiling.mountBand(
+            viewportMinY: scroller.scrollY,
+            viewportHeight: scroller.viewportHeight,
+            overscan: Self.overscan
+        )
+        var keep = Set<String>()
+        keep.reserveCapacity(band.count)
+        for index in band {
+            let layout = tiling.rowLayout(at: index)
+            guard let spec = specsById[layout.id] else { continue }
+            keep.insert(layout.id)
+            let (view, _) = pool.view(for: spec)
+            if view.superview !== scroller.flippedDocumentView {
+                scroller.flippedDocumentView.addSubview(view)
+            }
+            assert(
+                view.lastMeasuredWidth == contentWidth,
+                "row \(layout.id) placed at width \(contentWidth) but last measured at \(String(describing: view.lastMeasuredWidth))"
+            )
+            view.frame = NSRect(
+                x: 0, y: layout.minY,
+                width: contentWidth, height: layout.height
+            )
+        }
+        pool.releaseAll(except: keep)
+    }
+
+    #if DEBUG
+    var mountedRowIdsForTesting: Set<String> { pool.mountedIds }
+    #endif
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -484,18 +484,37 @@ final class ACPTranscriptScrollerReconciler {
     /// correctly zero — but that leaves the viewport at its old offset while
     /// the document grew underneath it, stranding it above the new bottom
     /// even though tail-follow is still active. Re-pin explicitly using
-    /// `lastFollowsTail`, which is guaranteed current here: this method only
-    /// runs once `isApplyingSpecs` is false, i.e. after some `apply()` call
-    /// has fully finished and already assigned `lastFollowsTail` from its
-    /// own `followsTail` argument. If the user scrolled away, the resulting
-    /// `apply()` (driven by `session.followsTranscriptTail` flipping to
-    /// false) already latched `lastFollowsTail = false` before this can run,
-    /// so this never fights a user who has genuinely left the tail.
+    /// `lastFollowsTail`.
+    ///
+    /// `apply()` alone does not keep `lastFollowsTail` current. A user
+    /// scrolling away flips `session.followsTranscriptTail` to false, but
+    /// the `apply()` that latches it only arrives on the NEXT SwiftUI
+    /// update — and the scroll handler mounts newly exposed rows in the
+    /// meantime. If mounting one of those synchronously invalidates its
+    /// intrinsic size, this method runs inside that window and would re-pin
+    /// a user who has just scrolled up, stranding them at the bottom with
+    /// tail-follow off. The scroll handler therefore calls
+    /// `setFollowsTail(false)` as it pauses, before mounting anything, so
+    /// the state read here is current and this never fights a user who has
+    /// genuinely left the tail.
     /// `scroller.scrollToBottom()` is idempotent when already there — its
     /// `setScrollY` clamp reports no `onScroll` change (`reportScroll` skips
     /// when the offset is unchanged) — so calling it unconditionally on
     /// every tail-following remeasure, not just ones that grow the tail,
     /// costs nothing extra in the common case.
+    /// Updates the tail-follow state that `remeasureRow` re-pins against,
+    /// without waiting for the `apply()` that will carry the same value.
+    ///
+    /// This exists so the scroll handler can close the window described on
+    /// `remeasureRow`: it pauses or resumes tail-follow synchronously, one
+    /// SwiftUI update ahead of the `apply()` that latches the session's new
+    /// `followsTranscriptTail`. Only the re-pin decision is affected —
+    /// nothing here mounts, measures, or moves the viewport, and the next
+    /// `apply()` overwrites it with the authoritative value either way.
+    func setFollowsTail(_ followsTail: Bool) {
+        lastFollowsTail = followsTail
+    }
+
     func remeasureRow(id: String) {
         guard !isApplyingSpecs else { return }
         guard let spec = specsById[id] else { return }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -50,7 +50,17 @@ final class ACPTranscriptScrollerReconciler {
     /// measurement `apply()` needs is already performed directly by its own
     /// code paths, so ignoring the reentrant signal during this window loses
     /// nothing.
-    private var isApplyingSpecs = false
+    ///
+    /// Exposed read-only so `ACPTranscriptScroller.Coordinator`'s `onScroll`
+    /// callback can skip its own `layoutMountedRows()` call while `apply()`
+    /// is mid-mutation: `apply()`'s own programmatic scrolls
+    /// (`applyPrepend`, `scrollToBottom`) report synchronously through the
+    /// same callback, and running a layout pass against `specsById`/
+    /// `orderedIds` before `apply()` has finished updating them would mount
+    /// rows against stale state — the same hazard this flag already guards
+    /// `remeasureRow` against. `apply()`'s own trailing `layoutMountedRows()`
+    /// call covers the pass once it's safe to run.
+    private(set) var isApplyingSpecs = false
 
     /// Reentrancy guard for `layoutMountedRows()`. A layout pass can itself
     /// trigger a nested re-measure (mounting/measuring a row can invalidate
@@ -82,28 +92,49 @@ final class ACPTranscriptScrollerReconciler {
 
     enum Diff: Equatable {
         case unchanged
-        case prepended(count: Int)
-        case appended(count: Int)
-        case prependedAndAppended(prepended: Int, appended: Int)
+        /// `count` new ids inserted at `index` in the new list; every other
+        /// id is unchanged and in the same relative order. Subsumes what
+        /// used to be separate prepend (`index == 0`) and append
+        /// (`index == oldIds.count`) cases — a fixed row at either end (the
+        /// head pagination spinner, the composer spacer) no longer forces a
+        /// full reset just because it sits at position 0 or the tail.
+        case inserted(index: Int, count: Int)
+        /// `count` ids removed starting at `index` in the old list; every
+        /// other id is unchanged and in the same relative order (e.g. the
+        /// streaming caret disappearing at the end of a turn).
+        case removed(index: Int, count: Int)
         case reset
     }
 
-    /// Old ids must appear as a contiguous run inside new ids for an
-    /// incremental classification; anything else is a reset.
+    /// Classifies the transition from `oldIds` to `newIds` by trimming the
+    /// common prefix and common suffix. What remains between them is either
+    /// nothing (`unchanged`), a pure insertion, a pure removal, or — if
+    /// ids changed on both sides at once, or content was replaced in place —
+    /// a `reset`. This subsumes the old prepend/append cases (insertion at
+    /// index 0 or at the old list's end) without needing a fixed row at
+    /// either end to defeat the classification: a common-prefix/suffix trim
+    /// still finds the single insertion/removal point even when both list
+    /// ends are pinned by rows whose ids never change (e.g. a head
+    /// pagination spinner at index 0 and a composer spacer at the tail).
     nonisolated static func diff(oldIds: [String], newIds: [String]) -> Diff {
         if oldIds == newIds { return .unchanged }
-        guard let oldFirst = oldIds.first else { return newIds.isEmpty ? .unchanged : .reset }
-        guard let start = newIds.firstIndex(of: oldFirst) else { return .reset }
-        let end = start + oldIds.count
-        guard end <= newIds.count, Array(newIds[start..<end]) == oldIds else { return .reset }
-        let prepended = start
-        let appended = newIds.count - end
-        switch (prepended > 0, appended > 0) {
-        case (true, true): return .prependedAndAppended(prepended: prepended, appended: appended)
-        case (true, false): return .prepended(count: prepended)
-        case (false, true): return .appended(count: appended)
-        case (false, false): return .unchanged
+        let minCount = min(oldIds.count, newIds.count)
+        var prefix = 0
+        while prefix < minCount, oldIds[prefix] == newIds[prefix] {
+            prefix += 1
         }
+        var suffix = 0
+        while suffix < minCount - prefix,
+              oldIds[oldIds.count - 1 - suffix] == newIds[newIds.count - 1 - suffix] {
+            suffix += 1
+        }
+        if prefix + suffix == oldIds.count, newIds.count > oldIds.count {
+            return .inserted(index: prefix, count: newIds.count - oldIds.count)
+        }
+        if prefix + suffix == newIds.count, oldIds.count > newIds.count {
+            return .removed(index: prefix, count: oldIds.count - newIds.count)
+        }
+        return .reset
     }
 
     func apply(specs: [ACPTranscriptRowSpec], contentWidth width: CGFloat, followsTail: Bool) {
@@ -165,18 +196,28 @@ final class ACPTranscriptScrollerReconciler {
         switch change {
         case .unchanged:
             updateChangedContent(specs: specs)
-        case .prepended(let count):
-            let delta = tiling.prepend(rows: measure(specs[0..<count]))
-            scroller.applyPrepend(delta: delta, newDocumentHeight: tiling.documentHeight)
+        case .inserted(let index, let count):
+            let insertedSpecs = Array(specs[index..<(index + count)])
+            let compensation = tiling.insert(
+                rows: measure(insertedSpecs), at: index, viewportMinY: scroller.scrollY
+            )
+            if compensation != 0 {
+                scroller.applyPrepend(delta: compensation, newDocumentHeight: tiling.documentHeight)
+            } else {
+                scroller.setDocumentHeight(tiling.documentHeight)
+            }
             updateChangedContent(specs: specs)
-        case .appended(let count):
-            tiling.append(rows: measure(specs[(specs.count - count)...]))
-            scroller.setDocumentHeight(tiling.documentHeight)
-            updateChangedContent(specs: specs)
-        case .prependedAndAppended(let prepended, let appended):
-            let delta = tiling.prepend(rows: measure(specs[0..<prepended]))
-            tiling.append(rows: measure(specs[(specs.count - appended)...]))
-            scroller.applyPrepend(delta: delta, newDocumentHeight: tiling.documentHeight)
+        case .removed(let index, let count):
+            let compensation = tiling.remove(at: index, count: count, viewportMinY: scroller.scrollY)
+            if compensation != 0 {
+                scroller.applyPrepend(delta: compensation, newDocumentHeight: tiling.documentHeight)
+            } else {
+                scroller.setDocumentHeight(tiling.documentHeight)
+            }
+            // Hosting views for the removed ids are released by the
+            // trailing `layoutMountedRows()` pass in `apply()`: they're no
+            // longer in `specsById`/the tiling controller, so they fall out
+            // of `keep` and `pool.releaseAll(except:)` cleans them up.
             updateChangedContent(specs: specs)
         case .reset:
             pool.releaseAll()

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -47,10 +47,9 @@ final class ACPTranscriptScrollerReconciler {
     /// the tiling controller are mid-mutation (most sharply during a
     /// `.reset`, where `resetHeights` measures re-used ids while `specsById`
     /// still holds their OLD specs and `tiling` still holds the OLD
-    /// geometry). Every
-    /// measurement `apply()` needs is already performed directly by its own
-    /// code paths, so ignoring the reentrant signal during this window loses
-    /// nothing.
+    /// geometry). Every measurement `apply()` needs is already performed
+    /// directly by its own code paths, so ignoring the reentrant signal
+    /// during this window loses nothing.
     ///
     /// Exposed read-only so `ACPTranscriptScroller.Coordinator`'s `onScroll`
     /// callback can skip its own `layoutMountedRows()` call while `apply()`
@@ -175,9 +174,16 @@ final class ACPTranscriptScrollerReconciler {
             widthSettleTimer.poke()
         } else {
             let change: Diff = widthChanged ? .reset : idDiff
-            if change == .reset {
-                // We're about to do the full remeasure ourselves; any
-                // earlier pending width-settle reset is now redundant.
+            if change == .reset, widthChanged {
+                // A reset AT A NEW WIDTH re-measures everything against that
+                // width, so any earlier pending width-settle reset is now
+                // redundant. An id-change reset at the SAME width is not a
+                // substitute: `canReuseMeasuredHeight` carries every off-band
+                // height forward untouched, and those were measured at the
+                // pre-resize width. Cancelling here would silently drop the
+                // "off-band rows are correct once the resize settles"
+                // guarantee for any reset that happens to land inside the
+                // settle window.
                 widthSettleTimer.cancel()
             }
             applyDiff(change, specs: specs, widthChanged: widthChanged, followsTail: followsTail)
@@ -263,20 +269,49 @@ final class ACPTranscriptScrollerReconciler {
         let offsetWithinRow: CGFloat
     }
 
+    /// Anchors to the first NON-synthetic row at or below the viewport top,
+    /// not simply to the topmost visible row.
+    ///
+    /// Synthetic rows are exactly the ones a reset is most likely to delete,
+    /// and the worst case is the one that matters most: the head pagination
+    /// spinner occupies row 0 (`minY 24`, `maxY 38`), so any `scrollY < 38`
+    /// — the top-of-history bounce, i.e. precisely the gesture that CAUSES
+    /// the final head step — would otherwise capture `__top_pagination__`
+    /// as the anchor. That is the very row the final head step removes, so
+    /// restoration would find nothing to aim at, silently no-op, and leave
+    /// the original hard jump intact at exactly the position it was fixed
+    /// for.
+    ///
+    /// `offsetWithinRow` is deliberately allowed to be negative: the chosen
+    /// row may start below the current scroll position (the spinner is on
+    /// screen and the first message begins under it). Restoration
+    /// reproduces the same relationship either way, so a negative offset is
+    /// exact rather than approximate.
     private func captureScrollAnchor() -> ScrollAnchor? {
-        guard let id = tiling.topVisibleRowId(viewportMinY: scroller.scrollY),
-              let row = tiling.row(withId: id)
-        else { return nil }
-        return ScrollAnchor(id: id, offsetWithinRow: scroller.scrollY - row.minY)
+        let viewportMinY = scroller.scrollY
+        guard var index = tiling.firstRowIndex(intersectingY: viewportMinY) else { return nil }
+        while index < tiling.rowCount, tiling.rowId(at: index).hasPrefix(Self.syntheticIdPrefix) {
+            index += 1
+        }
+        guard index < tiling.rowCount else { return nil }
+        let row = tiling.rowLayout(at: index)
+        return ScrollAnchor(id: row.id, offsetWithinRow: viewportMinY - row.minY)
     }
 
     /// Puts the anchored row back where it was on screen. A nil anchor, or
     /// one whose row no longer exists in the new geometry, leaves the offset
     /// alone — there is nothing better to aim at, and `setScrollY`'s clamp
     /// still keeps it inside the new document.
+    ///
+    /// The offset is capped at the anchor row's NEW height: a row that
+    /// shrank across the reset (a tall tool-output row collapsing, say)
+    /// would otherwise place the viewport top past its own end by
+    /// `oldHeight - newHeight`. The viewport top can be at most the anchor
+    /// row's bottom edge. No lower cap — see `captureScrollAnchor` on why
+    /// negative offsets are legitimate.
     private func restoreScrollAnchor(_ anchor: ScrollAnchor?) {
         guard let anchor, let row = tiling.row(withId: anchor.id) else { return }
-        scroller.setScrollY(row.minY + anchor.offsetWithinRow)
+        scroller.setScrollY(row.minY + min(anchor.offsetWithinRow, row.height))
     }
 
     /// Heights for a wholesale geometry replacement. Rows whose recorded

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -45,8 +45,9 @@ final class ACPTranscriptScrollerReconciler {
     /// itself makes (e.g. via `addSubview` or re-pinning `rootView`), which
     /// would otherwise route back into `remeasureRow` while `specsById` and
     /// the tiling controller are mid-mutation (most sharply during a
-    /// `.reset`, between `pool.releaseAll()` and `tiling.replaceAll`, where
-    /// `specsById` still holds the OLD specs for ids being reused). Every
+    /// `.reset`, where `resetHeights` measures re-used ids while `specsById`
+    /// still holds their OLD specs and `tiling` still holds the OLD
+    /// geometry). Every
     /// measurement `apply()` needs is already performed directly by its own
     /// code paths, so ignoring the reentrant signal during this window loses
     /// nothing.
@@ -170,7 +171,7 @@ final class ACPTranscriptScrollerReconciler {
             // visible content is never wrong), and debounce the full
             // re-measure-every-row reset until the resize settles — so a
             // live drag doesn't rebuild thousands of hosting views per tick.
-            applyDiff(idDiff, specs: specs)
+            applyDiff(idDiff, specs: specs, widthChanged: true, followsTail: followsTail)
             widthSettleTimer.poke()
         } else {
             let change: Diff = widthChanged ? .reset : idDiff
@@ -179,7 +180,7 @@ final class ACPTranscriptScrollerReconciler {
                 // earlier pending width-settle reset is now redundant.
                 widthSettleTimer.cancel()
             }
-            applyDiff(change, specs: specs)
+            applyDiff(change, specs: specs, widthChanged: widthChanged, followsTail: followsTail)
         }
 
         orderedIds = newIds
@@ -192,7 +193,9 @@ final class ACPTranscriptScrollerReconciler {
         layoutMountedRows()
     }
 
-    private func applyDiff(_ change: Diff, specs: [ACPTranscriptRowSpec]) {
+    private func applyDiff(
+        _ change: Diff, specs: [ACPTranscriptRowSpec], widthChanged: Bool, followsTail: Bool
+    ) {
         switch change {
         case .unchanged:
             updateChangedContent(specs: specs)
@@ -220,10 +223,103 @@ final class ACPTranscriptScrollerReconciler {
             // of `keep` and `pool.releaseAll(except:)` cleans them up.
             updateChangedContent(specs: specs)
         case .reset:
-            pool.releaseAll()
-            tiling.replaceAll(rows: measure(specs[...]))
-            scroller.setDocumentHeight(tiling.documentHeight)
+            performReset(specs: specs, widthChanged: widthChanged, followsTail: followsTail)
         }
+    }
+
+    /// Replaces the entire geometry from `specs`, preserving what the user
+    /// is looking at.
+    ///
+    /// Two properties every other diff case already had, and `.reset` did
+    /// not:
+    ///   - the scroll offset is re-anchored to the row that was at the
+    ///     viewport top, instead of keeping its old numeric value against a
+    ///     completely different document (a hard content jump — most
+    ///     visibly on the FINAL head step, where `__top_pagination__`
+    ///     disappearing in the same update that inserts older rows changes
+    ///     ids at both ends and so falls to `.reset`);
+    ///   - rows whose measured height is still valid keep it instead of
+    ///     being rebuilt and re-measured. The mount band bounds how many
+    ///     hosting views are LIVE, but nothing bounded how many this path
+    ///     CONSTRUCTED: `pool.releaseAll()` + measuring every spec meant a
+    ///     reset after browsing deep into a long transcript allocated and
+    ///     synchronously measured a hosting view per row in the whole render
+    ///     window.
+    private func performReset(specs: [ACPTranscriptRowSpec], widthChanged: Bool, followsTail: Bool) {
+        // While following the tail, `apply()`'s own `scrollToBottom()` (or
+        // `performWidthSettledReset`'s) is the correct final position and
+        // must win — don't fight it with a restored anchor.
+        let anchor = followsTail ? nil : captureScrollAnchor()
+        tiling.replaceAll(rows: resetHeights(specs: specs, widthChanged: widthChanged))
+        scroller.setDocumentHeight(tiling.documentHeight)
+        restoreScrollAnchor(anchor)
+    }
+
+    /// The scroll offset expressed relative to a row rather than to the
+    /// document, so it survives a wholesale geometry replacement.
+    private struct ScrollAnchor {
+        let id: String
+        let offsetWithinRow: CGFloat
+    }
+
+    private func captureScrollAnchor() -> ScrollAnchor? {
+        guard let id = tiling.topVisibleRowId(viewportMinY: scroller.scrollY),
+              let row = tiling.row(withId: id)
+        else { return nil }
+        return ScrollAnchor(id: id, offsetWithinRow: scroller.scrollY - row.minY)
+    }
+
+    /// Puts the anchored row back where it was on screen. A nil anchor, or
+    /// one whose row no longer exists in the new geometry, leaves the offset
+    /// alone — there is nothing better to aim at, and `setScrollY`'s clamp
+    /// still keeps it inside the new document.
+    private func restoreScrollAnchor(_ anchor: ScrollAnchor?) {
+        guard let anchor, let row = tiling.row(withId: anchor.id) else { return }
+        scroller.setScrollY(row.minY + anchor.offsetWithinRow)
+    }
+
+    /// Heights for a wholesale geometry replacement. Rows whose recorded
+    /// height is still valid are carried forward WITHOUT building or
+    /// measuring a hosting view; everything else is measured now.
+    private func resetHeights(
+        specs: [ACPTranscriptRowSpec], widthChanged: Bool
+    ) -> [(id: String, height: CGFloat)] {
+        let mounted = pool.mountedIds
+        return specs.map { spec in
+            if let known = tiling.row(withId: spec.id)?.height,
+               canReuseMeasuredHeight(
+                   for: spec, isMounted: mounted.contains(spec.id), widthChanged: widthChanged
+               ) {
+                return (spec.id, known)
+            }
+            let (view, _) = pool.view(for: spec)
+            return (spec.id, view.measuredHeight(forWidth: contentWidth))
+        }
+    }
+
+    /// Whether the height already on record for `spec`'s row can stand.
+    ///
+    /// The safety net this leans on is `performLayoutPass`'s mount-time
+    /// fallback: any row without a live hosting view gets a fresh one when
+    /// it next enters the mount band, whose `lastMeasuredWidth` is nil, so
+    /// it is re-measured at that moment. That makes a carried-forward height
+    /// on an UNMOUNTED row self-correcting — it can only ever be observed
+    /// after the row has been re-measured. A mounted row has no such net
+    /// (its view is already pinned at `contentWidth`, so the fallback won't
+    /// fire), which is what the `isMounted` cases below turn on.
+    private func canReuseMeasuredHeight(
+        for spec: ACPTranscriptRowSpec, isMounted: Bool, widthChanged: Bool
+    ) -> Bool {
+        let contentChanged = specsById[spec.id]
+            .map { !$0.equalityToken.isEqual(to: spec.equalityToken) } ?? true
+        if contentChanged { return !isMounted }
+        if !widthChanged { return true }
+        // The width changed, so a height measured at the old width is stale.
+        // Only rows the layout pass already re-pinned to the new width (the
+        // mount band, corrected lazily while the resize drag was still
+        // ticking) are current; everything else must be measured here — this
+        // is the whole reason the width-settle reset exists.
+        return isMounted && pool.mountedView(id: spec.id)?.lastMeasuredWidth == contentWidth
     }
 
     /// Fires once a width-only change has stopped ticking for
@@ -237,9 +333,7 @@ final class ACPTranscriptScrollerReconciler {
     private func performWidthSettledReset() {
         isApplyingSpecs = true
         defer { isApplyingSpecs = false }
-        pool.releaseAll()
-        tiling.replaceAll(rows: measure(lastAppliedSpecs[...]))
-        scroller.setDocumentHeight(tiling.documentHeight)
+        performReset(specs: lastAppliedSpecs, widthChanged: true, followsTail: lastFollowsTail)
         if lastFollowsTail {
             scroller.scrollToBottom()
         }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -30,6 +30,13 @@ final class ACPTranscriptScrollerReconciler {
     private var orderedIds: [String] = []
     private var contentWidth: CGFloat = 0
 
+    /// Ids of specs whose `keepsMountedOffscreen` flag is set — recomputed
+    /// alongside `specsById` on every `apply()`. Kept as its own small set
+    /// (rather than filtering `specsById.values` on every layout pass, which
+    /// runs on every scroll tick) so the per-pass cost of the exemption stays
+    /// O(kept rows), not O(window). See `ACPTranscriptRowSpec.keepsMountedOffscreen`.
+    private var keepMountedOffscreenIds: Set<String> = []
+
     /// The full spec list and tail-follow flag from the most recent
     /// `apply()` call, kept so the deferred width-settle reset (which can
     /// fire well after the `apply()` call that scheduled it returned) always
@@ -191,6 +198,7 @@ final class ACPTranscriptScrollerReconciler {
 
         orderedIds = newIds
         specsById = newSpecs
+        keepMountedOffscreenIds = Set(specs.lazy.filter(\.keepsMountedOffscreen).map(\.id))
         lastAppliedSpecs = specs
         lastFollowsTail = followsTail
         if followsTail {
@@ -569,9 +577,21 @@ final class ACPTranscriptScrollerReconciler {
             viewportHeight: scroller.viewportHeight,
             overscan: Self.overscan
         )
+        // Rows in the band, PLUS any row exempted from unmounting regardless
+        // of distance from the viewport (an in-progress form prompt, say).
+        // The exemption only widens which rows get mounted/kept — `band`
+        // itself, which governs ordinary rows and the memory bound, is
+        // untouched. Kept rows are placed at their real tiled coordinates
+        // like any other mounted row (they just happen to sit outside the
+        // visible rect), not at some arbitrary position.
+        var indices = Array(band)
+        for id in keepMountedOffscreenIds {
+            guard let index = tiling.index(ofId: id), !band.contains(index) else { continue }
+            indices.append(index)
+        }
         var keep = Set<String>()
-        keep.reserveCapacity(band.count)
-        for index in band {
+        keep.reserveCapacity(indices.count)
+        for index in indices {
             let layout = tiling.rowLayout(at: index)
             guard let spec = specsById[layout.id] else { continue }
             keep.insert(layout.id)

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -469,11 +469,33 @@ final class ACPTranscriptScrollerReconciler {
     /// streaming row growing in place). No-ops while `apply()` (or the
     /// deferred width-settle reset) is itself mutating row state — see
     /// `isApplyingSpecs`'s doc comment.
+    ///
+    /// A mounted TAIL row growing this way (an image finishing its load, an
+    /// expandable row changing its own internal state) is never "entirely
+    /// above the viewport", so `applyHeightToTiling`'s compensation is
+    /// correctly zero — but that leaves the viewport at its old offset while
+    /// the document grew underneath it, stranding it above the new bottom
+    /// even though tail-follow is still active. Re-pin explicitly using
+    /// `lastFollowsTail`, which is guaranteed current here: this method only
+    /// runs once `isApplyingSpecs` is false, i.e. after some `apply()` call
+    /// has fully finished and already assigned `lastFollowsTail` from its
+    /// own `followsTail` argument. If the user scrolled away, the resulting
+    /// `apply()` (driven by `session.followsTranscriptTail` flipping to
+    /// false) already latched `lastFollowsTail = false` before this can run,
+    /// so this never fights a user who has genuinely left the tail.
+    /// `scroller.scrollToBottom()` is idempotent when already there — its
+    /// `setScrollY` clamp reports no `onScroll` change (`reportScroll` skips
+    /// when the offset is unchanged) — so calling it unconditionally on
+    /// every tail-following remeasure, not just ones that grow the tail,
+    /// costs nothing extra in the common case.
     func remeasureRow(id: String) {
         guard !isApplyingSpecs else { return }
         guard let spec = specsById[id] else { return }
         let (view, _) = pool.view(for: spec)
         applyMeasuredHeight(id: id, view: view)
+        if lastFollowsTail {
+            scroller.scrollToBottom()
+        }
     }
 
     /// Measures `view` at the current content width and pushes the result

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -14,12 +14,52 @@ final class ACPTranscriptScrollerReconciler {
     /// 1.5 viewport-heights on a typical window; tuned by feel in QA.
     static let overscan: CGFloat = 1200
 
+    /// Trailing-edge delay before a width-only change triggers the
+    /// expensive "re-measure every row" reset. A live resize/split-view
+    /// drag delivers a new width on essentially every frame (tens of
+    /// milliseconds apart); 150ms comfortably absorbs that whole burst
+    /// (so the drag never rebuilds thousands of hosting views per tick)
+    /// while staying well under the ~200-300ms threshold where a settle
+    /// delay starts reading as sluggish once the user stops dragging.
+    static let widthChangeSettleInterval: TimeInterval = 0.15
+
     private let tiling: ACPTranscriptTilingController
     private let pool: ACPTranscriptRowHostingPool
     private unowned let scroller: ACPTranscriptScrollerView
     private var specsById: [String: ACPTranscriptRowSpec] = [:]
     private var orderedIds: [String] = []
     private var contentWidth: CGFloat = 0
+
+    /// The full spec list and tail-follow flag from the most recent
+    /// `apply()` call, kept so the deferred width-settle reset (which can
+    /// fire well after the `apply()` call that scheduled it returned) always
+    /// measures against current state rather than a stale captured snapshot.
+    private var lastAppliedSpecs: [ACPTranscriptRowSpec] = []
+    private var lastFollowsTail = false
+    private let widthSettleTimer: DebounceTimer
+
+    /// True for the entire duration of `apply()` (and the deferred
+    /// width-settle reset). Suppresses `remeasureRow`'s reentrant path:
+    /// AppKit/SwiftUI can synchronously invalidate a hosting view's
+    /// intrinsic size as a side effect of the measurement calls `apply()`
+    /// itself makes (e.g. via `addSubview` or re-pinning `rootView`), which
+    /// would otherwise route back into `remeasureRow` while `specsById` and
+    /// the tiling controller are mid-mutation (most sharply during a
+    /// `.reset`, between `pool.releaseAll()` and `tiling.replaceAll`, where
+    /// `specsById` still holds the OLD specs for ids being reused). Every
+    /// measurement `apply()` needs is already performed directly by its own
+    /// code paths, so ignoring the reentrant signal during this window loses
+    /// nothing.
+    private var isApplyingSpecs = false
+
+    /// Reentrancy guard for `layoutMountedRows()`. A layout pass can itself
+    /// trigger a nested re-measure (mounting/measuring a row can invalidate
+    /// its intrinsic size synchronously), which must coalesce into another
+    /// full pass afterward rather than recurse mid-pass — recursing would
+    /// let the outer pass's stale `band`/`keep` release views the inner
+    /// pass just mounted.
+    private var isLayingOutRows = false
+    private var pendingRelayout = false
 
     init(
         tiling: ACPTranscriptTilingController,
@@ -29,8 +69,14 @@ final class ACPTranscriptScrollerReconciler {
         self.tiling = tiling
         self.pool = pool
         self.scroller = scroller
+        widthSettleTimer = DebounceTimer(interval: Self.widthChangeSettleInterval)
         pool.onRowIntrinsicSizeInvalidated = { [weak self] id in
             self?.remeasureRow(id: id)
+        }
+        widthSettleTimer.onFire = { [weak self] in
+            MainActor.assumeIsolated {
+                self?.performWidthSettledReset()
+            }
         }
     }
 
@@ -61,14 +107,61 @@ final class ACPTranscriptScrollerReconciler {
     }
 
     func apply(specs: [ACPTranscriptRowSpec], contentWidth width: CGFloat, followsTail: Bool) {
-        let widthChanged = width != contentWidth
-        contentWidth = width
+        // A non-positive width is transient (e.g. a host view not yet laid
+        // out). Nothing can be usefully measured against it — every row
+        // would collapse to zero height and `lastMeasuredWidth` would stay
+        // unset, permanently failing the placement invariant below. Defer
+        // entirely: state is left exactly as it was, so the next call with a
+        // real width is diffed as a normal (likely initial) update.
+        guard width > 0 else { return }
+
         let newIds = specs.map(\.id)
         var newSpecs: [String: ACPTranscriptRowSpec] = [:]
         newSpecs.reserveCapacity(specs.count)
         for spec in specs { newSpecs[spec.id] = spec }
 
-        let change: Diff = widthChanged ? .reset : Self.diff(oldIds: orderedIds, newIds: newIds)
+        let idDiff = Self.diff(oldIds: orderedIds, newIds: newIds)
+        let widthChanged = width != contentWidth
+        // A width change whose row identity is otherwise unchanged (or only
+        // incrementally so) does not need the eager "measure every row"
+        // reset applied immediately: see `performWidthSettledReset`.
+        let isPureWidthChange = widthChanged && idDiff != .reset
+
+        isApplyingSpecs = true
+        defer { isApplyingSpecs = false }
+
+        contentWidth = width
+        if isPureWidthChange {
+            // Apply the ordinary incremental diff at the new width (so
+            // genuinely new rows are measured correctly right away), let
+            // `layoutMountedRows` lazily re-pin already-mounted rows to the
+            // new width as they're placed (bounded by the mount band, so the
+            // visible content is never wrong), and debounce the full
+            // re-measure-every-row reset until the resize settles — so a
+            // live drag doesn't rebuild thousands of hosting views per tick.
+            applyDiff(idDiff, specs: specs)
+            widthSettleTimer.poke()
+        } else {
+            let change: Diff = widthChanged ? .reset : idDiff
+            if change == .reset {
+                // We're about to do the full remeasure ourselves; any
+                // earlier pending width-settle reset is now redundant.
+                widthSettleTimer.cancel()
+            }
+            applyDiff(change, specs: specs)
+        }
+
+        orderedIds = newIds
+        specsById = newSpecs
+        lastAppliedSpecs = specs
+        lastFollowsTail = followsTail
+        if followsTail {
+            scroller.scrollToBottom()
+        }
+        layoutMountedRows()
+    }
+
+    private func applyDiff(_ change: Diff, specs: [ACPTranscriptRowSpec]) {
         switch change {
         case .unchanged:
             updateChangedContent(specs: specs)
@@ -90,10 +183,23 @@ final class ACPTranscriptScrollerReconciler {
             tiling.replaceAll(rows: measure(specs[...]))
             scroller.setDocumentHeight(tiling.documentHeight)
         }
+    }
 
-        orderedIds = newIds
-        specsById = newSpecs
-        if followsTail {
+    /// Fires once a width-only change has stopped ticking for
+    /// `widthChangeSettleInterval`. Performs the full eager-build reset the
+    /// coalesced `apply()` path deferred, so off-screen rows (never touched
+    /// by the lazy per-row fallback in `layoutMountedRows`) end up with
+    /// correct, non-stale heights too. Always reads current state
+    /// (`lastAppliedSpecs`/`contentWidth`/`lastFollowsTail`) rather than a
+    /// captured snapshot, since this can fire well after the `apply()` call
+    /// that scheduled it returned.
+    private func performWidthSettledReset() {
+        isApplyingSpecs = true
+        defer { isApplyingSpecs = false }
+        pool.releaseAll()
+        tiling.replaceAll(rows: measure(lastAppliedSpecs[...]))
+        scroller.setDocumentHeight(tiling.documentHeight)
+        if lastFollowsTail {
             scroller.scrollToBottom()
         }
         layoutMountedRows()
@@ -115,22 +221,43 @@ final class ACPTranscriptScrollerReconciler {
         }
     }
 
+    /// Wired to `pool.onRowIntrinsicSizeInvalidated`. Re-measures a row
+    /// whose SwiftUI content invalidated its own intrinsic size (e.g. a
+    /// streaming row growing in place). No-ops while `apply()` (or the
+    /// deferred width-settle reset) is itself mutating row state — see
+    /// `isApplyingSpecs`'s doc comment.
     func remeasureRow(id: String) {
+        guard !isApplyingSpecs else { return }
         guard let spec = specsById[id] else { return }
         let (view, _) = pool.view(for: spec)
         applyMeasuredHeight(id: id, view: view)
     }
 
+    /// Measures `view` at the current content width and pushes the result
+    /// into the tiling controller; triggers a relayout pass only if the
+    /// height actually changed. Safe to call from within a layout pass:
+    /// `layoutMountedRows()` coalesces re-entrant calls rather than
+    /// recursing, so this never interleaves with an in-progress pass.
     private func applyMeasuredHeight(id: String, view: ACPTranscriptRowHostingView) {
         let height = view.measuredHeight(forWidth: contentWidth)
-        let compensation = tiling.updateHeight(
-            id: id, to: height, viewportMinY: scroller.scrollY
-        )
+        if applyHeightToTiling(id: id, height: height) {
+            layoutMountedRows()
+        }
+    }
+
+    /// Pushes a freshly measured height into the tiling controller, only if
+    /// it actually differs from what's on record — an unchanged height is a
+    /// no-op that must not cost a relayout pass. Returns whether geometry
+    /// changed.
+    @discardableResult
+    private func applyHeightToTiling(id: String, height: CGFloat) -> Bool {
+        guard let oldHeight = tiling.row(withId: id)?.height, oldHeight != height else { return false }
+        let compensation = tiling.updateHeight(id: id, to: height, viewportMinY: scroller.scrollY)
         scroller.setDocumentHeight(tiling.documentHeight)
         if compensation != 0 {
             scroller.setScrollY(scroller.scrollY + compensation)
         }
-        layoutMountedRows()
+        return true
     }
 
     private func measure<S: Sequence>(_ specs: S) -> [(id: String, height: CGFloat)]
@@ -142,8 +269,32 @@ final class ACPTranscriptScrollerReconciler {
     }
 
     /// Mount hosting views for rows in the band, position them, unmount the
-    /// rest. Called after every apply and on every scroll tick.
+    /// rest. Called after every apply and on every scroll tick. Re-entrant
+    /// calls (triggered by AppKit/SwiftUI invalidating a row's intrinsic
+    /// size as a side effect of a mount/measure happening inside a pass)
+    /// coalesce into an extra pass afterward instead of recursing.
     func layoutMountedRows() {
+        guard !isLayingOutRows else {
+            pendingRelayout = true
+            return
+        }
+        isLayingOutRows = true
+        defer { isLayingOutRows = false }
+
+        performLayoutPass()
+        var safetyCount = 0
+        while pendingRelayout {
+            pendingRelayout = false
+            performLayoutPass()
+            safetyCount += 1
+            if safetyCount > 8 {
+                assertionFailure("layoutMountedRows did not converge after \(safetyCount) extra passes")
+                break
+            }
+        }
+    }
+
+    private func performLayoutPass() {
         guard tiling.rowCount > 0 else {
             pool.releaseAll()
             return
@@ -163,13 +314,24 @@ final class ACPTranscriptScrollerReconciler {
             if view.superview !== scroller.flippedDocumentView {
                 scroller.flippedDocumentView.addSubview(view)
             }
+            // A freshly mounted (or previously-released-and-now-remounted)
+            // view has never been measured at the current width, or was
+            // last measured at a since-superseded one. Make the invariant
+            // below true by construction rather than relying on AppKit
+            // happening to invalidate the view's intrinsic size as a side
+            // effect of `addSubview` — that isn't contractual behavior.
+            if view.lastMeasuredWidth != contentWidth {
+                let height = view.measuredHeight(forWidth: contentWidth)
+                applyHeightToTiling(id: layout.id, height: height)
+            }
             assert(
                 view.lastMeasuredWidth == contentWidth,
                 "row \(layout.id) placed at width \(contentWidth) but last measured at \(String(describing: view.lastMeasuredWidth))"
             )
+            let placedLayout = tiling.rowLayout(at: index)
             view.frame = NSRect(
-                x: 0, y: layout.minY,
-                width: contentWidth, height: layout.height
+                x: 0, y: placedLayout.minY,
+                width: contentWidth, height: placedLayout.height
             )
         }
         pool.releaseAll(except: keep)

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -202,7 +202,8 @@ final class ACPTranscriptScrollerReconciler {
         case .inserted(let index, let count):
             let insertedSpecs = Array(specs[index..<(index + count)])
             let compensation = tiling.insert(
-                rows: measure(insertedSpecs), at: index, viewportMinY: scroller.scrollY
+                rows: measure(insertedSpecs), at: index,
+                viewportMinY: effectiveViewportMinY(forInsertionAt: index)
             )
             if compensation != 0 {
                 scroller.applyPrepend(delta: compensation, newDocumentHeight: tiling.documentHeight)
@@ -320,6 +321,41 @@ final class ACPTranscriptScrollerReconciler {
         // ticking) are current; everything else must be measured here — this
         // is the whole reason the width-settle reset exists.
         return isMounted && pool.mountedView(id: spec.id)?.lastMeasuredWidth == contentWidth
+    }
+
+    /// Synthetic rows (the head pagination spinner, the composer spacer, the
+    /// streaming caret, …) all use this id prefix — see
+    /// `ACPTranscriptScroller.Coordinator.rowSpecs`.
+    private static let syntheticIdPrefix = "__"
+
+    /// The viewport top to hand `ACPTranscriptTilingController.insert` when
+    /// it decides whether an insertion needs offset compensation.
+    ///
+    /// Normally that is simply the real viewport top: content grafted in at
+    /// or above it must push the offset down by the same amount to keep the
+    /// reading position still. But the head pagination spinner occupies row
+    /// 0, so a head step inserts at index 1 — i.e. at `topPadding +
+    /// spinnerHeight + rowSpacing`, roughly 56pt down — and bouncing to the
+    /// very top of history (the natural gesture that TRIGGERS a head step)
+    /// leaves `scrollY` below that. The plain `insertionY <= viewportMinY`
+    /// rule then declines to compensate and the whole inserted block, tens
+    /// of rows and thousands of points, shoves the reading position down.
+    ///
+    /// When every row above the insertion point is synthetic there is no
+    /// real content up there to hold still, so the insertion is logically
+    /// above the viewport however small `scrollY` happens to be: report the
+    /// insertion point itself as the viewport top so the rule fires. (An
+    /// insertion at index 0 satisfies this vacuously, which is also exactly
+    /// right — inserting above every row is what `prepend` always
+    /// compensated for unconditionally.) Insertions with real message rows
+    /// above them — every append, every mid-list insert — are unaffected.
+    private func effectiveViewportMinY(forInsertionAt index: Int) -> CGFloat {
+        let viewportMinY = scroller.scrollY
+        guard index <= orderedIds.count,
+              orderedIds[0..<index].allSatisfy({ $0.hasPrefix(Self.syntheticIdPrefix) })
+        else { return viewportMinY }
+        let insertionY = index < tiling.rowCount ? tiling.rowLayout(at: index).minY : tiling.documentHeight
+        return max(viewportMinY, insertionY)
     }
 
     /// Fires once a width-only change has stopped ticking for
@@ -457,7 +493,16 @@ final class ACPTranscriptScrollerReconciler {
             // effect of `addSubview` — that isn't contractual behavior.
             if view.lastMeasuredWidth != contentWidth {
                 let height = view.measuredHeight(forWidth: contentWidth)
-                applyHeightToTiling(id: layout.id, height: height)
+                // A changed height supersedes the `band`/`keep` computed at
+                // the top of this pass: rows that shrank pull later rows up
+                // into the band this pass will never look at, leaving a gap
+                // at the bottom of the viewport until the next scroll tick.
+                // Coalesce into another pass instead (`layoutMountedRows`
+                // drains `pendingRelayout` before returning) — the same
+                // thing `applyMeasuredHeight` does for out-of-pass callers.
+                if applyHeightToTiling(id: layout.id, height: height) {
+                    pendingRelayout = true
+                }
             }
             assert(
                 view.lastMeasuredWidth == contentWidth,

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -406,7 +406,11 @@ final class ACPTranscriptScrollerReconciler {
     /// Synthetic rows (the head pagination spinner, the composer spacer, the
     /// streaming caret, …) all use this id prefix — see
     /// `ACPTranscriptScroller.Coordinator.rowSpecs`.
-    private static let syntheticIdPrefix = "__"
+    /// Prefix marking rows that are not messages: the head pagination
+    /// spinner, queued prompts, the context-recovery row, the composer
+    /// spacer. Internal so the coordinator's anchor logic shares this one
+    /// definition rather than re-spelling the literal.
+    static let syntheticIdPrefix = "__"
 
     /// The viewport top to hand `ACPTranscriptTilingController.insert` when
     /// it decides whether an insertion needs offset compensation.
@@ -514,6 +518,13 @@ final class ACPTranscriptScrollerReconciler {
     func setFollowsTail(_ followsTail: Bool) {
         lastFollowsTail = followsTail
     }
+
+    /// The tail-follow state this reconciler is currently acting on. Read by
+    /// the coordinator's height-change path, which has to make the same
+    /// re-pin decision `remeasureRow` makes and must read it from the same
+    /// place rather than from the session (which the scroll handler has not
+    /// necessarily mirrored yet).
+    var followsTail: Bool { lastFollowsTail }
 
     func remeasureRow(id: String) {
         guard !isApplyingSpecs else { return }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -17,6 +17,21 @@ final class ACPTranscriptScrollerView: NSScrollView {
     let flippedDocumentView = ACPTranscriptDocumentView()
     var onScroll: ((_ previousY: CGFloat?, _ newY: CGFloat, _ viewportHeight: CGFloat, _ contentHeight: CGFloat, _ isProgrammatic: Bool) -> Void)?
 
+    /// Fired from `layout()` whenever `contentView.bounds.width` differs
+    /// from the last width reported — including the very first non-zero
+    /// width the view ever receives. This is the sole notification path for
+    /// "the scroller got a real size with no accompanying SwiftUI model
+    /// change": `makeNSView` builds the view at `frame: .zero`, and the
+    /// Coordinator's first `update(host:)` therefore always runs against
+    /// width 0, which `ACPTranscriptScrollerReconciler.apply` deliberately
+    /// defers on. Without this hook, a fully hydrated but otherwise idle
+    /// transcript could stay empty until some unrelated SwiftUI update
+    /// happened to call `updateNSView` again — see
+    /// `ACPTranscriptScroller.Coordinator.reconcileForContentWidthChange`,
+    /// the sole subscriber.
+    var onContentWidthChange: (() -> Void)?
+    private var lastReportedContentWidth: CGFloat?
+
     private var lastReportedY: CGFloat?
     private var programmaticAdjustmentDepth = 0
     private var boundsObserver: NSObjectProtocol?
@@ -47,6 +62,30 @@ final class ACPTranscriptScrollerView: NSScrollView {
         if let boundsObserver {
             NotificationCenter.default.removeObserver(boundsObserver)
         }
+    }
+
+    /// Explicitly marks the view as needing a layout pass whenever its own
+    /// frame SIZE changes, rather than relying on AppKit to infer that from
+    /// a plain (non-Auto-Layout, manually-`.frame`-positioned) view tree.
+    /// This is what makes `layout()` below fire reliably both for real
+    /// AppKit-driven resizes (SwiftUI placing/resizing the representable,
+    /// a window/split-view resize) and for a test directly assigning
+    /// `.frame` and then calling `layoutSubtreeIfNeeded()`.
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        // `super.layout()` runs AppKit's own scroll-view tiling first, so
+        // `contentView.bounds.width` already reflects any scroller-visibility
+        // change that layout may have made — reading it before `super.layout()`
+        // could observe a stale, pre-tile width.
+        let width = contentView.bounds.width
+        guard width != lastReportedContentWidth else { return }
+        lastReportedContentWidth = width
+        onContentWidthChange?()
     }
 
     var scrollY: CGFloat { contentView.bounds.origin.y }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -32,6 +32,33 @@ final class ACPTranscriptScrollerView: NSScrollView {
     var onContentWidthChange: (() -> Void)?
     private var lastReportedContentWidth: CGFloat?
 
+    /// Fired from `layout()` whenever `contentView.bounds.height` differs
+    /// from the last height reported, PROVIDED the width did NOT also
+    /// change on this same pass (a combined width+height change is already
+    /// fully covered by `onContentWidthChange`'s reconcile, which ends in
+    /// its own mount/relayout pass — see `reconcileForContentWidthChange`).
+    ///
+    /// This closes a distinct gap from the width one above: `boundsDidChange`
+    /// (see `reportScroll` below) only reports when the clip view's
+    /// y-ORIGIN moves, and `layout()` used to only notify on a width change
+    /// — so a HEIGHT-only resize (the window dragged taller/shorter with no
+    /// width change) reported through neither path. That matters because
+    /// the reconciler's mount band
+    /// (`ACPTranscriptScrollerReconciler.performLayoutPass`) is derived from
+    /// `viewportHeight`: growing the window revealed space no newly-mounted
+    /// row filled, and shrinking it left rows mounted that should have been
+    /// released.
+    ///
+    /// Unlike a width change, a height change never invalidates a row's
+    /// MEASURED content — nothing about a row reflows because the viewport
+    /// got taller or shorter, only which rows fall inside the band changes.
+    /// The coordinator's subscriber (`reconcileForViewportHeightChange`)
+    /// responds with the cheap operation for that — a mount/relayout pass —
+    /// not the full `update(host:)`/`apply()` re-measure the width path
+    /// uses; see that method's doc comment.
+    var onViewportHeightChange: (() -> Void)?
+    private var lastReportedViewportHeight: CGFloat?
+
     private var lastReportedY: CGFloat?
     private var programmaticAdjustmentDepth = 0
     private var boundsObserver: NSObjectProtocol?
@@ -79,13 +106,25 @@ final class ACPTranscriptScrollerView: NSScrollView {
     override func layout() {
         super.layout()
         // `super.layout()` runs AppKit's own scroll-view tiling first, so
-        // `contentView.bounds.width` already reflects any scroller-visibility
+        // `contentView.bounds` already reflects any scroller-visibility
         // change that layout may have made — reading it before `super.layout()`
-        // could observe a stale, pre-tile width.
+        // could observe stale, pre-tile values.
         let width = contentView.bounds.width
-        guard width != lastReportedContentWidth else { return }
+        let height = contentView.bounds.height
+        let widthChanged = width != lastReportedContentWidth
+        let heightChanged = height != lastReportedViewportHeight
+        guard widthChanged || heightChanged else { return }
         lastReportedContentWidth = width
-        onContentWidthChange?()
+        lastReportedViewportHeight = height
+        if widthChanged {
+            // Subsumes the height-only response: `onContentWidthChange`'s
+            // subscriber ends its own reconcile with a full mount/relayout
+            // pass, so firing `onViewportHeightChange` too on a combined
+            // width+height change would just be a redundant extra pass.
+            onContentWidthChange?()
+        } else {
+            onViewportHeightChange?()
+        }
     }
 
     var scrollY: CGFloat { contentView.bounds.origin.y }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -65,22 +65,35 @@ final class ACPTranscriptScrollerView: NSScrollView {
 
     /// Grow the document by prepended content and shift the scroll offset by
     /// the same delta, in one pass — the viewport does not move visually.
+    ///
+    /// The resulting offset is clamped exactly as `setScrollY` clamps, and
+    /// against the NEW document height (already installed at that point).
+    /// `delta` is not always positive: removal compensation routes a
+    /// negative delta through this same primitive, and a removal straddling
+    /// the viewport top would otherwise leave the clip view at a negative
+    /// bounds origin — parked above the document's own content until the
+    /// next user scroll happens to correct it.
     func applyPrepend(delta: CGFloat, newDocumentHeight: CGFloat) {
         performProgrammatic {
             flippedDocumentView.frame.size.height = newDocumentHeight
-            var origin = contentView.bounds.origin
-            origin.y += delta
-            contentView.setBoundsOrigin(origin)
+            let origin = contentView.bounds.origin
+            contentView.setBoundsOrigin(NSPoint(x: origin.x, y: clampedScrollY(origin.y + delta)))
             reflectScrolledClipView(contentView)
         }
     }
 
     func setScrollY(_ y: CGFloat) {
-        let clamped = max(0, min(y, max(0, contentHeight - viewportHeight)))
+        let clamped = clampedScrollY(y)
         performProgrammatic {
             contentView.setBoundsOrigin(NSPoint(x: contentView.bounds.origin.x, y: clamped))
             reflectScrolledClipView(contentView)
         }
+    }
+
+    /// The scrollable range's clamp, shared by every programmatic offset
+    /// adjustment so they cannot disagree about what a legal offset is.
+    private func clampedScrollY(_ y: CGFloat) -> CGFloat {
+        max(0, min(y, max(0, contentHeight - viewportHeight)))
     }
 
     func scrollToBottom() {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -1,0 +1,103 @@
+import AppKit
+
+/// Flipped document canvas: y = 0 is the top, y grows downward, matching
+/// the tiling controller's coordinates.
+@MainActor
+final class ACPTranscriptDocumentView: NSView {
+    override var isFlipped: Bool { true }
+}
+
+/// The transcript's NSScrollView. Exposes the one primitive SwiftUI's
+/// ScrollView can't provide on macOS 26: synchronous scroll-offset
+/// adjustment in the same pass as a content mutation (`applyPrepend`), so
+/// older rows graft in with zero visible movement and live trackpad
+/// momentum keeps working against the same scroll view.
+@MainActor
+final class ACPTranscriptScrollerView: NSScrollView {
+    let flippedDocumentView = ACPTranscriptDocumentView()
+    var onScroll: ((_ previousY: CGFloat?, _ newY: CGFloat, _ viewportHeight: CGFloat, _ contentHeight: CGFloat, _ isProgrammatic: Bool) -> Void)?
+
+    private var lastReportedY: CGFloat?
+    private var programmaticAdjustmentDepth = 0
+    private var boundsObserver: NSObjectProtocol?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        drawsBackground = false
+        hasVerticalScroller = true
+        hasHorizontalScroller = false
+        automaticallyAdjustsContentInsets = false
+        documentView = flippedDocumentView
+        flippedDocumentView.frame = NSRect(x: 0, y: 0, width: frameRect.width, height: 0)
+        flippedDocumentView.autoresizingMask = [.width]
+        contentView.postsBoundsChangedNotifications = true
+        boundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: contentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.reportScroll() }
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    deinit {
+        if let boundsObserver {
+            NotificationCenter.default.removeObserver(boundsObserver)
+        }
+    }
+
+    var scrollY: CGFloat { contentView.bounds.origin.y }
+    var viewportHeight: CGFloat { contentView.bounds.height }
+    var contentHeight: CGFloat { flippedDocumentView.frame.height }
+    var distanceFromBottom: CGFloat {
+        max(0, contentHeight - viewportHeight - scrollY)
+    }
+
+    func setDocumentHeight(_ height: CGFloat) {
+        guard flippedDocumentView.frame.height != height else { return }
+        performProgrammatic {
+            flippedDocumentView.frame.size.height = height
+        }
+    }
+
+    /// Grow the document by prepended content and shift the scroll offset by
+    /// the same delta, in one pass — the viewport does not move visually.
+    func applyPrepend(delta: CGFloat, newDocumentHeight: CGFloat) {
+        performProgrammatic {
+            flippedDocumentView.frame.size.height = newDocumentHeight
+            var origin = contentView.bounds.origin
+            origin.y += delta
+            contentView.setBoundsOrigin(origin)
+            reflectScrolledClipView(contentView)
+        }
+    }
+
+    func setScrollY(_ y: CGFloat) {
+        let clamped = max(0, min(y, max(0, contentHeight - viewportHeight)))
+        performProgrammatic {
+            contentView.setBoundsOrigin(NSPoint(x: contentView.bounds.origin.x, y: clamped))
+            reflectScrolledClipView(contentView)
+        }
+    }
+
+    func scrollToBottom() {
+        setScrollY(max(0, contentHeight - viewportHeight))
+    }
+
+    private func performProgrammatic(_ body: () -> Void) {
+        programmaticAdjustmentDepth += 1
+        body()
+        programmaticAdjustmentDepth -= 1
+    }
+
+    private func reportScroll() {
+        let newY = scrollY
+        guard newY != lastReportedY else { return }
+        let previous = lastReportedY
+        lastReportedY = newY
+        onScroll?(previous, newY, viewportHeight, contentHeight, programmaticAdjustmentDepth > 0)
+    }
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
@@ -185,6 +185,29 @@ final class ACPTranscriptTilingController {
         firstRowIndex(intersectingY: viewportMinY).map { rows[$0].id }
     }
 
+    /// Like `topVisibleRowId`, but walks forward over synthetic rows (the
+    /// head pagination spinner, queued prompts, the composer spacer) to the
+    /// first real message row at or below the viewport top.
+    ///
+    /// A remembered anchor names a message, so a synthetic id is not a usable
+    /// answer — but neither is giving up. Scrolling to the top of a paginated
+    /// transcript puts the pagination spinner at the viewport top, and simply
+    /// discarding that update leaves a paused session with no anchor at all,
+    /// which restoration then resolves as "go to the bottom". Returns nil
+    /// only when every remaining row is synthetic, i.e. the viewport top is
+    /// already inside the synthetic tail and there is no message below it to
+    /// name.
+    func firstNonSyntheticRowId(
+        atOrBelow viewportMinY: CGFloat, syntheticIdPrefix: String
+    ) -> String? {
+        guard var index = firstRowIndex(intersectingY: viewportMinY) else { return nil }
+        while index < rows.count, rows[index].id.hasPrefix(syntheticIdPrefix) {
+            index += 1
+        }
+        guard index < rows.count else { return nil }
+        return rows[index].id
+    }
+
     /// Indices of rows that should have live hosting views: everything
     /// intersecting the viewport extended by `overscan` on both sides. Rows
     /// outside this range keep their measured heights but have no mounted

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
@@ -208,6 +208,40 @@ final class ACPTranscriptTilingController {
         return rows[index].id
     }
 
+    /// The nearest real message row to `viewportMinY`, searching downward
+    /// first and then upward.
+    ///
+    /// The upward half covers the viewport sitting inside the synthetic tail
+    /// — queued prompts, the context-recovery row, the composer spacer —
+    /// where the downward scan runs off the end. The persisted anchor format
+    /// is an id plus a transcript index with no intra-row offset, so there
+    /// is no way to record "300pt into the tail"; the last message above is
+    /// the closest expressible position. Restoring lands at the top of that
+    /// message rather than the user's exact depth into the tail, which is
+    /// approximate — but the alternative is recording nothing, and a missing
+    /// anchor is read downstream as "go to the bottom", discarding the
+    /// user's position outright.
+    ///
+    /// Returns nil only for a document with no message rows at all, where
+    /// there is genuinely nothing to name.
+    func nearestNonSyntheticRowId(
+        to viewportMinY: CGFloat, syntheticIdPrefix: String
+    ) -> String? {
+        if let below = firstNonSyntheticRowId(
+            atOrBelow: viewportMinY, syntheticIdPrefix: syntheticIdPrefix
+        ) {
+            return below
+        }
+        guard !rows.isEmpty else { return nil }
+        let start = firstRowIndex(intersectingY: viewportMinY) ?? rows.count
+        var index = min(start, rows.count) - 1
+        while index >= 0 {
+            if !rows[index].id.hasPrefix(syntheticIdPrefix) { return rows[index].id }
+            index -= 1
+        }
+        return nil
+    }
+
     /// Indices of rows that should have live hosting views: everything
     /// intersecting the viewport extended by `overscan` on both sides. Rows
     /// outside this range keep their measured heights but have no mounted

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
@@ -43,29 +43,75 @@ final class ACPTranscriptTilingController {
         rebuildIndex()
     }
 
+    /// Core insertion primitive shared by `prepend`, `append`, and the
+    /// general `insert(rows:at:viewportMinY:)`. Returns three things a
+    /// caller needs to decide compensation:
+    ///   - `insertionY`: the pre-mutation `minY` of the row that will end up
+    ///     right after the inserted block, using the same half-open
+    ///     convention as `updateHeight` (or the pre-mutation `documentHeight`
+    ///     when inserting at the end — `index == rows.count`).
+    ///   - `hadExistingRows`: whether the controller held any rows before
+    ///     this call. A first-ever populate (empty → N) has nothing to keep
+    ///     visually still, so compensation must never apply to it even
+    ///     though `insertionY` trivially equals `viewportMinY == 0` in that
+    ///     case.
+    ///   - `delta`: total height inserted (row heights + one spacing per row).
+    private func insertCore(
+        rows newRows: [(id: String, height: CGFloat)], at index: Int
+    ) -> (insertionY: CGFloat, hadExistingRows: Bool, delta: CGFloat) {
+        let hadExistingRows = !rows.isEmpty
+        let insertionY = index < rows.count ? rows[index].minY : documentHeight
+        guard !newRows.isEmpty else { return (insertionY, hadExistingRows, 0) }
+        let delta = newRows.reduce(CGFloat(0)) { $0 + $1.height + metrics.rowSpacing }
+        rows.insert(
+            contentsOf: newRows.map { RowLayout(id: $0.id, height: $0.height, minY: 0) },
+            at: index
+        )
+        retile(from: index)
+        rebuildIndex()
+        return (insertionY, hadExistingRows, delta)
+    }
+
     /// Insert rows before the current first row. Returns the y-delta every
     /// pre-existing row moved down by — the exact amount the scroll offset
     /// must grow to keep the viewport visually still.
     func prepend(rows newRows: [(id: String, height: CGFloat)]) -> CGFloat {
-        guard !newRows.isEmpty else { return 0 }
-        let delta = newRows.reduce(CGFloat(0)) { $0 + $1.height + metrics.rowSpacing }
-        rows.insert(
-            contentsOf: newRows.map { RowLayout(id: $0.id, height: $0.height, minY: 0) },
-            at: 0
-        )
-        retile(from: 0)
-        rebuildIndex()
-        return delta
+        insertCore(rows: newRows, at: 0).delta
     }
 
     func append(rows newRows: [(id: String, height: CGFloat)]) {
-        guard !newRows.isEmpty else { return }
-        let firstNewIndex = rows.count
-        rows.append(
-            contentsOf: newRows.map { RowLayout(id: $0.id, height: $0.height, minY: 0) }
-        )
-        retile(from: firstNewIndex)
+        _ = insertCore(rows: newRows, at: rows.count)
+    }
+
+    /// Insert rows at an arbitrary index. Returns the scroll-offset
+    /// compensation the caller must add to keep the viewport visually
+    /// still: the inserted height iff there was existing content AND the
+    /// insertion point lies at or above the current viewport top
+    /// (`insertionY <= viewportMinY`), zero otherwise. Same half-open
+    /// convention as `updateHeight`.
+    func insert(
+        rows newRows: [(id: String, height: CGFloat)], at index: Int, viewportMinY: CGFloat
+    ) -> CGFloat {
+        let clampedIndex = max(0, min(index, rows.count))
+        let (insertionY, hadExistingRows, delta) = insertCore(rows: newRows, at: clampedIndex)
+        return hadExistingRows && insertionY <= viewportMinY ? delta : 0
+    }
+
+    /// Remove `count` rows starting at `index`. Returns the scroll-offset
+    /// compensation the caller must add to keep the viewport visually
+    /// still: the negative removed height iff the removal point lies at or
+    /// above the current viewport top (`removalY <= viewportMinY`), zero
+    /// otherwise. Same half-open convention as `updateHeight` and `insert`.
+    @discardableResult
+    func remove(at index: Int, count: Int, viewportMinY: CGFloat) -> CGFloat {
+        guard count > 0, index >= 0, index < rows.count else { return 0 }
+        let upperBound = min(index + count, rows.count)
+        let removalY = rows[index].minY
+        let delta = rows[index..<upperBound].reduce(CGFloat(0)) { $0 + $1.height + metrics.rowSpacing }
+        rows.removeSubrange(index..<upperBound)
+        retile(from: index)
         rebuildIndex()
+        return removalY <= viewportMinY ? -delta : 0
     }
 
     func removeSuffix(from index: Int) {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
@@ -1,0 +1,99 @@
+import CoreGraphics
+
+/// Single authority on transcript row placement for the AppKit scroller:
+/// ordered rows, measured heights, cumulative y-offsets (flipped/top-down
+/// coordinates), and total document height. Pure layout math — no AppKit —
+/// so every behavior is unit-testable.
+@MainActor
+final class ACPTranscriptTilingController {
+    struct Metrics: Equatable {
+        var rowSpacing: CGFloat = 18
+        var topPadding: CGFloat = 24
+    }
+
+    struct RowLayout: Equatable {
+        let id: String
+        var height: CGFloat
+        var minY: CGFloat
+        var maxY: CGFloat { minY + height }
+    }
+
+    private let metrics: Metrics
+    private var rows: [RowLayout] = []
+    private var indexById: [String: Int] = [:]
+    private(set) var documentHeight: CGFloat = 0
+
+    init(metrics: Metrics = Metrics()) {
+        self.metrics = metrics
+    }
+
+    var rowCount: Int { rows.count }
+
+    func row(withId id: String) -> RowLayout? {
+        indexById[id].map { rows[$0] }
+    }
+
+    func rowLayout(at index: Int) -> RowLayout { rows[index] }
+    func rowId(at index: Int) -> String { rows[index].id }
+    func index(ofId id: String) -> Int? { indexById[id] }
+
+    func replaceAll(rows newRows: [(id: String, height: CGFloat)]) {
+        rows = newRows.map { RowLayout(id: $0.id, height: $0.height, minY: 0) }
+        retile(from: 0)
+        rebuildIndex()
+    }
+
+    /// Insert rows before the current first row. Returns the y-delta every
+    /// pre-existing row moved down by — the exact amount the scroll offset
+    /// must grow to keep the viewport visually still.
+    func prepend(rows newRows: [(id: String, height: CGFloat)]) -> CGFloat {
+        guard !newRows.isEmpty else { return 0 }
+        let delta = newRows.reduce(CGFloat(0)) { $0 + $1.height + metrics.rowSpacing }
+        rows.insert(
+            contentsOf: newRows.map { RowLayout(id: $0.id, height: $0.height, minY: 0) },
+            at: 0
+        )
+        retile(from: 0)
+        rebuildIndex()
+        return delta
+    }
+
+    func append(rows newRows: [(id: String, height: CGFloat)]) {
+        guard !newRows.isEmpty else { return }
+        let firstNewIndex = rows.count
+        rows.append(
+            contentsOf: newRows.map { RowLayout(id: $0.id, height: $0.height, minY: 0) }
+        )
+        retile(from: firstNewIndex)
+        rebuildIndex()
+    }
+
+    func removeSuffix(from index: Int) {
+        guard index < rows.count else { return }
+        rows.removeSubrange(index...)
+        retile(from: index)
+        rebuildIndex()
+    }
+
+    /// Recompute minY for rows[from...] and the document height.
+    private func retile(from index: Int) {
+        var y: CGFloat
+        if index == 0 {
+            y = metrics.topPadding
+        } else {
+            let prev = rows[index - 1]
+            y = prev.maxY + metrics.rowSpacing
+        }
+        for i in index..<rows.count {
+            rows[i].minY = y
+            y = rows[i].maxY + metrics.rowSpacing
+        }
+        documentHeight = rows.last?.maxY ?? 0
+    }
+
+    private func rebuildIndex() {
+        indexById = Dictionary(
+            uniqueKeysWithValues: rows.enumerated().map { ($0.element.id, $0.offset) }
+        )
+    }
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
@@ -75,6 +75,30 @@ final class ACPTranscriptTilingController {
         rebuildIndex()
     }
 
+    /// Apply a re-measured height. Returns the scroll-offset compensation the
+    /// caller must add to keep the viewport visually still: non-zero only when
+    /// the row lies entirely above the viewport top (its resize would otherwise
+    /// push/pull everything the user is looking at).
+    ///
+    /// Height changes never alter row identity or order, so this does not call
+    /// `rebuildIndex()` — that would be wasted work re-deriving an id → index
+    /// map that hasn't changed.
+    func updateHeight(id: String, to height: CGFloat, viewportMinY: CGFloat) -> CGFloat {
+        guard let index = indexById[id] else { return 0 }
+        let old = rows[index]
+        guard old.height != height else { return 0 }
+        let delta = height - old.height
+        // A row's extent is the half-open range [minY, maxY): it occupies
+        // every y up to, but not including, maxY. When old.maxY <= viewportMinY,
+        // none of the row's pixels are at or past the viewport's top edge, so
+        // it is entirely above the viewport (not merely "at" the boundary) and
+        // its resize must be compensated to keep the visible content still.
+        let isEntirelyAboveViewport = old.maxY <= viewportMinY
+        rows[index].height = height
+        retile(from: index)
+        return isEntirelyAboveViewport ? delta : 0
+    }
+
     /// Recompute minY for rows[from...] and the document height.
     private func retile(from index: Int) {
         var y: CGFloat

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
@@ -115,6 +115,47 @@ final class ACPTranscriptTilingController {
         documentHeight = rows.last?.maxY ?? 0
     }
 
+    /// Binary search: index of the first row whose bottom edge is below `y`
+    /// (i.e. the row occupying or first following that y-line). Nil when empty
+    /// or `y` is past the last row.
+    ///
+    /// Uses the same half-open-interval convention as `updateHeight`: a row
+    /// whose `maxY` exactly equals `y` is treated as entirely above `y`, not
+    /// intersecting it, so the search requires `maxY > y` (strict).
+    func firstRowIndex(intersectingY y: CGFloat) -> Int? {
+        guard !rows.isEmpty else { return nil }
+        var lo = 0, hi = rows.count - 1
+        guard rows[hi].maxY > y else { return nil }
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if rows[mid].maxY > y { hi = mid } else { lo = mid + 1 }
+        }
+        return lo
+    }
+
+    /// The id of the topmost row intersecting the viewport top, used to
+    /// remember the user's scroll position across sessions.
+    func topVisibleRowId(viewportMinY: CGFloat) -> String? {
+        firstRowIndex(intersectingY: viewportMinY).map { rows[$0].id }
+    }
+
+    /// Indices of rows that should have live hosting views: everything
+    /// intersecting the viewport extended by `overscan` on both sides. Rows
+    /// outside this range keep their measured heights but have no mounted
+    /// view, bounding memory as the render window grows.
+    func mountBand(viewportMinY: CGFloat, viewportHeight: CGFloat, overscan: CGFloat) -> Range<Int> {
+        guard !rows.isEmpty else { return 0..<0 }
+        let lowY = viewportMinY - overscan
+        let highY = viewportMinY + viewportHeight + overscan
+        let first = firstRowIndex(intersectingY: lowY) ?? rows.count
+        guard first < rows.count else { return rows.count..<rows.count }
+        var last = first
+        while last + 1 < rows.count, rows[last + 1].minY < highY {
+            last += 1
+        }
+        return first..<(last + 1)
+    }
+
     /// Rebuilds the id → index lookup, tolerating duplicate row ids rather
     /// than trapping (as `Dictionary(uniqueKeysWithValues:)` would). Duplicate
     /// ids should never happen, but this controller drives the live

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptTilingController.swift
@@ -91,9 +91,22 @@ final class ACPTranscriptTilingController {
         documentHeight = rows.last?.maxY ?? 0
     }
 
+    /// Rebuilds the id → index lookup, tolerating duplicate row ids rather
+    /// than trapping (as `Dictionary(uniqueKeysWithValues:)` would). Duplicate
+    /// ids should never happen, but this controller drives the live
+    /// transcript in the user's daily-driver app: the legacy SwiftUI
+    /// `ForEach` path merely degrades (collapses/misrenders rows) on
+    /// duplicate ids, so a hard trap here would be a strictly harsher
+    /// regression than silently keeping the last occurrence. The
+    /// `assertionFailure` still makes the condition loud during development
+    /// while staying safe in release.
     private func rebuildIndex() {
-        indexById = Dictionary(
-            uniqueKeysWithValues: rows.enumerated().map { ($0.element.id, $0.offset) }
-        )
+        indexById.removeAll(keepingCapacity: true)
+        for (offset, row) in rows.enumerated() {
+            if indexById[row.id] != nil {
+                assertionFailure("duplicate row id \(row.id)")
+            }
+            indexById[row.id] = offset
+        }
     }
 }

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -15,6 +15,18 @@ struct AdvancedPane: View {
                     .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 12)
 
+                SettingsGroup(title: "Experiments") {
+                    SettingsRow(
+                        name: "AppKit transcript scroller",
+                        desc: "Replaces the transcript's scrolling implementation with an AppKit-backed scroller, keeping pagination through long chat history jump-free. Toggling this re-creates the transcript view, so the scroll position in any open chats is lost."
+                    ) {
+                        AlasToggle(on: Binding(
+                            get: { ACPTranscriptScrollerFlag.isEnabled },
+                            set: { ACPTranscriptScrollerFlag.setOverride($0) }
+                        ))
+                    }
+                }
+
                 SettingsGroup(title: "Cleanup") {
                     SettingsRow(
                         name: "Clear all projects",

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -11,7 +11,7 @@ struct AdvancedPane: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Advanced").font(.system(size: 18, weight: .semibold))
-                Text("Destructive maintenance actions for Alas project tracking.")
+                Text("Experimental features and destructive maintenance actions.")
                     .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 12)
 

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -6,6 +6,11 @@ struct AdvancedPane: View {
     @State private var pendingAction: CleanupAction?
     @State private var cleanupMessage: String?
     @State private var isCleaningStaleProjects = false
+    /// Mirrors `ACPTranscriptScrollerFlag.isEnabled` in observable state.
+    /// Reading the flag straight from a `Binding` getter renders the toggle
+    /// correctly once but never invalidates this view, so the switch could
+    /// keep drawing its old position after the override had already changed.
+    @State private var appKitScrollerEnabled = ACPTranscriptScrollerFlag.isEnabled
 
     var body: some View {
         ScrollView {
@@ -21,8 +26,11 @@ struct AdvancedPane: View {
                         desc: "Replaces the transcript's scrolling implementation with an AppKit-backed scroller, keeping pagination through long chat history jump-free. Toggling this re-creates the transcript view, so the scroll position in any open chats is lost."
                     ) {
                         AlasToggle(on: Binding(
-                            get: { ACPTranscriptScrollerFlag.isEnabled },
-                            set: { ACPTranscriptScrollerFlag.setOverride($0) }
+                            get: { appKitScrollerEnabled },
+                            set: {
+                                appKitScrollerEnabled = $0
+                                ACPTranscriptScrollerFlag.setOverride($0)
+                            }
                         ))
                     }
                 }
@@ -72,6 +80,13 @@ struct AdvancedPane: View {
             }
         } message: { action in
             Text(action.message(projectCount: state.projects.count))
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: ACPTranscriptScrollerFlag.overrideDidChangeNotification)
+        ) { _ in
+            // Keeps the switch honest when the override changes from outside
+            // this pane — a `defaults write`, or another window's copy of it.
+            appKitScrollerEnabled = ACPTranscriptScrollerFlag.isEnabled
         }
     }
 

--- a/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
@@ -276,4 +276,42 @@ struct ACPTranscriptWindowTests {
 
         #expect(t.visibleTail == tailBefore)
     }
+
+    @Test("stepHeadBack(boundTail: false) keeps the tail while revealing older rows")
+    func unboundedHeadStepKeepsTail() {
+        let t = ACPTranscript()
+        for _ in 0..<200 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.resetWindowToTail()          // head 170, tail nil
+        t.freezeVisibleTail()          // tail 200
+        for _ in 0..<5 { t.stepHeadBack(boundTail: false) }
+        #expect(t.visibleHead == 20)   // 170 - 5*30
+        #expect(t.visibleTailBound == 200)  // never trimmed
+    }
+
+    @Test("stepHeadBack default still bounds the tail to maxVisibleRows")
+    func boundedHeadStepUnchanged() {
+        let t = ACPTranscript()
+        for _ in 0..<200 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.resetWindowToTail()
+        t.freezeVisibleTail()
+        for _ in 0..<5 { t.stepHeadBack() }
+        #expect(t.visibleHead == 20)
+        #expect(t.visibleTailBound == 20 + ACPTranscript.maxVisibleRows)
+    }
+
+    @Test("stepTailForward(boundHead: false) keeps the head while revealing newer rows")
+    func unboundedTailStepKeepsHead() {
+        let t = ACPTranscript()
+        for _ in 0..<200 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.setVisibleWindow(containing: 0)   // head 0, tail 90
+        t.stepTailForward(preserving: nil, boundHead: false)
+        #expect(t.visibleHead == 0)
+        #expect(t.visibleTailBound == 120)  // 90 + tailWindow
+    }
 }

--- a/AlasTests/ACP/UI/ACPMessageListSwitchTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListSwitchTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPMessageList scroller switch")
+struct ACPMessageListSwitchTests {
+    @Test("switch follows the flag")
+    func followsFlag() {
+        #expect(ACPMessageList.usesAppKitScroller(flagEnabled: true))
+        #expect(!ACPMessageList.usesAppKitScroller(flagEnabled: false))
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptRowHostingPoolTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowHostingPoolTests.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscriptRowHostingPool")
+struct ACPTranscriptRowHostingPoolTests {
+    private func spec(id: String, token: Int, text: String = "x") -> ACPTranscriptRowSpec {
+        ACPTranscriptRowSpec(
+            id: id,
+            equalityToken: ACPRowEqualityToken(token),
+            build: { AnyView(Text(text)) }
+        )
+    }
+
+    @Test("same id returns the same hosting view instance")
+    func reusesInstance() {
+        let pool = ACPTranscriptRowHostingPool()
+        let first = pool.view(for: spec(id: "a", token: 1)).view
+        let second = pool.view(for: spec(id: "a", token: 1)).view
+        #expect(first === second)
+    }
+
+    @Test("unchanged token reports contentChanged false; changed token true")
+    func tokenGating() {
+        let pool = ACPTranscriptRowHostingPool()
+        _ = pool.view(for: spec(id: "a", token: 1))
+        #expect(pool.view(for: spec(id: "a", token: 1)).contentChanged == false)
+        #expect(pool.view(for: spec(id: "a", token: 2)).contentChanged == true)
+    }
+
+    @Test("release forgets the id; a later request builds fresh state")
+    func release() {
+        let pool = ACPTranscriptRowHostingPool()
+        _ = pool.view(for: spec(id: "a", token: 1))
+        pool.release(id: "a")
+        #expect(!pool.mountedIds.contains("a"))
+        #expect(pool.view(for: spec(id: "a", token: 1)).contentChanged == true)
+    }
+
+    @Test("releaseAll keeps only the requested ids")
+    func releaseAllExcept() {
+        let pool = ACPTranscriptRowHostingPool()
+        _ = pool.view(for: spec(id: "a", token: 1))
+        _ = pool.view(for: spec(id: "b", token: 1))
+        _ = pool.view(for: spec(id: "c", token: 1))
+        pool.releaseAll(except: ["b"])
+        #expect(pool.mountedIds == ["b"])
+    }
+
+    @Test("intrinsic size invalidation surfaces the row id")
+    func invalidationRouting() {
+        let pool = ACPTranscriptRowHostingPool()
+        var invalidated: [String] = []
+        pool.onRowIntrinsicSizeInvalidated = { invalidated.append($0) }
+        let view = pool.view(for: spec(id: "a", token: 1)).view
+        view.invalidateIntrinsicContentSize()
+        #expect(invalidated == ["a"])
+    }
+
+    @Test("equality tokens of different types compare unequal")
+    func tokenTypeMismatch() {
+        let a = ACPRowEqualityToken(1)
+        let b = ACPRowEqualityToken("1")
+        #expect(!a.isEqual(to: b))
+        #expect(a.isEqual(to: ACPRowEqualityToken(1)))
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptRowHostingViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowHostingViewTests.swift
@@ -80,4 +80,25 @@ struct ACPTranscriptRowHostingViewTests {
         #expect(measuredView.measuredHeight(forWidth: -10) == 0)
         #expect(measuredView.lastMeasuredWidth == 320)
     }
+
+    @Test("updateRootView replaces the pristine base, so a later measurement reflects the new content")
+    func updateRootViewReplacesPristineBase() {
+        let view = ACPTranscriptRowHostingView(
+            rootView: AnyView(Text("short").frame(maxWidth: .infinity, alignment: .leading))
+        )
+        let shortHeight = view.measuredHeight(forWidth: 300)
+
+        view.updateRootView(
+            AnyView(
+                Text(String(repeating: "a fairly long sentence that will wrap. ", count: 20))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            )
+        )
+        let longHeight = view.measuredHeight(forWidth: 300)
+
+        // If updateRootView failed to refresh the internal pristine copy,
+        // this second measurement would re-pin the ORIGINAL short content
+        // and longHeight would equal shortHeight.
+        #expect(longHeight > shortHeight)
+    }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptRowHostingViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowHostingViewTests.swift
@@ -49,4 +49,35 @@ struct ACPTranscriptRowHostingViewTests {
         view.invalidateIntrinsicContentSize()
         #expect(fired == 1)
     }
+
+    @Test("lastMeasuredWidth reflects the last successful measurement")
+    func lastMeasuredWidthTracksMeasurement() {
+        let view = ACPTranscriptRowHostingView(rootView: AnyView(Text("hello world")))
+        #expect(view.lastMeasuredWidth == nil)
+
+        _ = view.measuredHeight(forWidth: 320)
+        #expect(view.lastMeasuredWidth == 320)
+
+        _ = view.measuredHeight(forWidth: 150)
+        #expect(view.lastMeasuredWidth == 150)
+    }
+
+    @Test("non-positive width is rejected without pinning the view to a degenerate frame")
+    func nonPositiveWidthIsRejected() {
+        let freshView = ACPTranscriptRowHostingView(rootView: AnyView(Text("hello world")))
+        #expect(freshView.measuredHeight(forWidth: 0) == 0)
+        #expect(freshView.lastMeasuredWidth == nil)
+        #expect(freshView.measuredHeight(forWidth: -50) == 0)
+        #expect(freshView.lastMeasuredWidth == nil)
+
+        let measuredView = ACPTranscriptRowHostingView(rootView: AnyView(Text("hello world")))
+        _ = measuredView.measuredHeight(forWidth: 320)
+        #expect(measuredView.lastMeasuredWidth == 320)
+
+        #expect(measuredView.measuredHeight(forWidth: 0) == 0)
+        #expect(measuredView.lastMeasuredWidth == 320)
+
+        #expect(measuredView.measuredHeight(forWidth: -10) == 0)
+        #expect(measuredView.lastMeasuredWidth == 320)
+    }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptRowHostingViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowHostingViewTests.swift
@@ -1,0 +1,52 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscriptRowHostingView measurement")
+struct ACPTranscriptRowHostingViewTests {
+    @Test("measures positive height for a text row at a fixed width")
+    func measuresText() {
+        let view = ACPTranscriptRowHostingView(
+            rootView: AnyView(Text("hello world").font(.system(size: 13)))
+        )
+        let height = view.measuredHeight(forWidth: 400)
+        #expect(height > 0)
+        #expect(height < 100)
+    }
+
+    @Test("longer content measures taller at the same width")
+    func longerContentIsTaller() {
+        let short = ACPTranscriptRowHostingView(
+            rootView: AnyView(Text("one line").frame(maxWidth: .infinity, alignment: .leading))
+        )
+        let long = ACPTranscriptRowHostingView(
+            rootView: AnyView(
+                Text(String(repeating: "a fairly long sentence that will wrap. ", count: 20))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            )
+        )
+        #expect(long.measuredHeight(forWidth: 300) > short.measuredHeight(forWidth: 300))
+    }
+
+    @Test("narrower width measures taller for wrapping content")
+    func narrowerWidthIsTaller() {
+        let view = ACPTranscriptRowHostingView(
+            rootView: AnyView(
+                Text(String(repeating: "wrap me please ", count: 30))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            )
+        )
+        #expect(view.measuredHeight(forWidth: 200) > view.measuredHeight(forWidth: 600))
+    }
+
+    @Test("intrinsic size invalidation fires the callback")
+    func invalidationCallback() {
+        let view = ACPTranscriptRowHostingView(rootView: AnyView(Text("x")))
+        var fired = 0
+        view.onIntrinsicSizeInvalidated = { fired += 1 }
+        view.invalidateIntrinsicContentSize()
+        #expect(fired == 1)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollBookkeepingResetTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollBookkeepingResetTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscriptScrollBookkeeping reset")
+struct ACPTranscriptScrollBookkeepingResetTests {
+    /// Switching the transcript between the legacy and AppKit scrollers
+    /// rebuilds the subtree via `.id(scrollerFlagState)`, but this object is
+    /// `@State` on `ACPMessageList` itself and survives that identity
+    /// change. `restoredRememberedAnchor` is the field that matters: if it
+    /// carries over, `restoreRememberedAnchorIfNeeded` sees the current
+    /// anchor as already restored and returns early, leaving a paused chat
+    /// at the rebuilt scroll view's default position instead of where the
+    /// user was reading.
+    @Test("reset clears the restored-anchor latch so the rebuilt scroll view restores again")
+    func resetClearsRestoredAnchorLatch() {
+        let book = ACPTranscriptScrollBookkeeping()
+        book.restoredRememberedAnchor = "msg-42"
+
+        book.reset()
+
+        #expect(book.restoredRememberedAnchor == nil)
+    }
+
+    @Test("reset returns every field to its initial value")
+    func resetClearsEveryField() {
+        let book = ACPTranscriptScrollBookkeeping()
+        book.isRestoringTail = true
+        book.restoredRememberedAnchor = "msg-42"
+        book.latestRememberedScrollAnchorIndex = 7
+        book.lastHeadStepAt = Date(timeIntervalSince1970: 1)
+        book.lastTailStepAt = Date(timeIntervalSince1970: 2)
+        book.pendingTailScrollGeneration = 3
+        book.pendingContentShrinkResetGeneration = 4
+        book.scrollGeometryGeneration = 5
+        book.lastContentGrowthTailRestoreSourceHeight = 100
+        book.lastContentGrowthTailRestoreHeight = 200
+
+        book.reset()
+
+        #expect(book.isRestoringTail == false)
+        #expect(book.restoredRememberedAnchor == nil)
+        #expect(book.latestRememberedScrollAnchorIndex == nil)
+        #expect(book.lastHeadStepAt == .distantPast)
+        #expect(book.lastTailStepAt == .distantPast)
+        #expect(book.pendingTailScrollGeneration == 0)
+        #expect(book.pendingContentShrinkResetGeneration == 0)
+        #expect(book.scrollGeometryGeneration == 0)
+        #expect(book.lastScrollProbe == nil)
+        #expect(book.pendingContentGrowthTailRestore == nil)
+        #expect(book.lastContentGrowthTailRestoreSourceHeight == nil)
+        #expect(book.lastContentGrowthTailRestoreHeight == nil)
+    }
+
+    /// A tail scroll scheduled against the outgoing scroll view must not
+    /// land on the incoming one after the switch.
+    @Test("reset cancels scheduled scroll work")
+    func resetCancelsPendingTasks() async {
+        let book = ACPTranscriptScrollBookkeeping()
+        let started = AsyncChannel()
+        book.pendingTailScrollTask = Task {
+            await started.signal()
+            try? await Task.sleep(for: .seconds(60))
+        }
+        book.pendingContentShrinkResetTask = Task {
+            try? await Task.sleep(for: .seconds(60))
+        }
+        let tailTask = book.pendingTailScrollTask
+        let shrinkTask = book.pendingContentShrinkResetTask
+        await started.wait()
+
+        book.reset()
+
+        _ = await tailTask?.value
+        _ = await shrinkTask?.value
+        #expect(tailTask?.isCancelled == true)
+        #expect(shrinkTask?.isCancelled == true)
+        #expect(book.pendingTailScrollTask == nil)
+        #expect(book.pendingContentShrinkResetTask == nil)
+    }
+}
+
+/// Minimal one-shot signal so the cancellation test can wait for the task to
+/// actually start before cancelling it, rather than sleeping.
+private actor AsyncChannel {
+    private var isSignalled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        isSignalled = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        if isSignalled { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerFlagTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerFlagTests.swift
@@ -1,0 +1,17 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPTranscriptScrollerFlag")
+struct ACPTranscriptScrollerFlagTests {
+    @Test("explicit override wins in both build types")
+    func overrideWins() {
+        #expect(ACPTranscriptScrollerFlag.resolve(override: true, isDebugBuild: false) == true)
+        #expect(ACPTranscriptScrollerFlag.resolve(override: false, isDebugBuild: true) == false)
+    }
+
+    @Test("no override: on for debug builds, off for release")
+    func defaults() {
+        #expect(ACPTranscriptScrollerFlag.resolve(override: nil, isDebugBuild: true) == true)
+        #expect(ACPTranscriptScrollerFlag.resolve(override: nil, isDebugBuild: false) == false)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerFlagTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerFlagTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import Alas
 
 @Suite("ACPTranscriptScrollerFlag")
@@ -13,5 +14,71 @@ struct ACPTranscriptScrollerFlagTests {
     func defaults() {
         #expect(ACPTranscriptScrollerFlag.resolve(override: nil, isDebugBuild: true) == true)
         #expect(ACPTranscriptScrollerFlag.resolve(override: nil, isDebugBuild: false) == false)
+    }
+}
+
+@Suite("ACPTranscriptScrollerFlag UserDefaults Integration")
+struct ACPTranscriptScrollerFlagUserDefaultsTests {
+    @Test("UserDefaults round-trip: boolean written as true is read back as true")
+    func userDefaultsRoundTripTrue() throws {
+        let suiteName = "ACPTranscriptScrollerFlagTest-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.set(true, forKey: ACPTranscriptScrollerFlag.defaultsKey)
+        let override = ACPTranscriptScrollerFlag.readOverride(from: defaults)
+        #expect(override == true)
+    }
+
+    @Test("UserDefaults round-trip: boolean written as false is read back as false")
+    func userDefaultsRoundTripFalse() throws {
+        let suiteName = "ACPTranscriptScrollerFlagTest-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.set(false, forKey: ACPTranscriptScrollerFlag.defaultsKey)
+        let override = ACPTranscriptScrollerFlag.readOverride(from: defaults)
+        #expect(override == false)
+    }
+
+    @Test("UserDefaults round-trip: absent key returns nil")
+    func userDefaultsRoundTripNil() throws {
+        let suiteName = "ACPTranscriptScrollerFlagTest-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let override = ACPTranscriptScrollerFlag.readOverride(from: defaults)
+        #expect(override == nil)
+    }
+
+    @Test("isEnabled delegates to resolve with readOverride result and debug build flag")
+    func isEnabledDelegatesCorrectly() throws {
+        let suiteName = "ACPTranscriptScrollerFlagTest-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        // Test with override = true (should win regardless of build type)
+        defaults.set(true, forKey: ACPTranscriptScrollerFlag.defaultsKey)
+        let result1 = ACPTranscriptScrollerFlag.isEnabledWithDefaults(defaults)
+        #expect(result1 == true)
+
+        // Test with override = false (should win regardless of build type)
+        defaults.set(false, forKey: ACPTranscriptScrollerFlag.defaultsKey)
+        let result2 = ACPTranscriptScrollerFlag.isEnabledWithDefaults(defaults)
+        #expect(result2 == false)
+
+        // Test with no override (should default to debug mode, which is true in tests)
+        defaults.removeObject(forKey: ACPTranscriptScrollerFlag.defaultsKey)
+        let result3 = ACPTranscriptScrollerFlag.isEnabledWithDefaults(defaults)
+        // In test environment (DEBUG mode), should be true
+        #expect(result3 == true)
     }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerFlagTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerFlagTests.swift
@@ -82,3 +82,83 @@ struct ACPTranscriptScrollerFlagUserDefaultsTests {
         #expect(result3 == true)
     }
 }
+
+/// The exact contract the Debug settings toggle relies on: what it should
+/// display given whatever is (or isn't) currently stored. This is `resolve`
+/// itself — the toggle must never diverge from the semantics that govern the
+/// transcript — spelled out as its own cases so a future change to `resolve`
+/// that silently breaks the settings toggle fails here too.
+@Suite("ACPTranscriptScrollerFlag settings toggle display value")
+struct ACPTranscriptScrollerFlagToggleDisplayTests {
+    @Test("unset in a DEBUG build displays on")
+    func unsetInDebugDisplaysOn() {
+        #expect(ACPTranscriptScrollerFlag.resolve(override: nil, isDebugBuild: true) == true)
+    }
+
+    @Test("unset in a release build displays off")
+    func unsetInReleaseDisplaysOff() {
+        #expect(ACPTranscriptScrollerFlag.resolve(override: nil, isDebugBuild: false) == false)
+    }
+
+    @Test("explicit true displays on, including in a release build")
+    func explicitTrueDisplaysOn() {
+        #expect(ACPTranscriptScrollerFlag.resolve(override: true, isDebugBuild: false) == true)
+    }
+
+    @Test("explicit false displays off, including in a DEBUG build")
+    func explicitFalseDisplaysOff() {
+        #expect(ACPTranscriptScrollerFlag.resolve(override: false, isDebugBuild: true) == false)
+    }
+}
+
+@Suite("ACPTranscriptScrollerFlag setOverride")
+struct ACPTranscriptScrollerFlagSetOverrideTests {
+    @Test("writing true persists an explicit true override")
+    func writesTrue() throws {
+        let suiteName = "ACPTranscriptScrollerFlagTest-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        ACPTranscriptScrollerFlag.setOverride(true, in: defaults, notificationCenter: NotificationCenter())
+        #expect(ACPTranscriptScrollerFlag.readOverride(from: defaults) == true)
+        #expect(ACPTranscriptScrollerFlag.isEnabledWithDefaults(defaults) == true)
+    }
+
+    @Test("writing false persists an explicit false override, even in a DEBUG build")
+    func writesFalse() throws {
+        let suiteName = "ACPTranscriptScrollerFlagTest-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        ACPTranscriptScrollerFlag.setOverride(false, in: defaults, notificationCenter: NotificationCenter())
+        #expect(ACPTranscriptScrollerFlag.readOverride(from: defaults) == false)
+        #expect(ACPTranscriptScrollerFlag.isEnabledWithDefaults(defaults) == false)
+    }
+
+    @Test("posts overrideDidChangeNotification so open transcripts can re-evaluate isEnabled")
+    func postsChangeNotification() async throws {
+        let suiteName = "ACPTranscriptScrollerFlagTest-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let center = NotificationCenter()
+
+        await confirmation { didReceive in
+            let observer = center.addObserver(
+                forName: ACPTranscriptScrollerFlag.overrideDidChangeNotification,
+                object: nil,
+                queue: nil
+            ) { _ in
+                didReceive()
+            }
+            defer { center.removeObserver(observer) }
+
+            ACPTranscriptScrollerFlag.setOverride(true, in: defaults, notificationCenter: center)
+        }
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -175,6 +175,22 @@ struct ACPTranscriptScrollerPolicyTests {
             visibleHead: 30, scrollY: 800, isUserDriven: false, threshold: 1500))
     }
 
+    @Test("a head step already awaiting its compensating update does not queue another")
+    func headStepIsLatchedUntilTheNextUpdate() {
+        // `stepHeadBack` mutates `visibleHead` synchronously, but the
+        // compensating prepend only lands on the NEXT SwiftUI update. Every
+        // intervening scroll tick still sees a positive `visibleHead` and a
+        // `scrollY` under threshold, so without a latch a single flick near
+        // the head queues several steps that arrive as one 60-150 row
+        // insertion measured in a single synchronous pass.
+        #expect(!ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 30, scrollY: 800, isUserDriven: true, threshold: 1500,
+            hasPendingHeadStep: true))
+        #expect(ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 30, scrollY: 800, isUserDriven: true, threshold: 1500,
+            hasPendingHeadStep: false))
+    }
+
     @Test("tail step fires near the bottom when newer rows are hidden")
     func tailStep() {
         #expect(ACPTranscriptScroller.shouldStepTailForward(

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -376,3 +376,115 @@ struct ACPTranscriptScrollerPolicyTests {
         #expect(ACPTranscriptScroller.headStepThreshold(viewportHeight: 900) == 1800)
     }
 }
+
+/// Regression coverage for the review's fix-round-2 finding: a click on the
+/// scrollbar track arrives as a plain `.leftMouseDown`, which
+/// `ACPUserScrollEvent.isUserDriven` alone rejects. `handleScroll` now
+/// widens the tail-follow pause/resume classification and the head-step
+/// gate to `ACPUserScrollEvent.isHeadPaginationDriven` — which additionally
+/// accepts a `.leftMouseDown` when it is a genuine scrollbar-track hit AND
+/// the geometry actually moved upward — while leaving `shouldStepTailForward`
+/// on the plain `isUserDriven` signal, mirroring
+/// `ACPMessageList.handleScrollGeometry` exactly (compare
+/// `ACPMessageList.swift`'s `handleScrollGeometry`/
+/// `shouldStepHeadBackFromGeometry` call sites).
+///
+/// `handleScroll` itself is a private, `NSApp.currentEvent`-driven method
+/// that needs a real `NSEvent` routed through an actual window's view
+/// hierarchy (for `isScrollbarTrackMouseDown`'s hit-test) to exercise for
+/// real — not something a headless unit test can synthesize. These tests
+/// instead exercise the pure `nonisolated static` predicates directly
+/// (`ACPUserScrollEvent.isHeadPaginationDriven`, `ACPScrollDirectionClassifier
+/// .decide`, `ACPTranscriptScroller.shouldStepHeadBack`/
+/// `shouldStepTailForward`), composed exactly the way `handleScroll` composes
+/// them, which is why those predicates are `nonisolated static` in the first
+/// place.
+@Suite("ACPTranscriptScroller scrollbar-track click classification")
+struct ACPTranscriptScrollerScrollbarTrackClickTests {
+    private static let threshold: CGFloat = 1500
+
+    @Test("an upward scrollbar-track click pauses tail-follow, same as a live scroll gesture")
+    func scrollbarTrackClickPausesTailFollow() {
+        // A track click landing above the current position: previousMinY
+        // 2000 -> newMinY 100, a genuine scrollbar hit.
+        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown, previousMinY: 2000, newMinY: 100, isScrollbarTrackHit: true
+        )
+        #expect(isHeadPaginationDriven)
+
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: 2000, newOffsetY: 100,
+            viewportHeight: 400, contentHeight: 5000,
+            isRestoring: false, isUserDriven: isHeadPaginationDriven
+        )
+        #expect(decision == .userScrolledUp)
+    }
+
+    @Test("a scrollbar-track click away from the track does not pause tail-follow")
+    func nonScrollbarClickDoesNotPauseTailFollow() {
+        // Same geometry as the passing case above, but the click did not
+        // land on the scrollbar (e.g. a transcript control).
+        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown, previousMinY: 2000, newMinY: 100, isScrollbarTrackHit: false
+        )
+        #expect(!isHeadPaginationDriven)
+
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: 2000, newOffsetY: 100,
+            viewportHeight: 400, contentHeight: 5000,
+            isRestoring: false, isUserDriven: isHeadPaginationDriven
+        )
+        #expect(decision == .noChange)
+    }
+
+    @Test("a scrollbar-track click that does not move the geometry upward does not pause tail-follow")
+    func scrollbarClickWithoutUpwardMovementDoesNotPauseTailFollow() {
+        // Downward or no-op track click: geometry did not move up.
+        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown, previousMinY: 100, newMinY: 2000, isScrollbarTrackHit: true
+        )
+        #expect(!isHeadPaginationDriven)
+
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: 100, newOffsetY: 2000,
+            viewportHeight: 400, contentHeight: 5000,
+            isRestoring: false, isUserDriven: isHeadPaginationDriven
+        )
+        #expect(decision == .noChange)
+    }
+
+    @Test("an upward scrollbar-track click can also trigger head pagination")
+    func scrollbarTrackClickTriggersHeadPagination() {
+        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown, previousMinY: 2000, newMinY: 100, isScrollbarTrackHit: true
+        )
+        #expect(ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 30, scrollY: 100, isUserDriven: isHeadPaginationDriven, threshold: Self.threshold
+        ))
+    }
+
+    @Test("a non-scrollbar click does not trigger head pagination")
+    func nonScrollbarClickDoesNotTriggerHeadPagination() {
+        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
+            .leftMouseDown, previousMinY: 2000, newMinY: 100, isScrollbarTrackHit: false
+        )
+        #expect(!ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 30, scrollY: 100, isUserDriven: isHeadPaginationDriven, threshold: Self.threshold
+        ))
+    }
+
+    @Test("a scrollbar-track click does not drive tail pagination, matching the legacy plain-isUserDriven gate")
+    func scrollbarTrackClickDoesNotDriveTailPagination() {
+        // `shouldStepTailForward` mirrors `ACPMessageList
+        // .shouldStepTailForwardFromBottomGeometry`, which the legacy path
+        // gates on plain `isUserDriven`, NOT `isHeadPaginationDriven` — a
+        // scrollbar-track click must not page in hidden newer messages.
+        let plainIsUserDriven = ACPUserScrollEvent.isUserDriven(.leftMouseDown)
+        #expect(!plainIsUserDriven)
+        #expect(!ACPTranscriptScroller.shouldStepTailForward(
+            visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
+            isUserDriven: plainIsUserDriven, threshold: Self.threshold,
+            previousScrollY: 2000, newScrollY: 2050
+        ))
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -582,6 +582,53 @@ struct ACPTranscriptScrollerViewportHeightReconciliationTests {
         #expect(scroller.contentHeight == documentHeightBefore)
         #expect(scroller.contentView.bounds.width == widthBefore)
     }
+
+    @Test("a height-only resize keeps a tail-following transcript pinned to the bottom")
+    func heightOnlyResizeRepinsWhileFollowingTail() {
+        // A height-only resize never changes `contentHeight`, but it does
+        // move the maximum legal offset: a shorter viewport pushes the
+        // bottom further down, leaving the unchanged `scrollY` legal yet no
+        // longer at the end. Re-tiling alone would let the newest content
+        // drift below the viewport while tail-follow still reports true.
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.followsTranscriptTail = true
+        let host = makeHost(session: session)
+        host.transcript.messages = (0..<300).map { _ in
+            ACPMessage.systemNotice(id: UUID(), text: String(repeating: "line ", count: 20))
+        }
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: 1200))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        #expect(scroller.distanceFromBottom < 1, "fixture should start pinned to the tail")
+
+        // Shrink the viewport only. Width is untouched, so this drives the
+        // height path rather than the width-settle reset.
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        scroller.layoutSubtreeIfNeeded()
+
+        #expect(scroller.distanceFromBottom < 1)
+    }
+
+    @Test("a height-only resize does not drag a browsing user back to the bottom")
+    func heightOnlyResizeDoesNotRepinWhileBrowsing() {
+        // The mirror of the above: re-pinning must be conditional on
+        // tail-follow, not on the resize itself.
+        let (host, scroller) = tallHost()   // followsTranscriptTail == false
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        scroller.setScrollY(max(0, (scroller.contentHeight - scroller.viewportHeight) / 2))
+        let scrollYBefore = scroller.scrollY
+
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 300)
+        scroller.layoutSubtreeIfNeeded()
+
+        #expect(abs(scroller.scrollY - scrollYBefore) < 0.5)
+    }
 }
 
 @Suite("ACPTranscriptScroller policies")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -8,13 +8,15 @@ import Testing
 /// not about what any particular callback does when invoked.
 @MainActor
 private func makeHost(
-    session: ACPSession = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+    session: ACPSession = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t"),
+    contentMaxWidth: CGFloat = 800,
+    typography: ACPChatTypography = .default
 ) -> ACPTranscriptScroller {
     ACPTranscriptScroller(
         session: session,
         transcript: session.transcript,
-        contentMaxWidth: 800,
-        typography: .default,
+        contentMaxWidth: contentMaxWidth,
+        typography: typography,
         trustedImageRoot: nil,
         onOpenDiff: { _ in },
         onLoadFullToolCallContent: { _ in nil },
@@ -107,6 +109,137 @@ struct ACPTranscriptScrollerRowSpecsTests {
         expected.append("__composer_spacer__")
 
         #expect(ids == expected)
+    }
+}
+
+/// Regression coverage for the review's fix-round-2 finding: the queued-
+/// bubble spec's `build` closure captures `host.contentMaxWidth`,
+/// `host.typography`, and the enumeration index `idx` (used by the drop
+/// handler for reordering), but its equality token used to fold in only the
+/// `QueuedPrompt` and `host.theme`. A mounted bubble whose closure was
+/// retained (because the token still compared equal) rendered/measured
+/// with stale typography or width, and — worse — its retained drop handler
+/// kept dragging against a stale `idx` after the queue reordered.
+///
+/// These tests exercise `rowSpecs(host:)`'s emitted `equalityToken` (via
+/// `ACPRowEqualityToken.isEqual(to:)`) directly, the same token the
+/// hosting pool compares to decide whether to rebuild a mounted row.
+@MainActor
+@Suite("ACPTranscriptScroller queue bubble equality token")
+struct ACPTranscriptScrollerQueueBubbleTokenTests {
+    private func queueBubbleToken(host: ACPTranscriptScroller, id: UUID) -> ACPRowEqualityToken? {
+        ACPTranscriptScroller.Coordinator.rowSpecs(host: host)
+            .first { $0.id == "__queue_\(id)" }?
+            .equalityToken
+    }
+
+    @Test("token is unchanged when nothing relevant changed")
+    func tokenStableAcrossIdenticalHosts() throws {
+        let id = UUID()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.queue = [QueuedPrompt(id: id, blocks: [.text("hello")], status: .pending)]
+        let hostA = makeHost(session: session, contentMaxWidth: 800, typography: .default)
+        let hostB = makeHost(session: session, contentMaxWidth: 800, typography: .default)
+
+        let tokenA = try #require(queueBubbleToken(host: hostA, id: id))
+        let tokenB = try #require(queueBubbleToken(host: hostB, id: id))
+        #expect(tokenA.isEqual(to: tokenB))
+    }
+
+    @Test("token changes when contentMaxWidth changes, QueuedPrompt unchanged")
+    func tokenChangesOnContentMaxWidth() throws {
+        let id = UUID()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.queue = [QueuedPrompt(id: id, blocks: [.text("hello")], status: .pending)]
+        let narrow = makeHost(session: session, contentMaxWidth: 600, typography: .default)
+        let wide = makeHost(session: session, contentMaxWidth: 900, typography: .default)
+
+        let narrowToken = try #require(queueBubbleToken(host: narrow, id: id))
+        let wideToken = try #require(queueBubbleToken(host: wide, id: id))
+        #expect(!narrowToken.isEqual(to: wideToken))
+    }
+
+    @Test("token changes when typography changes, QueuedPrompt unchanged")
+    func tokenChangesOnTypography() throws {
+        let id = UUID()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.queue = [QueuedPrompt(id: id, blocks: [.text("hello")], status: .pending)]
+        let hostA = makeHost(session: session, typography: .default)
+        let hostB = makeHost(session: session, typography: ACPChatTypography(fontFamily: "Menlo", fontSize: 18))
+
+        let tokenA = try #require(queueBubbleToken(host: hostA, id: id))
+        let tokenB = try #require(queueBubbleToken(host: hostB, id: id))
+        #expect(!tokenA.isEqual(to: tokenB))
+    }
+
+    @Test("token changes when the item's queue position changes, QueuedPrompt unchanged")
+    func tokenChangesOnIndex() throws {
+        let movedId = UUID()
+        let movedItem = QueuedPrompt(id: movedId, blocks: [.text("hello")], status: .pending)
+        let otherItem = QueuedPrompt(id: UUID(), blocks: [.text("other")], status: .pending)
+
+        // `movedItem` sits at index 0 in the first session, index 1 in the
+        // second — same QueuedPrompt value, different enumeration index.
+        let sessionFirst = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        sessionFirst.queue = [movedItem, otherItem]
+        let sessionSecond = ACPSession(id: "s2", agentId: "claude", worktreeId: "w", title: "t")
+        sessionSecond.queue = [otherItem, movedItem]
+
+        let hostFirst = makeHost(session: sessionFirst)
+        let hostSecond = makeHost(session: sessionSecond)
+
+        let tokenFirst = try #require(queueBubbleToken(host: hostFirst, id: movedId))
+        let tokenSecond = try #require(queueBubbleToken(host: hostSecond, id: movedId))
+        #expect(!tokenFirst.isEqual(to: tokenSecond))
+    }
+}
+
+/// Regression coverage for the same finding, generalized: `wrapRow` applies
+/// `.frame(maxWidth: host.contentMaxWidth, ...)` to EVERY row, synthetic
+/// rows included, via the shared `token(_:host:)` helper. Picks one
+/// representative synthetic spec (the top pagination sentinel) to confirm
+/// the fix is systemic, not just applied to the queue bubble.
+@MainActor
+@Suite("ACPTranscriptScroller synthetic row tokens fold contentMaxWidth")
+struct ACPTranscriptScrollerSyntheticTokenTests {
+    @Test("top pagination sentinel token changes when contentMaxWidth changes")
+    func topPaginationTokenChangesOnContentMaxWidth() throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let messages = (0..<5).map { _ in ACPMessage.systemNotice(id: UUID(), text: "hello") }
+        session.transcript.messages = messages
+        session.transcript.visibleHead = 2
+        session.transcript.visibleTail = nil
+
+        let narrow = makeHost(session: session, contentMaxWidth: 600)
+        let wide = makeHost(session: session, contentMaxWidth: 900)
+
+        let narrowToken = try #require(
+            ACPTranscriptScroller.Coordinator.rowSpecs(host: narrow).first { $0.id == "__top_pagination__" }?.equalityToken
+        )
+        let wideToken = try #require(
+            ACPTranscriptScroller.Coordinator.rowSpecs(host: wide).first { $0.id == "__top_pagination__" }?.equalityToken
+        )
+        #expect(!narrowToken.isEqual(to: wideToken))
+    }
+
+    @Test("top pagination sentinel token unchanged when nothing relevant changed")
+    func topPaginationTokenStable() throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let messages = (0..<5).map { _ in ACPMessage.systemNotice(id: UUID(), text: "hello") }
+        session.transcript.messages = messages
+        session.transcript.visibleHead = 2
+        session.transcript.visibleTail = nil
+
+        let hostA = makeHost(session: session, contentMaxWidth: 800)
+        let hostB = makeHost(session: session, contentMaxWidth: 800)
+
+        let tokenA = try #require(
+            ACPTranscriptScroller.Coordinator.rowSpecs(host: hostA).first { $0.id == "__top_pagination__" }?.equalityToken
+        )
+        let tokenB = try #require(
+            ACPTranscriptScroller.Coordinator.rowSpecs(host: hostB).first { $0.id == "__top_pagination__" }?.equalityToken
+        )
+        #expect(tokenA.isEqual(to: tokenB))
     }
 }
 

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -1,5 +1,113 @@
+import Foundation
 import Testing
 @testable import Alas
+
+/// Fabricates a fully-wired `ACPTranscriptScroller` host with no-op
+/// callbacks, for tests that only care about the emitted row-spec id list —
+/// not about what any particular callback does when invoked.
+@MainActor
+private func makeHost(
+    session: ACPSession = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+) -> ACPTranscriptScroller {
+    ACPTranscriptScroller(
+        session: session,
+        transcript: session.transcript,
+        contentMaxWidth: 800,
+        typography: .default,
+        trustedImageRoot: nil,
+        onOpenDiff: { _ in },
+        onLoadFullToolCallContent: { _ in nil },
+        forkTargets: [],
+        onFork: { _, _ in },
+        rememberedScrollAnchor: { nil },
+        onRememberScrollAnchor: { _, _, _ in },
+        onOpenTranscriptLink: { _ in true },
+        policy: nil,
+        scopeKey: "scope",
+        onUserInputResponse: { _, _ in },
+        onOpenElicitationURL: { _ in true },
+        onDismissElicitationURLWait: { _ in },
+        onQueueEdit: { _ in },
+        onQueueForceSend: { _ in },
+        onQueueRemove: { _ in },
+        onQueueRetry: { _ in },
+        onQueueReorder: { _, _ in },
+        onQueueClearAll: {},
+        onRetryContextRecovery: {},
+        onOpenForkSource: { _ in },
+        agentDisplayName: { $0 }
+    )
+}
+
+@MainActor
+@Suite("ACPTranscriptScroller rowSpecs id list")
+struct ACPTranscriptScrollerRowSpecsTests {
+    private func message() -> ACPMessage {
+        .systemNotice(id: UUID(), text: "hello")
+    }
+
+    @Test("plain transcript: message rows followed by the composer spacer, no head sentinel")
+    func plainTranscriptIdList() {
+        let host = makeHost()
+        let messages = (0..<3).map { _ in message() }
+        host.transcript.messages = messages
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+
+        let specs = ACPTranscriptScroller.Coordinator.rowSpecs(host: host)
+        let ids = specs.map(\.id)
+        let expectedMessageIds = messages.map { host.transcript.stableId(for: $0) }
+
+        #expect(ids == expectedMessageIds + ["__composer_spacer__"])
+    }
+
+    @Test("head pagination sentinel is first when older rows are hidden")
+    func headSentinelIsFirst() {
+        let host = makeHost()
+        let messages = (0..<5).map { _ in message() }
+        host.transcript.messages = messages
+        host.transcript.visibleHead = 2
+        host.transcript.visibleTail = nil
+
+        let specs = ACPTranscriptScroller.Coordinator.rowSpecs(host: host)
+        let ids = specs.map(\.id)
+        let expectedMessageIds = messages[2...].map { host.transcript.stableId(for: $0) }
+
+        #expect(ids.first == "__top_pagination__")
+        #expect(ids == ["__top_pagination__"] + expectedMessageIds + ["__composer_spacer__"])
+    }
+
+    @Test("streaming caret and queue rows are ordered after messages and before the composer spacer")
+    func syntheticTailOrdering() {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.queue = [
+            QueuedPrompt(blocks: [.text("queued one")], status: .pending),
+            QueuedPrompt(blocks: [.text("queued two")], status: .pending),
+        ]
+        let host = makeHost(session: session)
+        let messages = (0..<2).map { _ in message() }
+        host.transcript.messages = messages
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+        host.transcript.streamingState = .streaming
+
+        let specs = ACPTranscriptScroller.Coordinator.rowSpecs(host: host)
+        let ids = specs.map(\.id)
+        let expectedMessageIds = messages.map { host.transcript.stableId(for: $0) }
+
+        // Exact expected order: messages, then streaming caret, then the
+        // queue header (2 pending items > 1), then each queued bubble in
+        // order, then the composer spacer. No permission/user-input/
+        // elicitation/context-recovery rows since none apply here.
+        var expected = expectedMessageIds
+        expected.append("__streaming_caret__")
+        expected.append("__queue_header__")
+        for item in session.queue { expected.append("__queue_\(item.id)") }
+        expected.append("__composer_spacer__")
+
+        #expect(ids == expected)
+    }
+}
 
 @Suite("ACPTranscriptScroller policies")
 struct ACPTranscriptScrollerPolicyTests {

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -337,6 +337,84 @@ struct ACPTranscriptScrollerRestoreLatchTests {
         // if the latch had been consumed prematurely, this would still be 0.
         #expect(scroller.distanceFromBottom < 1)
     }
+
+    /// Regression test for the P1 finding (codex round 5): `attach()`'s
+    /// first `update(host:)` always runs against `frame: .zero`, where
+    /// `reconciler.apply` defers. Nothing besides a later SwiftUI-driven
+    /// `updateNSView` used to re-run `update(host:)`, so a real width
+    /// arriving purely through the scroller's own AppKit layout pass — with
+    /// no accompanying model mutation — left a fully hydrated transcript
+    /// empty. Unlike `restoreLatchWaitsForPositiveWidth` above, this test
+    /// deliberately does NOT call `coordinator.update(host:)` again after
+    /// the layout pass: the scroller's own layout must drive reconciliation
+    /// on its own.
+    @Test("a real width arriving only through the scroller's own layout pass reconciles, with no further update(host:) call")
+    func layoutAloneReconcilesAfterZeroWidthBootstrap() {
+        let host = makeHost() // default session: followsTranscriptTail == true
+        let messages = (0..<40).map { _ in
+            ACPMessage.systemNotice(id: UUID(), text: String(repeating: "line ", count: 20))
+        }
+        host.transcript.messages = messages
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+
+        // Mirrors `makeNSView`'s `ACPTranscriptScrollerView(frame: .zero)`.
+        let scroller = ACPTranscriptScrollerView(frame: .zero)
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+
+        // Width-0 bootstrap pass: `reconciler.apply` deferred. Nothing
+        // measured or mounted yet.
+        #expect(scroller.flippedDocumentView.frame.height == 0)
+        #expect(scroller.flippedDocumentView.subviews.isEmpty)
+
+        // The view receives its real size purely through AppKit's own
+        // layout pass — exactly what happens once SwiftUI actually places
+        // the representable — with NO further `update(host:)` call.
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        scroller.layoutSubtreeIfNeeded()
+
+        // The reconciler must have run against the real width on its own:
+        // the document is measured and rows are mounted.
+        #expect(scroller.flippedDocumentView.frame.height > 0)
+        #expect(!scroller.flippedDocumentView.subviews.isEmpty)
+    }
+
+    /// A layout pass at an UNCHANGED width must not re-run the reconciler —
+    /// only a genuine width change (or the deferred zero-width case above)
+    /// should. Verified indirectly: the document is only ever set to a
+    /// positive height once, from the single genuine width change: a
+    /// second no-op layout pass at the same width must not perturb it.
+    @Test("a layout pass at an unchanged width does not re-run the reconciler")
+    func layoutAtUnchangedWidthDoesNotReapply() {
+        let host = makeHost()
+        let messages = (0..<10).map { _ in ACPMessage.systemNotice(id: UUID(), text: "hello") }
+        host.transcript.messages = messages
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+
+        let scroller = ACPTranscriptScrollerView(frame: .zero)
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        scroller.layoutSubtreeIfNeeded()
+        let heightAfterFirstLayout = scroller.flippedDocumentView.frame.height
+        #expect(heightAfterFirstLayout > 0)
+
+        // Scroll away from the bottom so a spurious re-apply (which
+        // re-pins to the bottom while `followsTranscriptTail` is true)
+        // would be observable.
+        scroller.setScrollY(0)
+        #expect(scroller.scrollY == 0)
+
+        // A second layout pass at the SAME width/frame must be a no-op:
+        // the document height is unchanged and the viewport was not
+        // re-pinned to the bottom.
+        scroller.layoutSubtreeIfNeeded()
+        #expect(scroller.flippedDocumentView.frame.height == heightAfterFirstLayout)
+        #expect(scroller.scrollY == 0)
+    }
 }
 
 @Suite("ACPTranscriptScroller policies")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPTranscriptScroller policies")
+struct ACPTranscriptScrollerPolicyTests {
+    @Test("head step fires near the top during a user scroll when older rows exist")
+    func headStep() {
+        #expect(ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 30, scrollY: 800, isUserDriven: true, threshold: 1500))
+        #expect(!ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 0, scrollY: 800, isUserDriven: true, threshold: 1500))
+        #expect(!ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 30, scrollY: 2000, isUserDriven: true, threshold: 1500))
+        #expect(!ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 30, scrollY: 800, isUserDriven: false, threshold: 1500))
+    }
+
+    @Test("tail step fires near the bottom when newer rows are hidden")
+    func tailStep() {
+        #expect(ACPTranscriptScroller.shouldStepTailForward(
+            visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
+            isUserDriven: true, threshold: 1500))
+        #expect(!ACPTranscriptScroller.shouldStepTailForward(
+            visibleTail: 200, messageCount: 200, distanceFromBottom: 900,
+            isUserDriven: true, threshold: 1500))
+        #expect(!ACPTranscriptScroller.shouldStepTailForward(
+            visibleTail: 100, messageCount: 200, distanceFromBottom: 5000,
+            isUserDriven: true, threshold: 1500))
+    }
+
+    @Test("head step threshold scales with viewport but has a floor")
+    func threshold() {
+        #expect(ACPTranscriptScroller.headStepThreshold(viewportHeight: 500) == 1500)
+        #expect(ACPTranscriptScroller.headStepThreshold(viewportHeight: 900) == 1800)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 @testable import Alas
@@ -106,6 +107,57 @@ struct ACPTranscriptScrollerRowSpecsTests {
         expected.append("__composer_spacer__")
 
         #expect(ids == expected)
+    }
+}
+
+@MainActor
+@Suite("ACPTranscriptScroller restore latch")
+struct ACPTranscriptScrollerRestoreLatchTests {
+    /// Regression test for the review's fix-round-2 finding: `attach()`
+    /// (mirroring `makeNSView`, which builds the scroller at `frame: .zero`)
+    /// always runs its first `update(host:)` at `contentWidth == 0`, where
+    /// `reconciler.apply` defers and the tiling map stays empty even though
+    /// `hasNonSyntheticRow` is already true from the spec list alone. A
+    /// non-tail-following host with real messages and no remembered anchor
+    /// must NOT latch `didRestoreInitialPosition` on that width-0 pass —
+    /// otherwise the real restore, once actual rows exist, is skipped
+    /// forever and the transcript opens at `scrollY == 0` instead of at the
+    /// bottom (the correct fallback when there is nothing to restore).
+    @Test("the restore latch waits for a positive-width apply before consuming itself")
+    func restoreLatchWaitsForPositiveWidth() {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.followsTranscriptTail = false
+        let host = makeHost(session: session)
+        // Enough real content that the measured document is taller than the
+        // eventual 400pt viewport, so `scrollToBottom()` is distinguishable
+        // from "nothing happened, still at 0".
+        let messages = (0..<40).map { _ in
+            ACPMessage.systemNotice(id: UUID(), text: String(repeating: "line ", count: 20))
+        }
+        host.transcript.messages = messages
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+        // `makeHost`'s `rememberedScrollAnchor` always returns nil — no
+        // anchor to restore, so the correct outcome is `scrollToBottom()`.
+
+        // Mirrors `makeNSView`'s `ACPTranscriptScrollerView(frame: .zero)`.
+        let scroller = ACPTranscriptScrollerView(frame: .zero)
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+
+        // Width-0 pass: `reconciler.apply` deferred, tiling map is empty.
+        // Nothing should have latched or moved.
+        #expect(scroller.scrollY == 0)
+
+        // The view is laid out for real (as SwiftUI does once the
+        // representable actually gets placed), and `update` runs again.
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        scroller.layoutSubtreeIfNeeded()
+        coordinator.update(host: host)
+
+        // The restore must actually run on this first positive-width pass —
+        // if the latch had been consumed prematurely, this would still be 0.
+        #expect(scroller.distanceFromBottom < 1)
     }
 }
 

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -110,6 +110,51 @@ struct ACPTranscriptScrollerRowSpecsTests {
 
         #expect(ids == expected)
     }
+
+    /// Regression test for the P2 finding (codex round 4): `ACPUserInputPrompt`
+    /// holds live `@State`/`@FocusState` form data that a fresh
+    /// `NSHostingView` would silently discard, so its spec must opt out of
+    /// the reconciler's ordinary "unmount when off-band" policy. Ordinary
+    /// synthetic rows (the streaming caret, a queued bubble — neither holds
+    /// state whose loss is user-visible) and message rows must NOT opt in,
+    /// or the exemption would stop being small and bounded.
+    @Test("only the pending user-input row opts into staying mounted off-band")
+    func onlyPendingUserInputKeepsMountedOffscreen() {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.queue = [QueuedPrompt(blocks: [.text("queued")], status: .pending)]
+        let host = makeHost(session: session)
+        let messages = (0..<2).map { _ in message() }
+        host.transcript.messages = messages
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+        host.transcript.streamingState = .streaming
+        host.transcript.pendingUserInputs = [
+            ACPUserInputRequest(
+                id: UUID(),
+                source: .cursor(
+                    id: .string("q1"),
+                    params: ACPQuestionRequestParams(toolCallId: "t1", title: "Pick one", questions: [])
+                ),
+                title: "Pick one",
+                message: "Pick one",
+                fields: [],
+                mode: .form
+            ),
+        ]
+
+        let specs = ACPTranscriptScroller.Coordinator.rowSpecs(host: host)
+        let byId = Dictionary(uniqueKeysWithValues: specs.map { ($0.id, $0) })
+
+        let pendingInputId = specs.map(\.id).first { $0.hasPrefix("__pending_user_input_") }
+        #expect(pendingInputId != nil)
+        #expect(byId[pendingInputId!]?.keepsMountedOffscreen == true)
+
+        // Every other row — message rows and the other synthetic rows —
+        // stays with the default (unmount when off-band).
+        for id in specs.map(\.id) where id != pendingInputId {
+            #expect(byId[id]?.keepsMountedOffscreen == false, "\(id) unexpectedly opted into keepsMountedOffscreen")
+        }
+    }
 }
 
 /// Regression coverage for the review's fix-round-2 finding: the queued-

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -191,17 +191,50 @@ struct ACPTranscriptScrollerPolicyTests {
             hasPendingHeadStep: false))
     }
 
-    @Test("tail step fires near the bottom when newer rows are hidden")
+    @Test("tail step fires near the bottom when newer rows are hidden and the user is scrolling down")
     func tailStep() {
         #expect(ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
-            isUserDriven: true, threshold: 1500))
+            isUserDriven: true, threshold: 1500,
+            previousScrollY: 1000, newScrollY: 1050))
         #expect(!ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 200, messageCount: 200, distanceFromBottom: 900,
-            isUserDriven: true, threshold: 1500))
+            isUserDriven: true, threshold: 1500,
+            previousScrollY: 1000, newScrollY: 1050))
         #expect(!ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 100, messageCount: 200, distanceFromBottom: 5000,
-            isUserDriven: true, threshold: 1500))
+            isUserDriven: true, threshold: 1500,
+            previousScrollY: 1000, newScrollY: 1050))
+    }
+
+    @Test("tail step does not fire while the user is scrolling up, even within threshold")
+    func tailStepWithholdsOnUpwardScroll() {
+        // Same visibleTail/messageCount/distanceFromBottom/isUserDriven/threshold
+        // as the passing case in `tailStep`, but the offset moved UP
+        // (newScrollY < previousScrollY) — browsing older content should not
+        // page in hidden newer messages.
+        #expect(!ACPTranscriptScroller.shouldStepTailForward(
+            visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
+            isUserDriven: true, threshold: 1500,
+            previousScrollY: 1050, newScrollY: 1000))
+    }
+
+    @Test("tail step withholds when direction is unknown (no previous offset yet)")
+    func tailStepWithholdsWithoutPreviousOffset() {
+        #expect(!ACPTranscriptScroller.shouldStepTailForward(
+            visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
+            isUserDriven: true, threshold: 1500,
+            previousScrollY: nil, newScrollY: 1050))
+    }
+
+    @Test("tail step ignores sub-epsilon jitter as downward movement")
+    func tailStepWithholdsOnJitter() {
+        // A change smaller than `ACPScrollDirectionClassifier.upwardEpsilon`
+        // (0.5pt) must not be treated as a deliberate downward scroll.
+        #expect(!ACPTranscriptScroller.shouldStepTailForward(
+            visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
+            isUserDriven: true, threshold: 1500,
+            previousScrollY: 1000, newScrollY: 1000.2))
     }
 
     @Test("head step threshold scales with viewport but has a floor")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -288,6 +288,84 @@ struct ACPTranscriptScrollerSyntheticTokenTests {
     }
 }
 
+/// Regression coverage for the P2 finding (codex round 6, Finding 2): the
+/// fork divider's `build` closure derives its displayed title by CALLING
+/// `host.agentDisplayName(fork.sourceAgentID)` — a value computed from the
+/// host, not present anywhere in the token itself (which only folded
+/// `fork`, theme, and contentMaxWidth). A live rename of the source agent's
+/// display name therefore left an already-mounted divider showing the OLD
+/// name, because the token still compared equal and the pool never called
+/// `build()` again.
+@MainActor
+@Suite("ACPTranscriptScroller fork divider equality token")
+struct ACPTranscriptScrollerForkDividerTokenTests {
+    private func hostWithFork(agentDisplayName: @escaping (String) -> String) -> ACPTranscriptScroller {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.forkRecord = ACPSessionForkRecord(
+            targetSessionID: "target", sourceSessionID: "source", sourceAgentID: "agentA",
+            sourceBoundarySequence: 0, inheritedMessageCount: 1,
+            phase: .ready, mechanism: .transcriptTransfer, contextDeliveryPending: false
+        )
+        let host = ACPTranscriptScroller(
+            session: session,
+            transcript: session.transcript,
+            contentMaxWidth: 800,
+            typography: .default,
+            trustedImageRoot: nil,
+            onOpenDiff: { _ in },
+            onLoadFullToolCallContent: { _ in nil },
+            forkTargets: [],
+            onFork: { _, _ in },
+            rememberedScrollAnchor: { nil },
+            onRememberScrollAnchor: { _, _, _ in },
+            onOpenTranscriptLink: { _ in true },
+            policy: nil,
+            scopeKey: "scope",
+            onUserInputResponse: { _, _ in },
+            onOpenElicitationURL: { _ in true },
+            onDismissElicitationURLWait: { _ in },
+            onQueueEdit: { _ in },
+            onQueueForceSend: { _ in },
+            onQueueRemove: { _ in },
+            onQueueRetry: { _ in },
+            onQueueReorder: { _, _ in },
+            onQueueClearAll: {},
+            onRetryContextRecovery: {},
+            onOpenForkSource: { _ in },
+            agentDisplayName: agentDisplayName
+        )
+        host.transcript.messages = [.systemNotice(id: UUID(), text: "hello")]
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+        return host
+    }
+
+    private func forkDividerToken(host: ACPTranscriptScroller) -> ACPRowEqualityToken? {
+        ACPTranscriptScroller.Coordinator.rowSpecs(host: host)
+            .first { $0.id == "__fork_divider__" }?.equalityToken
+    }
+
+    @Test("token changes when the resolved agent display name changes, everything else identical")
+    func tokenChangesOnResolvedDisplayName() throws {
+        let hostA = hostWithFork(agentDisplayName: { _ in "Claude" })
+        let hostB = hostWithFork(agentDisplayName: { _ in "Claude (renamed)" })
+
+        let tokenA = try #require(forkDividerToken(host: hostA))
+        let tokenB = try #require(forkDividerToken(host: hostB))
+        #expect(!tokenA.isEqual(to: tokenB))
+    }
+
+    @Test("token is unchanged when nothing relevant changed, including the resolved display name")
+    func tokenStableWhenNothingChanged() throws {
+        let hostA = hostWithFork(agentDisplayName: { _ in "Claude" })
+        let hostB = hostWithFork(agentDisplayName: { _ in "Claude" })
+
+        let tokenA = try #require(forkDividerToken(host: hostA))
+        let tokenB = try #require(forkDividerToken(host: hostB))
+        #expect(tokenA.isEqual(to: tokenB))
+    }
+}
+
 @MainActor
 @Suite("ACPTranscriptScroller restore latch")
 struct ACPTranscriptScrollerRestoreLatchTests {
@@ -414,6 +492,95 @@ struct ACPTranscriptScrollerRestoreLatchTests {
         scroller.layoutSubtreeIfNeeded()
         #expect(scroller.flippedDocumentView.frame.height == heightAfterFirstLayout)
         #expect(scroller.scrollY == 0)
+    }
+}
+
+/// Regression coverage for the P2 finding (codex round 6, Finding 1):
+/// `ACPTranscriptScrollerView.layout()` used to notify the Coordinator only
+/// when `contentView.bounds.width` changed, so a HEIGHT-only resize (window
+/// dragged taller/shorter, width unchanged) never re-ran anything — not
+/// `onContentWidthChange` (width didn't change) and not `onScroll`
+/// (`reportScroll` only fires when the clip view's y-origin moves, which a
+/// pure height change does not do). The mount band
+/// (`ACPTranscriptScrollerReconciler.performLayoutPass`) is derived from
+/// `scroller.viewportHeight`, so nothing recomputed it: growing the window
+/// revealed space no newly-mounted row filled.
+@MainActor
+@Suite("ACPTranscriptScroller viewport height reconciliation")
+struct ACPTranscriptScrollerViewportHeightReconciliationTests {
+    /// Enough real message rows, positioned deep enough into the document,
+    /// that the mount band (viewport ± 1200pt overscan) neither covers the
+    /// whole document nor runs out of rows below the viewport when the
+    /// height grows — so a change in mounted count is a genuine signal, not
+    /// an artifact of hitting either end.
+    private func tallHost() -> (host: ACPTranscriptScroller, scroller: ACPTranscriptScrollerView) {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.followsTranscriptTail = false
+        let host = makeHost(session: session)
+        host.transcript.messages = (0..<300).map { _ in
+            ACPMessage.systemNotice(id: UUID(), text: String(repeating: "line ", count: 20))
+        }
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        return (host, scroller)
+    }
+
+    @Test("a height-only resize mounts more rows for a taller viewport, and fewer for a shorter one, with no accompanying model update")
+    func heightOnlyResizeUpdatesMountedRowCount() {
+        let (host, scroller) = tallHost()
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+
+        // Scrolled to the middle of a document tall enough that growing or
+        // shrinking the viewport extends/shrinks the mount band without
+        // hitting either edge of the document.
+        let midY = max(0, (scroller.contentHeight - scroller.viewportHeight) / 2)
+        scroller.setScrollY(midY)
+        #expect(scroller.contentHeight > 10_000, "test fixture is not tall enough")
+
+        let mountedAtSmallHeight = scroller.flippedDocumentView.subviews.count
+        #expect(mountedAtSmallHeight > 0)
+
+        // Height-only resize: width is unchanged. Deliberately does NOT call
+        // `coordinator.update(host:)` — the scroller's own layout pass must
+        // drive this on its own, exactly like the existing width case.
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 1600)
+        scroller.layoutSubtreeIfNeeded()
+        let mountedAtLargeHeight = scroller.flippedDocumentView.subviews.count
+        #expect(mountedAtLargeHeight > mountedAtSmallHeight)
+
+        // Shrinking back down releases rows again.
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        scroller.layoutSubtreeIfNeeded()
+        let mountedAfterShrink = scroller.flippedDocumentView.subviews.count
+        #expect(mountedAfterShrink < mountedAtLargeHeight)
+    }
+
+    @Test("a height-only resize does not change any row's measured height or the document height")
+    func heightOnlyResizeDoesNotRemeasure() {
+        let (host, scroller) = tallHost()
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        scroller.setScrollY(max(0, (scroller.contentHeight - scroller.viewportHeight) / 2))
+
+        let documentHeightBefore = scroller.contentHeight
+        let widthBefore = scroller.contentView.bounds.width
+
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 1600)
+        scroller.layoutSubtreeIfNeeded()
+
+        // No row reflows on a height-only change: the document's total
+        // height (the sum of every row's height) and the pinned content
+        // width are exactly unchanged — a full re-measure at an unchanged
+        // width would coincidentally reproduce the same numbers, but a
+        // remeasure is never even attempted; see the reconciler-level
+        // build-count proof in `ACPTranscriptScrollerReconcilerApplyTests`.
+        #expect(scroller.contentHeight == documentHeightBefore)
+        #expect(scroller.contentView.bounds.width == widthBefore)
     }
 }
 

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -296,6 +296,72 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(mounted == Set(band.map { tiling.rowId(at: $0) }))
     }
 
+    /// Regression coverage for the P2 finding (codex round 6, Finding 1):
+    /// `layoutMountedRows()` is what `ACPTranscriptScroller.Coordinator`'s
+    /// height-only reconcile hook calls directly — deliberately NOT a full
+    /// `apply()` — because a viewport-height change never invalidates a
+    /// row's measured content. This proves that contract at the reconciler
+    /// level: growing/shrinking the viewport and re-running
+    /// `layoutMountedRows()` alone changes which rows are mounted without
+    /// re-building (and therefore re-measuring) any row that was already
+    /// mounted before the height change.
+    @Test("layoutMountedRows alone mounts/unmounts rows for a changed viewport height without rebuilding already-mounted rows")
+    func layoutMountedRowsRespondsToHeightChangeWithoutRebuildingMountedRows() {
+        let (reconciler, scroller, tiling) = makeStack()
+        let counter = RowBuildCounter()
+        reconciler.apply(
+            specs: (0..<200).map { countingSpec("r\($0)", counter: counter) },
+            contentWidth: 600, followsTail: false
+        )
+        scroller.setScrollY(10_000)
+        reconciler.layoutMountedRows()
+
+        let mountedBefore = reconciler.mountedRowIdsForTesting
+        #expect(!mountedBefore.isEmpty)
+        #expect(mountedBefore.count < 200)
+        // Snapshot each mounted row's build count as the baseline — NOT
+        // asserted to be 1: the initial `apply()`'s own `measure()` call
+        // builds every one of the 200 specs once (heights are needed for
+        // every row's tiled position, not just mounted ones), and rows
+        // outside the band at that point are immediately released again by
+        // `apply()`'s own trailing `layoutMountedRows()`, deleting their
+        // pool entries — so a row that only entered the mount band via the
+        // `setScrollY`/`layoutMountedRows()` above has already been built
+        // twice by this point (once by `measure()`, once remounting after
+        // eviction). What this test isolates is the height-only step below:
+        // it must not add a THIRD build for any row already mounted here.
+        let countsBefore = Dictionary(uniqueKeysWithValues: mountedBefore.map { ($0, counter.count($0)) })
+
+        // Grow the viewport (height-only, matching what a window resize
+        // reports through `onViewportHeightChange`) and re-run just the
+        // relayout pass — not `apply()`.
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 1600)
+        reconciler.layoutMountedRows()
+
+        let mountedAfterGrow = reconciler.mountedRowIdsForTesting
+        #expect(mountedAfterGrow.count > mountedBefore.count)
+        // Growing only extends the band's far edge (`mountBand`'s `highY`),
+        // so every previously-mounted row is still mounted.
+        #expect(mountedAfterGrow.isSuperset(of: mountedBefore))
+        // Rows that were ALREADY mounted are not rebuilt — the "no
+        // re-measure" guarantee: their build count is exactly what it was
+        // right before the height-only change.
+        for id in mountedBefore { #expect(counter.count(id) == countsBefore[id]) }
+
+        // Shrink back down: releases newly-out-of-band rows again, without
+        // touching anything that remains mounted.
+        let countsAfterGrow = Dictionary(uniqueKeysWithValues: mountedAfterGrow.map { ($0, counter.count($0)) })
+        scroller.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        reconciler.layoutMountedRows()
+        let mountedAfterShrink = reconciler.mountedRowIdsForTesting
+        #expect(mountedAfterShrink.count < mountedAfterGrow.count)
+        for id in mountedAfterShrink { #expect(counter.count(id) == countsAfterGrow[id]) }
+
+        // Document geometry itself never changed — only which rows are
+        // mounted did.
+        #expect(tiling.rowCount == 200)
+    }
+
     @Test("a row marked keepsMountedOffscreen stays mounted far outside the band; an ordinary row at the same position does not")
     func keepsMountedOffscreenSurvivesOutsideBand() {
         // Regression test for the P2 finding (codex round 4): scrolling a

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -69,6 +69,36 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         )
     }
 
+    /// Like `makeStack`, but also hands back the pool so a test can reach
+    /// into a mounted row's live hosting view directly (to simulate content
+    /// growing in place, without going through another `apply()` call).
+    private func makeStackWithPool() -> (
+        ACPTranscriptScrollerReconciler, ACPTranscriptScrollerView,
+        ACPTranscriptTilingController, ACPTranscriptRowHostingPool
+    ) {
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        let tiling = ACPTranscriptTilingController()
+        let pool = ACPTranscriptRowHostingPool()
+        let reconciler = ACPTranscriptScrollerReconciler(tiling: tiling, pool: pool, scroller: scroller)
+        return (reconciler, scroller, tiling, pool)
+    }
+
+    /// Text content whose measured height genuinely depends on the width
+    /// it's pinned at (unlike `spec`'s fixed-height `Color.clear`), so tests
+    /// can tell a real re-measure at a new width apart from a stale one.
+    private func wrappingSpec(_ id: String, token: Int = 0) -> ACPTranscriptRowSpec {
+        ACPTranscriptRowSpec(
+            id: id,
+            equalityToken: ACPRowEqualityToken(token),
+            build: {
+                AnyView(
+                    Text(String(repeating: "wrap me please ", count: 30))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                )
+            }
+        )
+    }
+
     @Test("initial apply builds the document and mounts rows")
     func initialApply() {
         let (reconciler, scroller, tiling) = makeStack()
@@ -135,5 +165,128 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
             overscan: ACPTranscriptScrollerReconciler.overscan
         )
         #expect(mounted == Set(band.map { tiling.rowId(at: $0) }))
+    }
+
+    @Test("apply with a non-positive width is deferred rather than collapsing the document")
+    func nonPositiveWidthIsDeferred() {
+        let (reconciler, scroller, tiling) = makeStack()
+        reconciler.apply(specs: (0..<5).map { spec("r\($0)") }, contentWidth: 0, followsTail: false)
+        #expect(tiling.rowCount == 0)
+        #expect(scroller.contentHeight == 0)
+
+        reconciler.apply(specs: (0..<5).map { spec("r\($0)") }, contentWidth: -10, followsTail: false)
+        #expect(tiling.rowCount == 0)
+
+        // A later call with a real width behaves as a normal initial apply.
+        reconciler.apply(specs: (0..<5).map { spec("r\($0)") }, contentWidth: 600, followsTail: false)
+        #expect(tiling.rowCount == 5)
+        #expect(tiling.documentHeight > 0)
+    }
+
+    @Test("remeasureRow re-measures a mounted row in place and updates the document")
+    func remeasureRowUpdatesHeight() {
+        let (reconciler, scroller, tiling, pool) = makeStackWithPool()
+        let specs = (0..<10).map { spec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        let heightBefore = tiling.row(withId: "r0")!.height
+
+        // Simulate the row's SwiftUI content growing in place (e.g. a
+        // streaming row), independent of any `apply()` call: replace the
+        // mounted view's content directly and rely on `remeasureRow` — the
+        // callback path `pool.onRowIntrinsicSizeInvalidated` exists for.
+        let (view0, _) = pool.view(for: specs[0])
+        view0.updateRootView(AnyView(Color.clear.frame(height: 250)))
+        reconciler.remeasureRow(id: "r0")
+
+        #expect(tiling.row(withId: "r0")!.height == 250)
+        #expect(tiling.row(withId: "r0")!.height != heightBefore)
+        #expect(scroller.contentHeight == tiling.documentHeight)
+    }
+
+    @Test("remeasureRow compensates the viewport when the grown row is entirely above it")
+    func remeasureRowCompensatesAboveViewport() {
+        let (reconciler, scroller, tiling, pool) = makeStackWithPool()
+        let specs = (0..<10).map { spec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        // r0 spans minY 24..124; scrolling to 500 puts it entirely above.
+        scroller.setScrollY(500)
+        let scrollYBefore = scroller.scrollY
+
+        let (view0, _) = pool.view(for: specs[0])
+        view0.updateRootView(AnyView(Color.clear.frame(height: 250)))
+        reconciler.remeasureRow(id: "r0")
+
+        #expect(tiling.row(withId: "r0")!.height == 250)
+        #expect(scroller.scrollY > scrollYBefore)
+    }
+
+    @Test("remeasureRow is a no-op for an id that isn't currently tracked")
+    func remeasureRowUnknownIdNoOps() {
+        let (reconciler, _, tiling, _) = makeStackWithPool()
+        reconciler.apply(specs: (0..<3).map { spec("r\($0)") }, contentWidth: 600, followsTail: false)
+        let heightBefore = tiling.documentHeight
+        reconciler.remeasureRow(id: "does-not-exist")
+        #expect(tiling.documentHeight == heightBefore)
+    }
+
+    @Test("a genuine reset with overlapping ids and changed content does not corrupt geometry via reentrant remeasure")
+    func resetWithOverlappingIdsDoesNotCorrupt() {
+        let (reconciler, scroller, tiling) = makeStack()
+        // Old: r5...r14. New: r0...r9 — overlaps at r5...r9, but the old
+        // head "r5" isn't a contiguous prefix of the new list (length
+        // mismatch), so `diff` classifies this as `.reset`, not a
+        // prepend/append. The overlapping ids get a different token, so
+        // they're genuinely different content reusing the same id.
+        reconciler.apply(specs: (5..<15).map { spec("r\($0)", token: 0) }, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(300)
+        reconciler.apply(specs: (0..<10).map { spec("r\($0)", token: 1) }, contentWidth: 600, followsTail: false)
+
+        #expect(tiling.rowCount == 10)
+        for id in (0..<10).map({ "r\($0)" }) {
+            #expect(tiling.row(withId: id) != nil)
+        }
+        #expect(tiling.documentHeight > 0)
+        // No stray compensation from a reentrant remeasure operating against
+        // the old (pre-reset) tiling geometry: `.reset` doesn't touch
+        // scrollY on its own (followsTail is false here).
+        #expect(scroller.scrollY == 300)
+    }
+
+    @Test("a pure width change with identical ids coalesces: bounded interim work, full correction after settling")
+    func widthChangeCoalescesThenSettles() async throws {
+        let (reconciler, scroller, tiling) = makeStack()
+        // Enough rows that the mount band is a small fraction of the total,
+        // so an eager "remeasure everything" reset is distinguishable from
+        // the bounded interim work the coalesced path is allowed to do.
+        let wideSpecs = (0..<200).map { wrappingSpec("r\($0)") }
+        reconciler.apply(specs: wideSpecs, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(0)
+        let onBandHeightWide = tiling.row(withId: "r0")!.height
+        let offBandHeightWide = tiling.row(withId: "r199")!.height
+
+        // Three rapid ticks of a narrowing drag, same ids/tokens throughout.
+        reconciler.apply(specs: wideSpecs, contentWidth: 400, followsTail: false)
+        reconciler.apply(specs: wideSpecs, contentWidth: 300, followsTail: false)
+        reconciler.apply(specs: wideSpecs, contentWidth: 150, followsTail: false)
+
+        // Interim: the on-screen row is corrected immediately (lazily, as
+        // it's placed), but the off-screen row must NOT have been eagerly
+        // remeasured yet — that's the expensive whole-document reset this
+        // coalescing exists to defer.
+        #expect(tiling.row(withId: "r0")!.height > onBandHeightWide)
+        #expect(tiling.row(withId: "r199")!.height == offBandHeightWide)
+
+        // Let the debounce settle well past the interval. Generous grace
+        // (interval + 400ms) matches this codebase's established margin for
+        // DispatchWorkItem-based debounce tests (see DebounceTimerTests),
+        // which found tighter margins flaky under CI scheduling load.
+        let graceNanoseconds = UInt64((ACPTranscriptScrollerReconciler.widthChangeSettleInterval + 0.4) * 1_000_000_000)
+        try await Task.sleep(nanoseconds: graceNanoseconds)
+
+        // After settling, every row — including the off-screen one — has
+        // been correctly re-measured at the final (narrowest) width.
+        #expect(tiling.row(withId: "r199")!.height > offBandHeightWide)
+        #expect(tiling.rowCount == 200)
+        #expect(scroller.contentHeight == tiling.documentHeight)
     }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -1,0 +1,139 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite("ACPTranscriptScrollerReconciler diff")
+struct ACPTranscriptScrollerReconcilerDiffTests {
+    typealias Diff = ACPTranscriptScrollerReconciler.Diff
+
+    @Test("identical id lists are unchanged")
+    func unchanged() {
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b"], newIds: ["a", "b"]) == .unchanged)
+    }
+
+    @Test("new ids before the old head are a prepend")
+    func prepend() {
+        #expect(
+            ACPTranscriptScrollerReconciler.diff(oldIds: ["c", "d"], newIds: ["a", "b", "c", "d"])
+            == .prepended(count: 2)
+        )
+    }
+
+    @Test("new ids after the old tail are an append")
+    func append() {
+        #expect(
+            ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b"], newIds: ["a", "b", "c"])
+            == .appended(count: 1)
+        )
+    }
+
+    @Test("prepend and append together are recognized")
+    func both() {
+        #expect(
+            ACPTranscriptScrollerReconciler.diff(oldIds: ["b"], newIds: ["a", "b", "c"])
+            == .prependedAndAppended(prepended: 1, appended: 1)
+        )
+    }
+
+    @Test("anything else is a reset")
+    func reset() {
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b"], newIds: ["a", "c"]) == .reset)
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b"], newIds: ["b"]) == .reset)
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a"], newIds: ["z"]) == .reset)
+    }
+
+    @Test("empty transitions")
+    func empties() {
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: [], newIds: ["a"]) == .reset)
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: [], newIds: []) == .unchanged)
+    }
+}
+
+@MainActor
+@Suite("ACPTranscriptScrollerReconciler apply")
+struct ACPTranscriptScrollerReconcilerApplyTests {
+    private func makeStack() -> (ACPTranscriptScrollerReconciler, ACPTranscriptScrollerView, ACPTranscriptTilingController) {
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        let tiling = ACPTranscriptTilingController()
+        let pool = ACPTranscriptRowHostingPool()
+        let reconciler = ACPTranscriptScrollerReconciler(tiling: tiling, pool: pool, scroller: scroller)
+        return (reconciler, scroller, tiling)
+    }
+
+    private func spec(_ id: String, token: Int = 0, height: CGFloat = 100) -> ACPTranscriptRowSpec {
+        ACPTranscriptRowSpec(
+            id: id,
+            equalityToken: ACPRowEqualityToken(token),
+            build: { AnyView(Color.clear.frame(height: height)) }
+        )
+    }
+
+    @Test("initial apply builds the document and mounts rows")
+    func initialApply() {
+        let (reconciler, scroller, tiling) = makeStack()
+        reconciler.apply(specs: (0..<5).map { spec("r\($0)") }, contentWidth: 600, followsTail: false)
+        #expect(tiling.rowCount == 5)
+        #expect(scroller.contentHeight == tiling.documentHeight)
+        #expect(tiling.documentHeight > 0)
+    }
+
+    @Test("prepend keeps the viewport visually still")
+    func prependStillViewport() {
+        let (reconciler, scroller, tiling) = makeStack()
+        reconciler.apply(specs: (10..<20).map { spec("r\($0)") }, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(150)
+        let bottomDistanceBefore = scroller.distanceFromBottom
+        reconciler.apply(
+            specs: (0..<20).map { spec("r\($0)") },
+            contentWidth: 600, followsTail: false
+        )
+        #expect(tiling.rowCount == 20)
+        #expect(abs(scroller.distanceFromBottom - bottomDistanceBefore) < 1)
+        #expect(scroller.scrollY > 150)  // compensated upward by the prepended height
+    }
+
+    @Test("append while following tail pins to the bottom")
+    func appendFollowsTail() {
+        let (reconciler, scroller, _) = makeStack()
+        reconciler.apply(specs: (0..<10).map { spec("r\($0)") }, contentWidth: 600, followsTail: true)
+        reconciler.apply(specs: (0..<12).map { spec("r\($0)") }, contentWidth: 600, followsTail: true)
+        #expect(scroller.distanceFromBottom < 1)
+    }
+
+    @Test("append while browsing does not move the viewport")
+    func appendWhileBrowsing() {
+        let (reconciler, scroller, _) = makeStack()
+        reconciler.apply(specs: (0..<10).map { spec("r\($0)") }, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(100)
+        reconciler.apply(specs: (0..<12).map { spec("r\($0)") }, contentWidth: 600, followsTail: false)
+        #expect(abs(scroller.scrollY - 100) < 0.5)
+    }
+
+    @Test("reset replaces everything and follows the tail when asked")
+    func resetToTail() {
+        let (reconciler, scroller, tiling) = makeStack()
+        reconciler.apply(specs: (0..<10).map { spec("r\($0)") }, contentWidth: 600, followsTail: false)
+        reconciler.apply(specs: (50..<60).map { spec("r\($0)") }, contentWidth: 600, followsTail: true)
+        #expect(tiling.rowCount == 10)
+        #expect(tiling.row(withId: "r50") != nil)
+        #expect(scroller.distanceFromBottom < 1)
+    }
+
+    @Test("only rows in the mount band have hosting views mounted")
+    func mountBandLimitsMounting() {
+        let (reconciler, scroller, tiling) = makeStack()
+        // 200 rows x ~100pt ≈ 20,000pt document, 400pt viewport, 1200pt overscan.
+        reconciler.apply(specs: (0..<200).map { spec("r\($0)") }, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(10_000)
+        reconciler.layoutMountedRows()
+        let mounted = reconciler.mountedRowIdsForTesting
+        #expect(mounted.count < 60)
+        #expect(tiling.rowCount == 200)
+        let band = tiling.mountBand(
+            viewportMinY: 10_000, viewportHeight: 400,
+            overscan: ACPTranscriptScrollerReconciler.overscan
+        )
+        #expect(mounted == Set(band.map { tiling.rowId(at: $0) }))
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -104,6 +104,16 @@ struct ACPTranscriptScrollerReconcilerDiffTests {
     }
 }
 
+/// Counts how many times each row's SwiftUI content was actually built, so a
+/// test can prove a code path did NOT construct (and therefore did not
+/// measure) a hosting view for a row it already knew the height of.
+@MainActor
+private final class RowBuildCounter {
+    private(set) var counts: [String: Int] = [:]
+    func record(_ id: String) { counts[id, default: 0] += 1 }
+    func count(_ id: String) -> Int { counts[id] ?? 0 }
+}
+
 @MainActor
 @Suite("ACPTranscriptScrollerReconciler apply")
 struct ACPTranscriptScrollerReconcilerApplyTests {
@@ -135,6 +145,29 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         let pool = ACPTranscriptRowHostingPool()
         let reconciler = ACPTranscriptScrollerReconciler(tiling: tiling, pool: pool, scroller: scroller)
         return (reconciler, scroller, tiling, pool)
+    }
+
+    /// Like `spec`, but records every `build()` invocation into `counter`.
+    private func countingSpec(
+        _ id: String, token: Int = 0, height: CGFloat = 100, counter: RowBuildCounter
+    ) -> ACPTranscriptRowSpec {
+        ACPTranscriptRowSpec(
+            id: id,
+            equalityToken: ACPRowEqualityToken(token),
+            build: {
+                counter.record(id)
+                return AnyView(Color.clear.frame(height: height))
+            }
+        )
+    }
+
+    /// The on-screen y of a row: how far below the viewport's top edge it
+    /// currently sits. Anchor preservation means this value survives a
+    /// geometry replacement.
+    private func screenOffset(
+        of id: String, tiling: ACPTranscriptTilingController, scroller: ACPTranscriptScrollerView
+    ) -> CGFloat {
+        tiling.row(withId: id)!.minY - scroller.scrollY
     }
 
     /// Text content whose measured height genuinely depends on the width
@@ -340,9 +373,121 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         }
         #expect(tiling.documentHeight > 0)
         // No stray compensation from a reentrant remeasure operating against
-        // the old (pre-reset) tiling geometry: `.reset` doesn't touch
-        // scrollY on its own (followsTail is false here).
-        #expect(scroller.scrollY == 300)
+        // the old (pre-reset) tiling geometry. `.reset` now re-anchors the
+        // offset to the row that was at the viewport top (final-review
+        // CRITICAL 1) — here "r7", which sat at minY 260 with scrollY 300,
+        // i.e. 40pt into the row — and nothing else may move it. In the new
+        // (shorter) geometry that target lands past the document's end, so
+        // the expected value is the anchor clamped to the scrollable range,
+        // exactly what `setScrollY` produces.
+        let anchorRowMinY = tiling.row(withId: "r7")!.minY
+        let expected = min(anchorRowMinY + 40, max(0, tiling.documentHeight - scroller.viewportHeight))
+        #expect(abs(scroller.scrollY - expected) < 0.5)
+    }
+
+    // MARK: reset preserves the scroll anchor (final-review CRITICAL 1)
+
+    /// The real spec shape of the FINAL head step: once `visibleHead` reaches
+    /// 0 the `__top_pagination__` row at index 0 disappears in the very same
+    /// update that inserts the last block of older messages. Ids change at
+    /// both ends at once, so prefix/suffix trimming can't classify it and it
+    /// falls to `.reset` — the one diff case that used to replace all
+    /// geometry while leaving `scrollY` at its old numeric value, jumping the
+    /// transcript at exactly the moment head pagination is supposed to feel
+    /// seamless.
+    private func finalHeadStepSpecs() -> (old: [ACPTranscriptRowSpec], new: [ACPTranscriptRowSpec]) {
+        (
+            old: [spec("__top_pagination__", height: 14)]
+                + (30..<90).map { spec("m\($0)") }
+                + [spec("__composer_spacer__", height: 220)],
+            new: (0..<90).map { spec("m\($0)") }
+                + [spec("__composer_spacer__", height: 220)]
+        )
+    }
+
+    @Test("the final head step is a reset, and the reset keeps the top-visible row visually put")
+    func resetPreservesScrollAnchor() {
+        let (reconciler, scroller, tiling) = makeStack()
+        let (old, new) = finalHeadStepSpecs()
+        #expect(
+            ACPTranscriptScrollerReconciler.diff(oldIds: old.map(\.id), newIds: new.map(\.id)) == .reset
+        )
+
+        reconciler.apply(specs: old, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(800)
+        let anchorId = tiling.topVisibleRowId(viewportMinY: scroller.scrollY)!
+        #expect(!anchorId.hasPrefix("__"))
+        let before = screenOffset(of: anchorId, tiling: tiling, scroller: scroller)
+
+        reconciler.apply(specs: new, contentWidth: 600, followsTail: false)
+
+        #expect(tiling.row(withId: anchorId) != nil)
+        #expect(abs(screenOffset(of: anchorId, tiling: tiling, scroller: scroller) - before) < 1)
+    }
+
+    @Test("a reset while following the tail still pins to the bottom rather than restoring an anchor")
+    func resetWhileFollowingTailStillPinsToBottom() {
+        let (reconciler, scroller, _) = makeStack()
+        let (old, new) = finalHeadStepSpecs()
+        reconciler.apply(specs: old, contentWidth: 600, followsTail: true)
+        reconciler.apply(specs: new, contentWidth: 600, followsTail: true)
+        #expect(scroller.distanceFromBottom < 1)
+    }
+
+    @Test("the width-settled reset preserves the scroll anchor")
+    func widthSettledResetPreservesScrollAnchor() async throws {
+        let (reconciler, scroller, tiling) = makeStack()
+        let specs = (0..<200).map { wrappingSpec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(2000)
+
+        // A resize while browsing history: same ids, narrower width. The
+        // coalesced path applies immediately; the expensive full re-measure
+        // lands 150ms later and used to teleport the viewport.
+        reconciler.apply(specs: specs, contentWidth: 300, followsTail: false)
+        let anchorId = tiling.topVisibleRowId(viewportMinY: scroller.scrollY)!
+        let before = screenOffset(of: anchorId, tiling: tiling, scroller: scroller)
+
+        let graceNanoseconds = UInt64(
+            (ACPTranscriptScrollerReconciler.widthChangeSettleInterval + 0.4) * 1_000_000_000
+        )
+        try await Task.sleep(nanoseconds: graceNanoseconds)
+
+        #expect(abs(screenOffset(of: anchorId, tiling: tiling, scroller: scroller) - before) < 1)
+    }
+
+    // MARK: reset does not re-measure rows it already knows (final-review CRITICAL 2)
+
+    @Test("a reset at unchanged width does not rebuild rows whose content is unchanged")
+    func resetReusesKnownHeights() {
+        let counter = RowBuildCounter()
+        let (reconciler, scroller, tiling) = makeStack()
+        let old = [countingSpec("__top_pagination__", height: 14, counter: counter)]
+            + (30..<90).map { countingSpec("m\($0)", counter: counter) }
+            + [countingSpec("__composer_spacer__", height: 220, counter: counter)]
+        reconciler.apply(specs: old, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(800)
+        reconciler.layoutMountedRows()
+
+        // "m89" sits ~10,000pt down a ~7,300pt-tall document's worth of rows
+        // below the viewport: far outside the mount band, so it has no live
+        // hosting view and its measured height is already on record.
+        #expect(!reconciler.mountedRowIdsForTesting.contains("m89"))
+        let offBandBuildsBefore = counter.count("m89")
+        #expect(offBandBuildsBefore == 1)
+
+        let new = (0..<90).map { countingSpec("m\($0)", counter: counter) }
+            + [countingSpec("__composer_spacer__", height: 220, counter: counter)]
+        reconciler.apply(specs: new, contentWidth: 600, followsTail: false)
+
+        // The reset must carry "m89"'s known height forward rather than
+        // constructing an NSHostingView for it and measuring it again — the
+        // whole point being that a reset costs O(new rows), not O(window).
+        #expect(counter.count("m89") == offBandBuildsBefore)
+        // ...while genuinely new rows are of course measured.
+        #expect(counter.count("m0") >= 1)
+        #expect(tiling.rowCount == 91)
+        #expect(scroller.contentHeight == tiling.documentHeight)
     }
 
     @Test("a pure width change with identical ids coalesces: bounded interim work, full correction after settling")
@@ -381,5 +526,59 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(tiling.row(withId: "r199")!.height > offBandHeightWide)
         #expect(tiling.rowCount == 200)
         #expect(scroller.contentHeight == tiling.documentHeight)
+    }
+}
+
+@MainActor
+@Suite("ACPTranscriptScrollerReconciler window layout")
+struct ACPTranscriptScrollerReconcilerWindowLayoutTests {
+    /// `ACPTranscriptRowHostingView` sets
+    /// `translatesAutoresizingMaskIntoConstraints = false` (NSHostingView
+    /// boilerplate) while the reconciler places every row by assigning
+    /// `frame` directly. Those two are normally mutually exclusive: a view
+    /// opted into Auto Layout with no constraints describing it is the
+    /// classic "everything collapses to the origin" failure.
+    ///
+    /// This test pins down what actually happens, inside a real key window
+    /// with a real layout pass — the configuration the app runs in — so the
+    /// setting is known-correct rather than known-lucky.
+
+    @Test("rows placed by frame keep their frames through a real window layout pass")
+    func framePlacedRowsSurviveWindowLayout() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+            styleMask: [.titled, .resizable], backing: .buffered, defer: false
+        )
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        window.contentView = scroller
+        let tiling = ACPTranscriptTilingController()
+        let pool = ACPTranscriptRowHostingPool()
+        let reconciler = ACPTranscriptScrollerReconciler(tiling: tiling, pool: pool, scroller: scroller)
+        scroller.layoutSubtreeIfNeeded()
+
+        let specs = (0..<8).map { index in
+            ACPTranscriptRowSpec(
+                id: "r\(index)",
+                equalityToken: ACPRowEqualityToken(0),
+                build: { AnyView(Color.gray.frame(height: 100)) }
+            )
+        }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+
+        window.layoutIfNeeded()
+        scroller.layoutSubtreeIfNeeded()
+        scroller.flippedDocumentView.displayIfNeeded()
+
+        let placed = scroller.flippedDocumentView.subviews
+        #expect(placed.count == reconciler.mountedRowIdsForTesting.count)
+        #expect(placed.count == 8)
+        for index in 0..<8 {
+            let layout = tiling.rowLayout(at: index)
+            let view = placed.first { $0 === pool.mountedView(id: layout.id) }
+            #expect(view != nil)
+            #expect(view?.frame.minY == layout.minY)
+            #expect(view?.frame.height == layout.height)
+            #expect(view?.frame.width == 600)
+        }
     }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -510,6 +510,56 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(abs(screenOffset(of: anchorId, tiling: tiling, scroller: scroller) - before) < 1)
     }
 
+    @Test("a width-settled reset preserves the viewport position when its top sits inside the synthetic tail region")
+    func widthSettledResetPreservesPositionInSyntheticTailRegion() async throws {
+        // The forward-only anchor walk in `captureScrollAnchor` finds the
+        // first NON-synthetic row at or below the viewport top. When the
+        // viewport top is already past every message row — parked over a
+        // queued bubble, say — there is no following message row to walk
+        // to, and the old behavior returned nil, silently skipping
+        // restoration. A width-settled reset still reflows the wrapping
+        // message rows ABOVE the viewport, which must not visibly drag the
+        // synthetic tail content the user is looking at.
+        let (reconciler, scroller, tiling) = makeStack()
+        // The composer spacer is made much taller than its real ~220pt so
+        // the tail region below "__queue_2__" comfortably exceeds the
+        // 400pt viewport height — otherwise `setScrollY`'s clamp (which
+        // never lets the viewport scroll past the document's end) would
+        // pull the requested offset back up onto a message row, defeating
+        // the point of parking the viewport inside the synthetic tail.
+        let specs = (0..<50).map { wrappingSpec("m\($0)") }
+            + [
+                spec("__queue_1__", height: 50), spec("__queue_2__", height: 50),
+                spec("__composer_spacer__", height: 600),
+            ]
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        let m0HeightBefore = tiling.row(withId: "m0")!.height
+
+        // Park the viewport top inside the synthetic tail region: every row
+        // from here through the document end is synthetic.
+        let queueRowMinY = tiling.row(withId: "__queue_2__")!.minY
+        scroller.setScrollY(queueRowMinY + 10)
+        #expect(tiling.topVisibleRowId(viewportMinY: scroller.scrollY) == "__queue_2__")
+        let distanceBefore = scroller.distanceFromBottom
+
+        // A resize while browsing the synthetic tail: same ids, narrower
+        // width. The coalesced path applies immediately; the full
+        // re-measure lands 150ms later.
+        reconciler.apply(specs: specs, contentWidth: 300, followsTail: false)
+
+        let graceNanoseconds = UInt64(
+            (ACPTranscriptScrollerReconciler.widthChangeSettleInterval + 0.4) * 1_000_000_000
+        )
+        try await Task.sleep(nanoseconds: graceNanoseconds)
+
+        // The message rows above genuinely reflowed (proves the assertion
+        // below isn't vacuously true), and the viewport's distance from the
+        // document's bottom edge — the synthetic tail's natural reference
+        // point — is unchanged.
+        #expect(tiling.row(withId: "m0")!.height != m0HeightBefore)
+        #expect(abs(scroller.distanceFromBottom - distanceBefore) < 1)
+    }
+
     // MARK: reset does not re-measure rows it already knows (final-review CRITICAL 2)
 
     @Test("a reset at unchanged width does not rebuild rows whose content is unchanged")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -490,6 +490,94 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(scroller.contentHeight == tiling.documentHeight)
     }
 
+    // MARK: mount-time fallback re-measure (final-review IMPORTANT 3)
+
+    @Test("a fallback re-measure of an already-mounted row schedules another layout pass")
+    func fallbackRemeasureSchedulesAnotherPass() {
+        // The fallback re-measure in `performLayoutPass` has two triggers.
+        // A row mounting for the first time is rescued by accident — AppKit
+        // fires `invalidateIntrinsicContentSize` synchronously from
+        // `addSubview`, which routes into `remeasureRow` and coalesces a
+        // relayout. An ALREADY-mounted row re-pinned to a new width has no
+        // such rescue: no `addSubview`, and re-assigning `rootView` inside
+        // `measuredHeight` does not invalidate. That is the live
+        // resize-drag path, and it is what this test drives.
+        let (reconciler, scroller, tiling) = makeStack()
+        let specs = (0..<60).map { wrappingSpec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 300, followsTail: false)
+        scroller.setScrollY(0)
+        reconciler.layoutMountedRows()
+        let narrowHeight = tiling.row(withId: "r0")!.height
+        let mountedWhenNarrow = reconciler.mountedRowIdsForTesting.count
+
+        // Widening makes every row shorter, so many more of them fit inside
+        // the mount band — but the band was computed from the pre-measure
+        // geometry, so without coalescing another pass the extra rows are
+        // never mounted and the bottom of the viewport is left empty.
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+
+        #expect(tiling.row(withId: "r0")!.height < narrowHeight)
+        let band = tiling.mountBand(
+            viewportMinY: scroller.scrollY, viewportHeight: scroller.viewportHeight,
+            overscan: ACPTranscriptScrollerReconciler.overscan
+        )
+        #expect(band.count > mountedWhenNarrow)
+        #expect(reconciler.mountedRowIdsForTesting == Set(band.map { tiling.rowId(at: $0) }))
+    }
+
+    // MARK: head step at the very top (final-review IMPORTANT 5)
+
+    @Test("a head step taken at the very top of the document still keeps the reading position still")
+    func headStepAtTopOfDocumentCompensates() {
+        let (reconciler, scroller, tiling) = makeStack()
+        func specsWithFixedEnds(messageIds: [String]) -> [ACPTranscriptRowSpec] {
+            [spec("__top_pagination__", height: 14)]
+                + messageIds.map { spec($0) }
+                + [spec("__composer_spacer__", height: 220)]
+        }
+        reconciler.apply(
+            specs: specsWithFixedEnds(messageIds: (30..<90).map { "m\($0)" }),
+            contentWidth: 600, followsTail: false
+        )
+        // The top-of-history bounce: the head pagination spinner occupies
+        // index 0, so the first message starts at topPadding(24) +
+        // spinner(14) + spacing(18) == 56. Parked above that, the plain
+        // `insertionY <= viewportMinY` rule declines to compensate and the
+        // whole inserted block shoves the reading position down.
+        #expect(tiling.row(withId: "m30")!.minY == 56)
+        scroller.setScrollY(10)
+        let before = screenOffset(of: "m30", tiling: tiling, scroller: scroller)
+
+        reconciler.apply(
+            specs: specsWithFixedEnds(messageIds: (10..<90).map { "m\($0)" }),
+            contentWidth: 600, followsTail: false
+        )
+
+        #expect(abs(screenOffset(of: "m30", tiling: tiling, scroller: scroller) - before) < 1)
+    }
+
+    @Test("an append below the reading position never compensates")
+    func appendBelowReadingPositionDoesNotCompensate() {
+        // Guard against the head-step fix over-reaching: an insertion with
+        // real message rows above it must still leave the offset alone.
+        let (reconciler, scroller, _) = makeStack()
+        func specsWithFixedEnds(messageIds: [String]) -> [ACPTranscriptRowSpec] {
+            [spec("__top_pagination__", height: 14)]
+                + messageIds.map { spec($0) }
+                + [spec("__composer_spacer__", height: 220)]
+        }
+        reconciler.apply(
+            specs: specsWithFixedEnds(messageIds: (0..<60).map { "m\($0)" }),
+            contentWidth: 600, followsTail: false
+        )
+        scroller.setScrollY(10)
+        reconciler.apply(
+            specs: specsWithFixedEnds(messageIds: (0..<62).map { "m\($0)" }),
+            contentWidth: 600, followsTail: false
+        )
+        #expect(abs(scroller.scrollY - 10) < 0.5)
+    }
+
     @Test("a pure width change with identical ids coalesces: bounded interim work, full correction after settling")
     func widthChangeCoalescesThenSettles() async throws {
         let (reconciler, scroller, tiling) = makeStack()

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -425,6 +425,60 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(abs(screenOffset(of: anchorId, tiling: tiling, scroller: scroller) - before) < 1)
     }
 
+    @Test("the reset anchor skips the synthetic row that the reset itself deletes")
+    func resetAnchorSkipsSyntheticRows() {
+        // The head pagination spinner occupies row 0 (minY 24, maxY 38), so
+        // any scrollY < 38 makes it the topmost VISIBLE row — and that
+        // position, the top-of-history bounce, is precisely what triggers
+        // the final head step, which deletes that very row. Anchoring to it
+        // means restoration finds nothing to aim at and silently no-ops,
+        // leaving the original hard jump exactly where it was reported.
+        let (reconciler, scroller, tiling) = makeStack()
+        let (old, new) = finalHeadStepSpecs()
+        reconciler.apply(specs: old, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(30)
+        #expect(tiling.topVisibleRowId(viewportMinY: scroller.scrollY) == "__top_pagination__")
+        // The anchor row starts BELOW the scroll position here, so its
+        // offset within the row is negative — which must still restore
+        // exactly, not be floored to zero.
+        #expect(tiling.row(withId: "m30")!.minY > scroller.scrollY)
+        let before = screenOffset(of: "m30", tiling: tiling, scroller: scroller)
+
+        reconciler.apply(specs: new, contentWidth: 600, followsTail: false)
+
+        #expect(abs(screenOffset(of: "m30", tiling: tiling, scroller: scroller) - before) < 1)
+    }
+
+    @Test("the restored anchor offset is capped at the anchor row's new height")
+    func resetClampsAnchorOffsetToRowHeight() {
+        let (reconciler, scroller, tiling) = makeStack()
+        let old = [spec("__top_pagination__", height: 14), spec("m0", token: 0, height: 1000)]
+            + (1..<6).map { spec("m\($0)") }
+            + [spec("__composer_spacer__", height: 220)]
+        reconciler.apply(specs: old, contentWidth: 600, followsTail: false)
+        #expect(tiling.row(withId: "m0")!.minY == 56)
+        scroller.setScrollY(600)
+        #expect(tiling.topVisibleRowId(viewportMinY: scroller.scrollY) == "m0")
+
+        // Ids change at both ends at once (the head sentinel replaced by a
+        // real row) so this is a `.reset`, and the anchor row itself
+        // collapses from 1000pt to 100pt in the same update.
+        let new = [spec("mA"), spec("m0", token: 1, height: 100)]
+            + (1..<6).map { spec("m\($0)") }
+            + [spec("__composer_spacer__", height: 220)]
+        #expect(
+            ACPTranscriptScrollerReconciler.diff(oldIds: old.map(\.id), newIds: new.map(\.id)) == .reset
+        )
+        reconciler.apply(specs: new, contentWidth: 600, followsTail: false)
+
+        let row = tiling.row(withId: "m0")!
+        #expect(row.height == 100)
+        // The offset within the row was 544pt; unclamped it would land far
+        // past a row that is now only 100pt tall. The viewport top can be at
+        // most the anchor row's bottom edge.
+        #expect(abs(scroller.scrollY - row.maxY) < 0.5)
+    }
+
     @Test("a reset while following the tail still pins to the bottom rather than restoring an anchor")
     func resetWhileFollowingTailStillPinsToBottom() {
         let (reconciler, scroller, _) = makeStack()
@@ -488,6 +542,41 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(counter.count("m0") >= 1)
         #expect(tiling.rowCount == 91)
         #expect(scroller.contentHeight == tiling.documentHeight)
+    }
+
+    @Test("an id-change reset inside the settle window does not cancel the pending width settle")
+    func idChangeResetDoesNotCancelPendingWidthSettle() async throws {
+        let (reconciler, scroller, tiling) = makeStack()
+        let rows = (0..<200).map { wrappingSpec("r\($0)") }
+        reconciler.apply(specs: rows, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(0)
+        let offBandHeightWide = tiling.row(withId: "r199")!.height
+
+        // A resize: same ids, so this coalesces and schedules the settle
+        // reset rather than re-measuring everything now.
+        reconciler.apply(specs: rows, contentWidth: 300, followsTail: false)
+
+        // An id change now lands at the width that has ALREADY been applied,
+        // so `widthChanged` is false. It is a `.reset`, but not a substitute
+        // for the settle reset: every off-band height it carries forward was
+        // measured at 600. Cancelling the pending settle here would strand
+        // them there permanently.
+        let reshuffled = [wrappingSpec("head")] + rows + [wrappingSpec("tail")]
+        #expect(
+            ACPTranscriptScrollerReconciler.diff(
+                oldIds: rows.map(\.id), newIds: reshuffled.map(\.id)
+            ) == .reset
+        )
+        reconciler.apply(specs: reshuffled, contentWidth: 300, followsTail: false)
+        #expect(tiling.row(withId: "r199")!.height == offBandHeightWide)
+
+        let graceNanoseconds = UInt64(
+            (ACPTranscriptScrollerReconciler.widthChangeSettleInterval + 0.4) * 1_000_000_000
+        )
+        try await Task.sleep(nanoseconds: graceNanoseconds)
+
+        // The settle reset still fires and corrects the off-band rows.
+        #expect(tiling.row(withId: "r199")!.height > offBandHeightWide)
     }
 
     // MARK: mount-time fallback re-measure (final-review IMPORTANT 3)

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -525,6 +525,35 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(scroller.contentHeight == tiling.documentHeight)
     }
 
+    @Test("remeasureRow does not re-pin once tail-follow is paused, even before the next apply")
+    func remeasureRowDoesNotRepinAfterTailFollowPaused() {
+        // The window this closes: a user scrolls up, the scroll handler
+        // pauses tail-follow and then mounts the rows that scroll exposed.
+        // The `apply()` carrying `followsTail: false` is still one SwiftUI
+        // update away, so a row whose intrinsic size invalidates as it
+        // mounts lands in `remeasureRow` with the reconciler still
+        // believing tail-follow is on — and drags the user back to the
+        // bottom with following already off. `setFollowsTail(false)` is
+        // what the handler calls before mounting anything.
+        let (reconciler, scroller, tiling, pool) = makeStackWithPool()
+        let specs = (0..<10).map { spec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: true)
+        #expect(scroller.distanceFromBottom < 1)
+
+        // The user scrolls up. No `apply()` yet — only the synchronous
+        // pause the scroll handler performs.
+        reconciler.setFollowsTail(false)
+        scroller.setScrollY(0)
+        let scrollYBefore = scroller.scrollY
+
+        let (lastView, _) = pool.view(for: specs[9])
+        lastView.updateRootView(AnyView(Color.clear.frame(height: 250)))
+        reconciler.remeasureRow(id: "r9")
+
+        #expect(tiling.row(withId: "r9")!.height == 250)
+        #expect(abs(scroller.scrollY - scrollYBefore) < 0.5)
+    }
+
     @Test("remeasureRow does not move the viewport when a tail row grows while browsing (not following the tail)")
     func remeasureRowDoesNotRepinWhileBrowsing() {
         // Guard against the fix over-reaching: a user who has scrolled away

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -12,41 +12,95 @@ struct ACPTranscriptScrollerReconcilerDiffTests {
         #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b"], newIds: ["a", "b"]) == .unchanged)
     }
 
-    @Test("new ids before the old head are a prepend")
+    @Test("new ids before the old head are an insert at index 0")
     func prepend() {
         #expect(
             ACPTranscriptScrollerReconciler.diff(oldIds: ["c", "d"], newIds: ["a", "b", "c", "d"])
-            == .prepended(count: 2)
+            == .inserted(index: 0, count: 2)
         )
     }
 
-    @Test("new ids after the old tail are an append")
+    @Test("new ids after the old tail are an insert at the old list's end")
     func append() {
         #expect(
             ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b"], newIds: ["a", "b", "c"])
-            == .appended(count: 1)
+            == .inserted(index: 2, count: 1)
         )
     }
 
-    @Test("prepend and append together are recognized")
-    func both() {
+    @Test("ids removed from the middle are a removal, not a reset")
+    func midListRemoval() {
+        #expect(
+            ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b", "c", "d"], newIds: ["a", "d"])
+            == .removed(index: 1, count: 2)
+        )
+    }
+
+    @Test("ids inserted in the middle are an insertion, not a reset")
+    func midListInsertion() {
+        #expect(
+            ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b", "d", "e"], newIds: ["a", "b", "c", "d", "e"])
+            == .inserted(index: 2, count: 1)
+        )
+    }
+
+    @Test("changes at both ends simultaneously are a reset")
+    func bothEndsChangingIsAReset() {
+        // The generalized diff only classifies a SINGLE insertion or
+        // removal point (found by trimming one common prefix and one
+        // common suffix). Ids changing at both ends in the same update
+        // don't reduce to either shape, so this is deliberately a reset —
+        // simpler and rarer than the single-direction cases the fixed
+        // synthetic rows (head pagination spinner, composer spacer) made
+        // common once they stopped defeating incremental classification.
         #expect(
             ACPTranscriptScrollerReconciler.diff(oldIds: ["b"], newIds: ["a", "b", "c"])
-            == .prependedAndAppended(prepended: 1, appended: 1)
+            == .reset
         )
     }
 
     @Test("anything else is a reset")
     func reset() {
         #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b"], newIds: ["a", "c"]) == .reset)
-        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a", "b"], newIds: ["b"]) == .reset)
         #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a"], newIds: ["z"]) == .reset)
     }
 
     @Test("empty transitions")
     func empties() {
-        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: [], newIds: ["a"]) == .reset)
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: [], newIds: ["a"]) == .inserted(index: 0, count: 1))
         #expect(ACPTranscriptScrollerReconciler.diff(oldIds: [], newIds: []) == .unchanged)
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: ["a"], newIds: []) == .removed(index: 0, count: 1))
+    }
+
+    // MARK: fixed rows at both ends (the bug this generalization fixes)
+
+    /// Mirrors `ACPTranscriptScroller.rowSpecs`'s actual shape: a fixed
+    /// `__top_pagination__` row at index 0 and a fixed `__composer_spacer__`
+    /// row at the tail, both unaffected by the mutation in between. Before
+    /// the common-prefix/suffix generalization, having a fixed row at BOTH
+    /// ends defeated the old "old ids are a contiguous run in new ids"
+    /// check for every head-step and every append, forcing a `.reset` (full
+    /// rebuild, no offset compensation) on what should have been a cheap
+    /// incremental update — the bug CRITICAL #1 in the task-10 review fixed.
+    @Test("a fixed row at both ends does not defeat head-step insertion")
+    func headStepWithFixedRowsAtBothEnds() {
+        let old = ["__top_pagination__", "m30", "m31", "m32", "__composer_spacer__"]
+        let new = ["__top_pagination__", "m10", "m20", "m30", "m31", "m32", "__composer_spacer__"]
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: old, newIds: new) == .inserted(index: 1, count: 2))
+    }
+
+    @Test("a fixed trailing synthetic row does not defeat append insertion")
+    func appendWithFixedTrailingSyntheticRow() {
+        let old = ["m1", "m2", "__composer_spacer__"]
+        let new = ["m1", "m2", "m3", "__composer_spacer__"]
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: old, newIds: new) == .inserted(index: 2, count: 1))
+    }
+
+    @Test("the streaming caret disappearing at the end of a turn is a removal, not a reset")
+    func streamingCaretRemoval() {
+        let old = ["m1", "m2", "__streaming_caret__", "__composer_spacer__"]
+        let new = ["m1", "m2", "__composer_spacer__"]
+        #expect(ACPTranscriptScrollerReconciler.diff(oldIds: old, newIds: new) == .removed(index: 2, count: 1))
     }
 }
 
@@ -121,6 +175,45 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(tiling.rowCount == 20)
         #expect(abs(scroller.distanceFromBottom - bottomDistanceBefore) < 1)
         #expect(scroller.scrollY > 150)  // compensated upward by the prepended height
+    }
+
+    @Test("head-step insertion between fixed rows at both ends compensates end-to-end (no visible jump)")
+    func headStepBetweenFixedSyntheticRowsCompensates() {
+        // Regression test for CRITICAL #1 (task-10 review): with a fixed
+        // row at BOTH ends of the spec list — matching
+        // `ACPTranscriptScroller.rowSpecs`'s actual shape
+        // (`__top_pagination__` first, `__composer_spacer__` last) — the
+        // old contiguous-run diff always fell to `.reset` here, which never
+        // compensates the scroll offset and made the transcript visibly
+        // jump on every head-step. The generalized diff must classify this
+        // as `.inserted`, and `apply()` must compensate exactly like a
+        // pure prepend would.
+        let (reconciler, scroller, tiling) = makeStack()
+        func specsWithFixedEnds(messageIds: [String]) -> [ACPTranscriptRowSpec] {
+            [spec("__top_pagination__")] + messageIds.map { spec($0) } + [spec("__composer_spacer__")]
+        }
+        reconciler.apply(
+            specs: specsWithFixedEnds(messageIds: (30..<90).map { "m\($0)" }),
+            contentWidth: 600, followsTail: false
+        )
+        scroller.setScrollY(800)
+        let bottomDistanceBefore = scroller.distanceFromBottom
+
+        reconciler.apply(
+            specs: specsWithFixedEnds(messageIds: (10..<90).map { "m\($0)" }),
+            contentWidth: 600, followsTail: false
+        )
+
+        #expect(tiling.rowCount == 82)   // top sentinel + 80 messages + spacer
+        #expect(tiling.row(withId: "__top_pagination__") != nil)
+        #expect(tiling.row(withId: "__composer_spacer__") != nil)
+        // No visible jump: the viewport's distance from the bottom (and
+        // hence what's on screen) is preserved, and the compensation moved
+        // scrollY down by roughly the inserted content's height — exactly
+        // the `prependStillViewport` assertions, now proven to also hold
+        // when fixed rows bookend the list.
+        #expect(abs(scroller.distanceFromBottom - bottomDistanceBefore) < 1)
+        #expect(scroller.scrollY > 800)
     }
 
     @Test("append while following tail pins to the bottom")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -346,6 +346,48 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(scroller.scrollY > scrollYBefore)
     }
 
+    @Test("remeasureRow re-pins to the bottom when a mounted tail row grows while following the tail")
+    func remeasureRowRepinsToBottomWhileFollowingTail() {
+        // Headline scenario: streaming while pinned to the bottom stays
+        // pinned. The last row ("r9") growing in place (an image finishing
+        // its load, an expandable row toggling) is never "entirely above
+        // the viewport" while tail-following, so `updateHeight`'s
+        // compensation is correctly zero — the document grows underneath a
+        // scroll offset that doesn't move on its own. Without the fix, the
+        // viewport is left short of the new bottom by the growth amount.
+        let (reconciler, scroller, tiling, pool) = makeStackWithPool()
+        let specs = (0..<10).map { spec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: true)
+        #expect(scroller.distanceFromBottom < 1)
+
+        let (lastView, _) = pool.view(for: specs[9])
+        lastView.updateRootView(AnyView(Color.clear.frame(height: 250)))
+        reconciler.remeasureRow(id: "r9")
+
+        #expect(tiling.row(withId: "r9")!.height == 250)
+        #expect(scroller.distanceFromBottom < 1)
+        #expect(scroller.contentHeight == tiling.documentHeight)
+    }
+
+    @Test("remeasureRow does not move the viewport when a tail row grows while browsing (not following the tail)")
+    func remeasureRowDoesNotRepinWhileBrowsing() {
+        // Guard against the fix over-reaching: a user who has scrolled away
+        // from the tail must not be fought back to the bottom just because
+        // some row's content happened to change size.
+        let (reconciler, scroller, tiling, pool) = makeStackWithPool()
+        let specs = (0..<10).map { spec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(0)
+        let scrollYBefore = scroller.scrollY
+
+        let (lastView, _) = pool.view(for: specs[9])
+        lastView.updateRootView(AnyView(Color.clear.frame(height: 250)))
+        reconciler.remeasureRow(id: "r9")
+
+        #expect(tiling.row(withId: "r9")!.height == 250)
+        #expect(abs(scroller.scrollY - scrollYBefore) < 0.5)
+    }
+
     @Test("remeasureRow is a no-op for an id that isn't currently tracked")
     func remeasureRowUnknownIdNoOps() {
         let (reconciler, _, tiling, _) = makeStackWithPool()

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -125,11 +125,14 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         return (reconciler, scroller, tiling)
     }
 
-    private func spec(_ id: String, token: Int = 0, height: CGFloat = 100) -> ACPTranscriptRowSpec {
+    private func spec(
+        _ id: String, token: Int = 0, height: CGFloat = 100, keepsMountedOffscreen: Bool = false
+    ) -> ACPTranscriptRowSpec {
         ACPTranscriptRowSpec(
             id: id,
             equalityToken: ACPRowEqualityToken(token),
-            build: { AnyView(Color.clear.frame(height: height)) }
+            build: { AnyView(Color.clear.frame(height: height)) },
+            keepsMountedOffscreen: keepsMountedOffscreen
         )
     }
 
@@ -291,6 +294,93 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
             overscan: ACPTranscriptScrollerReconciler.overscan
         )
         #expect(mounted == Set(band.map { tiling.rowId(at: $0) }))
+    }
+
+    @Test("a row marked keepsMountedOffscreen stays mounted far outside the band; an ordinary row at the same position does not")
+    func keepsMountedOffscreenSurvivesOutsideBand() {
+        // Regression test for the P2 finding (codex round 4): scrolling a
+        // pending `ACPUserInputPrompt` more than the overscan distance away
+        // used to release its hosting view and, with it, the form data the
+        // user had already entered. A spec opted into `keepsMountedOffscreen`
+        // must stay in the pool's mounted set regardless of the viewport,
+        // while an ordinary row right next to it is released exactly as
+        // before.
+        let (reconciler, scroller, tiling, pool) = makeStackWithPool()
+        var specs = (0..<200).map { spec("r\($0)") }
+        specs[0] = spec("kept", keepsMountedOffscreen: true)
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(10_000)
+        reconciler.layoutMountedRows()
+
+        let mounted = reconciler.mountedRowIdsForTesting
+        let band = tiling.mountBand(
+            viewportMinY: 10_000, viewportHeight: 400,
+            overscan: ACPTranscriptScrollerReconciler.overscan
+        )
+        let ordinaryBandIds = Set(band.map { tiling.rowId(at: $0) })
+
+        // "kept" sits at row 0, far outside the band computed at scrollY
+        // 10,000 — proving the exemption, not the ordinary band, is what
+        // keeps it mounted.
+        #expect(!band.contains(tiling.index(ofId: "kept")!))
+        #expect(mounted.contains("kept"))
+        // The exemption is additive, not a widening of the band itself: the
+        // mounted set is exactly the band plus the one exempted row, and the
+        // kept row is positioned at its real tiled coordinates.
+        #expect(mounted == ordinaryBandIds.union(["kept"]))
+        // Row 0's real tiled position, unmoved by the exemption — a kept row
+        // is placed like any other mounted row, not at an arbitrary spot,
+        // and its live hosting view's frame reflects exactly that position.
+        let keptLayout = tiling.row(withId: "kept")!
+        #expect(keptLayout.minY == 24)
+        let keptView = pool.mountedView(id: "kept")
+        #expect(keptView?.frame.minY == keptLayout.minY)
+        #expect(keptView?.frame.height == keptLayout.height)
+        #expect(keptView?.superview === scroller.flippedDocumentView)
+
+        // An ordinary row at a nearby out-of-band position ("r1", right next
+        // to "kept") is released exactly as before.
+        #expect(!mounted.contains("r1"))
+    }
+
+    @Test("keepsMountedOffscreen survives a width-settled reset, which also unmounts ordinary off-band rows")
+    func keepsMountedOffscreenSurvivesWidthSettledReset() async throws {
+        // The other route to the same data loss: `.reset` (here, the
+        // width-settle reset a window resize schedules) re-measures via
+        // `performReset` and then runs the ordinary `layoutMountedRows()`
+        // pass — the SAME `pool.releaseAll(except: keep)` call site the
+        // scroll-driven case goes through, not a separate unconditional
+        // `pool.releaseAll()`. Because the fix lives in `performLayoutPass`
+        // itself, both routes are covered by the same `keep` union.
+        let (reconciler, scroller, tiling) = makeStack()
+        var specs = (0..<200).map { spec("r\($0)") }
+        specs[0] = spec("kept", keepsMountedOffscreen: true)
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(10_000)
+        reconciler.layoutMountedRows()
+        #expect(reconciler.mountedRowIdsForTesting.contains("kept"))
+
+        // A resize while browsing: same ids, narrower width. The coalesced
+        // path applies immediately (bounded interim work); the full
+        // re-measure-everything reset lands after the debounce settles.
+        reconciler.apply(specs: specs, contentWidth: 300, followsTail: false)
+
+        let graceNanoseconds = UInt64(
+            (ACPTranscriptScrollerReconciler.widthChangeSettleInterval + 0.4) * 1_000_000_000
+        )
+        try await Task.sleep(nanoseconds: graceNanoseconds)
+
+        // The settle reset ran (proves this isn't vacuous) and released the
+        // ordinary off-band rows exactly as before, but "kept" is still
+        // mounted at its real (re-tiled) position.
+        let mounted = reconciler.mountedRowIdsForTesting
+        #expect(!mounted.contains("r1"))
+        #expect(mounted.contains("kept"))
+        let band = tiling.mountBand(
+            viewportMinY: scroller.scrollY, viewportHeight: scroller.viewportHeight,
+            overscan: ACPTranscriptScrollerReconciler.overscan
+        )
+        #expect(!band.contains(tiling.index(ofId: "kept")!))
     }
 
     @Test("apply with a non-positive width is deferred rather than collapsing the document")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
@@ -39,6 +39,32 @@ struct ACPTranscriptScrollerViewTests {
         #expect(abs(s.distanceFromBottom - (5000 - s.viewportHeight - 300)) < 1)
     }
 
+    /// `applyPrepend` used to assign the clip view's bounds origin without
+    /// the clamp `setScrollY` applies, and `.removed` compensation routes a
+    /// NEGATIVE delta through this same primitive. Empirically AppKit's own
+    /// `NSClipView` already constrains the origin, so this held before the
+    /// clamp was added too — these expectations pin the guarantee at OUR
+    /// layer rather than leaving it to an AppKit implementation detail that
+    /// a `constrainBoundsRect` override (or a clip-view swap) could remove.
+    @Test("applyPrepend clamps its resulting offset exactly like setScrollY does")
+    func prependClamps() {
+        let s = scroller()
+        s.setScrollY(300)
+        s.applyPrepend(delta: -1000, newDocumentHeight: 4000)
+        #expect(s.scrollY == 0)
+
+        // The upper bound is clamped against the NEW document height, the
+        // same expression `setScrollY` uses.
+        s.applyPrepend(delta: 100_000, newDocumentHeight: 4000)
+        #expect(abs(s.scrollY - (4000 - s.viewportHeight)) < 1)
+
+        // A normal prepend (grow above, shift down by the same delta) is
+        // untouched by the clamp.
+        s.setScrollY(500)
+        s.applyPrepend(delta: 700, newDocumentHeight: 4700)
+        #expect(abs(s.scrollY - 1200) < 0.5)
+    }
+
     @Test("scrollToBottom lands within tolerance of the bottom")
     func toBottom() {
         let s = scroller()

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
@@ -1,0 +1,60 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscriptScrollerView")
+struct ACPTranscriptScrollerViewTests {
+    private func scroller(viewport: CGFloat = 800, document: CGFloat = 5000) -> ACPTranscriptScrollerView {
+        let s = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: viewport))
+        s.setDocumentHeight(document)
+        s.layoutSubtreeIfNeeded()
+        return s
+    }
+
+    @Test("document view is flipped so y grows downward")
+    func flipped() {
+        #expect(scroller().flippedDocumentView.isFlipped)
+    }
+
+    @Test("setScrollY moves the viewport and clamps to content")
+    func programmaticScroll() {
+        let s = scroller()
+        s.setScrollY(1000)
+        #expect(abs(s.scrollY - 1000) < 0.5)
+        s.setScrollY(999_999)
+        #expect(abs(s.scrollY - (5000 - s.viewportHeight)) < 1)
+        s.setScrollY(-50)
+        #expect(s.scrollY >= 0)
+    }
+
+    @Test("applyPrepend grows the document and keeps the viewport still")
+    func prependCompensation() {
+        let s = scroller()
+        s.setScrollY(300)
+        s.applyPrepend(delta: 700, newDocumentHeight: 5700)
+        #expect(abs(s.scrollY - 1000) < 0.5)
+        #expect(s.flippedDocumentView.frame.height == 5700)
+        // The same content y-range is visible: distance from bottom unchanged.
+        #expect(abs(s.distanceFromBottom - (5000 - s.viewportHeight - 300)) < 1)
+    }
+
+    @Test("scrollToBottom lands within tolerance of the bottom")
+    func toBottom() {
+        let s = scroller()
+        s.scrollToBottom()
+        #expect(s.distanceFromBottom < 1)
+    }
+
+    @Test("programmatic adjustments report isProgrammatic to onScroll")
+    func programmaticReporting() {
+        let s = scroller()
+        var reports: [(y: CGFloat, programmatic: Bool)] = []
+        s.onScroll = { _, newY, _, _, isProgrammatic in
+            reports.append((newY, isProgrammatic))
+        }
+        s.setScrollY(400)
+        #expect(reports.contains { abs($0.y - 400) < 0.5 && $0.programmatic })
+        #expect(!reports.contains { !$0.programmatic })
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
@@ -114,4 +114,52 @@ struct ACPTranscriptScrollerViewTests {
         s.layoutSubtreeIfNeeded()
         #expect(fireCount == 2)
     }
+
+    /// `onViewportHeightChange` is the hook `ACPTranscriptScroller
+    /// .Coordinator` uses to re-run just the mount/relayout pass when the
+    /// viewport's HEIGHT changes with no accompanying width change (P2
+    /// finding, codex round 6) — see `ACPTranscriptScrollerView
+    /// .onViewportHeightChange`'s doc comment. It must fire exactly once per
+    /// genuine height-only change, must NOT fire again on a same-size layout
+    /// pass, and must NOT fire when width changes too (that combined case is
+    /// fully covered by `onContentWidthChange`'s own reconcile).
+    @Test("onViewportHeightChange fires only on a height-only change, never together with a width change")
+    func viewportHeightChangeFiresOnlyOnHeightOnlyChange() {
+        let s = ACPTranscriptScrollerView(frame: .zero)
+        var widthFireCount = 0
+        var heightFireCount = 0
+        s.onContentWidthChange = { widthFireCount += 1 }
+        s.onViewportHeightChange = { heightFireCount += 1 }
+
+        // First real size: bootstraps through the width hook only, matching
+        // existing behavior — no height-only signal on the very first layout.
+        s.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        s.layoutSubtreeIfNeeded()
+        #expect(widthFireCount == 1)
+        #expect(heightFireCount == 0)
+
+        // Height-only change: fires the height hook, not the width hook.
+        s.frame = NSRect(x: 0, y: 0, width: 600, height: 900)
+        s.layoutSubtreeIfNeeded()
+        #expect(widthFireCount == 1)
+        #expect(heightFireCount == 1)
+
+        // A no-op layout pass at the same size: neither re-fires.
+        s.layoutSubtreeIfNeeded()
+        #expect(widthFireCount == 1)
+        #expect(heightFireCount == 1)
+
+        // Width AND height changing together: only the width hook fires.
+        s.frame = NSRect(x: 0, y: 0, width: 700, height: 500)
+        s.layoutSubtreeIfNeeded()
+        #expect(widthFireCount == 2)
+        #expect(heightFireCount == 1)
+
+        // Width-only change (height unchanged from the previous pass): only
+        // the width hook fires, exactly like `contentWidthChangeFiresOnlyOnRealChange`.
+        s.frame = NSRect(x: 0, y: 0, width: 800, height: 500)
+        s.layoutSubtreeIfNeeded()
+        #expect(widthFireCount == 3)
+        #expect(heightFireCount == 1)
+    }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
@@ -83,4 +83,35 @@ struct ACPTranscriptScrollerViewTests {
         #expect(reports.contains { abs($0.y - 400) < 0.5 && $0.programmatic })
         #expect(!reports.contains { !$0.programmatic })
     }
+
+    /// `onContentWidthChange` is the hook `ACPTranscriptScroller.Coordinator`
+    /// uses to reconcile after a real width arrives from AppKit's own layout
+    /// pass, without any accompanying SwiftUI model update (P1 finding,
+    /// codex round 5). It must fire exactly once per genuine content-width
+    /// change — including the very first non-zero width the view receives —
+    /// and must NOT fire again for a layout pass at an unchanged width: a
+    /// reconcile per layout pass would be a performance regression.
+    @Test("onContentWidthChange fires once per genuine width change, not on a same-width layout pass")
+    func contentWidthChangeFiresOnlyOnRealChange() {
+        let s = ACPTranscriptScrollerView(frame: .zero)
+        var fireCount = 0
+        s.onContentWidthChange = { fireCount += 1 }
+
+        // No layout pass has happened yet: no width to report.
+        #expect(fireCount == 0)
+
+        // First real width: fires.
+        s.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        s.layoutSubtreeIfNeeded()
+        #expect(fireCount == 1)
+
+        // A no-op layout pass at the SAME width: does not re-fire.
+        s.layoutSubtreeIfNeeded()
+        #expect(fireCount == 1)
+
+        // A genuinely different width: fires again.
+        s.frame = NSRect(x: 0, y: 0, width: 700, height: 400)
+        s.layoutSubtreeIfNeeded()
+        #expect(fireCount == 2)
+    }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
@@ -160,3 +160,53 @@ struct ACPTranscriptTilingHeightTests {
         #expect(c.documentHeight == 340)
     }
 }
+
+@MainActor
+@Suite("ACPTranscriptTilingController viewport queries")
+struct ACPTranscriptTilingViewportTests {
+    private func controller() -> ACPTranscriptTilingController {
+        let c = ACPTranscriptTilingController(metrics: .init(rowSpacing: 10, topPadding: 20))
+        c.replaceAll(rows: (0..<100).map { ("row-\($0)", 100) })
+        // row-i: minY = 20 + i*110, maxY = minY + 100
+        return c
+    }
+
+    @Test("top visible row is the first row whose bottom is past the viewport top")
+    func topVisible() {
+        let c = controller()
+        #expect(c.topVisibleRowId(viewportMinY: 0) == "row-0")
+        #expect(c.topVisibleRowId(viewportMinY: 121) == "row-1")   // row-0.maxY = 120
+        #expect(c.topVisibleRowId(viewportMinY: 5000) == "row-45") // first maxY > 5000: 120 + 110*45 = 5070
+    }
+
+    @Test("top visible row of an empty controller is nil")
+    func topVisibleEmpty() {
+        let c = ACPTranscriptTilingController()
+        #expect(c.topVisibleRowId(viewportMinY: 0) == nil)
+    }
+
+    @Test("mount band covers viewport plus overscan and clamps to bounds")
+    func mountBand() {
+        let c = controller()
+        let band = c.mountBand(viewportMinY: 1000, viewportHeight: 800, overscan: 500)
+        // covered y-range: [500, 2300]
+        let first = band.lowerBound, last = band.upperBound - 1
+        #expect(c.rowLayout(at: first).maxY > 500)
+        if first > 0 { #expect(c.rowLayout(at: first - 1).maxY <= 500) }
+        #expect(c.rowLayout(at: last).minY < 2300)
+        if last < c.rowCount - 1 { #expect(c.rowLayout(at: last + 1).minY >= 2300) }
+    }
+
+    @Test("mount band at the very top starts at zero")
+    func mountBandTop() {
+        let c = controller()
+        let band = c.mountBand(viewportMinY: 0, viewportHeight: 800, overscan: 500)
+        #expect(band.lowerBound == 0)
+    }
+
+    @Test("mount band of an empty controller is empty")
+    func mountBandEmpty() {
+        let c = ACPTranscriptTilingController()
+        #expect(c.mountBand(viewportMinY: 0, viewportHeight: 800, overscan: 500).isEmpty)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
@@ -95,3 +95,68 @@ struct ACPTranscriptTilingControllerTests {
         #expect(c.row(withId: "d")?.minY == c.rowLayout(at: 1).minY)
     }
 }
+
+@MainActor
+@Suite("ACPTranscriptTilingController height updates")
+struct ACPTranscriptTilingHeightTests {
+    private func controller() -> ACPTranscriptTilingController {
+        let c = ACPTranscriptTilingController(metrics: .init(rowSpacing: 10, topPadding: 20))
+        c.replaceAll(rows: [("a", 100), ("b", 50), ("c", 80), ("d", 40)])
+        // minY: a=20, b=130, c=190, d=280 ; documentHeight=320
+        return c
+    }
+
+    @Test("growing a row above the viewport returns the growth as compensation")
+    func growthAboveViewport() {
+        let c = controller()
+        let delta = c.updateHeight(id: "a", to: 150, viewportMinY: 190)
+        #expect(delta == 50)
+        #expect(c.row(withId: "b")?.minY == 180)
+        #expect(c.documentHeight == 370)
+    }
+
+    @Test("shrinking a row above the viewport returns negative compensation")
+    func shrinkAboveViewport() {
+        let c = controller()
+        let delta = c.updateHeight(id: "a", to: 60, viewportMinY: 190)
+        #expect(delta == -40)
+        #expect(c.documentHeight == 280)
+    }
+
+    @Test("growing a row visible in or below the viewport needs no compensation")
+    func growthBelowViewport() {
+        let c = controller()
+        let delta = c.updateHeight(id: "c", to: 120, viewportMinY: 100)
+        #expect(delta == 0)
+        #expect(c.row(withId: "d")?.minY == 320)
+        #expect(c.documentHeight == 360)
+    }
+
+    @Test("unchanged height is a no-op")
+    func unchangedNoop() {
+        let c = controller()
+        let delta = c.updateHeight(id: "b", to: 50, viewportMinY: 0)
+        #expect(delta == 0)
+        #expect(c.documentHeight == 320)
+    }
+
+    @Test("unknown id is a no-op")
+    func unknownId() {
+        let c = controller()
+        #expect(c.updateHeight(id: "zz", to: 99, viewportMinY: 0) == 0)
+        #expect(c.documentHeight == 320)
+    }
+
+    @Test("a row whose bottom edge exactly meets the viewport top counts as above")
+    func exactBoundaryIsAbove() {
+        let c = controller()
+        // b occupies the half-open range [minY, maxY) = [130, 180). When
+        // viewportMinY == 180, the first visible pixel is row b's old maxY:
+        // none of b's pixels are actually on screen, so it is entirely above
+        // the viewport (not "visible"), and its growth must be compensated.
+        let delta = c.updateHeight(id: "b", to: 70, viewportMinY: 180)
+        let expectedDelta: CGFloat = 70 - 50
+        #expect(delta == expectedDelta)
+        #expect(c.documentHeight == 340)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
@@ -71,6 +71,56 @@ struct ACPTranscriptTilingControllerTests {
         )
     }
 
+    @Test("nearestNonSyntheticRowId falls back upward when only synthetic rows remain below")
+    func nearestNonSyntheticFallsBackUpward() {
+        // Viewport stopped inside the synthetic tail. The forward scan has
+        // nothing to find, and recording no anchor at all is read downstream
+        // as "go to the bottom" — so the last real message above is the
+        // closest position the persisted anchor format can express.
+        let c = controller()
+        c.replaceAll(rows: [("m0", 100), ("m1", 100), ("__queued__", 60), ("__composer_spacer__", 220)])
+
+        #expect(
+            c.firstNonSyntheticRowId(atOrBelow: 300, syntheticIdPrefix: "__") == nil
+        )
+        #expect(
+            c.nearestNonSyntheticRowId(to: 300, syntheticIdPrefix: "__") == "m1"
+        )
+    }
+
+    @Test("nearestNonSyntheticRowId still prefers the row below when there is one")
+    func nearestNonSyntheticPrefersBelow() {
+        let c = controller()
+        c.replaceAll(rows: [("m0", 100), ("__queued__", 60), ("m1", 100)])
+
+        // Sitting on the queued bubble: "m1" is below and "m0" above, and
+        // the downward answer must win so the anchor never drifts backward
+        // while a real row is still in view.
+        #expect(
+            c.nearestNonSyntheticRowId(to: 130, syntheticIdPrefix: "__") == "m1"
+        )
+    }
+
+    @Test("nearestNonSyntheticRowId past the end of the document returns the last message")
+    func nearestNonSyntheticPastEnd() {
+        let c = controller()
+        c.replaceAll(rows: [("m0", 100), ("__composer_spacer__", 220)])
+
+        #expect(
+            c.nearestNonSyntheticRowId(to: 10_000, syntheticIdPrefix: "__") == "m0"
+        )
+    }
+
+    @Test("nearestNonSyntheticRowId returns nil when the document has no message rows")
+    func nearestNonSyntheticAllSynthetic() {
+        let c = controller()
+        c.replaceAll(rows: [("__top_pagination__", 40), ("__composer_spacer__", 220)])
+
+        #expect(
+            c.nearestNonSyntheticRowId(to: 0, syntheticIdPrefix: "__") == nil
+        )
+    }
+
     @Test("empty controller has zero document height")
     func emptyHeight() {
         let c = controller()

--- a/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
@@ -1,0 +1,76 @@
+import CoreGraphics
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscriptTilingController core")
+struct ACPTranscriptTilingControllerTests {
+    private func controller() -> ACPTranscriptTilingController {
+        ACPTranscriptTilingController(
+            metrics: .init(rowSpacing: 10, topPadding: 20)
+        )
+    }
+
+    @Test("replaceAll lays rows top-down with spacing and top padding")
+    func layoutBasics() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50), ("c", 80)])
+        #expect(c.rowCount == 3)
+        #expect(c.row(withId: "a")?.minY == 20)
+        #expect(c.row(withId: "b")?.minY == 130)   // 20 + 100 + 10
+        #expect(c.row(withId: "c")?.minY == 190)   // 130 + 50 + 10
+        #expect(c.documentHeight == 270)           // 190 + 80
+    }
+
+    @Test("empty controller has zero document height")
+    func emptyHeight() {
+        let c = controller()
+        #expect(c.rowCount == 0)
+        #expect(c.documentHeight == 0)
+    }
+
+    @Test("prepend returns the exact delta and shifts existing rows by it")
+    func prependDelta() {
+        let c = controller()
+        c.replaceAll(rows: [("c", 80), ("d", 40)])
+        let cMinYBefore = c.row(withId: "c")!.minY
+        let delta = c.prepend(rows: [("a", 100), ("b", 50)])
+        // heights + one spacing per row
+        let expectedDelta: CGFloat = 100 + 10 + 50 + 10
+        #expect(delta == expectedDelta)
+        #expect(c.row(withId: "a")?.minY == 20)
+        #expect(c.row(withId: "c")?.minY == cMinYBefore + delta)
+        let expectedDocumentHeight: CGFloat = 20 + 100 + 10 + 50 + 10 + 80 + 10 + 40
+        #expect(c.documentHeight == expectedDocumentHeight)
+    }
+
+    @Test("append extends the document without moving existing rows")
+    func appendKeepsExisting() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100)])
+        let aBefore = c.row(withId: "a")!.minY
+        c.append(rows: [("b", 60)])
+        #expect(c.row(withId: "a")?.minY == aBefore)
+        let expectedBMinY: CGFloat = 20 + 100 + 10
+        #expect(c.row(withId: "b")?.minY == expectedBMinY)
+        #expect(c.documentHeight == 190)
+    }
+
+    @Test("removeSuffix truncates rows and document height")
+    func removeSuffix() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50), ("c", 80)])
+        c.removeSuffix(from: 1)
+        #expect(c.rowCount == 1)
+        #expect(c.row(withId: "b") == nil)
+        #expect(c.documentHeight == 120)           // 20 + 100
+    }
+
+    @Test("rowId and rowLayout are index-addressable")
+    func indexAddressing() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50)])
+        #expect(c.rowId(at: 1) == "b")
+        #expect(c.rowLayout(at: 0).height == 100)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
@@ -97,6 +97,114 @@ struct ACPTranscriptTilingControllerTests {
 }
 
 @MainActor
+@Suite("ACPTranscriptTilingController generalized insert/remove")
+struct ACPTranscriptTilingInsertRemoveTests {
+    private func controller() -> ACPTranscriptTilingController {
+        ACPTranscriptTilingController(metrics: .init(rowSpacing: 10, topPadding: 20))
+    }
+
+    @Test("insert at a mid-list index shifts only rows from that index onward")
+    func midListInsertion() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50), ("d", 40), ("e", 30)])
+        // a=20, b=130, d=190, e=240; documentHeight = 270
+        let aMinYBefore = c.row(withId: "a")!.minY
+        let bMinYBefore = c.row(withId: "b")!.minY
+        _ = c.insert(rows: [("c", 80)], at: 2, viewportMinY: 10_000)
+        #expect(c.rowCount == 5)
+        #expect(c.row(withId: "a")?.minY == aMinYBefore)
+        #expect(c.row(withId: "b")?.minY == bMinYBefore)
+        let expectedCMinY: CGFloat = 190
+        #expect(c.row(withId: "c")?.minY == expectedCMinY)
+        let expectedDMinY: CGFloat = 280
+        #expect(c.row(withId: "d")?.minY == expectedDMinY)
+        let expectedDocumentHeight: CGFloat = 360
+        #expect(c.documentHeight == expectedDocumentHeight)
+    }
+
+    @Test("insert compensates when the insertion point is at or above the viewport top")
+    func insertCompensatesAboveViewport() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50)])
+        // a=20..120, b=130..180. Insertion point (b's pre-mutation minY,
+        // 130) exactly meets viewportMinY: half-open convention treats
+        // this as "at or above" (same boundary rule as `updateHeight`).
+        let compensation = c.insert(rows: [("z", 40)], at: 1, viewportMinY: 130)
+        let expectedDelta: CGFloat = 40 + 10
+        #expect(compensation == expectedDelta)
+        let expectedBMinY: CGFloat = 130 + expectedDelta
+        #expect(c.row(withId: "b")?.minY == expectedBMinY)
+    }
+
+    @Test("insert does not compensate when the insertion point is below the viewport top")
+    func insertDoesNotCompensateBelowViewport() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50)])
+        // Insertion point (b's pre-mutation minY, 130) is below viewportMinY 0:
+        // the viewport is scrolled to the very top, above where the insert lands.
+        let compensation = c.insert(rows: [("z", 40)], at: 1, viewportMinY: 0)
+        #expect(compensation == 0)
+    }
+
+    @Test("insert into an empty controller never compensates even at viewportMinY 0")
+    func insertIntoEmptyControllerDoesNotCompensate() {
+        let c = controller()
+        // insertionY and viewportMinY are both 0 here, which the naive rule
+        // would treat as "at or above" — but there was no existing content
+        // to protect, so a first-ever populate must never compensate.
+        let compensation = c.insert(rows: [("a", 100)], at: 0, viewportMinY: 0)
+        #expect(compensation == 0)
+        #expect(c.rowCount == 1)
+        #expect(c.row(withId: "a")?.minY == 20)
+    }
+
+    @Test("remove at a mid-list index shifts only rows after the removed range")
+    func midListRemoval() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50), ("c", 80), ("d", 40)])
+        // a=20, b=130, c=190, d=280; documentHeight=320
+        let aMinYBefore = c.row(withId: "a")!.minY
+        _ = c.remove(at: 1, count: 1, viewportMinY: 10_000)
+        #expect(c.rowCount == 3)
+        #expect(c.row(withId: "b") == nil)
+        #expect(c.row(withId: "a")?.minY == aMinYBefore)
+        let expectedCMinY: CGFloat = 130
+        #expect(c.row(withId: "c")?.minY == expectedCMinY)
+        let expectedDocumentHeight: CGFloat = 260
+        #expect(c.documentHeight == expectedDocumentHeight)
+    }
+
+    @Test("remove compensates negatively when the removal point is at or above the viewport top")
+    func removeCompensatesAboveViewport() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50), ("c", 80)])
+        // a=20..120, b=130..180, c=190..270. Removing "a" (removalY 20) is
+        // well above a viewport scrolled to 190.
+        let compensation = c.remove(at: 0, count: 1, viewportMinY: 190)
+        let expectedDelta: CGFloat = -(100 + 10)
+        #expect(compensation == expectedDelta)
+    }
+
+    @Test("remove does not compensate when the removal point is below the viewport top")
+    func removeDoesNotCompensateBelowViewport() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50), ("c", 80)])
+        // Removing "b" (removalY 130) while the viewport is at the very top.
+        let compensation = c.remove(at: 1, count: 1, viewportMinY: 0)
+        #expect(compensation == 0)
+    }
+
+    @Test("removing every row leaves an empty controller")
+    func removeEverything() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100)])
+        _ = c.remove(at: 0, count: 1, viewportMinY: 0)
+        #expect(c.rowCount == 0)
+        #expect(c.documentHeight == 0)
+    }
+}
+
+@MainActor
 @Suite("ACPTranscriptTilingController height updates")
 struct ACPTranscriptTilingHeightTests {
     private func controller() -> ACPTranscriptTilingController {

--- a/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
@@ -22,6 +22,55 @@ struct ACPTranscriptTilingControllerTests {
         #expect(c.documentHeight == 270)           // 190 + 80
     }
 
+    @Test("firstNonSyntheticRowId walks past a synthetic row at the viewport top")
+    func firstNonSyntheticSkipsLeadingSynthetic() {
+        // The reported case: scrolled to the head of a paginated transcript,
+        // where the pagination spinner is the topmost row. Returning nil
+        // there means no anchor is remembered at all, and restoration later
+        // reads "no anchor" as "go to the bottom".
+        let c = controller()
+        c.replaceAll(rows: [("__top_pagination__", 40), ("m0", 100), ("m1", 100)])
+
+        #expect(c.topVisibleRowId(viewportMinY: 20) == "__top_pagination__")
+        #expect(
+            c.firstNonSyntheticRowId(atOrBelow: 20, syntheticIdPrefix: "__") == "m0"
+        )
+    }
+
+    @Test("firstNonSyntheticRowId returns the row itself when it is not synthetic")
+    func firstNonSyntheticKeepsRealRow() {
+        let c = controller()
+        c.replaceAll(rows: [("__top_pagination__", 40), ("m0", 100), ("m1", 100)])
+
+        // Deep enough to be inside "m1", which is a real row: no scanning.
+        #expect(
+            c.firstNonSyntheticRowId(atOrBelow: 200, syntheticIdPrefix: "__") == "m1"
+        )
+    }
+
+    @Test("firstNonSyntheticRowId returns nil when only synthetic rows remain below")
+    func firstNonSyntheticNilInSyntheticTail() {
+        // Viewport top inside the synthetic tail (queued prompts, composer
+        // spacer): there is no message below to name, so there is genuinely
+        // nothing to remember.
+        let c = controller()
+        c.replaceAll(rows: [("m0", 100), ("__queued__", 60), ("__composer_spacer__", 220)])
+
+        #expect(
+            c.firstNonSyntheticRowId(atOrBelow: 200, syntheticIdPrefix: "__") == nil
+        )
+    }
+
+    @Test("firstNonSyntheticRowId returns nil past the end of the document")
+    func firstNonSyntheticNilPastEnd() {
+        let c = controller()
+        c.replaceAll(rows: [("m0", 100)])
+
+        #expect(
+            c.firstNonSyntheticRowId(atOrBelow: 10_000, syntheticIdPrefix: "__") == nil
+        )
+    }
+
     @Test("empty controller has zero document height")
     func emptyHeight() {
         let c = controller()

--- a/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptTilingControllerTests.swift
@@ -73,4 +73,25 @@ struct ACPTranscriptTilingControllerTests {
         #expect(c.rowId(at: 1) == "b")
         #expect(c.rowLayout(at: 0).height == 100)
     }
+
+    // Note: rebuildIndex()'s duplicate-id tolerance (last occurrence wins)
+    // cannot be covered by an in-process test here. It is guarded by
+    // `assertionFailure`, which traps as a genuine Fatal error under the
+    // Debug configuration this test target always runs in — verified
+    // empirically: a duplicate-id row crashed the entire xctest process
+    // rather than failing a single test. See the fix report for the
+    // reproduction. The test below instead covers the part that IS safely
+    // testable: that the id index only ever reflects current, non-duplicate
+    // rows after a mix of mutations.
+    @Test("index reflects only current rows after truncation and regrowth")
+    func indexRebuildsCleanlyAfterMutations() {
+        let c = controller()
+        c.replaceAll(rows: [("a", 100), ("b", 50), ("c", 80)])
+        c.removeSuffix(from: 1)
+        c.append(rows: [("d", 30)])
+        #expect(c.row(withId: "b") == nil)
+        #expect(c.row(withId: "c") == nil)
+        #expect(c.rowId(at: 1) == "d")
+        #expect(c.row(withId: "d")?.minY == c.rowLayout(at: 1).minY)
+    }
 }


### PR DESCRIPTION
## Why

Scrolling a large ACP transcript is janky despite the render-window pagination: each head step hitches, the content visibly jumps, and the scrollbar thumb resizes and jumps as the window changes.

Root cause: on macOS 26 the SwiftUI `ScrollView` is no longer `NSScrollView`-backed and offers no synchronous authority over the scroll offset. A head step mutates the row window, SwiftUI lays out the taller content, a frame renders with everything shifted, and only then does an async `proxy.scrollTo(anchor:)` re-anchor — which quantizes the fractional scroll position to a row top and kills trackpad momentum. The tail-trim on each step (to hold the 90-row cap) shrinks content height from the bottom, which is the scrollbar churn.

## What

Adds an AppKit-backed transcript scroller behind a feature flag, alongside the untouched legacy path.

- **`ACPTranscriptTilingController`** — pure layout authority: ordered rows, measured heights, cumulative top-down offsets, document height. Height invalidation returns the viewport compensation; binary-search viewport queries; a mount band bounding live views. No AppKit import, fully unit-tested.
- **`ACPTranscriptScrollerView`** — `NSScrollView` + flipped document view. `applyPrepend(delta:newDocumentHeight:)` grows the document and shifts `contentView.bounds.origin.y` in **one pass**, so older messages graft in with zero visible movement and live trackpad momentum survives. This is the primitive the whole change exists for.
- **`ACPTranscriptRowHostingPool`** / **`ACPTranscriptRowSpec`** — pooled `NSHostingView`s keyed by stable id, content-token gated (replacing the legacy `.equatable()` row gating).
- **`ACPTranscriptScrollerReconciler`** — diffs incoming row-spec lists via common-prefix/suffix trimming (`unchanged` / `inserted` / `removed` / `reset`), measures, applies compensation, mounts/unmounts around the viewport, and debounces width-settle resets so a live resize drag doesn't rebuild every row per tick.
- **`ACPTranscriptScroller`** — the `NSViewRepresentable` bridge: builds row specs from the render window and wires tail-follow, pagination, anchor persistence, and the backfill spinner.
- **`ACPTranscript`** gains grow-only window steps (`stepHeadBack(boundTail:)`, `stepTailForward(preserving:boundHead:)`); defaults preserve legacy behavior byte-for-byte.

Window growth replaces tail-trimming, so the scrollbar thumb becomes monotonic instead of resizing on every step. Off-band rows keep their measured heights but are unmounted, so memory stays bounded.

## Flag

`ACPTranscriptScrollerFlag` — on by default in DEBUG, off in release.

```
defaults write io.nlopez.alas alas.transcript.appkitScroller -bool NO   # force legacy
defaults delete io.nlopez.alas alas.transcript.appkitScroller           # back to default
```

The legacy SwiftUI path is untouched and fully selectable; deleting it is a deliberate follow-up once this has survived real use.

## Testing

178 tests across 19 suites, all green. Includes regression tests for the specific defects found in review: the head step between fixed synthetic rows, reset anchor preservation, same-width reset not re-measuring known rows, the fallback re-measure scheduling another pass, and the restore latch waiting for a positive width.

**Manual QA is still outstanding** — an 18-item checklist covers what unit tests structurally cannot reach: flick-scroll momentum across a graft, scrollbar thumb stability, live user-scroll event classification during inertia, post-reset viewport anchoring, resize-while-streaming, live theme switching, queued-bubble drag-reorder, and text selection in per-row hosting views.

## Known follow-ups (tracked, not blocking)

- The width-settle reset still eagerly measures off-band rows, so resizing with a very large render window remains O(window). The cheaper lazy alternative was rejected because it would delete the purpose of the debounce rather than compose with it; a bounded-eager middle ground is the intended fix.
- The AppKit path's render window has no upper bound (both grow-only step variants bypass `maxVisibleRows`), which is what amplifies the above.
- Legacy path deletion, and the tiling controller's now-unused `prepend`/`append`/`removeSuffix`, belong to that same follow-up.
