### PR TITLE
fix(acp): make the tail-follow pause reachable under responsive scrolling

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1297,6 +1297,7 @@
 		DB29057E7147A0774BC2B835 /* ReviewLoopDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */; };
 		DB305015BF666EEE0F9C7BAB /* ACPFileEditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D7631D754795D16E946440 /* ACPFileEditCard.swift */; };
 		DB40AA7EB6A31B5F232EDCA3 /* DiffPaneTextDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */; };
+		DB474070DDBFA87828543D60 /* ACPTranscriptScrollerLiveScrollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BA8B1CD4334FF7F7082E9A /* ACPTranscriptScrollerLiveScrollTests.swift */; };
 		DBE7AD7F869B444A7C48E5B2 /* TreeSitterJava in Frameworks */ = {isa = PBXBuildFile; productRef = 33EB43DCB691861654EC147A /* TreeSitterJava */; };
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
@@ -2920,6 +2921,7 @@
 		F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStreamingTextTests.swift; sourceTree = "<group>"; };
 		F18E4AD4B92330FB085C821C /* FileDeviceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDeviceStore.swift; sourceTree = "<group>"; };
 		F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetectorTests.swift; sourceTree = "<group>"; };
+		F1BA8B1CD4334FF7F7082E9A /* ACPTranscriptScrollerLiveScrollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerLiveScrollTests.swift; sourceTree = "<group>"; };
 		F1F0EED235328724082B570B /* GGActionEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGActionEvents.swift; sourceTree = "<group>"; };
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalog.swift; sourceTree = "<group>"; };
@@ -4072,6 +4074,7 @@
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
 				133BC58A28C72EA330CDCCA5 /* ACPTranscriptScrollBookkeepingResetTests.swift */,
 				BF85BC8414AE4C5A19C996C4 /* ACPTranscriptScrollerFlagTests.swift */,
+				F1BA8B1CD4334FF7F7082E9A /* ACPTranscriptScrollerLiveScrollTests.swift */,
 				B24F24D2FFBBC49868AC84B3 /* ACPTranscriptScrollerPolicyTests.swift */,
 				F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */,
 				E2EED77914E0B1E46C66A2B0 /* ACPTranscriptScrollerScrollBackTests.swift */,
@@ -6737,6 +6740,7 @@
 				98C2CDC077CE41DD4AA74E35 /* ACPTranscriptRowHostingViewTests.swift in Sources */,
 				15D264B7D73244CABCC5D22B /* ACPTranscriptScrollBookkeepingResetTests.swift in Sources */,
 				43F290B197CA5F56910EDD05 /* ACPTranscriptScrollerFlagTests.swift in Sources */,
