### PR TITLE
fix(acp): make the AppKit transcript scroller usable for scrolling back

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 		45EEE2F32712FDEE392A9707 /* ZmxEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E0BB32D1A3B26473464A0F /* ZmxEnv.swift */; };
 		466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240C5961343C3042D865570 /* GeneralPane.swift */; };
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
+		4683946F3ADACBE0DC350B88 /* ACPTranscriptScrollerScrollBackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2EED77914E0B1E46C66A2B0 /* ACPTranscriptScrollerScrollBackTests.swift */; };
 		46A9AFFA9A459522F71E073E /* DiffTabRenderContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F14E32DEBE042825BCA44A /* DiffTabRenderContext.swift */; };
 		46D0693DB76BC258780CE113 /* GGSplitCommitModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8257A2ECCB938BA608A972A /* GGSplitCommitModelTests.swift */; };
 		46E3CCB2AC426BD5F8CB55DC /* ACPImageBlocksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */; };
@@ -2789,6 +2790,7 @@
 		E2C385F7CAAA65DB82ABC48F /* AddMissionLegDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionLegDialogTests.swift; sourceTree = "<group>"; };
 		E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHistorySidebar.swift; sourceTree = "<group>"; };
 		E2D5632302DE981B0BD36273 /* ACPSelectChipMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipMetricsTests.swift; sourceTree = "<group>"; };
+		E2EED77914E0B1E46C66A2B0 /* ACPTranscriptScrollerScrollBackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerScrollBackTests.swift; sourceTree = "<group>"; };
 		E2F14E32DEBE042825BCA44A /* DiffTabRenderContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffTabRenderContext.swift; sourceTree = "<group>"; };
 		E30876871CAA012C1FD6F00D /* FileSystemOpen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemOpen.swift; sourceTree = "<group>"; };
 		E373805AEFD068B97BC33A82 /* StashDiffTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashDiffTabView.swift; sourceTree = "<group>"; };
@@ -4021,6 +4023,7 @@
 				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
 				B24F24D2FFBBC49868AC84B3 /* ACPTranscriptScrollerPolicyTests.swift */,
 				F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */,
+				E2EED77914E0B1E46C66A2B0 /* ACPTranscriptScrollerScrollBackTests.swift */,
 				009B1616C60DB50E1CC11264 /* ACPTranscriptScrollerViewTests.swift */,
 				0D536FED92C1F59BDA8924C3 /* ACPTranscriptTilingControllerTests.swift */,
 				79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */,
@@ -6658,6 +6661,7 @@
 				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
 				57C95148FA2594979E1B2583 /* ACPTranscriptScrollerPolicyTests.swift in Sources */,
 				7C5139851C6CA3CB4292B5B2 /* ACPTranscriptScrollerReconcilerTests.swift in Sources */,
