### PR TITLE
feat(drag): drag files out of Alas into other apps

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		3C5797EAA86E4D493E1EEED8 /* ParkChangesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B7B0E241FE2BEAE4623BA1 /* ParkChangesSheet.swift */; };
 		3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */; };
 		3C8FAA4464E4D928F1DC6C91 /* session-new-response-with-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */; };
+		3C91EAB9AE55849DE5CF1BC7 /* DragOutSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99890AC2531648EB5E9716A8 /* DragOutSessionTests.swift */; };
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
 		3CEE8409AAAAAE34D469B19D /* RemoteHelperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42BD0252E4292E53150CB8C /* RemoteHelperClient.swift */; };
 		3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9160AF4DDD35E2A02262D868 /* GGService.swift */; };
@@ -855,6 +856,7 @@
 		94FE17D9014F666C293EEFBE /* GitService+Stash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3F67549BDACF73DFC2E477 /* GitService+Stash.swift */; };
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
 		9547580C9DFECD838C120B90 /* DiffReviewRenderEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */; };
+		95582A36D7EC3E02D8431E39 /* DragOutSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4610C65B69BD08EF8DF12311 /* DragOutSession.swift */; };
 		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
 		95DAB9F9E361DFD0395CC4C2 /* GGStackSummaryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4FE9500B277A3921C8AB2 /* GGStackSummaryStoreTests.swift */; };
 		95E01DC5A933FCC077399762 /* ACPTranscriptRowHostingPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */; };
@@ -1910,6 +1912,7 @@
 		45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreCRUDTests.swift; sourceTree = "<group>"; };
 		45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModelTests.swift; sourceTree = "<group>"; };
 		45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridge.swift; sourceTree = "<group>"; };
+		4610C65B69BD08EF8DF12311 /* DragOutSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutSession.swift; sourceTree = "<group>"; };
 		46554893BA6205CD856B99B5 /* AppStateKeepSessionsAliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateKeepSessionsAliveTests.swift; sourceTree = "<group>"; };
 		467E833E3CE05D82DB88C5C5 /* ReviewReadinessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReadinessModel.swift; sourceTree = "<group>"; };
 		4723038DCD9A70A7DB96D13E /* ACPSessionForkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkManagerTests.swift; sourceTree = "<group>"; };
@@ -2379,6 +2382,7 @@
 		98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxStoreTests.swift; sourceTree = "<group>"; };
 		98EE59978053FA18629BC280 /* GGCommitMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGCommitMenuModelTests.swift; sourceTree = "<group>"; };
 		993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationModels.swift; sourceTree = "<group>"; };
+		99890AC2531648EB5E9716A8 /* DragOutSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutSessionTests.swift; sourceTree = "<group>"; };
 		99CD81CC540ACCF1132E62A8 /* ACPMCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPServer.swift; sourceTree = "<group>"; };
 		99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffLoaderTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
@@ -3309,6 +3313,7 @@
 				4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */,
 				EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */,
 				C43475DF341E0772A37EE034 /* DragOutPayloadTests.swift */,
+				99890AC2531648EB5E9716A8 /* DragOutSessionTests.swift */,
 				5DEE18D06DCB7DE3C8C8D91A /* EditorBufferExternalEditableTests.swift */,
 				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
 				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
@@ -4883,6 +4888,7 @@
 			isa = PBXGroup;
 			children = (
 				38228AE1419253ADBC80E226 /* DragOutPayload.swift */,
+				4610C65B69BD08EF8DF12311 /* DragOutSession.swift */,
 				12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */,
 			);
 			path = DragOut;
@@ -6094,6 +6100,7 @@
 				02DF9E0F3A3C1BE39026AF28 /* DraftReviewRequestTabView.swift in Sources */,
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
 				7D1B0EE0FC9379F72C82AE6C /* DragOutPayload.swift in Sources */,
+				95582A36D7EC3E02D8431E39 /* DragOutSession.swift in Sources */,
 				A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */,
 				B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */,
 				DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */,
@@ -6849,6 +6856,7 @@
 				804D11E10C7478C00C0F5C40 /* DraftCommitTabStateTests.swift in Sources */,
 				881AE2B2D456B36573346AD6 /* DraftCommitTabsManagerTests.swift in Sources */,
 				521917DA3E0979CFC9F1CE8A /* DragOutPayloadTests.swift in Sources */,
+				3C91EAB9AE55849DE5CF1BC7 /* DragOutSessionTests.swift in Sources */,
 				604583AA3E3CE525933DA2AA /* EditorBufferExternalEditableTests.swift in Sources */,
 				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
 				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */; };
 		51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */; };
 		520F19A37512D2FA0D10EB63 /* ReviewChangesLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC084336F2435440CE1E0AFB /* ReviewChangesLoader.swift */; };
+		521917DA3E0979CFC9F1CE8A /* DragOutPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43475DF341E0772A37EE034 /* DragOutPayloadTests.swift */; };
 		523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B45ECF898B83A616586D /* SubHeader.swift */; };
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
 		5255F92036DF00CB48082526 /* ReviewSessionTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */; };
@@ -719,6 +720,7 @@
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
 		7D087329E7B873B1E7A1CE89 /* CommitMessageEditorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */; };
 		7D0897F6872ABAC08F09281E /* SpacesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B7225443DF69C32D25338D /* SpacesPane.swift */; };
+		7D1B0EE0FC9379F72C82AE6C /* DragOutPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38228AE1419253ADBC80E226 /* DragOutPayload.swift */; };
 		7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4575017544CD7603B3AB9069 /* GitEventFilter.swift */; };
 		7DAAFE51C9C35BADB78B4A30 /* SSHIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */; };
 		7DEFB0A61614D65F509A11AE /* ImageDiffDifferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */; };
@@ -1824,6 +1826,7 @@
 		37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorEnvironment.swift; sourceTree = "<group>"; };
 		37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusResolver.swift; sourceTree = "<group>"; };
 		380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailureTests.swift; sourceTree = "<group>"; };
+		38228AE1419253ADBC80E226 /* DragOutPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutPayload.swift; sourceTree = "<group>"; };
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
 		38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptChangeLog.swift; sourceTree = "<group>"; };
@@ -2606,6 +2609,7 @@
 		C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSystemNoticeView.swift; sourceTree = "<group>"; };
 		C42BD0252E4292E53150CB8C /* RemoteHelperClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperClient.swift; sourceTree = "<group>"; };
 		C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftSummaryRail.swift; sourceTree = "<group>"; };
+		C43475DF341E0772A37EE034 /* DragOutPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutPayloadTests.swift; sourceTree = "<group>"; };
 		C465B80387939C91778E1AF7 /* MissionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionStoreTests.swift; sourceTree = "<group>"; };
 		C47AF847BD698EAB373D128B /* ZmxClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClient.swift; sourceTree = "<group>"; };
 		C48DB0098D71F26ABF594615 /* permission-request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "permission-request.json"; sourceTree = "<group>"; };
@@ -3304,6 +3308,7 @@
 				FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */,
 				4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */,
 				EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */,
+				C43475DF341E0772A37EE034 /* DragOutPayloadTests.swift */,
 				5DEE18D06DCB7DE3C8C8D91A /* EditorBufferExternalEditableTests.swift */,
 				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
 				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
@@ -4877,6 +4882,7 @@
 		B7F55BCF5A6A07CC612FB354 /* DragOut */ = {
 			isa = PBXGroup;
 			children = (
+				38228AE1419253ADBC80E226 /* DragOutPayload.swift */,
 				12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */,
 			);
 			path = DragOut;
@@ -6087,6 +6093,7 @@
 				27F842092C9CA4D871B6127A /* DraftReviewRequestDiffSessionBuilder.swift in Sources */,
 				02DF9E0F3A3C1BE39026AF28 /* DraftReviewRequestTabView.swift in Sources */,
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
+				7D1B0EE0FC9379F72C82AE6C /* DragOutPayload.swift in Sources */,
 				A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */,
 				B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */,
 				DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */,
@@ -6841,6 +6848,7 @@
 				5936DF2636F0B74BEAB33A57 /* DraftAmendPrefillTests.swift in Sources */,
 				804D11E10C7478C00C0F5C40 /* DraftCommitTabStateTests.swift in Sources */,
 				881AE2B2D456B36573346AD6 /* DraftCommitTabsManagerTests.swift in Sources */,
+				521917DA3E0979CFC9F1CE8A /* DragOutPayloadTests.swift in Sources */,
 				604583AA3E3CE525933DA2AA /* EditorBufferExternalEditableTests.swift in Sources */,
 				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
 				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */; };
 		00ED86F7E72AFBF6C8DD69C7 /* GitInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
+		018E8980EAA0FA97A08A6EF6 /* RevisionSnapshotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */; };
 		018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */; };
 		019CF838931D47EB13E8C107 /* PiMCPConfigWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B36F1F6A541E5ADB96FCA6 /* PiMCPConfigWriterTests.swift */; };
 		019D3627B3CEB44C34CC34F9 /* RemoteHelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B0D8590E0335CD31B758E0 /* RemoteHelperProtocol.swift */; };
@@ -595,6 +596,7 @@
 		64DD701281B8BF9468C50C58 /* ACPUserInputFormState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC35CACDC7D469C7D0382F31 /* ACPUserInputFormState.swift */; };
 		64FC756BD56C4997B7B3ADB2 /* PiMCPAdapterInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D8F686002C542458620289 /* PiMCPAdapterInspector.swift */; };
 		65095BDBA1E160D7DF4F2A65 /* AgentLauncherDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFB85AF60C0E4520ED0DA8E /* AgentLauncherDialog.swift */; };
+		652C66E1DA5C28C6FD1B5132 /* RevisionSnapshotCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6512F4CA47764514D593C1B /* RevisionSnapshotCacheTests.swift */; };
 		6574E0F5D8FC2144ECA324B1 /* MissionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D6CBC43AD597B23E365A85 /* MissionCoordinatorTests.swift */; };
 		659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */; };
 		65E2D21A8616B9E86E684136 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */; };
@@ -1609,6 +1611,7 @@
 		1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouter.swift; sourceTree = "<group>"; };
 		1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationModelsTests.swift; sourceTree = "<group>"; };
 		1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTests.swift; sourceTree = "<group>"; };
+		12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevisionSnapshotCache.swift; sourceTree = "<group>"; };
 		12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewTabView.swift; sourceTree = "<group>"; };
 		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		133BC58A28C72EA330CDCCA5 /* ACPTranscriptScrollBookkeepingResetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollBookkeepingResetTests.swift; sourceTree = "<group>"; };
@@ -2911,6 +2914,7 @@
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionStoreTests.swift; sourceTree = "<group>"; };
 		F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewScrollSpyTests.swift; sourceTree = "<group>"; };
+		F6512F4CA47764514D593C1B /* RevisionSnapshotCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevisionSnapshotCacheTests.swift; sourceTree = "<group>"; };
 		F66CF7F86AACAAEA759C8A1B /* PendingStashDropTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingStashDropTests.swift; sourceTree = "<group>"; };
 		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
 		F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBannerTests.swift; sourceTree = "<group>"; };
@@ -3444,6 +3448,7 @@
 				4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */,
 				A2506BDBA9F67B6516CE2BEF /* ReviewTargetPaletteModelTests.swift */,
 				B87101C6F8F27B57AEDC187D /* ReviewThreadWriteTests.swift */,
+				F6512F4CA47764514D593C1B /* RevisionSnapshotCacheTests.swift */,
 				94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */,
 				BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
