### PR TITLE
fix(commit): cap expanded commit details

### DIFF
--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -17,6 +17,7 @@ struct CommitHeaderView: View {
                 ScrollView(.vertical) {
                     expandedBlock
                 }
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(maxHeight: Self.maxExpandedHeight)
             }
         }

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct CommitHeaderView: View {
+    static let maxExpandedHeight: CGFloat = 180
+
     let details: CommitDetails
     @Binding var expanded: Bool
 
@@ -11,7 +13,12 @@ struct CommitHeaderView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             compactRow
-            if expanded { expandedBlock }
+            if expanded {
+                ScrollView(.vertical) {
+                    expandedBlock
+                }
+                .frame(maxHeight: Self.maxExpandedHeight)
+            }
         }
         .padding(.horizontal, 16).padding(.vertical, 10)
         .background(theme.color("bg-2"))

--- a/AlasTests/CommitHeaderViewTests.swift
+++ b/AlasTests/CommitHeaderViewTests.swift
@@ -73,6 +73,20 @@ struct CommitHeaderViewTests {
         #expect(controller.view != nil)
     }
 
+    @Test func expandedHeaderOnlyCapsLongBody() {
+        let shortView = CommitHeaderView(details: makeDetails(body: "Short body"), expanded: .constant(true))
+            .environment(\.theme, currentTheme())
+            .frame(width: 600)
+        let body = Array(repeating: "A long commit message line", count: 100)
+            .joined(separator: "\n")
+        let longView = CommitHeaderView(details: makeDetails(body: body), expanded: .constant(true))
+            .environment(\.theme, currentTheme())
+            .frame(width: 600)
+
+        #expect(NSHostingView(rootView: shortView).fittingSize.height < CommitHeaderView.maxExpandedHeight)
+        #expect(NSHostingView(rootView: longView).fittingSize.height <= CommitHeaderView.maxExpandedHeight + 80)
+    }
+
     @Test func headerRowHasButtonAccessibilityTrait() {
         let details = makeDetails(body: "Body")
         var expanded = false

--- a/AlasTests/CommitHeaderViewTests.swift
+++ b/AlasTests/CommitHeaderViewTests.swift
@@ -87,6 +87,17 @@ struct CommitHeaderViewTests {
         #expect(NSHostingView(rootView: longView).fittingSize.height <= CommitHeaderView.maxExpandedHeight + 80)
     }
 
+    @Test func expandedHeaderKeepsShortBodyIntrinsicInTallParent() {
+        let view = CommitHeaderView(details: makeDetails(body: "Short body"), expanded: .constant(true))
+            .environment(\.theme, currentTheme())
+            .frame(width: 600)
+        let size = NSHostingController(rootView: view).sizeThatFits(
+            in: NSSize(width: 600, height: CommitHeaderView.maxExpandedHeight + 200)
+        )
+
+        #expect(size.height <= CommitHeaderView.maxExpandedHeight + 40)
+    }
+
     @Test func headerRowHasButtonAccessibilityTrait() {
         let details = makeDetails(body: "Body")
         var expanded = false

--- a/docs/superpowers/specs/2026-08-04-capped-commit-details-design.md
+++ b/docs/superpowers/specs/2026-08-04-capped-commit-details-design.md
@@ -1,0 +1,15 @@
+# Capped Commit Details
+
+## Goal
+
+Keep the center pane's tab strip visible when a commit has a long message.
+
+## Design
+
+`CommitHeaderView` remains the shared read-only commit-details view. Its compact row stays fixed. When expanded, the details block is wrapped in a native vertical `ScrollView` and capped at 180 points. Content shorter than the cap keeps its natural height; longer content scrolls within the header instead of growing the center pane.
+
+The existing editable commit-message views are unchanged because their `TextEditor` already has a 150-point maximum height and scrolls internally.
+
+## Verification
+
+Add one Swift Testing regression test that hosts an expanded header with a very long body and verifies that its rendered height is bounded. Run the focused test, then the project's required `xcodegen`, build, and test commands.


### PR DESCRIPTION
## Summary
- cap expanded read-only commit details at 180pt in the shared `CommitHeaderView`
- keep the compact commit row outside the scrollable area so center-pane tabs remain reachable
- add a Swift Testing regression for long expanded commit bodies

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- full local `xcodebuild ... test` executed `expandedHeaderOnlyCapsLongBody` and it passed; the suite still has two unrelated failures in `DiffReviewSurfaceTests.aggregateBudgetDeferralHidesTextDiffUntilReviewerRequestsIt`