### PR TITLE
feat(reopen): reopen closed tab

### DIFF
--- a/.superpowers/sdd/2026-08-04-reopen-closed-tabs/progress.md
+++ b/.superpowers/sdd/2026-08-04-reopen-closed-tabs/progress.md
@@ -1,0 +1,28 @@
+# SDD ledger - plan: docs/superpowers/plans/2026-08-04-reopen-closed-tabs.md
+
+## Task 1 - Closed-tab history and placement model
+
+- Status: completed
+- Verification: passed (`ClosedTabHistoryTests` only)
+- Commit: 68d876c0 feat(tabs): add closed tab history model
+- Review: passed
+
+## Task 2 - Manager snapshot restoration
+
+- Status: completed
+- Implementation: adds local/global anchored insertion and stable-ID focus without duplication
+- Verification: passed; the focused GREEN xcresult at `/tmp/alas-reopen-tabs-task2-green-dd/Logs/Test/Test-Alas-2026.08.04_20-15-59-+0200.xcresult` reports 70 passed, 0 failed, 0 skipped; review follow-up persistence reload coverage also passed with exit 0 using `/tmp/alas-reopen-tabs-task2-review-dd`
+- Commit: a91c9e1b feat(tabs): restore closed tab snapshots
+
+## Task 3 - Explicit closure capture and non-terminal reopen
+
+- Status: completed
+- Implementation: recovered the partial AppState, RootView, CenterPaneView, test-target membership, and AppState boundary-test changes; regenerated `Alas.xcodeproj` with `rtk xcodegen`; added review follow-up coverage for overlapping terminal reopen attempts and archive-worktree cleanup.
+- Verification: passed. The focused run at `/tmp/alas-reopen-tabs-task3-reviewfix-dd/Logs/Test/Test-Alas-2026.08.04_21-06-34-+0200.xcresult` reports 124 passed, 0 failed, and 0 skipped.
+- Commit: cfa1649b feat(tabs): reopen explicitly closed tabs
+
+## Task 4 - Terminal tab reconstruction for reopen
+
+- Status: completed
+- Implementation: reconstructs closed terminal pane trees with fresh sessions at each leaf's last working directory, preserves tab and split metadata, clears Run Script markers, and rolls back opened sessions when reconstruction fails.
+- Verification: passed (`ClosedTabAppStateTests`, `TabsManagerPaneTests`, `AppStateKeepSessionsAliveTests`, and `AgentTerminalLaunchTests` with fresh DerivedData)

--- a/.superpowers/sdd/2026-08-04-reopen-closed-tabs/progress.md
+++ b/.superpowers/sdd/2026-08-04-reopen-closed-tabs/progress.md
@@ -26,3 +26,9 @@
 - Status: completed
 - Implementation: reconstructs closed terminal pane trees with fresh sessions at each leaf's last working directory, preserves tab and split metadata, clears Run Script markers, and rolls back opened sessions when reconstruction fails.
 - Verification: passed (`ClosedTabAppStateTests`, `TabsManagerPaneTests`, `AppStateKeepSessionsAliveTests`, and `AgentTerminalLaunchTests` with fresh DerivedData)
+
+## Task 5 - Menu command, notification, and Ghostty reservation
+
+- Status: completed
+- Implementation: reserves the fixed Command-Shift-T binding, adds the disabled-state-aware Reopen Closed Tab Tab-menu command, and routes its notification through AppState without relying on the selected worktree.
+- Verification: passed; the focused suite at `/tmp/alas-reopen-tabs-task5-dd/Logs/Test/Test-Alas-2026.08.04_21-29-07-+0200.xcresult` reports 50 passed, 0 failed, and 0 skipped.

--- a/.superpowers/sdd/2026-08-04-reopen-closed-tabs/task-4-report.md
+++ b/.superpowers/sdd/2026-08-04-reopen-closed-tabs/task-4-report.md
@@ -1,0 +1,18 @@
+# Task 4 report - terminal tab reconstruction
+
+## Completed
+
+- Replaced the terminal reopen placeholder with fresh terminal-session reconstruction.
+- Preserved terminal tab IDs, split structure, leaf order, focus mapping, and per-leaf last working directories.
+- Cleared Run Script fields so reopening never reruns a script.
+- Added transactional rollback for partial session-open failures, retaining the closed-tab history entry and reporting `Reopen Tab Failed`.
+
+## Tests
+
+Passed:
+
+```bash
+ALAS_ZMX_OPTIONAL=1 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-task4-dd test -only-testing:AlasTests/ClosedTabAppStateTests -only-testing:AlasTests/TabsManagerPaneTests -only-testing:AlasTests/AppStateKeepSessionsAliveTests -only-testing:AlasTests/AgentTerminalLaunchTests
+```
+
+The focused run completed with exit code 0.

--- a/.superpowers/sdd/2026-08-04-reopen-closed-tabs/task-5-report.md
+++ b/.superpowers/sdd/2026-08-04-reopen-closed-tabs/task-5-report.md
@@ -1,0 +1,18 @@
+# Task 5 report - reopen closed tab shortcut
+
+## Completed
+
+- Reserved the fixed Command-Shift-T binding, preventing configurable actions and Ghostty from consuming it.
+- Added Reopen Closed Tab immediately after Close Tab in the Tab command menu; it reflects `state.canReopenClosedTab`.
+- Added the app-wide reopen notification and async RootView handler, independent of the selected worktree.
+- Added reservation, recorder-validation, and focused-terminal shortcut regressions.
+
+## Tests
+
+Passed:
+
+```bash
+ALAS_ZMX_OPTIONAL=1 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-task5-dd test -only-testing:AlasTests/ShortcutReservationsTests -only-testing:AlasTests/SurfaceViewShortcutTests -only-testing:AlasTests/ShortcutRecorderValidationTests -only-testing:AlasTests/ClosedTabHistoryTests -only-testing:AlasTests/ClosedTabAppStateTests
+```
+
+The focused run reported 50 passed tests, 0 failed tests, and 0 skipped tests. Manual app-menu inspection was not performed in this headless environment.

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */; };
 		4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */; };
 		4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */; };
+		4B88A05E99FBAA788CAA4394 /* ClosedTabHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D19208F2DE728FB5D6F8FF /* ClosedTabHistoryTests.swift */; };
 		4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02E429B37288215EBC89571 /* CommitHeaderView.swift */; };
 		4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */; };
 		4BA49732C8D13ED574A0E35D /* GGStackGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */; };
@@ -943,6 +944,7 @@
 		A2340CCA2AA5C39B27545EA6 /* AppQuitActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2672B5B84D96BDDE9D80A0 /* AppQuitActionTests.swift */; };
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
 		A2B0E4C1D80EB12F7BECE7FC /* RepoSelectorDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */; };
+		A2BB622FA93936FAE9A3719A /* ClosedTabHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CE3FADE2353C1214143336 /* ClosedTabHistory.swift */; };
 		A2E0A755C2854FE489530FE3 /* ImageDiffDifferenceComputer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */; };
 		A383F1C9B0B00B2805576209 /* ACPScrollDirectionClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0190EE078ADB537982F7DC /* ACPScrollDirectionClassifierTests.swift */; };
 		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
@@ -1628,6 +1630,7 @@
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionChecker.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
+		15CE3FADE2353C1214143336 /* ClosedTabHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabHistory.swift; sourceTree = "<group>"; };
 		1688AB1B49758FAB5BF0AF2F /* light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = light.json; sourceTree = "<group>"; };
 		169FC38D03727F34855EB521 /* AlasFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasFieldTests.swift; sourceTree = "<group>"; };
 		16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeTests.swift; sourceTree = "<group>"; };
@@ -2179,6 +2182,7 @@
 		7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGServiceActionsTests.swift; sourceTree = "<group>"; };
 		7544FD20BC61E587CAFAC099 /* AgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistry.swift; sourceTree = "<group>"; };
 		7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkConflictResolveReport.swift; sourceTree = "<group>"; };
+		75D19208F2DE728FB5D6F8FF /* ClosedTabHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabHistoryTests.swift; sourceTree = "<group>"; };
 		75DFDC1BD30B1D1CC469D54C /* ZmxEnvTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxEnvTests.swift; sourceTree = "<group>"; };
 		7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManager.swift; sourceTree = "<group>"; };
 		764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ReviewLoop.swift"; sourceTree = "<group>"; };
@@ -3248,6 +3252,7 @@
 				3986789560012DF861565F12 /* ChatPaneTests.swift */,
 				A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */,
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
+				75D19208F2DE728FB5D6F8FF /* ClosedTabHistoryTests.swift */,
 				5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */,
 				E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */,
 				7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */,
@@ -4192,6 +4197,7 @@
 				FEF671D3D8D5F1D59AFBD8BF /* BreadcrumbView.swift */,
 				F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */,
 				0307CFD55404D01F14A5B602 /* CenterTypography.swift */,
+				15CE3FADE2353C1214143336 /* ClosedTabHistory.swift */,
 				C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */,
 				BF3AC3A1F7C5649E75015293 /* CreatingWorktreeView.swift */,
 				E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */,
@@ -5984,6 +5990,7 @@
 				87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */,
 				D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */,
 				2843F603A4D71AEEA4C09317 /* CloseTabConfirmationPolicy.swift in Sources */,
+				A2BB622FA93936FAE9A3719A /* ClosedTabHistory.swift in Sources */,
 				EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */,
 				41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */,
 				7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */,
@@ -6763,6 +6770,7 @@
 				E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */,
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
 				B83DBBA1D5090E5E757B01F5 /* CloseTabConfirmationPolicyTests.swift in Sources */,
+				4B88A05E99FBAA788CAA4394 /* ClosedTabHistoryTests.swift in Sources */,
 				D8A38BB7EC2D77C746B3631E /* CodeHostModelsTests.swift in Sources */,
 				8D5D146F9BF86EE4D058A309 /* CodeHostProviderTests.swift in Sources */,
 				3A222D407DC170E065771C56 /* CodeHostRemoteDetectorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -793,6 +793,7 @@
 		8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */; };
 		8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0317FF3C6E6D3F149FB4F5 /* ACPTranscript.swift */; };
 		8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */; };
+		895FB52619A3798A0F92C7D6 /* ClosedTabAppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7599B73CF1DC717E45FBF60 /* ClosedTabAppStateTests.swift */; };
 		899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */; };
 		899FB89D155619CF846C6BDC /* DiffDisplayModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6181842BEA798CB8606F222B /* DiffDisplayModelBuilderTests.swift */; };
 		89A3BEAA64625C766E73F58E /* ZmxSessionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */; };
@@ -2444,6 +2445,7 @@
 		A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderEligibilityTests.swift; sourceTree = "<group>"; };
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
 		A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigAgentsCodingTests.swift; sourceTree = "<group>"; };
+		A7599B73CF1DC717E45FBF60 /* ClosedTabAppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabAppStateTests.swift; sourceTree = "<group>"; };
 		A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommandTests.swift; sourceTree = "<group>"; };
 		A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerTests.swift; sourceTree = "<group>"; };
 		A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServerIntegrationTests.swift; sourceTree = "<group>"; };
@@ -3252,6 +3254,7 @@
 				3986789560012DF861565F12 /* ChatPaneTests.swift */,
 				A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */,
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
+				A7599B73CF1DC717E45FBF60 /* ClosedTabAppStateTests.swift */,
 				75D19208F2DE728FB5D6F8FF /* ClosedTabHistoryTests.swift */,
 				5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */,
 				E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */,
@@ -6770,6 +6773,7 @@
 				E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */,
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
 				B83DBBA1D5090E5E757B01F5 /* CloseTabConfirmationPolicyTests.swift in Sources */,