@@ -3819,6 +3824,7 @@
 				4884B807E1962E6CAE50F20D /* Code */,
 				07E359D8B18600D505C1B4C1 /* Diagnostics */,
 				1B7FB431695F35CED973CDD2 /* Dialogs */,
+				B7F55BCF5A6A07CC612FB354 /* DragOut */,
 				2DC32361E466DA20E974D106 /* Git */,
 				B4091CAB7D0E176C8D1E112C /* Harness */,
 				E25B7A3465E9FC8D717EAE2A /* Helpers */,
@@ -4866,6 +4872,14 @@
 				97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */,
 			);
 			path = Install;
+			sourceTree = "<group>";
+		};
+		B7F55BCF5A6A07CC612FB354 /* DragOut */ = {
+			isa = PBXGroup;
+			children = (
+				12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */,
+			);
+			path = DragOut;
 			sourceTree = "<group>";
 		};
 		B99EAA756E84360237C3E3D2 /* Editor */ = {
@@ -6413,6 +6427,7 @@
 				0A98E7EDC11BF68EAEEFED29 /* ReviewTargetPaletteEnvironment.swift in Sources */,
 				03C9B7EA452F3C62B39F7802 /* ReviewTargetPaletteModel.swift in Sources */,
 				4DF50D8995FBF711085A40AF /* ReviewThreadMutations.swift in Sources */,
+				018E8980EAA0FA97A08A6EF6 /* RevisionSnapshotCache.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
@@ -7093,6 +7108,7 @@
 				14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */,
 				D4DE0AC014387E216A904D2E /* ReviewTargetPaletteModelTests.swift in Sources */,
 				1ACB56B9AA0EC3C1C2AF5E18 /* ReviewThreadWriteTests.swift in Sources */,
+				652C66E1DA5C28C6FD1B5132 /* RevisionSnapshotCacheTests.swift in Sources */,
 				D4E6BD88D38563AF45E79C83 /* RightPaneGGLandTests.swift in Sources */,
 				4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1281,6 +1281,7 @@
 		D9FD24854A41DF2E9214E078 /* ReviewDraftCommentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */; };
 		DA0C1B28A1161C52F83C05DF /* CodeHostIssueProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28E0A73F117113D1DC84A91 /* CodeHostIssueProvider.swift */; };
 		DA5ED6D708DD8C0B5563AB4F /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */; };
+		DAA0AFA398C02EC663708825 /* ViewDragOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC461E04DD9DDF78F8825942 /* ViewDragOut.swift */; };
 		DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9E527A76820947F426A8 /* ACPFilesystem.swift */; };
 		DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */; };
 		DADDDA3FA289B52415EF4379 /* ACPDelayedHoverVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */; };
@@ -1312,6 +1313,7 @@
 		DF2960A73C07F97DA0A615D4 /* ReviewDraftSummaryRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C432B6C03738D6ACB4293471 /* ReviewDraftSummaryRail.swift */; };
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
+		DFA62A97A39B75AD9C7D4DC3 /* DragOutActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FE8C7594DE6CD4038A2113 /* DragOutActivationTests.swift */; };
 		DFD997286ABB95FBEA6A3AF2 /* ACPWorktreeSessionBootstrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B9DC1F684C319AFDB497B6 /* ACPWorktreeSessionBootstrapper.swift */; };
 		E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C511B229168DDEA87173A41 /* GGInboxStore.swift */; };
 		E099FB5101ED328389233B35 /* MermaidDiagramLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */; };
@@ -1566,6 +1568,7 @@
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08C66CE5C7DDA561C0970A50 /* ACPWorktreeSessionBootstrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPWorktreeSessionBootstrapperTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
+		08FE8C7594DE6CD4038A2113 /* DragOutActivationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutActivationTests.swift; sourceTree = "<group>"; };
 		09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffMode.swift; sourceTree = "<group>"; };
 		09140CEE45083CFDCE8D262B /* ACPRemoteMCPFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteMCPFilterTests.swift; sourceTree = "<group>"; };
 		0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResolvedEmptyView.swift; sourceTree = "<group>"; };
@@ -2870,6 +2873,7 @@
 		EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkPersistenceTests.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
 		EC35CACDC7D469C7D0382F31 /* ACPUserInputFormState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserInputFormState.swift; sourceTree = "<group>"; };
+		EC461E04DD9DDF78F8825942 /* ViewDragOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDragOut.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
 		EC6FA61556FA530605C9FE81 /* RemoteNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNetwork.swift; sourceTree = "<group>"; };
 		EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptCurrentPlanTests.swift; sourceTree = "<group>"; };
@@ -3312,6 +3316,7 @@
 				FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */,
 				4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */,
 				EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */,
+				08FE8C7594DE6CD4038A2113 /* DragOutActivationTests.swift */,
 				C43475DF341E0772A37EE034 /* DragOutPayloadTests.swift */,
 				99890AC2531648EB5E9716A8 /* DragOutSessionTests.swift */,
 				5DEE18D06DCB7DE3C8C8D91A /* EditorBufferExternalEditableTests.swift */,
@@ -4890,6 +4895,7 @@
 				38228AE1419253ADBC80E226 /* DragOutPayload.swift */,
 				4610C65B69BD08EF8DF12311 /* DragOutSession.swift */,
 				12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */,
+				EC461E04DD9DDF78F8825942 /* ViewDragOut.swift */,
 			);
 			path = DragOut;
 			sourceTree = "<group>";
@@ -6533,6 +6539,7 @@
 				B785053315764F42E3601F15 /* UpdateProgressSheet.swift in Sources */,
 				EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */,
 				C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */,
+				DAA0AFA398C02EC663708825 /* ViewDragOut.swift in Sources */,
 				B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */,
 				7C286DF876CD8F71D07B6A93 /* WebSocketFrame.swift in Sources */,
 				4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */,
@@ -6855,6 +6862,7 @@
 				5936DF2636F0B74BEAB33A57 /* DraftAmendPrefillTests.swift in Sources */,
 				804D11E10C7478C00C0F5C40 /* DraftCommitTabStateTests.swift in Sources */,
 				881AE2B2D456B36573346AD6 /* DraftCommitTabsManagerTests.swift in Sources */,
