### PR TITLE
fix(central): Show loading screen while repository loads

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1467,6 +1467,7 @@
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
 		F9FED997CCAD027FBBE36C1D /* PendingReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5679CA959D40E1682A91F31 /* PendingReview.swift */; };
+		FA29E844E6342559BA395893 /* LoadingProjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387FA8F2BEFE6A1D1A5BBD46 /* LoadingProjectView.swift */; };
 		FA2FB05351C86883B303D538 /* EditorFindHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94255B602EB04BD063346B3E /* EditorFindHighlightRenderer.swift */; };
 		FAC502C668FED52BEE4D32BD /* RunScriptTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708FAE890F75BC58098E7DDC /* RunScriptTemplate.swift */; };
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
@@ -1847,6 +1848,7 @@
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
 		38643438B0DF2F60F9B3B5AC /* ACPTranscriptChangeLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptChangeLog.swift; sourceTree = "<group>"; };
 		387BB7FB76FEF0181EF3BBE5 /* PiMCPConfigWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPConfigWriter.swift; sourceTree = "<group>"; };
+		387FA8F2BEFE6A1D1A5BBD46 /* LoadingProjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingProjectView.swift; sourceTree = "<group>"; };
 		389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderEligibility.swift; sourceTree = "<group>"; };
 		38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairKind.swift; sourceTree = "<group>"; };
 		38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceHeadMessageTests.swift; sourceTree = "<group>"; };
@@ -4246,6 +4248,7 @@
 				263044AF646D45F96CBB2186 /* GlobalTabsManager.swift */,
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
+				387FA8F2BEFE6A1D1A5BBD46 /* LoadingProjectView.swift */,
 				90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */,
 				EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */,
 				A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */,
@@ -6275,6 +6278,7 @@
 				E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */,
 				DE431266B60826A2EA3736DF /* LineBuffer.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
+				FA29E844E6342559BA395893 /* LoadingProjectView.swift in Sources */,
 				7339339EEA3D52B6F5BDE5F0 /* LocalACPBrokerService.swift in Sources */,
 				AC915AF49731E075051CA4FC /* MCPAttachmentPlanner.swift in Sources */,
 				01BB37E08A2DCC66374F643B /* MCPHelloEvent.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -58,6 +58,7 @@ final class AppState {
     private var unpersistedGGWorktreeModes: [String: [String: GGWorktreeMode]] = [:]
     var spacesManager: SpacesManager
     var selectedWorktreeId: String?
+    private(set) var isRefreshingProjectTopologies = false
     private(set) var missingMissionTab: MissionTabState?
     private var missingMissionRecoveryTarget: MissingMissionRecoveryTarget?
     private(set) var resolvedMissionPaneBaseRefs: [MissionLegID: String] = [:]
@@ -2915,6 +2916,9 @@ final class AppState {
         saveProjects()
         saveSpaces()
         _ = await refreshAllProjectTopologies()
+        if let worktreeId = projectsManager.visibleWorktrees(projectId: project.id).first?.id {
+            selectWorktree(id: worktreeId)
+        }
         let refreshedProject = projectsManager.projects.first { $0.id == project.id } ?? project
         startProjectGitWatcher(for: refreshedProject)
     }
@@ -3188,6 +3192,8 @@ final class AppState {
     /// existing watchers when a deleted linked-worktree anchor is replaced.
     @discardableResult
     func refreshAllProjectTopologies() async -> Bool {
+        isRefreshingProjectTopologies = true
+        defer { isRefreshingProjectTopologies = false }
         let previousPaths = Dictionary(uniqueKeysWithValues: projectsManager.projects.map { ($0.id, $0.path) })
         let changed = await projectsManager.refreshAll()
         if changed {

--- a/Alas/Sources/App/CenterSelectionState.swift
+++ b/Alas/Sources/App/CenterSelectionState.swift
@@ -6,6 +6,7 @@ enum CenterSelectionState: Equatable {
     case deleting(Worktree)
     case deleteFailed(Worktree, message: String)
     case creating(Worktree)
+    case loadingProject
     case empty
 }
 
@@ -13,6 +14,7 @@ struct CenterSelectionStateResolver {
     let selectedWorktreeId: String?
     let projects: [ProjectConfig]
     let projectsManager: ProjectsManager
+    var isRefreshingProjectTopologies = false
     var activeGlobalMissionTab: MissionTabState?
     var allowsHiddenSelectedWorktree = false
 
@@ -21,7 +23,9 @@ struct CenterSelectionStateResolver {
         if let activeGlobalMissionTab {
             return .globalMission(activeGlobalMissionTab)
         }
-        guard let id = selectedWorktreeId else { return .empty }
+        guard let id = selectedWorktreeId else {
+            return isRefreshingProjectTopologies && !projects.isEmpty ? .loadingProject : .empty
+        }
         if let op = projectsManager.operationState(for: id) {
             switch op {
             case .deleting:

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -223,6 +223,7 @@ struct RootView: View {
             selectedWorktreeId: state.selectedWorktreeId,
             projects: state.activeSpaceProjects,
             projectsManager: state.projectsManager,
+            isRefreshingProjectTopologies: state.isRefreshingProjectTopologies,
             activeGlobalMissionTab: state.globalTabs.activeMissionTab(),
             allowsHiddenSelectedWorktree: allowsHiddenSelectedWorktreeForMission
         )
@@ -274,6 +275,8 @@ struct RootView: View {
             )
         case .creating(let wt):
             CreatingWorktreeView(worktree: wt)
+        case .loadingProject:
+            LoadingProjectView()
         case .empty:
             if let tabState = state.missingMissionTab {
                 MissionTabView(state: state, worktree: nil, tabState: tabState)

--- a/Alas/Sources/Center/LoadingProjectView.swift
+++ b/Alas/Sources/Center/LoadingProjectView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct LoadingProjectView: View {
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Spinner()
+                .frame(width: 32, height: 32)
+            Text("Loading repository…")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-dim"))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+    }
+}

--- a/AlasTests/CenterSelectionStateResolverTests.swift
+++ b/AlasTests/CenterSelectionStateResolverTests.swift
@@ -54,6 +54,31 @@ struct CenterSelectionStateResolverTests {
         #expect(result == .empty)
     }
 
+    @Test func loadingProjectWhenProjectExistsBeforeWorktreesResolve() {
+        let project = ProjectConfig.fixture
+        let mgr = ProjectsManager(persistedProjects: [project])
+        let resolver = CenterSelectionStateResolver(
+            selectedWorktreeId: nil,
+            projects: [project],
+            projectsManager: mgr,
+            isRefreshingProjectTopologies: true
+        )
+        let result = resolver.resolve()
+        #expect(result == .loadingProject)
+    }
+
+    @Test func emptyWhenProjectExistsWithoutSelectionOrRefresh() {
+        let project = ProjectConfig.fixture
+        let mgr = ProjectsManager(persistedProjects: [project])
+        let resolver = CenterSelectionStateResolver(
+            selectedWorktreeId: nil,
+            projects: [project],
+            projectsManager: mgr
+        )
+        let result = resolver.resolve()
+        #expect(result == .empty)
+    }
+
     @Test func globalMissionTakesPrecedenceOverSelectedWorktree() {
         let project = ProjectConfig.fixture
         let worktree = Worktree.fixture(projectId: project.id)


### PR DESCRIPTION
## Summary
- show a centered loading state while a newly added repository is resolving its first worktree
- select the new repository's first discovered worktree after topology refresh
- add resolver coverage for the transient project-loading state

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`

