### PR TITLE
fix(worktree): activity timestamps from HEAD commits

### DIFF
--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -49,6 +49,8 @@ struct WorktreeService {
         )
         if let host {
             trees = await Self.fillingRemoteMetadata(trees, host: host)
+        } else {
+            trees = await Self.fillingHeadCommitTimes(trees)
         }
         return trees
     }
@@ -186,6 +188,30 @@ struct WorktreeService {
             + "if [ ! -s \"$f\" ]; then "
             + "(umask 077; set -C; printf '%s\\n' \"$c\" > \"$f\") 2>/dev/null || true; fi; "
             + "head -n 1 \"$f\""
+    }
+
+    private static func fillingHeadCommitTimes(_ trees: [Worktree]) async -> [Worktree] {
+        await withTaskGroup(of: (Int, Date?).self) { group in
+            for (index, tree) in trees.enumerated() {
+                group.addTask {
+                    let invocation = GitInvocation.build(
+                        gitArgs: ["log", "-1", "--format=%ct", "HEAD"],
+                        cwd: tree.path,
+                        host: nil
+                    )
+                    let result = try? await Process.run(
+                        invocation.executable,
+                        args: invocation.args,
+                        cwd: invocation.cwd,
+                        env: invocation.env
+                    )
+                    return (index, result.flatMap { $0.exitCode == 0 ? date(fromEpochOutput: $0.stdout) : nil })
+                }
+            }
+            var trees = trees
+            for await (index, date) in group where date != nil { trees[index].lastActivity = date! }
+            return trees
+        }
     }
 
     private static func fillingRemoteMetadata(_ trees: [Worktree], host: String) async -> [Worktree] {

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -28,6 +28,57 @@ struct WorktreeServiceTests {
         #expect(trees.first?.branch == "main")
     }
 
+    @Test func listUsesEachHeadCommitTimeWhenRefsArePacked() async throws {
+        let repo = try await makeRepo()
+        let root = repo.deletingLastPathComponent()
+        let one = root.appendingPathComponent("\(repo.lastPathComponent)-packed-one")
+        let two = root.appendingPathComponent("\(repo.lastPathComponent)-packed-two")
+        defer {
+            try? FileManager.default.removeItem(at: one)
+            try? FileManager.default.removeItem(at: two)
+            try? FileManager.default.removeItem(at: repo)
+        }
+
+        _ = try await Process.git(["branch", "packed-one"], cwd: repo)
+        _ = try await Process.git(["branch", "packed-two"], cwd: repo)
+        _ = try await Process.git(["worktree", "add", "-q", one.path, "packed-one"], cwd: repo)
+        _ = try await Process.git(["worktree", "add", "-q", two.path, "packed-two"], cwd: repo)
+
+        let oneEpoch: TimeInterval = 1_738_411_200
+        let twoEpoch: TimeInterval = 1_740_830_400
+
+        var oneEnv = Process.gitEnv()
+        oneEnv["GIT_AUTHOR_DATE"] = "2025-02-01T12:00:00Z"
+        oneEnv["GIT_COMMITTER_DATE"] = "2025-02-01T12:00:00Z"
+        let oneCommit = try await Process.run(
+            "/usr/bin/env",
+            args: ["git", "commit", "-q", "--allow-empty", "-m", "one"],
+            cwd: one,
+            env: oneEnv
+        )
+        try #require(oneCommit.exitCode == 0)
+
+        var twoEnv = Process.gitEnv()
+        twoEnv["GIT_AUTHOR_DATE"] = "2025-03-01T12:00:00Z"
+        twoEnv["GIT_COMMITTER_DATE"] = "2025-03-01T12:00:00Z"
+        let twoCommit = try await Process.run(
+            "/usr/bin/env",
+            args: ["git", "commit", "-q", "--allow-empty", "-m", "two"],
+            cwd: two,
+            env: twoEnv
+        )
+        try #require(twoCommit.exitCode == 0)
+
+        let packed = try await Process.git(["pack-refs", "--all", "--prune"], cwd: repo)
+        try #require(packed.exitCode == 0)
+
+        let trees = try await WorktreeService().list(repoPath: repo, projectId: "p")
+        let byBranch = Dictionary(uniqueKeysWithValues: trees.map { ($0.branch, $0) })
+
+        #expect(byBranch["packed-one"]?.lastActivity == Date(timeIntervalSince1970: oneEpoch))
+        #expect(byBranch["packed-two"]?.lastActivity == Date(timeIntervalSince1970: twoEpoch))
+    }
+
     @Test func addCreatesWorktree() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/docs/superpowers/plans/2026-08-04-worktree-import-timestamps.md
+++ b/docs/superpowers/plans/2026-08-04-worktree-import-timestamps.md
@@ -1,0 +1,186 @@
+# Worktree Import Timestamps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every discovered worktree the commit time of its own HEAD so packed Git refs cannot collapse last-update display and sorting onto one shared timestamp.
+
+**Architecture:** Keep `parsePorcelain` synchronous and retain its current filesystem/ref-derived `lastActivity` as a fallback. After parsing, enrich every local or SSH worktree concurrently with `git log -1 --format=%ct HEAD`; successful lookups replace the fallback while failures leave it unchanged.
+
+**Tech Stack:** Swift 5.9, Foundation `Process`, Swift structured concurrency, Swift Testing, Git CLI, macOS 15+
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Tests use Swift Testing (`import Testing`), not XCTest.
+- Do not add dependencies or persistence fields.
+- Preserve folder creation-date semantics for `createdAt`.
+- Preserve filesystem/ref-derived `lastActivity` as the fallback for empty repositories or failed Git lookups.
+- Use each worktree's HEAD commit time consistently for local and SSH repositories.
+
+---
+
+### Task 1: Resolve Worktree Last Activity From HEAD Commit Time
+
+**Files:**
+- Modify: `AlasTests/WorktreeServiceTests.swift`
+- Modify: `Alas/Sources/Git/WorktreeService.swift:32-42`
+- Modify: `Alas/Sources/Git/WorktreeService.swift:123-147`
+
+**Interfaces:**
+- Consumes: `Process.git(_:cwd:stdin:timeout:)`, `Process.run(_:args:cwd:env:stdin:timeout:)`, `Process.gitEnv()`, `GitInvocation.build(gitArgs:cwd:host:)`, and `WorktreeService.date(fromEpochOutput:)`.
+- Produces: `WorktreeService.list(repoPath:projectId:) async throws -> [Worktree]` whose successful rows use the checked-out HEAD commit time for `lastActivity` on both local and SSH repositories.
+- Internal helper: rename `fillingRemoteLastActivity(_:host:)` to `fillingHeadCommitTimes(_:host:)` and change `host` from `String` to `String?`.
+
+- [ ] **Step 1: Write the packed-refs regression test**
+
+Add this test inside `WorktreeServiceTests` after `listFindsMain()`:
+
+```swift
+@Test func listUsesEachHeadCommitTimeWhenRefsArePacked() async throws {
+    let repo = try await makeRepo()
+    let root = repo.deletingLastPathComponent()
+    let one = root.appendingPathComponent("\(repo.lastPathComponent)-packed-one")
+    let two = root.appendingPathComponent("\(repo.lastPathComponent)-packed-two")
+    defer {
+        try? FileManager.default.removeItem(at: one)
+        try? FileManager.default.removeItem(at: two)
+        try? FileManager.default.removeItem(at: repo)
+    }
+
+    _ = try await Process.git(["branch", "packed-one"], cwd: repo)
+    _ = try await Process.git(["branch", "packed-two"], cwd: repo)
+    _ = try await Process.git(["worktree", "add", "-q", one.path, "packed-one"], cwd: repo)
+    _ = try await Process.git(["worktree", "add", "-q", two.path, "packed-two"], cwd: repo)
+
+    let oneEpoch: TimeInterval = 1_738_411_200
+    let twoEpoch: TimeInterval = 1_740_830_400
+
+    var oneEnv = Process.gitEnv()
+    oneEnv["GIT_AUTHOR_DATE"] = "2025-02-01T12:00:00Z"
+    oneEnv["GIT_COMMITTER_DATE"] = "2025-02-01T12:00:00Z"
+    let oneCommit = try await Process.run(
+        "/usr/bin/env",
+        args: ["git", "commit", "-q", "--allow-empty", "-m", "one"],
+        cwd: one,
+        env: oneEnv
+    )
+    try #require(oneCommit.exitCode == 0)
+
+    var twoEnv = Process.gitEnv()
+    twoEnv["GIT_AUTHOR_DATE"] = "2025-03-01T12:00:00Z"
+    twoEnv["GIT_COMMITTER_DATE"] = "2025-03-01T12:00:00Z"
+    let twoCommit = try await Process.run(
+        "/usr/bin/env",
+        args: ["git", "commit", "-q", "--allow-empty", "-m", "two"],
+        cwd: two,
+        env: twoEnv
+    )
+    try #require(twoCommit.exitCode == 0)
+
+    let packed = try await Process.git(["pack-refs", "--all", "--prune"], cwd: repo)
+    try #require(packed.exitCode == 0)
+
+    let trees = try await WorktreeService().list(repoPath: repo, projectId: "p")
+    let byBranch = Dictionary(uniqueKeysWithValues: trees.map { ($0.branch, $0) })
+
+    #expect(byBranch["packed-one"]?.lastActivity == Date(timeIntervalSince1970: oneEpoch))
+    #expect(byBranch["packed-two"]?.lastActivity == Date(timeIntervalSince1970: twoEpoch))
+}
+```
+
+This test catches a regression where `list` returns the shared `packed-refs` mtime instead of each worktree's commit time. Its expected epoch values are fixed literals derived from the fixture dates, independent of production parsing.
+
+- [ ] **Step 2: Run the regression test and verify RED**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/WorktreeServiceTests/listUsesEachHeadCommitTimeWhenRefsArePacked test
+```
+
+Expected: FAIL because both linked worktrees receive the current shared `packed-refs` modification time rather than `2025-02-01T12:00:00Z` and `2025-03-01T12:00:00Z`.
+
+- [ ] **Step 3: Enrich every discovered worktree from its HEAD commit**
+
+Change `WorktreeService.list` to pass the optional host into one shared enrichment path:
+
+```swift
+func list(repoPath: URL, projectId: String) async throws -> [Worktree] {
+    let result = try await Process.git(["worktree", "list", "--porcelain"], cwd: repoPath)
+    guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
+    let trees = Self.parsePorcelain(result.stdout, projectId: projectId)
+    let host = RemoteHostRegistry.shared.host(forPath: repoPath.path)
+    return await Self.fillingHeadCommitTimes(trees, host: host)
+}
+```
+
+Rename and generalize the existing helper without changing its fallback behavior:
+
+```swift
+private static func fillingHeadCommitTimes(_ trees: [Worktree], host: String?) async -> [Worktree] {
+    await withTaskGroup(of: (Int, Date?).self) { group in
+        for (index, tree) in trees.enumerated() {
+            group.addTask {
+                let invocation = GitInvocation.build(
+                    gitArgs: ["log", "-1", "--format=%ct", "HEAD"],
+                    cwd: tree.path,
+                    host: host
+                )
+                let result = try? await Process.run(
+                    invocation.executable,
+                    args: invocation.args,
+                    cwd: invocation.cwd,
+                    env: invocation.env
+                )
+                return (
+                    index,
+                    result.flatMap {
+                        $0.exitCode == 0 ? date(fromEpochOutput: $0.stdout) : nil
+                    }
+                )
+            }
+        }
+        var trees = trees
+        for await (index, date) in group where date != nil {
+            trees[index].lastActivity = date!
+        }
+        return trees
+    }
+}
+```
+
+Do not remove `lastActivity(forWorktreeAt:)`: `parsePorcelain` still uses it to provide a value when a repository is empty or the HEAD lookup fails.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/WorktreeServiceTests \
+  -only-testing:AlasTests/WorktreeServiceCreatedAtTests test
+```
+
+Expected: PASS, including the packed-refs regression and the existing timestamp fallback/parser coverage.
+
+- [ ] **Step 5: Run project-required verification**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: all commands exit successfully. If `xcodegen` changes `Alas.xcodeproj/project.pbxproj`, include that generated change in the implementation commit as required by the project instructions.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add Alas/Sources/Git/WorktreeService.swift AlasTests/WorktreeServiceTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "fix: use HEAD commit times for worktree activity"
+```
+
+If `Alas.xcodeproj/project.pbxproj` is unchanged, omit it from `git add`.

--- a/docs/superpowers/specs/2026-08-04-worktree-import-timestamps-design.md
+++ b/docs/superpowers/specs/2026-08-04-worktree-import-timestamps-design.md
@@ -1,0 +1,75 @@
+# Worktree Import Timestamps Design
+
+## Problem
+
+When Alas discovers the worktrees of a newly added local repository, it derives
+`lastActivity` from Git ref-file modification times. If branches are stored in
+`packed-refs`, every affected worktree receives the modification time of the
+same shared file. The sidebar therefore displays an identical timestamp for
+worktrees whose HEAD commits were updated at different times, and automatic
+last-update sorting cannot distinguish them.
+
+## Semantics
+
+- `createdAt` continues to represent the worktree folder's filesystem creation
+  date, with the existing folder modification-date fallback.
+- `lastActivity` represents the commit time of the commit currently checked out
+  at the worktree's HEAD.
+- Filesystem and ref modification times remain best-effort fallbacks when Git
+  cannot resolve a HEAD commit timestamp.
+
+This definition is consistent for loose refs, packed refs, and detached HEADs,
+and matches the existing remote-repository behavior.
+
+## Design
+
+After parsing `git worktree list --porcelain`, `WorktreeService.list` resolves
+the HEAD commit time for each discovered worktree with:
+
+```text
+git log -1 --format=%ct HEAD
+```
+
+The lookups run concurrently, as the current SSH implementation already does.
+Successful results replace the provisional `lastActivity` populated by the
+synchronous porcelain parser. Failed or empty-history lookups leave that
+provisional value unchanged.
+
+The same enrichment path handles local and SSH repositories so timestamp
+semantics do not depend on transport. No new persistence fields or UI changes
+are required; `ProjectsManager` already sorts by `lastActivity`, and the
+sidebar already displays it.
+
+## Alternatives Considered
+
+1. Use commit time only when a loose ref is absent. This reduces subprocesses
+   but makes `lastActivity` mean ref-write time for some branches and commit
+   time for others.
+2. Batch branch timestamps from the main repository. This uses fewer processes
+   but complicates detached HEAD handling and mapping Git's worktree-specific
+   state.
+3. Use worktree folder modification time. Generated files, builds, and other
+   non-Git filesystem activity make it a noisy measure of repository updates.
+
+Per-worktree HEAD commit lookup is preferred because it is consistent and
+reuses the behavior already used for SSH worktrees.
+
+## Testing
+
+Add an integration regression test that:
+
+1. Creates a repository with multiple linked worktrees.
+2. Gives each worktree's HEAD commit a distinct commit time.
+3. Packs and prunes the repository's refs.
+4. Calls `WorktreeService.list`.
+5. Verifies that each worktree receives its own HEAD commit time rather than the
+   shared `packed-refs` modification time.
+
+Existing worktree-ordering tests continue to cover ascending and descending
+sorting once distinct `lastActivity` values reach `ProjectsManager`.
+
+## Scope
+
+The change only corrects initial and refreshed `lastActivity` discovery. It
+does not add a separate "last opened in Alas" metric, alter creation-time
+semantics, or change the main-worktree pinning rule.


### PR DESCRIPTION
## Summary

- Derive local worktree activity from each worktree's checked-out HEAD commit time.
- Prevent packed Git refs from making every imported worktree appear to have the same last-update time.
- Preserve existing local folder creation timestamps and upstream SSH metadata behavior.

## Root cause

When branches were stored in Git's shared `packed-refs` file, Alas used that single file's modification time for every worktree. The sidebar and automatic last-update sort therefore could not distinguish worktrees with different commit histories.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/WorktreeServiceTests -only-testing:AlasTests/RemoteLastActivityTests` (42 tests passed)

The full local suite has an unrelated, repeatable Diff Review accessibility-test failure; GitHub Actions is the final CI gate for this PR.