+				4683946F3ADACBE0DC350B88 /* ACPTranscriptScrollerScrollBackTests.swift in Sources */,
 				D7AEA4BEFB96EF86A83D6C16 /* ACPTranscriptScrollerViewTests.swift in Sources */,
 				625DD4666D7788F537A3E853 /* ACPTranscriptTests.swift in Sources */,
 				F0F6D9795D96C41F97B6B6BA /* ACPTranscriptTilingControllerTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -633,10 +633,14 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 return
             }
 
-            // The user has moved the viewport themselves, so a row that
-            // vanished from an earlier update is no longer worth restoring to
-            // if it comes back — see `PendingAnchorRestore`.
+            // This tick is the user moving the viewport, not us. Two things
+            // follow from that: a row that vanished from an earlier update is
+            // no longer worth restoring to if it comes back (see
+            // `PendingAnchorRestore`), and an update landing in the next
+            // moment must not re-pin the tail out from under the gesture (see
+            // `repinsToTail(followsTail:wasFollowingTail:)`).
             reconciler.invalidatePendingAnchorRestore()
+            reconciler.noteUserScroll()
 
             let event = NSApp.currentEvent
             let eventIsFresh = ACPUserScrollEvent.isFresh(

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -633,24 +633,30 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 return
             }
 
+            // The user has moved the viewport themselves, so a row that
+            // vanished from an earlier update is no longer worth restoring to
+            // if it comes back — see `PendingAnchorRestore`.
+            reconciler.invalidatePendingAnchorRestore()
+
             let event = NSApp.currentEvent
             let eventIsFresh = ACPUserScrollEvent.isFresh(
                 eventTimestamp: event?.timestamp,
                 now: ProcessInfo.processInfo.systemUptime
             )
             let currentEventType = eventIsFresh ? event?.type : nil
-            let isUserDriven = ACPUserScrollEvent.isUserDriven(currentEventType)
-            // Mirrors `ACPMessageList.handleScrollGeometry`: a click on the
-            // scrollbar track arrives as a plain `.leftMouseDown`, which
-            // `isUserDriven` alone rejects (a bare click can't be told apart
-            // from clicking a transcript control by event type). Widen to
-            // `isHeadPaginationDriven`, which additionally accepts that
-            // click when it actually hit the scrollbar track AND the
-            // geometry genuinely moved upward — so a track click both
-            // pauses tail-follow and can step the head window back, the
-            // same as a trackpad gesture or scroller-knob drag would,
-            // without misclassifying clicks on transcript controls (which
-            // aren't scrollbar hits) as scrolling.
+            // Classifies whether to PAUSE tail-follow, and nothing else — the
+            // pagination decisions below are geometric (see
+            // `shouldStepHeadBack`). Mirrors
+            // `ACPMessageList.handleScrollGeometry`: a click on the scrollbar
+            // track arrives as a plain `.leftMouseDown`, which
+            // `ACPUserScrollEvent.isUserDriven` alone rejects (a bare click
+            // can't be told apart from clicking a transcript control by event
+            // type). Widen to `isHeadPaginationDriven`, which additionally
+            // accepts that click when it actually hit the scrollbar track AND
+            // the geometry genuinely moved upward, so a track click pauses
+            // tail-follow the same as a trackpad gesture or scroller-knob
+            // drag would — without misclassifying clicks on transcript
+            // controls (which aren't scrollbar hits) as scrolling.
             let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
                 currentEventType,
                 previousMinY: previousY,
@@ -690,7 +696,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             let threshold = ACPTranscriptScroller.headStepThreshold(viewportHeight: viewportHeight)
             if ACPTranscriptScroller.shouldStepHeadBack(
                 visibleHead: host.transcript.visibleHead,
-                scrollY: newY, isUserDriven: isHeadPaginationDriven, threshold: threshold,
+                scrollY: newY, threshold: threshold,
                 hasPendingHeadStep: pendingHeadStep
             ) {
                 // `stepHeadBack` mutates `visibleHead` synchronously, but the
@@ -708,7 +714,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 visibleTail: host.transcript.visibleTailBound,
                 messageCount: host.transcript.messages.count,
                 distanceFromBottom: scroller.distanceFromBottom,
-                isUserDriven: isUserDriven, threshold: threshold,
+                threshold: threshold,
                 previousScrollY: previousY, newScrollY: newY
             ) {
                 host.transcript.stepTailForward(preserving: nil, boundHead: false)
@@ -837,11 +843,34 @@ extension ACPTranscriptScroller {
     /// `hasPendingHeadStep` is the caller's latch for "a step was already
     /// requested and its compensating update hasn't landed yet" — see the
     /// call site in `Coordinator.handleScroll`.
+    ///
+    /// Deliberately NOT gated on `ACPUserScrollEvent.isUserDriven`, unlike the
+    /// tail-follow pause decision next to it. `NSApp.currentEvent` is only the
+    /// scroll event while the bounds change is happening inside event
+    /// dispatch, and with `NSScrollView`'s responsive scrolling most of them
+    /// are not: measured against the live app, 1176 of 1209 scroll ticks
+    /// during ordinary trackpad paging (97%) classified as NOT user-driven.
+    /// Gating pagination on that flag meant reaching the top of the render
+    /// window and then waiting — a second or more — for a tick to coincide
+    /// with a recognizable fresh event before older messages loaded at all.
+    ///
+    /// The gate is right for PAUSING tail-follow, where a false positive
+    /// stops the follow mid-stream and is user-visible (see
+    /// `ACPUserScrollEvent`'s doc comment), and it stays there. It buys
+    /// nothing here: the worst a false positive can do is widen the render
+    /// window slightly early, which is the direction this wants to err in
+    /// anyway. What actually bounds the work is geometry — a step only fires
+    /// while the viewport is within `threshold` of the window's top, and each
+    /// step's compensation pushes the offset back down by the height it
+    /// grafted in, so the window stops growing as soon as there is
+    /// `threshold`-worth of loaded history above the viewport. The legacy
+    /// path paginated from a geometry sentinel coming into view
+    /// (`ACPMessageList.handleHeadFramePreference`) for the same reason.
     nonisolated static func shouldStepHeadBack(
-        visibleHead: Int, scrollY: CGFloat, isUserDriven: Bool, threshold: CGFloat,
+        visibleHead: Int, scrollY: CGFloat, threshold: CGFloat,
         hasPendingHeadStep: Bool = false
     ) -> Bool {
-        visibleHead > 0 && isUserDriven && scrollY < threshold && !hasPendingHeadStep
+        visibleHead > 0 && scrollY < threshold && !hasPendingHeadStep
     }
 
     /// Mirrors `ACPMessageList.shouldStepTailForwardFromBottomGeometry`: a
@@ -856,12 +885,20 @@ extension ACPTranscriptScroller {
     /// avoid. `previousScrollY` is `nil` only before the first reported
     /// scroll offset, in which case direction is unknown and paging is
     /// withheld.
+    ///
+    /// Like `shouldStepHeadBack`, this is not gated on
+    /// `ACPUserScrollEvent.isUserDriven` — see that method's doc comment for
+    /// why the flag is close to useless under responsive scrolling. The
+    /// downward-movement requirement below is the intent signal here, and it
+    /// is a geometric one: a viewport that is not moving down through the
+    /// document does not page in newer messages, whatever the event stream
+    /// happened to look like.
     nonisolated static func shouldStepTailForward(
         visibleTail: Int, messageCount: Int, distanceFromBottom: CGFloat,
-        isUserDriven: Bool, threshold: CGFloat,
+        threshold: CGFloat,
         previousScrollY: CGFloat?, newScrollY: CGFloat
     ) -> Bool {
-        guard visibleTail < messageCount, isUserDriven, distanceFromBottom < threshold,
+        guard visibleTail < messageCount, distanceFromBottom < threshold,
               let previousScrollY
         else { return false }
         return newScrollY > previousScrollY + ACPScrollDirectionClassifier.upwardEpsilon

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -112,6 +112,14 @@ final class ACPTranscriptScrollerReconciler {
     /// a long-gone anchor resurface.
     private static let pendingAnchorApplyBudget = 3
 
+    /// How long after a user-driven scroll tick the tail re-pin stays
+    /// suppressed — see `repinsToTail(followsTail:wasFollowingTail:)`.
+    static let userScrollSuppressionWindow: TimeInterval = 0.25
+
+    /// `ProcessInfo.systemUptime` of the last user-driven scroll tick, or nil
+    /// if the user has never moved this viewport.
+    private var lastUserScrollUptime: TimeInterval?
+
     init(
         tiling: ACPTranscriptTilingController,
         pool: ACPTranscriptRowHostingPool,
@@ -306,6 +314,25 @@ final class ACPTranscriptScrollerReconciler {
     /// runs `apply()` unconditionally — slammed the viewport back to the
     /// bottom mid-gesture.
     ///
+    /// Position alone is NOT enough to decide this, and gating on it alone
+    /// was wrong: between `bottomTolerance` and `pauseTolerance` (37–160pt
+    /// off the bottom) the session still reports that it follows the tail, so
+    /// suppressing the pin there indefinitely leaves a state with neither
+    /// behavior — streaming content accumulates below the viewport while the
+    /// "go to newest" affordance stays hidden, because it keys off
+    /// `session.followsTranscriptTail` which nothing has paused. The
+    /// suppression is therefore scoped to an ACTIVE GESTURE: the viewport
+    /// must be off the tail AND the user must have moved it within
+    /// `userScrollSuppressionWindow`. Once the gesture ends, an update
+    /// re-pins exactly as it always did, so the inconsistent state cannot
+    /// outlive the gesture that caused it.
+    ///
+    /// "The user moved it" is `noteUserScroll()`, driven by the scroller's own
+    /// programmatic/non-programmatic split, not by `NSApp.currentEvent` —
+    /// under responsive scrolling that event is absent for ~97% of scroll
+    /// ticks (see `ACPTranscriptScroller.shouldStepHeadBack`), so a gesture
+    /// detector built on it would suppress almost nothing.
+    ///
     /// The state machine still converges from here: scrolling back within
     /// `bottomTolerance` re-arms the glue through the coordinator's
     /// `.userAtBottom` → `resumeTailFollow`, and travelling past
@@ -328,7 +355,33 @@ final class ACPTranscriptScrollerReconciler {
     private func repinsToTail(followsTail: Bool, wasFollowingTail: Bool) -> Bool {
         guard followsTail else { return false }
         if !wasFollowingTail { return true }
-        return scroller.distanceFromBottom <= ACPScrollDirectionClassifier.bottomTolerance
+        guard scroller.distanceFromBottom > ACPScrollDirectionClassifier.bottomTolerance else {
+            return true
+        }
+        return !isUserScrollInFlight()
+    }
+
+    /// Whether the user has moved the viewport recently enough that an
+    /// update landing now would be interrupting a gesture still in progress.
+    ///
+    /// Scroll ticks arrive every ~8–25ms within a gesture (including the
+    /// momentum tail and the elastic bounce at either end), so the window
+    /// only has to outlast the gaps between them, not the gesture itself.
+    /// It deliberately does not outlast the gesture by much: everything the
+    /// window suppresses is behavior the user gets back the moment they stop.
+    private func isUserScrollInFlight() -> Bool {
+        guard let lastUserScrollUptime else { return false }
+        return ProcessInfo.processInfo.systemUptime - lastUserScrollUptime
+            <= Self.userScrollSuppressionWindow
+    }
+
+    /// Records that the viewport was just moved by the user rather than by
+    /// this reconciler. Called by the coordinator's scroll handler for every
+    /// non-programmatic tick — the scroller's own
+    /// `programmaticAdjustmentDepth` is what tells the two apart, which is
+    /// reliable where the event stream is not.
+    func noteUserScroll() {
+        lastUserScrollUptime = ProcessInfo.processInfo.systemUptime
     }
 
     /// `repinsToTail` is the caller's already-made decision about whether this

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -78,6 +78,40 @@ final class ACPTranscriptScrollerReconciler {
     private var isLayingOutRows = false
     private var pendingRelayout = false
 
+    /// A scroll anchor whose row was removed by an update, kept so the
+    /// position can be recovered if the row comes back.
+    ///
+    /// This exists because a transcript can drop rows and put the same rows
+    /// straight back: `ACPSessionManager.runMirrorRefresh` replaces a mirrored
+    /// session's transcript with its tail on every 2.5s poll, and the backfill
+    /// it schedules prepends the older messages again one update later. Across
+    /// that pair the row the user is reading does not exist, so neither offset
+    /// compensation (which clamps to 0 at the top of the document and silently
+    /// loses the correction) nor `performReset`'s anchor (which finds nothing
+    /// to aim at and declines to move) can hold the position — the user ends
+    /// up a page or more below where they were. Remembering the vanished
+    /// anchor and restoring it when the row reappears is what the legacy path
+    /// gets for free from `restoreRememberedAnchorIfNeeded`, which re-scrolls
+    /// to a remembered MESSAGE id after any rebuild.
+    ///
+    /// `applyBudget` bounds how long a vanished anchor stays interesting: a
+    /// row that returns many updates later is no longer what the user is
+    /// looking at, and restoring to it then would be its own teleport. The
+    /// coordinator additionally drops it outright on any user-driven scroll
+    /// (`invalidatePendingAnchorRestore`), so a live gesture is never fought.
+    private struct PendingAnchorRestore {
+        let id: String
+        let offsetWithinRow: CGFloat
+        var applyBudget: Int
+    }
+    private var pendingAnchorRestore: PendingAnchorRestore?
+
+    /// Number of subsequent `apply()` calls a vanished anchor stays eligible
+    /// for restoration. The mirror-refresh pair lands on consecutive updates;
+    /// a small budget covers an interleaved unrelated update without letting
+    /// a long-gone anchor resurface.
+    private static let pendingAnchorApplyBudget = 3
+
     init(
         tiling: ACPTranscriptTilingController,
         pool: ACPTranscriptRowHostingPool,
@@ -153,6 +187,12 @@ final class ACPTranscriptScrollerReconciler {
         // real width is diffed as a normal (likely initial) update.
         guard width > 0 else { return }
 
+        // Whether this update should end by re-pinning to the tail. Read
+        // BEFORE any mutation below moves the document or the offset, and
+        // gated on the viewport actually SITTING at the tail rather than on
+        // `followsTail` alone — see `repinsToTail(followsTail:wasFollowingTail:)`.
+        let repins = repinsToTail(followsTail: followsTail, wasFollowingTail: lastFollowsTail)
+
         let newIds = specs.map(\.id)
         var newSpecs: [String: ACPTranscriptRowSpec] = [:]
         newSpecs.reserveCapacity(specs.count)
@@ -168,6 +208,10 @@ final class ACPTranscriptScrollerReconciler {
         isApplyingSpecs = true
         defer { isApplyingSpecs = false }
 
+        // Read before the mutations below, so a row that this update removes
+        // can still be identified afterwards.
+        let anchorBeforeUpdate = repins ? nil : captureScrollAnchor()
+
         contentWidth = width
         if isPureWidthChange {
             // Apply the ordinary incremental diff at the new width (so
@@ -177,7 +221,7 @@ final class ACPTranscriptScrollerReconciler {
             // visible content is never wrong), and debounce the full
             // re-measure-every-row reset until the resize settles — so a
             // live drag doesn't rebuild thousands of hosting views per tick.
-            applyDiff(idDiff, specs: specs, widthChanged: true, followsTail: followsTail)
+            applyDiff(idDiff, specs: specs, widthChanged: true, repinsToTail: repins)
             widthSettleTimer.poke()
         } else {
             let change: Diff = widthChanged ? .reset : idDiff
@@ -193,22 +237,107 @@ final class ACPTranscriptScrollerReconciler {
                 // settle window.
                 widthSettleTimer.cancel()
             }
-            applyDiff(change, specs: specs, widthChanged: widthChanged, followsTail: followsTail)
+            applyDiff(change, specs: specs, widthChanged: widthChanged, repinsToTail: repins)
         }
+
+        trackAnchorAcrossUpdate(anchorBeforeUpdate, repinsToTail: repins)
 
         orderedIds = newIds
         specsById = newSpecs
         keepMountedOffscreenIds = Set(specs.lazy.filter(\.keepsMountedOffscreen).map(\.id))
         lastAppliedSpecs = specs
         lastFollowsTail = followsTail
-        if followsTail {
+        if repins {
             scroller.scrollToBottom()
         }
         layoutMountedRows()
     }
 
+    /// Drops any remembered vanished anchor. Called by the coordinator on
+    /// user-driven scrolling: once the user has moved the viewport themselves,
+    /// a row reappearing is no longer a reason to move it back.
+    func invalidatePendingAnchorRestore() {
+        pendingAnchorRestore = nil
+    }
+
+    /// Carries the reading position across an update that removes the row it
+    /// was anchored to — see `PendingAnchorRestore`.
+    ///
+    /// Three outcomes, in priority order: the anchor row went away (remember
+    /// it), a previously remembered row came back (restore and forget), or
+    /// neither (age out anything remembered). Restoration deliberately runs
+    /// after the diff's own compensation, overwriting it: compensation
+    /// computed against a document that was missing the block is exactly what
+    /// produced the wrong offset.
+    private func trackAnchorAcrossUpdate(_ before: ScrollAnchor?, repinsToTail: Bool) {
+        guard !repinsToTail else {
+            pendingAnchorRestore = nil
+            return
+        }
+        if case .row(let id, let offsetWithinRow) = before, tiling.row(withId: id) == nil {
+            pendingAnchorRestore = PendingAnchorRestore(
+                id: id, offsetWithinRow: offsetWithinRow,
+                applyBudget: Self.pendingAnchorApplyBudget
+            )
+            return
+        }
+        guard var pending = pendingAnchorRestore else { return }
+        if let row = tiling.row(withId: pending.id) {
+            pendingAnchorRestore = nil
+            scroller.setScrollY(row.minY + min(pending.offsetWithinRow, row.height))
+            return
+        }
+        pending.applyBudget -= 1
+        pendingAnchorRestore = pending.applyBudget > 0 ? pending : nil
+    }
+
+    /// Whether an update should end by re-pinning the viewport to the tail:
+    /// tail-follow is on AND the viewport is currently sitting at the tail.
+    ///
+    /// Those two are not the same thing, and treating `followsTail` alone as
+    /// the answer is what made the transcript jump to the newest message
+    /// while the user was scrolling back. `ACPScrollDirectionClassifier
+    /// .pauseTolerance` deliberately withholds the tail-follow pause for the
+    /// first 160pt of upward travel (so trackpad micro-hops and layout reflow
+    /// can't stop the follow), so throughout that band the coordinator is
+    /// still reporting `followsTail: true` while the user is demonstrably
+    /// scrolling away. Any update landing in that window — a streamed chunk,
+    /// a queue change, any SwiftUI invalidation at all, since `updateNSView`
+    /// runs `apply()` unconditionally — slammed the viewport back to the
+    /// bottom mid-gesture.
+    ///
+    /// The state machine still converges from here: scrolling back within
+    /// `bottomTolerance` re-arms the glue through the coordinator's
+    /// `.userAtBottom` → `resumeTailFollow`, and travelling past
+    /// `pauseTolerance` pauses the follow outright. What it no longer does is
+    /// fight a gesture that is still in progress.
+    ///
+    /// The "at the tail" test is skipped on the RISING EDGE of tail-follow —
+    /// `followsTail` true where `wasFollowingTail` is false. That transition
+    /// is somebody deliberately (re-)arming the follow from wherever the
+    /// viewport happens to be: the "go to newest" button (which sets
+    /// `session.followsTranscriptTail` and resets the render window WITHOUT
+    /// scrolling, leaving this re-pin as the only thing that makes it jump —
+    /// ACPMessageList.swift:222-226), `Coordinator.resumeTailFollow`, and the
+    /// initial load. Requiring the viewport to already be at the tail there
+    /// would defeat the whole point of the gesture.
+    ///
+    /// Must be read before an update mutates row geometry: afterwards, a tail
+    /// insertion has already grown the document and `distanceFromBottom`
+    /// answers a different question.
+    private func repinsToTail(followsTail: Bool, wasFollowingTail: Bool) -> Bool {
+        guard followsTail else { return false }
+        if !wasFollowingTail { return true }
+        return scroller.distanceFromBottom <= ACPScrollDirectionClassifier.bottomTolerance
+    }
+
+    /// `repinsToTail` is the caller's already-made decision about whether this
+    /// update ends by re-pinning to the tail (see
+    /// `repinsToTail(followsTail:wasFollowingTail:)`),
+    /// not the raw tail-follow flag: `performReset` must not capture and
+    /// restore a scroll anchor it is only going to overwrite.
     private func applyDiff(
-        _ change: Diff, specs: [ACPTranscriptRowSpec], widthChanged: Bool, followsTail: Bool
+        _ change: Diff, specs: [ACPTranscriptRowSpec], widthChanged: Bool, repinsToTail: Bool
     ) {
         switch change {
         case .unchanged:
@@ -217,7 +346,7 @@ final class ACPTranscriptScrollerReconciler {
             let insertedSpecs = Array(specs[index..<(index + count)])
             let compensation = tiling.insert(
                 rows: measure(insertedSpecs), at: index,
-                viewportMinY: effectiveViewportMinY(forInsertionAt: index)
+                viewportMinY: effectiveViewportMinY(forMutationAt: index)
             )
             if compensation != 0 {
                 scroller.applyPrepend(delta: compensation, newDocumentHeight: tiling.documentHeight)
@@ -226,7 +355,10 @@ final class ACPTranscriptScrollerReconciler {
             }
             updateChangedContent(specs: specs)
         case .removed(let index, let count):
-            let compensation = tiling.remove(at: index, count: count, viewportMinY: scroller.scrollY)
+            let compensation = tiling.remove(
+                at: index, count: count,
+                viewportMinY: effectiveViewportMinY(forMutationAt: index)
+            )
             if compensation != 0 {
                 scroller.applyPrepend(delta: compensation, newDocumentHeight: tiling.documentHeight)
             } else {
@@ -238,7 +370,7 @@ final class ACPTranscriptScrollerReconciler {
             // of `keep` and `pool.releaseAll(except:)` cleans them up.
             updateChangedContent(specs: specs)
         case .reset:
-            performReset(specs: specs, widthChanged: widthChanged, followsTail: followsTail)
+            performReset(specs: specs, widthChanged: widthChanged, repinsToTail: repinsToTail)
         }
     }
 
@@ -260,11 +392,15 @@ final class ACPTranscriptScrollerReconciler {
     ///     reset after browsing deep into a long transcript allocated and
     ///     synchronously measured a hosting view per row in the whole render
     ///     window.
-    private func performReset(specs: [ACPTranscriptRowSpec], widthChanged: Bool, followsTail: Bool) {
-        // While following the tail, `apply()`'s own `scrollToBottom()` (or
-        // `performWidthSettledReset`'s) is the correct final position and
-        // must win — don't fight it with a restored anchor.
-        let anchor = followsTail ? nil : captureScrollAnchor()
+    private func performReset(specs: [ACPTranscriptRowSpec], widthChanged: Bool, repinsToTail: Bool) {
+        // When the update ends by re-pinning, `apply()`'s own
+        // `scrollToBottom()` (or `performWidthSettledReset`'s) is the correct
+        // final position and must win — don't fight it with a restored
+        // anchor. When it does NOT re-pin — including a tail-following
+        // viewport the user has scrolled off the tail, which no longer
+        // re-pins — the anchor is what keeps the reset from moving the
+        // content under them.
+        let anchor = repinsToTail ? nil : captureScrollAnchor()
         tiling.replaceAll(rows: resetHeights(specs: specs, widthChanged: widthChanged))
         scroller.setDocumentHeight(tiling.documentHeight)
         restoreScrollAnchor(anchor)
@@ -412,8 +548,9 @@ final class ACPTranscriptScrollerReconciler {
     /// definition rather than re-spelling the literal.
     static let syntheticIdPrefix = "__"
 
-    /// The viewport top to hand `ACPTranscriptTilingController.insert` when
-    /// it decides whether an insertion needs offset compensation.
+    /// The viewport top to hand `ACPTranscriptTilingController.insert` /
+    /// `.remove` when they decide whether a mutation needs offset
+    /// compensation.
     ///
     /// Normally that is simply the real viewport top: content grafted in at
     /// or above it must push the offset down by the same amount to keep the
@@ -425,15 +562,28 @@ final class ACPTranscriptScrollerReconciler {
     /// rule then declines to compensate and the whole inserted block, tens
     /// of rows and thousands of points, shoves the reading position down.
     ///
-    /// When every row above the insertion point is synthetic there is no
-    /// real content up there to hold still, so the insertion is logically
+    /// When every row above the mutation point is synthetic there is no
+    /// real content up there to hold still, so the mutation is logically
     /// above the viewport however small `scrollY` happens to be: report the
-    /// insertion point itself as the viewport top so the rule fires. (An
-    /// insertion at index 0 satisfies this vacuously, which is also exactly
+    /// mutation point itself as the viewport top so the rule fires. (A
+    /// mutation at index 0 satisfies this vacuously, which is also exactly
     /// right — inserting above every row is what `prepend` always
-    /// compensated for unconditionally.) Insertions with real message rows
+    /// compensated for unconditionally.) Mutations with real message rows
     /// above them — every append, every mid-list insert — are unaffected.
-    private func effectiveViewportMinY(forInsertionAt index: Int) -> CGFloat {
+    ///
+    /// REMOVALS go through the same rule as insertions, and must: a model
+    /// that removes a block and then re-inserts the same block is not
+    /// hypothetical, it is the steady state for a mirrored session
+    /// (`ACPSessionManager.runMirrorRefresh` replaces the transcript with its
+    /// tail every poll, then `scheduleBackfillIfNeeded` prepends the older
+    /// messages straight back). With only the insertion side overridden, the
+    /// removal declined to compensate while the matching re-insertion
+    /// compensated in full, so each round trip teleported the viewport DOWN
+    /// by the block's entire height — thousands of points, landing the user
+    /// a page or more below where they had been reading. The two sides have
+    /// to answer "is this above me?" identically or the round trip cannot
+    /// net out.
+    private func effectiveViewportMinY(forMutationAt index: Int) -> CGFloat {
         let viewportMinY = scroller.scrollY
         guard index <= orderedIds.count,
               orderedIds[0..<index].allSatisfy({ $0.hasPrefix(Self.syntheticIdPrefix) })
@@ -453,8 +603,9 @@ final class ACPTranscriptScrollerReconciler {
     private func performWidthSettledReset() {
         isApplyingSpecs = true
         defer { isApplyingSpecs = false }
-        performReset(specs: lastAppliedSpecs, widthChanged: true, followsTail: lastFollowsTail)
-        if lastFollowsTail {
+        let repins = repinsToTail(followsTail: lastFollowsTail, wasFollowingTail: lastFollowsTail)
+        performReset(specs: lastAppliedSpecs, widthChanged: true, repinsToTail: repins)
+        if repins {
             scroller.scrollToBottom()
         }
         layoutMountedRows()
@@ -501,11 +652,36 @@ final class ACPTranscriptScrollerReconciler {
     /// `setFollowsTail(false)` as it pauses, before mounting anything, so
     /// the state read here is current and this never fights a user who has
     /// genuinely left the tail.
-    /// `scroller.scrollToBottom()` is idempotent when already there — its
+    /// The re-pin additionally requires the viewport to have BEEN at the tail
+    /// when the invalidation arrived, not merely `lastFollowsTail`. Those two
+    /// are not the same thing, and conflating them made scrolling back
+    /// impossible: `ACPScrollDirectionClassifier.pauseTolerance` deliberately
+    /// withholds the tail-follow pause for the first 160pt of upward travel
+    /// (so trackpad micro-hops and layout reflow don't stop the follow), so
+    /// every scroll tick inside that band still reports `lastFollowsTail ==
+    /// true`. Each such tick mounts the rows the scroll exposed, and
+    /// `performLayoutPass`'s mount-time `measuredHeight(forWidth:)` reassigns
+    /// `rootView`, which SwiftUI answers by invalidating the hosting view's
+    /// intrinsic size — landing right here. Re-pinning then yanked the user
+    /// straight back to the bottom, so they could never travel the 160pt that
+    /// would have paused the follow in the first place: the transcript
+    /// oscillated within one row-height of the bottom and never escaped.
+    /// (Note that this fires on a bare scroll gesture with no model update
+    /// and no content change at all — the invalidation is a side effect of
+    /// measuring, not evidence that anything grew.)
+    ///
+    /// Gating on `repinsToTail(followsTail:wasFollowingTail:)` — which
+    /// additionally requires
+    /// the viewport to BE at the tail — keeps the behavior this method exists for —
+    /// content growing under a viewport that IS sitting at the tail keeps the
+    /// tail glued — while leaving a viewport the user has already moved off
+    /// the tail alone. `bottomTolerance` (not `pauseTolerance`) is the right
+    /// threshold: the question here is "is the viewport at the tail right
+    /// now", which is exactly what that constant answers for the classifier.
+    /// While genuinely pinned, `scrollToBottom()` remains idempotent — its
     /// `setScrollY` clamp reports no `onScroll` change (`reportScroll` skips
-    /// when the offset is unchanged) — so calling it unconditionally on
-    /// every tail-following remeasure, not just ones that grow the tail,
-    /// costs nothing extra in the common case.
+    /// when the offset is unchanged) — so calling it on every tail-following
+    /// remeasure, not just ones that grow the tail, costs nothing extra.
     /// Updates the tail-follow state that `remeasureRow` re-pins against,
     /// without waiting for the `apply()` that will carry the same value.
     ///
@@ -529,9 +705,13 @@ final class ACPTranscriptScrollerReconciler {
     func remeasureRow(id: String) {
         guard !isApplyingSpecs else { return }
         guard let spec = specsById[id] else { return }
+        // Read BEFORE measuring: `applyMeasuredHeight` can change both the
+        // document height and the offset, after which "was the viewport at
+        // the tail when this arrived?" is no longer answerable.
+        let repins = repinsToTail(followsTail: lastFollowsTail, wasFollowingTail: lastFollowsTail)
         let (view, _) = pool.view(for: spec)
         applyMeasuredHeight(id: id, view: view)
-        if lastFollowsTail {
+        if repins {
             scroller.scrollToBottom()
         }
     }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -633,16 +633,30 @@ struct ACPTranscriptScrollerViewportHeightReconciliationTests {
 
 @Suite("ACPTranscriptScroller policies")
 struct ACPTranscriptScrollerPolicyTests {
-    @Test("head step fires near the top during a user scroll when older rows exist")
+    @Test("head step fires near the top when older rows exist")
     func headStep() {
         #expect(ACPTranscriptScroller.shouldStepHeadBack(
-            visibleHead: 30, scrollY: 800, isUserDriven: true, threshold: 1500))
+            visibleHead: 30, scrollY: 800, threshold: 1500))
         #expect(!ACPTranscriptScroller.shouldStepHeadBack(
-            visibleHead: 0, scrollY: 800, isUserDriven: true, threshold: 1500))
+            visibleHead: 0, scrollY: 800, threshold: 1500))
         #expect(!ACPTranscriptScroller.shouldStepHeadBack(
-            visibleHead: 30, scrollY: 2000, isUserDriven: true, threshold: 1500))
-        #expect(!ACPTranscriptScroller.shouldStepHeadBack(
-            visibleHead: 30, scrollY: 800, isUserDriven: false, threshold: 1500))
+            visibleHead: 30, scrollY: 2000, threshold: 1500))
+    }
+
+    /// Pagination is geometric, not event-gated. `NSApp.currentEvent` is only
+    /// the scroll event while the bounds change happens inside event
+    /// dispatch, and under `NSScrollView`'s responsive scrolling it usually
+    /// does not: 97% of scroll ticks measured in the running app classified
+    /// as not user-driven, which left the user parked at the top of the
+    /// render window waiting seconds for a tick to coincide with a
+    /// recognizable event before older messages loaded at all.
+    @Test("head step does not wait for a recognizable user event")
+    func headStepIsNotEventGated() {
+        // The exact state a trackpad fling leaves behind: at the top of the
+        // window, older rows available, and no fresh event to be found.
+        #expect(ACPTranscriptScroller.shouldStepHeadBack(
+            visibleHead: 30, scrollY: 0, threshold: 1500))
+        #expect(!ACPUserScrollEvent.isUserDriven(nil))
     }
 
     @Test("a head step already awaiting its compensating update does not queue another")
@@ -654,10 +668,10 @@ struct ACPTranscriptScrollerPolicyTests {
         // the head queues several steps that arrive as one 60-150 row
         // insertion measured in a single synchronous pass.
         #expect(!ACPTranscriptScroller.shouldStepHeadBack(
-            visibleHead: 30, scrollY: 800, isUserDriven: true, threshold: 1500,
+            visibleHead: 30, scrollY: 800, threshold: 1500,
             hasPendingHeadStep: true))
         #expect(ACPTranscriptScroller.shouldStepHeadBack(
-            visibleHead: 30, scrollY: 800, isUserDriven: true, threshold: 1500,
+            visibleHead: 30, scrollY: 800, threshold: 1500,
             hasPendingHeadStep: false))
     }
 
@@ -665,15 +679,15 @@ struct ACPTranscriptScrollerPolicyTests {
     func tailStep() {
         #expect(ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
-            isUserDriven: true, threshold: 1500,
+            threshold: 1500,
             previousScrollY: 1000, newScrollY: 1050))
         #expect(!ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 200, messageCount: 200, distanceFromBottom: 900,
-            isUserDriven: true, threshold: 1500,
+            threshold: 1500,
             previousScrollY: 1000, newScrollY: 1050))
         #expect(!ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 100, messageCount: 200, distanceFromBottom: 5000,
-            isUserDriven: true, threshold: 1500,
+            threshold: 1500,
             previousScrollY: 1000, newScrollY: 1050))
     }
 
@@ -685,7 +699,7 @@ struct ACPTranscriptScrollerPolicyTests {
         // page in hidden newer messages.
         #expect(!ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
-            isUserDriven: true, threshold: 1500,
+            threshold: 1500,
             previousScrollY: 1050, newScrollY: 1000))
     }
 
@@ -693,7 +707,7 @@ struct ACPTranscriptScrollerPolicyTests {
     func tailStepWithholdsWithoutPreviousOffset() {
         #expect(!ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
-            isUserDriven: true, threshold: 1500,
+            threshold: 1500,
             previousScrollY: nil, newScrollY: 1050))
     }
 
@@ -703,7 +717,7 @@ struct ACPTranscriptScrollerPolicyTests {
         // (0.5pt) must not be treated as a deliberate downward scroll.
         #expect(!ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
-            isUserDriven: true, threshold: 1500,
+            threshold: 1500,
             previousScrollY: 1000, newScrollY: 1000.2))
     }
 
@@ -716,15 +730,18 @@ struct ACPTranscriptScrollerPolicyTests {
 
 /// Regression coverage for the review's fix-round-2 finding: a click on the
 /// scrollbar track arrives as a plain `.leftMouseDown`, which
-/// `ACPUserScrollEvent.isUserDriven` alone rejects. `handleScroll` now
-/// widens the tail-follow pause/resume classification and the head-step
-/// gate to `ACPUserScrollEvent.isHeadPaginationDriven` — which additionally
-/// accepts a `.leftMouseDown` when it is a genuine scrollbar-track hit AND
-/// the geometry actually moved upward — while leaving `shouldStepTailForward`
-/// on the plain `isUserDriven` signal, mirroring
-/// `ACPMessageList.handleScrollGeometry` exactly (compare
-/// `ACPMessageList.swift`'s `handleScrollGeometry`/
-/// `shouldStepHeadBackFromGeometry` call sites).
+/// `ACPUserScrollEvent.isUserDriven` alone rejects. `handleScroll` widens the
+/// tail-follow pause/resume classification to
+/// `ACPUserScrollEvent.isHeadPaginationDriven` — which additionally accepts a
+/// `.leftMouseDown` when it is a genuine scrollbar-track hit AND the geometry
+/// actually moved upward.
+///
+/// That classification governs the tail-follow PAUSE only. Pagination (head
+/// and tail) no longer consults the event stream at all — see
+/// `ACPTranscriptScroller.shouldStepHeadBack`'s doc comment on why the event
+/// signal is unusable under responsive scrolling — so a track click paginates
+/// for the same reason any other way of arriving near the window's edge
+/// does: the geometry says so.
 ///
 /// `handleScroll` itself is a private, `NSApp.currentEvent`-driven method
 /// that needs a real `NSEvent` routed through an actual window's view
@@ -790,38 +807,40 @@ struct ACPTranscriptScrollerScrollbarTrackClickTests {
         #expect(decision == .noChange)
     }
 
-    @Test("an upward scrollbar-track click can also trigger head pagination")
-    func scrollbarTrackClickTriggersHeadPagination() {
-        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
-            .leftMouseDown, previousMinY: 2000, newMinY: 100, isScrollbarTrackHit: true
-        )
-        #expect(ACPTranscriptScroller.shouldStepHeadBack(
-            visibleHead: 30, scrollY: 100, isUserDriven: isHeadPaginationDriven, threshold: Self.threshold
-        ))
+    /// However the viewport got near the top of the render window — a track
+    /// click, a trackpad fling whose events were never seen, a restored
+    /// anchor — older rows load. The event classification that decides
+    /// whether to PAUSE tail-follow does not decide this.
+    @Test("head pagination follows the geometry, whatever the click was")
+    func headPaginationIsGeometricNotEventClassified() {
+        for isScrollbarTrackHit in [true, false] {
+            let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
+                .leftMouseDown, previousMinY: 2000, newMinY: 100,
+                isScrollbarTrackHit: isScrollbarTrackHit
+            )
+            #expect(isHeadPaginationDriven == isScrollbarTrackHit)
+            // Same answer either way: the viewport is near the top and older
+            // rows exist.
+            #expect(ACPTranscriptScroller.shouldStepHeadBack(
+                visibleHead: 30, scrollY: 100, threshold: Self.threshold
+            ))
+        }
     }
 
-    @Test("a non-scrollbar click does not trigger head pagination")
-    func nonScrollbarClickDoesNotTriggerHeadPagination() {
-        let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
-            .leftMouseDown, previousMinY: 2000, newMinY: 100, isScrollbarTrackHit: false
-        )
-        #expect(!ACPTranscriptScroller.shouldStepHeadBack(
-            visibleHead: 30, scrollY: 100, isUserDriven: isHeadPaginationDriven, threshold: Self.threshold
+    /// Tail pagination's intent signal is the direction the viewport moved,
+    /// not the event that moved it: a click that jumps DOWN the document
+    /// pages in newer messages, one that jumps up does not.
+    @Test("tail pagination follows the direction of travel, not the event")
+    func tailPaginationFollowsDirectionOfTravel() {
+        #expect(ACPTranscriptScroller.shouldStepTailForward(
+            visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
+            threshold: Self.threshold,
+            previousScrollY: 2000, newScrollY: 2050
         ))
-    }
-
-    @Test("a scrollbar-track click does not drive tail pagination, matching the legacy plain-isUserDriven gate")
-    func scrollbarTrackClickDoesNotDriveTailPagination() {
-        // `shouldStepTailForward` mirrors `ACPMessageList
-        // .shouldStepTailForwardFromBottomGeometry`, which the legacy path
-        // gates on plain `isUserDriven`, NOT `isHeadPaginationDriven` — a
-        // scrollbar-track click must not page in hidden newer messages.
-        let plainIsUserDriven = ACPUserScrollEvent.isUserDriven(.leftMouseDown)
-        #expect(!plainIsUserDriven)
         #expect(!ACPTranscriptScroller.shouldStepTailForward(
             visibleTail: 100, messageCount: 200, distanceFromBottom: 900,
-            isUserDriven: plainIsUserDriven, threshold: Self.threshold,
-            previousScrollY: 2000, newScrollY: 2050
+            threshold: Self.threshold,
+            previousScrollY: 2050, newScrollY: 2000
         ))
     }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerScrollBackTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerScrollBackTests.swift
@@ -1,0 +1,244 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Alas
+
+/// Scrolling BACK through the transcript, in a real window, with rows whose
+/// SwiftUI content is measured as they mount.
+///
+/// This is the shape of the bug that made the AppKit scroller unusable: a
+/// user scrolling up out of the tail is inside
+/// `ACPScrollDirectionClassifier.pauseTolerance` for the first 160pt, so
+/// tail-follow is deliberately still on. Every tick mounts the rows the
+/// scroll just exposed, mount-time measurement invalidates the hosting view's
+/// intrinsic size, and `remeasureRow` re-pinned to the bottom — putting the
+/// user back where they started, forever.
+@MainActor
+@Suite("ACPTranscriptScroller scroll-back")
+struct ACPTranscriptScrollerScrollBackTests {
+    /// Rows with real (text-measured, varying-height) SwiftUI content, not
+    /// fixed-size `Color` blocks: mount-time measurement of real content is
+    /// what triggers the intrinsic-size invalidation this exercises.
+    private func makeRows(_ count: Int) -> [ACPTranscriptRowSpec] {
+        (0..<count).map { index in
+            let body = String(repeating: "lorem ipsum dolor sit amet \(index) ", count: 6 + index % 7)
+            return ACPTranscriptRowSpec(
+                id: "r\(index)",
+                equalityToken: ACPRowEqualityToken(index),
+                build: {
+                    AnyView(
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("message \(index)").font(.system(size: 12, weight: .semibold))
+                            Text(body).font(.system(size: 13))
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    )
+                }
+            )
+        }
+    }
+
+    private func makeStackInWindow() -> (
+        ACPTranscriptScrollerReconciler, ACPTranscriptScrollerView,
+        ACPTranscriptTilingController, NSWindow
+    ) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 500),
+            styleMask: [.titled, .resizable], backing: .buffered, defer: false
+        )
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 800, height: 500))
+        window.contentView = scroller
+        let tiling = ACPTranscriptTilingController()
+        let pool = ACPTranscriptRowHostingPool()
+        let reconciler = ACPTranscriptScrollerReconciler(tiling: tiling, pool: pool, scroller: scroller)
+        scroller.layoutSubtreeIfNeeded()
+        return (reconciler, scroller, tiling, window)
+    }
+
+    /// Walks the viewport upward the way a trackpad gesture does — AppKit
+    /// moves the clip view's bounds origin, then the scroll handler runs a
+    /// mount pass — and reports every step the mount pass moved the offset
+    /// away from where the gesture put it.
+    private func scrollUpSteps(
+        _ steps: Int, step: CGFloat = 60,
+        reconciler: ACPTranscriptScrollerReconciler, scroller: ACPTranscriptScrollerView
+    ) -> [(step: Int, requested: CGFloat, resulting: CGFloat)] {
+        var perturbations: [(step: Int, requested: CGFloat, resulting: CGFloat)] = []
+        for index in 0..<steps {
+            let target = max(0, scroller.scrollY - step)
+            scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: target))
+            scroller.reflectScrolledClipView(scroller.contentView)
+            reconciler.layoutMountedRows()
+            if abs(scroller.scrollY - target) > 0.5 {
+                perturbations.append((index, target, scroller.scrollY))
+            }
+        }
+        return perturbations
+    }
+
+    @Test("scrolling back out of the tail is not re-pinned to the bottom", arguments: [true, false])
+    func scrollingBackIsNotRePinned(followsTail: Bool) {
+        let (reconciler, scroller, tiling, window) = makeStackInWindow()
+        reconciler.apply(specs: makeRows(120), contentWidth: 800, followsTail: followsTail)
+        if !followsTail { scroller.scrollToBottom() }
+        window.layoutIfNeeded()
+        #expect(scroller.distanceFromBottom < 1)
+
+        let perturbations = scrollUpSteps(40, reconciler: reconciler, scroller: scroller)
+
+        #expect(perturbations.isEmpty, "mount pass moved the offset: \(perturbations)")
+        // 40 steps of 60pt actually travelled, rather than oscillating within
+        // a row-height of the bottom.
+        #expect(scroller.scrollY <= tiling.documentHeight - scroller.viewportHeight - 40 * 60 + 1)
+    }
+
+    /// Head pagination: the coordinator's scroll handler asks the transcript
+    /// to step the render window back, and the NEXT apply carries the older
+    /// rows. The row the user is looking at must not move on screen — on any
+    /// step, including the FINAL one, where `__top_pagination__` disappears in
+    /// the same update that grafts rows in above (ids change at both ends, so
+    /// the diff falls to `.reset`).
+    @Test("head pagination keeps the reading position, including the final step")
+    func headPaginationKeepsReadingPosition() {
+        let (reconciler, scroller, tiling, nsWindow) = makeStackInWindow()
+        let allRows = makeRows(150)
+
+        reconciler.apply(specs: renderWindow(head: 100, allRows: allRows),
+                         contentWidth: 800, followsTail: false)
+        nsWindow.layoutIfNeeded()
+
+        // Walk the head back one chunk at a time, as the scroll handler does,
+        // from a viewport parked at the top of the current window.
+        for head in stride(from: 75, through: 0, by: -25) {
+            scroller.setScrollY(0)
+            reconciler.layoutMountedRows()
+            // The row the user is reading: the first real one below the top.
+            let referenceId = "r\(head + 25)"
+            let onScreenBefore = tiling.row(withId: referenceId)!.minY - scroller.scrollY
+
+            reconciler.apply(specs: renderWindow(head: head, allRows: allRows),
+                             contentWidth: 800, followsTail: false)
+
+            let onScreenAfter = tiling.row(withId: referenceId)!.minY - scroller.scrollY
+            #expect(
+                abs(onScreenAfter - onScreenBefore) < 1,
+                "head step to \(head) moved \(referenceId) by \(onScreenAfter - onScreenBefore)pt"
+            )
+        }
+    }
+
+    /// The row-spec list `ACPTranscriptScroller.Coordinator.rowSpecs` builds
+    /// for a render window starting at `head`: the head-pagination spinner
+    /// (present only while older history remains), the window's message rows,
+    /// and the composer spacer.
+    private func renderWindow(head: Int, allRows: [ACPTranscriptRowSpec]) -> [ACPTranscriptRowSpec] {
+        let spinner = ACPTranscriptRowSpec(
+            id: "__top_pagination__",
+            equalityToken: ACPRowEqualityToken(false),
+            build: { AnyView(Color.clear.frame(height: 14)) }
+        )
+        let spacer = ACPTranscriptRowSpec(
+            id: "__composer_spacer__",
+            equalityToken: ACPRowEqualityToken(true),
+            build: { AnyView(Color.clear.frame(height: 220)) }
+        )
+        return (head > 0 ? [spinner] : []) + Array(allRows[head..<allRows.count]) + [spacer]
+    }
+
+    /// A mirrored session's refresh poll (`ACPSessionManager.runMirrorRefresh`)
+    /// replaces the transcript with its tail and then prepends the older
+    /// messages straight back, so the reconciler sees a block removed and the
+    /// SAME block re-inserted one update later — every 2.5s, forever. The
+    /// round trip must net out: with only the insertion side treating an
+    /// all-synthetic prefix as "above the viewport", the removal declined to
+    /// compensate while the re-insertion compensated in full, teleporting the
+    /// viewport a page below where the user was reading.
+    @Test("removing and re-inserting the same block leaves the viewport where it was")
+    func removeThenReinsertRoundTripIsNeutral() {
+        let (reconciler, scroller, _, nsWindow) = makeStackInWindow()
+        let allRows = makeRows(150)
+        let full = renderWindow(head: 60, allRows: allRows)
+        reconciler.apply(specs: full, contentWidth: 800, followsTail: false)
+        nsWindow.layoutIfNeeded()
+
+        // The user is parked at the very top of the window, under the head
+        // pagination spinner — the position the round trip used to destroy.
+        scroller.setScrollY(0)
+        reconciler.layoutMountedRows()
+        let scrollYBefore = scroller.scrollY
+
+        // Poll tick: transcript replaced with its tail (the 60 window rows
+        // between the spinner and the composer spacer drop out) …
+        var tailOnly = full
+        tailOnly.removeSubrange(1..<61)
+        reconciler.apply(specs: tailOnly, contentWidth: 800, followsTail: false)
+        // … then the backfill puts them straight back.
+        reconciler.apply(specs: full, contentWidth: 800, followsTail: false)
+
+        #expect(
+            abs(scroller.scrollY - scrollYBefore) < 1,
+            "round trip moved the viewport \(scroller.scrollY - scrollYBefore)pt"
+        )
+    }
+
+    /// The mirror of the `remeasureRow` trap, one level up: inside
+    /// `ACPScrollDirectionClassifier.pauseTolerance` the coordinator has not
+    /// paused tail-follow yet, so any SwiftUI update landing mid-gesture
+    /// reaches `apply(followsTail: true)` and used to slam the viewport back
+    /// to the bottom — the user scrolls up, and the transcript jumps to the
+    /// newest message "for no reason".
+    @Test("an update landing mid-gesture does not slam the viewport back to the bottom")
+    func updateDuringUnpausedScrollUpDoesNotRePin() {
+        let (reconciler, scroller, _, nsWindow) = makeStackInWindow()
+        let specs = makeRows(120)
+        reconciler.apply(specs: specs, contentWidth: 800, followsTail: true)
+        nsWindow.layoutIfNeeded()
+        #expect(scroller.distanceFromBottom < 1)
+
+        // The user scrolls up less than `pauseTolerance`, so tail-follow is
+        // deliberately still on — exactly as the coordinator leaves it.
+        let target = scroller.scrollY - 90
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: target))
+        scroller.reflectScrolledClipView(scroller.contentView)
+        reconciler.layoutMountedRows()
+        #expect(abs(scroller.scrollY - target) < 0.5)
+
+        // A model update lands mid-gesture: a streaming row grows, so this is
+        // a genuine content change, not a no-op apply.
+        let grown = ACPTranscriptRowSpec(
+            id: "r119",
+            equalityToken: ACPRowEqualityToken(119_000),
+            build: { AnyView(Color.clear.frame(height: 400)) }
+        )
+        reconciler.apply(
+            specs: specs.dropLast() + [grown], contentWidth: 800, followsTail: true
+        )
+
+        #expect(abs(scroller.scrollY - target) < 0.5, "viewport was re-pinned to \(scroller.scrollY)")
+    }
+
+    /// The behavior `remeasureRow`'s re-pin exists for must survive the fix:
+    /// while the viewport IS at the tail, a row growing under it keeps the
+    /// tail glued.
+    @Test("a row growing while the viewport sits at the tail still re-pins")
+    func growthAtTailStillRePins() {
+        let (reconciler, scroller, _, window) = makeStackInWindow()
+        let specs = makeRows(30)
+        reconciler.apply(specs: specs, contentWidth: 800, followsTail: true)
+        window.layoutIfNeeded()
+        #expect(scroller.distanceFromBottom < 1)
+
+        let grown = ACPTranscriptRowSpec(
+            id: "r29",
+            equalityToken: ACPRowEqualityToken(29_000),
+            build: { AnyView(Color.clear.frame(height: 900)) }
+        )
+        reconciler.apply(
+            specs: specs.dropLast() + [grown], contentWidth: 800, followsTail: true
+        )
+        reconciler.remeasureRow(id: "r29")
+
+        #expect(scroller.distanceFromBottom < 1)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerScrollBackTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerScrollBackTests.swift
@@ -69,6 +69,7 @@ struct ACPTranscriptScrollerScrollBackTests {
             let target = max(0, scroller.scrollY - step)
             scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: target))
             scroller.reflectScrolledClipView(scroller.contentView)
+            reconciler.noteUserScroll()
             reconciler.layoutMountedRows()
             if abs(scroller.scrollY - target) > 0.5 {
                 perturbations.append((index, target, scroller.scrollY))
@@ -201,6 +202,7 @@ struct ACPTranscriptScrollerScrollBackTests {
         let target = scroller.scrollY - 90
         scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: target))
         scroller.reflectScrolledClipView(scroller.contentView)
+        reconciler.noteUserScroll()
         reconciler.layoutMountedRows()
         #expect(abs(scroller.scrollY - target) < 0.5)
 
@@ -216,6 +218,38 @@ struct ACPTranscriptScrollerScrollBackTests {
         )
 
         #expect(abs(scroller.scrollY - target) < 0.5, "viewport was re-pinned to \(scroller.scrollY)")
+    }
+
+    /// The suppression must not outlive the gesture. Between
+    /// `bottomTolerance` and `pauseTolerance` the session still reports that
+    /// it follows the tail, so a viewport left permanently unpinned there
+    /// would get neither behavior: streaming content piling up below the
+    /// fold while the "go to newest" affordance stays hidden, because it keys
+    /// off `session.followsTranscriptTail` and nothing paused it.
+    @Test("once the gesture ends, an update re-pins to the tail again")
+    func rePinResumesAfterTheGestureEnds() async throws {
+        let (reconciler, scroller, _, nsWindow) = makeStackInWindow()
+        let specs = makeRows(120)
+        reconciler.apply(specs: specs, contentWidth: 800, followsTail: true)
+        nsWindow.layoutIfNeeded()
+
+        // Parked in the band where tail-follow is deliberately still on:
+        // past `bottomTolerance`, short of `pauseTolerance`.
+        let target = scroller.scrollY - 90
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: target))
+        scroller.reflectScrolledClipView(scroller.contentView)
+        reconciler.noteUserScroll()
+        reconciler.layoutMountedRows()
+        #expect(abs(scroller.scrollY - target) < 0.5)
+
+        // The gesture ends. Generous grace over the window, matching this
+        // codebase's margin for time-based tests under CI scheduling load.
+        let grace = ACPTranscriptScrollerReconciler.userScrollSuppressionWindow + 0.4
+        try await Task.sleep(nanoseconds: UInt64(grace * 1_000_000_000))
+
+        reconciler.apply(specs: specs, contentWidth: 800, followsTail: true)
+
+        #expect(scroller.distanceFromBottom < 1)
     }
 
     /// The behavior `remeasureRow`'s re-pin exists for must survive the fix:


### PR DESCRIPTION
The AppKit transcript scroller (feature-flagged, `alas.transcript.appkitScroller`, on by default in DEBUG) made the ACP chat unusable: scrolling back stuttered and snapped the viewport into place again and again. Four separate defects, each found by tracing the running app rather than by reading the code.

## Tail-follow intent is not the viewport's position

`remeasureRow` and `apply()` both re-pinned to the bottom on `followsTail` alone. `ACPScrollDirectionClassifier.pauseTolerance` deliberately withholds the tail-follow pause for the first 160pt of upward travel, so every scroll tick inside that band still reports tail-follow on.

Mount-time measurement reassigns a hosting view's `rootView`, SwiftUI answers by invalidating its intrinsic size, and that invalidation lands in `remeasureRow`. So every tick that mounted a row — a bare scroll gesture on an idle transcript, no model update, nothing grown — snapped the viewport back to the bottom. Escaping needed 160pt of travel that each tick undid: the transcript oscillated within one row-height of the tail forever.

`apply()` had the same bug one level up, so any SwiftUI update landing mid-gesture slammed you to the newest message.

Both now additionally require the viewport to actually be at the tail. The rising edge of tail-follow is exempt — "go to newest" sets the flag and resets the render window *without* scrolling, relying on that re-pin to jump — which the existing `resetToTail` test caught when I first got it wrong.

## Anchor rows that vanish and come back

`ACPSessionManager.runMirrorRefresh` replaces a mirrored session's transcript with its tail on every 2.5s poll, and the backfill it schedules prepends the older messages straight back one update later. Across that pair the row you are reading does not exist:

```
apply diff=removed(index: 1, count: 60)    doc 4954 → 1836   compensation 0
apply diff=inserted(index: 1, count: 60)   applyPrepend +3118
```

The removal's compensation clamps to 0 at the top of the document and is silently lost; the matching re-insertion compensates in full. Net: a page-sized drop, every poll.

Removals now go through the same all-synthetic-prefix rule as insertions, and an anchor whose row was removed is remembered and restored when the row reappears — bounded to 3 updates, and dropped outright on any user-driven scroll so a live gesture is never fought. This is what the legacy path gets for free from `restoreRememberedAnchorIfNeeded` re-scrolling to a remembered message id after a rebuild.

## Pagination gated on `NSApp.currentEvent`

That event is only the scroll event while the bounds change happens inside event dispatch, and under `NSScrollView`'s responsive scrolling it usually is not. Measured in the running app:

```
userDriven=false : 1176 ticks (97%)
userDriven=true  :   33 ticks (3%)
```

Head pagination was gated on that flag, so reaching the top of the render window meant waiting — a second or more — for a tick to coincide with a recognizable fresh event before older messages loaded at all. The load itself takes 63ms:

```
18:19:24.257 noChange -1->0      ← bounce settles, sitting at the top
   (1.1s of nothing)
18:19:25.371 userScrolledUp 0->-1
18:19:25.372 stepHeadBack from head=69
18:19:25.435 applyPrepend delta=2620   ← content arrives
```

Head and tail pagination are now geometric, which is how the legacy path did it (a sentinel row coming into view, `handleHeadFramePreference`). What bounds the work is geometry: each step's compensation pushes the offset back down by the height it grafted in, so the window stops growing once there is a threshold's worth of loaded history above the viewport. The event classification stays where a false positive is user-visible — deciding whether to pause tail-follow.

## Testing

`ACPTranscriptScrollerScrollBackTests` drives a real `NSWindow` with 120 text-measured rows and walks the clip view's bounds origin the way a trackpad gesture does. Before the first fix it records 14 perturbations, every one snapping exactly back to the bottom, oscillating between 9098 and 8918 across all 40 steps; after, zero perturbations and the full 2400pt of travel. Companion tests cover the mirror-refresh round trip, head pagination preserving the reading position through the final step, and the behaviours the re-pins exist for.

122 tests pass across the 14 scroller/tiling/transcript-window suites. Verified by hand in the running app across several rounds.

## Not addressed here

Mirrored sessions still discard a paged-back render window every 2.5s (`runMirrorRefresh` → `applyRememberedTranscriptScrollWindow`), which undoes head paging and forces a 30-60 row insert *and* removal per poll. That is pre-existing session-manager behaviour that affects the legacy path too, and is left for its own change.