+				DFA62A97A39B75AD9C7D4DC3 /* DragOutActivationTests.swift in Sources */,
 				521917DA3E0979CFC9F1CE8A /* DragOutPayloadTests.swift in Sources */,
 				3C91EAB9AE55849DE5CF1BC7 /* DragOutSessionTests.swift in Sources */,
 				604583AA3E3CE525933DA2AA /* EditorBufferExternalEditableTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApplicationDelegate.swift
+++ b/Alas/Sources/App/AlasApplicationDelegate.swift
@@ -26,6 +26,8 @@ final class AlasApplicationDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        Task { await RevisionSnapshotCache.shared.removeSessionDirectory() }
+        // Synchronous and non-isolated: a detached Task would need to hop onto
+        // the actor before running, and the process exits before that happens.
+        try? FileManager.default.removeItem(at: RevisionSnapshotCache.shared.sessionDirectory)
     }
 }

--- a/Alas/Sources/App/AlasApplicationDelegate.swift
+++ b/Alas/Sources/App/AlasApplicationDelegate.swift
@@ -24,4 +24,8 @@ final class AlasApplicationDelegate: NSObject, NSApplicationDelegate {
         }
         return .terminateLater
     }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        Task { await RevisionSnapshotCache.shared.removeSessionDirectory() }
+    }
 }

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -136,7 +136,14 @@ struct CommitEditorTabView: View {
                     files: details.files,
                     selectedPath: $selectedPath,
                     onDropFile: { pendingDropFile = PendingCommitFileDrop(sha: tabState.currentSha, file: $0) },
-                    dropFileEnabled: canDropFile
+                    dropFileEnabled: canDropFile,
+                    dragPayload: { file in
+                        .commitFile(
+                            worktreePath: worktreePath,
+                            sha: tabState.currentSha,
+                            file: file
+                        )
+                    }
                 )
                     .frame(width: leftWidth)
                 DragHandle(

--- a/Alas/Sources/Center/Commit/CommitFilesListView.swift
+++ b/Alas/Sources/Center/Commit/CommitFilesListView.swift
@@ -6,6 +6,7 @@ struct CommitFilesListView: View {
     @Binding var selectedPath: String?
     let onDropFile: ((CommitChangedFile) -> Void)?
     let dropFileEnabled: (CommitChangedFile) -> Bool
+    let dragPayload: ((CommitChangedFile) -> DragOutPayload?)?
 
     @Environment(\.theme) private var theme
 
@@ -13,12 +14,14 @@ struct CommitFilesListView: View {
         files: [CommitChangedFile],
         selectedPath: Binding<String?>,
         onDropFile: ((CommitChangedFile) -> Void)? = nil,
-        dropFileEnabled: @escaping (CommitChangedFile) -> Bool = { _ in false }
+        dropFileEnabled: @escaping (CommitChangedFile) -> Bool = { _ in false },
+        dragPayload: ((CommitChangedFile) -> DragOutPayload?)? = nil
     ) {
         self.files = files
         self._selectedPath = selectedPath
         self.onDropFile = onDropFile
         self.dropFileEnabled = dropFileEnabled
+        self.dragPayload = dragPayload
     }
 
     var body: some View {
@@ -73,6 +76,7 @@ struct CommitFilesListView: View {
                     .disabled(!dropFileEnabled(file))
             }
         }
+        .dragOut { dragPayload?(file) }
     }
 
     private func statusColor(_ status: String) -> Color {

--- a/Alas/Sources/DragOut/DragOutPayload.swift
+++ b/Alas/Sources/DragOut/DragOutPayload.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// What a draggable row hands to the drag machinery. Every reason a drag can be
+/// impossible — a remote worktree, a deleted file, a blob missing at that
+/// revision — collapses into `resolve()` returning nil, so call sites carry no
+/// error handling of their own.
+enum DragOutPayload: Equatable, Sendable {
+    /// A file or directory that exists in a local worktree. Dragging this hands
+    /// over the live file, so edits in the receiving app land back in the repo.
+    case onDisk(URL)
+
+    /// A blob at a git revision, materialized to a temp file on demand.
+    case revision(worktreePath: URL, ref: String, path: String)
+
+    func resolve(using cache: RevisionSnapshotCache = .shared) async -> URL? {
+        switch self {
+        case .onDisk(let url):
+            guard !url.isRemoteAlasPath else { return nil }
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            return url
+        case .revision(let worktreePath, let ref, let path):
+            guard !worktreePath.isRemoteAlasPath else { return nil }
+            return await cache.snapshot(worktreePath: worktreePath, ref: ref, path: path)
+        }
+    }
+}
+
+extension DragOutPayload {
+    static func workingTreeFile(worktreePath: URL, relativePath: String) -> DragOutPayload {
+        .onDisk(worktreePath.appendingPathComponent(relativePath))
+    }
+
+    /// Untracked files live on the stash commit's third parent; tracked files
+    /// live on the stash commit itself.
+    static func stashFile(worktreePath: URL, stash: GitStash, file: GitStashFile) -> DragOutPayload {
+        .revision(
+            worktreePath: worktreePath,
+            ref: file.isUntracked ? "\(stash.ref)^3" : stash.ref,
+            path: file.path
+        )
+    }
+
+    static func commitFile(worktreePath: URL, sha: String, file: CommitChangedFile) -> DragOutPayload {
+        .revision(worktreePath: worktreePath, ref: sha, path: file.path)
+    }
+}

--- a/Alas/Sources/DragOut/DragOutPayload.swift
+++ b/Alas/Sources/DragOut/DragOutPayload.swift
@@ -35,7 +35,10 @@ extension DragOutPayload {
     static func stashFile(worktreePath: URL, stash: GitStash, file: GitStashFile) -> DragOutPayload {
         .revision(
             worktreePath: worktreePath,
-            ref: file.isUntracked ? "\(stash.ref)^3" : stash.ref,
+            // The stash's SHA, not its `stash@{N}` reflog name: that name is
+            // positional, so a stash pushed between rendering the row and
+            // starting the drag would silently resolve to a different stash.
+            ref: file.isUntracked ? "\(stash.sha)^3" : stash.sha,
             path: file.path
         )
     }

--- a/Alas/Sources/DragOut/DragOutSession.swift
+++ b/Alas/Sources/DragOut/DragOutSession.swift
@@ -1,0 +1,56 @@
+import AppKit
+
+/// Drag source for files dragged out of Alas.
+///
+/// The operation mask is the whole reason this is AppKit rather than SwiftUI's
+/// `.draggable`: pinning outside-app drags to `.copy` is what guarantees a
+/// Finder drop can never move a file out of a worktree.
+@MainActor
+final class DragOutSession: NSObject, NSDraggingSource {
+    static let shared = DragOutSession()
+
+    /// Drag image edge length, in points.
+    private static let iconSize: CGFloat = 32
+
+    nonisolated static func operationMask(for context: NSDraggingContext) -> NSDragOperation {
+        switch context {
+        case .outsideApplication: return .copy
+        case .withinApplication: return []
+        @unknown default: return .copy
+        }
+    }
+
+    /// Two flavors: the file URL for apps that open files, and the absolute
+    /// POSIX path for terminals and text fields.
+    nonisolated static func pasteboardItem(for url: URL) -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        item.setString(url.absoluteString, forType: .fileURL)
+        item.setString(url.path, forType: .string)
+        return item
+    }
+
+    nonisolated func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        Self.operationMask(for: context)
+    }
+
+    func begin(url: URL, event: NSEvent, in view: NSView) {
+        let item = NSDraggingItem(pasteboardWriter: Self.pasteboardItem(for: url))
+        let icon = NSWorkspace.shared.icon(forFile: url.path)
+        let size = NSSize(width: Self.iconSize, height: Self.iconSize)
+        icon.size = size
+        let origin = view.convert(event.locationInWindow, from: nil)
+        item.setDraggingFrame(
+            NSRect(
+                x: origin.x - size.width / 2,
+                y: origin.y - size.height / 2,
+                width: size.width,
+                height: size.height
+            ),
+            contents: icon
+        )
+        view.beginDraggingSession(with: [item], event: event, source: self)
+    }
+}

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -25,7 +25,7 @@ actor RevisionSnapshotCache {
     /// hopping onto the actor.
     nonisolated let sessionDirectory: URL
 
-    private var snapshots: [String: URL] = [:]
+    private var snapshots: [String: Snapshot] = [:]
     /// `(worktree, ref, path)` keys already known to have no blob, so a repeated failed
     /// lookup — e.g. dragging a deleted file's row — does not re-spawn `git
     /// show` for every gesture callback while the drag is held.
@@ -96,8 +96,8 @@ actor RevisionSnapshotCache {
         sweepStaleSessionsIfNeeded()
 
         let key = "\(worktreePath.path)\u{0}\(ref)\u{0}\(path)"
-        if let cached = snapshots[key], FileManager.default.fileExists(atPath: cached.path) {
-            return cached
+        if let cached = snapshots[key], cached.isIntact {
+            return cached.url
         }
         if missingSnapshots.contains(key) {
             return nil
@@ -117,6 +117,8 @@ actor RevisionSnapshotCache {
                 withIntermediateDirectories: true
             )
             try result.stdout.write(to: destination, options: .atomic)
+            snapshots[key] = Snapshot(recording: destination)
+            return destination
         } catch {
             // A thrown error here is either a cancellation (the task was
             // cancelled while `git show` was in flight, so `Process.runData`
@@ -127,9 +129,40 @@ actor RevisionSnapshotCache {
             // miss must not be memoized: a retry could still succeed.
             return nil
         }
+    }
 
-        snapshots[key] = destination
-        return destination
+    /// A materialized snapshot, plus the fingerprint the file had when it was
+    /// written.
+    ///
+    /// The receiving app of a drag can write to this file — an editor that
+    /// saves the dropped document writes straight back to this path. Handing
+    /// the same URL out again would then serve bytes that no longer match the
+    /// revision the caller asked for, so a changed fingerprint re-reads from
+    /// git instead.
+    private struct Snapshot {
+        let url: URL
+        let size: Int?
+        let modified: Date?
+
+        /// Read through `FileManager` rather than `URL.resourceValues`: the
+        /// latter caches values on the bridged `NSURL`, so re-querying the same
+        /// `URL` returns the fingerprint taken at write time and an external
+        /// edit is never detected.
+        private static func fingerprint(of url: URL) -> (size: Int?, modified: Date?) {
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            return (attributes?[.size] as? Int, attributes?[.modificationDate] as? Date)
+        }
+
+        init(recording url: URL) {
+            self.url = url
+            (size, modified) = Self.fingerprint(of: url)
+        }
+
+        var isIntact: Bool {
+            guard FileManager.default.fileExists(atPath: url.path) else { return false }
+            let current = Self.fingerprint(of: url)
+            return current.size == size && current.modified == modified
+        }
     }
 
     func removeSessionDirectory() {

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -97,6 +97,11 @@ actor RevisionSnapshotCache {
 
         let key = "\(worktreePath.path)\u{0}\(ref)\u{0}\(path)"
         if let cached = snapshots[key], cached.isIntact {
+            // Reusing a snapshot is activity too. Without this, a session whose
+            // drags are all cache hits never refreshes its root mtime, and
+            // another instance's sweep would delete the very file being handed
+            // out here.
+            touchSessionDirectory()
             return cached.url
         }
         if missingSnapshots.contains(key) {

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Materializes `git show <ref>:<path>` into a temp file so a historical
 /// revision can be dragged out of Alas as a real file. Snapshots are memoized
-/// per `(ref, path)` for the lifetime of the app session.
+/// per `(worktree, ref, path)` for the lifetime of the app session.
 actor RevisionSnapshotCache {
     static let shared = RevisionSnapshotCache()
 
@@ -26,7 +26,7 @@ actor RevisionSnapshotCache {
     nonisolated let sessionDirectory: URL
 
     private var snapshots: [String: URL] = [:]
-    /// `(ref, path)` keys already known to have no blob, so a repeated failed
+    /// `(worktree, ref, path)` keys already known to have no blob, so a repeated failed
     /// lookup — e.g. dragging a deleted file's row — does not re-spawn `git
     /// show` for every gesture callback while the drag is held.
     private var missingSnapshots: Set<String> = []

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Materializes `git show <ref>:<path>` into a temp file so a historical
+/// revision can be dragged out of Alas as a real file. Snapshots are memoized
+/// per `(ref, path)` for the lifetime of the app session.
+actor RevisionSnapshotCache {
+    static let shared = RevisionSnapshotCache()
+
+    /// Container holding one directory per app session, under the temp dir.
+    static let rootDirectoryName = "alas-drag"
+
+    /// This session's snapshot root. Immutable, so callers read it without
+    /// hopping onto the actor.
+    nonisolated let sessionDirectory: URL
+
+    private var snapshots: [String: URL] = [:]
+    private var didSweep = false
+
+    init(sessionID: String = UUID().uuidString) {
+        sessionDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(Self.rootDirectoryName, isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+    }
+
+    /// Directory-safe form of a git ref. `stash@{0}^3` is not a usable path
+    /// component, so every character outside `[A-Za-z0-9._-]` becomes `-`.
+    /// Distinct refs stay distinct for everything Alas drags; a collision would
+    /// at worst reuse a snapshot of the same path, never a different one.
+    nonisolated static func refComponent(_ ref: String) -> String {
+        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
+        return String(ref.map { allowed.contains($0) ? $0 : "-" })
+    }
+
+    /// Where the blob at `ref:path` is written. The original relative path is
+    /// preserved so the receiving app sees the real filename.
+    nonisolated func snapshotURL(ref: String, path: String) -> URL {
+        sessionDirectory
+            .appendingPathComponent(Self.refComponent(ref), isDirectory: true)
+            .appendingPathComponent(path)
+    }
+
+    /// Returns a local file holding the blob, or nil when the blob does not
+    /// exist at that revision or cannot be written.
+    func snapshot(worktreePath: URL, ref: String, path: String) async -> URL? {
+        sweepStaleSessionsIfNeeded()
+
+        let key = "\(ref)\u{0}\(path)"
+        if let cached = snapshots[key], FileManager.default.fileExists(atPath: cached.path) {
+            return cached
+        }
+
+        let destination = snapshotURL(ref: ref, path: path)
+        do {
+            let result = try await Process.gitData(["show", "\(ref):\(path)"], cwd: worktreePath)
+            guard result.exitCode == 0 else { return nil }
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try result.stdout.write(to: destination, options: .atomic)
+        } catch {
+            return nil
+        }
+
+        snapshots[key] = destination
+        return destination
+    }
+
+    func removeSessionDirectory() {
+        try? FileManager.default.removeItem(at: sessionDirectory)
+        snapshots.removeAll()
+    }
+
+    /// Removes session directories left behind by earlier runs. Done on first
+    /// use rather than at launch so it never sits on the startup path, and so a
+    /// crashed session still gets cleaned up by the next one.
+    private func sweepStaleSessionsIfNeeded() {
+        guard !didSweep else { return }
+        didSweep = true
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(Self.rootDirectoryName, isDirectory: true)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        for entry in entries
+        where entry.lastPathComponent != sessionDirectory.lastPathComponent {
+            try? FileManager.default.removeItem(at: entry)
+        }
+    }
+}

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -25,6 +25,10 @@ actor RevisionSnapshotCache {
     nonisolated let sessionDirectory: URL
 
     private var snapshots: [String: URL] = [:]
+    /// `(ref, path)` keys already known to have no blob, so a repeated failed
+    /// lookup — e.g. dragging a deleted file's row — does not re-spawn `git
+    /// show` for every gesture callback while the drag is held.
+    private var missingSnapshots: Set<String> = []
     private var didSweep = false
 
     init(sessionID: String = UUID().uuidString) {
@@ -58,25 +62,40 @@ actor RevisionSnapshotCache {
     }
 
     /// Returns a local file holding the blob, or nil when the blob does not
-    /// exist at that revision or cannot be written.
+    /// exist at that revision, the worktree is remote, or the blob cannot be
+    /// written.
+    ///
+    /// The remote check belongs here rather than only in the caller: this
+    /// method routes through `Process.gitData`, which follows
+    /// `RemoteHostRegistry` for a remote worktree path and would otherwise
+    /// silently `ssh` out to fetch a blob.
     func snapshot(worktreePath: URL, ref: String, path: String) async -> URL? {
+        guard !worktreePath.isRemoteAlasPath else { return nil }
+
         sweepStaleSessionsIfNeeded()
 
         let key = "\(ref)\u{0}\(path)"
         if let cached = snapshots[key], FileManager.default.fileExists(atPath: cached.path) {
             return cached
         }
+        if missingSnapshots.contains(key) {
+            return nil
+        }
 
         let destination = snapshotURL(ref: ref, path: path)
         do {
             let result = try await Process.gitData(["show", "\(ref):\(path)"], cwd: worktreePath)
-            guard result.exitCode == 0 else { return nil }
+            guard result.exitCode == 0 else {
+                missingSnapshots.insert(key)
+                return nil
+            }
             try FileManager.default.createDirectory(
                 at: destination.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
             try result.stdout.write(to: destination, options: .atomic)
         } catch {
+            missingSnapshots.insert(key)
             return nil
         }
 
@@ -87,6 +106,7 @@ actor RevisionSnapshotCache {
     func removeSessionDirectory() {
         try? FileManager.default.removeItem(at: sessionDirectory)
         snapshots.removeAll()
+        missingSnapshots.removeAll()
     }
 
     /// Removes session directories left behind by earlier runs. Done on first

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Materializes `git show <ref>:<path>` into a temp file so a historical
@@ -53,10 +54,30 @@ actor RevisionSnapshotCache {
         return String(ref.unicodeScalars.map { allowedRefComponentCharacters.contains($0) ? Character($0) : "-" })
     }
 
+    /// Short, deterministic, filesystem-safe stand-in for a worktree's full
+    /// path. The full path (e.g. `/Users/nacho/.alas/.worktrees/...`) is not
+    /// usable as a single path component — it would blow past the 255-byte
+    /// filename limit — so it is SHA256-hashed and truncated to 12 hex
+    /// characters. Must not use `String.hashValue`: that hash is reseeded
+    /// per process, so it would not even stay stable across two calls in the
+    /// same run, let alone the same session.
+    nonisolated static func worktreeComponent(_ worktreePath: URL) -> String {
+        SHA256.hash(data: Data(worktreePath.path.utf8))
+            .prefix(6)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
     /// Where the blob at `ref:path` is written. The original relative path is
-    /// preserved so the receiving app sees the real filename.
-    nonisolated func snapshotURL(ref: String, path: String) -> URL {
+    /// preserved so the receiving app sees the real filename. Segmented by
+    /// worktree first: `RevisionSnapshotCache.shared` is shared across every
+    /// open worktree tab in the app, so without this segment two repos
+    /// dragging the same `(ref, path)` (e.g. both have `stash@{0}` +
+    /// `README.md`) would write to and read back the same on-disk file,
+    /// silently handing one repo's bytes to the other's drag.
+    nonisolated func snapshotURL(worktreePath: URL, ref: String, path: String) -> URL {
         sessionDirectory
+            .appendingPathComponent(Self.worktreeComponent(worktreePath), isDirectory: true)
             .appendingPathComponent(Self.refComponent(ref), isDirectory: true)
             .appendingPathComponent(path)
     }
@@ -74,7 +95,7 @@ actor RevisionSnapshotCache {
 
         sweepStaleSessionsIfNeeded()
 
-        let key = "\(ref)\u{0}\(path)"
+        let key = "\(worktreePath.path)\u{0}\(ref)\u{0}\(path)"
         if let cached = snapshots[key], FileManager.default.fileExists(atPath: cached.path) {
             return cached
         }
@@ -82,11 +103,13 @@ actor RevisionSnapshotCache {
             return nil
         }
 
-        let destination = snapshotURL(ref: ref, path: path)
+        let destination = snapshotURL(worktreePath: worktreePath, ref: ref, path: path)
         do {
             let result = try await Process.gitData(["show", "\(ref):\(path)"], cwd: worktreePath)
             guard result.exitCode == 0 else {
-                missingSnapshots.insert(key)
+                if !Task.isCancelled {
+                    missingSnapshots.insert(key)
+                }
                 return nil
             }
             try FileManager.default.createDirectory(
@@ -95,7 +118,13 @@ actor RevisionSnapshotCache {
             )
             try result.stdout.write(to: destination, options: .atomic)
         } catch {
-            missingSnapshots.insert(key)
+            // A thrown error here is either a cancellation (the task was
+            // cancelled while `git show` was in flight, so `Process.runData`
+            // tore the process down but returned normally with a non-zero
+            // exit code above — that path is handled there) or a genuine
+            // failure such as the 30s watchdog timeout. Neither means git
+            // actually answered "this path is not in that tree", so the
+            // miss must not be memoized: a retry could still succeed.
             return nil
         }
 

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -9,6 +9,17 @@ actor RevisionSnapshotCache {
     /// Container holding one directory per app session, under the temp dir.
     static let rootDirectoryName = "alas-drag"
 
+    /// A session directory older than this is treated as abandoned by a
+    /// crashed or exited process. The threshold must be generous: the user
+    /// routinely runs multiple Alas instances at once, and a live instance's
+    /// snapshots must never be deleted out from under an in-flight drag.
+    static let staleSessionAge: TimeInterval = 24 * 60 * 60
+
+    /// Characters that are safe to use verbatim in a path component.
+    private static let allowedRefComponentCharacters = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-"
+    )
+
     /// This session's snapshot root. Immutable, so callers read it without
     /// hopping onto the actor.
     nonisolated let sessionDirectory: URL
@@ -23,12 +34,19 @@ actor RevisionSnapshotCache {
     }
 
     /// Directory-safe form of a git ref. `stash@{0}^3` is not a usable path
-    /// component, so every character outside `[A-Za-z0-9._-]` becomes `-`.
-    /// Distinct refs stay distinct for everything Alas drags; a collision would
-    /// at worst reuse a snapshot of the same path, never a different one.
+    /// component, so every character outside `[A-Za-z0-9._-]` is
+    /// percent-encoded (`stash@{0}^3` becomes `stash%40%7B0%7D%5E3`).
+    /// Percent-encoding is reversible and therefore injective, so distinct
+    /// refs never collide on disk — unlike a lossy replacement scheme, which
+    /// could map both `feature/foo` and a literal branch named `feature-foo`
+    /// to the same path and silently overwrite one snapshot with the other's
+    /// content. This directory name is internal and never shown to the user;
+    /// the preserved relative *filename* is what the receiving app sees.
     nonisolated static func refComponent(_ ref: String) -> String {
-        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
-        return String(ref.map { allowed.contains($0) ? $0 : "-" })
+        if let encoded = ref.addingPercentEncoding(withAllowedCharacters: allowedRefComponentCharacters) {
+            return encoded
+        }
+        return String(ref.unicodeScalars.map { allowedRefComponentCharacters.contains($0) ? Character($0) : "-" })
     }
 
     /// Where the blob at `ref:path` is written. The original relative path is
@@ -73,7 +91,10 @@ actor RevisionSnapshotCache {
 
     /// Removes session directories left behind by earlier runs. Done on first
     /// use rather than at launch so it never sits on the startup path, and so a
-    /// crashed session still gets cleaned up by the next one.
+    /// crashed session still gets cleaned up by the next one. Only entries
+    /// older than `staleSessionAge` are removed: concurrent Alas instances
+    /// must not delete each other's live snapshots, so anything that could
+    /// plausibly belong to a still-running instance is left alone.
     private func sweepStaleSessionsIfNeeded() {
         guard !didSweep else { return }
         didSweep = true
@@ -81,10 +102,16 @@ actor RevisionSnapshotCache {
             .appendingPathComponent(Self.rootDirectoryName, isDirectory: true)
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: root,
-            includingPropertiesForKeys: nil
+            includingPropertiesForKeys: [.contentModificationDateKey]
         ) else { return }
+        let cutoff = Date().addingTimeInterval(-Self.staleSessionAge)
         for entry in entries
         where entry.lastPathComponent != sessionDirectory.lastPathComponent {
+            guard
+                let values = try? entry.resourceValues(forKeys: [.contentModificationDateKey]),
+                let modified = values.contentModificationDate,
+                modified < cutoff
+            else { continue }
             try? FileManager.default.removeItem(at: entry)
         }
     }

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -136,6 +136,12 @@ actor RevisionSnapshotCache {
                 worktreePath: worktreePath
             ) ?? result.stdout
             try bytes.write(to: destination, options: .atomic)
+            await restoreExecutableBit(
+                on: destination,
+                worktreePath: worktreePath,
+                ref: ref,
+                path: path
+            )
             snapshots[key] = Snapshot(recording: destination)
             touchSessionDirectory()
             return destination
@@ -149,6 +155,34 @@ actor RevisionSnapshotCache {
             // miss must not be memoized: a retry could still succeed.
             return nil
         }
+    }
+
+    /// `git show` hands back blob bytes with no mode, so a snapshot of a
+    /// `100755` entry would otherwise drag out non-executable — unlike a
+    /// working-tree drag, which hands over the real file with its real mode.
+    /// Read the tree entry and restore the bit.
+    ///
+    /// Symlinks (`120000`) are deliberately left as the target text they
+    /// already are: recreating a link inside the snapshot directory would
+    /// point at a relative target that need not resolve wherever the drag is
+    /// dropped, which is not obviously better than the text.
+    ///
+    /// Best-effort throughout — a drag is never failed over a mode.
+    private func restoreExecutableBit(
+        on destination: URL,
+        worktreePath: URL,
+        ref: String,
+        path: String
+    ) async {
+        guard
+            let result = try? await Process.git(["ls-tree", ref, "--", path], cwd: worktreePath),
+            result.exitCode == 0,
+            result.stdout.hasPrefix("100755")
+        else { return }
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: destination.path
+        )
     }
 
     /// A materialized snapshot, plus the fingerprint the file had when it was

--- a/Alas/Sources/DragOut/RevisionSnapshotCache.swift
+++ b/Alas/Sources/DragOut/RevisionSnapshotCache.swift
@@ -116,8 +116,23 @@ actor RevisionSnapshotCache {
                 at: destination.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
-            try result.stdout.write(to: destination, options: .atomic)
+            // `git show` returns the LFS *pointer* text for an LFS-tracked
+            // path, not the real asset, so a naive write here would drag out
+            // a ~130-byte stub that opens as a broken file in the receiving
+            // app. Try resolving it against the local LFS object store and
+            // write that instead; `lfsObjectData` returns nil for anything
+            // that is not a valid pointer, so a non-LFS file falls through
+            // to the plain git bytes unchanged. If the path is a pointer but
+            // the object has never been fetched locally, this also returns
+            // nil and the pointer is written as-is — an honest reflection of
+            // what's actually available, rather than failing the drag.
+            let bytes = await GitLFSBlobResolver.lfsObjectData(
+                forPointerData: result.stdout,
+                worktreePath: worktreePath
+            ) ?? result.stdout
+            try bytes.write(to: destination, options: .atomic)
             snapshots[key] = Snapshot(recording: destination)
+            touchSessionDirectory()
             return destination
         } catch {
             // A thrown error here is either a cancellation (the task was
@@ -163,6 +178,24 @@ actor RevisionSnapshotCache {
             let current = Self.fingerprint(of: url)
             return current.size == size && current.modified == modified
         }
+    }
+
+    /// Bumps the session root's modification date to now.
+    ///
+    /// A snapshot write happens deep inside `<session>/<worktree>/<ref>/...`,
+    /// which does not touch the root directory's own mtime — only creating a
+    /// direct child does. Without this, `sweepStaleSessionsIfNeeded()` reads
+    /// the root's mtime as "whenever this session started" rather than "when
+    /// it was last used", and a long-running instance (this user routinely
+    /// keeps several open for days) looks abandoned to another instance's
+    /// sweep after `staleSessionAge` elapses, even while it is actively
+    /// writing snapshots. Failing to update the timestamp is never fatal to
+    /// the drag: at worst the session looks a little more idle than it is.
+    private func touchSessionDirectory() {
+        try? FileManager.default.setAttributes(
+            [.modificationDate: Date()],
+            ofItemAtPath: sessionDirectory.path
+        )
     }
 
     func removeSessionDirectory() {

--- a/Alas/Sources/DragOut/ViewDragOut.swift
+++ b/Alas/Sources/DragOut/ViewDragOut.swift
@@ -1,0 +1,84 @@
+import AppKit
+import SwiftUI
+
+/// Distance thresholds separating a click from a drag.
+enum DragOutActivation {
+    /// Travel after which the payload starts resolving. Kept above zero so a
+    /// plain click never spawns a `git show`.
+    static let prefetchDistance: CGFloat = 2
+
+    /// Travel after which the drag session begins.
+    static let activationDistance: CGFloat = 6
+
+    static func travel(_ translation: CGSize) -> CGFloat {
+        (translation.width * translation.width + translation.height * translation.height)
+            .squareRoot()
+    }
+}
+
+extension View {
+    /// Makes a row draggable out of Alas as a real file.
+    ///
+    /// The closure runs when the press starts travelling, and returning nil —
+    /// or a payload that fails to resolve — simply means no drag lifts. Nothing
+    /// is reported: an alert thrown mid-gesture is worse than the drag that
+    /// quietly does not start.
+    func dragOut(_ payload: @escaping () -> DragOutPayload?) -> some View {
+        modifier(DragOutModifier(payload: payload))
+    }
+}
+
+/// Per-row gesture state. A `@MainActor` reference type rather than `@State`
+/// on the modifier, so the drag-start task captures only this — capturing the
+/// modifier itself would drag in its non-Sendable payload closure, which
+/// `SWIFT_STRICT_CONCURRENCY: complete` rejects.
+@MainActor
+private final class DragOutState: ObservableObject {
+    var armed = false
+    var began = false
+    var resolveTask: Task<URL?, Never>?
+
+    /// Called both when a drag begins — `onEnded` never fires once AppKit takes
+    /// over the mouse — and when the gesture ends without one.
+    func reset() {
+        resolveTask = nil
+        armed = false
+        began = false
+    }
+}
+
+private struct DragOutModifier: ViewModifier {
+    let payload: () -> DragOutPayload?
+
+    @StateObject private var state = DragOutState()
+
+    func body(content: Content) -> some View {
+        content.simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    let travel = DragOutActivation.travel(value.translation)
+                    if !state.armed, travel >= DragOutActivation.prefetchDistance {
+                        state.armed = true
+                        if let payload = payload() {
+                            state.resolveTask = Task { await payload.resolve() }
+                        }
+                    }
+                    guard !state.began,
+                          travel >= DragOutActivation.activationDistance,
+                          let resolveTask = state.resolveTask
+                    else { return }
+                    state.began = true
+                    let state = state
+                    Task { @MainActor in
+                        defer { state.reset() }
+                        guard let url = await resolveTask.value,
+                              let event = NSApp.currentEvent,
+                              let view = event.window?.contentView
+                        else { return }
+                        DragOutSession.shared.begin(url: url, event: event, in: view)
+                    }
+                }
+                .onEnded { _ in state.reset() }
+        )
+    }
+}

--- a/Alas/Sources/DragOut/ViewDragOut.swift
+++ b/Alas/Sources/DragOut/ViewDragOut.swift
@@ -37,11 +37,18 @@ private final class DragOutState: ObservableObject {
     var armed = false
     var began = false
     var resolveTask: Task<URL?, Never>?
+    var beginTask: Task<Void, Never>?
 
-    /// Called both when a drag begins — `onEnded` never fires once AppKit takes
-    /// over the mouse — and when the gesture ends without one.
+    /// Called when the gesture ends without a drag ever lifting (a plain
+    /// click, or a resolve that failed or lost the race with mouse-up).
+    /// Once a drag actually lifts, `onEnded` never fires — AppKit has taken
+    /// the mouse — so the success path resets state itself instead of
+    /// relying on this.
     func reset() {
+        resolveTask?.cancel()
         resolveTask = nil
+        beginTask?.cancel()
+        beginTask = nil
         armed = false
         began = false
     }
@@ -69,13 +76,14 @@ private struct DragOutModifier: ViewModifier {
                     else { return }
                     state.began = true
                     let state = state
-                    Task { @MainActor in
-                        defer { state.reset() }
-                        guard let url = await resolveTask.value,
+                    state.beginTask = Task { @MainActor in
+                        guard let url = await resolveTask.value, !Task.isCancelled,
                               let event = NSApp.currentEvent,
+                              event.type == .leftMouseDragged || event.type == .leftMouseDown,
                               let view = event.window?.contentView
-                        else { return }
+                        else { return }        // no reset: onEnded will clean up
                         DragOutSession.shared.begin(url: url, event: event, in: view)
+                        state.reset()          // only here — onEnded won't fire
                     }
                 }
                 .onEnded { _ in state.reset() }

--- a/Alas/Sources/Git/GitLFSBlobResolver.swift
+++ b/Alas/Sources/Git/GitLFSBlobResolver.swift
@@ -12,7 +12,10 @@ enum GitLFSBlobResolver {
         return NSImage(data: objectData)
     }
 
-    private static func lfsObjectData(forPointerData data: Data, worktreePath: URL) async -> Data? {
+    /// Resolves an LFS pointer's bytes to the real object data from the local
+    /// LFS store, or nil when `data` is not a valid pointer, or when the
+    /// object is not present locally (LFS files can be un-fetched).
+    static func lfsObjectData(forPointerData data: Data, worktreePath: URL) async -> Data? {
         guard let pointer = parsePointer(data) else { return nil }
         guard let commonDir = await gitCommonDirectory(worktreePath: worktreePath) else { return nil }
         guard let storageDir = await lfsStorageDirectory(

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -39,11 +39,15 @@ struct ChangedRow: View {
                 if let onStage {
                     StageChip(state: resolvedStageState, action: onStage)
                 }
-                FileTypeIconView(filename: basename, size: 18)
-                Text(basename)
-                    .font(.system(size: 11.5, design: .monospaced))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                HStack(spacing: 6) {
+                    FileTypeIconView(filename: basename, size: 18)
+                    Text(basename)
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .contentShape(Rectangle())
+                .dragOut { dragPayload?() }
                 Spacer()
                 if add > 0 { Text("+\(add)").foregroundColor(theme.color("add")) }
                 if del > 0 { Text("−\(del)").foregroundColor(theme.color("del")) }
@@ -88,7 +92,6 @@ struct ChangedRow: View {
                 ignoreMenu
             }
         }
-        .dragOut { dragPayload?() }
     }
 }
 

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -22,6 +22,7 @@ struct ChangedRow: View {
     var openFileEnabled:  Bool = true
     var viewAtHEADEnabled: Bool = true
     var ignoreMenu:       AnyView? = nil
+    var dragPayload: (() -> DragOutPayload?)? = nil
     @Environment(\.theme) var theme
 
     nonisolated static func rowLeadingPadding(depth: Int) -> CGFloat {
@@ -87,6 +88,7 @@ struct ChangedRow: View {
                 ignoreMenu
             }
         }
+        .dragOut { dragPayload?() }
     }
 }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -207,7 +207,10 @@ struct ChangesTabView: View {
                     )
                 },
                 onCancelBulkResolve: { rps.cancelBulkResolve() },
-                onDismissBulkReport: { rps.dismissBulkResolveReport() }
+                onDismissBulkReport: { rps.dismissBulkResolveReport() },
+                dragPayload: { file in
+                    .workingTreeFile(worktreePath: rps.worktree.path, relativePath: file.path)
+                }
             )
 
             if Self.shouldShowChangesPreparationCard(
@@ -285,6 +288,9 @@ struct ChangesTabView: View {
                         worktreePath: rps.worktree.path,
                         relativePath: file.path
                     )
+                },
+                dragPayload: { file in
+                    .workingTreeFile(worktreePath: rps.worktree.path, relativePath: file.path)
                 }
             )
             StashesSectionView(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -306,7 +306,10 @@ struct ChangesTabView: View {
                 },
                 onApply: { rps.applyStash($0) },
                 onPop: { rps.popStash($0) },
-                onDrop: { rps.requestDropStash($0) }
+                onDrop: { rps.requestDropStash($0) },
+                dragPayload: { stash, file in
+                    .stashFile(worktreePath: rps.worktree.path, stash: stash, file: file)
+                }
             )
             Divider().opacity(0.4)
             CommitsSectionView(

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -25,6 +25,7 @@ struct ConflictsSection: View {
     let onCancelBulkResolve: () -> Void
     /// Triggered when the user closes the post-run banner.
     let onDismissBulkReport: () -> Void
+    var dragPayload: ((ChangedFile) -> DragOutPayload?)? = nil
 
     @State private var pendingBothDeletedConfirm: ChangedFile?
 
@@ -148,6 +149,12 @@ struct ConflictsSection: View {
 
     @ViewBuilder
     private func row(for file: ChangedFile) -> some View {
+        rowContent(for: file)
+            .dragOut { dragPayload?(file) }
+    }
+
+    @ViewBuilder
+    private func rowContent(for file: ChangedFile) -> some View {
         switch file.conflict {
         case .bothDeleted:
             bothDeletedRow(file)

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -150,7 +150,6 @@ struct ConflictsSection: View {
     @ViewBuilder
     private func row(for file: ChangedFile) -> some View {
         rowContent(for: file)
-            .dragOut { dragPayload?(file) }
     }
 
     @ViewBuilder
@@ -188,6 +187,7 @@ struct ConflictsSection: View {
         .contextMenu {
             menuItems(for: file)
         }
+        .dragOut { dragPayload?(file) }
     }
 
     private func bothDeletedRow(_ file: ChangedFile) -> some View {
@@ -224,6 +224,7 @@ struct ConflictsSection: View {
             }
             Button("Cancel", role: .cancel) {}
         }
+        .dragOut { dragPayload?(file) }
     }
 
     private func deleteSideRow(_ file: ChangedFile) -> some View {
@@ -241,6 +242,7 @@ struct ConflictsSection: View {
                     Spacer()
                 }
                 .contentShape(Rectangle())
+                .dragOut { dragPayload?(file) }
             }
             .buttonStyle(.plain)
             Button(isOursDeleted ? "Keep theirs" : "Keep ours") {

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -14,6 +14,10 @@ struct FilesTabView: View {
     let revealTick: Int
     let onClearReveal: () -> Void
 
+    /// Root of the worktree the tree belongs to. Nil disables dragging for the
+    /// whole tree; payload resolution rejects remote roots on its own.
+    var worktreeRoot: URL? = nil
+
     @Environment(\.theme) private var theme
 
     nonisolated static func rowLeadingPadding(depth: Int) -> CGFloat {
@@ -152,6 +156,9 @@ struct FilesTabView: View {
                     }
                     .buttonStyle(.plain)
                     .contextMenu { contextMenu(for: terminal) }
+                    .dragOut {
+                        worktreeRoot.map { DragOutPayload.onDisk($0.appendingPathComponent(terminal.path)) }
+                    }
                     if open && canExpand {
                         switch terminal.childrenState {
                         case .loading, .loaded:
@@ -204,6 +211,9 @@ struct FilesTabView: View {
                 }
                 .buttonStyle(.plain)
                 .contextMenu { contextMenu(for: node) }
+                .dragOut {
+                    worktreeRoot.map { DragOutPayload.onDisk($0.appendingPathComponent(node.path)) }
+                }
             )
         }
     }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -92,7 +92,8 @@ struct RightPaneView: View {
                                 showIgnored: state.config.files.showIgnored,
                                 revealPath: rps.revealPath,
                                 revealTick: rps.revealTick,
-                                onClearReveal: { rps.clearReveal() }
+                                onClearReveal: { rps.clearReveal() },
+                                worktreeRoot: rps.worktree.path
                             )
                         }
                     } else {

--- a/Alas/Sources/Right/StashesSectionView.swift
+++ b/Alas/Sources/Right/StashesSectionView.swift
@@ -12,6 +12,7 @@ struct StashesSectionView: View {
     let onApply: (GitStash) -> Void
     let onPop: (GitStash) -> Void
     let onDrop: (GitStash) -> Void
+    var dragPayload: ((GitStash, GitStashFile) -> DragOutPayload?)? = nil
 
     @Environment(\.theme) private var theme
 
@@ -136,6 +137,7 @@ struct StashesSectionView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .dragOut { dragPayload?(stash, file) }
             }
         }
     }

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -21,6 +21,7 @@ struct WorkingTreeSectionView: View {
     var onParkChanges:     (() -> Void)? = nil
     var parkChangesDisabled: Bool = false
     var isOpenFileEnabled: ((ChangedFile) -> Bool)? = nil
+    var dragPayload: ((ChangedFile) -> DragOutPayload?)? = nil
 
     @Environment(\.theme) private var theme
 
@@ -252,7 +253,8 @@ struct WorkingTreeSectionView: View {
                     onDiscard: onDiscardFile.map { fn in { fn(file) } },
                     openFileEnabled: isOpenFileEnabled?(file) ?? true,
                     viewAtHEADEnabled: hasHeadVersion(group),
-                    ignoreMenu: ignore
+                    ignoreMenu: ignore,
+                    dragPayload: dragPayload.map { fn in { fn(file) } }
                 )
             )
         } else {

--- a/AlasTests/DragOutActivationTests.swift
+++ b/AlasTests/DragOutActivationTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct DragOutActivationTests {
+    @Test func aClickDoesNotTravelFarEnoughToPrefetch() {
+        #expect(DragOutActivation.travel(CGSize(width: 0, height: 0))
+            < DragOutActivation.prefetchDistance)
+    }
+
+    @Test func prefetchStartsBeforeTheDragActivates() {
+        #expect(DragOutActivation.prefetchDistance < DragOutActivation.activationDistance)
+    }
+
+    @Test func shortTravelDoesNotActivate() {
+        #expect(DragOutActivation.travel(CGSize(width: 3, height: 0))
+            < DragOutActivation.activationDistance)
+    }
+
+    @Test func travelIsDiagonalDistanceNotAxisDistance() {
+        // 5-12-13 triangle: neither axis reaches the threshold on its own.
+        #expect(DragOutActivation.travel(CGSize(width: 5, height: 12)) == 13)
+    }
+
+    @Test func longTravelActivates() {
+        #expect(DragOutActivation.travel(CGSize(width: 0, height: -20))
+            >= DragOutActivation.activationDistance)
+    }
+}

--- a/AlasTests/DragOutPayloadTests.swift
+++ b/AlasTests/DragOutPayloadTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct DragOutPayloadTests {
+    private func makeTempDir(_ name: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-dragpayload-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func workingTreeFileJoinsTheWorktreePath() {
+        let root = URL(fileURLWithPath: "/tmp/wt")
+        let payload = DragOutPayload.workingTreeFile(worktreePath: root, relativePath: "a/b.txt")
+        #expect(payload == .onDisk(URL(fileURLWithPath: "/tmp/wt/a/b.txt")))
+    }
+
+    @Test func trackedStashFileUsesTheStashRef() {
+        let root = URL(fileURLWithPath: "/tmp/wt")
+        let stash = GitStash(ref: "stash@{0}", subject: "wip", relativeTime: "1m", sha: "abc")
+        let file = GitStashFile(path: "a.txt", status: "M", add: 1, del: 0)
+        let payload = DragOutPayload.stashFile(worktreePath: root, stash: stash, file: file)
+        #expect(payload == .revision(worktreePath: root, ref: "stash@{0}", path: "a.txt"))
+    }
+
+    @Test func untrackedStashFileUsesTheThirdParent() {
+        let root = URL(fileURLWithPath: "/tmp/wt")
+        let stash = GitStash(ref: "stash@{0}", subject: "wip", relativeTime: "1m", sha: "abc")
+        let file = GitStashFile(path: "new.txt", status: "A", add: 3, del: 0, isUntracked: true)
+        let payload = DragOutPayload.stashFile(worktreePath: root, stash: stash, file: file)
+        #expect(payload == .revision(worktreePath: root, ref: "stash@{0}^3", path: "new.txt"))
+    }
+
+    @Test func commitFileUsesTheCommitSHA() {
+        let root = URL(fileURLWithPath: "/tmp/wt")
+        let file = CommitChangedFile(path: "src/x.swift", originalPath: nil, status: "M", add: 2, del: 1)
+        let payload = DragOutPayload.commitFile(worktreePath: root, sha: "a1b2c3d", file: file)
+        #expect(payload == .revision(worktreePath: root, ref: "a1b2c3d", path: "src/x.swift"))
+    }
+
+    @Test func resolveReturnsAnExistingFile() async throws {
+        let dir = try makeTempDir("exists")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("a.txt")
+        try "x".write(to: file, atomically: true, encoding: .utf8)
+
+        #expect(await DragOutPayload.onDisk(file).resolve() == file)
+    }
+
+    @Test func resolveReturnsAnExistingDirectory() async throws {
+        let dir = try makeTempDir("dir")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sub = dir.appendingPathComponent("nested")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+
+        #expect(await DragOutPayload.onDisk(sub).resolve() == sub)
+    }
+
+    @Test func resolveReturnsNilForAMissingFile() async throws {
+        let dir = try makeTempDir("missing")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        #expect(await DragOutPayload.onDisk(dir.appendingPathComponent("gone.txt")).resolve() == nil)
+    }
+
+    @Test func resolveReturnsNilInsideARemoteWorktree() async throws {
+        let dir = try makeTempDir("remote")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("a.txt")
+        try "x".write(to: file, atomically: true, encoding: .utf8)
+
+        RemoteHostRegistry.shared.register(root: dir.path, host: "example")
+        defer { RemoteHostRegistry.shared.unregister(root: dir.path) }
+
+        #expect(await DragOutPayload.onDisk(file).resolve() == nil)
+        let revision = DragOutPayload.revision(worktreePath: dir, ref: "HEAD", path: "a.txt")
+        #expect(await revision.resolve() == nil)
+    }
+}

--- a/AlasTests/DragOutPayloadTests.swift
+++ b/AlasTests/DragOutPayloadTests.swift
@@ -16,12 +16,22 @@ struct DragOutPayloadTests {
         #expect(payload == .onDisk(URL(fileURLWithPath: "/tmp/wt/a/b.txt")))
     }
 
-    @Test func trackedStashFileUsesTheStashRef() {
+    @Test func trackedStashFileUsesTheStashSHA() {
         let root = URL(fileURLWithPath: "/tmp/wt")
         let stash = GitStash(ref: "stash@{0}", subject: "wip", relativeTime: "1m", sha: "abc")
         let file = GitStashFile(path: "a.txt", status: "M", add: 1, del: 0)
         let payload = DragOutPayload.stashFile(worktreePath: root, stash: stash, file: file)
-        #expect(payload == .revision(worktreePath: root, ref: "stash@{0}", path: "a.txt"))
+        #expect(payload == .revision(worktreePath: root, ref: "abc", path: "a.txt"))
+    }
+
+    /// `stash@{N}` is positional, so a stash pushed between rendering the row
+    /// and starting the drag would resolve to a different stash entirely.
+    @Test func stashFileIgnoresThePositionalReflogName() {
+        let root = URL(fileURLWithPath: "/tmp/wt")
+        let stash = GitStash(ref: "stash@{7}", subject: "wip", relativeTime: "1m", sha: "abc")
+        let file = GitStashFile(path: "a.txt", status: "M", add: 1, del: 0)
+        let payload = DragOutPayload.stashFile(worktreePath: root, stash: stash, file: file)
+        #expect(payload == .revision(worktreePath: root, ref: "abc", path: "a.txt"))
     }
 
     @Test func untrackedStashFileUsesTheThirdParent() {
@@ -29,7 +39,7 @@ struct DragOutPayloadTests {
         let stash = GitStash(ref: "stash@{0}", subject: "wip", relativeTime: "1m", sha: "abc")
         let file = GitStashFile(path: "new.txt", status: "A", add: 3, del: 0, isUntracked: true)
         let payload = DragOutPayload.stashFile(worktreePath: root, stash: stash, file: file)
-        #expect(payload == .revision(worktreePath: root, ref: "stash@{0}^3", path: "new.txt"))
+        #expect(payload == .revision(worktreePath: root, ref: "abc^3", path: "new.txt"))
     }
 
     @Test func commitFileUsesTheCommitSHA() {

--- a/AlasTests/DragOutSessionTests.swift
+++ b/AlasTests/DragOutSessionTests.swift
@@ -1,0 +1,26 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Alas
+
+struct DragOutSessionTests {
+    @Test func dragsOutsideTheAppAreCopyOnly() {
+        #expect(DragOutSession.operationMask(for: .outsideApplication) == .copy)
+    }
+
+    @Test func dragsInsideTheAppAreRefused() {
+        #expect(DragOutSession.operationMask(for: .withinApplication) == [])
+    }
+
+    @Test func pasteboardItemCarriesTheFileURL() {
+        let url = URL(fileURLWithPath: "/tmp/alas drag/a b.txt")
+        let item = DragOutSession.pasteboardItem(for: url)
+        #expect(item.string(forType: .fileURL) == url.absoluteString)
+    }
+
+    @Test func pasteboardItemCarriesThePOSIXPathAsText() {
+        let url = URL(fileURLWithPath: "/tmp/alas drag/a b.txt")
+        let item = DragOutSession.pasteboardItem(for: url)
+        #expect(item.string(forType: .string) == "/tmp/alas drag/a b.txt")
+    }
+}

--- a/AlasTests/RevisionSnapshotCacheTests.swift
+++ b/AlasTests/RevisionSnapshotCacheTests.swift
@@ -67,6 +67,30 @@ struct RevisionSnapshotCacheTests {
         #expect(snapshot == nil)
     }
 
+    @Test func snapshotMemoizesAMissingBlobAndDoesNotReRunGitShow() async throws {
+        let repo = try await makeRepo(name: "missing-memo")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let first = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "nope.txt")
+        #expect(first == nil)
+
+        // The blob now genuinely exists at the (new) HEAD. If the second
+        // lookup re-ran `git show` it would succeed; a repeat nil here can
+        // only come from the negative-memoization cache keyed on the ref
+        // string "HEAD", not from re-inspecting the repository.
+        let file = repo.appendingPathComponent("nope.txt")
+        try "now it exists".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "nope.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add nope.txt"], cwd: repo)
+
+        let second = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "nope.txt")
+        #expect(second == nil)
+
+        await cache.removeSessionDirectory()
+    }
+
     @Test func removeSessionDirectoryDeletesWrittenSnapshots() async throws {
         let repo = try await makeRepo(name: "cleanup")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/RevisionSnapshotCacheTests.swift
+++ b/AlasTests/RevisionSnapshotCacheTests.swift
@@ -350,6 +350,42 @@ struct RevisionSnapshotCacheTests {
         await cache.removeSessionDirectory()
     }
 
+    /// `git show` returns blob bytes with no mode, so without restoring it a
+    /// script dragged out of a commit lands non-executable.
+    @Test func snapshotOfAnExecutableBlobKeepsTheExecutableBit() async throws {
+        let repo = try await makeRepo(name: "exec-bit")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let script = repo.appendingPathComponent("run.sh")
+        try "#!/bin/sh\necho hi\n".write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: script.path
+        )
+        _ = try await Process.git(["add", "run.sh"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add script"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let snapshot = try #require(await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "run.sh"))
+
+        #expect(FileManager.default.isExecutableFile(atPath: snapshot.path))
+        await cache.removeSessionDirectory()
+    }
+
+    @Test func snapshotOfANonExecutableBlobStaysNonExecutable() async throws {
+        let repo = try await makeRepo(name: "no-exec-bit")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let file = repo.appendingPathComponent("notes.txt")
+        try "plain".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "notes.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add notes"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let snapshot = try #require(await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "notes.txt"))
+
+        #expect(!FileManager.default.isExecutableFile(atPath: snapshot.path))
+        await cache.removeSessionDirectory()
+    }
+
     /// Reusing a memoized snapshot is activity too. A session whose drags are
     /// all cache hits writes nothing, so without touching the root on that path
     /// it still ages out and another instance's sweep deletes the very file

--- a/AlasTests/RevisionSnapshotCacheTests.swift
+++ b/AlasTests/RevisionSnapshotCacheTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RevisionSnapshotCacheTests {
+    private func makeRepo(name: String) async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-dragout-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "Test"], cwd: dir)
+        return dir
+    }
+
+    @Test func refComponentReplacesUnsafeCharacters() {
+        #expect(RevisionSnapshotCache.refComponent("stash@{0}^3") == "stash--0--3")
+    }
+
+    @Test func refComponentKeepsShasIntact() {
+        #expect(RevisionSnapshotCache.refComponent("a1b2c3d") == "a1b2c3d")
+    }
+
+    @Test func refComponentDistinguishesStashFromItsUntrackedParent() {
+        let tracked = RevisionSnapshotCache.refComponent("stash@{0}")
+        let untracked = RevisionSnapshotCache.refComponent("stash@{0}^3")
+        #expect(tracked != untracked)
+    }
+
+    @Test func snapshotURLPreservesRelativePath() {
+        let cache = RevisionSnapshotCache(sessionID: "fixed-session")
+        let url = cache.snapshotURL(ref: "a1b2c3d", path: "Sources/Right/ChangedRow.swift")
+        #expect(Array(url.pathComponents.suffix(4)) == ["a1b2c3d", "Sources", "Right", "ChangedRow.swift"])
+        #expect(url.path.hasPrefix(cache.sessionDirectory.path))
+    }
+
+    @Test func snapshotWritesTheBlobAtThatRevisionNotTheWorkingTree() async throws {
+        let repo = try await makeRepo(name: "snapshot")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let file = repo.appendingPathComponent("hello.txt")
+        try "committed".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "hello.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add hello"], cwd: repo)
+        try "working tree".write(to: file, atomically: true, encoding: .utf8)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let snapshot = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "hello.txt")
+
+        let unwrapped = try #require(snapshot)
+        #expect(try String(contentsOf: unwrapped, encoding: .utf8) == "committed")
+        #expect(unwrapped.lastPathComponent == "hello.txt")
+        await cache.removeSessionDirectory()
+    }
+
+    @Test func snapshotReturnsNilWhenTheBlobDoesNotExistAtThatRevision() async throws {
+        let repo = try await makeRepo(name: "missing")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let snapshot = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "nope.txt")
+
+        #expect(snapshot == nil)
+    }
+
+    @Test func removeSessionDirectoryDeletesWrittenSnapshots() async throws {
+        let repo = try await makeRepo(name: "cleanup")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let file = repo.appendingPathComponent("a.txt")
+        try "x".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "a"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        _ = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "a.txt")
+        #expect(FileManager.default.fileExists(atPath: cache.sessionDirectory.path))
+
+        await cache.removeSessionDirectory()
+        #expect(!FileManager.default.fileExists(atPath: cache.sessionDirectory.path))
+    }
+}

--- a/AlasTests/RevisionSnapshotCacheTests.swift
+++ b/AlasTests/RevisionSnapshotCacheTests.swift
@@ -14,7 +14,7 @@ struct RevisionSnapshotCacheTests {
     }
 
     @Test func refComponentReplacesUnsafeCharacters() {
-        #expect(RevisionSnapshotCache.refComponent("stash@{0}^3") == "stash--0--3")
+        #expect(RevisionSnapshotCache.refComponent("stash@{0}^3") == "stash%40%7B0%7D%5E3")
     }
 
     @Test func refComponentKeepsShasIntact() {
@@ -25,6 +25,10 @@ struct RevisionSnapshotCacheTests {
         let tracked = RevisionSnapshotCache.refComponent("stash@{0}")
         let untracked = RevisionSnapshotCache.refComponent("stash@{0}^3")
         #expect(tracked != untracked)
+    }
+
+    @Test func refComponentIsInjectiveForCollidingRefs() {
+        #expect(RevisionSnapshotCache.refComponent("feature/foo") != RevisionSnapshotCache.refComponent("feature-foo"))
     }
 
     @Test func snapshotURLPreservesRelativePath() {
@@ -77,5 +81,26 @@ struct RevisionSnapshotCacheTests {
 
         await cache.removeSessionDirectory()
         #expect(!FileManager.default.fileExists(atPath: cache.sessionDirectory.path))
+    }
+
+    @Test func sweepDoesNotDeleteFreshSiblingSessionDirectories() async throws {
+        let repo = try await makeRepo(name: "sweep")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let file = repo.appendingPathComponent("a.txt")
+        try "x".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "a"], cwd: repo)
+
+        let sibling = RevisionSnapshotCache(sessionID: "sibling-\(UUID().uuidString)")
+        _ = await sibling.snapshot(worktreePath: repo, ref: "HEAD", path: "a.txt")
+        #expect(FileManager.default.fileExists(atPath: sibling.sessionDirectory.path))
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        _ = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "a.txt")
+
+        #expect(FileManager.default.fileExists(atPath: sibling.sessionDirectory.path))
+
+        await sibling.removeSessionDirectory()
+        await cache.removeSessionDirectory()
     }
 }

--- a/AlasTests/RevisionSnapshotCacheTests.swift
+++ b/AlasTests/RevisionSnapshotCacheTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 @testable import Alas
@@ -11,6 +12,41 @@ struct RevisionSnapshotCacheTests {
         _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: dir)
         _ = try await Process.git(["config", "user.name", "Test"], cwd: dir)
         return dir
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Writes an LFS pointer file at `fileName`, and, unless `withObject` is
+    /// false, the real object bytes it resolves to under the repo's default
+    /// `.git/lfs/objects` store — mirroring what `git lfs` itself would leave
+    /// on disk after a real fetch, without needing `git-lfs` installed to
+    /// produce it.
+    private func writeLFSPointer(
+        for data: Data,
+        named fileName: String,
+        in repo: URL,
+        withObject: Bool = true
+    ) throws {
+        let oid = sha256Hex(data)
+        let pointer = """
+        version https://git-lfs.github.com/spec/v1
+        oid sha256:\(oid)
+        size \(data.count)
+
+        """
+        try pointer.write(
+            to: repo.appendingPathComponent(fileName),
+            atomically: true,
+            encoding: .utf8
+        )
+        guard withObject else { return }
+        let objectDir = repo.appendingPathComponent(".git/lfs/objects")
+            .appendingPathComponent(String(oid.prefix(2)))
+            .appendingPathComponent(String(oid.dropFirst(2).prefix(2)))
+        try FileManager.default.createDirectory(at: objectDir, withIntermediateDirectories: true)
+        try data.write(to: objectDir.appendingPathComponent(oid))
     }
 
     @Test func refComponentReplacesUnsafeCharacters() {
@@ -231,6 +267,85 @@ struct RevisionSnapshotCacheTests {
         let retried = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "big.bin")
         let unwrapped = try #require(retried)
         #expect(try Data(contentsOf: unwrapped) == bytes)
+
+        await cache.removeSessionDirectory()
+    }
+
+    /// `git show` on an LFS-tracked path returns the pointer stub, not the
+    /// asset. A snapshot of such a path must resolve to the real bytes from
+    /// the local LFS store, or a "broken image" is what lands in Finder.
+    @Test func snapshotResolvesAnLFSPointerToTheRealObjectData() async throws {
+        let repo = try await makeRepo(name: "lfs")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let payload = Data("this stands in for real image bytes".utf8)
+        try writeLFSPointer(for: payload, named: "logo.png", in: repo)
+        _ = try await Process.git(["add", "logo.png"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "lfs image"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let snapshot = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "logo.png")
+
+        let unwrapped = try #require(snapshot)
+        #expect(try Data(contentsOf: unwrapped) == payload)
+        await cache.removeSessionDirectory()
+    }
+
+    /// LFS objects can be un-fetched locally. In that case there is no real
+    /// asset to substitute, so the honest outcome is writing the pointer
+    /// unchanged rather than failing the drag.
+    @Test func snapshotWritesThePointerVerbatimWhenTheLFSObjectIsNotFetchedLocally() async throws {
+        let repo = try await makeRepo(name: "lfs-missing")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let payload = Data("bytes that were never fetched locally".utf8)
+        try writeLFSPointer(for: payload, named: "logo.png", in: repo, withObject: false)
+        _ = try await Process.git(["add", "logo.png"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "lfs image, object absent"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let snapshot = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "logo.png")
+
+        let unwrapped = try #require(snapshot)
+        let written = try String(contentsOf: unwrapped, encoding: .utf8)
+        #expect(written.hasPrefix("version https://git-lfs.github.com/spec/v1"))
+        await cache.removeSessionDirectory()
+    }
+
+    /// A snapshot write happens deep inside `<session>/<worktree>/<ref>/...`,
+    /// which does not by itself touch the session root's own mtime once that
+    /// subtree already exists — only creating a *direct* child of the root
+    /// does. Without an explicit touch, a long-running instance's session
+    /// root looks abandoned to another instance's stale sweep even while it
+    /// is actively writing snapshots.
+    @Test func snapshotOfADeepNestedFileRefreshesTheSessionRootModificationDate() async throws {
+        let repo = try await makeRepo(name: "touch-root")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let fileA = repo.appendingPathComponent("a.txt")
+        try "a".write(to: fileA, atomically: true, encoding: .utf8)
+        let fileB = repo.appendingPathComponent("b.txt")
+        try "b".write(to: fileB, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt", "b.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "a and b"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        // Establish the <session>/<worktree>/<ref>/ subtree first, so the
+        // second snapshot below writes a new file into an already-existing
+        // directory rather than creating a fresh direct child of the session
+        // root — the exact "deep nested write" scenario the fix targets.
+        _ = try #require(await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "a.txt"))
+
+        let backDated = Date().addingTimeInterval(-2 * RevisionSnapshotCache.staleSessionAge)
+        try FileManager.default.setAttributes(
+            [.modificationDate: backDated],
+            ofItemAtPath: cache.sessionDirectory.path
+        )
+        let attributesBeforeSecondWrite = try FileManager.default.attributesOfItem(atPath: cache.sessionDirectory.path)
+        let mtimeBeforeSecondWrite = try #require(attributesBeforeSecondWrite[.modificationDate] as? Date)
+
+        _ = try #require(await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "b.txt"))
+
+        let attributesAfterSecondWrite = try FileManager.default.attributesOfItem(atPath: cache.sessionDirectory.path)
+        let mtimeAfterSecondWrite = try #require(attributesAfterSecondWrite[.modificationDate] as? Date)
+        #expect(mtimeAfterSecondWrite > mtimeBeforeSecondWrite)
 
         await cache.removeSessionDirectory()
     }

--- a/AlasTests/RevisionSnapshotCacheTests.swift
+++ b/AlasTests/RevisionSnapshotCacheTests.swift
@@ -33,9 +33,23 @@ struct RevisionSnapshotCacheTests {
 
     @Test func snapshotURLPreservesRelativePath() {
         let cache = RevisionSnapshotCache(sessionID: "fixed-session")
-        let url = cache.snapshotURL(ref: "a1b2c3d", path: "Sources/Right/ChangedRow.swift")
+        let worktree = URL(fileURLWithPath: "/tmp/some-repo")
+        let url = cache.snapshotURL(worktreePath: worktree, ref: "a1b2c3d", path: "Sources/Right/ChangedRow.swift")
         #expect(Array(url.pathComponents.suffix(4)) == ["a1b2c3d", "Sources", "Right", "ChangedRow.swift"])
         #expect(url.path.hasPrefix(cache.sessionDirectory.path))
+    }
+
+    @Test func snapshotURLDiffersByWorktreeForTheSameRefAndPath() {
+        let cache = RevisionSnapshotCache(sessionID: "fixed-session")
+        let worktreeA = URL(fileURLWithPath: "/tmp/repo-a")
+        let worktreeB = URL(fileURLWithPath: "/tmp/repo-b")
+        let urlA = cache.snapshotURL(worktreePath: worktreeA, ref: "HEAD", path: "README.md")
+        let urlB = cache.snapshotURL(worktreePath: worktreeB, ref: "HEAD", path: "README.md")
+        #expect(urlA != urlB)
+        // Deterministic within a session: the same worktree must keep
+        // producing the same destination across calls, or a cache hit for
+        // one call would miss the file a later call actually wrote.
+        #expect(cache.snapshotURL(worktreePath: worktreeA, ref: "HEAD", path: "README.md") == urlA)
     }
 
     @Test func snapshotWritesTheBlobAtThatRevisionNotTheWorkingTree() async throws {
@@ -125,6 +139,77 @@ struct RevisionSnapshotCacheTests {
         #expect(FileManager.default.fileExists(atPath: sibling.sessionDirectory.path))
 
         await sibling.removeSessionDirectory()
+        await cache.removeSessionDirectory()
+    }
+
+    @Test func differentWorktreesDoNotShareCacheEntries() async throws {
+        let repoA = try await makeRepo(name: "worktree-a")
+        defer { try? FileManager.default.removeItem(at: repoA) }
+        let repoB = try await makeRepo(name: "worktree-b")
+        defer { try? FileManager.default.removeItem(at: repoB) }
+
+        // Same relative path, same ref name, different repos. Before the
+        // worktree was folded into the cache key, this collided on a single
+        // dictionary entry: the second repo's lookup would hit the first
+        // repo's cached URL and hand back the wrong file's bytes.
+        let fileA = repoA.appendingPathComponent("shared.txt")
+        try "content from repo A".write(to: fileA, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "shared.txt"], cwd: repoA)
+        _ = try await Process.git(["commit", "-q", "-m", "a"], cwd: repoA)
+
+        let fileB = repoB.appendingPathComponent("shared.txt")
+        try "content from repo B".write(to: fileB, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "shared.txt"], cwd: repoB)
+        _ = try await Process.git(["commit", "-q", "-m", "b"], cwd: repoB)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+
+        let snapshotA = await cache.snapshot(worktreePath: repoA, ref: "HEAD", path: "shared.txt")
+        let unwrappedA = try #require(snapshotA)
+        #expect(try String(contentsOf: unwrappedA, encoding: .utf8) == "content from repo A")
+
+        let snapshotB = await cache.snapshot(worktreePath: repoB, ref: "HEAD", path: "shared.txt")
+        let unwrappedB = try #require(snapshotB)
+        #expect(try String(contentsOf: unwrappedB, encoding: .utf8) == "content from repo B")
+
+        await cache.removeSessionDirectory()
+    }
+
+    @Test func cancelledSnapshotIsNotMemoizedAsMissing() async throws {
+        let repo = try await makeRepo(name: "cancel")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        // A sizeable blob gives `git show` real decompress/pipe/write work
+        // to do, so cancelling right after kicking off the task has a
+        // realistic chance of landing while the process is still running
+        // rather than after it has already exited on its own. 5MB is
+        // enough margin over Swift's task-scheduling overhead without
+        // making this test a heavy I/O cost in CI. If the process happens
+        // to finish first, the assertions below still hold (nothing was
+        // ever memoized as missing), so this test cannot go spuriously red
+        // — it just wouldn't have exercised the interesting path on that
+        // particular run.
+        let file = repo.appendingPathComponent("big.bin")
+        let bytes = Data(count: 5 * 1024 * 1024)
+        try bytes.write(to: file)
+        _ = try await Process.git(["add", "big.bin"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add big blob"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+
+        let task = Task {
+            await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "big.bin")
+        }
+        task.cancel()
+        _ = await task.value
+
+        // A fresh, uncancelled lookup for the same key must still succeed:
+        // the earlier cancellation must not have poisoned the cache with a
+        // "this blob does not exist" entry.
+        let retried = await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "big.bin")
+        let unwrapped = try #require(retried)
+        #expect(try Data(contentsOf: unwrapped) == bytes)
+
         await cache.removeSessionDirectory()
     }
 }

--- a/AlasTests/RevisionSnapshotCacheTests.swift
+++ b/AlasTests/RevisionSnapshotCacheTests.swift
@@ -349,4 +349,37 @@ struct RevisionSnapshotCacheTests {
 
         await cache.removeSessionDirectory()
     }
+
+    /// Reusing a memoized snapshot is activity too. A session whose drags are
+    /// all cache hits writes nothing, so without touching the root on that path
+    /// it still ages out and another instance's sweep deletes the very file
+    /// being handed to the drag.
+    @Test func reusingAMemoizedSnapshotRefreshesTheSessionRootModificationDate() async throws {
+        let repo = try await makeRepo(name: "touch-on-hit")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let file = repo.appendingPathComponent("a.txt")
+        try "a".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add a"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let first = try #require(await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "a.txt"))
+
+        let backDated = Date().addingTimeInterval(-2 * RevisionSnapshotCache.staleSessionAge)
+        try FileManager.default.setAttributes(
+            [.modificationDate: backDated],
+            ofItemAtPath: cache.sessionDirectory.path
+        )
+
+        // Same (worktree, ref, path), and the file on disk is untouched, so
+        // this must be served from the cache without rewriting anything.
+        let second = try #require(await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "a.txt"))
+        #expect(second == first)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: cache.sessionDirectory.path)
+        let mtime = try #require(attributes[.modificationDate] as? Date)
+        #expect(mtime > backDated)
+
+        await cache.removeSessionDirectory()
+    }
 }

--- a/AlasTests/RevisionSnapshotCacheTests.swift
+++ b/AlasTests/RevisionSnapshotCacheTests.swift
@@ -70,6 +70,28 @@ struct RevisionSnapshotCacheTests {
         await cache.removeSessionDirectory()
     }
 
+    /// The app receiving a drag can save over the snapshot file. Reusing it
+    /// would then hand out bytes that no longer match the revision.
+    @Test func snapshotIsRewrittenAfterTheReceivingAppEditsIt() async throws {
+        let repo = try await makeRepo(name: "clobbered")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let file = repo.appendingPathComponent("hello.txt")
+        try "committed".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "hello.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add hello"], cwd: repo)
+
+        let cache = RevisionSnapshotCache(sessionID: UUID().uuidString)
+        let first = try #require(await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "hello.txt"))
+        #expect(try String(contentsOf: first, encoding: .utf8) == "committed")
+
+        // Stand in for an editor saving the dropped file back to disk.
+        try "edited by the receiving app".write(to: first, atomically: true, encoding: .utf8)
+
+        let second = try #require(await cache.snapshot(worktreePath: repo, ref: "HEAD", path: "hello.txt"))
+        #expect(try String(contentsOf: second, encoding: .utf8) == "committed")
+        await cache.removeSessionDirectory()
+    }
+
     @Test func snapshotReturnsNilWhenTheBlobDoesNotExistAtThatRevision() async throws {
         let repo = try await makeRepo(name: "missing")
         defer { try? FileManager.default.removeItem(at: repo) }


### PR DESCRIPTION
Drag any file row in Alas out to another macOS app — a dock icon, an editor window, Finder, a terminal — and it lifts as a real file.

The drag carries two flavors: the **file URL** (apps open the file) and the **absolute POSIX path as text** (terminals and text fields get a usable path). The operation is pinned to **copy** for drops outside Alas, so a Finder drop can never move a file out of a worktree. That guarantee is the whole reason this is AppKit rather than SwiftUI's `.draggable`, which exposes no control over the operation mask.

## Draggable surfaces

| Surface | Source of the dragged file |
|---|---|
| Files tab — file and directory rows | the path on disk |
| Changes tab — working tree and conflict rows | the path on disk |
| Changes tab — stash file rows | `git show <sha>:<path>` snapshot |
| Commit editor — file rows | `git show <sha>:<path>` snapshot |

Working-tree rows drag the **live file**, so an edit in the receiving app lands back in the repo. Historical revisions have no on-disk form at that revision, so they drag a snapshot written to `<temp>/alas-drag/<session>/<worktree>/<ref>/<original/relative/path>` — the original filename and directory structure are preserved, so the receiving app shows `ChangedRow.swift` with working syntax highlighting.

## Design

One new module, `Alas/Sources/DragOut/`, and a single call-site API: `.dragOut { payloadOrNil }`.

- **`DragOutPayload`** — `.onDisk(URL)` or `.revision(worktreePath:ref:path:)`, with one `resolve() async -> URL?`. Every reason a drag is impossible — remote worktree, deleted file, blob missing at that revision — collapses into that `nil`, so no call site carries its own error handling. A `D` row needs no status check: its path doesn't exist, and `git show` exits non-zero for a path deleted at that revision.
- **`RevisionSnapshotCache`** — an actor that materializes blobs, memoized per `(worktree, ref, path)`.
- **`DragOutSession`** — the `NSDraggingSource` that pins the mask and writes both pasteboard flavors.
- **`.dragOut`** — a `simultaneousGesture` that prefetches at 2pt and begins the session at 6pt, so a click never spawns a `git show` and the row's existing tap and context menu keep working.

Remote (SSH) worktrees don't drag at all, matching what *Reveal in Finder* already does.

## Notes for review

Two rounds of review caught defects worth calling out, all fixed here:

- The drag-start task was uncancellable, so a drag could lift *after* the mouse was released, and a `D` row could spawn a `git show` per resolve latency for as long as the drag was held.
- The row-level gesture swallowed clicks on the stage chip and the conflict-resolution buttons. The drag hit area is now the file icon and name, leaving those controls as pure click targets.
- The snapshot cache and its on-disk paths were keyed without the worktree. In a multi-repo workspace that meant dragging repo B's `README.md` out of `stash@{0}` could hand over **repo A's bytes**.
- Stash drags resolved `stash@{N}`, which is positional — a stash pushed between rendering the row and starting the drag would resolve to a different stash. They now resolve by SHA.

## Testing

31 tests across four suites, covering ref construction, snapshot path layout and injectivity, cross-worktree isolation, cancellation not poisoning the negative cache, the remote and existence gates, the pasteboard flavors, and the operation mask.

**Manual verification still owed** — the drag gesture itself can't be unit tested:

- [ ] Dropping on a Finder window **copies** and leaves the original in place
- [ ] Dropping on an editor's dock icon opens the file
- [ ] Dropping in a terminal inserts the absolute path
- [ ] A commit editor row yields that revision's content, not the working tree's
- [ ] Clicking a stage chip with a few px of jitter still stages, rather than starting a drag
