### PR TITLE
feat(menu): Add Finder-style file actions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1445,6 +1445,7 @@
 		F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */; };
 		F8DFFC12D5F7F2E1F8F19A02 /* MermaidRenderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */; };
 		F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */; };
+		F927B660B51081F2FACA5070 /* FileSystemOpenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596BB6B295D768E2C0D3BC85 /* FileSystemOpenTests.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
 		F9FED997CCAD027FBBE36C1D /* PendingReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5679CA959D40E1682A91F31 /* PendingReview.swift */; };
@@ -2012,6 +2013,7 @@
 		57E1A9B42D47CC0244C24F7B /* ACPElicitationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitationTests.swift; sourceTree = "<group>"; };
 		58B78EE378B0A076C904E2E4 /* TreeSitterLua */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterLua; path = ThirdParty/TreeSitterLua; sourceTree = SOURCE_ROOT; };
 		58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentController.swift; sourceTree = "<group>"; };
+		596BB6B295D768E2C0D3BC85 /* FileSystemOpenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemOpenTests.swift; sourceTree = "<group>"; };
 		59C7BDB3BEEB5B23DCE7F2C0 /* GGWorktreeContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGWorktreeContext.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
 		59F17DE68E81565014FC9454 /* RemoteHelperWatchSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperWatchSession.swift; sourceTree = "<group>"; };
@@ -3306,6 +3308,7 @@
 				408F9FF672160D96B1C22648 /* FilesTabCompactChainTests.swift */,
 				1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */,
 				0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */,
+				596BB6B295D768E2C0D3BC85 /* FileSystemOpenTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
 				431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */,
 				2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */,
@@ -6823,6 +6826,7 @@
 				8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */,
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				BEF1C5E442CA7EB29929FCC6 /* FileSearchRankerTests.swift in Sources */,
+				F927B660B51081F2FACA5070 /* FileSystemOpenTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
 				3910AEED9AC1888582616BEA /* FileTreeRowIndentationTests.swift in Sources */,
 				6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1102,6 +1102,7 @@
 		BDEA5736B570C77CF4C965F5 /* DiffInlineAnnotationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1503D1CB549B39E499EFAB8 /* DiffInlineAnnotationCard.swift */; };
 		BE4E46595AF10611CE0B1C6B /* TabActivityPulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */; };
 		BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */; };
+		BE7AAB0C61C7D1ED4B0479CA /* FileContextMenuActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF737AC27636853CA933B0E1 /* FileContextMenuActions.swift */; };
 		BE7FA8E07C4A1FC48267C64D /* ACPAdapterUpdateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */; };
 		BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */; };
 		BEF1C5E442CA7EB29929FCC6 /* FileSearchRankerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F50B2E7675F40749566F54 /* FileSearchRankerTests.swift */; };
@@ -1454,6 +1455,7 @@
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
 		FB000FBA6BA9ED49F65681AC /* RemoteFileSearchGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7331F53100D12A0DDFD6B1D /* RemoteFileSearchGateTests.swift */; };
 		FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */; };
+		FB351F4FDB33432BB3902BFB /* FileContextMenuActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB94BF97B7E1E0C78DDDE441 /* FileContextMenuActionsTests.swift */; };
 		FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */; };
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
 		FB6FF6C91476DEE43E512E30 /* RemoteServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EACA79C819C9FBE68F9D84 /* RemoteServer.swift */; };
@@ -2674,6 +2676,7 @@
 		CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModel.swift; sourceTree = "<group>"; };
 		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
+		CF737AC27636853CA933B0E1 /* FileContextMenuActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileContextMenuActions.swift; sourceTree = "<group>"; };
 		CF798A386DD56B4127D5272A /* ACPTerminalCRLFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalCRLFTests.swift; sourceTree = "<group>"; };
 		CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStatePolicy.swift; sourceTree = "<group>"; };
 		CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayModel.swift; sourceTree = "<group>"; };
@@ -2742,6 +2745,7 @@
 		DAA7CD14A8FA2D335A59B062 /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
 		DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRunScriptDialog.swift; sourceTree = "<group>"; };
 		DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetailsTests.swift; sourceTree = "<group>"; };
+		DB94BF97B7E1E0C78DDDE441 /* FileContextMenuActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileContextMenuActionsTests.swift; sourceTree = "<group>"; };
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
 		DBB784CA59AB7163DF7B96A6 /* MissionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionPersistence.swift; sourceTree = "<group>"; };
 		DC3201ACD757677A7F42A8AE /* AlasMCPHTTPSupervisorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasMCPHTTPSupervisorTests.swift; sourceTree = "<group>"; };
@@ -3303,6 +3307,7 @@
 				DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */,
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
 				25493E3B18A1AB94EA6985C3 /* EventHolder.swift */,
+				DB94BF97B7E1E0C78DDDE441 /* FileContextMenuActionsTests.swift */,
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
 				F2F50B2E7675F40749566F54 /* FileSearchRankerTests.swift */,
 				408F9FF672160D96B1C22648 /* FilesTabCompactChainTests.swift */,
@@ -3879,6 +3884,7 @@
 				3DCEFADD952DB870B8BAB890 /* CommitRow.swift */,
 				6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */,
 				561094BA96058468F12002A1 /* ConflictsSection.swift */,
+				CF737AC27636853CA933B0E1 /* FileContextMenuActions.swift */,
 				BD4A3B9B1103346242438940 /* FilesTabView.swift */,
 				F721FB733081A583D4053DDA /* FileTypeIconView.swift */,
 				542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */,
@@ -6078,6 +6084,7 @@
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
 				950C937884477417569DC20B /* EmptyTabView.swift in Sources */,
 				7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */,
+				BE7AAB0C61C7D1ED4B0479CA /* FileContextMenuActions.swift in Sources */,
 				58A58A64E7E10EC5A1CC60C5 /* FileDeviceStore.swift in Sources */,
 				E1D9EF82D0A80D3E2036CAD6 /* FileHistoryTabView.swift in Sources */,
 				3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */,
@@ -6824,6 +6831,7 @@
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,
 				51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */,
 				8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */,
+				FB351F4FDB33432BB3902BFB /* FileContextMenuActionsTests.swift in Sources */,
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				BEF1C5E442CA7EB29929FCC6 /* FileSearchRankerTests.swift in Sources */,
 				F927B660B51081F2FACA5070 /* FileSystemOpenTests.swift in Sources */,

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -655,6 +655,14 @@ struct DiffReviewFileSection: View {
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier("diff-review-show-full-diff-\(file.id.rawValue)")
+            .background(
+                ReviewDraftCommentActionPressMarker(
+                    identifier: "diff-review-show-full-diff-\(file.id.rawValue)",
+                    label: "Show full diff"
+                ) {
+                    showFullDiffOverride = true
+                }
+            )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 14)

--- a/Alas/Sources/Center/FileSystemOpen.swift
+++ b/Alas/Sources/Center/FileSystemOpen.swift
@@ -1,17 +1,77 @@
 import AppKit
 
