### PR TITLE
feat(sidebar): worktree sort menu

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		52A5CDD852333A0C4BDC6995 /* ACPPermissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */; };
 		52AB869F9071103FD1649552 /* RemoteHostStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */; };
 		52D1F226CE8DB1967977D3F3 /* ACPQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */; };
+		52E3CDEB14242DB611348EEA /* WorktreeSortMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DEBCFA106423E38276E9C2 /* WorktreeSortMenu.swift */; };
 		5426DC977050AACBCBDA37E9 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */; };
 		542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */; };
 		551C15188490062DFC77A479 /* MemorySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */; };
@@ -785,6 +786,7 @@
 		881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */; };
 		8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
+		887B90FE9E87033A31567CC0 /* WorktreeSortMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3F4EE1590F6355AF2AD9DA /* WorktreeSortMenuTests.swift */; };
 		88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419EF533C4D29448483045DA /* ACPChangeNotifier.swift */; };
 		88C1A4EBC12F7F7BA7FE9B06 /* ACPMarkdownInlineTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */; };
 		8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */; };
@@ -1931,6 +1933,7 @@
 		4BECCB29ED6324C55C541D54 /* DiffReviewRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRail.swift; sourceTree = "<group>"; };
 		4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionTests.swift; sourceTree = "<group>"; };
 		4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTargetTests.swift; sourceTree = "<group>"; };
+		4C3F4EE1590F6355AF2AD9DA /* WorktreeSortMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSortMenuTests.swift; sourceTree = "<group>"; };
 		4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxHelpersTests.swift; sourceTree = "<group>"; };
 		4C4B9AC0713D961FC7E1DE22 /* RunScriptPaletteEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptPaletteEnvironment.swift; sourceTree = "<group>"; };
 		4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiACPInstallerTests.swift; sourceTree = "<group>"; };
@@ -2357,6 +2360,7 @@
 		9797C4D8F5DCCC9563D79007 /* ACPProcessLivenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPProcessLivenessTests.swift; sourceTree = "<group>"; };
 		97D73156DBE6DB95469D4D80 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextViewMeasurementCacheTests.swift; sourceTree = "<group>"; };
 		97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-options.json"; sourceTree = "<group>"; };
+		97DEBCFA106423E38276E9C2 /* WorktreeSortMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSortMenu.swift; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		980DF534CC718ACEB60FCB6F /* DiffReviewImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewImageProvider.swift; sourceTree = "<group>"; };
 		9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOptionTests.swift; sourceTree = "<group>"; };
@@ -3515,6 +3519,7 @@
 				C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */,
 				6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
+				4C3F4EE1590F6355AF2AD9DA /* WorktreeSortMenuTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
 				321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */,
 				4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */,
@@ -4285,6 +4290,7 @@
 				8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */,
 				A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */,
 				C995611A6313FABE30508248 /* WorktreeRowView.swift */,
+				97DEBCFA106423E38276E9C2 /* WorktreeSortMenu.swift */,
 			);
 			path = Sidebar;
 			sourceTree = "<group>";
@@ -6511,6 +6517,7 @@
 				F098EBE9088B2EE1DAAF1BFD /* WorktreePathTemplateRenderer.swift in Sources */,
 				4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */,
 				9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */,
+				52E3CDEB14242DB611348EEA /* WorktreeSortMenu.swift in Sources */,
 				E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */,
 				467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */,
 				9C73FEDF9B7B93D60FA3B51F /* ZmxClient.swift in Sources */,
@@ -7170,6 +7177,7 @@
 				E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */,
 				2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
