### PR TITLE
fix(acp): refuse outsized whole-file reads, and order requests by acceptance

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -298,6 +298,27 @@ final class ACPSessionRunner {
                             let target = try remoteServer.lexicallyResolveInsideWorktree(path: params.path)
                             let live = self.onLiveBufferRead?(target)
                             let full = try await remoteServer.read(path: params.path, liveBuffer: live)
+                            // Weaker than the local guard, and deliberately
+                            // so: the remote read fetches the whole file
+                            // regardless of range, so by the time its size is
+                            // known it has already crossed the network.
+                            // Sizing it first would add an `fs/stat` round
+                            // trip to every remote read to catch a rare one.
+                            // Refusing here still spares the JSON encode — a
+                            // second copy — and the undeliverable response
+                            // that would otherwise strand the adapter.
+                            if let refusal = Self.wholeFileReadRefusal(
+                                name: (target as NSString).lastPathComponent,
+                                bytes: full.utf8.count,
+                                line: params.line,
+                                limit: params.limit
+                            ) {
+                                self.connection.client.respondToFileRequest(
+                                    id: id,
+                                    result: .failure(.init(code: -32000, message: refusal, data: nil))
+                                )
+                                continue
+                            }
                             let body = try JSONEncoder().encode(ACPFsReadResult(content: Self.sliceLines(full, line: params.line, limit: params.limit)))
                             self.connection.client.respondToFileRequest(id: id, result: .success(body))
                             continue
@@ -936,13 +957,38 @@ final class ACPSessionRunner {
     /// Sendable outcome of an off-main agent `fs/read_text_file`. Kept minimal
     /// (only value types) so it can cross back to the main actor without an
     /// `@unchecked Sendable` escape hatch.
+    /// Whether a whole-file read should be refused, and what to tell the
+    /// adapter if so.
+    ///
+    /// Shared by the local and remote read paths so the two cannot drift into
+    /// different answers for the same request — they already differ in *when*
+    /// they can apply it, which is enough of a difference to keep in one
+    /// place.
+    ///
+    /// `bytes` being `nil` means the size could not be determined; that is not
+    /// grounds for refusing a read that would otherwise work.
+    nonisolated static func wholeFileReadRefusal(
+        name: String,
+        bytes: Int?,
+        line: Int?,
+        limit: Int?
+    ) -> String? {
+        // A ranged read returns a bounded slice however large the file is,
+        // which is exactly what the adapter is being pointed at below.
+        guard line == nil, limit == nil else { return nil }
+        guard let bytes, bytes > maxWholeFileReadBytes else { return nil }
+        return "\(name) is \(bytes) bytes, over the "
+            + "\(maxWholeFileReadBytes)-byte limit for reading a whole file. "
+            + "Request a range with the line and limit parameters."
+    }
+
     /// Largest file returned in full by `fs/read_text_file`.
     ///
     /// Sized by what a consumer can use rather than by what the machine can
     /// hold: this is already far past any model's context window, so a
     /// response beyond it is waste in both directions. Ranged reads are not
     /// subject to it.
-    static let maxWholeFileReadBytes = 64 * 1024 * 1024
+    nonisolated static let maxWholeFileReadBytes = 64 * 1024 * 1024
 
     enum FileReadOutcome: Sendable {
         case success(Data)
@@ -964,30 +1010,14 @@ final class ACPSessionRunner {
         limit: Int?
     ) async -> FileReadOutcome {
         do {
-            // Refuse a whole-file read that is too large to be worth
-            // returning, before anything is loaded.
-            //
-            // An unbounded `fs/read_text_file` is answered by building the
-            // file, a `String` copy of it and the encoded JSON all at once,
-            // and the result then has to cross the broker socket. Nothing
-            // downstream can use a response that size — it is orders of
-            // magnitude past any model's context — so the honest answer is to
-            // say so while the request can still be retried usefully, rather
-            // than spend the memory and fail late with a transport error.
-            //
-            // Only whole-file reads are refused. A ranged read returns a
-            // bounded slice however large the file is, which is what the
-            // adapter is being pointed at.
-            if line == nil, limit == nil {
-                let bytes = liveBuffer.map { $0.utf8.count }
-                    ?? (try? target.resourceValues(forKeys: [.fileSizeKey]))?.fileSize
-                if let bytes, bytes > Self.maxWholeFileReadBytes {
-                    return .failure(
-                        message: "\(target.lastPathComponent) is \(bytes) bytes, over the "
-                            + "\(Self.maxWholeFileReadBytes)-byte limit for reading a whole file. "
-                            + "Request a range with the line and limit parameters."
-                    )
-                }
+            if let refusal = Self.wholeFileReadRefusal(
+                name: target.lastPathComponent,
+                bytes: liveBuffer.map { $0.utf8.count }
+                    ?? (try? target.resourceValues(forKeys: [.fileSizeKey]))?.fileSize,
+                line: line,
+                limit: limit
+            ) {
+                return .failure(message: refusal)
             }
             let full: String
             if let liveBuffer {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -936,6 +936,14 @@ final class ACPSessionRunner {
     /// Sendable outcome of an off-main agent `fs/read_text_file`. Kept minimal
     /// (only value types) so it can cross back to the main actor without an
     /// `@unchecked Sendable` escape hatch.
+    /// Largest file returned in full by `fs/read_text_file`.
+    ///
+    /// Sized by what a consumer can use rather than by what the machine can
+    /// hold: this is already far past any model's context window, so a
+    /// response beyond it is waste in both directions. Ranged reads are not
+    /// subject to it.
+    static let maxWholeFileReadBytes = 64 * 1024 * 1024
+
     enum FileReadOutcome: Sendable {
         case success(Data)
         case failure(message: String)
@@ -956,6 +964,31 @@ final class ACPSessionRunner {
         limit: Int?
     ) async -> FileReadOutcome {
         do {
+            // Refuse a whole-file read that is too large to be worth
+            // returning, before anything is loaded.
+            //
+            // An unbounded `fs/read_text_file` is answered by building the
+            // file, a `String` copy of it and the encoded JSON all at once,
+            // and the result then has to cross the broker socket. Nothing
+            // downstream can use a response that size — it is orders of
+            // magnitude past any model's context — so the honest answer is to
+            // say so while the request can still be retried usefully, rather
+            // than spend the memory and fail late with a transport error.
+            //
+            // Only whole-file reads are refused. A ranged read returns a
+            // bounded slice however large the file is, which is what the
+            // adapter is being pointed at.
+            if line == nil, limit == nil {
+                let bytes = liveBuffer.map { $0.utf8.count }
+                    ?? (try? target.resourceValues(forKeys: [.fileSizeKey]))?.fileSize
+                if let bytes, bytes > Self.maxWholeFileReadBytes {
+                    return .failure(
+                        message: "\(target.lastPathComponent) is \(bytes) bytes, over the "
+                            + "\(Self.maxWholeFileReadBytes)-byte limit for reading a whole file. "
+                            + "Request a range with the line and limit parameters."
+                    )
+                }
+            }
             let full: String
             if let liveBuffer {
                 full = liveBuffer

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -307,11 +307,10 @@ final class ACPSessionRunner {
                             // Refusing here still spares the JSON encode — a
                             // second copy — and the undeliverable response
                             // that would otherwise strand the adapter.
-                            if let refusal = Self.wholeFileReadRefusal(
+                            let sliced = Self.sliceLines(full, line: params.line, limit: params.limit)
+                            if let refusal = Self.readRefusal(
                                 name: (target as NSString).lastPathComponent,
-                                bytes: full.utf8.count,
-                                line: params.line,
-                                limit: params.limit
+                                bytes: sliced.utf8.count
                             ) {
                                 self.connection.client.respondToFileRequest(
                                     id: id,
@@ -319,7 +318,7 @@ final class ACPSessionRunner {
                                 )
                                 continue
                             }
-                            let body = try JSONEncoder().encode(ACPFsReadResult(content: Self.sliceLines(full, line: params.line, limit: params.limit)))
+                            let body = try JSONEncoder().encode(ACPFsReadResult(content: sliced))
                             self.connection.client.respondToFileRequest(id: id, result: .success(body))
                             continue
                         }
@@ -957,29 +956,28 @@ final class ACPSessionRunner {
     /// Sendable outcome of an off-main agent `fs/read_text_file`. Kept minimal
     /// (only value types) so it can cross back to the main actor without an
     /// `@unchecked Sendable` escape hatch.
-    /// Whether a whole-file read should be refused, and what to tell the
+    /// Whether a read result is too large to return, and what to tell the
     /// adapter if so.
     ///
-    /// Shared by the local and remote read paths so the two cannot drift into
-    /// different answers for the same request — they already differ in *when*
-    /// they can apply it, which is enough of a difference to keep in one
-    /// place.
+    /// Judged on the bytes actually being returned. An earlier version asked
+    /// instead whether a range had been requested, which a caller could
+    /// satisfy without bounding anything: `sliceLines` runs to end of file
+    /// unless `limit` is present *and positive*, so `line: 1` alone — or
+    /// `limit: 0` — asks for the whole file while looking like a range.
     ///
-    /// `bytes` being `nil` means the size could not be determined; that is not
-    /// grounds for refusing a read that would otherwise work.
-    nonisolated static func wholeFileReadRefusal(
-        name: String,
-        bytes: Int?,
-        line: Int?,
-        limit: Int?
-    ) -> String? {
-        // A ranged read returns a bounded slice however large the file is,
-        // which is exactly what the adapter is being pointed at below.
-        guard line == nil, limit == nil else { return nil }
-        guard let bytes, bytes > maxWholeFileReadBytes else { return nil }
+    /// Shared by the local and remote read paths so the two cannot drift into
+    /// different answers for the same request.
+    nonisolated static func readRefusal(name: String, bytes: Int) -> String? {
+        guard bytes > maxWholeFileReadBytes else { return nil }
         return "\(name) is \(bytes) bytes, over the "
-            + "\(maxWholeFileReadBytes)-byte limit for reading a whole file. "
-            + "Request a range with the line and limit parameters."
+            + "\(maxWholeFileReadBytes)-byte limit for a single read. "
+            + "Request a smaller range with the line and limit parameters."
+    }
+
+    /// Whether a request bounds its own result. Only a positive `limit` does;
+    /// see `readRefusal`.
+    nonisolated static func requestIsBounded(limit: Int?) -> Bool {
+        (limit ?? 0) > 0
     }
 
     /// Largest file returned in full by `fs/read_text_file`.
@@ -1010,14 +1008,18 @@ final class ACPSessionRunner {
         limit: Int?
     ) async -> FileReadOutcome {
         do {
-            if let refusal = Self.wholeFileReadRefusal(
-                name: target.lastPathComponent,
-                bytes: liveBuffer.map { $0.utf8.count }
-                    ?? (try? target.resourceValues(forKeys: [.fileSizeKey]))?.fileSize,
-                line: line,
-                limit: limit
-            ) {
-                return .failure(message: refusal)
+            // Cheap first pass: a request that does not bound its own result
+            // cannot return less than the source, so an oversized source can
+            // be refused without reading it.
+            if !Self.requestIsBounded(limit: limit) {
+                let sourceBytes = liveBuffer.map { $0.utf8.count }
+                    ?? (try? target.resourceValues(forKeys: [.fileSizeKey]))?.fileSize
+                if let sourceBytes,
+                   let refusal = Self.readRefusal(
+                       name: target.lastPathComponent, bytes: sourceBytes
+                   ) {
+                    return .failure(message: refusal)
+                }
             }
             let full: String
             if let liveBuffer {
@@ -1027,6 +1029,13 @@ final class ACPSessionRunner {
                 full = String(data: data, encoding: .utf8) ?? ""
             }
             let sliced = sliceLines(full, line: line, limit: limit)
+            // Authoritative: whatever was asked for, this is what would be
+            // returned, and a generous `limit` can still ask for everything.
+            if let refusal = Self.readRefusal(
+                name: target.lastPathComponent, bytes: sliced.utf8.count
+            ) {
+                return .failure(message: refusal)
+            }
             let body = try JSONEncoder().encode(ACPFsReadResult(content: sliced))
             return .success(body)
         } catch {

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1053,6 +1053,12 @@ struct OrderState {
 
 #[cfg(unix)]
 impl OrderState {
+    /// The earliest moment a pending reservation stops holding its place, if
+    /// any is outstanding. What a waiter has to wake for.
+    fn soonest_deadline(&self) -> Option<std::time::Instant> {
+        self.pending.values().min().copied()
+    }
+
     /// Steps `serving` past every place that no longer has a claim on it:
     /// abandoned connections, and reservations whose grace has run out.
     fn advance(&mut self) {
@@ -1112,12 +1118,20 @@ impl Reservation {
             .state
             .lock()
             .unwrap_or_else(|error| error.into_inner());
+        // Forfeiture is decided by the deadline, not by whether another
+        // thread has got round to advancing `serving` yet. Reading it off
+        // `serving` made the answer depend on scheduling: a request claiming
+        // just after its grace expired kept its place if nobody had woken to
+        // notice, and lost it if someone had.
+        let expired = state
+            .pending
+            .get(&self.ticket)
+            .is_none_or(|deadline| std::time::Instant::now() >= *deadline);
         state.pending.remove(&self.ticket);
-        // If the grace ran out while this was still arriving, the place has
-        // already been given to whoever was behind it. Rejoin at the back
-        // rather than wait for a turn that will never come round again —
-        // waiting on a forfeited ticket is a deadlock, not a delay.
-        let ticket = if state.serving > self.ticket {
+        // A place that has been given up cannot be waited for — it will not
+        // come round again, so waiting on it is a deadlock rather than a
+        // delay. Rejoin at the back instead.
+        let ticket = if expired || state.serving > self.ticket {
             let ticket = state.next;
             state.next += 1;
             ticket
@@ -1133,9 +1147,19 @@ impl Reservation {
             }
             // Timed, because the head may be a reservation that has to be
             // waited out rather than woken: nothing signals a grace expiring.
+            // Wait only as long as the soonest one actually has left, or a
+            // waiter arriving late in a grace period sleeps a whole fresh one
+            // past it — turning a 5s bound into nearly 10s.
+            let wait = state
+                .soonest_deadline()
+                .map_or(RESERVATION_GRACE, |deadline| {
+                    deadline
+                        .saturating_duration_since(std::time::Instant::now())
+                        .max(Duration::from_millis(1))
+                });
             let (guard, _) = order
                 .turn
-                .wait_timeout(state, RESERVATION_GRACE)
+                .wait_timeout(state, wait)
                 .unwrap_or_else(|error| error.into_inner());
             state = guard;
         }
@@ -2651,6 +2675,83 @@ mod tests {
 
         let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
         assert_eq!(*observed, vec!["first", "second"]);
+    }
+
+    /// Forfeiture must follow the deadline, not whichever thread happened to
+    /// run first. Deciding it from `serving` meant a request claiming just
+    /// after its grace expired kept its place when nobody had yet woken to
+    /// notice, and lost it when someone had — the same request, two answers,
+    /// depending on the scheduler.
+    #[cfg(unix)]
+    #[test]
+    fn forfeiture_follows_the_deadline_not_the_scheduler() {
+        let order = Arc::new(RequestOrder::default());
+        let stale = order.reserve();
+
+        // Let its grace lapse with nobody waiting, so nothing has advanced
+        // `serving` past it.
+        std::thread::sleep(RESERVATION_GRACE + Duration::from_millis(200));
+
+        // Reserved after the lapse, so this one still holds a live place.
+        let fresh = order.reserve();
+        {
+            let state = order.state.lock().expect("state");
+            assert_eq!(
+                state.serving, 0,
+                "nothing should have advanced the queue while no one was waiting"
+            );
+        }
+
+        // The stale one now arrives. Its place is gone by the clock, so it
+        // must go behind the request that was still holding a live place.
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let watcher = {
+            let observed = Arc::clone(&observed);
+            std::thread::spawn(move || {
+                let _turn = stale.claim();
+                observed
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .push("stale");
+            })
+        };
+        std::thread::sleep(Duration::from_millis(200));
+        {
+            let _turn = fresh.claim();
+            observed
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push("fresh");
+        }
+        watcher.join().expect("stale worker");
+
+        let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
+        assert_eq!(*observed, vec!["fresh", "stale"]);
+    }
+
+    /// A waiter must wake when the place ahead of it actually expires, not a
+    /// full grace later. Waiting a fresh interval each time turns a five
+    /// second bound into nearly ten for anything that arrives late in one.
+    #[cfg(unix)]
+    #[test]
+    fn a_waiter_wakes_when_the_place_ahead_expires_not_a_grace_later() {
+        let order = Arc::new(RequestOrder::default());
+        let abandoned = order.reserve();
+        let waiting = order.reserve();
+
+        // Arrive most of the way through the grace ahead of us.
+        std::thread::sleep(RESERVATION_GRACE.mul_f64(0.8));
+        let started = std::time::Instant::now();
+        {
+            let _turn = waiting.claim();
+        }
+        let waited = started.elapsed();
+        drop(abandoned);
+
+        assert!(
+            waited < RESERVATION_GRACE.mul_f64(0.6),
+            "waited past the deadline ahead of it: {waited:?}"
+        );
     }
 
     /// A request that arrives after its grace has run out must still be

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -969,12 +969,12 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
                 continue;
             }
             let request_runtime = runtime.clone();
-            let request_order = Arc::clone(&order);
+            let request_reservation = order.reserve();
             let request_inflight = Arc::clone(&inflight);
             request_inflight.fetch_add(1, Ordering::AcqRel);
             if std::thread::Builder::new()
                 .spawn(move || {
-                    let _ = handle_connection(request_runtime, stream, request_order);
+                    let _ = handle_connection(request_runtime, stream, request_reservation);
                     request_inflight.fetch_sub(1, Ordering::AcqRel);
                 })
                 .is_err()
@@ -1005,8 +1005,9 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
     }
 }
 
-/// Hands out turns so requests are dispatched in the order they finished
-/// arriving, rather than in whatever order the scheduler wakes their threads.
+/// Hands out turns so requests reach the broker in the order they were
+/// accepted, rather than in whatever order their threads happen to finish
+/// reading or the scheduler happens to wake them.
 ///
 /// One helper already orders its own calls per broker, but a broker outlives
 /// the app that started it and more than one helper can adopt the same one —
@@ -1015,55 +1016,172 @@ fn serve_broker_ipc(runtime: Runtime, dir: PathBuf) -> Result<(), AcpBrokerProce
 /// applied before the `session/prompt` it was sent to stop, the same silent
 /// failure the helper's queue prevents within one process.
 ///
-/// The turn is taken once a request has finished arriving, not at accept.
-/// Ordering by acceptance would mean holding it across a read allowed to take
-/// minutes for a legacy sender still encoding, letting one slow caller stall
-/// every other client of the broker — reintroducing at the supervisor exactly
-/// what moving dispatch off the serve loop removed at the helper.
+/// A place is reserved at accept and held only for `RESERVATION_GRACE`. That
+/// split is the whole design. Ordering purely by acceptance would mean holding
+/// a place across a read allowed to take minutes for a legacy sender still
+/// encoding, letting one slow caller stall every other client of the broker —
+/// reintroducing at the supervisor exactly what moving dispatch off the serve
+/// loop removed at the helper. Ordering purely by arrival lets a small
+/// `session/cancel` overtake the large `session/prompt` that was sent first,
+/// which is the bug. A request that arrives promptly — a maximal prompt
+/// crosses this socket in ~0.2s — keeps the place it was accepted in; one that
+/// dawdles forfeits it and is ordered by arrival instead.
 #[cfg(unix)]
 #[derive(Default)]
 struct RequestOrder {
-    state: Mutex<(u64, u64)>,
+    state: Mutex<OrderState>,
     turn: Condvar,
 }
 
+/// How long a reserved place is held for a request that has not arrived yet.
+/// Far above what any request needs to cross the socket, far below the minutes
+/// a legacy sender may spend encoding before it writes anything.
 #[cfg(unix)]
-impl RequestOrder {
-    /// Claims the next place in line and waits for it. The returned guard
-    /// advances the queue on drop, including on panic — otherwise one failed
-    /// handler would stall every later request for this broker for good.
-    fn take_turn(&self) -> RequestTurn<'_> {
-        let ticket = {
-            let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-            let ticket = state.0;
-            state.0 += 1;
-            ticket
-        };
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        while state.1 != ticket {
-            state = self
-                .turn
-                .wait(state)
-                .unwrap_or_else(|error| error.into_inner());
+const RESERVATION_GRACE: Duration = Duration::from_secs(5);
+
+#[cfg(unix)]
+#[derive(Default)]
+struct OrderState {
+    next: u64,
+    serving: u64,
+    /// Accepted but not yet arrived, with the instant each stops holding its
+    /// place.
+    pending: std::collections::BTreeMap<u64, std::time::Instant>,
+    /// Arrived and waiting to run.
+    ready: std::collections::BTreeSet<u64>,
+}
+
+#[cfg(unix)]
+impl OrderState {
+    /// Steps `serving` past every place that no longer has a claim on it:
+    /// abandoned connections, and reservations whose grace has run out.
+    fn advance(&mut self) {
+        while self.serving < self.next {
+            if self.ready.contains(&self.serving) {
+                // Arrived and waiting — it runs next, so the queue stops here.
+                break;
+            }
+            match self.pending.get(&self.serving) {
+                Some(deadline) if std::time::Instant::now() < *deadline => break,
+                Some(_) => {
+                    self.pending.remove(&self.serving);
+                    self.serving += 1;
+                }
+                // Neither pending nor ready: the connection went away.
+                None => self.serving += 1,
+            }
         }
-        RequestTurn { order: self }
     }
 }
 
 #[cfg(unix)]
-struct RequestTurn<'a> {
-    order: &'a RequestOrder,
+impl RequestOrder {
+    /// Takes a place in line for a connection that has just been accepted.
+    fn reserve(self: &Arc<Self>) -> Reservation {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        let ticket = state.next;
+        state.next += 1;
+        state
+            .pending
+            .insert(ticket, std::time::Instant::now() + RESERVATION_GRACE);
+        Reservation {
+            order: Arc::clone(self),
+            ticket,
+            claimed: false,
+        }
+    }
+}
+
+/// A place held for a request that has not arrived yet.
+#[cfg(unix)]
+struct Reservation {
+    order: Arc<RequestOrder>,
+    ticket: u64,
+    claimed: bool,
 }
 
 #[cfg(unix)]
-impl Drop for RequestTurn<'_> {
+impl Reservation {
+    /// The request has arrived. Waits for this place to come up and returns a
+    /// guard that advances the queue when the request is done — on drop, so a
+    /// panicking handler cannot stall every later request for this broker.
+    fn claim(mut self) -> RequestTurn {
+        self.claimed = true;
+        let order = Arc::clone(&self.order);
+        let mut state = order
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        state.pending.remove(&self.ticket);
+        // If the grace ran out while this was still arriving, the place has
+        // already been given to whoever was behind it. Rejoin at the back
+        // rather than wait for a turn that will never come round again —
+        // waiting on a forfeited ticket is a deadlock, not a delay.
+        let ticket = if state.serving > self.ticket {
+            let ticket = state.next;
+            state.next += 1;
+            ticket
+        } else {
+            self.ticket
+        };
+        state.ready.insert(ticket);
+        loop {
+            state.advance();
+            if state.serving == ticket {
+                drop(state);
+                return RequestTurn { order, ticket };
+            }
+            // Timed, because the head may be a reservation that has to be
+            // waited out rather than woken: nothing signals a grace expiring.
+            let (guard, _) = order
+                .turn
+                .wait_timeout(state, RESERVATION_GRACE)
+                .unwrap_or_else(|error| error.into_inner());
+            state = guard;
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        if self.claimed {
+            return;
+        }
+        // The request never arrived — a failed read, or a peer that hung up.
+        // Give the place back now rather than making everyone behind it wait
+        // out a grace period for a connection that is already gone.
+        let mut state = self
+            .order
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        state.pending.remove(&self.ticket);
+        state.ready.remove(&self.ticket);
+        state.advance();
+        self.order.turn.notify_all();
+    }
+}
+
+#[cfg(unix)]
+struct RequestTurn {
+    order: Arc<RequestOrder>,
+    ticket: u64,
+}
+
+#[cfg(unix)]
+impl Drop for RequestTurn {
     fn drop(&mut self) {
         let mut state = self
             .order
             .state
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        state.1 += 1;
+        state.ready.remove(&self.ticket);
+        if state.serving == self.ticket {
+            state.serving += 1;
+        }
+        state.advance();
         self.order.turn.notify_all();
     }
 }
@@ -1075,15 +1193,16 @@ impl Drop for RequestTurn<'_> {
 fn handle_connection(
     runtime: Runtime,
     stream: UnixStream,
-    order: Arc<RequestOrder>,
+    reservation: Reservation,
 ) -> io::Result<()> {
+    // The reservation was taken in the accept loop, so the place reflects
+    // when this connection was accepted rather than when its thread happened
+    // to start — see `RequestOrder`.
     let (line, _framing) = {
         let mut reader = ipc_reader(&stream)?;
         read_ipc_message(&mut reader, IPC_REQUEST_HEAD_BUDGET, framed_body_budget)?
     };
-    // Ticketed here, not before the read: a caller allowed minutes to finish
-    // arriving must not hold the turn of one that already has.
-    let _turn = order.take_turn();
+    let _turn = reservation.claim();
     handle_ipc_line(runtime, stream, line)
 }
 
@@ -2488,46 +2607,115 @@ mod tests {
         );
     }
 
-    /// Turns are handed out in the order they are claimed, not in whatever
-    /// order the scheduler wakes the waiters. A mutex would satisfy the
-    /// mutual-exclusion half of this and still let a `session/cancel` overtake
-    /// the `session/prompt` it was sent to stop.
+    /// A request keeps the place it was accepted in, even when a later one
+    /// finishes arriving first.
     ///
-    /// Each worker holds its turn for a spell that *shrinks* with its ticket,
-    /// so the two behaviours produce different answers: granted in order, the
-    /// holds are serial and the record comes out ascending; granted freely,
-    /// they overlap and the shortest holds finish first.
+    /// This is the `session/cancel` overtaking `session/prompt` case: the
+    /// prompt is large and slower to cross the socket, the cancel is tiny.
+    /// Ordering by arrival applies the cancel to a turn that has not started,
+    /// after which the prompt runs uncancelled and the user believes they
+    /// stopped it.
     #[cfg(unix)]
     #[test]
-    fn request_turns_are_granted_in_the_order_they_are_claimed() {
-        const WORKERS: u64 = 8;
+    fn an_earlier_accepted_request_runs_first_even_if_it_arrives_second() {
         let order = Arc::new(RequestOrder::default());
         let observed = Arc::new(Mutex::new(Vec::new()));
 
-        // Held so every worker is queued behind it before any can proceed.
-        let first = order.take_turn();
-        let mut workers = Vec::new();
-        for index in 0..WORKERS {
-            let order = Arc::clone(&order);
+        // Accepted first: the slow, large one.
+        let first = order.reserve();
+        // Accepted second: the small one that will arrive well before it.
+        let second = order.reserve();
+
+        let quick = {
             let observed = Arc::clone(&observed);
-            workers.push(std::thread::spawn(move || {
-                let _turn = order.take_turn();
-                std::thread::sleep(Duration::from_millis(30 * (WORKERS - index)));
+            std::thread::spawn(move || {
+                let _turn = second.claim();
                 observed
                     .lock()
                     .unwrap_or_else(|error| error.into_inner())
-                    .push(index);
-            }));
-            // Sequences the claims only; it does not sequence the grants.
-            std::thread::sleep(Duration::from_millis(20));
+                    .push("second");
+            })
+        };
+
+        // Long enough that the second request is unambiguously waiting, and
+        // well inside the grace the first one is holding.
+        std::thread::sleep(Duration::from_millis(300));
+        {
+            let _turn = first.claim();
+            observed
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push("first");
         }
-        drop(first);
-        for worker in workers {
-            worker.join().expect("worker");
-        }
+        quick.join().expect("second worker");
 
         let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
-        assert_eq!(*observed, (0..WORKERS).collect::<Vec<_>>());
+        assert_eq!(*observed, vec!["first", "second"]);
+    }
+
+    /// A request that arrives after its grace has run out must still be
+    /// served. Its place is gone by then, so it rejoins at the back — waiting
+    /// for a turn that has already passed is a deadlock, and a legacy sender
+    /// allowed minutes to encode reaches exactly this path.
+    #[cfg(unix)]
+    #[test]
+    fn a_request_arriving_after_its_grace_still_gets_a_turn() {
+        let order = Arc::new(RequestOrder::default());
+        let slow = order.reserve();
+
+        // Someone accepted later goes ahead once the grace lapses.
+        let next = order.reserve();
+        {
+            let _turn = next.claim();
+        }
+
+        // The slow one now arrives, long past its place. It must run, not hang.
+        let started = std::time::Instant::now();
+        let ran = std::thread::spawn(move || {
+            let _turn = slow.claim();
+        });
+        // Generous: the point is that it finishes at all.
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        while !ran.is_finished() && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            ran.is_finished(),
+            "a request that outlived its reservation never got a turn after {:?}",
+            started.elapsed()
+        );
+        ran.join().expect("slow worker");
+    }
+
+    /// A reserved place is held only for a grace period, so a caller that
+    /// never delivers cannot stall everyone accepted after it. That bound is
+    /// what makes reserving at accept affordable at all: a legacy sender is
+    /// allowed minutes to encode before it writes, and nobody can be made to
+    /// wait that out.
+    #[cfg(unix)]
+    #[test]
+    fn a_reservation_that_never_arrives_stops_holding_its_place() {
+        let order = Arc::new(RequestOrder::default());
+        let abandoned = order.reserve();
+        let next = order.reserve();
+
+        // Never claimed, and deliberately not dropped either — this stands in
+        // for a connection still being read from, not one that went away.
+        let started = std::time::Instant::now();
+        {
+            let _turn = next.claim();
+        }
+        let waited = started.elapsed();
+        drop(abandoned);
+
+        assert!(
+            waited >= RESERVATION_GRACE,
+            "the place should be held for its grace: {waited:?}"
+        );
+        assert!(
+            waited < RESERVATION_GRACE * 3,
+            "the place should be forfeited once grace passes, not held on: {waited:?}"
+        );
     }
 
     /// A peer that drains a reply slowly must not be able to hold its handler

--- a/AlasHelper/src/acp_broker_process.rs
+++ b/AlasHelper/src/acp_broker_process.rs
@@ -1049,14 +1049,25 @@ struct OrderState {
     pending: std::collections::BTreeMap<u64, std::time::Instant>,
     /// Arrived and waiting to run.
     ready: std::collections::BTreeSet<u64>,
+    /// How many times a waiter has gone back round the loop. Only read by
+    /// tests, where it is the difference between waiting and spinning.
+    wakeups: u64,
 }
 
 #[cfg(unix)]
 impl OrderState {
-    /// The earliest moment a pending reservation stops holding its place, if
-    /// any is outstanding. What a waiter has to wake for.
-    fn soonest_deadline(&self) -> Option<std::time::Instant> {
-        self.pending.values().min().copied()
+    /// When the queue could next move on its own, if it can.
+    ///
+    /// Only the reservation at the head has a deadline worth waking for:
+    /// nothing behind it can advance anything, and a head that has already
+    /// arrived is released by its turn dropping, which notifies. Taking the
+    /// earliest deadline anywhere instead meant one expired reservation
+    /// sitting behind a running request handed every waiter a deadline
+    /// already in the past — so they woke, took the mutex, found `serving`
+    /// unchanged, and did it again a millisecond later, for as long as the
+    /// request took.
+    fn head_deadline(&self) -> Option<std::time::Instant> {
+        self.pending.get(&self.serving).copied()
     }
 
     /// Steps `serving` past every place that no longer has a claim on it:
@@ -1150,13 +1161,14 @@ impl Reservation {
             // Wait only as long as the soonest one actually has left, or a
             // waiter arriving late in a grace period sleeps a whole fresh one
             // past it — turning a 5s bound into nearly 10s.
-            let wait = state
-                .soonest_deadline()
-                .map_or(RESERVATION_GRACE, |deadline| {
-                    deadline
-                        .saturating_duration_since(std::time::Instant::now())
-                        .max(Duration::from_millis(1))
-                });
+            // A head that has arrived is woken by its turn dropping, so the
+            // timeout is only a backstop against a missed notification.
+            let wait = state.head_deadline().map_or(RESERVATION_GRACE, |deadline| {
+                deadline
+                    .saturating_duration_since(std::time::Instant::now())
+                    .max(Duration::from_millis(1))
+            });
+            state.wakeups += 1;
             let (guard, _) = order
                 .turn
                 .wait_timeout(state, wait)
@@ -2727,6 +2739,50 @@ mod tests {
 
         let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
         assert_eq!(*observed, vec!["fresh", "stale"]);
+    }
+
+    /// A waiter behind a running request must sleep, not spin.
+    ///
+    /// Waking for the earliest deadline anywhere meant an expired reservation
+    /// sitting behind a running request handed every waiter a deadline already
+    /// in the past. They woke on the one-millisecond floor, took the mutex,
+    /// found `serving` unchanged and went round again — for as long as the
+    /// request ran, across as many threads as were waiting.
+    #[cfg(unix)]
+    #[test]
+    fn a_waiter_behind_a_running_request_does_not_spin() {
+        let order = Arc::new(RequestOrder::default());
+        let running = order.reserve().claim();
+        // Sits behind the running request and lapses while it works.
+        let _stalled = order.reserve();
+        let queued = order.reserve();
+
+        let waiter = std::thread::spawn(move || {
+            let _turn = queued.claim();
+        });
+
+        // Let the reservation behind the head expire.
+        std::thread::sleep(RESERVATION_GRACE + Duration::from_millis(200));
+        let before = {
+            let state = order.state.lock().expect("state");
+            state.wakeups
+        };
+        // A window in which nothing can legitimately move: the head is still
+        // running, so any wakeup here is wasted work.
+        std::thread::sleep(Duration::from_millis(600));
+        let after = {
+            let state = order.state.lock().expect("state");
+            state.wakeups
+        };
+
+        drop(running);
+        waiter.join().expect("waiter");
+
+        assert!(
+            after - before <= 2,
+            "waiter spun {} times while the head was running",
+            after - before
+        );
     }
 
     /// A waiter must wake when the place ahead of it actually expires, not a

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -2452,6 +2452,31 @@ struct ACPSessionRunnerTests {
         #expect(decoded.content == "two\nthree")
     }
 
+    @Test("serveRead refuses an unbounded range that would return the whole file")
+    func serveReadRefusesRangeThatDoesNotBound() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sr-\(UUID())")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("huge.txt")
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: file)
+        try handle.truncate(atOffset: UInt64(ACPSessionRunner.maxWholeFileReadBytes) + 1)
+        try handle.close()
+
+        // `sliceLines` runs to end of file unless `limit` is present and
+        // positive, so each of these asks for the whole file while looking
+        // like a range. Exempting them was a limit anyone could step around.
+        for (line, limit) in [(1, nil as Int?), (nil, 0), (2, -1)] {
+            let outcome = await ACPSessionRunner.serveRead(
+                target: file, liveBuffer: nil, line: line, limit: limit
+            )
+            guard case .failure = outcome else {
+                Issue.record("line: \(String(describing: line)), limit: \(String(describing: limit)) should be refused")
+                return
+            }
+        }
+    }
+
     @Test("serveRead refuses a whole-file read past the limit and names the way out")
     func serveReadRefusesOversizedWholeFileRead() async throws {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sr-\(UUID())")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -2452,6 +2452,52 @@ struct ACPSessionRunnerTests {
         #expect(decoded.content == "two\nthree")
     }
 
+    @Test("serveRead refuses a whole-file read past the limit and names the way out")
+    func serveReadRefusesOversizedWholeFileRead() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sr-\(UUID())")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("huge.txt")
+        // Sparse, so this costs no disk and nothing is ever read: the point is
+        // that the refusal happens on the reported size alone.
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: file)
+        try handle.truncate(atOffset: UInt64(ACPSessionRunner.maxWholeFileReadBytes) + 1)
+        try handle.close()
+
+        let outcome = await ACPSessionRunner.serveRead(
+            target: file, liveBuffer: nil, line: nil, limit: nil
+        )
+        guard case .failure(let message) = outcome else {
+            Issue.record("expected an oversized whole-file read to be refused")
+            return
+        }
+        // The adapter has to be able to act on this, not merely see it fail.
+        #expect(message.contains("line"))
+        #expect(message.contains("limit"))
+    }
+
+    @Test("serveRead still serves a ranged read of a file past the whole-file limit")
+    func serveReadAllowsRangedReadOfLargeFile() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sr-\(UUID())")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("ranged.txt")
+        try "alpha\nbeta\ngamma".write(to: file, atomically: true, encoding: .utf8)
+
+        // The limit must not leak into ranged reads, which return a bounded
+        // slice however large the file is.
+        let outcome = await ACPSessionRunner.serveRead(
+            target: file, liveBuffer: nil, line: 2, limit: 1
+        )
+        guard case .success(let body) = outcome else {
+            Issue.record("expected a ranged read to succeed")
+            return
+        }
+        let decoded = try JSONDecoder().decode(ACPFsReadResult.self, from: body)
+        #expect(decoded.content == "beta")
+    }
+
     @Test("serveRead prefers the live buffer snapshot over disk")
     func serveReadPrefersLiveBuffer() async throws {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sr-\(UUID())")


### PR DESCRIPTION
The two follow-ups flagged on #942 and left open for a decision.

## Whole-file reads

An unbounded `fs/read_text_file` is answered by `ACPSessionRunner.serveRead` building the file, a `String` copy of it and the encoded JSON all at once, and the result then has to cross the broker socket. Nothing downstream can use a response that size — it is orders of magnitude past any model's context — so it is spent memory followed by a late transport error.

A whole-file read past 64 MiB is now refused before anything is loaded, with a message naming `line` and `limit` so the adapter can retry usefully. The limit is sized by what a consumer can use rather than by what the machine can hold.

**Ranged reads are untouched.** They return a bounded slice however large the file is, which is exactly what the adapter is being pointed at, and `serveReadAllowsRangedReadOfLargeFile` pins it — letting the limit leak into ranged reads is the obvious way to get this wrong.

## Request ordering

#942 ordered requests by which finished *arriving* first. That still lets a small `session/cancel` overtake the large `session/prompt` it was sent to stop — the bug that motivated ordering, surviving in the one case that matters, since the prompt is the slow one.

A place is now reserved at **accept** and held for a 5s grace. A request that arrives promptly keeps the place it was accepted in; one that dawdles forfeits it and is ordered by arrival. The grace is what makes reserving at accept affordable at all: ordering purely by acceptance means holding a place across a read allowed to take minutes for a legacy sender still encoding, which would let one slow caller stall every other client of the broker — reintroducing at the supervisor what moving dispatch off the serve loop removed at the helper.

A maximal prompt crosses this socket in ~0.2s, so the case this is for stays comfortably inside the grace.

## Verification

Every test checked against the unfixed code, since a passing test proves nothing on its own:

- `serveReadRefusesOversizedWholeFileRead` — fails without the guard.
- `an_earlier_accepted_request_runs_first_even_if_it_arrives_second` — the ordering case above.
- `a_request_arriving_after_its_grace_still_gets_a_turn` — **found a deadlock in my first version.** A request whose grace expired and then arrived waited for a place that had already come round, and hung forever; a slow legacy sender lands exactly there. It now rejoins at the back, and without that the test reports `never got a turn after 20s`.
- `a_reservation_that_never_arrives_stops_holding_its_place` — the grace bound itself.

Rust: 105 tests, repeated runs green, `cargo fmt` clean, clippy unchanged from baseline, `cargo check --target aarch64-unknown-linux-musl --all-targets` clean.
Swift: `build-for-testing` succeeds; `ACPSessionRunnerTests` + `ACPBrokerClientTests` = 105 tests passed.