### PR TITLE
fix(changed): file row clicks

### DIFF
--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -47,7 +47,6 @@ struct ChangedRow: View {
                         .truncationMode(.middle)
                 }
                 .contentShape(Rectangle())
-                .dragOut { dragPayload?() }
                 Spacer()
                 if add > 0 { Text("+\(add)").foregroundColor(theme.color("add")) }
                 if del > 0 { Text("−\(del)").foregroundColor(theme.color("del")) }
@@ -92,6 +91,7 @@ struct ChangedRow: View {
                 ignoreMenu
             }
         }
+        .dragOut { dragPayload?() }
     }
 }
 


### PR DESCRIPTION
## What changed

Moves the changed-file drag-out modifier from the filename label to the containing row button.

## Why

The nested drag gesture consumed ordinary clicks on working-tree changed-file rows, preventing file selection. Applying it to the button matches the established behavior in other draggable rows while retaining drag-out support.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DragOutActivationTests test` (5 tests passed)

The full macOS suite currently hits a reproducible, unrelated failure/hang in `MissionCoordinatorTests.restart advances creating legs independently`.