+				887B90FE9E87033A31567CC0 /* WorktreeSortMenuTests.swift in Sources */,
 				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,
 				98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */,
 				2ED82820F76F5032E4339926 /* ZmxClientTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1986,6 +1986,15 @@ final class AppState {
         return saved
     }
 
+    func setDefaultWorktreeOrdering(_ mode: AppConfig.WorktreeSortMode) {
+        guard config.worktrees.defaultOrdering != mode else { return }
+        config.worktrees.defaultOrdering = mode
+        saveConfig()
+        if projectsManager.reapplyOrderingForAllProjects() {
+            saveProjects()
+        }
+    }
+
     struct LanguageServerConfigChangeTracker {
         private var lastSavedLanguageServers: [LanguageServerConfig]
 

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -28,12 +28,9 @@ struct WorktreesPane: View {
                         desc: "Sort order for the worktrees sidebar list. Manual reordering of a repo overrides this for that repo."
                     ) {
                         Picker("", selection: defaultOrderingBinding) {
-                            Text("Last update time (most recent first)").tag(AppConfig.WorktreeSortMode.lastUpdateDesc)
-                            Text("Last update time (least recent first)").tag(AppConfig.WorktreeSortMode.lastUpdateAsc)
-                            Text("Creation time (newest first)").tag(AppConfig.WorktreeSortMode.creationDesc)
-                            Text("Creation time (oldest first)").tag(AppConfig.WorktreeSortMode.creationAsc)
-                            Text("Branch name").tag(AppConfig.WorktreeSortMode.branchAsc)
-                            Text("Manual").tag(AppConfig.WorktreeSortMode.manual)
+                            ForEach(AppConfig.WorktreeSortMode.allCases, id: \.self) { mode in
+                                Text(WorktreeSortPresentation.title(for: mode)).tag(mode)
+                            }
                         }
                         .pickerStyle(.menu)
                         .settingsDropdownFrame()

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -104,13 +104,7 @@ struct WorktreesPane: View {
     private var defaultOrderingBinding: Binding<AppConfig.WorktreeSortMode> {
         Binding(
             get: { state.config.worktrees.defaultOrdering },
-            set: { newValue in
-                state.config.worktrees.defaultOrdering = newValue
-                state.saveConfig()
-                if state.projectsManager.reapplyOrderingForAllProjects() {
-                    state.saveProjects()
-                }
-            }
+            set: { state.setDefaultWorktreeOrdering($0) }
         )
     }
 

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -28,7 +28,7 @@ struct WorktreesPane: View {
                         desc: "Sort order for the worktrees sidebar list. Manual reordering of a repo overrides this for that repo."
                     ) {
                         Picker("", selection: defaultOrderingBinding) {
-                            ForEach(AppConfig.WorktreeSortMode.allCases, id: \.self) { mode in
+                            ForEach(WorktreeSortPresentation.modes, id: \.self) { mode in
                                 Text(WorktreeSortPresentation.title(for: mode)).tag(mode)
                             }
                         }

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -1,16 +1,24 @@
 import SwiftUI
 
 struct SidebarHeaderView: View {
+    let worktreeSortMode: AppConfig.WorktreeSortMode
+    let onSetWorktreeSortMode: (AppConfig.WorktreeSortMode) -> Void
     let onSettings: () -> Void
     let onAddProject: () -> Void
     let onSearch: () -> Void
     let onHideSidebar: () -> Void
+    @State private var hovering = false
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             TrafficLights()
             Spacer()
             HStack(alignment: .center, spacing: 2) {
+                WorktreeSortMenu(
+                    selection: worktreeSortMode,
+                    onSelect: onSetWorktreeSortMode,
+                    headerHovered: hovering
+                )
                 ToolbarBtn(icon: "search", tooltip: "Search", action: onSearch)
                 ToolbarBtn(icon: "folder-plus", tooltip: "Add repository", action: onAddProject)
                 ToolbarBtn(icon: "gear", tooltip: "Settings", action: onSettings)
@@ -19,6 +27,8 @@ struct SidebarHeaderView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
         .windowDragHandle()
     }
 }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -24,6 +24,8 @@ struct SidebarView: View {
             )
             VStack(spacing: 0) {
                 SidebarHeaderView(
+                    worktreeSortMode: state.config.worktrees.defaultOrdering,
+                    onSetWorktreeSortMode: { state.setDefaultWorktreeOrdering($0) },
                     onSettings: onSettings,
                     onAddProject: onAddProject,
                     onSearch: {

--- a/Alas/Sources/Sidebar/WorktreeSortMenu.swift
+++ b/Alas/Sources/Sidebar/WorktreeSortMenu.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+
+enum WorktreeSortPresentation {
+    nonisolated static func title(for mode: AppConfig.WorktreeSortMode) -> String {
+        switch mode {
+        case .lastUpdateDesc: "Last update time (most recent first)"
+        case .lastUpdateAsc: "Last update time (least recent first)"
+        case .creationDesc: "Creation time (newest first)"
+        case .creationAsc: "Creation time (oldest first)"
+        case .branchAsc: "Branch name"
+        case .manual: "Manual"
+        }
+    }
+}
+
+struct WorktreeSortMenu: View {
+    let selection: AppConfig.WorktreeSortMode
+    let onSelect: (AppConfig.WorktreeSortMode) -> Void
+    let headerHovered: Bool
+
+    @Environment(\.theme) private var theme
+    @FocusState private var focused: Bool
+    @State private var hovering = false
+    @State private var menuTracking = false
+
+    nonisolated static func isVisible(
+        headerHovered: Bool,
+        focused: Bool,
+        menuTracking: Bool
+    ) -> Bool {
+        headerHovered || focused || menuTracking
+    }
+
+    private var visible: Bool {
+        Self.isVisible(
+            headerHovered: headerHovered,
+            focused: focused,
+            menuTracking: menuTracking
+        )
+    }
+
+    var body: some View {
+        Menu {
+            ForEach(AppConfig.WorktreeSortMode.allCases, id: \.self) { mode in
+                Toggle(
+                    WorktreeSortPresentation.title(for: mode),
+                    isOn: Binding(
+                        get: { selection == mode },
+                        set: { selected in
+                            if selected { onSelect(mode) }
+                        }
+                    )
+                )
+            }
+        } label: {
+            Icon(
+                name: "arrow.up.arrow.down",
+                size: 13,
+                color: hovering ? theme.color("fg") : theme.color("fg-muted")
+            )
+            .frame(width: 26, height: 22)
+            .contentShape(Rectangle())
+            .background(hovering ? theme.color("bg-3") : .clear)
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .accessibilityLabel("Sort worktrees")
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .opacity(visible ? 1 : 0)
+        .allowsHitTesting(visible)
+        .focusable()
+        .focused($focused)
+        .onHover { hovering = $0 }
+        .simultaneousGesture(TapGesture().onEnded { menuTracking = true })
+        .onReceive(NotificationCenter.default.publisher(for: NSMenu.didEndTrackingNotification)) { _ in
+            menuTracking = false
+        }
+        .animation(.easeOut(duration: 0.12), value: visible)
+        .background(WorktreeSortAccessibilityAnchor())
+        .accessibilityLabel("Sort worktrees")
+        .help("Sort worktrees")
+    }
+}
+
+private struct WorktreeSortAccessibilityAnchor: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.setAccessibilityElement(true)
+        view.setAccessibilityRole(.group)
+        view.setAccessibilityLabel("Sort worktrees")
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}

--- a/Alas/Sources/Sidebar/WorktreeSortMenu.swift
+++ b/Alas/Sources/Sidebar/WorktreeSortMenu.swift
@@ -2,6 +2,15 @@ import AppKit
 import SwiftUI
 
 enum WorktreeSortPresentation {
+    nonisolated static let modes: [AppConfig.WorktreeSortMode] = [
+        .lastUpdateDesc,
+        .lastUpdateAsc,
+        .creationDesc,
+        .creationAsc,
+        .branchAsc,
+        .manual,
+    ]
+
     nonisolated static func title(for mode: AppConfig.WorktreeSortMode) -> String {
         switch mode {
         case .lastUpdateDesc: "Last update time (most recent first)"
@@ -42,7 +51,7 @@ struct WorktreeSortMenu: View {
 
     var body: some View {
         Menu {
-            ForEach(AppConfig.WorktreeSortMode.allCases, id: \.self) { mode in
+            ForEach(WorktreeSortPresentation.modes, id: \.self) { mode in
                 Toggle(
                     WorktreeSortPresentation.title(for: mode),
                     isOn: Binding(
@@ -63,7 +72,6 @@ struct WorktreeSortMenu: View {
             .contentShape(Rectangle())
             .background(hovering ? theme.color("bg-3") : .clear)
             .clipShape(RoundedRectangle(cornerRadius: 5))
-            .accessibilityLabel("Sort worktrees")
         }
         .menuIndicator(.hidden)
         .buttonStyle(.plain)
@@ -77,20 +85,110 @@ struct WorktreeSortMenu: View {
             menuTracking = false
         }
         .animation(.easeOut(duration: 0.12), value: visible)
-        .background(WorktreeSortAccessibilityAnchor())
-        .accessibilityLabel("Sort worktrees")
+        .accessibilityHidden(true)
+        .background(
+            WorktreeSortAccessibilityButton(
+                selection: selection,
+                onSelect: onSelect,
+                onTrackingChanged: { menuTracking = $0 }
+            )
+        )
         .help("Sort worktrees")
     }
 }
 
-private struct WorktreeSortAccessibilityAnchor: NSViewRepresentable {
+private struct WorktreeSortAccessibilityButton: NSViewRepresentable {
+    let selection: AppConfig.WorktreeSortMode
+    let onSelect: (AppConfig.WorktreeSortMode) -> Void
+    let onTrackingChanged: (Bool) -> Void
+
     func makeNSView(context: Context) -> NSView {
-        let view = NSView(frame: .zero)
-        view.setAccessibilityElement(true)
-        view.setAccessibilityRole(.group)
-        view.setAccessibilityLabel("Sort worktrees")
-        return view
+        let button = PointerTransparentMenuButton(frame: .zero)
+        button.menu = context.coordinator.makeMenu()
+        button.setAccessibilityLabel("Sort worktrees")
+        button.setAccessibilityHelp("Sort worktrees")
+        return button
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onSelect = onSelect
+        context.coordinator.onTrackingChanged = onTrackingChanged
+        context.coordinator.updateSelection(selection)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onSelect: onSelect, onTrackingChanged: onTrackingChanged)
+    }
+
+    final class Coordinator: NSObject, NSMenuDelegate {
+        var onSelect: (AppConfig.WorktreeSortMode) -> Void
+        var onTrackingChanged: (Bool) -> Void
+        private weak var menu: NSMenu?
+
+        init(
+            onSelect: @escaping (AppConfig.WorktreeSortMode) -> Void,
+            onTrackingChanged: @escaping (Bool) -> Void
+        ) {
+            self.onSelect = onSelect
+            self.onTrackingChanged = onTrackingChanged
+        }
+
+        func makeMenu() -> NSMenu {
+            let menu = NSMenu()
+            menu.delegate = self
+            for mode in WorktreeSortPresentation.modes {
+                let item = NSMenuItem(
+                    title: WorktreeSortPresentation.title(for: mode),
+                    action: #selector(select(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = mode.rawValue
+                menu.addItem(item)
+            }
+            self.menu = menu
+            return menu
+        }
+
+        func updateSelection(_ selection: AppConfig.WorktreeSortMode) {
+            menu?.items.forEach { item in
+                item.state = item.representedObject as? String == selection.rawValue ? .on : .off
+            }
+        }
+
+        @objc private func select(_ sender: NSMenuItem) {
+            guard let rawValue = sender.representedObject as? String,
+                  let mode = AppConfig.WorktreeSortMode(rawValue: rawValue)
+            else { return }
+            onSelect(mode)
+        }
+
+        func menuWillOpen(_ menu: NSMenu) {
+            onTrackingChanged(true)
+        }
+
+        func menuDidClose(_ menu: NSMenu) {
+            onTrackingChanged(false)
+        }
+    }
+}
+
+private final class PointerTransparentMenuButton: NSButton {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func accessibilityRole() -> NSAccessibility.Role? {
+        .button
+    }
+
+    override func accessibilityActionNames() -> [NSAccessibility.Action] {
+        [.press]
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        guard let menu else { return false }
+        menu.popUp(positioning: nil, at: .zero, in: self)
+        return true
+    }
 }

--- a/AlasTests/AppStatePersistenceTests.swift
+++ b/AlasTests/AppStatePersistenceTests.swift
@@ -28,13 +28,19 @@ struct AppStatePersistenceTests {
 
     private final class RecordingStore: PersistenceStoreProtocol, @unchecked Sendable {
         let initialProjectsFile: ProjectsFile
+        var writtenConfig: AppConfig?
         var writtenProjectsFile: ProjectsFile?
+        var configWriteCount = 0
 
         init(initialProjectsFile: ProjectsFile) {
             self.initialProjectsFile = initialProjectsFile
         }
 
         func write<T: Encodable>(_ value: T, to _: URL) throws {
+            if let config = value as? AppConfig {
+                writtenConfig = config
+                configWriteCount += 1
+            }
             if let projectsFile = value as? ProjectsFile {
                 writtenProjectsFile = projectsFile
             }
@@ -43,6 +49,66 @@ struct AppStatePersistenceTests {
         func readIfExists<T: Decodable>(_ type: T.Type, from _: URL) throws -> T? {
             type == ProjectsFile.self ? initialProjectsFile as? T : nil
         }
+    }
+
+    @Test func setDefaultWorktreeOrderingPersistsAndPreservesManualOverrides() {
+        let inherited = ProjectConfig(
+            id: "inherited", name: "Inherited", path: "/repo/inherited",
+            color: "blue", addedAt: .now
+        )
+        let manualNew = Worktree.makeId(path: URL(fileURLWithPath: "/repo/manual/wts/new"))
+        let manualOld = Worktree.makeId(path: URL(fileURLWithPath: "/repo/manual/wts/old"))
+        let manual = ProjectConfig(
+            id: "manual", name: "Manual", path: "/repo/manual",
+            color: "red", addedAt: .now,
+            worktreeOrder: [manualOld, manualNew],
+            worktreeOrderIsManual: true
+        )
+        let store = RecordingStore(initialProjectsFile: .init(projects: [inherited, manual]))
+        let state = AppState(store: store)
+        let now = Date(timeIntervalSince1970: 2_000)
+
+        func worktree(projectID: String, path: String, branch: String, activity: Date) -> Worktree {
+            let url = URL(fileURLWithPath: path)
+            return Worktree(
+                id: Worktree.makeId(path: url), projectId: projectID,
+                name: branch, branch: branch, path: url, status: .clean,
+                lastActivity: activity, createdAt: activity
+            )
+        }
+
+        let rows = [
+            worktree(projectID: inherited.id, path: inherited.path, branch: "main", activity: now),
+            worktree(projectID: inherited.id, path: "/repo/inherited/wts/zeta", branch: "zeta", activity: now),
+            worktree(projectID: inherited.id, path: "/repo/inherited/wts/alpha", branch: "alpha", activity: now.addingTimeInterval(-60)),
+            worktree(projectID: manual.id, path: "/repo/manual/wts/old", branch: "old", activity: now.addingTimeInterval(-60)),
+            worktree(projectID: manual.id, path: manual.path, branch: "main", activity: now),
+            worktree(projectID: manual.id, path: "/repo/manual/wts/new", branch: "new", activity: now),
+        ]
+        for row in rows {
+            state.projectsManager.insertOptimisticWorktree(row)
+            state.projectsManager.setOperationState(id: row.id, state: nil)
+        }
+
+        state.setDefaultWorktreeOrdering(.branchAsc)
+
+        #expect(state.config.worktrees.defaultOrdering == .branchAsc)
+        #expect(store.writtenConfig?.worktrees.defaultOrdering == .branchAsc)
+        #expect(state.projectsManager.worktrees(projectId: inherited.id).map(\.branch)
+            == ["main", "alpha", "zeta"])
+        #expect(state.projectsManager.worktrees(projectId: manual.id).map(\.branch)
+            == ["main", "old", "new"])
+        #expect(state.projectsManager.projects[1].worktreeOrderIsManual)
+    }
+
+    @Test func setDefaultWorktreeOrderingDoesNotPersistTheActiveModeAgain() {
+        let store = RecordingStore(initialProjectsFile: .init(projects: []))
+        let state = AppState(store: store)
+
+        state.setDefaultWorktreeOrdering(state.config.worktrees.defaultOrdering)
+
+        #expect(store.configWriteCount == 0)
+        #expect(store.writtenProjectsFile == nil)
     }
 
     @Test func missionBaseReferenceNormalizesOnlyKnownRemoteAliases() {

--- a/AlasTests/SidebarHeaderViewTests.swift
+++ b/AlasTests/SidebarHeaderViewTests.swift
@@ -35,15 +35,18 @@ struct SidebarHeaderViewTests {
     @Test func sortMenuKeepsHeaderHeightAndAccessibilityLabel() throws {
         let controller = hostHeader()
         let fitted = controller.sizeThatFits(in: NSSize(width: 300, height: 100))
+        let sortControls = accessibilityElements(in: controller.view, matching: "Sort worktrees")
 
         #expect(abs(fitted.height - 42) < 0.5)
-        #expect(accessibilityLabel(in: controller.view, matching: "Sort worktrees") != nil)
+        #expect(sortControls.count == 1)
+        #expect(sortControls.first?.accessibilityRole() == .button)
+        #expect(sortControls.first?.accessibilityActionNames().contains(.press) == true)
     }
 
-    private func accessibilityLabel(in view: NSView, matching expected: String) -> String? {
-        if view.accessibilityLabel() == expected { return expected }
-        return view.subviews.lazy.compactMap {
-            accessibilityLabel(in: $0, matching: expected)
-        }.first
+    private func accessibilityElements(in view: NSView, matching expected: String) -> [NSView] {
+        let matches = view.accessibilityLabel() == expected ? [view] : []
+        return matches + view.subviews.flatMap {
+            accessibilityElements(in: $0, matching: expected)
+        }
     }
 }

--- a/AlasTests/SidebarHeaderViewTests.swift
+++ b/AlasTests/SidebarHeaderViewTests.swift
@@ -11,16 +11,39 @@ struct SidebarHeaderViewTests {
         try! ThemeStore().current
     }
 
-    @Test func headerRendersWithoutCrashing() {
+    private func hostHeader() -> NSHostingController<AnyView> {
         let view = SidebarHeaderView(
+            worktreeSortMode: .lastUpdateDesc,
+            onSetWorktreeSortMode: { _ in },
             onSettings: {},
             onAddProject: {},
             onSearch: {},
             onHideSidebar: {}
         )
         .environment(\.theme, currentTheme())
-        let controller = NSHostingController(rootView: view)
+        let controller = NSHostingController(rootView: AnyView(view))
+        controller.view.frame = NSRect(x: 0, y: 0, width: 300, height: 42)
         controller.view.layoutSubtreeIfNeeded()
+        return controller
+    }
+
+    @Test func headerRendersWithoutCrashing() {
+        let controller = hostHeader()
         #expect(controller.view != nil)
+    }
+
+    @Test func sortMenuKeepsHeaderHeightAndAccessibilityLabel() throws {
+        let controller = hostHeader()
+        let fitted = controller.sizeThatFits(in: NSSize(width: 300, height: 100))
+
+        #expect(abs(fitted.height - 42) < 0.5)
+        #expect(accessibilityLabel(in: controller.view, matching: "Sort worktrees") != nil)
+    }
+
+    private func accessibilityLabel(in view: NSView, matching expected: String) -> String? {
+        if view.accessibilityLabel() == expected { return expected }
+        return view.subviews.lazy.compactMap {
+            accessibilityLabel(in: $0, matching: expected)
+        }.first
     }
 }

--- a/AlasTests/WorktreeSortMenuTests.swift
+++ b/AlasTests/WorktreeSortMenuTests.swift
@@ -16,6 +16,17 @@ struct WorktreeSortMenuTests {
         #expect(WorktreeSortPresentation.title(for: .manual) == "Manual")
     }
 
+    @Test func modesFollowTheSettingsPresentationOrder() {
+        #expect(WorktreeSortPresentation.modes == [
+            .lastUpdateDesc,
+            .lastUpdateAsc,
+            .creationDesc,
+            .creationAsc,
+            .branchAsc,
+            .manual,
+        ])
+    }
+
     @Test func visibilityIncludesHeaderHoverFocusAndMenuTracking() {
         #expect(!WorktreeSortMenu.isVisible(
             headerHovered: false, focused: false, menuTracking: false

--- a/AlasTests/WorktreeSortMenuTests.swift
+++ b/AlasTests/WorktreeSortMenuTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import Alas
+
+@Suite
+struct WorktreeSortMenuTests {
+    @Test func titlesMatchTheExistingSettingsCopy() {
+        #expect(WorktreeSortPresentation.title(for: .lastUpdateDesc)
+            == "Last update time (most recent first)")
+        #expect(WorktreeSortPresentation.title(for: .lastUpdateAsc)
+            == "Last update time (least recent first)")
+        #expect(WorktreeSortPresentation.title(for: .creationDesc)
+            == "Creation time (newest first)")
+        #expect(WorktreeSortPresentation.title(for: .creationAsc)
+            == "Creation time (oldest first)")
+        #expect(WorktreeSortPresentation.title(for: .branchAsc) == "Branch name")
+        #expect(WorktreeSortPresentation.title(for: .manual) == "Manual")
+    }
+
+    @Test func visibilityIncludesHeaderHoverFocusAndMenuTracking() {
+        #expect(!WorktreeSortMenu.isVisible(
+            headerHovered: false, focused: false, menuTracking: false
+        ))
+        #expect(WorktreeSortMenu.isVisible(
+            headerHovered: true, focused: false, menuTracking: false
+        ))
+        #expect(WorktreeSortMenu.isVisible(
+            headerHovered: false, focused: true, menuTracking: false
+        ))
+        #expect(WorktreeSortMenu.isVisible(
+            headerHovered: false, focused: false, menuTracking: true
+        ))
+    }
+}

--- a/docs/superpowers/specs/2026-08-04-sidebar-worktree-sort-menu-design.md
+++ b/docs/superpowers/specs/2026-08-04-sidebar-worktree-sort-menu-design.md
@@ -1,0 +1,91 @@
+# Sidebar Worktree Sort Menu Design
+
+## Summary
+
+Add a compact menu to the left sidebar header for changing the global worktree ordering. The control stays visually hidden until the user hovers anywhere over the header, avoiding permanent toolbar density while keeping sorting close to the list it affects.
+
+The menu is a second surface for the existing **Settings → Worktrees → Default ordering** preference. It does not introduce a new sort model or per-project sort selector.
+
+## Goals
+
+- Make the global worktree ordering readily available from the sidebar.
+- Communicate that the setting applies across repositories rather than to one repository.
+- Avoid adding permanent visual density to the sidebar header.
+- Preserve per-repository manual ordering created by drag-and-drop.
+- Keep the sidebar menu and Settings picker synchronized through one mutation path.
+
+## Non-goals
+
+- Adding a separately chosen automatic sort mode for each repository.
+- Removing or changing drag-and-drop manual ordering.
+- Removing the repository context menu's **Reset Sort to Default** action.
+- Changing the ordering algorithms or the rule that pins the main worktree first.
+
+## Placement and visibility
+
+Place the sort control in `SidebarHeaderView`'s existing trailing action cluster, immediately before Search. Use a compact semantic sort glyph and the help text **Sort worktrees**.
+
+The sort control is visually hidden in the header's resting state. It fades in when the pointer is anywhere within the full sidebar header, not only when the pointer reaches the control's bounds. It remains visible while its menu is open and when reached through keyboard navigation. The control remains available to accessibility APIs while visually hidden. Search, Add Repository, Settings, and Hide Sidebar retain their current always-visible behavior.
+
+The control must not change the header's height or shift the existing actions when its visibility changes. Its layout space remains reserved; only its visual presentation and pointer interaction change.
+
+## Menu interaction
+
+Use a standard macOS menu rather than a popover or cycling button. Show all existing `AppConfig.WorktreeSortMode` values directly:
+
+- Last update time (most recent first)
+- Last update time (least recent first)
+- Creation time (newest first)
+- Creation time (oldest first)
+- Branch name
+- Manual
+
+Mark the current global mode with a checkmark. Opening the menu does not mutate state. Selecting the already-active mode is a no-op. Selecting another mode updates and persists the global preference immediately, then reapplies ordering to repositories that inherit the global default.
+
+## Manual overrides
+
+A repository becomes manually ordered when the user drags its worktrees. Changing the global mode from the header does not clear or alter such an override. The repository continues to display its manual order.
+
+The existing **Reset Sort to Default** item in the repository context menu remains the way to clear that repository's manual override. After reset, the repository immediately follows whichever global mode is currently checked in the header menu and Settings picker.
+
+The menu's checkmark always represents the global default. It does not attempt to summarize whether some repositories currently have manual overrides.
+
+## State ownership and data flow
+
+Add one `AppState` action for changing the default worktree ordering. It owns the complete mutation sequence:
+
+1. Return without work when the requested mode already matches the configured mode.
+2. Update `config.worktrees.defaultOrdering`.
+3. Persist the app configuration.
+4. Ask `ProjectsManager` to reapply ordering across projects.
+5. Persist project state if reapplication normalizes stored worktree-order data.
+
+Both `WorktreesPane` and the new sidebar menu call this action. The existing private Settings binding becomes a thin adapter around the shared action rather than duplicating persistence and reapplication logic.
+
+`SidebarView` passes the configured mode and the change callback into `SidebarHeaderView`. `SidebarHeaderView` owns only menu presentation, hover/focus visibility, and accessibility metadata. Sorting and persistence remain outside the view.
+
+## Failure behavior
+
+This feature adds no new fallible operation or recovery UI. It follows the existing local config/project persistence behavior. The menu selection updates the observable in-memory state immediately, so both surfaces remain synchronized during the current app session.
+
+## Accessibility
+
+- Expose the control as a menu button with the label/help **Sort worktrees**.
+- Keep it reachable through keyboard navigation even when it is not visually shown by hover.
+- Reveal it visually while keyboard-focused.
+- Preserve a stable hit target consistent with the other sidebar toolbar buttons.
+- Use the native checked state of menu items to communicate the selected mode without relying on color.
+
+## Verification
+
+Add focused regression coverage for the shared mutation and sidebar presentation:
+
+- Changing the global mode updates the config and reapplies ordering.
+- Inherited repositories adopt the new ordering.
+- Repositories with manual drag-order overrides remain unchanged.
+- Resetting a repository override makes it follow the active global mode.
+- The Settings picker and sidebar menu read and mutate the same global value.
+- The sort control exposes the expected accessibility label/help.
+- Reserving the hidden control's layout space keeps the sidebar header height stable.
+
+Run the focused tests, regenerate the Xcode project if test or source membership changes, then run the project build and test checks required by `AGENTS.md`.


### PR DESCRIPTION
## Summary
- add a hover-revealed worktree sort menu to the left sidebar header before Search
- centralize global worktree ordering changes through AppState so Settings and the sidebar share one mutation path
- preserve repository manual ordering overrides and add accessibility coverage for the hidden menu control

## Verification
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/WorktreeSortMenuTests -only-testing:AlasTests/SidebarHeaderViewTests -only-testing:AlasTests/AppStatePersistenceTests -only-testing:AlasTests/ProjectsManagerWorktreeOrderingTests\n\n## Notes\n- Full local suite was also run before the rebase and failed in two unrelated existing tests: DiffReviewSurfaceTests.aggregateBudgetDeferralHidesTextDiffUntilReviewerRequestsIt and RightPaneStateBaseBranchTests.storeRefreshesWhenConfigMatchesClearedOverride.