### PR TITLE
fix(changes): stale GG land eligibility

### DIFF
--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -828,7 +828,9 @@ final class RightPaneState: GGSplitCommitServicing {
             if self.commits != commits { self.commits = commits }
             self.ggStackSourceCommits = reviewLoopBaseResult?.commits ?? commits
             ggStackRefreshTask?.cancel()
-            ggStackRefreshTask = Task { @MainActor [weak self] in await self?.refreshGGStack() }
+            ggStackRefreshTask = Task { @MainActor [weak self] in
+                await self?.refreshGGStack(forceRemote: forceReviewLoopRemote)
+            }
             if self.comparisonRef != ref { self.comparisonRef = ref }
             let preferredCommitRemoteRef = ref ?? baseBranch
             let commitRemote = CodeHostRemoteDetector.detect(
@@ -922,7 +924,7 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     @MainActor
-    func refreshGGStack() async {
+    func refreshGGStack(forceRemote: Bool = false) async {
         let snapshotGeneration = snapshotInvalidationGeneration
         ggStackRefreshGeneration &+= 1
         let refreshGeneration = ggStackRefreshGeneration
@@ -943,16 +945,15 @@ final class RightPaneState: GGSplitCommitServicing {
             return
         }
         ggEffectiveConfig = GGConfigReader.effectiveConfig(repoPath: worktree.path.path)
-        // `gg ls --json` reaches out to gh/glab for PR state — skip when
-        // the branch and commit set are unchanged since the last query. PR-
-        // state churn from the outside world refreshes on the next commits
-        // change (a manual-refresh hook can come with the phase-2 drawer).
+        // `gg ls --json` reaches out to gh/glab for PR state — skip watcher-
+        // driven refreshes when the branch and commit set are unchanged.
+        // Explicit remote refreshes must still pick up approval and CI changes.
         // The branch is part of the key because `gg ls` answers for the
         // *current* branch — a checkout to a different branch that happens
         // to share the same commits (e.g. right after `git checkout -b`)
         // must not reuse the old branch's cached stack.
         let key = currentGGStackCommitsKey
-        guard key != ggStackCommitsKey else {
+        guard forceRemote || key != ggStackCommitsKey else {
             await reconcileGGUndoCandidateIfNeeded()
             return
         }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -195,7 +195,7 @@ struct RightPaneView: View {
                 comparisonMode: state.config.changes.comparisonMode
             )
             rps = activated
-            await activated.refresh()
+            await activated.refresh(forceReviewLoopRemote: true)
         }
         // When the right pane is hidden or unmounted (no worktree selected),
         // stop the active state's filesystem watcher and 5-min sync timer

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -643,6 +643,21 @@ struct RightPaneGGStackTests {
         #expect(runner.callCount == 1)
     }
 
+    @Test func forcedRemoteRefreshReloadsUnchangedStack() async {
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "r", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        await state.refreshGGStack(forceRemote: true)
+
+        #expect(runner.callCount == 2)
+    }
+
     @Test func unchangedStackKeyReconcilesUndoAgainstExternalLaterOperation() async throws {
         let wt = makeWorktree()
         try FileManager.default.createDirectory(


### PR DESCRIPTION
## Summary
- Force explicit right-pane refreshes to reload GG remote PR state.
- Keep watcher-driven GG stack refreshes deduped when branch and commits are unchanged.
- Add regression coverage for forced reloads on unchanged stacks.

## Root cause
Land eligibility used cached `gg ls --json` data keyed only by branch and local commits, so remote-only approval or CI changes could leave Land actions disabled until a local commit changed the stack.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` ran 7,256 tests; failed only in existing `DiffReviewSurfaceTests.aggregateBudgetDeferralHidesTextDiffUntilReviewerRequestsIt()` UI/accessibility assertions. The new `RightPaneGGStackTests.forcedRemoteRefreshReloadsUnchangedStack()` passed.