+				895FB52619A3798A0F92C7D6 /* ClosedTabAppStateTests.swift in Sources */,
 				4B88A05E99FBAA788CAA4394 /* ClosedTabHistoryTests.swift in Sources */,
 				D8A38BB7EC2D77C746B3631E /* CodeHostModelsTests.swift in Sources */,
 				8D5D146F9BF86EE4D058A309 /* CodeHostProviderTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -275,6 +275,11 @@ struct AlasApp: App {
                 NotificationCenter.default.post(name: .alasCloseTab, object: nil)
             }
             .keyboardShortcut("w", modifiers: .command)
+            Button("Reopen Closed Tab") {
+                NotificationCenter.default.post(name: .alasReopenClosedTab, object: nil)
+            }
+            .keyboardShortcut("t", modifiers: [.command, .shift])
+            .disabled(!state.canReopenClosedTab)
             Divider()
             Button("Select Tab 1") {
                 NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 1)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -40,7 +40,6 @@ private struct MissingMissionRecoveryTarget: Equatable {
 final class AppState {
     typealias MissionArchiveRecorder = @MainActor (String) async -> Void
     typealias CloseTabConfirmer = @MainActor (CloseTabConfirmationPolicy.Prompt) -> Bool
-    typealias TerminalTabReopenPlaceholder = @MainActor (ClosedTabEntry, String, Tab) async -> Void
     static let piMCPGeneratedConfigExcludePath = ".pi/mcp.json"
 
     /// Stable for this process; identifies this app instance to the ACP
@@ -552,7 +551,6 @@ final class AppState {
     @ObservationIgnored
     private let fileActionErrorHandler: (String, String) -> Void
     @ObservationIgnored
-    private let terminalTabReopenPlaceholder: TerminalTabReopenPlaceholder?
     @ObservationIgnored
     private var scheduledSpacesSave: Task<Void, Never>?
 
@@ -571,7 +569,6 @@ final class AppState {
         persistenceErrorHandler: ((String, String) -> Void)? = nil,
         fileActionErrorHandler: ((String, String) -> Void)? = nil,
         closeTabConfirmer: CloseTabConfirmer? = nil,
-        terminalTabReopenPlaceholder: TerminalTabReopenPlaceholder? = nil,
         terminalSessionOpener: TerminalSessionOpener? = nil,
         projectGitWatcherFactory: @escaping @MainActor (URL) -> ProjectGitWatcher = { ProjectGitWatcher(repoPath: $0) },
         missionStartupReviewSnapshot: MissionStartupReviewSnapshot? = nil,
@@ -590,7 +587,6 @@ final class AppState {
         }
         self.terminalSessionOpener = terminalSessionOpener
         self.closeTabConfirmer = closeTabConfirmer
-        self.terminalTabReopenPlaceholder = terminalTabReopenPlaceholder
         self.projectGitWatcherFactory = projectGitWatcherFactory
         self.missionStartupReviewSnapshot = missionStartupReviewSnapshot
         self.missionBranchTipOverride = missionBranchTipOverride
@@ -3842,6 +3838,42 @@ final class AppState {
         )
     }
 
+    private func openTerminalSessionForReopen(
+        worktree: Worktree,
+        project: ProjectConfig,
+        forcedCwd: URL?
+    ) throws -> OpenedTerminalSession {
+        let opened: OpenedTerminalSession
+        if let terminalSessionOpener {
+            opened = try terminalSessionOpener(
+                worktree,
+                project,
+                config.terminal,
+                themeStore.current,
+                forcedCwd,
+                nil,
+                true,
+                [:],
+                []
+            )
+        } else {
+            let leafID = UUID().uuidString
+            let session = try terminal.openSession(
+                worktree: worktree,
+                project: project,
+                cfg: config.terminal,
+                theme: themeStore.current,
+                forcedCwd: forcedCwd,
+                leafId: leafID
+            )
+            opened = .init(id: session.id, foregroundPid: { [weak session] in
+                session?.surface.foregroundPid
+            })
+        }
+        harness.detector.register(sessionId: opened.id, pidProvider: opened.foregroundPid)
+        return opened
+    }
+
     @discardableResult
     func openTerminalTab(
         for worktree: Worktree,
@@ -4965,17 +4997,56 @@ final class AppState {
         }
     }
 
-    /// Terminal reconstruction belongs to the terminal-specific reopen task.
-    /// Keep the history entry so a later retry can reconstruct it transactionally.
     private func reopenTerminalTab(entry: ClosedTabEntry, worktreeID: String, tab: Tab) async {
-        if let terminalTabReopenPlaceholder {
-            await terminalTabReopenPlaceholder(entry, worktreeID, tab)
+        guard case .terminal(let oldState) = tab,
+              let worktree = worktree(withId: worktreeID),
+              let project = projects.first(where: { $0.id == worktree.projectId }) else {
+            showFileActionError(
+                title: "Reopen Tab Failed",
+                message: "Could not find the terminal tab's worktree or project."
+            )
             return
         }
-        fileActionErrorHandler(
-            "Reopen Tab Failed",
-            "Terminal tabs cannot be reopened until their terminal session is reconstructed."
-        )
+
+        await prepareRemoteAccelerationIfNeeded(for: project)
+
+        var openedIDs: [String] = []
+        do {
+            var replacements: [String: PaneLeaf] = [:]
+            var focusedLeafID = oldState.focusedLeafId
+            for oldLeaf in oldState.root.leaves() {
+                let opened = try openTerminalSessionForReopen(
+                    worktree: worktree,
+                    project: project,
+                    forcedCwd: oldLeaf.lastCwd.map(URL.init(fileURLWithPath:))
+                )
+                openedIDs.append(opened.id)
+                replacements[oldLeaf.id] = PaneLeaf(
+                    id: opened.id,
+                    sessionId: opened.id,
+                    lastCwd: oldLeaf.lastCwd
+                )
+                if oldLeaf.id == oldState.focusedLeafId {
+                    focusedLeafID = opened.id
+                }
+            }
+
+            let reopened = TerminalTabState(
+                id: oldState.id,
+                title: oldState.title,
+                root: oldState.root.replacingLeaves(using: replacements),
+                focusedLeafId: focusedLeafID
+            )
+            _ = tabs.restore(tab: .terminal(reopened), worktreeID: worktreeID, placement: entry.placement)
+            selectWorktree(id: worktreeID)
+            activateWorktreeCenterTab(worktreeId: worktreeID, tabId: reopened.id)
+            closedTabHistory.remove(id: entry.id)
+        } catch {
+            for id in openedIDs {
+                closeTerminalSession(id: id, worktreeId: worktreeID, projectPath: project.path)
+            }
+            showFileActionError(title: "Reopen Tab Failed", message: error.localizedDescription)
+        }
     }
 
     /// Tear down every tab/terminal/harness reference for a worktree id without

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -103,6 +103,11 @@ final class AppState {
 
     @ObservationIgnored
     private var pendingACPDetachTasks: [String: [ACPSession.ID: PendingACPDetach]] = [:]
+#if DEBUG
+    var pendingACPDetachCountForTesting: Int {
+        pendingACPDetachTasks.values.reduce(0) { $0 + $1.count }
+    }
+#endif
     @ObservationIgnored
     private var acpAuthTerminalExitHandlers: [String: () -> Void] = [:]
     @ObservationIgnored
@@ -4927,24 +4932,32 @@ final class AppState {
         if let runner = manager.runners[sessionId] {
             runner.stop()
         }
-        let pending = PendingACPDetach(id: UUID(), task: Task { @MainActor in
+        let pendingID = UUID()
+        let task = Task { @MainActor in
             if let acpDetachRunner {
                 await acpDetachRunner(manager, sessionId)
             } else {
                 await manager.detach(sessionId: sessionId)
             }
-        })
-        pendingACPDetachTasks[worktreeId, default: [:]][sessionId] = pending
+        }
+        pendingACPDetachTasks[worktreeId, default: [:]][sessionId] = PendingACPDetach(id: pendingID, task: task)
+        Task { @MainActor [weak self] in
+            await task.value
+            self?.clearPendingACPDetach(worktreeId: worktreeId, sessionId: sessionId, id: pendingID)
+        }
     }
 
     private func awaitPendingACPDetach(worktreeId: String, sessionId: ACPSession.ID) async {
         guard let pending = pendingACPDetachTasks[worktreeId]?[sessionId] else { return }
         await pending.task.value
-        if pendingACPDetachTasks[worktreeId]?[sessionId]?.id == pending.id {
-            pendingACPDetachTasks[worktreeId]?.removeValue(forKey: sessionId)
-            if pendingACPDetachTasks[worktreeId]?.isEmpty == true {
-                pendingACPDetachTasks.removeValue(forKey: worktreeId)
-            }
+        clearPendingACPDetach(worktreeId: worktreeId, sessionId: sessionId, id: pending.id)
+    }
+
+    private func clearPendingACPDetach(worktreeId: String, sessionId: ACPSession.ID, id: UUID) {
+        guard pendingACPDetachTasks[worktreeId]?[sessionId]?.id == id else { return }
+        pendingACPDetachTasks[worktreeId]?.removeValue(forKey: sessionId)
+        if pendingACPDetachTasks[worktreeId]?.isEmpty == true {
+            pendingACPDetachTasks.removeValue(forKey: worktreeId)
         }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -41,6 +41,7 @@ final class AppState {
     typealias MissionArchiveRecorder = @MainActor (String) async -> Void
     typealias CloseTabConfirmer = @MainActor (CloseTabConfirmationPolicy.Prompt) -> Bool
     typealias ACPDetachRunner = @MainActor (ACPSessionManager, ACPSession.ID) async -> Void
+    typealias RemoteAccelerationPreparer = @MainActor (ProjectConfig) async -> Void
     static let piMCPGeneratedConfigExcludePath = ".pi/mcp.json"
 
     /// Stable for this process; identifies this app instance to the ACP
@@ -95,6 +96,8 @@ final class AppState {
     private let closeTabConfirmer: CloseTabConfirmer?
     @ObservationIgnored
     private let acpDetachRunner: ACPDetachRunner?
+    @ObservationIgnored
+    private let remoteAccelerationPreparer: RemoteAccelerationPreparer?
 
     private struct PendingACPDetach {
         let id: UUID
@@ -587,6 +590,7 @@ final class AppState {
         closeTabConfirmer: CloseTabConfirmer? = nil,
         terminalSessionOpener: TerminalSessionOpener? = nil,
         acpDetachRunner: ACPDetachRunner? = nil,
+        remoteAccelerationPreparer: RemoteAccelerationPreparer? = nil,
         projectGitWatcherFactory: @escaping @MainActor (URL) -> ProjectGitWatcher = { ProjectGitWatcher(repoPath: $0) },
         missionStartupReviewSnapshot: MissionStartupReviewSnapshot? = nil,
         missionBranchTipOverride: MissionBranchTip? = nil,
@@ -605,6 +609,7 @@ final class AppState {
         self.terminalSessionOpener = terminalSessionOpener
         self.closeTabConfirmer = closeTabConfirmer
         self.acpDetachRunner = acpDetachRunner
+        self.remoteAccelerationPreparer = remoteAccelerationPreparer
         self.projectGitWatcherFactory = projectGitWatcherFactory
         self.missionStartupReviewSnapshot = missionStartupReviewSnapshot
         self.missionBranchTipOverride = missionBranchTipOverride
@@ -3957,6 +3962,10 @@ final class AppState {
     }
 
     private func prepareRemoteAccelerationIfNeeded(for project: ProjectConfig) async {
+        if let remoteAccelerationPreparer {
+            await remoteAccelerationPreparer(project)
+            return
+        }
         guard let host = project.host else { return }
         if let running = remoteAccelerationTasks[host] {
             await running.value
@@ -5059,8 +5068,8 @@ final class AppState {
             return
         }
 
-        guard let worktree = worktree(withId: worktreeID),
-              let project = projects.first(where: { $0.id == worktree.projectId }) else {
+        guard let initialWorktree = worktree(withId: worktreeID),
+              let initialProject = projects.first(where: { $0.id == initialWorktree.projectId }) else {
             showFileActionError(
                 title: "Reopen Tab Failed",
                 message: "Could not find the terminal tab's worktree or project."
@@ -5068,7 +5077,14 @@ final class AppState {
             return
         }
 
-        await prepareRemoteAccelerationIfNeeded(for: project)
+        await prepareRemoteAccelerationIfNeeded(for: initialProject)
+
+        guard closedTabHistory.last?.id == entry.id else { return }
+        guard let worktree = worktree(withId: worktreeID),
+              let project = projects.first(where: { $0.id == worktree.projectId }) else {
+            closedTabHistory.remove(id: entry.id)
+            return
+        }
 
         var openedIDs: [String] = []
         do {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -40,6 +40,7 @@ private struct MissingMissionRecoveryTarget: Equatable {
 final class AppState {
     typealias MissionArchiveRecorder = @MainActor (String) async -> Void
     typealias CloseTabConfirmer = @MainActor (CloseTabConfirmationPolicy.Prompt) -> Bool
+    typealias ACPDetachRunner = @MainActor (ACPSessionManager, ACPSession.ID) async -> Void
     static let piMCPGeneratedConfigExcludePath = ".pi/mcp.json"
 
     /// Stable for this process; identifies this app instance to the ACP
@@ -92,6 +93,16 @@ final class AppState {
     private let terminalSessionOpener: TerminalSessionOpener?
     @ObservationIgnored
     private let closeTabConfirmer: CloseTabConfirmer?
+    @ObservationIgnored
+    private let acpDetachRunner: ACPDetachRunner?
+
+    private struct PendingACPDetach {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    @ObservationIgnored
+    private var pendingACPDetachTasks: [String: [ACPSession.ID: PendingACPDetach]] = [:]
     @ObservationIgnored
     private var acpAuthTerminalExitHandlers: [String: () -> Void] = [:]
     @ObservationIgnored
@@ -570,6 +581,7 @@ final class AppState {
         fileActionErrorHandler: ((String, String) -> Void)? = nil,
         closeTabConfirmer: CloseTabConfirmer? = nil,
         terminalSessionOpener: TerminalSessionOpener? = nil,
+        acpDetachRunner: ACPDetachRunner? = nil,
         projectGitWatcherFactory: @escaping @MainActor (URL) -> ProjectGitWatcher = { ProjectGitWatcher(repoPath: $0) },
         missionStartupReviewSnapshot: MissionStartupReviewSnapshot? = nil,
         missionBranchTipOverride: MissionBranchTip? = nil,
@@ -587,6 +599,7 @@ final class AppState {
         }
         self.terminalSessionOpener = terminalSessionOpener
         self.closeTabConfirmer = closeTabConfirmer
+        self.acpDetachRunner = acpDetachRunner
         self.projectGitWatcherFactory = projectGitWatcherFactory
         self.missionStartupReviewSnapshot = missionStartupReviewSnapshot
         self.missionBranchTipOverride = missionBranchTipOverride
@@ -4914,8 +4927,24 @@ final class AppState {
         if let runner = manager.runners[sessionId] {
             runner.stop()
         }
-        Task { @MainActor in
-            await manager.detach(sessionId: sessionId)
+        let pending = PendingACPDetach(id: UUID(), task: Task { @MainActor in
+            if let acpDetachRunner {
+                await acpDetachRunner(manager, sessionId)
+            } else {
+                await manager.detach(sessionId: sessionId)
+            }
+        })
+        pendingACPDetachTasks[worktreeId, default: [:]][sessionId] = pending
+    }
+
+    private func awaitPendingACPDetach(worktreeId: String, sessionId: ACPSession.ID) async {
+        guard let pending = pendingACPDetachTasks[worktreeId]?[sessionId] else { return }
+        await pending.task.value
+        if pendingACPDetachTasks[worktreeId]?[sessionId]?.id == pending.id {
+            pendingACPDetachTasks[worktreeId]?.removeValue(forKey: sessionId)
+            if pendingACPDetachTasks[worktreeId]?.isEmpty == true {
+                pendingACPDetachTasks.removeValue(forKey: worktreeId)
+            }
         }
     }
 
@@ -4987,6 +5016,9 @@ final class AppState {
                 if case .terminal = tab {
                     await reopenTerminalTab(entry: entry, worktreeID: worktreeID, tab: tab)
                     return
+                }
+                if case .acpSession(let state) = tab {
+                    await awaitPendingACPDetach(worktreeId: worktreeID, sessionId: state.sessionId)
                 }
                 selectWorktree(id: worktreeID)
                 _ = tabs.restore(tab: tab, worktreeID: worktreeID, placement: entry.placement)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5032,6 +5032,11 @@ final class AppState {
                 }
                 if case .acpSession(let state) = tab {
                     await awaitPendingACPDetach(worktreeId: worktreeID, sessionId: state.sessionId)
+                    guard closedTabHistory.last?.id == entry.id else { continue }
+                    guard worktree(withId: worktreeID) != nil else {
+                        closedTabHistory.remove(id: entry.id)
+                        continue
+                    }
                 }
                 selectWorktree(id: worktreeID)
                 _ = tabs.restore(tab: tab, worktreeID: worktreeID, placement: entry.placement)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -39,6 +39,8 @@ private struct MissingMissionRecoveryTarget: Equatable {
 @MainActor
 final class AppState {
     typealias MissionArchiveRecorder = @MainActor (String) async -> Void
+    typealias CloseTabConfirmer = @MainActor (CloseTabConfirmationPolicy.Prompt) -> Bool
+    typealias TerminalTabReopenPlaceholder = @MainActor (ClosedTabEntry, String, Tab) async -> Void
     static let piMCPGeneratedConfigExcludePath = ".pi/mcp.json"
 
     /// Stable for this process; identifies this app instance to the ACP
@@ -49,6 +51,9 @@ final class AppState {
     var themeStore: ThemeStore
     var projectsManager: ProjectsManager
     let globalTabs: GlobalTabsManager
+    private(set) var closedTabHistory = ClosedTabHistory()
+    private(set) var isReopeningClosedTab = false
+    var canReopenClosedTab: Bool { !isReopeningClosedTab && !closedTabHistory.isEmpty }
     private var unpersistedGGWorktreeModes: [String: [String: GGWorktreeMode]] = [:]
     var spacesManager: SpacesManager
     var selectedWorktreeId: String?
@@ -86,6 +91,8 @@ final class AppState {
 
     @ObservationIgnored
     private let terminalSessionOpener: TerminalSessionOpener?
+    @ObservationIgnored
+    private let closeTabConfirmer: CloseTabConfirmer?
     @ObservationIgnored
     private var acpAuthTerminalExitHandlers: [String: () -> Void] = [:]
     @ObservationIgnored
@@ -545,6 +552,8 @@ final class AppState {
     @ObservationIgnored
     private let fileActionErrorHandler: (String, String) -> Void
     @ObservationIgnored
+    private let terminalTabReopenPlaceholder: TerminalTabReopenPlaceholder?
+    @ObservationIgnored
     private var scheduledSpacesSave: Task<Void, Never>?
 
     /// One FSEvents watcher per project, watching `<repo>/.git` to auto-refresh
@@ -561,6 +570,8 @@ final class AppState {
         missionPersistence: MissionPersistence = MissionPersistence(),
         persistenceErrorHandler: ((String, String) -> Void)? = nil,
         fileActionErrorHandler: ((String, String) -> Void)? = nil,
+        closeTabConfirmer: CloseTabConfirmer? = nil,
+        terminalTabReopenPlaceholder: TerminalTabReopenPlaceholder? = nil,
         terminalSessionOpener: TerminalSessionOpener? = nil,
         projectGitWatcherFactory: @escaping @MainActor (URL) -> ProjectGitWatcher = { ProjectGitWatcher(repoPath: $0) },
         missionStartupReviewSnapshot: MissionStartupReviewSnapshot? = nil,
@@ -578,6 +589,8 @@ final class AppState {
             AppState.showWarningAlert(title: title, message: message)
         }
         self.terminalSessionOpener = terminalSessionOpener
+        self.closeTabConfirmer = closeTabConfirmer
+        self.terminalTabReopenPlaceholder = terminalTabReopenPlaceholder
         self.projectGitWatcherFactory = projectGitWatcherFactory
         self.missionStartupReviewSnapshot = missionStartupReviewSnapshot
         self.missionBranchTipOverride = missionBranchTipOverride
@@ -4231,7 +4244,7 @@ final class AppState {
 
     func handleCloseCenterShortcut(worktreeId: String?) {
         if let activeGlobalTabID = globalTabs.activeTabId {
-            closeGlobalTab(tabId: activeGlobalTabID)
+            requestCloseGlobalTab(tabID: activeGlobalTabID)
             return
         }
         guard let worktreeId else { return }
@@ -4248,6 +4261,15 @@ final class AppState {
             missingMissionTab = nil
             missingMissionRecoveryTarget = nil
         }
+    }
+
+    func requestCloseGlobalTab(tabID: TabID) {
+        guard let tab = globalTabs.tabs.first(where: { $0.id == tabID }) else { return }
+        closedTabHistory.record(ClosedTabEntry(
+            snapshot: .global(tab),
+            placement: .init(tabID: tabID, orderedIDs: globalTabs.tabs.map(\.id))
+        ))
+        closeGlobalTab(tabId: tabID)
     }
 
     @discardableResult
@@ -4790,10 +4812,17 @@ final class AppState {
            !confirmCloseTab(prompt) {
             return
         }
+        closedTabHistory.record(ClosedTabEntry(
+            snapshot: .worktree(worktreeID: worktreeId, tab: tab),
+            placement: .init(tabID: tabId, orderedIDs: tabs.tabs(forWorktree: worktreeId).map(\.id))
+        ))
         closeTab(worktreeId: worktreeId, tabId: tabId)
     }
 
     private func confirmCloseTab(_ prompt: CloseTabConfirmationPolicy.Prompt) -> Bool {
+        if let closeTabConfirmer {
+            return closeTabConfirmer(prompt)
+        }
         let alert = NSAlert()
         alert.messageText = prompt.title
         alert.informativeText = prompt.message
@@ -4869,6 +4898,7 @@ final class AppState {
     func closeCenterTabs(worktreeId: String, tabIds: [TabID]) {
         let ids = Set(tabIds)
         guard !ids.isEmpty else { return }
+        closedTabHistory.record(contentsOf: closedTabEntries(worktreeID: worktreeId, tabIDs: tabIds))
         for id in stateGlobalTabIDs().intersection(ids) {
             closeGlobalTab(tabId: id)
         }
@@ -4887,10 +4917,72 @@ final class AppState {
         Set(globalTabs.tabs.map(\.id))
     }
 
+    private func closedTabEntries(worktreeID: String, tabIDs: [TabID]) -> [ClosedTabEntry] {
+        let global = globalTabs.tabs
+        let local = tabs.tabs(forWorktree: worktreeID)
+        return tabIDs.compactMap { tabID in
+            if let tab = global.first(where: { $0.id == tabID }) {
+                return ClosedTabEntry(
+                    snapshot: .global(tab),
+                    placement: .init(tabID: tabID, orderedIDs: global.map(\.id))
+                )
+            }
+            guard let tab = local.first(where: { $0.id == tabID }) else { return nil }
+            return ClosedTabEntry(
+                snapshot: .worktree(worktreeID: worktreeID, tab: tab),
+                placement: .init(tabID: tabID, orderedIDs: local.map(\.id))
+            )
+        }
+    }
+
+    func reopenLastClosedTab() async {
+        guard !isReopeningClosedTab else { return }
+        isReopeningClosedTab = true
+        defer { isReopeningClosedTab = false }
+
+        while let entry = closedTabHistory.last {
+            switch entry.snapshot {
+            case .global(let tab):
+                _ = globalTabs.restore(tab: tab, placement: entry.placement)
+                closedTabHistory.remove(id: entry.id)
+                return
+
+            case .worktree(let worktreeID, let tab):
+                guard worktree(withId: worktreeID) != nil else {
+                    closedTabHistory.remove(id: entry.id)
+                    continue
+                }
+                if case .terminal = tab {
+                    await reopenTerminalTab(entry: entry, worktreeID: worktreeID, tab: tab)
+                    return
+                }
+                selectWorktree(id: worktreeID)
+                _ = tabs.restore(tab: tab, worktreeID: worktreeID, placement: entry.placement)
+                activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
+                closedTabHistory.remove(id: entry.id)
+                return
+            }
+        }
+    }
+
+    /// Terminal reconstruction belongs to the terminal-specific reopen task.
+    /// Keep the history entry so a later retry can reconstruct it transactionally.
+    private func reopenTerminalTab(entry: ClosedTabEntry, worktreeID: String, tab: Tab) async {
+        if let terminalTabReopenPlaceholder {
+            await terminalTabReopenPlaceholder(entry, worktreeID, tab)
+            return
+        }
+        fileActionErrorHandler(
+            "Reopen Tab Failed",
+            "Terminal tabs cannot be reopened until their terminal session is reconstructed."
+        )
+    }
+
     /// Tear down every tab/terminal/harness reference for a worktree id without
     /// touching git or persistence. Shared between Close-All, archive, and
     /// delete so the bookkeeping stays in one place.
     private func cleanupWorktreeState(worktreeId: String) {
+        closedTabHistory.purge(worktreeID: worktreeId)
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeAll(worktreeId: worktreeId)
         cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4998,8 +4998,18 @@ final class AppState {
     }
 
     private func reopenTerminalTab(entry: ClosedTabEntry, worktreeID: String, tab: Tab) async {
-        guard case .terminal(let oldState) = tab,
-              let worktree = worktree(withId: worktreeID),
+        guard case .terminal(let oldState) = tab else {
+            return
+        }
+
+        if tabs.tabs(forWorktree: worktreeID).contains(where: { $0.id == tab.id }) {
+            selectWorktree(id: worktreeID)
+            activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
+            closedTabHistory.remove(id: entry.id)
+            return
+        }
+
+        guard let worktree = worktree(withId: worktreeID),
               let project = projects.first(where: { $0.id == worktree.projectId }) else {
             showFileActionError(
                 title: "Reopen Tab Failed",

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -241,7 +241,7 @@ struct RootView: View {
                         tabs: state.globalTabs.tabs,
                         activeId: tabState.id,
                         onActivate: { state.globalTabs.activate(tabId: $0) },
-                        onClose: { state.closeGlobalTab(tabId: $0) },
+                        onClose: { state.requestCloseGlobalTab(tabID: $0) },
                         onRevealSidebar: {
                             state.config.sidebarVisible = true
                             state.saveConfig()

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -827,7 +827,13 @@ private struct RootBaseHandlers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .alasCloseTab)) { _ in
                 state.handleCloseCenterShortcut(worktreeId: selectedWorktree()?.id)
             }
-        let g = f
+        let fReopenClosedTab = f
+            .onReceive(NotificationCenter.default.publisher(for: .alasReopenClosedTab)) { _ in
+                Task { @MainActor in
+                    await state.reopenLastClosedTab()
+                }
+            }
+        let g = fReopenClosedTab
             .onReceive(NotificationCenter.default.publisher(for: .alasActivateTabByNumber)) { notification in
                 guard let number = notification.object as? Int else { return }
                 state.activateCenterTabNumber(number, worktreeId: selectedWorktree()?.id)
@@ -991,6 +997,7 @@ extension Notification.Name {
     static let alasNewTerminalTab  = Notification.Name("AlasNewTerminalTab")
     static let alasOpenAgentLauncher = Notification.Name("AlasOpenAgentLauncher")
     static let alasCloseTab        = Notification.Name("AlasCloseTab")
+    static let alasReopenClosedTab = Notification.Name("AlasReopenClosedTab")
     static let alasActivateTabByNumber = Notification.Name("AlasActivateTabByNumber")
     static let alasOpenSettings    = Notification.Name("AlasOpenSettings")
     static let alasOpenSearch      = Notification.Name("AlasOpenSearch")

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -91,7 +91,7 @@ struct CenterPaneView: View {
                 },
                 onClose: { id in
                     if state.globalTabs.tabs.contains(where: { $0.id == id }) {
-                        state.closeGlobalTab(tabId: id)
+                        state.requestCloseGlobalTab(tabID: id)
                     } else {
                         state.requestCloseTab(worktreeId: worktree.id, tabId: id)
                     }

--- a/Alas/Sources/Center/ClosedTabHistory.swift
+++ b/Alas/Sources/Center/ClosedTabHistory.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+enum ClosedTabSnapshot: Equatable {
+    case worktree(worktreeID: String, tab: Tab)
+    case global(GlobalTab)
+
+    var tabID: TabID {
+        switch self {
+        case .worktree(_, let tab): tab.id
+        case .global(let tab): tab.id
+        }
+    }
+
+    var worktreeID: String? {
+        guard case .worktree(let worktreeID, _) = self else { return nil }
+        return worktreeID
+    }
+}
+
+struct ClosedTabPlacement: Equatable {
+    let previousID: TabID?
+    let nextID: TabID?
+    let ordinal: Int
+
+    init(tabID: TabID, orderedIDs: [TabID]) {
+        guard let index = orderedIDs.firstIndex(of: tabID) else {
+            previousID = nil
+            nextID = nil
+            ordinal = orderedIDs.count
+            return
+        }
+        previousID = index > orderedIDs.startIndex ? orderedIDs[index - 1] : nil
+        nextID = orderedIDs.indices.contains(index + 1) ? orderedIDs[index + 1] : nil
+        ordinal = index
+    }
+
+    init(previousID: TabID?, nextID: TabID?, ordinal: Int) {
+        self.previousID = previousID
+        self.nextID = nextID
+        self.ordinal = ordinal
+    }
+
+    func insertionIndex(in currentIDs: [TabID]) -> Int {
+        if let nextID, let index = currentIDs.firstIndex(of: nextID) { return index }
+        if let previousID, let index = currentIDs.firstIndex(of: previousID) { return index + 1 }
+        return min(max(ordinal, 0), currentIDs.count)
+    }
+}
+
+struct ClosedTabEntry: Identifiable, Equatable {
+    let id: UUID
+    let snapshot: ClosedTabSnapshot
+    let placement: ClosedTabPlacement
+
+    init(id: UUID = UUID(), snapshot: ClosedTabSnapshot, placement: ClosedTabPlacement) {
+        self.id = id
+        self.snapshot = snapshot
+        self.placement = placement
+    }
+}
+
+struct ClosedTabHistory: Equatable {
+    static let capacity = 50
+
+    private(set) var entries: [ClosedTabEntry] = []
+
+    var last: ClosedTabEntry? { entries.last }
+    var count: Int { entries.count }
+    var isEmpty: Bool { entries.isEmpty }
+
+    mutating func record(_ entry: ClosedTabEntry) {
+        entries.append(entry)
+        if entries.count > Self.capacity {
+            entries.removeFirst(entries.count - Self.capacity)
+        }
+    }
+
+    mutating func record(contentsOf newEntries: [ClosedTabEntry]) {
+        for entry in newEntries { record(entry) }
+    }
+
+    mutating func remove(id: ClosedTabEntry.ID) {
+        entries.removeAll { $0.id == id }
+    }
+
+    mutating func purge(worktreeID: String) {
+        entries.removeAll { $0.snapshot.worktreeID == worktreeID }
+    }
+}
+
+extension PaneNode {
+    func replacingLeaves(using replacements: [String: PaneLeaf]) -> PaneNode {
+        switch self {
+        case .leaf(let leaf):
+            return replacements[leaf.id].map(PaneNode.leaf) ?? self
+        case .split(var split):
+            split.children = split.children.map { $0.replacingLeaves(using: replacements) }
+            return .split(split)
+        }
+    }
+}

--- a/Alas/Sources/Center/GlobalTabsManager.swift
+++ b/Alas/Sources/Center/GlobalTabsManager.swift
@@ -95,6 +95,19 @@ final class GlobalTabsManager {
         try? persist()
     }
 
+    @discardableResult
+    func restore(tab: GlobalTab, placement: ClosedTabPlacement) -> TabID {
+        if tabs.contains(where: { $0.id == tab.id }) {
+            activeTabId = tab.id
+        } else {
+            let index = placement.insertionIndex(in: tabs.map(\.id))
+            tabs.insert(tab, at: index)
+            activeTabId = tab.id
+        }
+        try? persist()
+        return tab.id
+    }
+
     func clearActiveTab() {
         guard activeTabId != nil else { return }
         activeTabId = nil

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1366,6 +1366,21 @@ final class TabsManager {
         persist(worktreeId)
     }
 
+    @discardableResult
+    func restore(tab: Tab, worktreeID: String, placement: ClosedTabPlacement) -> TabID {
+        var file = byWorktree[worktreeID] ?? TabsFile(tabs: [], activeTabId: nil)
+        if file.tabs.contains(where: { $0.id == tab.id }) {
+            file.activeTabId = tab.id
+        } else {
+            let index = placement.insertionIndex(in: file.tabs.map(\.id))
+            file.tabs.insert(tab, at: index)
+            file.activeTabId = tab.id
+        }
+        byWorktree[worktreeID] = file
+        persist(worktreeID)
+        return tab.id
+    }
+
     /// Capture a draft commit tab's state into `file.stashedDraft` before
     /// removal. Non-empty drafts stash so they survive close/reopen. Empty
     /// drafts CLEAR the stash so a user who opens an old stashed draft,

--- a/Alas/Sources/Harness/HarnessDetector.swift
+++ b/Alas/Sources/Harness/HarnessDetector.swift
@@ -19,6 +19,10 @@ final class HarnessDetector {
         queue.async { self.providers.removeValue(forKey: sessionId) }
     }
 
+    func isRegistered(sessionId: String) -> Bool {
+        queue.sync { providers[sessionId] != nil }
+    }
+
     func start() {
         let t = DispatchSource.makeTimerSource(queue: queue)
         t.schedule(deadline: .now() + 0.5, repeating: 1.0)

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -791,6 +791,7 @@ extension AppConfig {
         shortcutOverrides =
             (try? c.decode([String: ShortcutBinding?].self, forKey: .shortcutOverrides)) ?? [:]
         migrateLegacyFindAndReplaceShortcutOverride()
+        removeShortcutOverridesCollidingWithReservedBindings()
     }
 }
 
@@ -806,6 +807,14 @@ private extension AppConfig {
         }
         shortcutOverrides.updateValue(legacyOverride, forKey: replaceKey)
         shortcutOverrides.removeValue(forKey: legacyKey)
+    }
+
+    mutating func removeShortcutOverridesCollidingWithReservedBindings() {
+        let reserved = Set(ShortcutAction.reservedBindings)
+        for (key, override) in shortcutOverrides {
+            guard let binding = override, reserved.contains(binding) else { continue }
+            shortcutOverrides.removeValue(forKey: key)
+        }
     }
 }
 

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -145,6 +145,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     static let reservedBindings: [ShortcutBinding] = [
         .init(key: "q", modifiers: [.command]),
         .init(key: "w", modifiers: [.command]),
+        .init(key: "t", modifiers: [.command, .shift]),
         .init(key: "s", modifiers: [.command]),
         .init(key: "s", modifiers: [.command, .shift]),
         .init(key: "s", modifiers: [.command, .option]),

--- a/AlasTests/AppConfigShortcutsCodingTests.swift
+++ b/AlasTests/AppConfigShortcutsCodingTests.swift
@@ -94,4 +94,22 @@ struct AppConfigShortcutsCodingTests {
         #expect(decoded.shortcutOverrides[ShortcutAction.replaceInEditor.rawValue] == .some(nil))
         #expect(decoded.shortcutOverrides[ShortcutAction.findAndReplace.rawValue] == nil)
     }
+
+    @Test func dropsOverridesThatCollideWithReservedBindingsOnDecode() throws {
+        var cfg = AppConfig.defaults
+        let preserved = ShortcutBinding(key: "j", modifiers: [.command, .option])
+        cfg.shortcutOverrides = [
+            ShortcutAction.searchFiles.rawValue: ShortcutBinding(key: "t", modifiers: [.command, .shift]),
+            ShortcutAction.switchRepository.rawValue: nil,
+            ShortcutAction.toggleRightPane.rawValue: preserved,
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.searchFiles.rawValue] == nil)
+        #expect(decoded.shortcutOverrides.keys.contains(ShortcutAction.switchRepository.rawValue))
+        #expect(decoded.shortcutOverrides[ShortcutAction.switchRepository.rawValue] == .some(nil))
+        #expect(decoded.shortcutOverrides[ShortcutAction.toggleRightPane.rawValue] == .some(preserved))
+    }
 }

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct ClosedTabAppStateTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    private struct Fixture {
+        let state: AppState
+        let first: Worktree
+        let second: Worktree
+    }
+
+    private func makeFixture(state: AppState = AppState(store: MemoryStore())) -> Fixture {
+        let project = ProjectConfig(
+            id: "closed-tabs-project",
+            name: "Closed Tabs",
+            path: "/tmp/closed-tabs-project",
+            color: "blue",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+        let first = Worktree(
+            id: "closed-tabs-first",
+            projectId: project.id,
+            name: "first",
+            branch: "first",
+            path: URL(fileURLWithPath: "/tmp/closed-tabs-first"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let second = Worktree(
+            id: "closed-tabs-second",
+            projectId: project.id,
+            name: "second",
+            branch: "second",
+            path: URL(fileURLWithPath: "/tmp/closed-tabs-second"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        state.projectsManager.insertOptimisticWorktree(first)
+        state.projectsManager.insertOptimisticWorktree(second)
+        return Fixture(state: state, first: first, second: second)
+    }
+
+    @Test func explicitCloseRecordsAndReopenSwitchesWorktree() async {
+        let fixture = makeFixture()
+        let tab = fixture.state.tabs.appendEditor(
+            worktreeId: fixture.second.id,
+            title: "README.md",
+            relativePath: "README.md"
+        )
+        fixture.state.selectWorktree(id: fixture.first.id)
+
+        fixture.state.requestCloseTab(worktreeId: fixture.second.id, tabId: tab.id)
+        #expect(fixture.state.canReopenClosedTab)
+
+        await fixture.state.reopenLastClosedTab()
+
+        #expect(fixture.state.selectedWorktreeId == fixture.second.id)
+        #expect(fixture.state.tabs.activeTabId(forWorktree: fixture.second.id) == tab.id)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
+    @Test func automaticCloseDoesNotRecordHistory() {
+        let fixture = makeFixture()
+        let tab = fixture.state.tabs.appendEditor(
+            worktreeId: fixture.first.id,
+            title: "README.md",
+            relativePath: "README.md"
+        )
+
+        fixture.state.closeTab(worktreeId: fixture.first.id, tabId: tab.id)
+
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
+    @Test func explicitGlobalCloseRecordsAndReopensMission() async {
+        let fixture = makeFixture()
+        let tab = fixture.state.globalTabs.openOrFocusMission(missionID: MissionID(rawValue: "closed-tabs-mission"), title: "Mission")
+
+        fixture.state.requestCloseGlobalTab(tabID: tab.id)
+        #expect(fixture.state.canReopenClosedTab)
+
+        await fixture.state.reopenLastClosedTab()
+
+        #expect(fixture.state.globalTabs.activeTabId == tab.id)
+        #expect(fixture.state.globalTabs.tabs.count == 1)
+    }
+
+    @Test func reopenFocusesManuallyRestoredGlobalTabWithoutDuplication() async {
+        let fixture = makeFixture()
+        let tab = fixture.state.globalTabs.openOrFocusMission(missionID: MissionID(rawValue: "closed-tabs-mission"), title: "Mission")
+        fixture.state.requestCloseGlobalTab(tabID: tab.id)
+        _ = fixture.state.globalTabs.restore(
+            tab: tab,
+            placement: .init(previousID: nil, nextID: nil, ordinal: 0)
+        )
+
+        await fixture.state.reopenLastClosedTab()
+
+        #expect(fixture.state.globalTabs.tabs.map(\.id) == [tab.id])
+        #expect(fixture.state.globalTabs.activeTabId == tab.id)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
+    @Test func canceledTerminalCloseDoesNotRecordHistory() {
+        let project = ProjectConfig(
+            id: "closed-tabs-confirmation-project",
+            name: "Closed Tabs",
+            path: "/tmp/closed-tabs-confirmation-project",
+            color: "blue",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+        let worktree = Worktree(
+            id: "closed-tabs-confirmation-worktree",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/closed-tabs-confirmation-worktree"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let state = AppState(store: MemoryStore(), closeTabConfirmer: { _ in false })
+        state.config.terminal.confirmCloseTabs = true
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        let tab = state.tabs.appendTerminal(worktreeId: worktree.id, title: "Terminal", sessionId: "session")
+
+        state.requestCloseTab(worktreeId: worktree.id, tabId: tab.id)
+
+        #expect(!state.canReopenClosedTab)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains(where: { $0.id == tab.id }))
+    }
+
+    @Test func closeCenterTabsRecordsGlobalAndLocalTabsInVisibleOrder() {
+        let fixture = makeFixture()
+        let global = fixture.state.globalTabs.openOrFocusMission(missionID: MissionID(rawValue: "closed-tabs-mission"), title: "Mission")
+        let local = fixture.state.tabs.appendEditor(
+            worktreeId: fixture.first.id,
+            title: "README.md",
+            relativePath: "README.md"
+        )
+
+        fixture.state.closeCenterTabs(worktreeId: fixture.first.id, tabIds: [global.id, local.id])
+
+        #expect(fixture.state.closedTabHistory.entries.map(\.snapshot.tabID) == [global.id, local.id])
+    }
+
+    @Test func overlappingTerminalReopenDoesNotStartSecondAttempt() async {
+        var attempts = 0
+        var placeholderContinuation: CheckedContinuation<Void, Never>?
+        let state = AppState(
+            store: MemoryStore(),
+            terminalTabReopenPlaceholder: { _, _, _ in
+                attempts += 1
+                await withCheckedContinuation { continuation in
+                    placeholderContinuation = continuation
+                }
+            }
+        )
+        let fixture = makeFixture(state: state)
+        let tab = fixture.state.tabs.appendTerminal(worktreeId: fixture.first.id, title: "Terminal", sessionId: "session")
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+
+        let reopenTask = Task { await fixture.state.reopenLastClosedTab() }
+        while placeholderContinuation == nil {
+            await Task.yield()
+        }
+        #expect(fixture.state.isReopeningClosedTab)
+
+        await fixture.state.reopenLastClosedTab()
+        #expect(attempts == 1)
+
+        placeholderContinuation?.resume()
+        await reopenTask.value
+
+        #expect(attempts == 1)
+        #expect(fixture.state.canReopenClosedTab)
+        #expect(fixture.state.closedTabHistory.entries.map(\.snapshot.tabID) == [tab.id])
+    }
+
+    @Test func reopenDiscardsStaleWorktreeEntryAndRestoresNextEntry() async {
+        let fixture = makeFixture()
+        let valid = fixture.state.tabs.appendEditor(worktreeId: fixture.first.id, title: "valid", relativePath: "valid")
+        let stale = fixture.state.tabs.appendEditor(worktreeId: fixture.second.id, title: "stale", relativePath: "stale")
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: valid.id)
+        fixture.state.requestCloseTab(worktreeId: fixture.second.id, tabId: stale.id)
+        fixture.state.projectsManager.removeOptimisticWorktree(id: fixture.second.id, projectId: fixture.second.projectId)
+
+        await fixture.state.reopenLastClosedTab()
+
+        #expect(fixture.state.tabs.activeTabId(forWorktree: fixture.first.id) == valid.id)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
+    @Test func worktreeCleanupPurgesItsClosedTabEntries() {
+        let fixture = makeFixture()
+        let tab = fixture.state.tabs.appendEditor(worktreeId: fixture.first.id, title: "README.md", relativePath: "README.md")
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+
+        fixture.state.archiveWorktree(fixture.first)
+
+        #expect(!fixture.state.canReopenClosedTab)
+        #expect(fixture.state.closedTabHistory.entries.isEmpty)
+    }
+}

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -9,6 +9,36 @@ struct ClosedTabAppStateTests {
         case sessionOpenFailed
     }
 
+    private actor AsyncGate {
+        private var entered = false
+        private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+        func enterAndWait() async {
+            entered = true
+            let waiters = entryWaiters
+            entryWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+            await withCheckedContinuation { continuation in
+                releaseContinuation = continuation
+            }
+        }
+
+        func waitUntilEntered() async {
+            if entered { return }
+            await withCheckedContinuation { continuation in
+                entryWaiters.append(continuation)
+            }
+        }
+
+        func release() {
+            releaseContinuation?.resume()
+            releaseContinuation = nil
+        }
+    }
+
     private struct MemoryStore: PersistenceStoreProtocol {
         func write<T: Encodable>(_: T, to _: URL) throws {}
         func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
@@ -110,6 +140,43 @@ struct ClosedTabAppStateTests {
 
         #expect(fixture.state.globalTabs.tabs.map(\.id) == [tab.id])
         #expect(fixture.state.globalTabs.activeTabId == tab.id)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
+    @Test func reopenACPSessionWaitsForCloseDetachBeforeRestoring() async {
+        let gate = AsyncGate()
+        var detachCalls = 0
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, _ in
+                detachCalls += 1
+                await gate.enterAndWait()
+            }
+        )
+        let fixture = makeFixture(state: state)
+        _ = fixture.state.acpManager(for: fixture.first)
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: "closed-acp", title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        await gate.waitUntilEntered()
+
+        let reopenTask = Task { @MainActor in
+            await fixture.state.reopenLastClosedTab()
+        }
+        await Task.yield()
+
+        #expect(detachCalls == 1)
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).isEmpty)
+        #expect(!fixture.state.canReopenClosedTab)
+
+        await gate.release()
+        await reopenTask.value
+
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).map(\.id) == [tab.id])
+        #expect(fixture.state.tabs.activeTabId(forWorktree: fixture.first.id) == tab.id)
         #expect(!fixture.state.canReopenClosedTab)
     }
 

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -180,6 +180,35 @@ struct ClosedTabAppStateTests {
         #expect(!fixture.state.canReopenClosedTab)
     }
 
+    @Test func completedACPDetachIsDroppedEvenWithoutReopen() async {
+        let gate = AsyncGate()
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, _ in
+                await gate.enterAndWait()
+            }
+        )
+        let fixture = makeFixture(state: state)
+        _ = fixture.state.acpManager(for: fixture.first)
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: "drop-detach", title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        await gate.waitUntilEntered()
+
+        #expect(fixture.state.pendingACPDetachCountForTesting == 1)
+
+        await gate.release()
+        for _ in 0 ..< 20 where fixture.state.pendingACPDetachCountForTesting != 0 {
+            await Task.yield()
+        }
+
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+        #expect(fixture.state.canReopenClosedTab)
+    }
+
     @Test func canceledTerminalCloseDoesNotRecordHistory() {
         let project = ProjectConfig(
             id: "closed-tabs-confirmation-project",

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -217,6 +217,37 @@ struct ClosedTabAppStateTests {
         #expect(split.children.map { $0.firstLeaf().id } == ["fresh-1", "fresh-2"])
     }
 
+    @Test func reopeningManuallyRestoredTerminalDoesNotOpenDuplicateSessions() async {
+        var openAttempts = 0
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
+                openAttempts += 1
+                return .init(id: "unexpected-session", foregroundPid: { nil })
+            }
+        )
+        let fixture = makeFixture(state: state)
+        let tab = TerminalTabState(
+            id: "manually-restored-terminal",
+            title: "Terminal",
+            root: .leaf(PaneLeaf(id: "existing-session", sessionId: "existing-session")),
+            focusedLeafId: "existing-session"
+        )
+        let placement = ClosedTabPlacement(previousID: nil, nextID: nil, ordinal: 0)
+
+        _ = fixture.state.tabs.restore(tab: .terminal(tab), worktreeID: fixture.first.id, placement: placement)
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        _ = fixture.state.tabs.restore(tab: .terminal(tab), worktreeID: fixture.first.id, placement: placement)
+        fixture.state.activateWorktreeCenterTab(worktreeId: fixture.first.id, tabId: tab.id)
+
+        await fixture.state.reopenLastClosedTab()
+
+        #expect(openAttempts == 0)
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).map(\.id) == [tab.id])
+        #expect(fixture.state.tabs.activeTabId(forWorktree: fixture.first.id) == tab.id)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
     @Test func failedTerminalReopenRollsBackOpenedSessionsAndRetainsHistory() async {
         var openAttempts = 0
         var errorTitle: String?

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -5,6 +5,10 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct ClosedTabAppStateTests {
+    private enum ReopenTestError: Error {
+        case sessionOpenFailed
+    }
+
     private struct MemoryStore: PersistenceStoreProtocol {
         func write<T: Encodable>(_: T, to _: URL) throws {}
         func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
@@ -152,37 +156,108 @@ struct ClosedTabAppStateTests {
         #expect(fixture.state.closedTabHistory.entries.map(\.snapshot.tabID) == [global.id, local.id])
     }
 
-    @Test func overlappingTerminalReopenDoesNotStartSecondAttempt() async {
-        var attempts = 0
-        var placeholderContinuation: CheckedContinuation<Void, Never>?
+    @Test func reopeningTerminalRebuildsLayoutWithFreshSessions() async {
+        var openedCwds: [String?] = []
+        var openedIDs = ["fresh-1", "fresh-2"]
         let state = AppState(
             store: MemoryStore(),
-            terminalTabReopenPlaceholder: { _, _, _ in
-                attempts += 1
-                await withCheckedContinuation { continuation in
-                    placeholderContinuation = continuation
-                }
+            terminalSessionOpener: { _, _, _, _, forcedCwd, startupScriptSuffix, includeUserStartupScript, environmentOverrides, environmentRemovals in
+                openedCwds.append(forcedCwd?.path)
+                #expect(startupScriptSuffix == nil)
+                #expect(includeUserStartupScript)
+                #expect(environmentOverrides.isEmpty)
+                #expect(environmentRemovals.isEmpty)
+                return .init(id: openedIDs.removeFirst(), foregroundPid: { nil })
             }
         )
         let fixture = makeFixture(state: state)
-        let tab = fixture.state.tabs.appendTerminal(worktreeId: fixture.first.id, title: "Terminal", sessionId: "session")
-        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
-
-        let reopenTask = Task { await fixture.state.reopenLastClosedTab() }
-        while placeholderContinuation == nil {
-            await Task.yield()
-        }
-        #expect(fixture.state.isReopeningClosedTab)
+        let original = TerminalTabState(
+            id: "reopen-terminal",
+            title: "Terminal",
+            root: .split(PaneSplit(
+                id: "split-id",
+                axis: .vertical,
+                fraction: 0.37,
+                children: [
+                    .leaf(PaneLeaf(id: "old-1", sessionId: "old-1", lastCwd: "/tmp/first")),
+                    .leaf(PaneLeaf(id: "old-2", sessionId: "old-2", lastCwd: "/tmp/second"))
+                ]
+            )),
+            focusedLeafId: "old-2",
+            runScriptKey: "worktree:run.sh",
+            runScriptLeafId: "old-2"
+        )
+        _ = fixture.state.tabs.restore(
+            tab: .terminal(original),
+            worktreeID: fixture.first.id,
+            placement: .init(previousID: nil, nextID: nil, ordinal: 0)
+        )
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: original.id)
 
         await fixture.state.reopenLastClosedTab()
-        #expect(attempts == 1)
 
-        placeholderContinuation?.resume()
-        await reopenTask.value
+        #expect(openedCwds == ["/tmp/first", "/tmp/second"])
+        guard case .terminal(let reopened) = fixture.state.tabs.activeTab(forWorktree: fixture.first.id) else {
+            Issue.record("Expected reopened terminal")
+            return
+        }
+        #expect(reopened.id == original.id)
+        #expect(reopened.root.leaves().map(\.id) == ["fresh-1", "fresh-2"])
+        #expect(reopened.root.leaves().map(\.lastCwd) == ["/tmp/first", "/tmp/second"])
+        #expect(reopened.focusedLeafId == "fresh-2")
+        #expect(reopened.runScriptKey == nil)
+        #expect(reopened.runScriptLeafId == nil)
+        guard case .split(let split) = reopened.root else {
+            Issue.record("Expected split terminal layout")
+            return
+        }
+        #expect(split.id == "split-id")
+        #expect(split.axis == .vertical)
+        #expect(split.fraction == 0.37)
+        #expect(split.children.map { $0.firstLeaf().id } == ["fresh-1", "fresh-2"])
+    }
 
-        #expect(attempts == 1)
+    @Test func failedTerminalReopenRollsBackOpenedSessionsAndRetainsHistory() async {
+        var openAttempts = 0
+        var errorTitle: String?
+        let state = AppState(
+            store: MemoryStore(),
+            fileActionErrorHandler: { title, _ in errorTitle = title },
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
+                openAttempts += 1
+                if openAttempts == 2 { throw ReopenTestError.sessionOpenFailed }
+                return .init(id: "fresh-1", foregroundPid: { nil })
+            }
+        )
+        let fixture = makeFixture(state: state)
+        let original = TerminalTabState(
+            id: "reopen-terminal-failure",
+            title: "Terminal",
+            root: .split(PaneSplit(
+                id: "split-id",
+                axis: .vertical,
+                fraction: 0.5,
+                children: [
+                    .leaf(PaneLeaf(id: "old-1", sessionId: "old-1", lastCwd: "/tmp/first")),
+                    .leaf(PaneLeaf(id: "old-2", sessionId: "old-2", lastCwd: "/tmp/second"))
+                ]
+            )),
+            focusedLeafId: "old-1"
+        )
+        _ = fixture.state.tabs.restore(
+            tab: .terminal(original),
+            worktreeID: fixture.first.id,
+            placement: .init(previousID: nil, nextID: nil, ordinal: 0)
+        )
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: original.id)
+
+        await fixture.state.reopenLastClosedTab()
+
+        #expect(errorTitle == "Reopen Tab Failed")
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).isEmpty)
         #expect(fixture.state.canReopenClosedTab)
-        #expect(fixture.state.closedTabHistory.entries.map(\.snapshot.tabID) == [tab.id])
+        #expect(fixture.state.closedTabHistory.last?.snapshot.tabID == original.id)
+        #expect(!fixture.state.harness.detector.isRegistered(sessionId: "fresh-1"))
     }
 
     @Test func reopenDiscardsStaleWorktreeEntryAndRestoresNextEntry() async {

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -209,6 +209,39 @@ struct ClosedTabAppStateTests {
         #expect(fixture.state.canReopenClosedTab)
     }
 
+    @Test func reopeningACPSessionDoesNotRestoreAfterWorktreeCleanupDuringDetach() async {
+        let gate = AsyncGate()
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, _ in
+                await gate.enterAndWait()
+            }
+        )
+        let fixture = makeFixture(state: state)
+        _ = fixture.state.acpManager(for: fixture.first)
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: "removed-worktree-chat", title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        await gate.waitUntilEntered()
+
+        let reopenTask = Task { @MainActor in
+            await fixture.state.reopenLastClosedTab()
+        }
+        await Task.yield()
+
+        fixture.state.archiveWorktree(fixture.first)
+
+        await gate.release()
+        await reopenTask.value
+
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).isEmpty)
+        #expect(fixture.state.selectedWorktreeId != fixture.first.id)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
     @Test func canceledTerminalCloseDoesNotRecordHistory() {
         let project = ProjectConfig(
             id: "closed-tabs-confirmation-project",

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -420,6 +420,49 @@ struct ClosedTabAppStateTests {
         #expect(!fixture.state.harness.detector.isRegistered(sessionId: "fresh-1"))
     }
 
+    @Test func reopeningTerminalDoesNotRestoreAfterWorktreeCleanupDuringRemotePrep() async {
+        let gate = AsyncGate()
+        var openAttempts = 0
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
+                openAttempts += 1
+                return .init(id: "unexpected-session", foregroundPid: { nil })
+            },
+            remoteAccelerationPreparer: { _ in
+                await gate.enterAndWait()
+            }
+        )
+        let fixture = makeFixture(state: state)
+        let original = TerminalTabState(
+            id: "remote-prep-removed-worktree",
+            title: "Terminal",
+            root: .leaf(PaneLeaf(id: "old-terminal", sessionId: "old-terminal")),
+            focusedLeafId: "old-terminal"
+        )
+        _ = fixture.state.tabs.restore(
+            tab: .terminal(original),
+            worktreeID: fixture.first.id,
+            placement: .init(previousID: nil, nextID: nil, ordinal: 0)
+        )
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: original.id)
+
+        let reopenTask = Task { @MainActor in
+            await fixture.state.reopenLastClosedTab()
+        }
+        await gate.waitUntilEntered()
+
+        fixture.state.archiveWorktree(fixture.first)
+
+        await gate.release()
+        await reopenTask.value
+
+        #expect(openAttempts == 0)
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).isEmpty)
+        #expect(fixture.state.selectedWorktreeId != fixture.first.id)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
     @Test func reopenDiscardsStaleWorktreeEntryAndRestoresNextEntry() async {
         let fixture = makeFixture()
         let valid = fixture.state.tabs.appendEditor(worktreeId: fixture.first.id, title: "valid", relativePath: "valid")

--- a/AlasTests/ClosedTabHistoryTests.swift
+++ b/AlasTests/ClosedTabHistoryTests.swift
@@ -1,0 +1,116 @@
+import Testing
+@testable import Alas
+
+struct ClosedTabHistoryTests {
+    private func tab(_ id: String) -> Tab {
+        .terminal(.init(id: id, title: id, sessionId: "session-\(id)"))
+    }
+
+    private func entry(_ id: String, worktreeID: String = "wt") -> ClosedTabEntry {
+        ClosedTabEntry(
+            snapshot: .worktree(worktreeID: worktreeID, tab: tab(id)),
+            placement: .init(previousID: nil, nextID: nil, ordinal: 0)
+        )
+    }
+
+    @Test func popsNewestEntryFirst() {
+        var history = ClosedTabHistory()
+        history.record(entry("a"))
+        history.record(entry("b"))
+
+        #expect(history.last?.snapshot.tabID == "b")
+        history.remove(id: history.last!.id)
+        #expect(history.last?.snapshot.tabID == "a")
+    }
+
+    @Test func retainsOnlyFiftyNewestEntries() {
+        var history = ClosedTabHistory()
+        for index in 0..<51 { history.record(entry("tab-\(index)")) }
+
+        #expect(history.count == 50)
+        #expect(history.entries.first?.snapshot.tabID == "tab-1")
+        #expect(history.last?.snapshot.tabID == "tab-50")
+    }
+
+    @Test func removesBulkEntriesInReverseVisibleOrder() {
+        var history = ClosedTabHistory()
+        history.record(contentsOf: [entry("a"), entry("c"), entry("d")])
+
+        #expect(history.last?.snapshot.tabID == "d")
+        history.remove(id: history.last!.id)
+        #expect(history.last?.snapshot.tabID == "c")
+        history.remove(id: history.last!.id)
+        #expect(history.last?.snapshot.tabID == "a")
+    }
+
+    @Test func placementPrefersNextThenPreviousThenOrdinal() {
+        let beforeC = ClosedTabPlacement(previousID: "a", nextID: "c", ordinal: 1)
+        #expect(beforeC.insertionIndex(in: ["a", "c"]) == 1)
+        #expect(beforeC.insertionIndex(in: ["a", "d"]) == 1)
+        #expect(beforeC.insertionIndex(in: ["d"]) == 1)
+        #expect(beforeC.insertionIndex(in: []) == 0)
+    }
+
+    @Test func placementReconstructsOriginalOrderFromOneSurvivingTab() {
+        let placements = [
+            "a": ClosedTabPlacement(previousID: nil, nextID: "b", ordinal: 0),
+            "c": ClosedTabPlacement(previousID: "b", nextID: "d", ordinal: 2),
+            "d": ClosedTabPlacement(previousID: "c", nextID: nil, ordinal: 3),
+        ]
+        var current = ["b"]
+
+        for id in ["a", "c", "d"] {
+            current.insert(id, at: placements[id]!.insertionIndex(in: current))
+        }
+
+        #expect(current == ["a", "b", "c", "d"])
+    }
+
+    @Test func purgeRemovesOnlyMatchingWorktreeEntries() {
+        var history = ClosedTabHistory()
+        history.record(entry("a", worktreeID: "first"))
+        history.record(entry("b", worktreeID: "second"))
+        history.purge(worktreeID: "first")
+
+        #expect(history.entries.map(\.snapshot.tabID) == ["b"])
+    }
+
+    @Test func replacingLeavesPreservesSplitLayoutAndUnchangedLeaves() {
+        let original: PaneNode = .split(PaneSplit(
+            id: "root", axis: .vertical, fraction: 0.7,
+            children: [
+                .leaf(PaneLeaf(id: "old-a", sessionId: "old-a", lastCwd: "/original/a")),
+                .split(PaneSplit(
+                    id: "inner", axis: .horizontal, fraction: 0.25,
+                    children: [
+                        .leaf(PaneLeaf(id: "old-b", sessionId: "old-b", lastCwd: "/original/b")),
+                        .leaf(PaneLeaf(id: "unchanged", sessionId: "unchanged", lastCwd: "/original/c")),
+                    ]
+                )),
+            ]
+        ))
+        let replacements = [
+            "old-a": PaneLeaf(id: "new-a", sessionId: "new-a", lastCwd: "/restored/a"),
+            "old-b": PaneLeaf(id: "new-b", sessionId: "new-b", lastCwd: "/restored/b"),
+        ]
+
+        let restored = original.replacingLeaves(using: replacements)
+
+        guard case .split(let root) = restored,
+              case .leaf(let first) = root.children[0],
+              case .split(let inner) = root.children[1],
+              case .leaf(let second) = inner.children[0],
+              case .leaf(let third) = inner.children[1] else {
+            Issue.record("expected the original split layout")
+            return
+        }
+        #expect(root.id == "root")
+        #expect(root.axis == .vertical)
+        #expect(root.fraction == 0.7)
+        #expect(inner.id == "inner")
+        #expect(inner.axis == .horizontal)
+        #expect(inner.fraction == 0.25)
+        #expect([first.id, second.id, third.id] == ["new-a", "new-b", "unchanged"])
+        #expect([first.lastCwd, second.lastCwd, third.lastCwd] == ["/restored/a", "/restored/b", "/original/c"])
+    }
+}

--- a/AlasTests/GlobalTabsManagerTests.swift
+++ b/AlasTests/GlobalTabsManagerTests.swift
@@ -5,6 +5,55 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct GlobalTabsManagerTests {
+    @Test("restore inserts a Mission at its anchored position and activates it")
+    func restoreInsertsAtAnchoredPositionAndActivates() throws {
+        let harness = try GlobalTabsHarness()
+        let first = harness.global.openOrFocusMission(
+            missionID: MissionID(rawValue: "mission-1"), title: "First Mission"
+        )
+        let restored = GlobalTab.mission(.init(
+            missionID: MissionID(rawValue: "mission-2"), title: "Restored Mission"
+        ))
+        let third = harness.global.openOrFocusMission(
+            missionID: MissionID(rawValue: "mission-3"), title: "Third Mission"
+        )
+
+        let id = harness.global.restore(
+            tab: restored,
+            placement: .init(previousID: first.id, nextID: third.id, ordinal: 1)
+        )
+
+        #expect(id == restored.id)
+        #expect(harness.global.tabs.map(\.id) == [first.id, restored.id, third.id])
+        #expect(harness.global.activeTabId == restored.id)
+    }
+
+    @Test("restore focuses an existing stable Mission ID without duplication")
+    func restoreFocusesExistingStableIDWithoutDuplication() throws {
+        let harness = try GlobalTabsHarness()
+        let first = harness.global.openOrFocusMission(
+            missionID: MissionID(rawValue: "mission-1"), title: "First Mission"
+        )
+        let existing = harness.global.openOrFocusMission(
+            missionID: MissionID(rawValue: "mission-2"), title: "Existing Mission"
+        )
+        let originalIDs = harness.global.tabs.map(\.id)
+
+        let id = harness.global.restore(
+            tab: existing,
+            placement: .init(previousID: nil, nextID: first.id, ordinal: 0)
+        )
+
+        #expect(id == existing.id)
+        #expect(harness.global.tabs.map(\.id) == originalIDs)
+        #expect(harness.global.activeTabId == existing.id)
+
+        let reloaded = GlobalTabsManager(fileURL: harness.globalTabsFile)
+        try reloaded.loadAndMigrate(worktreeTabs: harness.tabs)
+        #expect(reloaded.tabs.map(\.id) == originalIDs)
+        #expect(reloaded.activeTabId == existing.id)
+    }
+
     @Test("global Mission tabs round trip with their stable Mission ID")
     func roundTripsGlobalMissionTabs() throws {
         let harness = try GlobalTabsHarness()

--- a/AlasTests/ShortcutRecorderValidationTests.swift
+++ b/AlasTests/ShortcutRecorderValidationTests.swift
@@ -32,6 +32,11 @@ struct ShortcutRecorderValidationTests {
         #expect(ShortcutRecorder.validate(b) == .reserved)
     }
 
+    @Test func rejectsReservedReopenClosedTabShortcut() {
+        let binding = ShortcutBinding(key: "t", modifiers: [.command, .shift])
+        #expect(ShortcutRecorder.validate(binding) == .reserved)
+    }
+
     @Test func acceptsCommandLetter() {
         let b = ShortcutBinding(key: "j", modifiers: [.command])
         #expect(ShortcutRecorder.validate(b) == .ok)

--- a/AlasTests/ShortcutReservationsTests.swift
+++ b/AlasTests/ShortcutReservationsTests.swift
@@ -21,8 +21,13 @@ struct ShortcutReservationsTests {
 
     @Test func defaultsIncludeStandardsAndTabSwitchers() {
         let reserved = ShortcutReservations.defaultReserved
-        // ⌘W (Close Tab) and ⌘1..⌘9 stay reserved regardless of rebinds.
+        // ⌘W (Close Tab), ⌘⇧T (Reopen Closed Tab), and ⌘1..⌘9 stay reserved
+        // regardless of rebinds.
+        let reopen = ShortcutBinding(key: "t", modifiers: [.command, .shift])
         #expect(reserved.contains(ShortcutBinding(key: "w", modifiers: [.command])))
+        #expect(ShortcutAction.reservedBindings.contains(reopen))
+        #expect(reserved.contains(reopen))
+        #expect(ShortcutReservations.snapshot(from: .defaults).contains(reopen))
         #expect(reserved.contains(ShortcutBinding(key: "1", modifiers: [.command])))
         #expect(reserved.contains(ShortcutBinding(key: "9", modifiers: [.command])))
     }

--- a/AlasTests/SurfaceViewShortcutTests.swift
+++ b/AlasTests/SurfaceViewShortcutTests.swift
@@ -30,7 +30,7 @@ struct SurfaceViewShortcutTests {
         #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
-    @Test func modifiedCommandTIsNotReserved() throws {
+    @Test func commandShiftTIsReservedForReopenClosedTab() throws {
         let event = try keyEvent(
             characters: "T",
             ignoringModifiers: "t",
@@ -38,7 +38,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 17
         )
 
-        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandDigitOneIsReservedForAppCommand() throws {

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -4,6 +4,48 @@ import Foundation
 
 @MainActor
 struct TabsManagerTests {
+    @Test func restoreInsertsAtAnchoredPositionAndActivates() {
+        let worktreeID = "tabs-manager-restore-position"
+        let manager = TabsManager(store: RestoreMemoryStore())
+        let first = manager.appendTerminal(worktreeId: worktreeID, title: "a", sessionId: "a")
+        let restored = Tab.terminal(.init(id: "b", title: "b", sessionId: "b"))
+        let third = manager.appendTerminal(worktreeId: worktreeID, title: "c", sessionId: "c")
+
+        let id = manager.restore(
+            tab: restored,
+            worktreeID: worktreeID,
+            placement: .init(previousID: first.id, nextID: third.id, ordinal: 1)
+        )
+
+        #expect(id == restored.id)
+        #expect(manager.tabs(forWorktree: worktreeID).map(\.id) == [first.id, restored.id, third.id])
+        #expect(manager.activeTabId(forWorktree: worktreeID) == restored.id)
+    }
+
+    @Test func restoreFocusesExistingStableIDWithoutChangingOrder() {
+        let worktreeID = "tabs-manager-restore-existing"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeID)) }
+        let manager = TabsManager()
+        let first = manager.appendTerminal(worktreeId: worktreeID, title: "a", sessionId: "a")
+        let existing = manager.appendTerminal(worktreeId: worktreeID, title: "b", sessionId: "b")
+        let originalIDs = manager.tabs(forWorktree: worktreeID).map(\.id)
+
+        let id = manager.restore(
+            tab: existing,
+            worktreeID: worktreeID,
+            placement: .init(previousID: nil, nextID: first.id, ordinal: 0)
+        )
+
+        #expect(id == existing.id)
+        #expect(manager.tabs(forWorktree: worktreeID).map(\.id) == originalIDs)
+        #expect(manager.activeTabId(forWorktree: worktreeID) == existing.id)
+
+        let reloaded = TabsManager()
+        reloaded.loadAll(worktreeIds: [worktreeID])
+        #expect(reloaded.tabs(forWorktree: worktreeID).map(\.id) == originalIDs)
+        #expect(reloaded.activeTabId(forWorktree: worktreeID) == existing.id)
+    }
+
     @Test func newTerminalAppendsAndActivates() {
         let worktreeId = "tabs-manager-new-terminal"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
@@ -850,6 +892,11 @@ struct TabsManagerTests {
         #expect(mgr.commitEditorTab(worktreeId: worktreeId, currentSha: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")?.id == target.id)
         #expect(mgr.commitEditorTab(worktreeId: worktreeId, currentSha: "ffffffffffffffffffffffffffffffffffffffff")?.id == descendant.id)
     }
+}
+
+private struct RestoreMemoryStore: PersistenceStoreProtocol {
+    func write<T: Encodable>(_: T, to _: URL) throws {}
+    func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
 }
 
 // MARK: - Pane tree mutations

--- a/docs/superpowers/plans/2026-08-04-reopen-closed-tabs.md
+++ b/docs/superpowers/plans/2026-08-04-reopen-closed-tabs.md
@@ -1,0 +1,825 @@
+# Reopen Closed Tabs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fixed `Command-Shift-T` action that reopens explicitly closed Alas tabs from a session-only app-wide history, including cross-worktree restoration and fresh reconstruction of closed terminal layouts.
+
+**Architecture:** `AppState` owns a bounded `ClosedTabHistory` containing complete local/global tab snapshots plus collection-local placement anchors. Tab managers provide narrow snapshot-insertion APIs, while `AppState` alone decides which closures are user initiated, switches worktrees, recreates terminal resources transactionally, and consumes history entries only after success.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Observation, AppKit command menus and notifications, Ghostty terminal integration, Swift Testing, XcodeGen, XcodeBuild.
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Keep the history process-local and capped at exactly 50 entries.
+- Use the fixed `Command-Shift-T` shortcut; do not add a configurable shortcut action.
+- Explicit close actions are reopenable; automatic lifecycle cleanup is not.
+- Reopened terminal panes use fresh identities and shells at their prior `lastCwd`; never revive a process or rerun a Run Script.
+- Do not change tab persistence formats or add dependencies.
+- Tests use Swift Testing (`import Testing`), not XCTest.
+- Run Xcode and test commands serially.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/Center/ClosedTabHistory.swift`: value types for local/global snapshots, placement anchors, the bounded LIFO history, and pure terminal-tree remapping.
+- Create `AlasTests/ClosedTabHistoryTests.swift`: pure ordering, capacity, placement, purge, and tree-remapping tests.
+- Modify `Alas/Sources/Center/TabsManager.swift`: insert or focus a saved worktree tab using a resolved placement.
+- Modify `Alas/Sources/Center/GlobalTabsManager.swift`: insert or focus a saved global tab using a resolved placement.
+- Modify `AlasTests/TabsManagerTests.swift`: local snapshot restoration tests.
+- Modify `AlasTests/GlobalTabsManagerTests.swift`: global snapshot restoration tests.
+- Modify `Alas/Sources/App/AppState.swift`: observable history state, explicit-close capture, reopen orchestration, terminal session creation/rollback, and cleanup purging.
+- Create `AlasTests/ClosedTabAppStateTests.swift`: user-close boundaries, cross-worktree restoration, stable-ID focus, stale-entry skipping, and transactional terminal tests.
+- Modify `Alas/Sources/Center/CenterPaneView.swift`: route global close buttons through the explicit user-close API.
+- Modify `Alas/Sources/App/AlasApp.swift`: add the menu command and fixed key equivalent.
+- Modify `Alas/Sources/App/RootView.swift`: receive the reopen notification and launch the async operation.
+- Modify `Alas/Sources/Shortcuts/ShortcutAction.swift`: reserve the fixed key combination.
+- Modify `AlasTests/ShortcutReservationsTests.swift`: prove reservation and conflict prevention.
+- Modify `AlasTests/SurfaceViewShortcutTests.swift`: prove Ghostty yields the key equivalent to the app.
+- Modify `AlasTests/ShortcutRecorderValidationTests.swift`: prove the fixed combination cannot be assigned elsewhere.
+- Regenerate `Alas.xcodeproj/project.pbxproj` after adding source and test files.
+
+---
+
+### Task 1: Closed-tab history and placement model
+
+**Files:**
+- Create: `Alas/Sources/Center/ClosedTabHistory.swift`
+- Create: `AlasTests/ClosedTabHistoryTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via `rtk xcodegen`
+
+**Interfaces:**
+- Produces: `ClosedTabSnapshot`, `ClosedTabPlacement`, `ClosedTabEntry`, and `ClosedTabHistory`.
+- Produces: `ClosedTabPlacement.insertionIndex(in:) -> Int` for both tab managers.
+- Produces: `PaneNode.replacingLeaves(using:) -> PaneNode` for terminal reconstruction in Task 4.
+
+- [ ] **Step 1: Add failing history tests**
+
+Create `AlasTests/ClosedTabHistoryTests.swift` with fixtures based on terminal tabs because they require no filesystem state:
+
+```swift
+import Testing
+@testable import Alas
+
+struct ClosedTabHistoryTests {
+    private func tab(_ id: String) -> Tab {
+        .terminal(.init(id: id, title: id, sessionId: "session-\(id)"))
+    }
+
+    private func entry(_ id: String, worktreeID: String = "wt") -> ClosedTabEntry {
+        ClosedTabEntry(
+            snapshot: .worktree(worktreeID: worktreeID, tab: tab(id)),
+            placement: .init(previousID: nil, nextID: nil, ordinal: 0)
+        )
+    }
+
+    @Test func popsNewestEntryFirst() {
+        var history = ClosedTabHistory()
+        history.record(entry("a"))
+        history.record(entry("b"))
+
+        #expect(history.last?.snapshot.tabID == "b")
+        history.remove(id: history.last!.id)
+        #expect(history.last?.snapshot.tabID == "a")
+    }
+
+    @Test func retainsOnlyFiftyNewestEntries() {
+        var history = ClosedTabHistory()
+        for index in 0..<51 { history.record(entry("tab-\(index)")) }
+
+        #expect(history.count == 50)
+        #expect(history.entries.first?.snapshot.tabID == "tab-1")
+        #expect(history.last?.snapshot.tabID == "tab-50")
+    }
+
+    @Test func placementPrefersNextThenPreviousThenOrdinal() {
+        let beforeC = ClosedTabPlacement(previousID: "a", nextID: "c", ordinal: 1)
+        #expect(beforeC.insertionIndex(in: ["a", "c"]) == 1)
+        #expect(beforeC.insertionIndex(in: ["a", "d"]) == 1)
+        #expect(beforeC.insertionIndex(in: ["d"]) == 1)
+        #expect(beforeC.insertionIndex(in: []) == 0)
+    }
+
+    @Test func purgeRemovesOnlyMatchingWorktreeEntries() {
+        var history = ClosedTabHistory()
+        history.record(entry("a", worktreeID: "first"))
+        history.record(entry("b", worktreeID: "second"))
+        history.purge(worktreeID: "first")
+
+        #expect(history.entries.map(\.snapshot.tabID) == ["b"])
+    }
+}
+```
+
+Also add a bulk-order regression that records `a`, `c`, `d` in visible order and proves removal yields `d`, `c`, `a`. Add placement regressions reconstructing `[a, b, c, d]` from `[b]` with saved anchors for `a`, `c`, and `d`.
+
+- [ ] **Step 2: Regenerate the project and verify the new suite fails**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-dd test -only-testing:AlasTests/ClosedTabHistoryTests
+```
+
+Expected: build failure because `ClosedTabHistory`, `ClosedTabEntry`, and related types do not exist.
+
+- [ ] **Step 3: Implement the bounded history and placement algorithm**
+
+Create `Alas/Sources/Center/ClosedTabHistory.swift` with these concrete shapes:
+
+```swift
+import Foundation
+
+enum ClosedTabSnapshot: Equatable {
+    case worktree(worktreeID: String, tab: Tab)
+    case global(GlobalTab)
+
+    var tabID: TabID {
+        switch self {
+        case .worktree(_, let tab): tab.id
+        case .global(let tab): tab.id
+        }
+    }
+
+    var worktreeID: String? {
+        guard case .worktree(let worktreeID, _) = self else { return nil }
+        return worktreeID
+    }
+}
+
+struct ClosedTabPlacement: Equatable {
+    let previousID: TabID?
+    let nextID: TabID?
+    let ordinal: Int
+
+    init(tabID: TabID, orderedIDs: [TabID]) {
+        guard let index = orderedIDs.firstIndex(of: tabID) else {
+            previousID = nil
+            nextID = nil
+            ordinal = orderedIDs.count
+            return
+        }
+        previousID = index > orderedIDs.startIndex ? orderedIDs[index - 1] : nil
+        nextID = orderedIDs.indices.contains(index + 1) ? orderedIDs[index + 1] : nil
+        ordinal = index
+    }
+
+    init(previousID: TabID?, nextID: TabID?, ordinal: Int) {
+        self.previousID = previousID
+        self.nextID = nextID
+        self.ordinal = ordinal
+    }
+
+    func insertionIndex(in currentIDs: [TabID]) -> Int {
+        if let nextID, let index = currentIDs.firstIndex(of: nextID) { return index }
+        if let previousID, let index = currentIDs.firstIndex(of: previousID) { return index + 1 }
+        return min(max(ordinal, 0), currentIDs.count)
+    }
+}
+
+struct ClosedTabEntry: Identifiable, Equatable {
+    let id: UUID
+    let snapshot: ClosedTabSnapshot
+    let placement: ClosedTabPlacement
+
+    init(id: UUID = UUID(), snapshot: ClosedTabSnapshot, placement: ClosedTabPlacement) {
+        self.id = id
+        self.snapshot = snapshot
+        self.placement = placement
+    }
+}
+
+struct ClosedTabHistory: Equatable {
+    static let capacity = 50
+    private(set) var entries: [ClosedTabEntry] = []
+    var last: ClosedTabEntry? { entries.last }
+    var count: Int { entries.count }
+    var isEmpty: Bool { entries.isEmpty }
+
+    mutating func record(_ entry: ClosedTabEntry) {
+        entries.append(entry)
+        if entries.count > Self.capacity {
+            entries.removeFirst(entries.count - Self.capacity)
+        }
+    }
+
+    mutating func record(contentsOf newEntries: [ClosedTabEntry]) {
+        for entry in newEntries { record(entry) }
+    }
+
+    mutating func remove(id: ClosedTabEntry.ID) {
+        entries.removeAll { $0.id == id }
+    }
+
+    mutating func purge(worktreeID: String) {
+        entries.removeAll { $0.snapshot.worktreeID == worktreeID }
+    }
+}
+```
+
+Add a pure recursive helper which preserves split IDs/axis/fraction while replacing leaves from an old-ID keyed dictionary:
+
+```swift
+extension PaneNode {
+    func replacingLeaves(using replacements: [String: PaneLeaf]) -> PaneNode {
+        switch self {
+        case .leaf(let leaf): return replacements[leaf.id].map(PaneNode.leaf) ?? self
+        case .split(var split):
+            split.children = split.children.map { $0.replacingLeaves(using: replacements) }
+            return .split(split)
+        }
+    }
+}
+```
+
+Add tests proving split axis, fraction, child order, and `lastCwd` survive while replacement leaf IDs are used.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run the same `xcodebuild ... -only-testing:AlasTests/ClosedTabHistoryTests` command.
+
+Expected: PASS for every history, placement, capacity, purge, and pane-remapping test.
+
+- [ ] **Step 5: Commit the model**
+
+```bash
+git add Alas/Sources/Center/ClosedTabHistory.swift AlasTests/ClosedTabHistoryTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(tabs): model closed tab history"
+```
+
+---
+
+### Task 2: Snapshot insertion in tab managers
+
+**Files:**
+- Modify: `Alas/Sources/Center/TabsManager.swift`
+- Modify: `Alas/Sources/Center/GlobalTabsManager.swift`
+- Modify: `AlasTests/TabsManagerTests.swift`
+- Modify: `AlasTests/GlobalTabsManagerTests.swift`
+
+**Interfaces:**
+- Consumes: `ClosedTabPlacement.insertionIndex(in:)` from Task 1.
+- Produces: `TabsManager.restore(tab:worktreeID:placement:) -> TabID`.
+- Produces: `GlobalTabsManager.restore(tab:placement:) -> TabID`.
+
+- [ ] **Step 1: Add failing local and global restoration tests**
+
+Add to `TabsManagerTests`:
+
+```swift
+@Test func restoreInsertsAtAnchoredPositionAndActivates() {
+    let worktreeID = "tabs-manager-restore-position"
+    let manager = TabsManager(store: RestoreMemoryStore())
+    let first = manager.appendTerminal(worktreeId: worktreeID, title: "a", sessionId: "a")
+    let restored = Tab.terminal(.init(id: "b", title: "b", sessionId: "b"))
+    let third = manager.appendTerminal(worktreeId: worktreeID, title: "c", sessionId: "c")
+
+    let id = manager.restore(
+        tab: restored,
+        worktreeID: worktreeID,
+        placement: .init(previousID: first.id, nextID: third.id, ordinal: 1)
+    )
+
+    #expect(id == restored.id)
+    #expect(manager.tabs(forWorktree: worktreeID).map(\.id) == [first.id, restored.id, third.id])
+    #expect(manager.activeTabId(forWorktree: worktreeID) == restored.id)
+}
+```
+
+Add this store inside `TabsManagerTests` so the new tests never touch shared tab files:
+
+```swift
+private struct RestoreMemoryStore: PersistenceStoreProtocol {
+    func write<T: Encodable>(_: T, to _: URL) throws {}
+    func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+}
+```
+
+Add a second test where `restored.id` is already present; assert the existing tab is activated, the count is unchanged, and persisted ordering is unchanged.
+
+Add equivalent Mission tests to `GlobalTabsManagerTests`, using the existing `GlobalTabsHarness`, and assert both anchored insertion and stable-ID focus-without-duplication.
+
+- [ ] **Step 2: Run manager suites and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-dd test -only-testing:AlasTests/TabsManagerTests -only-testing:AlasTests/GlobalTabsManagerTests
+```
+
+Expected: build failure because both `restore` methods are missing.
+
+- [ ] **Step 3: Implement narrow restore methods**
+
+Add to `TabsManager` near `activate`:
+
+```swift
+@discardableResult
+func restore(tab: Tab, worktreeID: String, placement: ClosedTabPlacement) -> TabID {
+    var file = byWorktree[worktreeID] ?? TabsFile(tabs: [], activeTabId: nil)
+    if file.tabs.contains(where: { $0.id == tab.id }) {
+        file.activeTabId = tab.id
+    } else {
+        let index = placement.insertionIndex(in: file.tabs.map(\.id))
+        file.tabs.insert(tab, at: index)
+        file.activeTabId = tab.id
+    }
+    byWorktree[worktreeID] = file
+    persist(worktreeID)
+    return tab.id
+}
+```
+
+Add the analogous method to `GlobalTabsManager`, using `tabs`, `activeTabId`, and `try? persist()`.
+
+- [ ] **Step 4: Run both manager suites**
+
+Run the Task 2 focused command again.
+
+Expected: PASS, including existing persistence and migration tests.
+
+- [ ] **Step 5: Commit manager restoration**
+
+```bash
+git add Alas/Sources/Center/TabsManager.swift Alas/Sources/Center/GlobalTabsManager.swift AlasTests/TabsManagerTests.swift AlasTests/GlobalTabsManagerTests.swift
+git commit -m "feat(tabs): restore closed tab snapshots"
+```
+
+---
+
+### Task 3: Explicit-close capture and non-terminal reopening
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Modify: `Alas/Sources/App/RootView.swift`
+- Create: `AlasTests/ClosedTabAppStateTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via `rtk xcodegen`
+
+**Interfaces:**
+- Consumes: history and manager restore APIs from Tasks 1-2.
+- Produces: `AppState.canReopenClosedTab: Bool`.
+- Produces: `AppState.requestCloseGlobalTab(tabID:)` for user-facing global closure.
+- Produces: `AppState.reopenLastClosedTab() async` for Task 5 command wiring.
+- Keeps `closeGlobalTab`, `closeTab`, and `cleanupWorktreeState` as raw lifecycle operations that never record history themselves.
+
+- [ ] **Step 1: Add failing AppState boundary tests**
+
+Create `AlasTests/ClosedTabAppStateTests.swift` as a serialized main-actor suite. Define a local no-op `PersistenceStoreProtocol`, plus a helper that creates a `ProjectConfig`, two `Worktree` values, and an `AppState` whose `projectsManager` contains them. Follow the concrete fixture construction used in `AgentTerminalLaunchTests` and `AppStatePersistenceTests`.
+
+Add these tests with explicit assertions:
+
+```swift
+@Test func explicitCloseRecordsAndReopenSwitchesWorktree() async throws {
+    let fixture = makeFixture()
+    let tab = fixture.state.tabs.appendEditor(
+        worktreeId: fixture.second.id,
+        title: "README.md",
+        relativePath: "README.md"
+    )
+    fixture.state.selectWorktree(id: fixture.first.id)
+
+    fixture.state.requestCloseTab(worktreeId: fixture.second.id, tabId: tab.id)
+    #expect(fixture.state.canReopenClosedTab)
+
+    await fixture.state.reopenLastClosedTab()
+
+    #expect(fixture.state.selectedWorktreeId == fixture.second.id)
+    #expect(fixture.state.tabs.activeTabId(forWorktree: fixture.second.id) == tab.id)
+    #expect(!fixture.state.canReopenClosedTab)
+}
+
+@Test func automaticCloseDoesNotRecordHistory() {
+    let fixture = makeFixture()
+    let tab = fixture.state.tabs.appendEditor(
+        worktreeId: fixture.first.id,
+        title: "README.md",
+        relativePath: "README.md"
+    )
+
+    fixture.state.closeTab(worktreeId: fixture.first.id, tabId: tab.id)
+
+    #expect(!fixture.state.canReopenClosedTab)
+}
+```
+
+Add coverage for:
+
+- `requestCloseGlobalTab` recording and reopening a Mission;
+- stable-ID Mission already reopened manually, which is focused without duplication;
+- `closeCenterTabs` recording mixed global/local IDs in the supplied visible order;
+- a canceled confirmation not recording history, using an injectable confirmation seam described in Step 3;
+- cleanup purging entries owned by a removed worktree;
+- a stale top entry being discarded and the next valid entry reopening during the same call;
+- `isReopeningClosedTab` preventing two overlapping reopen attempts.
+
+- [ ] **Step 2: Regenerate and verify the AppState suite fails**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-dd test -only-testing:AlasTests/ClosedTabAppStateTests
+```
+
+Expected: build failure because AppState has no history or reopen API.
+
+- [ ] **Step 3: Add observable history state and capture helpers**
+
+In `AppState`, add:
+
+```swift
+private(set) var closedTabHistory = ClosedTabHistory()
+private(set) var isReopeningClosedTab = false
+var canReopenClosedTab: Bool { !isReopeningClosedTab && !closedTabHistory.isEmpty }
+```
+
+Inject close confirmation without changing production behavior:
+
+```swift
+typealias CloseTabConfirmer = @MainActor (CloseTabConfirmationPolicy.Prompt) -> Bool
+@ObservationIgnored private let closeTabConfirmer: CloseTabConfirmer?
+```
+
+Add `closeTabConfirmer: CloseTabConfirmer? = nil` to `AppState.init`; `confirmCloseTab` calls it when present and otherwise shows the existing `NSAlert`.
+
+Add a pure capture helper that walks the requested visible `tabIDs` in order, reads each snapshot before removal, and computes placement against the complete owning collection:
+
+```swift
+private func closedTabEntries(worktreeID: String, tabIDs: [TabID]) -> [ClosedTabEntry] {
+    let global = globalTabs.tabs
+    let local = tabs.tabs(forWorktree: worktreeID)
+    return tabIDs.compactMap { tabID in
+        if let tab = global.first(where: { $0.id == tabID }) {
+            return ClosedTabEntry(
+                snapshot: .global(tab),
+                placement: .init(tabID: tabID, orderedIDs: global.map(\.id))
+            )
+        }
+        guard let tab = local.first(where: { $0.id == tabID }) else { return nil }
+        return ClosedTabEntry(
+            snapshot: .worktree(worktreeID: worktreeID, tab: tab),
+            placement: .init(tabID: tabID, orderedIDs: local.map(\.id))
+        )
+    }
+}
+```
+
+After confirmation succeeds, `requestCloseTab` records its one captured entry immediately before calling raw `closeTab`. Add `requestCloseGlobalTab(tabID:)` with the same record-then-raw-close ordering. Update the global close closure in `CenterPaneView`, the no-worktree `GlobalMissionTabBarView` close closure in `RootView`, and the global branch of `handleCloseCenterShortcut` to use the request method.
+
+In `closeCenterTabs`, capture all entries before any removal, record them in supplied visible order, then run the existing global/local cleanup. Do not add recording to `closeTab`, `closeGlobalTab`, `closeAllTabs`, process-exit handling, or manager removal methods.
+
+At the beginning of `cleanupWorktreeState(worktreeId:)`, call `closedTabHistory.purge(worktreeID:)`. This covers deletion, archival, failed optimistic cleanup, and missing-worktree reconciliation without making them record closures.
+
+- [ ] **Step 4: Implement non-terminal reopen orchestration**
+
+Add `reopenLastClosedTab() async` with an in-flight guard and identity-based consumption:
+
+```swift
+func reopenLastClosedTab() async {
+    guard !isReopeningClosedTab else { return }
+    isReopeningClosedTab = true
+    defer { isReopeningClosedTab = false }
+
+    while let entry = closedTabHistory.last {
+        switch entry.snapshot {
+        case .global(let tab):
+            _ = globalTabs.restore(tab: tab, placement: entry.placement)
+            closedTabHistory.remove(id: entry.id)
+            return
+
+        case .worktree(let worktreeID, let tab):
+            guard worktree(withId: worktreeID) != nil else {
+                closedTabHistory.remove(id: entry.id)
+                continue
+            }
+            if case .terminal = tab {
+                await reopenTerminalTab(entry: entry, worktreeID: worktreeID, tab: tab)
+                return
+            }
+            selectWorktree(id: worktreeID)
+            _ = tabs.restore(tab: tab, worktreeID: worktreeID, placement: entry.placement)
+            activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
+            closedTabHistory.remove(id: entry.id)
+            return
+        }
+    }
+}
+```
+
+Declare the terminal branch as a private async method that Task 4 will fill. For Task 3, make it report `Reopen Tab Failed` and retain the entry; the tests in this task use only non-terminal snapshots.
+
+- [ ] **Step 5: Run focused AppState and manager tests**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-dd test -only-testing:AlasTests/ClosedTabAppStateTests -only-testing:AlasTests/TabsManagerTests -only-testing:AlasTests/GlobalTabsManagerTests -only-testing:AlasTests/AppStatePersistenceTests
+```
+
+Expected: PASS. In particular, the existing missing-Mission cleanup tests must continue to use raw closure without unexpected history side effects.
+
+- [ ] **Step 6: Commit explicit closure and non-terminal reopen**
+
+```bash
+git add Alas/Sources/App/AppState.swift Alas/Sources/Center/CenterPaneView.swift Alas/Sources/App/RootView.swift AlasTests/ClosedTabAppStateTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(tabs): reopen explicitly closed tabs"
+```
+
+---
+
+### Task 4: Transactional terminal-tab reconstruction
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `AlasTests/ClosedTabAppStateTests.swift`
+
+**Interfaces:**
+- Consumes: `PaneNode.replacingLeaves(using:)`, `ClosedTabEntry`, and `TabsManager.restore`.
+- Completes: the private `AppState.reopenTerminalTab(entry:worktreeID:tab:) async` branch introduced in Task 3.
+- Reuses: `terminalSessionOpener`, `prepareRemoteAccelerationIfNeeded(for:)`, `closeTerminalSession`, and `fileActionErrorHandler`.
+
+- [ ] **Step 1: Add failing terminal reconstruction tests**
+
+Extend `ClosedTabAppStateTests` with a fixture whose injected `terminalSessionOpener` records each `forcedCwd` and returns deterministic fresh IDs.
+
+Create a closed terminal snapshot with a vertical split, non-default fraction, two old leaf IDs and distinct `lastCwd` values, the second leaf focused, and non-nil Run Script fields. Record it through an explicit close, invoke reopen, then assert:
+
+```swift
+#expect(openedCwds == ["/tmp/first", "/tmp/second"])
+guard case .terminal(let reopened) = fixture.state.tabs.activeTab(forWorktree: fixture.worktree.id) else {
+    Issue.record("Expected reopened terminal")
+    return
+}
+#expect(reopened.id == original.id)
+#expect(reopened.root.leaves().map(\.id) == ["fresh-1", "fresh-2"])
+#expect(reopened.root.leaves().map(\.lastCwd) == ["/tmp/first", "/tmp/second"])
+#expect(reopened.focusedLeafId == "fresh-2")
+#expect(reopened.runScriptKey == nil)
+#expect(reopened.runScriptLeafId == nil)
+```
+
+Pattern-match the reopened root and assert the original split axis, fraction, split ID, and child order.
+
+Add a failure test where the opener succeeds once and throws on the second call. Capture the error title, then assert no terminal tab was inserted, `canReopenClosedTab` becomes true again after the operation, the same entry remains last, and the first fresh session is absent from harness ownership after rollback.
+
+- [ ] **Step 2: Run the terminal-focused tests and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-dd test -only-testing:AlasTests/ClosedTabAppStateTests
+```
+
+Expected: terminal tests FAIL because the Task 3 temporary failure branch does not reconstruct sessions.
+
+- [ ] **Step 3: Implement fresh-session opening without appending a tab**
+
+Add a private helper next to `openTerminalTab` so it can access the existing private injected opener:
+
+```swift
+private func openTerminalSessionForReopen(
+    worktree: Worktree,
+    project: ProjectConfig,
+    forcedCwd: URL?
+) throws -> OpenedTerminalSession {
+    let opened: OpenedTerminalSession
+    if let terminalSessionOpener {
+        opened = try terminalSessionOpener(
+            worktree, project, config.terminal, themeStore.current,
+            forcedCwd, nil, true, [:], []
+        )
+    } else {
+        let leafID = UUID().uuidString
+        let session = try terminal.openSession(
+            worktree: worktree,
+            project: project,
+            cfg: config.terminal,
+            theme: themeStore.current,
+            forcedCwd: forcedCwd,
+            leafId: leafID
+        )
+        opened = .init(id: session.id, foregroundPid: { [weak session] in
+            session?.surface.foregroundPid
+        })
+    }
+    harness.detector.register(sessionId: opened.id, pidProvider: opened.foregroundPid)
+    return opened
+}
+```
+
+Do not pass a startup script suffix or Run Script environment. This intentionally creates ordinary fresh shells.
+
+- [ ] **Step 4: Implement transactional tree reconstruction and rollback**
+
+Replace the Task 3 temporary terminal failure branch with logic that:
+
+1. Resolves the `Worktree` and `ProjectConfig`.
+2. Awaits `prepareRemoteAccelerationIfNeeded(for:)`.
+3. Traverses `oldState.root.leaves()` in render order.
+4. Opens one session per old leaf using `oldLeaf.lastCwd.map(URL.init(fileURLWithPath:))`.
+5. Builds `replacements[oldLeaf.id] = PaneLeaf(id: opened.id, sessionId: opened.id, lastCwd: oldLeaf.lastCwd)` and maps the old focused ID to the fresh ID.
+6. Replaces leaves in the old tree, clears both Run Script fields, inserts the reconstructed `.terminal` tab, switches worktree, activates it, and removes `entry.id` from history.
+
+Use this exact rollback shape:
+
+```swift
+var openedIDs: [String] = []
+do {
+    // Open and collect every replacement, then insert only after all succeed.
+} catch {
+    let projectPath = project.path
+    for id in openedIDs {
+        closeTerminalSession(id: id, worktreeId: worktreeID, projectPath: projectPath)
+    }
+    showFileActionError(title: "Reopen Tab Failed", message: error.localizedDescription)
+}
+```
+
+The catch path must not remove `entry.id`. Because `isReopeningClosedTab` is reset by the outer `defer`, the menu becomes enabled again for retry. If a new tab is closed while the async reconstruction is suspended, identity-based removal consumes only the attempted entry and leaves the newer entry on top.
+
+- [ ] **Step 5: Run terminal and existing terminal lifecycle suites**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-dd test -only-testing:AlasTests/ClosedTabAppStateTests -only-testing:AlasTests/TabsManagerPaneTests -only-testing:AlasTests/AppStateKeepSessionsAliveTests -only-testing:AlasTests/AgentTerminalLaunchTests
+```
+
+Expected: PASS, including partial-failure rollback and existing persistent-terminal behavior.
+
+- [ ] **Step 6: Commit terminal reconstruction**
+
+```bash
+git add Alas/Sources/App/AppState.swift AlasTests/ClosedTabAppStateTests.swift
+git commit -m "feat(terminal): rebuild reopened tab layouts"
+```
+
+---
+
+### Task 5: Menu command, notification, and Ghostty reservation
+
+**Files:**
+- Modify: `Alas/Sources/App/AlasApp.swift`
+- Modify: `Alas/Sources/App/RootView.swift`
+- Modify: `Alas/Sources/Shortcuts/ShortcutAction.swift`
+- Modify: `AlasTests/ShortcutReservationsTests.swift`
+- Modify: `AlasTests/SurfaceViewShortcutTests.swift`
+- Modify: `AlasTests/ShortcutRecorderValidationTests.swift`
+
+**Interfaces:**
+- Consumes: `AppState.canReopenClosedTab` and `AppState.reopenLastClosedTab()` from Task 3.
+- Produces: `Notification.Name.alasReopenClosedTab`.
+- Reserves: `ShortcutBinding(key: "t", modifiers: [.command, .shift])`.
+
+- [ ] **Step 1: Add failing shortcut tests**
+
+Extend `ShortcutReservationsTests.defaultsIncludeStandardsAndTabSwitchers`:
+
+```swift
+let reopen = ShortcutBinding(key: "t", modifiers: [.command, .shift])
+#expect(ShortcutAction.reservedBindings.contains(reopen))
+#expect(ShortcutReservations.defaultReserved.contains(reopen))
+#expect(ShortcutReservations.snapshot(from: .defaults).contains(reopen))
+```
+
+Add to `ShortcutRecorderValidationTests`:
+
+```swift
+@Test func rejectsReservedReopenClosedTabShortcut() {
+    let binding = ShortcutBinding(key: "t", modifiers: [.command, .shift])
+    #expect(ShortcutRecorder.validate(binding) == .reserved)
+}
+```
+
+Extend `SurfaceViewShortcutTests` with an `NSEvent` for `t` plus Command and Shift and assert `isReservedAppKeyEquivalent` returns true.
+
+- [ ] **Step 2: Run shortcut suites and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-dd test -only-testing:AlasTests/ShortcutReservationsTests -only-testing:AlasTests/SurfaceViewShortcutTests -only-testing:AlasTests/ShortcutRecorderValidationTests
+```
+
+Expected: FAIL because the fixed shortcut has not been reserved.
+
+- [ ] **Step 3: Reserve the fixed shortcut**
+
+Add this entry to `ShortcutAction.reservedBindings` next to Command-W:
+
+```swift
+.init(key: "t", modifiers: [.command, .shift]),
+```
+
+Do not add a `ShortcutAction` case; the command is intentionally fixed like Close Tab.
+
+- [ ] **Step 4: Wire the app command and notification**
+
+In `AlasApp`, add the button immediately after Close Tab:
+
+```swift
+Button("Reopen Closed Tab") {
+    NotificationCenter.default.post(name: .alasReopenClosedTab, object: nil)
+}
+.keyboardShortcut("t", modifiers: [.command, .shift])
+.disabled(!state.canReopenClosedTab)
+```
+
+In `Notification.Name`, add:
+
+```swift
+static let alasReopenClosedTab = Notification.Name("AlasReopenClosedTab")
+```
+
+In `RootBaseHandlers`, add a receiver directly after `.alasCloseTab`:
+
+```swift
+.onReceive(NotificationCenter.default.publisher(for: .alasReopenClosedTab)) { _ in
+    Task { @MainActor in
+        await state.reopenLastClosedTab()
+    }
+}
+```
+
+Keep the receiver independent of `selectedWorktree()` because history resolves and switches its own worktree.
+
+- [ ] **Step 5: Run shortcut and closed-tab suites**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-dd test -only-testing:AlasTests/ShortcutReservationsTests -only-testing:AlasTests/SurfaceViewShortcutTests -only-testing:AlasTests/ShortcutRecorderValidationTests -only-testing:AlasTests/ClosedTabHistoryTests -only-testing:AlasTests/ClosedTabAppStateTests
+```
+
+Expected: PASS. Manually inspect the built app's tab command menu to confirm **Reopen Closed Tab** displays `Shift-Command-T`, is disabled initially, enables after an explicit close, and works while a terminal has focus.
+
+- [ ] **Step 6: Commit command integration**
+
+```bash
+git add Alas/Sources/App/AlasApp.swift Alas/Sources/App/RootView.swift Alas/Sources/Shortcuts/ShortcutAction.swift AlasTests/ShortcutReservationsTests.swift AlasTests/SurfaceViewShortcutTests.swift AlasTests/ShortcutRecorderValidationTests.swift
+git commit -m "feat(tabs): add reopen closed tab shortcut"
+```
+
+---
+
+### Task 6: Final regression and repository verification
+
+**Files:**
+- Modify only files needed to fix regressions discovered by verification.
+
+**Interfaces:**
+- Consumes the complete feature from Tasks 1-5.
+- Produces a clean, formatted, fully verified branch.
+
+- [ ] **Step 1: Regenerate and inspect generated membership**
+
+```bash
+rtk xcodegen
+git status --short
+git diff --check
+```
+
+Expected: the two new Swift files appear in the generated project, and `git diff --check` reports no whitespace errors. Commit `Alas.xcodeproj/project.pbxproj` if Task 1 or Task 3 regeneration did not already capture its final form.
+
+- [ ] **Step 2: Run formatting lint**
+
+```bash
+rtk swiftformat --lint Alas/Sources AlasTests
+```
+
+Expected: exit 0. Apply only mechanical formatting fixes reported for touched files, rerun lint, and commit those fixes with the closest owning task if not yet published.
+
+- [ ] **Step 3: Run the required build serially**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run the required full test suite serially**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exit 0 with all existing and new tests passing. A run that stalls before `xctest` or fails because another process locked `build.db` is incomplete; rerun serially with a fresh explicit DerivedData path before classifying it as a source failure.
+
+- [ ] **Step 5: Review the final diff against the approved spec**
+
+```bash
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD -- Alas/Sources/Center/ClosedTabHistory.swift Alas/Sources/Center/TabsManager.swift Alas/Sources/Center/GlobalTabsManager.swift Alas/Sources/App/AppState.swift Alas/Sources/Center/CenterPaneView.swift Alas/Sources/App/AlasApp.swift Alas/Sources/App/RootView.swift Alas/Sources/Shortcuts/ShortcutAction.swift AlasTests
+git status --short
+```
+
+Confirm all of the following before completion:
+
+- only explicit closure paths record history;
+- deletion/archive/missing-worktree cleanup purges without recording;
+- repeated reopen is LIFO and cross-worktree;
+- stable IDs focus instead of duplicating;
+- terminal layouts use fresh sessions and preserve directories without rerunning scripts;
+- terminal failure rolls back and stays retryable;
+- `Command-Shift-T` works through Ghostty and remains non-configurable;
+- the worktree is clean.
+
+- [ ] **Step 6: Commit any final verification-only correction**
+
+If verification required a source correction, rerun the directly affected focused suite and Steps 2-4, then commit only that correction:
+
+```bash
+git add Alas/Sources/Center/ClosedTabHistory.swift Alas/Sources/Center/TabsManager.swift Alas/Sources/Center/GlobalTabsManager.swift Alas/Sources/App/AppState.swift Alas/Sources/Center/CenterPaneView.swift Alas/Sources/App/AlasApp.swift Alas/Sources/App/RootView.swift Alas/Sources/Shortcuts/ShortcutAction.swift AlasTests/ClosedTabHistoryTests.swift AlasTests/ClosedTabAppStateTests.swift AlasTests/TabsManagerTests.swift AlasTests/GlobalTabsManagerTests.swift AlasTests/ShortcutReservationsTests.swift AlasTests/SurfaceViewShortcutTests.swift AlasTests/ShortcutRecorderValidationTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "fix(tabs): harden closed tab restoration"
+```
+
+If no correction was needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-08-04-reopen-closed-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-04-reopen-closed-tabs-design.md
@@ -1,0 +1,233 @@
+# Reopen Closed Tabs Design
+
+## Summary
+
+Add the standard `Command-Shift-T` action to reopen tabs closed during the
+current Alas process. Repeated invocations walk one app-wide, most-recently
+closed-first history. Reopening can switch back to the tab's owning worktree,
+and terminal tabs return with their prior pane layout but fresh shell sessions.
+
+## Goals
+
+- Add a **Reopen Closed Tab** menu command with the fixed `Command-Shift-T`
+  shortcut.
+- Reopen multiple explicitly closed tabs in reverse close order.
+- Keep one app-wide history across worktree-local tabs and global Mission tabs.
+- Restore a worktree-local tab in its owning worktree and select that worktree.
+- Restore tabs near their original position and activate the reopened tab.
+- Recreate a terminal tab's pane layout with fresh sessions rooted at the last
+  known working directory for each pane.
+- Treat explicit bulk actions such as Close Others, Close All, Close Tabs to
+  Left, and Close Tabs to Right as reopenable closures.
+- Keep automatic lifecycle cleanup out of reopen history.
+
+## Non-goals
+
+- Do not persist closed-tab history across app launches.
+- Do not add a history browser, recently closed menu, or tab preview UI.
+- Do not revive a terminated terminal process or rerun a Run Script.
+- Do not make Close Tab or Reopen Closed Tab configurable shortcuts.
+- Do not make tabs removed by worktree deletion, archival, or other automatic
+  cleanup reopenable.
+- Do not change tab persistence formats.
+
+## User Experience
+
+The existing tab command group gains **Reopen Closed Tab** next to **Close
+Tab**. It uses `Command-Shift-T` and is disabled when the session history has no
+reopenable entry. The shortcut remains owned by Alas while a Ghostty terminal
+surface has focus.
+
+Each invocation reopens one entry. If it belongs to another worktree, Alas
+selects that worktree before activating the restored tab. If the same stable
+tab ID is already open, Alas focuses the existing tab and consumes the history
+entry instead of creating a duplicate stable-ID tab.
+
+Explicit bulk closure records each removed tab as an individual history entry.
+Entries are added in visible left-to-right order, so the rightmost removed tab
+reopens first. Collection-local neighbor anchors ensure that continuing to
+invoke the shortcut reconstructs the original ordering, including when tabs on
+both sides of a kept tab were closed.
+
+## Closed-Tab History
+
+Add a small, in-memory `ClosedTabHistory` owned by `AppState`. It holds at most
+50 entries. Pushing entry 51 removes the oldest entry. The history is not
+encoded by `AppState`, `TabsManager`, or `GlobalTabsManager`.
+
+Each entry contains:
+
+- the complete `Tab` or `GlobalTab` value captured immediately before removal;
+- the owning worktree ID for a worktree-local tab;
+- the preceding and following tab IDs within the same underlying collection;
+- the original collection-local ordinal as a fallback insertion point.
+
+Reinsertion prefers the surviving following neighbor, then the surviving
+preceding neighbor, then the clamped original ordinal. This preserves placement
+across repeated restoration of a bulk close without coupling the history model
+to the rendered composition of global and worktree-local tabs.
+
+The history exposes focused operations for push, peek/pop, and purging every
+entry owned by a worktree. Its ordering and placement decisions are pure and
+unit-testable; resource cleanup remains in `AppState`.
+
+## Explicit and Automatic Closure Boundaries
+
+`AppState` remains the lifecycle owner. User-facing closure paths capture the
+snapshot only after any close confirmation succeeds and immediately before
+the existing teardown begins. These paths include:
+
+- a tab-bar close button;
+- `Command-W` when it closes a tab rather than one pane of a split terminal;
+- Close Others, Close All, Close Tabs to Left, and Close Tabs to Right.
+
+Low-level manager removal and cleanup APIs do not implicitly write history.
+Worktree deletion, worktree archival, disappearing-worktree reconciliation,
+operation-driven tab removal, and other automatic cleanup continue to call
+those raw paths. Deleting or archiving a worktree also purges older history
+entries owned by that worktree.
+
+This boundary prevents an automatic cleanup from unexpectedly becoming the
+next result of `Command-Shift-T` while keeping every explicit tab-management
+action undoable.
+
+## Restoring Non-Terminal Tabs
+
+`TabsManager` and `GlobalTabsManager` gain internal insertion operations that
+accept a saved tab plus its placement anchors. The operation inserts the tab,
+activates it, and persists the normal open-tab collection using the existing
+format.
+
+Before insertion, `AppState` resolves the owner:
+
+1. A global Mission tab uses `GlobalTabsManager` and does not require a
+   worktree switch.
+2. A worktree tab requires a currently available owning worktree. Alas selects
+   it, inserts the snapshot, clears global-Mission presentation, and activates
+   the restored tab.
+3. If the same tab ID already exists in the target collection, Alas activates
+   that existing tab and treats the reopen as successful.
+
+The complete saved value retains the tab-specific view state already modeled
+by `Tab`, such as editor reveal state, draft text, review selection, and diff
+configuration. Normal view lifecycle code recreates disposable resources such
+as editor buffers and ACP attachments when the tab becomes visible.
+
+## Restoring Terminal Tabs
+
+Closing a terminal tab continues to terminate its sessions. Reopen therefore
+reconstructs the tab rather than routing through persisted-session restoration.
+
+The reconstruction preserves:
+
+- the terminal tab ID and title;
+- the split topology, axes, fractions, and focused-pane position;
+- each leaf's `lastCwd`.
+
+It replaces every terminal leaf ID/session ID with a fresh identity, maps the
+focused leaf to its replacement, and clears `runScriptKey` and
+`runScriptLeafId`. A closed Run Script tab therefore returns as ordinary fresh
+shells and never reruns the script merely because the user invoked
+`Command-Shift-T`.
+
+Terminal reconstruction is asynchronous and transactional:
+
+1. Resolve the worktree and prepare the existing remote terminal prerequisites
+   when needed.
+2. Build the replacement pane tree and open one fresh session per leaf, passing
+   the old leaf's `lastCwd` as its forced working directory.
+3. Register each successfully opened session with existing terminal and
+   harness ownership.
+4. Insert and activate the reconstructed terminal tab only after every leaf
+   succeeds.
+5. If a leaf fails, close and unregister sessions created by that attempt,
+   leave the UI unchanged, retain the history entry for retry, and show
+   **Reopen Tab Failed** through the existing app error presentation.
+
+The history entry is consumed only after successful reconstruction and
+insertion. This avoids the existing relaunch restoration rule that deliberately
+drops stale terminal tabs when terminal persistence is disabled.
+
+## Command and Shortcut Wiring
+
+`AlasApp` posts a dedicated reopen notification from **Reopen Closed Tab**.
+`RootView` receives it and starts `AppState.reopenLastClosedTab()` in a
+main-actor task. The command's disabled state reads whether history currently
+contains an entry.
+
+`Command-Shift-T` joins `ShortcutAction.reservedBindings` alongside the fixed
+Close Tab and tab-number shortcuts. That both prevents assignment to a
+configurable action and makes `ShortcutReservations` keep the key equivalent
+away from a focused Ghostty surface.
+
+## Stale Entries and Failure Semantics
+
+Worktree removal proactively purges its entries. As a defensive fallback, if
+reopen encounters an entry whose owning worktree can no longer be resolved, it
+discards that entry and continues to the next entry during the same invocation.
+If no valid entry remains, the command is a quiet no-op.
+
+A non-terminal snapshot remains reopenable even if its underlying file,
+commit, review, or other resource changed after closure. The restored tab uses
+the existing per-tab loading, missing-resource, and unavailable-state behavior
+rather than adding a second validation system to closed-tab history.
+
+Terminal setup is the only new fallible restoration stage. Its transactional
+rollback and retained history entry make the failure retryable without leaving
+a partial tab or leaked sessions.
+
+## Testing
+
+### History Model
+
+- Entries pop in most-recently-closed-first order.
+- The history retains only its 50 newest entries.
+- Visible left-to-right bulk input reopens right-to-left.
+- Following-neighbor, preceding-neighbor, and ordinal fallback placement each
+  produce the expected insertion point.
+- Reopening every entry from Close Others reconstructs the original order.
+- Purging a worktree removes only that worktree's entries.
+
+### Tab Managers and AppState
+
+- Local and global insertion restore and activate a snapshot at its resolved
+  position.
+- An already-open stable tab ID is focused rather than duplicated.
+- A confirmed explicit single close records one entry; a canceled confirmation
+  records none.
+- Explicit bulk close records every removed local and global tab in visible
+  order.
+- `Command-W` closing a terminal pane records nothing; closing the last pane's
+  tab records the tab.
+- Worktree cleanup records nothing and purges prior entries for that worktree.
+- Reopening a local tab selects its owning worktree and activates the tab.
+- A missing-worktree entry is skipped in favor of the next valid entry.
+
+### Terminal Reconstruction
+
+- A single-pane terminal reopens with a fresh leaf/session identity and its
+  prior `lastCwd`.
+- A split terminal retains topology, fractions, and focused-pane position while
+  every leaf receives a fresh identity.
+- Run Script ownership is cleared.
+- Injected failure after one or more successful session opens rolls those
+  sessions back, inserts no tab, and retains the history entry for retry.
+
+### Shortcut Integration
+
+- Default and configured reservation snapshots include `Command-Shift-T`.
+- Ghostty recognizes `Command-Shift-T` as an app-reserved key equivalent.
+- The shortcut recorder rejects `Command-Shift-T` for configurable actions.
+- The menu command is disabled with empty history and enabled with a valid
+  entry.
+
+## Verification
+
+Run focused history, tab-manager, AppState, terminal, and shortcut tests first.
+Then run the repository-required verification serially:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```


### PR DESCRIPTION
## Summary
- Add session-only closed-tab history and restore support for local/global tabs
- Rebuild reopened terminal layouts with fresh sessions and rollback on failure
- Add fixed Shift-Command-T menu command and reserve the shortcut from terminal/recorder handling

## Verification
- rtk xcodegen
- rtk swiftformat --lint Alas/Sources AlasTests
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- ALAS_ZMX_OPTIONAL=1 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-reopen-tabs-postrebase-dd test -only-testing:AlasTests/ClosedTabHistoryTests -only-testing:AlasTests/ClosedTabAppStateTests -only-testing:AlasTests/TabsManagerTests -only-testing:AlasTests/GlobalTabsManagerTests -only-testing:AlasTests/TabsManagerPaneTests -only-testing:AlasTests/ShortcutReservationsTests -only-testing:AlasTests/SurfaceViewShortcutTests -only-testing:AlasTests/ShortcutRecorderValidationTests

Note: full local suite completed build and ran 7,381 tests, but two unrelated tests failed in the aggregate run and passed when rerun individually.