+				DB474070DDBFA87828543D60 /* ACPTranscriptScrollerLiveScrollTests.swift in Sources */,
 				57C95148FA2594979E1B2583 /* ACPTranscriptScrollerPolicyTests.swift in Sources */,
 				7C5139851C6CA3CB4292B5B2 /* ACPTranscriptScrollerReconcilerTests.swift in Sources */,
 				4683946F3ADACBE0DC350B88 /* ACPTranscriptScrollerScrollBackTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -661,12 +661,29 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // tail-follow the same as a trackpad gesture or scroller-knob
             // drag would — without misclassifying clicks on transcript
             // controls (which aren't scrollbar hits) as scrolling.
-            let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(
-                currentEventType,
-                previousMinY: previousY,
-                newMinY: newY,
-                isScrollbarTrackHit: ACPUserScrollEvent.isScrollbarTrackMouseDown(eventIsFresh ? event : nil)
-            )
+            //
+            // `scroller.isUserScrollActive` is what makes this reachable at
+            // all. The event-based test alone answers false for ~97-99% of
+            // scroll ticks under responsive scrolling (the same measurement
+            // `shouldStepHeadBack` documents), so the pause it gates almost
+            // never fired: a reader who scrolled up out of the tail kept
+            // `followsTranscriptTail` set, and once their gesture ended —
+            // and with it the suppression window in
+            // `ACPTranscriptScrollerReconciler.repinsToTail` — the next
+            // update pinned them straight back to the bottom. The scroll
+            // view's own live-scroll notifications are posted only for
+            // genuine user scrolling and never for a programmatic
+            // `setBoundsOrigin`, so they identify the gesture where the event
+            // stream cannot. The event test is kept alongside because it
+            // additionally covers input that never opens a live-scroll
+            // session (a scrollbar-track click, magnify, swipe).
+            let isHeadPaginationDriven = scroller.isUserScrollActive
+                || ACPUserScrollEvent.isHeadPaginationDriven(
+                    currentEventType,
+                    previousMinY: previousY,
+                    newMinY: newY,
+                    isScrollbarTrackHit: ACPUserScrollEvent.isScrollbarTrackMouseDown(eventIsFresh ? event : nil)
+                )
 
             let decision = ACPScrollDirectionClassifier.decide(
                 previousOffsetY: previousY,
@@ -836,6 +853,23 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             didRestoreInitialPosition = true
             scroller.setScrollY(row.minY)
         }
+
+        #if DEBUG
+        /// Re-measures every mounted row, reproducing what streaming content
+        /// does continuously (`acp-thought:`/`tc-*` rows invalidating their
+        /// intrinsic size). This is the path that used to yank a scrolled-away
+        /// reader back to the bottom.
+        func remeasureMountedRowsForTesting() {
+            guard let reconciler else { return }
+            for id in reconciler.mountedRowIdsForTesting {
+                reconciler.remeasureRow(id: id)
+            }
+        }
+
+        var mountedRowCountForTesting: Int {
+            reconciler?.mountedRowIdsForTesting.count ?? 0
+        }
+        #endif
     }
 }
 

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -62,6 +62,57 @@ final class ACPTranscriptScrollerView: NSScrollView {
     private var lastReportedY: CGFloat?
     private var programmaticAdjustmentDepth = 0
     private var boundsObserver: NSObjectProtocol?
+    private var liveScrollObservers: [NSObjectProtocol] = []
+
+    /// True between `willStartLiveScroll` and `didEndLiveScroll`.
+    private var isLiveScrolling = false
+    /// `systemUptime` at the last `didEndLiveScroll`, or nil if a gesture has
+    /// never finished. Same timebase as `ACPUserScrollEvent`.
+    private var lastLiveScrollEnd: TimeInterval?
+
+    /// How long after a gesture ends the scroller still counts as
+    /// user-driven. Trackpad momentum and the elastic bounce-back keep moving
+    /// the viewport after `didEndLiveScroll`, and re-pinning to the tail
+    /// during that settle is precisely the rebound jank this guards against.
+    /// Matches `ACPUserScrollEvent.freshnessWindow` so the two notions of
+    /// "recent enough to be the user" cannot drift apart.
+    nonisolated static let userScrollGracePeriod: TimeInterval = ACPUserScrollEvent.freshnessWindow
+
+    /// Whether the user is scrolling right now, or has just stopped.
+    ///
+    /// This is the authoritative signal for user intent, and it exists
+    /// because `NSApp.currentEvent` is not: as the transcript slides under a
+    /// stationary cursor, AppKit generates `mouseEntered`/`mouseExited`
+    /// tracking events, and one of those — not the scroll wheel event — is
+    /// almost always what is current when the clip view posts its
+    /// bounds-change notification. A capture of one real gesture classified
+    /// 414 of 417 ticks as not-user-driven on that basis, which left
+    /// `pauseTailFollow()` unreachable and trapped the reader at the bottom
+    /// of the transcript (see `ACPTranscriptScrollerLiveScrollTests`).
+    ///
+    /// `NSScrollView` posts the live-scroll notifications only for genuine
+    /// user-driven scrolling — never for a programmatic `setBoundsOrigin` —
+    /// so this cleanly separates the two without inspecting events at all.
+    var isUserScrollActive: Bool {
+        Self.isUserScrollActive(
+            isLiveScrolling: isLiveScrolling,
+            lastLiveScrollEnd: lastLiveScrollEnd,
+            now: ProcessInfo.processInfo.systemUptime
+        )
+    }
+
+    /// Pure form of `isUserScrollActive`, so the grace-period boundary is
+    /// testable without waiting in real time.
+    nonisolated static func isUserScrollActive(
+        isLiveScrolling: Bool,
+        lastLiveScrollEnd: TimeInterval?,
+        now: TimeInterval,
+        grace: TimeInterval = userScrollGracePeriod
+    ) -> Bool {
+        if isLiveScrolling { return true }
+        guard let lastLiveScrollEnd else { return false }
+        return now - lastLiveScrollEnd <= grace
+    }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -80,6 +131,31 @@ final class ACPTranscriptScrollerView: NSScrollView {
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.reportScroll() }
         }
+        installLiveScrollObservers()
+    }
+
+    /// Tracks the scroll view's own live-scroll notifications, which is what
+    /// `isUserScrollActive` reports. Registered with `queue: nil` so the
+    /// flags are already current by the time the bounds-change notification
+    /// for the same gesture runs.
+    private func installLiveScrollObservers() {
+        let center = NotificationCenter.default
+        liveScrollObservers.append(center.addObserver(
+            forName: NSScrollView.willStartLiveScrollNotification, object: self, queue: nil
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.isLiveScrolling = true
+            }
+        })
+        liveScrollObservers.append(center.addObserver(
+            forName: NSScrollView.didEndLiveScrollNotification, object: self, queue: nil
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.isLiveScrolling = false
+                self.lastLiveScrollEnd = ProcessInfo.processInfo.systemUptime
+            }
+        })
     }
 
     @available(*, unavailable)
@@ -88,6 +164,9 @@ final class ACPTranscriptScrollerView: NSScrollView {
     deinit {
         if let boundsObserver {
             NotificationCenter.default.removeObserver(boundsObserver)
+        }
+        for observer in liveScrollObservers {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 
@@ -162,6 +241,8 @@ final class ACPTranscriptScrollerView: NSScrollView {
 
     func setScrollY(_ y: CGFloat) {
         let clamped = clampedScrollY(y)
+        if abs(clamped - scrollY) > 0.01 {
+        }
         performProgrammatic {
             contentView.setBoundsOrigin(NSPoint(x: contentView.bounds.origin.x, y: clamped))
             reflectScrolledClipView(contentView)
@@ -189,6 +270,7 @@ final class ACPTranscriptScrollerView: NSScrollView {
         guard newY != lastReportedY else { return }
         let previous = lastReportedY
         lastReportedY = newY
+        let maxY = max(0, contentHeight - viewportHeight)
         onScroll?(previous, newY, viewportHeight, contentHeight, programmaticAdjustmentDepth > 0)
     }
 }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
@@ -1,0 +1,184 @@
+import AppKit
+import Testing
+@testable import Alas
+
+/// Regression tests for the tail-follow trap at the bottom of the transcript.
+///
+/// The scroller used to infer "a human is scrolling" solely from
+/// `NSApp.currentEvent`. That is unreliable in an AppKit scroll view: as the
+/// transcript slides under a stationary cursor, AppKit generates a stream of
+/// `mouseEntered`/`mouseExited` tracking events, and those — not the scroll
+/// wheel event — are what is current when the clip view posts its
+/// bounds-change notification. A live capture of a single real gesture showed
+/// 414 of 417 scroll ticks classified as NOT user-driven (309 `mouseEntered`,
+/// 73 `mouseExited`, 28 `cursorUpdate`, versus 3 `scrollWheel`).
+///
+/// The consequence was a trap rather than a cosmetic misclassification:
+/// `ACPScrollDirectionClassifier.decide` only returns `.userScrolledUp` for a
+/// user-driven tick, so `pauseTailFollow()` never ran, `followsTail` stayed
+/// true, and every `remeasureRow`/`apply` re-pinned the viewport to the bottom
+/// via `scrollToBottom()`. The user was dragged back to the tail and could not
+/// scroll away at all while the session was streaming.
+///
+/// `NSScrollView`'s own live-scroll notifications are the authoritative signal
+/// — they are posted for genuine user scrolling and never for a programmatic
+/// `setBoundsOrigin` — so these tests drive them directly. Note that
+/// `NSApp.currentEvent` is nil throughout a unit-test run, which is exactly
+/// the condition the old code failed under.
+@MainActor
+@Suite("ACPTranscriptScroller live-scroll user intent")
+struct ACPTranscriptScrollerLiveScrollTests {
+    private func tailFollowingHost() -> (
+        host: ACPTranscriptScroller,
+        scroller: ACPTranscriptScrollerView,
+        coordinator: ACPTranscriptScroller.Coordinator
+    ) {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.followsTranscriptTail = true
+        let host = makeLiveScrollHost(session: session)
+        host.transcript.messages = (0..<120).map { _ in
+            ACPMessage.systemNotice(id: UUID(), text: String(repeating: "line ", count: 20))
+        }
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: 500))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        return (host, scroller, coordinator)
+    }
+
+    /// Moves the viewport the way a real trackpad gesture does: bracketed by
+    /// the scroll view's live-scroll notifications, with the clip view's
+    /// bounds set directly (NOT through `setScrollY`, which would mark the
+    /// change programmatic).
+    private func liveScroll(_ scroller: ACPTranscriptScrollerView, to y: CGFloat) {
+        NotificationCenter.default.post(
+            name: NSScrollView.willStartLiveScrollNotification, object: scroller
+        )
+        scroller.contentView.setBoundsOrigin(
+            NSPoint(x: scroller.contentView.bounds.origin.x, y: y)
+        )
+        scroller.reflectScrolledClipView(scroller.contentView)
+        NotificationCenter.default.post(
+            name: NSScrollView.didEndLiveScrollNotification, object: scroller
+        )
+    }
+
+    @Test("an upward live scroll past the pause tolerance pauses tail-follow, with no current NSEvent")
+    func liveScrollUpPausesTailFollow() {
+        // The coordinator must stay in scope: its `onScroll` closure captures
+        // it weakly, so binding it to `_` would silently disable every scroll
+        // handler under test.
+        let (host, scroller, coordinator) = tailFollowingHost()
+        #expect(host.session.followsTranscriptTail, "fixture should start following the tail")
+        #expect(scroller.distanceFromBottom < 1, "fixture should start pinned to the bottom")
+
+        // 470pt from the bottom: the furthest the real captured gesture got,
+        // and comfortably past `pauseTolerance` (160).
+        liveScroll(scroller, to: max(0, scroller.contentHeight - scroller.viewportHeight - 470))
+
+        #expect(
+            host.session.followsTranscriptTail == false,
+            "a deliberate upward scroll must pause tail-follow even though NSApp.currentEvent is not a scrollWheel"
+        )
+        withExtendedLifetime(coordinator) {}
+    }
+
+    @Test("after an upward live scroll, a tail row re-measuring does not drag the viewport back to the bottom")
+    func remeasureDoesNotYankBackAfterLiveScroll() {
+        let (_, scroller, coordinator) = tailFollowingHost()
+        let target = max(0, scroller.contentHeight - scroller.viewportHeight - 470)
+        liveScroll(scroller, to: target)
+        let yAfterScroll = scroller.scrollY
+        #expect(abs(yAfterScroll - target) < 1, "the live scroll itself should land where asked")
+
+        // The exact event that used to yank the user back: a mounted row
+        // re-measures while the reconciler still believes it is following the
+        // tail. This is constant during streaming (`acp-thought:`/`tc-*` rows).
+        #expect(
+            coordinator.mountedRowCountForTesting > 0,
+            "fixture must have mounted rows, or the re-pin path is never exercised"
+        )
+        coordinator.remeasureMountedRowsForTesting()
+
+        #expect(
+            abs(scroller.scrollY - yAfterScroll) < 1,
+            "the viewport must stay where the user left it, not snap back to the bottom"
+        )
+    }
+
+    @Test("a programmatic scroll is never mistaken for a user gesture")
+    func programmaticScrollDoesNotPauseTailFollow() {
+        let (host, scroller, coordinator) = tailFollowingHost()
+        // No live-scroll notifications: this is the app moving the viewport,
+        // which must not be read as the user abandoning the tail.
+        scroller.setScrollY(max(0, scroller.contentHeight - scroller.viewportHeight - 470))
+
+        #expect(
+            host.session.followsTranscriptTail,
+            "a programmatic offset change must not pause tail-follow"
+        )
+        withExtendedLifetime(coordinator) {}
+    }
+
+    @Test("live-scroll activity lapses after the gesture settles")
+    func userScrollActivityLapses() {
+        let (_, scroller, coordinator) = tailFollowingHost()
+        defer { withExtendedLifetime(coordinator) {} }
+        NotificationCenter.default.post(
+            name: NSScrollView.willStartLiveScrollNotification, object: scroller
+        )
+        #expect(scroller.isUserScrollActive, "a gesture in flight is user activity")
+
+        NotificationCenter.default.post(
+            name: NSScrollView.didEndLiveScrollNotification, object: scroller
+        )
+        // Still active immediately after the gesture ends: momentum and the
+        // elastic bounce-back are still the user's scroll, and re-pinning
+        // during that settle is exactly the rebound jank being fixed.
+        #expect(scroller.isUserScrollActive, "the settle right after a gesture is still user activity")
+
+        #expect(
+            ACPTranscriptScrollerView.isUserScrollActive(
+                isLiveScrolling: false,
+                lastLiveScrollEnd: 100,
+                now: 100 + ACPTranscriptScrollerView.userScrollGracePeriod + 0.01
+            ) == false,
+            "well after the gesture, the scroller is idle again"
+        )
+    }
+}
+
+@MainActor
+private func makeLiveScrollHost(session: ACPSession) -> ACPTranscriptScroller {
+    ACPTranscriptScroller(
+        session: session,
+        transcript: session.transcript,
+        contentMaxWidth: 800,
+        typography: .default,
+        trustedImageRoot: nil,
+        onOpenDiff: { _ in },
+        onLoadFullToolCallContent: { _ in nil },
+        forkTargets: [],
+        onFork: { _, _ in },
+        rememberedScrollAnchor: { nil },
+        onRememberScrollAnchor: { _, _, _ in },
+        onOpenTranscriptLink: { _ in true },
+        policy: nil,
+        scopeKey: "scope",
+        onUserInputResponse: { _, _ in },
+        onOpenElicitationURL: { _ in true },
+        onDismissElicitationURLWait: { _ in },
+        onQueueEdit: { _ in },
+        onQueueForceSend: { _ in },
+        onQueueRemove: { _ in },
+        onQueueRetry: { _ in },
+        onQueueReorder: { _, _ in },
+        onQueueClearAll: {},
+        onRetryContextRecovery: {},
+        onOpenForkSource: { _ in },
+        agentDisplayName: { $0 }
+    )
+}


### PR DESCRIPTION
Rebased onto `main` (now includes #950). Scope is narrower than the original description: #950 already fixed the re-pin-during-gesture problem, so what remains here is the one gap it left open.

## The gap

#950 established that `NSApp.currentEvent` is unusable as a scroll-intent signal under responsive scrolling — it measured 1176 of 1209 ticks (97%) as not-user-driven. It removed that gate from the pagination decisions and neutralised the re-pin with `noteUserScroll()` / `repinsToTail(followsTail:wasFollowingTail:)`, which use the reliable programmatic/non-programmatic split.

It deliberately left the gate in place for the tail-follow **pause**:

```swift
let isHeadPaginationDriven = ACPUserScrollEvent.isHeadPaginationDriven(...)
decide(..., isUserDriven: isHeadPaginationDriven)
```

`ACPScrollDirectionClassifier.decide` only returns `.userScrolledUp` for a user-driven tick, so `pauseTailFollow()` fires only on the ~3% of ticks that coincide with a recognisable fresh event. A reader who scrolls up out of the tail therefore keeps `session.followsTranscriptTail` set. During the gesture that is harmless — `repinsToTail` suppresses the re-pin — but the suppression window is deliberately short-lived ("everything the window suppresses is behavior the user gets back the moment they stop"). Once the gesture ends, `repinsToTail` returns `!isUserScrollInFlight()` → `true`, and the next update pins them back to the bottom.

An independent capture on this branch measured the same signal quality: **414 of 417** ticks not-user-driven (`mouseEntered` 309x, `mouseExited` 73x, `cursorUpdate` 28x, `scrollWheel` 3x), `pauseTailFollow()` called **0** times across a gesture that reached 470pt from the bottom — well past the 160pt `pauseTolerance`.

## Fix

`ACPTranscriptScrollerView` tracks the scroll view's own `willStartLiveScroll`/`didEndLiveScroll` notifications, which AppKit posts only for genuine user scrolling and never for a programmatic `setBoundsOrigin`, and exposes `isUserScrollActive` with a grace period (matching `ACPUserScrollEvent.freshnessWindow`) so momentum and the elastic bounce still count as the gesture.

That is OR-ed into `isHeadPaginationDriven`, the pause gate only. Pagination stays geometric, exactly as #950 left it. The existing event test is kept alongside, since it covers input that never opens a live-scroll session (scrollbar-track click, magnify, swipe).

This is complementary to `noteUserScroll()` rather than a replacement: that one answers "is a gesture in flight right now" to suppress re-pinning; this one answers "was this tick the user" so the pause can latch and the state converges instead of relying on the suppression window.

## Tests

New suite `ACPTranscriptScrollerLiveScrollTests` (4 tests). `NSApp.currentEvent` is nil throughout a unit-test run, which is exactly the condition the old gate failed under:

- an upward live scroll past the pause tolerance pauses tail-follow
- a tail row re-measuring afterwards does not drag the viewport back
- a programmatic scroll is not mistaken for a user gesture
- live-scroll activity lapses after the gesture settles

111 tests across 11 scroller suites pass, including #950's `ACPTranscriptScrollerScrollBackTests`.

## Follow-ups (not in this PR)

- `headStepThreshold` is `max(1500, viewportHeight * 2)`, an absolute distance from the document top. On a transcript whose whole scroll range is smaller than that, head pagination fires even at the bottom; a capture showed a 30-row insert growing the document 2041pt mid-gesture.
- Every streaming tick classifies as `.reset` (59 in 15s, unchanged row count), each re-measuring rows into slightly different heights and wandering the document height by 16-58pt.