### PR TITLE
fix(sidebar): sort control chrome

### DIFF
--- a/Alas/Sources/Sidebar/WorktreeSortMenu.swift
+++ b/Alas/Sources/Sidebar/WorktreeSortMenu.swift
@@ -29,22 +29,19 @@ struct WorktreeSortMenu: View {
     let headerHovered: Bool
 
     @Environment(\.theme) private var theme
-    @FocusState private var focused: Bool
     @State private var hovering = false
     @State private var menuTracking = false
 
     nonisolated static func isVisible(
         headerHovered: Bool,
-        focused: Bool,
         menuTracking: Bool
     ) -> Bool {
-        headerHovered || focused || menuTracking
+        headerHovered || menuTracking
     }
 
     private var visible: Bool {
         Self.isVisible(
             headerHovered: headerHovered,
-            focused: focused,
             menuTracking: menuTracking
         )
     }
@@ -77,8 +74,6 @@ struct WorktreeSortMenu: View {
         .buttonStyle(.plain)
         .opacity(visible ? 1 : 0)
         .allowsHitTesting(visible)
-        .focusable()
-        .focused($focused)
         .onHover { hovering = $0 }
         .simultaneousGesture(TapGesture().onEnded { menuTracking = true })
         .onReceive(NotificationCenter.default.publisher(for: NSMenu.didEndTrackingNotification)) { _ in
@@ -104,6 +99,8 @@ private struct WorktreeSortAccessibilityButton: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSView {
         let button = PointerTransparentMenuButton(frame: .zero)
+        button.title = ""
+        button.isBordered = false
         button.menu = context.coordinator.makeMenu()
         button.setAccessibilityLabel("Sort worktrees")
         button.setAccessibilityHelp("Sort worktrees")
@@ -174,6 +171,8 @@ private struct WorktreeSortAccessibilityButton: NSViewRepresentable {
 }
 
 private final class PointerTransparentMenuButton: NSButton {
+    override var acceptsFirstResponder: Bool { false }
+
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
     }

--- a/AlasTests/SidebarHeaderViewTests.swift
+++ b/AlasTests/SidebarHeaderViewTests.swift
@@ -43,6 +43,15 @@ struct SidebarHeaderViewTests {
         #expect(sortControls.first?.accessibilityActionNames().contains(.press) == true)
     }
 
+    @Test func sortAccessibilityButtonHasNoVisibleChromeOrFocus() {
+        let controller = hostHeader()
+        let sortButton = accessibilityElements(in: controller.view, matching: "Sort worktrees").first as? NSButton
+
+        #expect(sortButton?.title == "")
+        #expect(sortButton?.isBordered == false)
+        #expect(sortButton?.acceptsFirstResponder == false)
+    }
+
     private func accessibilityElements(in view: NSView, matching expected: String) -> [NSView] {
         let matches = view.accessibilityLabel() == expected ? [view] : []
         return matches + view.subviews.flatMap {

--- a/AlasTests/WorktreeSortMenuTests.swift
+++ b/AlasTests/WorktreeSortMenuTests.swift
@@ -27,18 +27,15 @@ struct WorktreeSortMenuTests {
         ])
     }
 
-    @Test func visibilityIncludesHeaderHoverFocusAndMenuTracking() {
+    @Test func visibilityIncludesHeaderHoverAndMenuTracking() {
         #expect(!WorktreeSortMenu.isVisible(
-            headerHovered: false, focused: false, menuTracking: false
+            headerHovered: false, menuTracking: false
         ))
         #expect(WorktreeSortMenu.isVisible(
-            headerHovered: true, focused: false, menuTracking: false
+            headerHovered: true, menuTracking: false
         ))
         #expect(WorktreeSortMenu.isVisible(
-            headerHovered: false, focused: true, menuTracking: false
-        ))
-        #expect(WorktreeSortMenu.isVisible(
-            headerHovered: false, focused: false, menuTracking: true
+            headerHovered: false, menuTracking: true
         ))
     }
 }


### PR DESCRIPTION
## Summary

- Remove the accidental AppKit "Button" chrome from the sidebar sort control.
- Keep the sort control out of keyboard focus while retaining its accessibility action.

## Root cause

The pointer-transparent AppKit accessibility button inherited NSButton's default title, border, and first-responder behavior.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Targeted sidebar and sort-menu tests
- Full suite run: one unrelated persistence test flaked, then passed in isolation.