### PR TITLE
feat(missions): prefill manual ticket metadata

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
 		0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */; };
+		0DC76A1F203DBF3A0076E308 /* WebPageMetadataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C57BE3DB7A4035DCF3705C /* WebPageMetadataFetcher.swift */; };
 		0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */; };
 		0E054800F6B09275885CF5B6 /* GGMutationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70E37676F2A14E6C9E84B2D /* GGMutationCoordinatorTests.swift */; };
 		0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */; };
@@ -835,6 +836,7 @@
 		8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */; };
 		8FA22790805C973E9EF64477 /* EditorLSPStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */; };
 		8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */; };
+		8FCE76D3F04703C25B443C0C /* WebPageMetadataFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D50D01BE1271F22DD2ED1A0 /* WebPageMetadataFetcherTests.swift */; };
 		8FD71F989EFA5BF22B92B4CD /* SidebarMaterialChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */; };
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
 		8FFF1CF8720587ADC3FFA688 /* DiffReviewSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312DC027D433B496FD010F85 /* DiffReviewSurfaceTests.swift */; };
@@ -1681,6 +1683,7 @@
 		1CA759D2C99D1FEE3C67A1BA /* RemoteImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageCacheTests.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
+		1D50D01BE1271F22DD2ED1A0 /* WebPageMetadataFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageMetadataFetcherTests.swift; sourceTree = "<group>"; };
 		1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrationStateTests.swift; sourceTree = "<group>"; };
 		1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatusTests.swift; sourceTree = "<group>"; };
 		1EC659A56A08A30F7784428D /* ACPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPClient.swift; sourceTree = "<group>"; };
@@ -1825,6 +1828,7 @@
 		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
 		35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
 		35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelper.swift; sourceTree = "<group>"; };
+		35C57BE3DB7A4035DCF3705C /* WebPageMetadataFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageMetadataFetcher.swift; sourceTree = "<group>"; };
 		35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilterTests.swift; sourceTree = "<group>"; };
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHostTests.swift; sourceTree = "<group>"; };
@@ -4628,6 +4632,7 @@
 				F3BF7A5409A551E913EED82F /* MissionStore.swift */,
 				FC5B49C51E7A8F1FB5226777 /* MissionTabView.swift */,
 				246D436645310B14BB2874A5 /* NewMissionDialog.swift */,
+				35C57BE3DB7A4035DCF3705C /* WebPageMetadataFetcher.swift */,
 			);
 			path = Missions;
 			sourceTree = "<group>";
@@ -4846,6 +4851,7 @@
 				78FFB4147D92264DEEB09DB7 /* MissionTabTests.swift */,
 				F90F265EBA9431630D56836C /* MissionTestFixtures.swift */,
 				4F8159507CB24E70049E75FA /* NewMissionDialogTests.swift */,
+				1D50D01BE1271F22DD2ED1A0 /* WebPageMetadataFetcherTests.swift */,
 			);
 			path = Missions;
 			sourceTree = "<group>";
@@ -6566,6 +6572,7 @@
 				C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */,
 				DAA0AFA398C02EC663708825 /* ViewDragOut.swift in Sources */,
 				B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */,
+				0DC76A1F203DBF3A0076E308 /* WebPageMetadataFetcher.swift in Sources */,
 				7C286DF876CD8F71D07B6A93 /* WebSocketFrame.swift in Sources */,
 				4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */,
 				CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */,
@@ -7235,6 +7242,7 @@
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
 				0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */,
+				8FCE76D3F04703C25B443C0C /* WebPageMetadataFetcherTests.swift in Sources */,
 				2DDF8175D7490F505AED7DF4 /* WebSocketFrameTests.swift in Sources */,
 				175AA2192F1DBD9836E08E77 /* WorkingTreeChangeGroupTests.swift in Sources */,
 				9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */,