-/// Thin wrapper around `NSWorkspace` for system-open and reveal-in-Finder
-/// affordances exposed in the editor/image/binary panes and tab-bar menus.
+struct FileSystemApplication: Identifiable, Equatable {
+    let url: URL
+    let name: String
+    let isDefault: Bool
+
+    var id: String { url.standardizedFileURL.path }
+    var menuTitle: String { isDefault ? "\(name) (default)" : name }
+
+    @MainActor var icon: NSImage {
+        NSWorkspace.shared.icon(forFile: url.path)
+    }
+}
+
 enum FileSystemOpen {
-    /// Open `url` with the system's default handler (same as `open <url>` on the CLI).
-    @MainActor
-    static func open(url: URL) {
+    @MainActor static func open(url: URL) {
         NSWorkspace.shared.open(url)
     }
 
-    /// Reveal `url` in a Finder window with the item selected.
-    @MainActor
-    static func reveal(url: URL) {
+    @MainActor static func open(url: URL, with application: FileSystemApplication) {
+        NSWorkspace.shared.open(
+            [url],
+            withApplicationAt: application.url,
+            configuration: NSWorkspace.OpenConfiguration(),
+            completionHandler: nil
+        )
+    }
+
+    @MainActor static func reveal(url: URL) {
         NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    @MainActor static func applications(for url: URL) -> [FileSystemApplication] {
+        let workspace = NSWorkspace.shared
+        return orderedApplications(
+            candidateURLs: workspace.urlsForApplications(toOpen: url),
+            defaultApplicationURL: workspace.urlForApplication(toOpen: url),
+            displayName: applicationDisplayName(for:)
+        )
+    }
+
+    static func orderedApplications(
+        candidateURLs: [URL],
+        defaultApplicationURL: URL?,
+        displayName: (URL) -> String
+    ) -> [FileSystemApplication] {
+        let defaultURL = defaultApplicationURL?.standardizedFileURL
+        var uniqueURLs: [String: URL] = [:]
+        for url in candidateURLs + [defaultApplicationURL].compactMap({ $0 }) {
+            let standardized = url.standardizedFileURL
+            if uniqueURLs[standardized.path] == nil {
+                uniqueURLs[standardized.path] = standardized
+            }
+        }
+        return uniqueURLs.values
+            .map { url in
+                FileSystemApplication(
+                    url: url,
+                    name: displayName(url),
+                    isDefault: url == defaultURL
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.isDefault != rhs.isDefault { return lhs.isDefault }
+                let order = lhs.name.localizedStandardCompare(rhs.name)
+                if order != .orderedSame { return order == .orderedAscending }
+                return lhs.url.path.localizedStandardCompare(rhs.url.path) == .orderedAscending
+            }
+    }
+
+    private static func applicationDisplayName(for url: URL) -> String {
+        let values = try? url.resourceValues(forKeys: [.localizedNameKey])
+        let rawName = values?.localizedName ?? url.lastPathComponent
+        return rawName.hasSuffix(".app") ? String(rawName.dropLast(4)) : rawName
     }
 }

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ChangedRow: View {
     let file: ChangedFile
+    let fileContextTarget: FileContextMenuTarget
     var depth: Int = 0
     let onSelect: () -> Void
     var onStage: (() -> Void)? = nil
@@ -13,7 +14,6 @@ struct ChangedRow: View {
     var onOpenFile:       (() -> Void)? = nil
     var onCopyRelative:   (() -> Void)? = nil
     var onCopyFull:       (() -> Void)? = nil
-    var onRevealInFinder: (() -> Void)? = nil
     var onCopyDiff:       (() -> Void)? = nil
     var onViewAtHEAD:     (() -> Void)? = nil
     var onCompareWithHEAD: (() -> Void)? = nil
@@ -57,17 +57,17 @@ struct ChangedRow: View {
         }
         .buttonStyle(.plain)
         .contextMenu {
-            Button("Open File") { onOpenFile?() }
-                .disabled(!openFileEnabled || onOpenFile == nil)
-            Button("View at HEAD") { onViewAtHEAD?() }
-                .disabled(!viewAtHEADEnabled || onViewAtHEAD == nil)
-            Button("Compare with HEAD") { onCompareWithHEAD?() }
-                .disabled(onCompareWithHEAD == nil)
-            Button("File History") { onFileHistory?() }
-                .disabled(onFileHistory == nil)
-            Button("Copy Relative Path") { onCopyRelative?() }
-            Button("Copy Full Path") { onCopyFull?() }
-            Button("Reveal in Finder") { onRevealInFinder?() }
+            FileContextMenuActions(
+                configuration: .workingTreeFile(target: fileContextTarget),
+                onOpenInAlas: onOpenFile,
+                openInAlasEnabled: openFileEnabled,
+                onViewAtHEAD: onViewAtHEAD,
+                viewAtHEADEnabled: viewAtHEADEnabled,
+                onCompareWithHEAD: onCompareWithHEAD,
+                onFileHistory: onFileHistory,
+                onCopyRelativePath: onCopyRelative,
+                onCopyFullPath: onCopyFull
+            )
             Divider()
             Button("Copy Diff") { onCopyDiff?() }
             Divider()

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import AppKit
 
 struct ChangesTabView: View {
     @Bindable var rps: RightPaneState
@@ -231,6 +230,13 @@ struct ChangesTabView: View {
                 changes: nonConflictChanges,
                 expanded: $rps.workingTreeExpanded,
                 onSelect: onSelect,
+                fileContextTarget: { file in
+                    FileContextMenuTarget.resolve(
+                        kind: .file,
+                        worktreePath: rps.worktree.path,
+                        relativePath: file.path
+                    )
+                },
                 onStageAll: { rps.stageAll($0) },
                 onUnstageAll: { rps.unstageAll($0) },
                 onIgnore: { path, isDir, dest in
@@ -247,10 +253,6 @@ struct ChangesTabView: View {
                 onCopyFull: { file in
                     let absolute = rps.worktree.path.appendingPathComponent(file.path).path
                     Clipboard.copy(absolute)
-                },
-                onRevealInFinder: rps.worktree.path.isRemoteAlasPath ? nil : { file in
-                    let url = rps.worktree.path.appendingPathComponent(file.path)
-                    NSWorkspace.shared.activateFileViewerSelecting([url])
                 },
                 onCopyDiff: { file in
                     rps.copyDiff(for: file.path, renameFrom: file.renameFrom)

--- a/Alas/Sources/Right/FileContextMenuActions.swift
+++ b/Alas/Sources/Right/FileContextMenuActions.swift
@@ -1,0 +1,102 @@
+import AppKit
+import SwiftUI
+
+struct FileContextMenuTarget: Equatable {
+    let kind: FileTreeNode.Kind
+    let localURL: URL?
+
+    static func resolve(
+        kind: FileTreeNode.Kind,
+        worktreePath: URL,
+        relativePath: String,
+        fileExists: (URL) -> Bool = { FileManager.default.fileExists(atPath: $0.path) }
+    ) -> Self {
+        guard !worktreePath.isRemoteAlasPath else { return Self(kind: kind, localURL: nil) }
+        let url = worktreePath.appendingPathComponent(relativePath)
+        return Self(kind: kind, localURL: fileExists(url) ? url : nil)
+    }
+}
+
+enum FileContextMenuAction: Hashable {
+    case openInAlas, open, openWith, viewAtHEAD, compareWithHEAD
+    case fileHistory, copyRelativePath, copyFullPath, revealInFinder
+}
+
+struct FileContextMenuConfiguration: Equatable {
+    let target: FileContextMenuTarget
+    let actions: [FileContextMenuAction]
+
+    static func workingTreeFile(target: FileContextMenuTarget) -> Self {
+        var actions: [FileContextMenuAction] = [.openInAlas]
+        if target.localURL != nil { actions += [.open, .openWith] }
+        actions += [.viewAtHEAD, .compareWithHEAD, .fileHistory, .copyRelativePath, .copyFullPath]
+        if target.localURL != nil { actions.append(.revealInFinder) }
+        return Self(target: target, actions: actions)
+    }
+}
+
+struct FileContextMenuActions: View {
+    let configuration: FileContextMenuConfiguration
+    var onOpenInAlas: (() -> Void)? = nil
+    var openInAlasEnabled = true
+    var onViewAtHEAD: (() -> Void)? = nil
+    var viewAtHEADEnabled = true
+    var onCompareWithHEAD: (() -> Void)? = nil
+    var onFileHistory: (() -> Void)? = nil
+    var onCopyRelativePath: (() -> Void)? = nil
+    var onCopyFullPath: (() -> Void)? = nil
+
+    @ViewBuilder var body: some View {
+        ForEach(configuration.actions, id: \.self) { action in
+            switch action {
+            case .openInAlas:
+                Button("Open in Alas") { onOpenInAlas?() }
+                    .disabled(!openInAlasEnabled || onOpenInAlas == nil)
+            case .open:
+                if let url = configuration.target.localURL {
+                    Button("Open") { FileSystemOpen.open(url: url) }
+                }
+            case .openWith:
+                if let url = configuration.target.localURL { openWithMenu(url: url) }
+            case .viewAtHEAD:
+                Button("View at HEAD") { onViewAtHEAD?() }
+                    .disabled(!viewAtHEADEnabled || onViewAtHEAD == nil)
+            case .compareWithHEAD:
+                Button("Compare with HEAD") { onCompareWithHEAD?() }
+                    .disabled(onCompareWithHEAD == nil)
+            case .fileHistory:
+                Button("File History") { onFileHistory?() }
+                    .disabled(onFileHistory == nil)
+            case .copyRelativePath:
+                Button("Copy Relative Path") { onCopyRelativePath?() }
+                    .disabled(onCopyRelativePath == nil)
+            case .copyFullPath:
+                Button("Copy Full Path") { onCopyFullPath?() }
+                    .disabled(onCopyFullPath == nil)
+            case .revealInFinder:
+                if let url = configuration.target.localURL {
+                    Button("Reveal in Finder") { FileSystemOpen.reveal(url: url) }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private func openWithMenu(url: URL) -> some View {
+        Menu("Open With") {
+            let applications = FileSystemOpen.applications(for: url)
+            if applications.isEmpty {
+                Button("No Compatible Applications") {}.disabled(true)
+            } else {
+                ForEach(applications) { application in
+                    Button { FileSystemOpen.open(url: url, with: application) } label: {
+                        Label {
+                            Text(application.menuTitle)
+                        } icon: {
+                            Image(nsImage: application.icon).resizable().frame(width: 16, height: 16)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Alas/Sources/Right/FileContextMenuActions.swift
+++ b/Alas/Sources/Right/FileContextMenuActions.swift
@@ -33,6 +33,19 @@ struct FileContextMenuConfiguration: Equatable {
         if target.localURL != nil { actions.append(.revealInFinder) }
         return Self(target: target, actions: actions)
     }
+
+    static func filesTab(target: FileContextMenuTarget) -> Self {
+        var actions: [FileContextMenuAction] = []
+        if target.kind == .file { actions.append(.openInAlas) }
+        if target.localURL != nil {
+            actions.append(.open)
+            if target.kind == .file { actions.append(.openWith) }
+        }
+        if target.kind == .file { actions.append(.fileHistory) }
+        actions += [.copyRelativePath, .copyFullPath]
+        if target.localURL != nil { actions.append(.revealInFinder) }
+        return Self(target: target, actions: actions)
+    }
 }
 
 struct FileContextMenuActions: View {

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 struct FilesTabView: View {
     let nodes: [FileTreeNode]
     let fileTreeGeneration: Int
+    let worktreePath: URL
     @Binding var openPaths: Set<String>
     let onSelectFile: (FileTreeNode) -> Void
+    let onFileHistory: (FileTreeNode) -> Void
     let shouldAutoLoadChildren: (String, DirectoryChildrenState) -> Bool
     let onLoadChildren: (String) -> Void
     let showIgnored: Bool
@@ -149,6 +151,7 @@ struct FilesTabView: View {
                         }
                     }
                     .buttonStyle(.plain)
+                    .contextMenu { contextMenu(for: terminal) }
                     if open && canExpand {
                         switch terminal.childrenState {
                         case .loading, .loaded:
@@ -200,8 +203,24 @@ struct FilesTabView: View {
                     .id(node.id)
                 }
                 .buttonStyle(.plain)
+                .contextMenu { contextMenu(for: node) }
             )
         }
+    }
+
+    @ViewBuilder private func contextMenu(for node: FileTreeNode) -> some View {
+        let target = FileContextMenuTarget.resolve(
+            kind: node.kind,
+            worktreePath: worktreePath,
+            relativePath: node.path
+        )
+        FileContextMenuActions(
+            configuration: .filesTab(target: target),
+            onOpenInAlas: node.kind == .file ? { onSelectFile(node) } : nil,
+            onFileHistory: node.kind == .file ? { onFileHistory(node) } : nil,
+            onCopyRelativePath: { Clipboard.copy(node.path) },
+            onCopyFullPath: { Clipboard.copy(worktreePath.appendingPathComponent(node.path).path) }
+        )
     }
 
     private func loadTaskID(for node: FileTreeNode, open: Bool) -> String {

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -76,11 +76,15 @@ struct RightPaneView: View {
                             FilesTabView(
                                 nodes: rps.fileTree,
                                 fileTreeGeneration: rps.fileTreeGeneration,
+                                worktreePath: worktree.path,
                                 openPaths: Binding(
                                     get: { rps.openPaths },
                                     set: { rps.openPaths = $0 }
                                 ),
                                 onSelectFile: onSelectTreeFile,
+                                onFileHistory: { node in
+                                    state.openFileHistory(relativePath: node.path, worktreeId: worktree.id)
+                                },
                                 shouldAutoLoadChildren: { path, childrenState in
                                     rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
                                 },

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -4,6 +4,7 @@ struct WorkingTreeSectionView: View {
     let changes: [ChangedFile]
     @Binding var expanded: Bool
     let onSelect: (ChangedFile) -> Void
+    let fileContextTarget: (ChangedFile) -> FileContextMenuTarget
     var onStageAll: (([ChangedFile]) -> Void)? = nil
     var onUnstageAll: (([ChangedFile]) -> Void)? = nil
     var onIgnore: ((_ path: String, _ isDirectory: Bool, _ destination: IgnoreDestination) -> Void)? = nil
@@ -12,7 +13,6 @@ struct WorkingTreeSectionView: View {
     var onOpenFile:        ((ChangedFile) -> Void)? = nil
     var onCopyRelative:    ((ChangedFile) -> Void)? = nil
     var onCopyFull:        ((ChangedFile) -> Void)? = nil
-    var onRevealInFinder:  ((ChangedFile) -> Void)? = nil
     var onCopyDiff:        ((ChangedFile) -> Void)? = nil
     var onViewAtHEAD:      ((ChangedFile) -> Void)? = nil
     var onCompareWithHEAD: ((ChangedFile) -> Void)? = nil
@@ -233,6 +233,7 @@ struct WorkingTreeSectionView: View {
             return AnyView(
                 ChangedRow(
                     file: file,
+                    fileContextTarget: fileContextTarget(file),
                     depth: depth,
                     onSelect: { onSelect(file) },
                     onStage: primaryStageAction(for: group),
@@ -244,7 +245,6 @@ struct WorkingTreeSectionView: View {
                     onOpenFile: onOpenFile.map { fn in { fn(file) } },
                     onCopyRelative: onCopyRelative.map { fn in { fn(file) } },
                     onCopyFull: onCopyFull.map { fn in { fn(file) } },
-                    onRevealInFinder: onRevealInFinder.map { fn in { fn(file) } },
                     onCopyDiff: onCopyDiff.map { fn in { fn(file) } },
                     onViewAtHEAD: onViewAtHEAD.map { fn in { fn(headPathEntry) } },
                     onCompareWithHEAD: onCompareWithHEAD.map { fn in { fn(headPathEntry) } },

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -21,6 +21,8 @@ struct DiffReviewSurfaceTests {
             defer: false
         )
         window.contentViewController = controller
+        controller.view.frame = window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 480, height: 240)
+        controller.view.layoutSubtreeIfNeeded()
         defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
 
         await drainSwiftUI(controller.view)
@@ -497,6 +499,8 @@ struct DiffReviewSurfaceTests {
             defer: false
         )
         window.contentViewController = controller
+        controller.view.frame = window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 900, height: 520)
+        controller.view.layoutSubtreeIfNeeded()
         defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
 
         await drainSwiftUI(controller.view)
@@ -4157,6 +4161,7 @@ struct DiffReviewSurfaceTests {
     private func drainSwiftUI(_ view: NSView) async {
         for _ in 0..<6 {
             view.layoutSubtreeIfNeeded()
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.001))
             await Task.yield()
         }
     }

--- a/AlasTests/FileContextMenuActionsTests.swift
+++ b/AlasTests/FileContextMenuActionsTests.swift
@@ -46,4 +46,30 @@ struct FileContextMenuActionsTests {
             .fileHistory, .copyRelativePath, .copyFullPath
         ])
     }
+
+    @Test func filesTabFileHasGeneralFinderActionsOnly() {
+        let target = FileContextMenuTarget(kind: .file, localURL: URL(fileURLWithPath: "/repo/README.md"))
+        #expect(FileContextMenuConfiguration.filesTab(target: target).actions == [
+            .openInAlas, .open, .openWith, .fileHistory,
+            .copyRelativePath, .copyFullPath, .revealInFinder
+        ])
+    }
+
+    @Test func filesTabDirectoryOmitsEditorHistoryAndOpenWith() {
+        let target = FileContextMenuTarget(kind: .dir, localURL: URL(fileURLWithPath: "/repo/Sources"))
+        #expect(FileContextMenuConfiguration.filesTab(target: target).actions == [
+            .open, .copyRelativePath, .copyFullPath, .revealInFinder
+        ])
+    }
+
+    @Test func remoteFilesTabTargetsKeepPortableActions() {
+        let file = FileContextMenuTarget(kind: .file, localURL: nil)
+        let directory = FileContextMenuTarget(kind: .dir, localURL: nil)
+        #expect(FileContextMenuConfiguration.filesTab(target: file).actions == [
+            .openInAlas, .fileHistory, .copyRelativePath, .copyFullPath
+        ])
+        #expect(FileContextMenuConfiguration.filesTab(target: directory).actions == [
+            .copyRelativePath, .copyFullPath
+        ])
+    }
 }

--- a/AlasTests/FileContextMenuActionsTests.swift
+++ b/AlasTests/FileContextMenuActionsTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct FileContextMenuActionsTests {
+    @Test func resolvesExistingLocalFileButRejectsMissingFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-context-menu-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let file = root.appendingPathComponent("README.md")
+        try "hello".write(to: file, atomically: true, encoding: .utf8)
+
+        let existing = FileContextMenuTarget.resolve(kind: .file, worktreePath: root, relativePath: "README.md")
+        let missing = FileContextMenuTarget.resolve(kind: .file, worktreePath: root, relativePath: "missing.md")
+
+        #expect(existing.localURL == file)
+        #expect(missing.localURL == nil)
+    }
+
+    @Test func remoteTargetOmitsLocalURL() {
+        let root = URL(fileURLWithPath: "/srv/remote-\(UUID().uuidString)")
+        RemoteHostRegistry.shared.register(root: root.path, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root.path) }
+        let target = FileContextMenuTarget.resolve(
+            kind: .file,
+            worktreePath: root,
+            relativePath: "Sources/App.swift",
+            fileExists: { _ in true }
+        )
+        #expect(target.localURL == nil)
+    }
+
+    @Test func workingTreeFileOrdersFinderAndRevisionActions() {
+        let target = FileContextMenuTarget(kind: .file, localURL: URL(fileURLWithPath: "/repo/App.swift"))
+        #expect(FileContextMenuConfiguration.workingTreeFile(target: target).actions == [
+            .openInAlas, .open, .openWith, .viewAtHEAD, .compareWithHEAD,
+            .fileHistory, .copyRelativePath, .copyFullPath, .revealInFinder
+        ])
+    }
+
+    @Test func workingTreeMissingTargetKeepsNonSystemActions() {
+        let target = FileContextMenuTarget(kind: .file, localURL: nil)
+        #expect(FileContextMenuConfiguration.workingTreeFile(target: target).actions == [
+            .openInAlas, .viewAtHEAD, .compareWithHEAD,
+            .fileHistory, .copyRelativePath, .copyFullPath
+        ])
+    }
+}

--- a/AlasTests/FileSystemOpenTests.swift
+++ b/AlasTests/FileSystemOpenTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct FileSystemOpenTests {
+    @Test func ordersDefaultFirstDeduplicatesAndSortsByName() {
+        let preview = URL(fileURLWithPath: "/Applications/Preview.app")
+        let duplicatePreview = URL(fileURLWithPath: "/Applications/Utilities/../Preview.app")
+        let textEdit = URL(fileURLWithPath: "/System/Applications/TextEdit.app")
+        let xcode = URL(fileURLWithPath: "/Applications/Xcode.app")
+        let names = [
+            preview.standardizedFileURL.path: "Preview",
+            textEdit.standardizedFileURL.path: "TextEdit",
+            xcode.standardizedFileURL.path: "Xcode"
+        ]
+
+        let applications = FileSystemOpen.orderedApplications(
+            candidateURLs: [xcode, duplicatePreview, textEdit, preview],
+            defaultApplicationURL: textEdit,
+            displayName: { names[$0.standardizedFileURL.path] ?? $0.lastPathComponent }
+        )
+
+        #expect(applications.map(\.url) == [textEdit, preview, xcode])
+        #expect(applications.map(\.name) == ["TextEdit", "Preview", "Xcode"])
+        #expect(applications.map(\.isDefault) == [true, false, false])
+        #expect(applications.map(\.menuTitle) == ["TextEdit (default)", "Preview", "Xcode"])
+    }
+
+    @Test func includesDefaultWhenCandidateListOmitsIt() {
+        let preview = URL(fileURLWithPath: "/Applications/Preview.app")
+        let textEdit = URL(fileURLWithPath: "/System/Applications/TextEdit.app")
+
+        let applications = FileSystemOpen.orderedApplications(
+            candidateURLs: [preview],
+            defaultApplicationURL: textEdit,
+            displayName: { $0.deletingPathExtension().lastPathComponent }
+        )
+
+        #expect(applications.map(\.url) == [textEdit, preview])
+        #expect(applications.first?.isDefault == true)
+    }
+}

--- a/docs/superpowers/plans/2026-08-04-finder-style-file-actions.md
+++ b/docs/superpowers/plans/2026-08-04-finder-style-file-actions.md
@@ -1,0 +1,653 @@
+# Finder-Style File Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Finder-style Open, Open With, and general file context actions to Working Tree and Files-tab rows.
+
+**Architecture:** Extend `FileSystemOpen` with a testable Launch Services application model. Add a shared `FileContextMenuActions` SwiftUI view driven by a pure action-order configuration and a target that removes local-system actions for remote or missing paths. Working Tree and Files provide different configurations while sharing rendering and system behavior.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AppKit `NSWorkspace`, macOS 15.0, Swift Testing, XcodeGen/Xcode.
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Keep the deployment target at macOS 15.0 and add no dependencies.
+- Keep Git mutations in Changes; do not add Stage, Unstage, Discard, Ignore, or Copy Diff to Files.
+- Omit Open, Open With, and Reveal in Finder for remote or missing targets.
+- Do not add agent attribution to code, documentation, commits, or PR text.
+- Run `xcodegen` when adding Swift files and commit generated `Alas.xcodeproj` changes with them.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/Center/FileSystemOpen.swift`: Launch Services discovery, ordering, icons, and selected-app opening.
+- Create `Alas/Sources/Right/FileContextMenuActions.swift`: target resolution, action configurations, and shared menu rendering.
+- Modify `Alas/Sources/Right/ChangedRow.swift`, `WorkingTreeSectionView.swift`, and `ChangesTabView.swift`: Working Tree integration.
+- Modify `Alas/Sources/Right/FilesTabView.swift` and `RightPaneView.swift`: Files-tab integration.
+- Create `AlasTests/FileSystemOpenTests.swift` and `AlasTests/FileContextMenuActionsTests.swift`.
+- Regenerate `Alas.xcodeproj/project.pbxproj`.
+
+---
+
+### Task 1: Launch Services Application Discovery
+
+**Files:**
+- Modify: `Alas/Sources/Center/FileSystemOpen.swift:1-17`
+- Create: `AlasTests/FileSystemOpenTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via `xcodegen`
+
+**Interfaces:**
+- Consumes: `NSWorkspace.urlsForApplications(toOpen:)`, `urlForApplication(toOpen:)`, and the existing default-open/reveal methods.
+- Produces: `FileSystemApplication`, `applications(for:)`, `orderedApplications(candidateURLs:defaultApplicationURL:displayName:)`, and `open(url:with:)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `AlasTests/FileSystemOpenTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+struct FileSystemOpenTests {
+    @Test func ordersDefaultFirstDeduplicatesAndSortsByName() {
+        let preview = URL(fileURLWithPath: "/Applications/Preview.app")
+        let duplicatePreview = URL(fileURLWithPath: "/Applications/Utilities/../Preview.app")
+        let textEdit = URL(fileURLWithPath: "/System/Applications/TextEdit.app")
+        let xcode = URL(fileURLWithPath: "/Applications/Xcode.app")
+        let names = [
+            preview.standardizedFileURL.path: "Preview",
+            textEdit.standardizedFileURL.path: "TextEdit",
+            xcode.standardizedFileURL.path: "Xcode"
+        ]
+
+        let applications = FileSystemOpen.orderedApplications(
+            candidateURLs: [xcode, duplicatePreview, textEdit, preview],
+            defaultApplicationURL: textEdit,
+            displayName: { names[$0.standardizedFileURL.path] ?? $0.lastPathComponent }
+        )
+
+        #expect(applications.map(\.url) == [textEdit, preview, xcode])
+        #expect(applications.map(\.name) == ["TextEdit", "Preview", "Xcode"])
+        #expect(applications.map(\.isDefault) == [true, false, false])
+        #expect(applications.map(\.menuTitle) == ["TextEdit (default)", "Preview", "Xcode"])
+    }
+
+    @Test func includesDefaultWhenCandidateListOmitsIt() {
+        let preview = URL(fileURLWithPath: "/Applications/Preview.app")
+        let textEdit = URL(fileURLWithPath: "/System/Applications/TextEdit.app")
+
+        let applications = FileSystemOpen.orderedApplications(
+            candidateURLs: [preview],
+            defaultApplicationURL: textEdit,
+            displayName: { $0.deletingPathExtension().lastPathComponent }
+        )
+
+        #expect(applications.map(\.url) == [textEdit, preview])
+        #expect(applications.first?.isDefault == true)
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate and confirm the test fails**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/FileSystemOpenTests
+```
+
+Expected: compilation fails because the application model and ordering method do not exist.
+
+- [ ] **Step 3: Implement the model and bridge**
+
+Replace `FileSystemOpen.swift` with:
+
+```swift
+import AppKit
+
+struct FileSystemApplication: Identifiable, Equatable {
+    let url: URL
+    let name: String
+    let isDefault: Bool
+
+    var id: String { url.standardizedFileURL.path }
+    var menuTitle: String { isDefault ? "\(name) (default)" : name }
+
+    @MainActor var icon: NSImage {
+        NSWorkspace.shared.icon(forFile: url.path)
+    }
+}
+
+enum FileSystemOpen {
+    @MainActor static func open(url: URL) {
+        NSWorkspace.shared.open(url)
+    }
+
+    @MainActor static func open(url: URL, with application: FileSystemApplication) {
+        NSWorkspace.shared.open(
+            [url],
+            withApplicationAt: application.url,
+            configuration: NSWorkspace.OpenConfiguration(),
+            completionHandler: nil
+        )
+    }
+
+    @MainActor static func reveal(url: URL) {
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    @MainActor static func applications(for url: URL) -> [FileSystemApplication] {
+        let workspace = NSWorkspace.shared
+        return orderedApplications(
+            candidateURLs: workspace.urlsForApplications(toOpen: url),
+            defaultApplicationURL: workspace.urlForApplication(toOpen: url),
+            displayName: applicationDisplayName(for:)
+        )
+    }
+
+    static func orderedApplications(
+        candidateURLs: [URL],
+        defaultApplicationURL: URL?,
+        displayName: (URL) -> String
+    ) -> [FileSystemApplication] {
+        let defaultURL = defaultApplicationURL?.standardizedFileURL
+        var uniqueURLs: [String: URL] = [:]
+        for url in candidateURLs + [defaultApplicationURL].compactMap({ $0 }) {
+            let standardized = url.standardizedFileURL
+            if uniqueURLs[standardized.path] == nil {
+                uniqueURLs[standardized.path] = standardized
+            }
+        }
+        return uniqueURLs.values
+            .map { url in
+                FileSystemApplication(
+                    url: url,
+                    name: displayName(url),
+                    isDefault: url == defaultURL
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.isDefault != rhs.isDefault { return lhs.isDefault }
+                let order = lhs.name.localizedStandardCompare(rhs.name)
+                if order != .orderedSame { return order == .orderedAscending }
+                return lhs.url.path.localizedStandardCompare(rhs.url.path) == .orderedAscending
+            }
+    }
+
+    private static func applicationDisplayName(for url: URL) -> String {
+        let values = try? url.resourceValues(forKeys: [.localizedNameKey])
+        let rawName = values?.localizedName ?? url.lastPathComponent
+        return rawName.hasSuffix(".app") ? String(rawName.dropLast(4)) : rawName
+    }
+}
+```
+
+- [ ] **Step 4: Run the focused test**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/FileSystemOpenTests
+```
+
+Expected: `FileSystemOpenTests` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Center/FileSystemOpen.swift AlasTests/FileSystemOpenTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat: add system application discovery"
+```
+
+---
+
+### Task 2: Shared Menu and Working Tree Integration
+
+**Files:**
+- Create: `Alas/Sources/Right/FileContextMenuActions.swift`
+- Modify: `Alas/Sources/Right/ChangedRow.swift:3-89`
+- Modify: `Alas/Sources/Right/WorkingTreeSectionView.swift:3-25, 142-257`
+- Modify: `Alas/Sources/Right/ChangesTabView.swift:1-2, 230-286`
+- Create: `AlasTests/FileContextMenuActionsTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via `xcodegen`
+
+**Interfaces:**
+- Consumes: Task 1's `FileSystemApplication` and `FileSystemOpen` API, `FileTreeNode.Kind`, and existing Working Tree callbacks.
+- Produces: `FileContextMenuTarget.resolve`, `FileContextMenuAction`, `FileContextMenuConfiguration.workingTreeFile`, and `FileContextMenuActions`.
+
+- [ ] **Step 1: Write failing target and action-order tests**
+
+Create `AlasTests/FileContextMenuActionsTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+struct FileContextMenuActionsTests {
+    @Test func resolvesExistingLocalFileButRejectsMissingFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-context-menu-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let file = root.appendingPathComponent("README.md")
+        try "hello".write(to: file, atomically: true, encoding: .utf8)
+
+        let existing = FileContextMenuTarget.resolve(kind: .file, worktreePath: root, relativePath: "README.md")
+        let missing = FileContextMenuTarget.resolve(kind: .file, worktreePath: root, relativePath: "missing.md")
+
+        #expect(existing.localURL == file)
+        #expect(missing.localURL == nil)
+    }
+
+    @Test func remoteTargetOmitsLocalURL() {
+        let root = URL(fileURLWithPath: "/srv/remote-\(UUID().uuidString)")
+        RemoteHostRegistry.shared.register(root: root.path, host: "devbox")
+        defer { RemoteHostRegistry.shared.unregister(root: root.path) }
+        let target = FileContextMenuTarget.resolve(
+            kind: .file,
+            worktreePath: root,
+            relativePath: "Sources/App.swift",
+            fileExists: { _ in true }
+        )
+        #expect(target.localURL == nil)
+    }
+
+    @Test func workingTreeFileOrdersFinderAndRevisionActions() {
+        let target = FileContextMenuTarget(kind: .file, localURL: URL(fileURLWithPath: "/repo/App.swift"))
+        #expect(FileContextMenuConfiguration.workingTreeFile(target: target).actions == [
+            .openInAlas, .open, .openWith, .viewAtHEAD, .compareWithHEAD,
+            .fileHistory, .copyRelativePath, .copyFullPath, .revealInFinder
+        ])
+    }
+
+    @Test func workingTreeMissingTargetKeepsNonSystemActions() {
+        let target = FileContextMenuTarget(kind: .file, localURL: nil)
+        #expect(FileContextMenuConfiguration.workingTreeFile(target: target).actions == [
+            .openInAlas, .viewAtHEAD, .compareWithHEAD,
+            .fileHistory, .copyRelativePath, .copyFullPath
+        ])
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate and confirm failure**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/FileContextMenuActionsTests
+```
+
+Expected: compilation fails because the context-menu types do not exist.
+
+- [ ] **Step 3: Implement target and action configuration**
+
+Create `FileContextMenuActions.swift` with:
+
+```swift
+import AppKit
+import SwiftUI
+
+struct FileContextMenuTarget: Equatable {
+    let kind: FileTreeNode.Kind
+    let localURL: URL?
+
+    static func resolve(
+        kind: FileTreeNode.Kind,
+        worktreePath: URL,
+        relativePath: String,
+        fileExists: (URL) -> Bool = { FileManager.default.fileExists(atPath: $0.path) }
+    ) -> Self {
+        guard !worktreePath.isRemoteAlasPath else { return Self(kind: kind, localURL: nil) }
+        let url = worktreePath.appendingPathComponent(relativePath)
+        return Self(kind: kind, localURL: fileExists(url) ? url : nil)
+    }
+}
+
+enum FileContextMenuAction: Hashable {
+    case openInAlas, open, openWith, viewAtHEAD, compareWithHEAD
+    case fileHistory, copyRelativePath, copyFullPath, revealInFinder
+}
+
+struct FileContextMenuConfiguration: Equatable {
+    let target: FileContextMenuTarget
+    let actions: [FileContextMenuAction]
+
+    static func workingTreeFile(target: FileContextMenuTarget) -> Self {
+        var actions: [FileContextMenuAction] = [.openInAlas]
+        if target.localURL != nil { actions += [.open, .openWith] }
+        actions += [.viewAtHEAD, .compareWithHEAD, .fileHistory, .copyRelativePath, .copyFullPath]
+        if target.localURL != nil { actions.append(.revealInFinder) }
+        return Self(target: target, actions: actions)
+    }
+}
+```
+
+- [ ] **Step 4: Implement the reusable renderer**
+
+Append:
+
+```swift
+struct FileContextMenuActions: View {
+    let configuration: FileContextMenuConfiguration
+    var onOpenInAlas: (() -> Void)? = nil
+    var openInAlasEnabled = true
+    var onViewAtHEAD: (() -> Void)? = nil
+    var viewAtHEADEnabled = true
+    var onCompareWithHEAD: (() -> Void)? = nil
+    var onFileHistory: (() -> Void)? = nil
+    var onCopyRelativePath: (() -> Void)? = nil
+    var onCopyFullPath: (() -> Void)? = nil
+
+    @ViewBuilder var body: some View {
+        ForEach(configuration.actions, id: \.self) { action in
+            switch action {
+            case .openInAlas:
+                Button("Open in Alas") { onOpenInAlas?() }
+                    .disabled(!openInAlasEnabled || onOpenInAlas == nil)
+            case .open:
+                if let url = configuration.target.localURL {
+                    Button("Open") { FileSystemOpen.open(url: url) }
+                }
+            case .openWith:
+                if let url = configuration.target.localURL { openWithMenu(url: url) }
+            case .viewAtHEAD:
+                Button("View at HEAD") { onViewAtHEAD?() }
+                    .disabled(!viewAtHEADEnabled || onViewAtHEAD == nil)
+            case .compareWithHEAD:
+                Button("Compare with HEAD") { onCompareWithHEAD?() }
+                    .disabled(onCompareWithHEAD == nil)
+            case .fileHistory:
+                Button("File History") { onFileHistory?() }
+                    .disabled(onFileHistory == nil)
+            case .copyRelativePath:
+                Button("Copy Relative Path") { onCopyRelativePath?() }
+                    .disabled(onCopyRelativePath == nil)
+            case .copyFullPath:
+                Button("Copy Full Path") { onCopyFullPath?() }
+                    .disabled(onCopyFullPath == nil)
+            case .revealInFinder:
+                if let url = configuration.target.localURL {
+                    Button("Reveal in Finder") { FileSystemOpen.reveal(url: url) }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private func openWithMenu(url: URL) -> some View {
+        Menu("Open With") {
+            let applications = FileSystemOpen.applications(for: url)
+            if applications.isEmpty {
+                Button("No Compatible Applications") {}.disabled(true)
+            } else {
+                ForEach(applications) { application in
+                    Button { FileSystemOpen.open(url: url, with: application) } label: {
+                        Label {
+                            Text(application.menuTitle)
+                        } icon: {
+                            Image(nsImage: application.icon).resizable().frame(width: 16, height: 16)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Integrate ChangedRow**
+
+Add `let fileContextTarget: FileContextMenuTarget`, remove `onRevealInFinder`, and replace its general menu buttons with:
+
+```swift
+FileContextMenuActions(
+    configuration: .workingTreeFile(target: fileContextTarget),
+    onOpenInAlas: onOpenFile,
+    openInAlasEnabled: openFileEnabled,
+    onViewAtHEAD: onViewAtHEAD,
+    viewAtHEADEnabled: viewAtHEADEnabled,
+    onCompareWithHEAD: onCompareWithHEAD,
+    onFileHistory: onFileHistory,
+    onCopyRelativePath: onCopyRelative,
+    onCopyFullPath: onCopyFull
+)
+```
+
+Keep the existing divider, Copy Diff, staging, discard, and ignore blocks after it.
+
+- [ ] **Step 6: Wire WorkingTreeSectionView and ChangesTabView**
+
+Add this required `WorkingTreeSectionView` input:
+
+```swift
+let fileContextTarget: (ChangedFile) -> FileContextMenuTarget
+```
+
+Pass `fileContextTarget(file)` to `ChangedRow`, and remove the old `onRevealInFinder` property and argument. In `ChangesTabView`, remove `import AppKit`, remove the old Finder callback, and add:
+
+```swift
+fileContextTarget: { file in
+    FileContextMenuTarget.resolve(
+        kind: .file,
+        worktreePath: rps.worktree.path,
+        relativePath: file.path
+    )
+},
+```
+
+- [ ] **Step 7: Test and build**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/FileContextMenuActionsTests
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: focused tests pass and Working Tree compiles with the shared menu.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Alas/Sources/Right/FileContextMenuActions.swift Alas/Sources/Right/ChangedRow.swift Alas/Sources/Right/WorkingTreeSectionView.swift Alas/Sources/Right/ChangesTabView.swift AlasTests/FileContextMenuActionsTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat: add system file actions to changes"
+```
+
+---
+
+### Task 3: Files-Tab Context Menus
+
+**Files:**
+- Modify: `Alas/Sources/Right/FileContextMenuActions.swift`
+- Modify: `Alas/Sources/Right/FilesTabView.swift:3-13, 79-204`
+- Modify: `Alas/Sources/Right/RightPaneView.swift:75-92`
+- Modify: `AlasTests/FileContextMenuActionsTests.swift`
+
+**Interfaces:**
+- Consumes: Task 2's shared context-menu types and `AppState.openFileHistory(relativePath:worktreeId:)`.
+- Produces: `FileContextMenuConfiguration.filesTab(target:)` and Files-tab file/directory menus.
+
+- [ ] **Step 1: Write failing Files-tab configuration tests**
+
+Append inside `FileContextMenuActionsTests`:
+
+```swift
+@Test func filesTabFileHasGeneralFinderActionsOnly() {
+    let target = FileContextMenuTarget(kind: .file, localURL: URL(fileURLWithPath: "/repo/README.md"))
+    #expect(FileContextMenuConfiguration.filesTab(target: target).actions == [
+        .openInAlas, .open, .openWith, .fileHistory,
+        .copyRelativePath, .copyFullPath, .revealInFinder
+    ])
+}
+
+@Test func filesTabDirectoryOmitsEditorHistoryAndOpenWith() {
+    let target = FileContextMenuTarget(kind: .dir, localURL: URL(fileURLWithPath: "/repo/Sources"))
+    #expect(FileContextMenuConfiguration.filesTab(target: target).actions == [
+        .open, .copyRelativePath, .copyFullPath, .revealInFinder
+    ])
+}
+
+@Test func remoteFilesTabTargetsKeepPortableActions() {
+    let file = FileContextMenuTarget(kind: .file, localURL: nil)
+    let directory = FileContextMenuTarget(kind: .dir, localURL: nil)
+    #expect(FileContextMenuConfiguration.filesTab(target: file).actions == [
+        .openInAlas, .fileHistory, .copyRelativePath, .copyFullPath
+    ])
+    #expect(FileContextMenuConfiguration.filesTab(target: directory).actions == [
+        .copyRelativePath, .copyFullPath
+    ])
+}
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/FileContextMenuActionsTests
+```
+
+Expected: compilation fails because `filesTab(target:)` does not exist.
+
+- [ ] **Step 3: Add the Files configuration**
+
+Add to `FileContextMenuConfiguration`:
+
+```swift
+static func filesTab(target: FileContextMenuTarget) -> Self {
+    var actions: [FileContextMenuAction] = []
+    if target.kind == .file { actions.append(.openInAlas) }
+    if target.localURL != nil {
+        actions.append(.open)
+        if target.kind == .file { actions.append(.openWith) }
+    }
+    if target.kind == .file { actions.append(.fileHistory) }
+    actions += [.copyRelativePath, .copyFullPath]
+    if target.localURL != nil { actions.append(.revealInFinder) }
+    return Self(target: target, actions: actions)
+}
+```
+
+- [ ] **Step 4: Add FilesTabView inputs and menu helper**
+
+Add:
+
+```swift
+let worktreePath: URL
+let onFileHistory: (FileTreeNode) -> Void
+```
+
+Add below `renderNode`:
+
+```swift
+@ViewBuilder private func contextMenu(for node: FileTreeNode) -> some View {
+    let target = FileContextMenuTarget.resolve(
+        kind: node.kind,
+        worktreePath: worktreePath,
+        relativePath: node.path
+    )
+    FileContextMenuActions(
+        configuration: .filesTab(target: target),
+        onOpenInAlas: node.kind == .file ? { onSelectFile(node) } : nil,
+        onFileHistory: node.kind == .file ? { onFileHistory(node) } : nil,
+        onCopyRelativePath: { Clipboard.copy(node.path) },
+        onCopyFullPath: { Clipboard.copy(worktreePath.appendingPathComponent(node.path).path) }
+    )
+}
+```
+
+- [ ] **Step 5: Attach the row menus**
+
+After the directory button's `.buttonStyle(.plain)`, add:
+
+```swift
+.contextMenu { contextMenu(for: terminal) }
+```
+
+Using `terminal` makes a compacted `Sources/Center` row act on the displayed terminal directory. After the file button's `.buttonStyle(.plain)`, add:
+
+```swift
+.contextMenu { contextMenu(for: node) }
+```
+
+- [ ] **Step 6: Wire RightPaneView**
+
+Add these arguments to `FilesTabView`:
+
+```swift
+worktreePath: worktree.path,
+onFileHistory: { node in
+    state.openFileHistory(relativePath: node.path, worktreeId: worktree.id)
+},
+```
+
+- [ ] **Step 7: Test, regenerate, and build**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/FileContextMenuActionsTests
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: focused tests pass and both Files-tab row types compile with context menus.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Alas/Sources/Right/FileContextMenuActions.swift Alas/Sources/Right/FilesTabView.swift Alas/Sources/Right/RightPaneView.swift AlasTests/FileContextMenuActionsTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat: add contextual actions to files tab"
+```
+
+---
+
+### Task 4: Full Verification
+
+**Files:**
+- Verify: all files modified in Tasks 1-3
+- Modify only if regeneration changes it: `Alas.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: the completed Finder-style menus.
+- Produces: a clean build, passing full suite, and clean generated project state.
+
+- [ ] **Step 1: Regenerate and inspect**
+
+```bash
+xcodegen
+git diff --check
+git status --short
+```
+
+Expected: XcodeGen succeeds and `git diff --check` reports no errors.
+
+- [ ] **Step 2: Build**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exit code 0 and all tests pass.
+
+- [ ] **Step 4: Commit a generated-project change only if present**
+
+If `git status --short` lists `Alas.xcodeproj/project.pbxproj`, run:
+
+```bash
+git add Alas.xcodeproj/project.pbxproj
+git commit -m "chore: regenerate Xcode project"
+```
+
+If status is clean, do not create an empty commit.
+
+- [ ] **Step 5: Record final evidence**
+
+```bash
+git status --short
+git log -5 --oneline
+```
+
+Expected: the worktree is clean and the design plus three feature commits are visible, along with an optional generated-project commit.

--- a/docs/superpowers/specs/2026-08-04-finder-style-file-actions-design.md
+++ b/docs/superpowers/specs/2026-08-04-finder-style-file-actions-design.md
@@ -1,0 +1,91 @@
+# Finder-Style File Actions
+
+## Goal
+
+Add consistent macOS file-opening actions to changed-file and Files-tab context menus. Files can be opened inside Alas, with their default system application, or with another compatible application. The Files tab also gains the general navigation and path actions that are useful outside the Changes workflow.
+
+## Scope
+
+This change covers file rows in the Working Tree section and file and directory rows in the Files tab. It does not add Git mutation actions to the Files tab. Staging, unstaging, discarding, ignoring, and copying diffs remain part of the Changes workflow.
+
+## Menu Behavior
+
+### Working Tree files
+
+The existing context menu will contain:
+
+1. Open in Alas
+2. Open
+3. Open With
+4. View at HEAD
+5. Compare with HEAD
+6. File History
+7. Copy Relative Path
+8. Copy Full Path
+9. Reveal in Finder
+10. Existing diff, staging, discard, and ignore actions
+
+`Open in Alas` is the existing editor or preview action. `Open` asks macOS to use the default handler. `Open With` lists the compatible applications reported by Launch Services.
+
+### Files-tab files
+
+File rows will contain:
+
+1. Open in Alas
+2. Open
+3. Open With
+4. File History
+5. Copy Relative Path
+6. Copy Full Path
+7. Reveal in Finder
+
+The normal primary click remains unchanged and opens the file in Alas.
+
+### Files-tab directories
+
+Directory rows will contain:
+
+1. Open
+2. Copy Relative Path
+3. Copy Full Path
+4. Reveal in Finder
+
+`Open` uses the system default for a directory, normally Finder. Directories do not offer Open in Alas, Open With, or File History. The normal primary click continues to expand or collapse the row.
+
+## Architecture
+
+Extend `FileSystemOpen` with compatible-application discovery and opening a URL with a selected application. A small application value will carry the application bundle URL, display name, icon, and whether it is the default handler.
+
+Application discovery will use macOS Launch Services through `NSWorkspace`. Results will be deduplicated by standardized application URL. The default handler will be listed first and identified as the default; remaining applications will be sorted by localized display name.
+
+A reusable SwiftUI context-menu section will render the common general actions. Optional callbacks control whether Open in Alas, File History, path copying, and Finder reveal are present. Supplying a local URL enables Open and Open With. Working Tree composes its Git-specific actions around this shared section, while Files-tab rows use the general section directly.
+
+The right-pane parents remain responsible for resolving a worktree-relative path into a local file URL and for providing Alas-native callbacks. This keeps path and worktree knowledge out of the reusable menu.
+
+## Local, Remote, and Missing Targets
+
+System Open, Open With, and Reveal in Finder are available only for local worktrees. Remote worktrees keep Open in Alas, File History, Copy Relative Path, and Copy Full Path, but omit local-system actions.
+
+An on-disk existence check controls system opening. Deleted or otherwise missing Working Tree paths cannot be opened by macOS, but revision-based actions such as View at HEAD and File History remain available. Files-tab nodes normally exist by construction; the same guard protects against filesystem races.
+
+If Launch Services finds no compatible applications, Open With contains one disabled `No Compatible Applications` item. Application launch failures continue to use the existing `NSWorkspace` behavior; this feature does not introduce a separate alert system.
+
+## Testing
+
+Unit tests will cover the pure policy and ordering logic:
+
+- application URL deduplication;
+- default application ordering and marking;
+- localized name ordering for non-default applications;
+- availability for local files and directories;
+- omission of system actions for remote paths;
+- omission of system opening for missing targets; and
+- differences between file and directory action sets.
+
+Implementation verification will run the project-required commands:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```


### PR DESCRIPTION
## Summary
- add system Open/Open With application discovery and launch helpers
- add Finder-style file actions to working tree and changes context menus
- add contextual actions to the Files tab, including Open, Open With, Reveal in Finder, path copying, history, and file opening where applicable
- stabilize DiffReview accessibility test harness uncovered during final verification

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test