--- a/Alas/Sources/Missions/MissionSourceProvider.swift
+++ b/Alas/Sources/Missions/MissionSourceProvider.swift
@@ -124,9 +124,10 @@ struct ManualMissionSourceProvider: MissionSourceProviding {
         guard case .url(let url) = reference else {
             throw CodeHostProviderError.malformedOutput("Enter an issue number or an absolute HTTP(S) URL.")
         }
-        let metadata = try? await metadataFetcher?.metadata(for: url)
+        let metadata = (try? await metadataFetcher?.metadata(for: url))
+            .flatMap { Self.metadataDescribingInput($0, inputURL: url) }
         let source = try Self.snapshot(
-            for: metadata?.canonicalURL ?? url,
+            for: url,
             displayReference: metadata?.displayReference,
             providerLabel: metadata?.providerLabel,
             title: metadata?.title ?? "",
@@ -215,6 +216,47 @@ struct ManualMissionSourceProvider: MissionSourceProviding {
         return best.count == 1 ? best[0].id : nil
     }
 
+    private static func metadataDescribingInput(
+        _ metadata: WebPageMetadata,
+        inputURL: URL
+    ) -> WebPageMetadata? {
+        guard !looksLikeAuthenticationPage(metadata),
+              canonicalURL(metadata.canonicalURL, describes: inputURL, displayReference: metadata.displayReference)
+        else { return nil }
+        return metadata
+    }
+
+    private static func canonicalURL(
+        _ canonicalURL: URL,
+        describes inputURL: URL,
+        displayReference: String?
+    ) -> Bool {
+        guard canonicalURL.host?.caseInsensitiveCompare(inputURL.host ?? "") == .orderedSame else {
+            return false
+        }
+        if normalizedPath(canonicalURL.path) == normalizedPath(inputURL.path) {
+            return true
+        }
+        guard let displayReference, !displayReference.isEmpty else { return false }
+        return inputURL.absoluteString.range(
+            of: displayReference,
+            options: [.caseInsensitive, .diacriticInsensitive]
+        ) != nil
+    }
+
+    private static func looksLikeAuthenticationPage(_ metadata: WebPageMetadata) -> Bool {
+        let title = metadata.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !title.isEmpty else { return false }
+        let authenticationTitles = [
+            "log in",
+            "login",
+            "sign in",
+            "signin",
+            "authentication required",
+        ]
+        return authenticationTitles.contains { title == $0 || title.hasPrefix("\($0) ") || title.hasPrefix("\($0) -") }
+    }
+
     private static func projectNameScore(_ project: ProjectConfig, context: String) -> Int {
         let names = Set([
             project.name.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -249,11 +291,15 @@ struct ManualMissionSourceProvider: MissionSourceProviding {
     }
 
     private static func normalizedRepositoryPath(_ path: String) -> String {
-        var normalized = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        var normalized = normalizedPath(path)
         if normalized.lowercased().hasSuffix(".git") {
             normalized.removeLast(4)
         }
         return normalized.lowercased()
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        path.trimmingCharacters(in: CharacterSet(charactersIn: "/")).lowercased()
     }
 
     static func canonicalURL(_ url: URL) throws -> URL {

--- a/Alas/Sources/Missions/MissionSourceProvider.swift
+++ b/Alas/Sources/Missions/MissionSourceProvider.swift
@@ -104,6 +104,11 @@ private extension MissionSourceReference {
 
 struct ManualMissionSourceProvider: MissionSourceProviding {
     let id: MissionSourceProviderID = .manual
+    private let metadataFetcher: WebPageMetadataFetcher?
+
+    init(metadataFetcher: WebPageMetadataFetcher? = nil) {
+        self.metadataFetcher = metadataFetcher
+    }
 
     func recognizes(_ reference: MissionSourceReference) -> Bool {
         guard case .url = reference else { return false }
@@ -119,12 +124,29 @@ struct ManualMissionSourceProvider: MissionSourceProviding {
         guard case .url(let url) = reference else {
             throw CodeHostProviderError.malformedOutput("Enter an issue number or an absolute HTTP(S) URL.")
         }
-        let source = try Self.snapshot(for: url)
+        let metadata = try? await metadataFetcher?.metadata(for: url)
+        let source = try Self.snapshot(
+            for: metadata?.canonicalURL ?? url,
+            displayReference: metadata?.displayReference,
+            providerLabel: metadata?.providerLabel,
+            title: metadata?.title ?? "",
+            body: metadata?.summary ?? ""
+        )
+        let inferredProjectID: String?
+        if let metadata {
+            inferredProjectID = await self.inferredProjectID(
+                for: metadata,
+                projects: projects,
+                remotes: remotes
+            )
+        } else {
+            inferredProjectID = nil
+        }
         return .init(
             source: source,
             repositoryLocator: nil,
             candidateProjectIDs: projects.map(\.id),
-            selectedProjectID: selectedProjectID
+            selectedProjectID: inferredProjectID ?? selectedProjectID
         )
     }
 
@@ -141,19 +163,23 @@ struct ManualMissionSourceProvider: MissionSourceProviding {
         identity: MissionSourceIdentity? = nil,
         repositoryLocator: MissionRepositoryLocator? = nil,
         displayReference: String? = nil,
+        providerLabel: String? = nil,
+        title: String = "",
+        body: String = "",
         isRefreshable: Bool = false
     ) throws -> MissionSourceSnapshot {
         let canonicalURL = try canonicalURL(url)
         return .init(
             identity: identity ?? .init(providerID: .manual, stableID: canonicalURL.absoluteString),
             canonicalURL: canonicalURL,
-            providerLabel: repositoryLocator?.provider.displayName
+            providerLabel: providerLabel
+                ?? repositoryLocator?.provider.displayName
                 ?? URLComponents(url: canonicalURL, resolvingAgainstBaseURL: false)?.host
                 ?? "Manual",
             displayReference: displayReference,
             repositoryLocator: repositoryLocator,
-            title: "",
-            body: "",
+            title: title,
+            body: body,
             state: .unknown,
             labels: [],
             assignees: [],
@@ -164,6 +190,70 @@ struct ManualMissionSourceProvider: MissionSourceProviding {
             isEditable: true,
             isRefreshable: isRefreshable
         )
+    }
+
+    private func inferredProjectID(
+        for metadata: WebPageMetadata,
+        projects: [ProjectConfig],
+        remotes: @escaping @Sendable (ProjectConfig) async throws -> [GitRemote]
+    ) async -> String? {
+        let context = "\(metadata.title)\n\(metadata.summary)"
+        var scores: [(id: String, score: Int)] = []
+        for project in projects {
+            var score = Self.projectNameScore(project, context: context)
+            if let projectRemotes = try? await remotes(project) {
+                for remote in CodeHostRemoteDetector.detectAll(from: projectRemotes) {
+                    score = max(score, Self.remoteScore(remote, metadata: metadata))
+                }
+            }
+            if score > 0 {
+                scores.append((project.id, score))
+            }
+        }
+        guard let highest = scores.map(\.score).max() else { return nil }
+        let best = scores.filter { $0.score == highest }
+        return best.count == 1 ? best[0].id : nil
+    }
+
+    private static func projectNameScore(_ project: ProjectConfig, context: String) -> Int {
+        let names = Set([
+            project.name.trimmingCharacters(in: .whitespacesAndNewlines),
+            URL(fileURLWithPath: project.path).lastPathComponent,
+        ])
+        return names.contains { name in
+            name.count >= 3 && context.range(
+                of: name,
+                options: [.caseInsensitive, .diacriticInsensitive]
+            ) != nil
+        } ? 10 : 0
+    }
+
+    private static func remoteScore(
+        _ remote: CodeHostRemote,
+        metadata: WebPageMetadata
+    ) -> Int {
+        let remoteHost = remote.webURL.host?.lowercased()
+        let remotePath = normalizedRepositoryPath(remote.webURL.path)
+        if metadata.links.contains(where: { link in
+            guard link.host?.lowercased() == remoteHost else { return false }
+            let linkPath = normalizedRepositoryPath(link.path)
+            return linkPath == remotePath || linkPath.hasPrefix("\(remotePath)/")
+        }) {
+            return 100
+        }
+        let context = "\(metadata.title)\n\(metadata.summary)"
+        return context.range(
+            of: remote.repositorySlug,
+            options: [.caseInsensitive, .diacriticInsensitive]
+        ) == nil ? 0 : 50
+    }
+
+    private static func normalizedRepositoryPath(_ path: String) -> String {
+        var normalized = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if normalized.lowercased().hasSuffix(".git") {
+            normalized.removeLast(4)
+        }
+        return normalized.lowercased()
     }
 
     static func canonicalURL(_ url: URL) throws -> URL {

--- a/Alas/Sources/Missions/NewMissionDialog.swift
+++ b/Alas/Sources/Missions/NewMissionDialog.swift
@@ -245,8 +245,8 @@ final class NewMissionDialogModel {
             projectID: projectId
         )
         branchIsUserOwned = false
-        sourceTitle = resolution.source.contentOrigin == .manual ? "" : resolution.source.title
-        sourceBody = resolution.source.contentOrigin == .manual ? "" : resolution.source.body
+        sourceTitle = resolution.source.title
+        sourceBody = resolution.source.body
         prompt = MissionPromptBuilder.build(source: resolution.source)
         promptIsUserOwned = false
         agentId = agentOptions.first?.id ?? ""
@@ -909,7 +909,7 @@ extension NewMissionDialogModel.Environment {
                     providers: MissionSourceProviderRegistry([
                         CodeHostMissionSourceProvider(kind: .github, providers: .live()),
                         CodeHostMissionSourceProvider(kind: .gitlab, providers: .live()),
-                        ManualMissionSourceProvider()
+                        ManualMissionSourceProvider(metadataFetcher: .live)
                     ])
                 ))
                 return try await resolver.resolve(reference)

--- a/Alas/Sources/Missions/WebPageMetadataFetcher.swift
+++ b/Alas/Sources/Missions/WebPageMetadataFetcher.swift
@@ -1,0 +1,448 @@
+import Foundation
+
+struct WebPageMetadata: Equatable, Sendable {
+    let canonicalURL: URL
+    let providerLabel: String
+    let displayReference: String?
+    let title: String
+    let summary: String
+    let links: [URL]
+}
+
+struct WebPageMetadataFetcher: Sendable {
+    struct Response: Sendable {
+        let data: Data
+        let url: URL
+        let mimeType: String?
+        let textEncodingName: String?
+    }
+
+    enum FetchError: LocalizedError {
+        case unsupportedContent
+        case responseTooLarge
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedContent:
+                "The linked page did not return HTML."
+            case .responseTooLarge:
+                "The linked page is too large to inspect."
+            }
+        }
+    }
+
+    typealias Fetch = @Sendable (URL) async throws -> Response
+
+    private static let maximumResponseSize = 2 * 1_024 * 1_024
+    private let fetch: Fetch
+
+    init(fetch: @escaping Fetch) {
+        self.fetch = fetch
+    }
+
+    func metadata(for url: URL) async throws -> WebPageMetadata {
+        let response = try await fetch(url)
+        guard response.data.count <= Self.maximumResponseSize else {
+            throw FetchError.responseTooLarge
+        }
+        if let mimeType = response.mimeType?.lowercased(),
+           !mimeType.contains("html") && mimeType != "text/plain" {
+            throw FetchError.unsupportedContent
+        }
+        let html = Self.decode(response.data, encodingName: response.textEncodingName)
+        return Self.parse(html: html, url: response.url)
+    }
+
+    static let live = Self(fetch: defaultFetch)
+
+    static func parse(html: String, url: URL) -> WebPageMetadata {
+        let metadata = metaValues(in: html)
+        let jsonLD = jsonLDValues(in: html)
+        let providerLabel = providerLabel(for: url, html: html)
+        let rawTitle = firstNonempty(
+            metadata["og:title"],
+            metadata["twitter:title"],
+            metadata["ajs-page-title"],
+            jsonLD.title,
+            firstCapture(in: html, pattern: #"(?is)<title\b[^>]*>(.*?)</title>"#)
+        )
+        let rawSummary = firstNonempty(
+            metadata["og:description"],
+            metadata["twitter:description"],
+            metadata["description"],
+            jsonLD.summary
+        )
+        let canonical = canonicalURL(in: html, relativeTo: url) ?? url
+        return WebPageMetadata(
+            canonicalURL: canonical,
+            providerLabel: providerLabel,
+            displayReference: displayReference(for: canonical, providerLabel: providerLabel, metadata: metadata),
+            title: cleanTitle(plainText(rawTitle ?? ""), providerLabel: providerLabel),
+            summary: limited(plainText(rawSummary ?? ""), to: 8_000),
+            links: links(in: html, relativeTo: canonical)
+        )
+    }
+
+    private static func defaultFetch(_ url: URL) async throws -> Response {
+        var request = URLRequest(url: url, timeoutInterval: 12)
+        request.setValue(
+            "text/html,application/xhtml+xml;q=0.9,text/plain;q=0.5",
+            forHTTPHeaderField: "Accept"
+        )
+        request.setValue("Alas/1.0", forHTTPHeaderField: "User-Agent")
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.httpShouldSetCookies = false
+        let session = URLSession(configuration: configuration)
+        defer { session.finishTasksAndInvalidate() }
+        let (bytes, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode),
+              let responseURL = http.url
+        else {
+            throw URLError(.badServerResponse)
+        }
+        var data = Data()
+        let expectedSize = http.expectedContentLength > 0 ? Int(http.expectedContentLength) : 0
+        data.reserveCapacity(min(expectedSize, maximumResponseSize))
+        for try await byte in bytes {
+            guard data.count < maximumResponseSize else {
+                throw FetchError.responseTooLarge
+            }
+            data.append(byte)
+        }
+        return Response(
+            data: data,
+            url: responseURL,
+            mimeType: http.mimeType,
+            textEncodingName: http.textEncodingName
+        )
+    }
+
+    private static func decode(_ data: Data, encodingName: String?) -> String {
+        let encoding: String.Encoding? = switch encodingName?.lowercased() {
+        case "iso-8859-1", "latin1":
+            .isoLatin1
+        case "windows-1252":
+            .windowsCP1252
+        case "us-ascii":
+            .ascii
+        default:
+            nil
+        }
+        if let encoding, let decoded = String(data: data, encoding: encoding) {
+            return decoded
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func metaValues(in html: String) -> [String: String] {
+        var values: [String: String] = [:]
+        for tag in matches(in: html, pattern: #"(?is)<meta\b[^>]*>"#) {
+            let attributes = attributes(in: tag)
+            guard let key = (attributes["property"] ?? attributes["name"])?.lowercased(),
+                  let content = attributes["content"],
+                  values[key] == nil
+            else { continue }
+            values[key] = content
+        }
+        return values
+    }
+
+    private static func canonicalURL(in html: String, relativeTo baseURL: URL) -> URL? {
+        for tag in matches(in: html, pattern: #"(?is)<link\b[^>]*>"#) {
+            let attributes = attributes(in: tag)
+            guard attributes["rel"]?.lowercased().split(separator: " ").contains("canonical") == true,
+                  let href = attributes["href"],
+                  let url = URL(string: decodeEntities(href), relativeTo: baseURL)?.absoluteURL,
+                  ["http", "https"].contains(url.scheme?.lowercased() ?? "")
+            else { continue }
+            return url
+        }
+        return nil
+    }
+
+    private static func links(in html: String, relativeTo baseURL: URL) -> [URL] {
+        var results: [URL] = []
+        var seen: Set<String> = []
+        let decodedEscapes = html
+            .replacingOccurrences(of: #"\/"#, with: "/")
+            .replacingOccurrences(of: #"\u002F"#, with: "/", options: .caseInsensitive)
+
+        for tag in matches(in: decodedEscapes, pattern: #"(?is)<a\b[^>]*>"#) {
+            guard let href = attributes(in: tag)["href"],
+                  let url = URL(string: decodeEntities(href), relativeTo: baseURL)?.absoluteURL
+            else { continue }
+            append(url, to: &results, seen: &seen)
+        }
+        for rawURL in matches(in: decodedEscapes, pattern: #"(?i)https?://[^\s"'<>]+"#) {
+            let trimmed = rawURL.trimmingCharacters(in: CharacterSet(charactersIn: ".,);]}"))
+            guard let url = URL(string: decodeEntities(trimmed)) else { continue }
+            append(url, to: &results, seen: &seen)
+        }
+        return results
+    }
+
+    private static func append(_ url: URL, to results: inout [URL], seen: inout Set<String>) {
+        guard ["http", "https"].contains(url.scheme?.lowercased() ?? "") else { return }
+        let key = url.absoluteString
+        guard seen.insert(key).inserted else { return }
+        results.append(url)
+    }
+
+    private static func providerLabel(for url: URL, html: String) -> String {
+        let host = url.host?.lowercased() ?? ""
+        let path = url.path.lowercased()
+        let lowercasedHTML = html.lowercased()
+        if host == "linear.app" || host.hasSuffix(".linear.app") || host.contains("linear.") {
+            return "Linear"
+        }
+        if host == "trello.com" || host.hasSuffix(".trello.com") {
+            return "Trello"
+        }
+        if host.contains("jira") || host.contains("atlassian")
+            || path.contains("/browse/") || lowercasedHTML.contains("ajs-issue-key") {
+            return "Jira"
+        }
+        if host == "app.asana.com" || host.hasSuffix(".asana.com") {
+            return "Asana"
+        }
+        if host == "app.shortcut.com" || host.hasSuffix(".shortcut.com") {
+            return "Shortcut"
+        }
+        if host.contains("clickup.com") {
+            return "ClickUp"
+        }
+        if host.contains("monday.com") {
+            return "Monday"
+        }
+        return host.isEmpty ? "Manual" : host
+    }
+
+    private static func displayReference(
+        for url: URL,
+        providerLabel: String,
+        metadata: [String: String]
+    ) -> String? {
+        if providerLabel == "Jira" {
+            if let key = metadata["ajs-issue-key"], !key.isEmpty {
+                return key.uppercased()
+            }
+            return firstCapture(
+                in: url.path,
+                pattern: #"(?i)/browse/([a-z][a-z0-9]+-\d+)(?:/|$)"#,
+                captureGroup: 1
+            )?.uppercased()
+        }
+        if providerLabel == "Linear" {
+            return firstCapture(
+                in: url.path,
+                pattern: #"(?i)/issue/([a-z][a-z0-9]+-\d+)(?:/|$)"#,
+                captureGroup: 1
+            )?.uppercased()
+        }
+        if providerLabel == "Trello" {
+            return firstCapture(
+                in: url.path,
+                pattern: #"(?i)/c/([^/]+)"#,
+                captureGroup: 1
+            )
+        }
+        return nil
+    }
+
+    private static func cleanTitle(_ title: String, providerLabel: String) -> String {
+        var title = limited(title, to: 300)
+        let suffixes = [
+            " | \(providerLabel)",
+            " · \(providerLabel)",
+            " - \(providerLabel)",
+            " on \(providerLabel)",
+            " - Atlassian Jira",
+            " | Atlassian",
+        ]
+        for suffix in suffixes where title.range(
+            of: suffix,
+            options: [.caseInsensitive, .anchored, .backwards]
+        ) != nil {
+            title.removeLast(suffix.count)
+            title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            break
+        }
+        return title
+    }
+
+    private static func plainText(_ value: String) -> String {
+        let withoutTags = replacingMatches(
+            in: value,
+            pattern: #"(?is)<[^>]+>"#,
+            with: " "
+        )
+        let decoded = decodeEntities(withoutTags)
+        return replacingMatches(in: decoded, pattern: #"\s+"#, with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func decodeEntities(_ value: String) -> String {
+        var decoded = value
+        let named = [
+            "&amp;": "&",
+            "&quot;": "\"",
+            "&#39;": "'",
+            "&apos;": "'",
+            "&lt;": "<",
+            "&gt;": ">",
+            "&nbsp;": " ",
+        ]
+        for (entity, replacement) in named {
+            decoded = decoded.replacingOccurrences(
+                of: entity,
+                with: replacement,
+                options: .caseInsensitive
+            )
+        }
+        guard let expression = try? NSRegularExpression(pattern: #"&#(x?[0-9a-fA-F]+);"#) else {
+            return decoded
+        }
+        let matches = expression.matches(
+            in: decoded,
+            range: NSRange(decoded.startIndex..., in: decoded)
+        )
+        for match in matches.reversed() {
+            guard let fullRange = Range(match.range(at: 0), in: decoded),
+                  let valueRange = Range(match.range(at: 1), in: decoded)
+            else { continue }
+            let raw = String(decoded[valueRange])
+            let radix = raw.lowercased().hasPrefix("x") ? 16 : 10
+            let digits = radix == 16 ? String(raw.dropFirst()) : raw
+            guard let number = UInt32(digits, radix: radix),
+                  let scalar = UnicodeScalar(number)
+            else { continue }
+            decoded.replaceSubrange(fullRange, with: String(scalar))
+        }
+        return decoded
+    }
+
+    private static func jsonLDValues(in html: String) -> (title: String?, summary: String?) {
+        var candidates: [(score: Int, title: String?, summary: String?)] = []
+        for tag in matches(in: html, pattern: #"(?is)<script\b[^>]*>.*?</script>"#) {
+            guard let openingEnd = tag.firstIndex(of: ">") else { continue }
+            let opening = String(tag[...openingEnd])
+            guard attributes(in: opening)["type"]?.lowercased() == "application/ld+json" else {
+                continue
+            }
+            let contentStart = tag.index(after: openingEnd)
+            guard let closingStart = tag.range(
+                of: "</script",
+                options: [.caseInsensitive, .backwards]
+            )?.lowerBound else { continue }
+            let content = String(tag[contentStart..<closingStart])
+            guard let data = content.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data)
+            else { continue }
+            collectJSONLDCandidates(object, into: &candidates)
+        }
+        let best = candidates.max { lhs, rhs in lhs.score < rhs.score }
+        return (best?.title, best?.summary)
+    }
+
+    private static func collectJSONLDCandidates(
+        _ value: Any,
+        into candidates: inout [(score: Int, title: String?, summary: String?)]
+    ) {
+        if let dictionary = value as? [String: Any] {
+            let type = (dictionary["@type"] as? String)?.lowercased() ?? ""
+            let title = dictionary["headline"] as? String
+                ?? dictionary["name"] as? String
+                ?? dictionary["title"] as? String
+            let summary = dictionary["description"] as? String
+            var score = title == nil ? 0 : 1
+            if ["issue", "task", "ticket", "article", "creativework"].contains(where: type.contains) {
+                score += 3
+            }
+            if title != nil || summary != nil {
+                candidates.append((score, title, summary))
+            }
+            for child in dictionary.values {
+                collectJSONLDCandidates(child, into: &candidates)
+            }
+        } else if let array = value as? [Any] {
+            for child in array {
+                collectJSONLDCandidates(child, into: &candidates)
+            }
+        }
+    }
+
+    private static func attributes(in tag: String) -> [String: String] {
+        guard let expression = try? NSRegularExpression(
+            pattern: #"([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))"#
+        ) else { return [:] }
+        let matches = expression.matches(
+            in: tag,
+            range: NSRange(tag.startIndex..., in: tag)
+        )
+        var attributes: [String: String] = [:]
+        for match in matches {
+            guard let nameRange = Range(match.range(at: 1), in: tag) else { continue }
+            let value = (2...4).compactMap { group -> String? in
+                guard match.range(at: group).location != NSNotFound,
+                      let range = Range(match.range(at: group), in: tag)
+                else { return nil }
+                return String(tag[range])
+            }.first ?? ""
+            attributes[String(tag[nameRange]).lowercased()] = decodeEntities(value)
+        }
+        return attributes
+    }
+
+    private static func firstNonempty(_ values: String?...) -> String? {
+        values.first { value in
+            guard let value else { return false }
+            return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        } ?? nil
+    }
+
+    private static func matches(in value: String, pattern: String) -> [String] {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return [] }
+        return expression.matches(
+            in: value,
+            range: NSRange(value.startIndex..., in: value)
+        ).compactMap { match in
+            Range(match.range, in: value).map { String(value[$0]) }
+        }
+    }
+
+    private static func firstCapture(
+        in value: String,
+        pattern: String,
+        captureGroup: Int = 1
+    ) -> String? {
+        guard let expression = try? NSRegularExpression(pattern: pattern),
+              let match = expression.firstMatch(
+                  in: value,
+                  range: NSRange(value.startIndex..., in: value)
+              ),
+              match.numberOfRanges > captureGroup,
+              let range = Range(match.range(at: captureGroup), in: value)
+        else { return nil }
+        return String(value[range])
+    }
+
+    private static func replacingMatches(
+        in value: String,
+        pattern: String,
+        with replacement: String
+    ) -> String {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return value }
+        return expression.stringByReplacingMatches(
+            in: value,
+            range: NSRange(value.startIndex..., in: value),
+            withTemplate: replacement
+        )
+    }
+
+    private static func limited(_ value: String, to maximumLength: Int) -> String {
+        guard value.count > maximumLength else { return value }
+        return String(value.prefix(maximumLength)).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/AlasTests/Missions/MissionSourceResolverTests.swift
+++ b/AlasTests/Missions/MissionSourceResolverTests.swift
@@ -25,6 +25,58 @@ struct MissionSourceResolverTests {
         #expect(await recorder.resolveCount == 0)
     }
 
+    @Test func arbitraryURLPrefillsMetadataAndInfersRepositoryProject() async throws {
+        let fetcher = WebPageMetadataFetcher { url in
+            let html = """
+            <meta property="og:title" content="ALAS-123 Fix delayed refresh | Linear">
+            <meta property="og:description" content="Update the sync logic.">
+            <a href="https://github.com/acme/alas/pull/99">Implementation</a>
+            """
+            return .init(
+                data: Data(html.utf8),
+                url: url,
+                mimeType: "text/html",
+                textEncodingName: "utf-8"
+            )
+        }
+        let resolver = MissionSourceResolver(environment: Self.environment(
+            providers: .init([ManualMissionSourceProvider(metadataFetcher: fetcher)]),
+            remotes: { project in
+                let slug = project.id == Self.projectA.id ? "acme/alas" : "other/project"
+                return [GitRemote(name: "origin", url: "git@github.com:\(slug).git")]
+            }
+        ))
+
+        let result = try await resolver.resolve(
+            "https://linear.app/acme/issue/ALAS-123/fix-delayed-refresh"
+        )
+
+        #expect(result.source.providerLabel == "Linear")
+        #expect(result.source.displayReference == "ALAS-123")
+        #expect(result.source.title == "ALAS-123 Fix delayed refresh")
+        #expect(result.source.body == "Update the sync logic.")
+        #expect(result.source.contentOrigin == .manual)
+        #expect(result.source.isEditable)
+        #expect(result.candidateProjectIDs == ["project-a", "project-b"])
+        #expect(result.selectedProjectID == "project-a")
+    }
+
+    @Test func failedArbitraryURLFetchStillProducesBlankManualSource() async throws {
+        let fetcher = WebPageMetadataFetcher { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        let resolver = MissionSourceResolver(environment: Self.environment(
+            providers: .init([ManualMissionSourceProvider(metadataFetcher: fetcher)])
+        ))
+
+        let result = try await resolver.resolve("https://example.com/tickets/ALAS-123")
+
+        #expect(result.source.title.isEmpty)
+        #expect(result.source.body.isEmpty)
+        #expect(result.source.providerLabel == "example.com")
+        #expect(result.selectedProjectID == "project-b")
+    }
+
     @Test func unconfiguredIssuesURLBecomesPlainManualSource() async throws {
         let recorder = SourceProviderRecorder()
         let resolver = MissionSourceResolver(environment: Self.environment(recorder: recorder))

--- a/AlasTests/Missions/MissionSourceResolverTests.swift
+++ b/AlasTests/Missions/MissionSourceResolverTests.swift
@@ -77,6 +77,39 @@ struct MissionSourceResolverTests {
         #expect(result.selectedProjectID == "project-b")
     }
 
+    @Test func loginPageMetadataDoesNotReplaceOriginalTicketURL() async throws {
+        let fetcher = WebPageMetadataFetcher { _ in
+            let html = """
+            <html>
+              <head>
+                <title>Log in - Jira</title>
+                <link rel="canonical" href="https://jira.example.com/login.jsp">
+              </head>
+            </html>
+            """
+            return .init(
+                data: Data(html.utf8),
+                url: URL(string: "https://jira.example.com/login.jsp")!,
+                mimeType: "text/html",
+                textEncodingName: "utf-8"
+            )
+        }
+        let resolver = MissionSourceResolver(environment: Self.environment(
+            providers: .init([ManualMissionSourceProvider(metadataFetcher: fetcher)])
+        ))
+
+        let result = try await resolver.resolve("https://jira.example.com/browse/ALAS-123")
+
+        #expect(result.source.identity == .init(
+            providerID: .manual,
+            stableID: "https://jira.example.com/browse/ALAS-123"
+        ))
+        #expect(result.source.canonicalURL.absoluteString == "https://jira.example.com/browse/ALAS-123")
+        #expect(result.source.title.isEmpty)
+        #expect(result.source.body.isEmpty)
+        #expect(result.source.providerLabel == "jira.example.com")
+    }
+
     @Test func unconfiguredIssuesURLBecomesPlainManualSource() async throws {
         let recorder = SourceProviderRecorder()
         let resolver = MissionSourceResolver(environment: Self.environment(recorder: recorder))

--- a/AlasTests/Missions/NewMissionDialogTests.swift
+++ b/AlasTests/Missions/NewMissionDialogTests.swift
@@ -160,6 +160,34 @@ struct NewMissionDialogTests {
         #expect(draft.projectId == "project-b")
     }
 
+    @Test("arbitrary link metadata prefills editable source and prompt")
+    func arbitraryLinkMetadataPrefillsConfirmation() async {
+        let manual = MissionFixtures.manualSource(
+            url: "https://linear.app/acme/issue/ALAS-123/fix-login-timeout",
+            title: "Fix login timeout",
+            body: "Sessions expire during refresh."
+        )
+        let fake = NewMissionDialogFake(
+            resolvedSource: ResolvedMissionSource(
+                source: manual,
+                repositoryLocator: nil,
+                candidateProjectIDs: ["alas"],
+                selectedProjectID: "alas"
+            )
+        )
+        let model = NewMissionDialogModel(environment: fake.environment)
+        model.reference = manual.canonicalURL.absoluteString
+
+        await model.resolve()
+
+        #expect(model.sourceTitle == "Fix login timeout")
+        #expect(model.sourceBody == "Sessions expire during refresh.")
+        #expect(model.branch == "feature/fix-login-timeout")
+        #expect(model.prompt.contains("Fix login timeout"))
+        #expect(model.prompt.contains("Sessions expire during refresh."))
+        #expect(model.validationMessage == nil)
+    }
+
     @Test("provider failure waits for explicit manual continuation")
     func providerFailureWaitsForExplicitManualContinuation() async {
         let fallbackSource = MissionFixtures.manualSource(

--- a/AlasTests/Missions/WebPageMetadataFetcherTests.swift
+++ b/AlasTests/Missions/WebPageMetadataFetcherTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct WebPageMetadataFetcherTests {
+    @Test func extractsJiraMetadataAndIssueKey() {
+        let html = """
+        <html>
+          <head>
+            <meta content="ALAS-123" name="ajs-issue-key">
+            <meta content="Fix sync &amp; retry behavior - Jira" property="og:title">
+            <meta name="description" content="Retries fail after a network change.">
+            <link href="https://jira.example.com/browse/ALAS-123" rel="canonical">
+          </head>
+        </html>
+        """
+
+        let result = WebPageMetadataFetcher.parse(
+            html: html,
+            url: URL(string: "https://jira.example.com/browse/ALAS-123?focused=true")!
+        )
+
+        #expect(result.providerLabel == "Jira")
+        #expect(result.displayReference == "ALAS-123")
+        #expect(result.title == "Fix sync & retry behavior")
+        #expect(result.summary == "Retries fail after a network change.")
+        #expect(result.canonicalURL.absoluteString == "https://jira.example.com/browse/ALAS-123")
+    }
+
+    @Test func extractsLinearOpenGraphMetadataAndRepositoryLink() {
+        let html = """
+        <html>
+          <head>
+            <meta property="og:title" content="ALAS-456 Improve mission setup | Linear">
+            <meta property="og:description" content="Use the mrmans0n/alas repository.">
+          </head>
+          <body>
+            <a href="https://github.com/mrmans0n/alas/issues/456">Related issue</a>
+          </body>
+        </html>
+        """
+
+        let result = WebPageMetadataFetcher.parse(
+            html: html,
+            url: URL(string: "https://linear.app/acme/issue/ALAS-456/improve-mission-setup")!
+        )
+
+        #expect(result.providerLabel == "Linear")
+        #expect(result.displayReference == "ALAS-456")
+        #expect(result.title == "ALAS-456 Improve mission setup")
+        #expect(result.summary == "Use the mrmans0n/alas repository.")
+        #expect(result.links.contains(URL(string: "https://github.com/mrmans0n/alas/issues/456")!))
+    }
+
+    @Test func extractsTrelloMetadataAndDecodesJSONLD() {
+        let html = """
+        <html>
+          <head>
+            <script type="application/ld+json">
+              {
+                "@type": "Task",
+                "name": "Ship release on Trello",
+                "description": "Verify checks, publish, and notify the team."
+              }
+            </script>
+          </head>
+        </html>
+        """
+
+        let result = WebPageMetadataFetcher.parse(
+            html: html,
+            url: URL(string: "https://trello.com/c/a1b2c3d4/42-ship-release")!
+        )
+
+        #expect(result.providerLabel == "Trello")
+        #expect(result.displayReference == "a1b2c3d4")
+        #expect(result.title == "Ship release")
+        #expect(result.summary == "Verify checks, publish, and notify the team.")
+    }
+
+    @Test func rejectsOversizedResponses() async {
+        let fetcher = WebPageMetadataFetcher { url in
+            .init(
+                data: Data(repeating: 0, count: 2 * 1_024 * 1_024 + 1),
+                url: url,
+                mimeType: "text/html",
+                textEncodingName: "utf-8"
+            )
+        }
+
+        await #expect(throws: WebPageMetadataFetcher.FetchError.responseTooLarge) {
+            try await fetcher.metadata(for: URL(string: "https://example.com/ticket/1")!)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fetch metadata from provider-neutral ticket links so new Missions can prefill editable title and context fields.
- Recognize common ticket tools like Jira, Linear, Trello, Asana, Shortcut, ClickUp, and Monday from public page metadata.
- Infer the best repository when the page links to a configured code-host repo or uniquely names a configured project.

## Test plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/WebPageMetadataFetcherTests -only-testing:AlasTests/MissionSourceResolverTests -only-testing:AlasTests/NewMissionDialogTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` failed once on unrelated `RightPaneStateSyncStatusTests/refreshSyncStatusFiresOnRebase`; rerunning that test passed.