### PR TITLE
feat(remote): queue parity for the remote web client

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -790,6 +790,7 @@
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */; };
+		87A20CF7F67C277344D97D45 /* RemoteQueueProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DE51A11B5F4C7A84D715B4 /* RemoteQueueProjectionTests.swift */; };
 		87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */; };
 		881AE2B2D456B36573346AD6 /* DraftCommitTabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */; };
 		881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */; };
@@ -1193,6 +1194,7 @@
 		CA4CE5E97DB02330A1151245 /* ACPSetupCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */; };
 		CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */; };
 		CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */; };
+		CAC084F6260D705CCA5D6FBE /* RemoteQueueProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C782D92A16724E99D824C8A7 /* RemoteQueueProjection.swift */; };
 		CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */; };
 		CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */; };
 		CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */; };
@@ -2402,6 +2404,7 @@
 		98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipTests.swift; sourceTree = "<group>"; };
 		98CA6A0F4862D9A29E4151B5 /* ACPComposerFocusPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerFocusPolicyTests.swift; sourceTree = "<group>"; };
 		98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxStoreTests.swift; sourceTree = "<group>"; };
+		98DE51A11B5F4C7A84D715B4 /* RemoteQueueProjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteQueueProjectionTests.swift; sourceTree = "<group>"; };
 		98EE59978053FA18629BC280 /* GGCommitMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGCommitMenuModelTests.swift; sourceTree = "<group>"; };
 		993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationModels.swift; sourceTree = "<group>"; };
 		99890AC2531648EB5E9716A8 /* DragOutSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutSessionTests.swift; sourceTree = "<group>"; };
@@ -2660,6 +2663,7 @@
 		C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStrip.swift; sourceTree = "<group>"; };
 		C72B05E51A4C6FAE18666DBC /* ACPSyntaxHighlightedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSyntaxHighlightedText.swift; sourceTree = "<group>"; };
 		C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSteerUndoToast.swift; sourceTree = "<group>"; };
+		C782D92A16724E99D824C8A7 /* RemoteQueueProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteQueueProjection.swift; sourceTree = "<group>"; };
 		C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTabConfirmationPolicy.swift; sourceTree = "<group>"; };
 		C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTheme.swift; sourceTree = "<group>"; };
 		C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulseTests.swift; sourceTree = "<group>"; };
@@ -3076,6 +3080,7 @@
 				2AF8084388AF564A1907548C /* RemoteNetworkTests.swift */,
 				BA59378FB8733DBAC67592A3 /* RemotePairingServiceTests.swift */,
 				C02B44D8CC0AE48BFA9CD88E /* RemoteProtocolTests.swift */,
+				98DE51A11B5F4C7A84D715B4 /* RemoteQueueProjectionTests.swift */,
 				A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */,
 				37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */,
 				5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */,
@@ -3201,6 +3206,7 @@
 		0F8A8BCD5083CA261EBDEC8C /* Gateway */ = {
 			isa = PBXGroup;
 			children = (
+				C782D92A16724E99D824C8A7 /* RemoteQueueProjection.swift */,
 				CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */,
 				33EBE6A3E0CA30D8910E68F8 /* RemoteSessionsProvider.swift */,
 				88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */,
@@ -6430,6 +6436,7 @@
 				342C28B197D5048F78D2E8D6 /* RemotePairingService.swift in Sources */,
 				316A645ECCB46A0F74915EA4 /* RemoteProjectGitWatcher.swift in Sources */,
 				32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */,
+				CAC084F6260D705CCA5D6FBE /* RemoteQueueProjection.swift in Sources */,
 				257D3CF69FE6A97D058FF959 /* RemoteRepoValidator.swift in Sources */,
 				FB6FF6C91476DEE43E512E30 /* RemoteServer.swift in Sources */,
 				D9C26E07021DC6938013FBBE /* RemoteServerError.swift in Sources */,
@@ -7135,6 +7142,7 @@
 				F53E906F828DEFF6A41C46BA /* RemotePollCadenceTests.swift in Sources */,
 				3D561C5EDA7AAB4831CA58CF /* RemoteProjectCollisionTests.swift in Sources */,
 				A7B9BDE0F2EB1D1769EC81B5 /* RemoteProtocolTests.swift in Sources */,
+				87A20CF7F67C277344D97D45 /* RemoteQueueProjectionTests.swift in Sources */,
 				DDBEA2D41ECA8F0F28CF5DF6 /* RemoteRepoValidatorTests.swift in Sources */,
 				A962107126052DEF597CB7FA /* RemoteServerIntegrationTests.swift in Sources */,
 				0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */,

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -234,6 +234,7 @@ function handle(msg) {
     case "transcriptPage": applyPage(msg); break;
     case "stopPending": if (msg.sessionId === currentSession) markStopping(true); break;
     case "queueState": applyQueueState(msg); break;
+    case "queueEditRestored": applyQueueEditRestored(msg); break;
     // Scope prompt events to the session currently open — a stale/in-flight
     // event for a session the user already left must not pop or close a sheet.
     case "permissionRequest": handlePromptRequest("permission", msg.sessionId, msg.payload); break;
@@ -698,8 +699,108 @@ function applyQueueState(msg) {
   renderDriveBar(lastStreamingState);
 }
 
-// Queued-prompt bubbles land in Task 7; this task only wires the message.
-function renderQueue() { /* queued bubbles land in Task 7 */ }
+// Append rather than replace, mirroring the native pane's
+// composerDraft.appending(restored) — the user may have started typing
+// something else before tapping Edit, and that must not be clobbered.
+function applyQueueEditRestored(msg) {
+  if (msg.sessionId !== currentSession || !msg.text) return;
+  const ta = $("prompt");
+  ta.value = ta.value ? ta.value + "\n" + msg.text : msg.text;
+  autoGrowPrompt();
+  renderDriveBar(lastStreamingState);
+  ta.focus();
+}
+
+function steerUndoToast() { return el("div", "steer-undo"); }
+
+let openQueuedId = null;   // which bubble has its actions revealed (tap-to-reveal)
+
+function setQueuedOpen(id) {
+  openQueuedId = openQueuedId === id ? null : id;
+  renderQueue();
+}
+
+function queueAction(type, itemId) {
+  if (!currentSession) return;
+  ensureWriter();
+  const msg = { type, sessionId: currentSession };
+  if (itemId) msg.itemId = itemId;
+  send(msg);
+  openQueuedId = null;
+}
+
+function renderQueue() {
+  const box = $("queued");
+  box.innerHTML = "";
+  box.classList.toggle("hidden", queueItems.length === 0 && !steerUndoAvailable);
+  if (steerUndoAvailable) box.appendChild(steerUndoToast());
+  if (queueItems.length === 0) return;
+
+  const waiting = queueBadgeCount();
+  if (waiting > 1) {
+    const header = el("div", "queued-header");
+    header.appendChild(el("span", null, waiting + " queued"));
+    const clear = el("button", "queued-clear", "Clear queue");
+    clear.onclick = () => queueAction("queueClear", null);
+    header.appendChild(clear);
+    box.appendChild(header);
+  }
+
+  queueItems.forEach(item => box.appendChild(queuedRow(item)));
+}
+
+function queuedRow(item) {
+  const pending = item.status === "pending";
+  const row = el("div", "queued-row");
+  if (!pending) row.classList.add("is-sending");
+  if (pending && openQueuedId === item.id) row.classList.add("is-open");
+
+  // A .sending item is mid-RPC — native hides its affordances for the same
+  // reason, so there is nothing to reveal and nothing to act on.
+  if (pending) row.appendChild(queuedActions(item));
+
+  const stack = el("div", "queued-stack");
+  const status = el("div", "queued-status");
+  status.appendChild(el("span", null, pending ? "Queued" : "Sending"));
+  if (item.lastError) status.appendChild(el("span", "queued-error", " · " + item.lastError));
+  stack.appendChild(status);
+
+  const bubble = el("div", "queued-bubble");
+  if (item.imageCount > 0) {
+    bubble.appendChild(el("span", "queued-images", "🖼 ×" + item.imageCount));
+  }
+  bubble.appendChild(document.createTextNode(item.text || ""));
+  if (pending) bubble.onclick = () => setQueuedOpen(item.id);
+  stack.appendChild(bubble);
+
+  row.appendChild(stack);
+  return row;
+}
+
+function queuedActions(item) {
+  const actions = el("div", "queued-actions");
+  const button = (cls, glyph, label, onclick) => {
+    const b = el("button", cls, glyph);
+    b.setAttribute("aria-label", label);
+    b.onclick = onclick;
+    return b;
+  };
+  actions.appendChild(button("qa-send", "▲", "Send now",
+    () => queueAction("queueForceSend", item.id)));
+  if (item.lastError) {
+    actions.appendChild(button("qa-retry", "↻", "Retry",
+      () => queueAction("queueRetry", item.id)));
+  }
+  // Editing an item whose images the web client never received would silently
+  // drop them, so the pencil is withheld rather than made lossy.
+  if (item.imageCount === 0) {
+    actions.appendChild(button("qa-edit", "✎", "Edit",
+      () => queueAction("queueEdit", item.id)));
+  }
+  actions.appendChild(button("qa-remove", "✕", "Remove from queue",
+    () => queueAction("queueRemove", item.id)));
+  return actions;
+}
 
 function applyPage(msg) {
   // Check the session BEFORE touching shared in-flight state: these globals

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -9,6 +9,9 @@ let messageNodes = new Map();                          // stableId → DOM node
 let transcriptMeta = null;   // {epoch, revision, firstIndex, totalCount} for the open session
 let olderFetchInFlight = false;
 let stopPending = false;
+let queueItems = [];             // [{id, text, imageCount, status, lastError}] from queueState
+let steerUndoAvailable = false;
+let lastStreamingState = "idle"; // so composer state can be recomputed on text input
 let sessionTitles = new Map();
 let canDrive = false, canDriveKnown = false;
 let reconnectDelay = 1500;
@@ -230,6 +233,7 @@ function handle(msg) {
     case "transcriptDelta": applyDelta(msg); break;
     case "transcriptPage": applyPage(msg); break;
     case "stopPending": if (msg.sessionId === currentSession) markStopping(true); break;
+    case "queueState": applyQueueState(msg); break;
     // Scope prompt events to the session currently open — a stale/in-flight
     // event for a session the user already left must not pop or close a sheet.
     case "permissionRequest": handlePromptRequest("permission", msg.sessionId, msg.payload); break;
@@ -355,7 +359,9 @@ function openSession(id) {
   $("back").classList.remove("hidden"); $("nav-title").classList.add("hidden");   // bar shows ‹ Sessions
   $("detail-title").classList.remove("hidden"); $("detail-rename").classList.remove("hidden"); setDetailTitle(id);
   $("sessions").classList.add("hidden"); $("transcript").classList.remove("hidden");
-  $("messages").innerHTML = ""; renderConfigAffordances(); renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
+  $("messages").innerHTML = ""; renderConfigAffordances();
+  queueItems = []; steerUndoAvailable = false; renderQueue();
+  renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
 }
 
 function clearSessionSheetsForOpen() {
@@ -683,6 +689,17 @@ function applyDelta(msg) {
   if (atBottom) requestAnimationFrame(() => { box.scrollTop = box.scrollHeight; });
   syncStreamingState(msg.streamingState);
 }
+
+function applyQueueState(msg) {
+  if (msg.sessionId !== currentSession) return;
+  queueItems = msg.items || [];
+  steerUndoAvailable = !!msg.steerUndoAvailable;
+  renderQueue();
+  renderDriveBar(lastStreamingState);
+}
+
+// Queued-prompt bubbles land in Task 7; this task only wires the message.
+function renderQueue() { /* queued bubbles land in Task 7 */ }
 
 function applyPage(msg) {
   // Check the session BEFORE touching shared in-flight state: these globals
@@ -2063,6 +2080,22 @@ function hideElicitation() {
   elicitationInputs = new Map();
 }
 
+// Direct port of composerAction(...) in ComposerAction.swift. Kept as a pure
+// function of (streamingState, hasText) so the two implementations can be
+// diffed against each other by eye.
+function composerAction(streamingState, hasText) {
+  if (streamingState === "idle") {
+    return hasText ? "send" : "hidden";
+  }
+  return hasText ? "queue" : "stop";
+}
+
+// Mirrors ACPSession.visibleQueueCount: the in-flight .sending head gets its
+// own bubble but is not part of the "still waiting" count.
+function queueBadgeCount() {
+  return queueItems.filter(i => i.status !== "sending").length;
+}
+
 function renderDriveBar(streamingState) {
   // Keep the whole bar hidden until the first snapshot tells us the real
   // canDrive — otherwise the take-over banner flashes while opening a session
@@ -2080,9 +2113,22 @@ function renderDriveBar(streamingState) {
   // (composerAction returns .stop for sending/streaming/awaiting*). Without
   // the awaiting states, dismissing a prompt sheet would strand the user on
   // Send with no way to cancel the running turn.
-  const busy = streamingState !== "idle";
-  $("send").classList.toggle("hidden", busy);
-  $("stop").classList.toggle("hidden", !busy);
+  lastStreamingState = streamingState;
+  const hasText = !!$("prompt").value.trim() || pendingAttachments.length > 0;
+  const action = composerAction(streamingState, hasText);
+  $("send").classList.toggle("hidden", action !== "send");
+  $("queue-capsule").classList.toggle("hidden", action !== "queue");
+  $("stop").classList.toggle("hidden", action !== "stop");
+  renderQueueBadges();
+}
+
+function renderQueueBadges() {
+  const count = queueBadgeCount();
+  ["send-badge", "queue-badge"].forEach(badgeId => {
+    const badge = $(badgeId);
+    badge.textContent = String(count);
+    badge.classList.toggle("hidden", count === 0);
+  });
 }
 
 let stopFallbackTimer = null;
@@ -2113,19 +2159,28 @@ function autoGrowPrompt() {
   ta.style.height = "auto";                          // shrink back before measuring
   ta.style.height = Math.min(ta.scrollHeight, window.innerHeight * 0.4) + "px";
 }
-function sendPrompt() {
+function submitPrompt(intent) {
   const ta = $("prompt");
   const text = ta.value.trim();
   if (!currentSession) return;
   if (!text && pendingAttachments.length === 0) return;   // nothing to send
   ensureWriter();                                    // grab the wheel first; ordered before the prompt
-  send({ type: "sendPrompt", sessionId: currentSession, text, attachments: pendingAttachments });
+  send({
+    type: "sendPrompt",
+    sessionId: currentSession,
+    text,
+    attachments: pendingAttachments,
+    intent: intent || "auto",
+  });
   lastSentText = text;                               // keep until the server accepts (or rejects) it
   lastSentAttachments = pendingAttachments;          // ditto for the staged images
   ta.value = "";
   clearAttachments();
   autoGrowPrompt();                                  // collapse back to one row
+  renderDriveBar(lastStreamingState);
 }
+
+function sendPrompt() { submitPrompt("auto"); }
 
 // The server dropped our prompt (lease went stale, materialize failed, etc.).
 // Put the text AND staged images back so the message isn't silently lost — but
@@ -2177,6 +2232,9 @@ function renderConfigSheet() {
 
 function showConfig() { renderConfigSheet(); $("cfg").classList.remove("hidden"); }
 function hideConfig() { $("cfg").classList.add("hidden"); }
+
+function showSteerSheet() { $("steer-sheet").classList.remove("hidden"); }
+function hideSteerSheet() { $("steer-sheet").classList.add("hidden"); }
 
 // --- Attachments ---
 function b64Bytes(b64) { return Math.floor(b64.length * 3 / 4); }   // decoded size estimate, good enough for the cap
@@ -2238,6 +2296,12 @@ listen("worktree-search", "input", (e) => {
 $("config").onclick = showConfig;
 $("cfg-close").onclick = hideConfig;
 $("cfg").onclick = (e) => { if (e.target.id === "cfg") hideConfig(); };
+$("queue-primary").onclick = () => submitPrompt("auto");
+$("queue-menu").onclick = showSteerSheet;
+$("steer-now").onclick = () => { hideSteerSheet(); submitPrompt("steer"); };
+$("steer-stop").onclick = () => { hideSteerSheet(); $("stop").click(); };
+$("steer-close").onclick = hideSteerSheet;
+$("steer-sheet").onclick = (e) => { if (e.target.id === "steer-sheet") hideSteerSheet(); };
 $("cfg-autorun").onchange = (e) => { ensureWriter(); send({ type: "setAutoRun", sessionId: currentSession, enabled: e.target.checked }); };
 $("detail-rename").onclick = () => { if (currentSession) showRenameSheet(currentSession); };
 $("rename-submit").onclick = submitRename;
@@ -2284,7 +2348,7 @@ $("stop").onclick = () => {
   send({ type: "stop", sessionId: currentSession });   // stop is leaseless — no lease takeover first
   markStopping(true);
 };
-listen("prompt", "input", autoGrowPrompt);
+listen("prompt", "input", () => { autoGrowPrompt(); renderDriveBar(lastStreamingState); });
 listen("prompt", "keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendPrompt(); }
 });

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -2257,6 +2257,10 @@ function renderChips() {
     box.appendChild(chip);
   });
   box.classList.toggle("hidden", pendingAttachments.length === 0);
+  // pendingAttachments feeds hasText in composerAction — an image-only message
+  // must be able to flip Send/Queue visible without any unrelated event (a
+  // keystroke, an incoming delta) happening to call renderDriveBar first.
+  renderDriveBar(lastStreamingState);
 }
 
 function readAttachment(file) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -742,9 +742,17 @@ function queueAction(type, itemId) {
 function renderQueue() {
   const box = $("queued");
   box.innerHTML = "";
-  box.classList.toggle("hidden", queueItems.length === 0 && !steerUndoAvailable);
+  // A .sending item stays in session.queue for the whole RPC round-trip
+  // (flushQueueIfIdle marks the head .sending before sendNow records the
+  // prompt into the transcript), but never gets its own bubble here —
+  // mirroring native's ACPMessageList.shouldRenderQueueBubble, which also
+  // returns false for .sending. Rendering it would double-show the same
+  // text: once as the transcript's user bubble, once as a ghosted queued
+  // one, for the entire duration of the turn.
+  const visible = queueItems.filter(i => i.status !== "sending");
+  box.classList.toggle("hidden", visible.length === 0 && !steerUndoAvailable);
   if (steerUndoAvailable) box.appendChild(steerUndoToast());
-  if (queueItems.length === 0) return;
+  if (visible.length === 0) return;
 
   const waiting = queueBadgeCount();
   if (waiting > 1) {
@@ -756,22 +764,21 @@ function renderQueue() {
     box.appendChild(header);
   }
 
-  queueItems.forEach(item => box.appendChild(queuedRow(item)));
+  visible.forEach(item => box.appendChild(queuedRow(item)));
 }
 
+// Only ever called with a `.pending` item — renderQueue() filters `.sending`
+// out before it reaches here — so every row always gets its actions and its
+// "Queued" status.
 function queuedRow(item) {
-  const pending = item.status === "pending";
   const row = el("div", "queued-row");
-  if (!pending) row.classList.add("is-sending");
-  if (pending && openQueuedId === item.id) row.classList.add("is-open");
+  if (openQueuedId === item.id) row.classList.add("is-open");
 
-  // A .sending item is mid-RPC — native hides its affordances for the same
-  // reason, so there is nothing to reveal and nothing to act on.
-  if (pending) row.appendChild(queuedActions(item));
+  row.appendChild(queuedActions(item));
 
   const stack = el("div", "queued-stack");
   const status = el("div", "queued-status");
-  status.appendChild(el("span", null, pending ? "Queued" : "Sending"));
+  status.appendChild(el("span", null, "Queued"));
   if (item.lastError) status.appendChild(el("span", "queued-error", " · " + item.lastError));
   stack.appendChild(status);
 
@@ -780,7 +787,7 @@ function queuedRow(item) {
     bubble.appendChild(el("span", "queued-images", "🖼 ×" + item.imageCount));
   }
   bubble.appendChild(document.createTextNode(item.text || ""));
-  if (pending) bubble.onclick = () => setQueuedOpen(item.id);
+  bubble.onclick = () => setQueuedOpen(item.id);
   stack.appendChild(bubble);
 
   row.appendChild(stack);
@@ -2308,6 +2315,11 @@ function restoreRejectedPrompt() {
   }
   lastSentText = null;
   lastSentAttachments = [];
+  // renderChips() above only runs when there were attachments — a text-only
+  // restore would otherwise leave the composer action (Send/Queue/hidden)
+  // stale at "hidden" from the submit that just got rejected, stranding the
+  // restored text with no way to send it.
+  renderDriveBar(lastStreamingState);
 }
 
 // --- Session config sheet (⚙) + attachments (📎) ---

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -711,7 +711,17 @@ function applyQueueEditRestored(msg) {
   ta.focus();
 }
 
-function steerUndoToast() { return el("div", "steer-undo"); }
+// The server owns the snapshot and its expiry (ACPSession.steerUndo +
+// ACPSessionRunner.armSteerUndoExpiry), so this is render-and-dispatch only:
+// the toast disappears when the next queueState reports the window closed.
+function steerUndoToast() {
+  const toast = el("div", "steer-undo");
+  toast.appendChild(el("span", null, "Queue cleared by steer"));
+  const undo = el("button", "steer-undo-btn", "Undo");
+  undo.onclick = () => queueAction("queueSteerUndo", null);
+  toast.appendChild(undo);
+  return toast;
+}
 
 let openQueuedId = null;   // which bubble has its actions revealed (tap-to-reveal)
 

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -9,7 +9,7 @@ let messageNodes = new Map();                          // stableId → DOM node
 let transcriptMeta = null;   // {epoch, revision, firstIndex, totalCount} for the open session
 let olderFetchInFlight = false;
 let stopPending = false;
-let queueItems = [];             // [{id, text, imageCount, status, lastError}] from queueState
+let queueItems = [];             // [{id, text, imageCount, resourceCount, status, lastError}] from queueState
 let steerUndoAvailable = false;
 let lastStreamingState = "idle"; // so composer state can be recomputed on text input
 let sessionTitles = new Map();
@@ -786,6 +786,9 @@ function queuedRow(item) {
   if (item.imageCount > 0) {
     bubble.appendChild(el("span", "queued-images", "🖼 ×" + item.imageCount));
   }
+  if (item.resourceCount > 0) {
+    bubble.appendChild(el("span", "queued-resources", "📎 ×" + item.resourceCount));
+  }
   bubble.appendChild(document.createTextNode(item.text || ""));
   bubble.onclick = () => setQueuedOpen(item.id);
   stack.appendChild(bubble);
@@ -808,9 +811,10 @@ function queuedActions(item) {
     actions.appendChild(button("qa-retry", "↻", "Retry",
       () => queueAction("queueRetry", item.id)));
   }
-  // Editing an item whose images the web client never received would silently
-  // drop them, so the pencil is withheld rather than made lossy.
-  if (item.imageCount === 0) {
+  // Editing an item whose images or file mentions the web client never
+  // received would silently drop them, so the pencil is withheld rather
+  // than made lossy.
+  if (item.imageCount === 0 && item.resourceCount === 0) {
     actions.appendChild(button("qa-edit", "✎", "Edit",
       () => queueAction("queueEdit", item.id)));
   }

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -40,13 +40,13 @@
             </button>
             <button id="send" aria-label="Send">
               <svg viewBox="0 0 24 24" width="19" height="19" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
-              <span id="send-badge" class="queue-badge hidden"></span>
+              <span id="send-badge" class="hidden"></span>
             </button>
             <div id="queue-capsule" class="hidden">
               <button id="queue-primary" aria-label="Queue message">
                 <svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 <span>Queue</span>
-                <span id="queue-badge" class="queue-badge hidden"></span>
+                <span id="queue-badge" class="hidden"></span>
               </button>
               <button id="queue-menu" aria-label="More send actions">
                 <svg viewBox="0 0 24 24" width="12" height="12" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=38" />
+  <link rel="stylesheet" href="/style.css?v=39" />
 </head>
 <body>
   <header id="bar">
@@ -40,7 +40,18 @@
             </button>
             <button id="send" aria-label="Send">
               <svg viewBox="0 0 24 24" width="19" height="19" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span id="send-badge" class="queue-badge hidden"></span>
             </button>
+            <div id="queue-capsule" class="hidden">
+              <button id="queue-primary" aria-label="Queue message">
+                <svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span>Queue</span>
+                <span id="queue-badge" class="queue-badge hidden"></span>
+              </button>
+              <button id="queue-menu" aria-label="More send actions">
+                <svg viewBox="0 0 24 24" width="12" height="12" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+            </div>
             <button id="stop" class="hidden" aria-label="Stop">
               <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><rect x="6" y="6" width="12" height="12" rx="2.6" fill="currentColor"/></svg>
             </button>
@@ -95,6 +106,14 @@
       <button id="cfg-close" class="sheet-close">Close</button>
     </div>
   </div>
+  <div id="steer-sheet" class="sheet hidden" role="dialog" aria-modal="true" aria-labelledby="steer-title">
+    <div class="sheet-card">
+      <p id="steer-title" class="sheet-title">Send actions</p>
+      <button id="steer-now" class="option-btn">Steer running turn</button>
+      <button id="steer-stop" class="option-btn is-destructive">Stop running turn</button>
+      <button id="steer-close" class="sheet-close">Close</button>
+    </div>
+  </div>
   <div id="new-session-sheet" class="sheet hidden" role="dialog" aria-modal="true" aria-labelledby="new-session-title">
     <div class="sheet-card create-sheet">
       <p id="new-session-title" class="sheet-title">New session</p>
@@ -131,7 +150,7 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=60"></script>
+  <script src="/app.js?v=61"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -26,6 +26,7 @@
     <section id="sessions" class="view"><h1>Sessions</h1><div id="session-list"></div></section>
     <section id="transcript" class="view hidden">
       <div id="messages"></div>
+      <div id="queued" class="hidden"></div>
       <div id="drivebar">
         <button id="takeover" class="hidden">Take over</button>
         <div id="composer" class="hidden">

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -283,3 +283,6 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .qa-send { color: var(--accent); }
 .qa-retry { color: oklch(0.80 0.14 85); }
 .qa-edit, .qa-remove { color: var(--fg-muted); }
+
+.steer-undo { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 7px 12px; border: 0.5px solid var(--line); border-radius: 10px; background: color-mix(in oklab, var(--bg-2) 80%, transparent); color: var(--fg-muted); font-size: 12px; }
+.steer-undo-btn { border: none; background: none; color: var(--accent); font: inherit; font-size: 12px; font-weight: 650; cursor: pointer; -webkit-tap-highlight-color: transparent; }

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -173,6 +173,21 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 #attach, #config { background: none; color: var(--fg-dim); }
 #attach:active, #config:active { color: var(--fg-muted); }
 
+/* Queue split capsule — the web twin of ACPComposerActionButton's .queue case:
+   a labelled primary half plus a chevron half that opens the steer/stop sheet. */
+/* Every rule that has to beat `#composer-row button` (one id + one type) is
+   written as `#queue-capsule #<id>` (two ids) so it wins outright — relying on
+   source order alone breaks the moment these rules move. */
+#queue-capsule { flex-shrink: 0; display: flex; align-items: stretch; height: 34px; border: 0.5px solid var(--line); border-radius: 17px; background: var(--bg-3); }
+#queue-capsule #queue-primary { width: auto; height: 34px; display: flex; align-items: center; gap: 5px; padding: 0 11px; border: none; border-radius: 17px 0 0 17px; background: none; color: var(--fg); font: inherit; font-size: 13px; font-weight: 650; position: relative; overflow: visible; }
+#queue-capsule #queue-menu { width: auto; height: 34px; padding: 0 9px; border: none; border-left: 0.5px solid var(--line); border-radius: 0 17px 17px 0; background: none; color: var(--fg-muted); }
+#queue-capsule button:active { background: var(--bg-4); }
+
+/* Count badge, mirroring native's warn-colored pill offset off the capsule corner. */
+#send-badge, #queue-badge { position: absolute; top: -5px; right: -6px; min-width: 16px; height: 15px; padding: 0 4px; border-radius: 999px; background: oklch(0.80 0.14 85); border: 1px solid var(--bg-0); color: var(--bg-0); font-size: 10px; font-weight: 700; font-variant-numeric: tabular-nums; line-height: 13px; display: flex; align-items: center; justify-content: center; pointer-events: none; }
+#send { position: relative; overflow: visible; }
+.option-btn.is-destructive { color: var(--del); }
+
 /* Config sheet (⚙) — reuses .option-btn / .is-selected for the radio lists. */
 #cfg .sheet-card { max-height: min(85vh, 640px); display: flex; flex-direction: column; }
 #cfg-scroll { min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; }

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -268,12 +268,10 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .queued-clear { border: none; background: none; color: var(--fg-muted); font: inherit; font-size: 10px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 
 .queued-row { display: flex; align-items: center; justify-content: flex-end; gap: 8px; opacity: 0.6; }
-.queued-row.is-sending { opacity: 0.85; }
 .queued-stack { display: flex; flex-direction: column; align-items: flex-end; gap: 3px; min-width: 0; }
 .queued-status { align-self: flex-end; color: var(--fg-faint); font-size: 9px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase; padding-right: 2px; }
 .queued-status .queued-error { color: var(--del); }
 .queued-bubble { max-width: 82%; padding: 9px 13px; color: var(--fg); background: color-mix(in oklab, var(--accent) 10%, transparent); border: 0.75px dashed color-mix(in oklab, var(--accent) 50%, transparent); border-radius: 13px 13px 4px 13px; font-size: 14px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; cursor: pointer; -webkit-tap-highlight-color: transparent; }
-.queued-row.is-sending .queued-bubble { border-style: solid; cursor: default; }
 .queued-images { display: inline-block; margin-right: 6px; color: var(--fg-muted); font-size: 12px; }
 
 .queued-actions { display: none; gap: 4px; flex-shrink: 0; }

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -272,7 +272,7 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .queued-status { align-self: flex-end; color: var(--fg-faint); font-size: 9px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase; padding-right: 2px; }
 .queued-status .queued-error { color: var(--del); }
 .queued-bubble { max-width: 82%; padding: 9px 13px; color: var(--fg); background: color-mix(in oklab, var(--accent) 10%, transparent); border: 0.75px dashed color-mix(in oklab, var(--accent) 50%, transparent); border-radius: 13px 13px 4px 13px; font-size: 14px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; cursor: pointer; -webkit-tap-highlight-color: transparent; }
-.queued-images { display: inline-block; margin-right: 6px; color: var(--fg-muted); font-size: 12px; }
+.queued-images, .queued-resources { display: inline-block; margin-right: 6px; color: var(--fg-muted); font-size: 12px; }
 
 .queued-actions { display: none; gap: 4px; flex-shrink: 0; }
 .queued-row.is-open .queued-actions { display: flex; }

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -258,3 +258,28 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .elicitation-input { box-sizing: border-box; width: 100%; padding: 11px 12px; border: 1px solid var(--bg-4); border-radius: 9px; background: var(--bg-0); color: var(--fg); font: inherit; font-size: 16px; }
 .elicitation-check { display: flex; align-items: center; gap: 9px; color: var(--fg); font-size: 14px; }
 .elicitation-url { padding: 10px 11px; border: 1px solid var(--bg-4); border-radius: 8px; background: var(--bg-0); color: var(--fg-muted); font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; user-select: text; }
+
+/* Queued prompts — the web twin of ACPQueuedBubble. Rendered in their own
+   pinned strip rather than inside #messages: that container is strictly
+   index-ordered (insertMessage walks dataset.index, applyPage prepends
+   backfilled pages), so nodes with no transcript index would fight it. */
+#queued { flex: 0 0 auto; max-height: 34vh; overflow-y: auto; padding: 6px 10px 0; display: flex; flex-direction: column; gap: 6px; }
+.queued-header { display: flex; align-items: center; justify-content: space-between; padding: 0 2px; color: var(--fg-faint); font-size: 10px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase; }
+.queued-clear { border: none; background: none; color: var(--fg-muted); font: inherit; font-size: 10px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+
+.queued-row { display: flex; align-items: center; justify-content: flex-end; gap: 8px; opacity: 0.6; }
+.queued-row.is-sending { opacity: 0.85; }
+.queued-stack { display: flex; flex-direction: column; align-items: flex-end; gap: 3px; min-width: 0; }
+.queued-status { align-self: flex-end; color: var(--fg-faint); font-size: 9px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase; padding-right: 2px; }
+.queued-status .queued-error { color: var(--del); }
+.queued-bubble { max-width: 82%; padding: 9px 13px; color: var(--fg); background: color-mix(in oklab, var(--accent) 10%, transparent); border: 0.75px dashed color-mix(in oklab, var(--accent) 50%, transparent); border-radius: 13px 13px 4px 13px; font-size: 14px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+.queued-row.is-sending .queued-bubble { border-style: solid; cursor: default; }
+.queued-images { display: inline-block; margin-right: 6px; color: var(--fg-muted); font-size: 12px; }
+
+.queued-actions { display: none; gap: 4px; flex-shrink: 0; }
+.queued-row.is-open .queued-actions { display: flex; }
+.queued-actions button { width: 26px; height: 26px; padding: 0; border: none; border-radius: 50%; background: color-mix(in oklab, var(--bg-3) 70%, transparent); font-size: 12px; line-height: 1; display: flex; align-items: center; justify-content: center; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+.queued-actions button:active { background: var(--bg-4); }
+.qa-send { color: var(--accent); }
+.qa-retry { color: oklch(0.80 0.14 85); }
+.qa-edit, .qa-remove { color: var(--fg-muted); }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "alas-remote-shell-v38";
+const CACHE_NAME = "alas-remote-shell-v39";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=38",
-  "/app.js?v=60",
+  "/style.css?v=39",
+  "/app.js?v=61",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -287,9 +287,28 @@ final class ACPSessionManager: ObservableObject {
 
     /// Pull a queued item out for editing and hand its text back. `nil` when
     /// the item is gone or `.sending` — `takeForEditing` refuses in-flight
-    /// items so an edit can never duplicate a prompt already on the wire.
+    /// items so an edit can never duplicate a prompt already on the wire —
+    /// or when its draft carries a mention or an image.
+    ///
+    /// The web composer is plain text: it has no authenticated way to
+    /// re-stage a mention's URI or an image's bytes, so editing such an item
+    /// there would silently drop that content once the user resubmits. The
+    /// web client already hides Edit when `imageCount > 0 || resourceCount >
+    /// 0` for exactly this reason; this mirrors that rule server-side so a
+    /// client that doesn't know it (or a hand-rolled one) can't cause the
+    /// same loss. The draft is inspected BEFORE calling `takeForEditing`,
+    /// which removes-and-returns atomically — refusing after removal would
+    /// strand the prompt outside the queue instead of just leaving it be.
     func queueEdit(for id: ACPSession.ID, itemId: UUID) async -> String? {
         guard await confirmedWriterLease(for: id), let session = sessions[id] else { return nil }
+        guard let idx = session.queue.firstIndex(where: { $0.id == itemId }) else { return nil }
+        let hasUnrepresentableSegment = session.queue[idx].restorableDraft.segments.contains { segment in
+            switch segment {
+            case .text: return false
+            case .mention, .image: return true
+            }
+        }
+        guard !hasUnrepresentableSegment else { return nil }
         guard let draft = session.takeForEditing(id: itemId) else { return nil }
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -260,6 +260,67 @@ final class ACPSessionManager: ObservableObject {
         await runner.userCancel(confirmingLease: false)
     }
 
+    // MARK: - Remote queue control
+
+    /// Promote a queued item to the head (or steer to it when a turn is
+    /// running) — the remote-web twin of the queued bubble's "send now".
+    func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
+        guard await confirmedWriterLease(for: id) else { return }
+        runners[id]?.forceSendQueuedItem(id: itemId)
+    }
+
+    func queueRemove(for id: ACPSession.ID, itemId: UUID) async {
+        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
+        session.removeFromQueue(id: itemId)
+        persistQueue(for: session)
+        runners[id]?.flushQueueIfIdle()
+    }
+
+    /// Clear a failed item's error so the flusher re-attempts it.
+    func queueRetry(for id: ACPSession.ID, itemId: UUID) async {
+        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
+        guard let idx = session.queue.firstIndex(where: { $0.id == itemId }) else { return }
+        session.queue[idx].lastError = nil
+        persistQueue(for: session)
+        runners[id]?.flushQueueIfIdle()
+    }
+
+    /// Pull a queued item out for editing and hand its text back. `nil` when
+    /// the item is gone or `.sending` — `takeForEditing` refuses in-flight
+    /// items so an edit can never duplicate a prompt already on the wire.
+    func queueEdit(for id: ACPSession.ID, itemId: UUID) async -> String? {
+        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return nil }
+        guard let draft = session.takeForEditing(id: itemId) else { return nil }
+        persistQueue(for: session)
+        runners[id]?.flushQueueIfIdle()
+        return RemoteQueueProjection.plainText(from: draft)
+    }
+
+    func queueClear(for id: ACPSession.ID) async {
+        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
+        session.clearPendingQueue()
+        persistQueue(for: session)
+        runners[id]?.flushQueueIfIdle()
+    }
+
+    func queueSteerUndo(for id: ACPSession.ID) async {
+        guard await confirmedWriterLease(for: id) else { return }
+        runners[id]?.steerUndo()
+    }
+
+    /// Steer from the remote client: same route the composer's ⌥⏎ takes.
+    /// `ACPSubmitRoute.resolve` handles the degenerate idle+empty case by
+    /// falling back to a plain send.
+    func steerPrompt(for id: ACPSession.ID, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) async {
+        guard await confirmedWriterLease(for: id) else {
+            onResult(false)
+            return
+        }
+        let accepted = submit(sessionId: id, text: text, attachments: attachments, intent: .steer,
+                              onCompleted: { ok in onResult(ok) })
+        if !accepted { onResult(false) }
+    }
+
     /// Pending model/mode to apply once a runner registers (the writer took over
     /// but `attach` is still in flight). Keyed by session id. Applied in `attach`.
     var pendingModel: [ACPSession.ID: String] = [:]

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7787,6 +7787,56 @@ extension AppState: RemoteSessionsProvider {
         }
     }
 
+    func queueForceSend(for id: String, itemId: UUID) async {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            await mgr.queueForceSend(for: id, itemId: itemId)
+            return
+        }
+    }
+
+    func queueRemove(for id: String, itemId: UUID) async {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            await mgr.queueRemove(for: id, itemId: itemId)
+            return
+        }
+    }
+
+    func queueRetry(for id: String, itemId: UUID) async {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            await mgr.queueRetry(for: id, itemId: itemId)
+            return
+        }
+    }
+
+    func queueEdit(for id: String, itemId: UUID) async -> String? {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            return await mgr.queueEdit(for: id, itemId: itemId)
+        }
+        return nil
+    }
+
+    func queueClear(for id: String) async {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            await mgr.queueClear(for: id)
+            return
+        }
+    }
+
+    func queueSteerUndo(for id: String) async {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            await mgr.queueSteerUndo(for: id)
+            return
+        }
+    }
+
+    func steerPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) async {
+        for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
+            await mgr.steerPrompt(for: id, text: text, attachments: attachments, onResult: onResult)
+            return
+        }
+        onResult(false)
+    }
+
     func setModel(for id: String, modelId: String) async {
         for mgr in acpManagers.values where mgr.liveSession(for: id) != nil {
             await mgr.setModel(for: id, modelId: modelId)

--- a/Alas/Sources/Remote/Gateway/RemoteQueueProjection.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteQueueProjection.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Pure translation between the in-process queue model and the remote wire
+/// shape. Kept free of the gateway, the session, and SwiftUI so the mapping
+/// can be unit-tested on its own — it is the single place that knows how a
+/// `QueuedPrompt` becomes something a browser can render.
+enum RemoteQueueProjection {
+    static func project(_ items: [QueuedPrompt]) -> [RemoteQueuedPrompt] {
+        items.map { item in
+            var text = ""
+            var imageCount = 0
+            for block in item.blocks {
+                switch block {
+                case .text(let value):
+                    text += value
+                case .image:
+                    imageCount += 1
+                case .resourceLink, .resource:
+                    break
+                }
+            }
+            return RemoteQueuedPrompt(
+                id: item.id.uuidString,
+                text: text,
+                imageCount: imageCount,
+                status: item.status.rawValue,
+                lastError: item.lastError)
+        }
+    }
+
+    /// Queue-count badge value. Mirrors `ACPSession.visibleQueueCount`: an
+    /// in-flight `.sending` head is rendered as its own bubble but is not
+    /// part of the "still waiting" count.
+    static func visibleCount(_ items: [RemoteQueuedPrompt]) -> Int {
+        items.reduce(0) { $0 + ($1.status == "sending" ? 0 : 1) }
+    }
+
+    /// Flatten a restored composer draft into the plain text the web
+    /// composer can hold. Mentions become their `@displayName` marker (the
+    /// same form the submit path serializes them to); image segments are
+    /// dropped, since the web client cannot re-stage bytes it never had.
+    /// The queued bubble hides Edit when `imageCount > 0`, so dropping here
+    /// is a defensive fallback rather than the expected path.
+    static func plainText(from draft: ACPComposerDraft) -> String {
+        var out = ""
+        for segment in draft.segments {
+            switch segment {
+            case .text(let value):
+                out += value
+            case .mention(let displayName, _):
+                out += "@\(displayName) "
+            case .image:
+                break
+            }
+        }
+        return out
+    }
+}

--- a/Alas/Sources/Remote/Gateway/RemoteQueueProjection.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteQueueProjection.swift
@@ -9,6 +9,7 @@ enum RemoteQueueProjection {
         items.map { item in
             var text = ""
             var imageCount = 0
+            var resourceCount = 0
             for block in item.blocks {
                 switch block {
                 case .text(let value):
@@ -16,13 +17,14 @@ enum RemoteQueueProjection {
                 case .image:
                     imageCount += 1
                 case .resourceLink, .resource:
-                    break
+                    resourceCount += 1
                 }
             }
             return RemoteQueuedPrompt(
                 id: item.id.uuidString,
                 text: text,
                 imageCount: imageCount,
+                resourceCount: resourceCount,
                 status: item.status.rawValue,
                 lastError: item.lastError)
         }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -129,7 +129,6 @@ final class RemoteSessionGateway {
                 send(.promptRejected(sessionId: id))   // oversize / non-image
                 return
             }
-            _ = intent // Task 5 wires steer routing; parked here for now.
             // The manager owns the writer/lease re-check and the eventual
             // delivery result. Emit promptRejected on any failure — refused
             // now (not writer / needs auth) OR a session/prompt RPC that fails
@@ -143,12 +142,20 @@ final class RemoteSessionGateway {
             // these file URIs (the transcript bubble references them), so we
             // must keep the files.
             var refusalIsSynchronous = true
-            await provider.sendPrompt(for: id, text: trimmed, attachments: materialized) { [weak self] accepted in
+            let onResult: @MainActor (Bool) -> Void = { [weak self] accepted in
                 guard let self else { return }
                 if !accepted {
                     self.send(.promptRejected(sessionId: id))
                     if refusalIsSynchronous { self.discardAttachmentFiles(materialized) }
                 }
+            }
+            // "steer" cancels the running turn and discards the queue before
+            // sending; "auto" (the default, and everything an older client
+            // sends) takes the ordinary enqueue-or-send route.
+            if intent == "steer" {
+                await provider.steerPrompt(for: id, text: trimmed, attachments: materialized, onResult: onResult)
+            } else {
+                await provider.sendPrompt(for: id, text: trimmed, attachments: materialized, onResult: onResult)
             }
             refusalIsSynchronous = false
         case .stop(let id):
@@ -217,9 +224,32 @@ final class RemoteSessionGateway {
                                      messages: wire))
                 break
             }
-        // Wire protocol only for now — Task 5 wires the actual queue mutations.
-        case .queueForceSend, .queueRemove, .queueRetry, .queueEdit, .queueClear, .queueSteerUndo:
-            break
+        case .queueForceSend(let id, let itemId):
+            await withQueueItem(id: id, itemId: itemId) { uuid in
+                await self.provider.queueForceSend(for: id, itemId: uuid)
+            }
+        case .queueRemove(let id, let itemId):
+            await withQueueItem(id: id, itemId: itemId) { uuid in
+                await self.provider.queueRemove(for: id, itemId: uuid)
+            }
+        case .queueRetry(let id, let itemId):
+            await withQueueItem(id: id, itemId: itemId) { uuid in
+                await self.provider.queueRetry(for: id, itemId: uuid)
+            }
+        case .queueEdit(let id, let itemId):
+            await withQueueItem(id: id, itemId: itemId) { uuid in
+                // No reply when the item is gone or already `.sending` —
+                // `takeForEditing` refuses in-flight items so an edit can
+                // never duplicate a prompt that is already on the wire.
+                guard let text = await self.provider.queueEdit(for: id, itemId: uuid) else { return }
+                self.send(.queueEditRestored(sessionId: id, itemId: itemId, text: text))
+            }
+        case .queueClear(let id):
+            guard provider.isWriter(for: id) else { return }
+            await provider.queueClear(for: id)
+        case .queueSteerUndo(let id):
+            guard provider.isWriter(for: id) else { return }
+            await provider.queueSteerUndo(for: id)
         }
     }
 
@@ -551,6 +581,16 @@ final class RemoteSessionGateway {
         guard force || lastQueue[id] != snapshot else { return }
         lastQueue[id] = snapshot
         send(.queueState(sessionId: id, items: items, steerUndoAvailable: steerUndoAvailable))
+    }
+
+    /// Shared preamble for the per-item queue verbs: writer gate plus item-id
+    /// parsing. A non-writer or an unparseable id is dropped silently — the
+    /// next `queueState` re-asserts server truth, so there is nothing for the
+    /// client to reconcile.
+    private func withQueueItem(id: String, itemId: String, _ body: (UUID) async -> Void) async {
+        guard provider.isWriter(for: id) else { return }
+        guard let uuid = UUID(uuidString: itemId) else { return }
+        await body(uuid)
     }
 
     private func wireMessages(id: String, session: ACPSession, indices: [Int]) async -> [RemoteWireMessage] {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -104,7 +104,7 @@ final class RemoteSessionGateway {
             if let session = provider.session(for: id) {
                 await sendSnapshot(id: id, session: session)
             }
-        case .sendPrompt(let id, let text, let attachments):
+        case .sendPrompt(let id, let text, let attachments, let intent):
             // Pre-check the lease BEFORE materializing — `materialize` writes the
             // decoded images to disk, and a non-writer must be rejected without
             // leaving orphan files under acp-attachments/. The manager re-checks
@@ -126,6 +126,7 @@ final class RemoteSessionGateway {
                 send(.promptRejected(sessionId: id))   // oversize / non-image
                 return
             }
+            _ = intent // Task 5 wires steer routing; parked here for now.
             // The manager owns the writer/lease re-check and the eventual
             // delivery result. Emit promptRejected on any failure — refused
             // now (not writer / needs auth) OR a session/prompt RPC that fails
@@ -213,6 +214,9 @@ final class RemoteSessionGateway {
                                      messages: wire))
                 break
             }
+        // Wire protocol only for now — Task 5 wires the actual queue mutations.
+        case .queueForceSend, .queueRemove, .queueRetry, .queueEdit, .queueClear, .queueSteerUndo:
+            break
         }
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -20,7 +20,7 @@ final class RemoteSessionGateway {
     private var configSubscriptions: [String: AnyCancellable] = [:]
     private var configCoalesce: [String: Task<Void, Never>] = [:]
     private var lastConfig: [String: RemoteSessionConfig] = [:]
-    private var lastQueue: [String: [RemoteQueuedPrompt]] = [:]
+    private var lastQueue: [String: RemoteQueueSnapshot] = [:]
     private var coalesce: [String: Task<Void, Never>] = [:]
     private var sessionListRefresh: Task<Void, Never>?
     private var sessionListGeneration = 0
@@ -530,6 +530,16 @@ final class RemoteSessionGateway {
         emitPendingElicitationIfAny(id: id, session: session)
     }
 
+    /// Everything `sendQueueState` dedupes on. `steerUndoAvailable` can flip
+    /// (e.g. the 5s steer-undo window expiring) while `items` stays the same
+    /// (already emptied by the steer itself) — both must be in the cache key
+    /// or that flip would be silently swallowed and the client would keep
+    /// showing a stale "undo available" affordance.
+    private struct RemoteQueueSnapshot: Equatable {
+        let items: [RemoteQueuedPrompt]
+        let steerUndoAvailable: Bool
+    }
+
     /// Push the session's queue to the client. `force` bypasses the dedupe so
     /// a fresh subscribe always gets a baseline — otherwise an unchanged
     /// (typically empty) queue would be suppressed and the client would show
@@ -537,8 +547,9 @@ final class RemoteSessionGateway {
     private func sendQueueState(id: String, session: ACPSession, force: Bool = false) {
         let items = RemoteQueueProjection.project(session.queue)
         let steerUndoAvailable = !(session.steerUndo?.snapshot.isEmpty ?? true)
-        guard force || lastQueue[id] != items else { return }
-        lastQueue[id] = items
+        let snapshot = RemoteQueueSnapshot(items: items, steerUndoAvailable: steerUndoAvailable)
+        guard force || lastQueue[id] != snapshot else { return }
+        lastQueue[id] = snapshot
         send(.queueState(sessionId: id, items: items, steerUndoAvailable: steerUndoAvailable))
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -20,6 +20,7 @@ final class RemoteSessionGateway {
     private var configSubscriptions: [String: AnyCancellable] = [:]
     private var configCoalesce: [String: Task<Void, Never>] = [:]
     private var lastConfig: [String: RemoteSessionConfig] = [:]
+    private var lastQueue: [String: [RemoteQueuedPrompt]] = [:]
     private var coalesce: [String: Task<Void, Never>] = [:]
     private var sessionListRefresh: Task<Void, Never>?
     private var sessionListGeneration = 0
@@ -67,6 +68,7 @@ final class RemoteSessionGateway {
             if let cfg = provider.sessionConfig(for: id) {
                 send(.sessionConfig(cfg))
             }
+            sendQueueState(id: id, session: session, force: true)
             observe(id: id, session: session)
         case .unsubscribe(let id):
             subscriptions[id] = nil
@@ -74,6 +76,7 @@ final class RemoteSessionGateway {
             configCoalesce[id]?.cancel()
             configCoalesce[id] = nil
             lastConfig[id] = nil
+            lastQueue[id] = nil
             coalesce[id]?.cancel()
             coalesce[id] = nil
             lastPermissionReq[id] = nil
@@ -323,6 +326,7 @@ final class RemoteSessionGateway {
         configCoalesce.values.forEach { $0.cancel() }
         configCoalesce.removeAll()
         lastConfig.removeAll()
+        lastQueue.removeAll()
         coalesce.values.forEach { $0.cancel() }
         coalesce.removeAll()
         lastPermissionReq.removeAll()
@@ -435,6 +439,10 @@ final class RemoteSessionGateway {
             self.configCoalesce[id]?.cancel()
             self.configCoalesce[id] = Task { @MainActor [weak self, weak session] in
                 guard !Task.isCancelled, let self, let session else { return }
+                // Same publisher, independently deduped: ACPSession's
+                // objectWillChange fires for queue mutations too, and the
+                // queue changes far more often than the config does.
+                self.sendQueueState(id: id, session: session)
                 let cfg = RemoteSessionConfig(
                     sessionId: id,
                     models: session.availableModels.map { RemoteModelInfo(id: $0.id, name: $0.name) },
@@ -520,6 +528,18 @@ final class RemoteSessionGateway {
         emitPendingPermissionIfAny(id: id, session: session)
         emitPendingQuestionIfAny(id: id, session: session)
         emitPendingElicitationIfAny(id: id, session: session)
+    }
+
+    /// Push the session's queue to the client. `force` bypasses the dedupe so
+    /// a fresh subscribe always gets a baseline — otherwise an unchanged
+    /// (typically empty) queue would be suppressed and the client would show
+    /// nothing until the next mutation.
+    private func sendQueueState(id: String, session: ACPSession, force: Bool = false) {
+        let items = RemoteQueueProjection.project(session.queue)
+        let steerUndoAvailable = !(session.steerUndo?.snapshot.isEmpty ?? true)
+        guard force || lastQueue[id] != items else { return }
+        lastQueue[id] = items
+        send(.queueState(sessionId: id, items: items, steerUndoAvailable: steerUndoAvailable))
     }
 
     private func wireMessages(id: String, session: ACPSession, indices: [Int]) async -> [RemoteWireMessage] {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -28,6 +28,20 @@ protocol RemoteSessionsProvider: AnyObject {
     func setMode(for id: String, modeId: String) async
     func setAutoRun(for id: String, enabled: Bool) async
     func renameSession(for id: String, title: String) -> Bool
+    /// Queue mutation. All of these are writer-gated inside the manager (the
+    /// gateway also pre-checks, mirroring `sendPrompt`) and delegate to the
+    /// same native call sites the ACP pane uses, so the `.sending`-head,
+    /// persistence, and flush invariants are not duplicated for the remote path.
+    func queueForceSend(for id: String, itemId: UUID) async
+    func queueRemove(for id: String, itemId: UUID) async
+    func queueRetry(for id: String, itemId: UUID) async
+    /// Removes the item and returns its text for the web composer, or nil if
+    /// the item is gone or already `.sending` (mid-RPC, must not be duplicated).
+    func queueEdit(for id: String, itemId: UUID) async -> String?
+    func queueClear(for id: String) async
+    func queueSteerUndo(for id: String) async
+    /// Cancel the in-flight turn, discard the queue, send this prompt instead.
+    func steerPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) async
     /// Projection of the session's config for the `sessionConfig` wire message,
     /// or nil if the session isn't live.
     func sessionConfig(for id: String) -> RemoteSessionConfig?

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -11,6 +11,18 @@ struct RemoteWireMessage: Codable, Equatable, Sendable {
     let index: Int            // transcript position; the client orders and windows by this
 }
 
+/// One queued prompt as sent to the web client. Deliberately carries an image
+/// COUNT, never image bytes or URIs — the web client has no authenticated way
+/// to fetch attachment data, and a queued bubble only needs to say "there are
+/// images here" to render its placeholder.
+struct RemoteQueuedPrompt: Codable, Equatable, Sendable {
+    let id: String          // QueuedPrompt.id, uuidString
+    let text: String        // .text blocks, joined
+    let imageCount: Int
+    let status: String      // "pending" | "sending"
+    let lastError: String?
+}
+
 struct RemoteWorktreeSummary: Codable, Equatable, Sendable {
     let projectName: String
     let worktreeName: String

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -14,11 +14,14 @@ struct RemoteWireMessage: Codable, Equatable, Sendable {
 /// One queued prompt as sent to the web client. Deliberately carries an image
 /// COUNT, never image bytes or URIs — the web client has no authenticated way
 /// to fetch attachment data, and a queued bubble only needs to say "there are
-/// images here" to render its placeholder.
+/// images here" to render its placeholder. `resourceCount` mirrors the same
+/// idea for `.resourceLink`/`.resource` blocks (file mentions): the browser
+/// never receives the underlying URI, only a count to render as a chip.
 struct RemoteQueuedPrompt: Codable, Equatable, Sendable {
     let id: String          // QueuedPrompt.id, uuidString
     let text: String        // .text blocks, joined
     let imageCount: Int
+    let resourceCount: Int
     let status: String      // "pending" | "sending"
     let lastError: String?
 }

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -38,17 +38,23 @@ enum RemoteClientMessage: Equatable, Sendable {
         content: [String: ACPElicitationValue]?
     )
     case takeOver(sessionId: String)
-    case sendPrompt(sessionId: String, text: String, attachments: [RemoteAttachment])
+    case sendPrompt(sessionId: String, text: String, attachments: [RemoteAttachment], intent: String)
     case stop(sessionId: String)
     case setModel(sessionId: String, modelId: String)
     case setMode(sessionId: String, modeId: String)
     case setAutoRun(sessionId: String, enabled: Bool)
     case renameSession(sessionId: String, title: String)
     case fetchOlder(sessionId: String, beforeIndex: Int, limit: Int)
+    case queueForceSend(sessionId: String, itemId: String)
+    case queueRemove(sessionId: String, itemId: String)
+    case queueRetry(sessionId: String, itemId: String)
+    case queueEdit(sessionId: String, itemId: String)
+    case queueClear(sessionId: String)
+    case queueSteerUndo(sessionId: String)
 }
 
 extension RemoteClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit }
+    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit, itemId, intent }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -89,7 +95,10 @@ extension RemoteClientMessage: Codable {
             self = .sendPrompt(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 text: try c.decode(String.self, forKey: .text),
-                attachments: try c.decodeIfPresent([RemoteAttachment].self, forKey: .attachments) ?? [])
+                attachments: try c.decodeIfPresent([RemoteAttachment].self, forKey: .attachments) ?? [],
+                // Absent on clients cached before queue parity shipped; those
+                // clients only ever meant "auto".
+                intent: try c.decodeIfPresent(String.self, forKey: .intent) ?? "auto")
         case "stop":
             self = .stop(sessionId: try c.decode(String.self, forKey: .sessionId))
         case "setModel":
@@ -107,6 +116,26 @@ extension RemoteClientMessage: Codable {
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 beforeIndex: try c.decode(Int.self, forKey: .beforeIndex),
                 limit: try c.decode(Int.self, forKey: .limit))
+        case "queueForceSend":
+            self = .queueForceSend(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                itemId: try c.decode(String.self, forKey: .itemId))
+        case "queueRemove":
+            self = .queueRemove(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                itemId: try c.decode(String.self, forKey: .itemId))
+        case "queueRetry":
+            self = .queueRetry(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                itemId: try c.decode(String.self, forKey: .itemId))
+        case "queueEdit":
+            self = .queueEdit(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                itemId: try c.decode(String.self, forKey: .itemId))
+        case "queueClear":
+            self = .queueClear(sessionId: try c.decode(String.self, forKey: .sessionId))
+        case "queueSteerUndo":
+            self = .queueSteerUndo(sessionId: try c.decode(String.self, forKey: .sessionId))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
         }
@@ -148,11 +177,12 @@ extension RemoteClientMessage: Codable {
         case .takeOver(let s):
             try c.encode("takeOver", forKey: .type)
             try c.encode(s, forKey: .sessionId)
-        case .sendPrompt(let s, let t, let a):
+        case .sendPrompt(let s, let t, let a, let intent):
             try c.encode("sendPrompt", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encode(t, forKey: .text)
             try c.encode(a, forKey: .attachments)
+            try c.encode(intent, forKey: .intent)
         case .stop(let s):
             try c.encode("stop", forKey: .type)
             try c.encode(s, forKey: .sessionId)
@@ -177,6 +207,28 @@ extension RemoteClientMessage: Codable {
             try c.encode(id, forKey: .sessionId)
             try c.encode(beforeIndex, forKey: .beforeIndex)
             try c.encode(limit, forKey: .limit)
+        case .queueForceSend(let s, let itemId):
+            try c.encode("queueForceSend", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(itemId, forKey: .itemId)
+        case .queueRemove(let s, let itemId):
+            try c.encode("queueRemove", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(itemId, forKey: .itemId)
+        case .queueRetry(let s, let itemId):
+            try c.encode("queueRetry", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(itemId, forKey: .itemId)
+        case .queueEdit(let s, let itemId):
+            try c.encode("queueEdit", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(itemId, forKey: .itemId)
+        case .queueClear(let s):
+            try c.encode("queueClear", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+        case .queueSteerUndo(let s):
+            try c.encode("queueSteerUndo", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
         }
     }
 }
@@ -200,7 +252,10 @@ extension RemoteClientMessage {
     /// stop stays fast when a client is simply scrolled up mid-backfill.
     var isDriveOrdering: Bool {
         switch self {
-        case .sendPrompt, .takeOver: return true
+        case .sendPrompt, .takeOver,
+             .queueForceSend, .queueRemove, .queueRetry, .queueEdit,
+             .queueClear, .queueSteerUndo:
+            return true
         default: return false
         }
     }
@@ -234,6 +289,8 @@ enum RemoteServerMessage: Equatable, Sendable {
     case promptRejected(sessionId: String)
     case sessionConfig(RemoteSessionConfig)
     case sessionRenamed(sessionId: String, title: String)
+    case queueState(sessionId: String, items: [RemoteQueuedPrompt], steerUndoAvailable: Bool)
+    case queueEditRestored(sessionId: String, itemId: String, text: String)
     case error(message: String)
 }
 
@@ -243,6 +300,7 @@ extension RemoteServerMessage: Codable {
         case worktrees, agents, session
         case models, modes, currentModel, currentMode, autoRunEnabled, acceptsImages, title
         case firstIndex, totalCount, epoch, revision
+        case items, steerUndoAvailable, itemId, text
     }
 
     init(from decoder: Decoder) throws {
@@ -324,6 +382,16 @@ extension RemoteServerMessage: Codable {
             self = .sessionRenamed(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 title: try c.decode(String.self, forKey: .title))
+        case "queueState":
+            self = .queueState(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                items: try c.decode([RemoteQueuedPrompt].self, forKey: .items),
+                steerUndoAvailable: try c.decodeIfPresent(Bool.self, forKey: .steerUndoAvailable) ?? false)
+        case "queueEditRestored":
+            self = .queueEditRestored(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                itemId: try c.decode(String.self, forKey: .itemId),
+                text: try c.decode(String.self, forKey: .text))
         case "error": self = .error(message: try c.decode(String.self, forKey: .message))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
@@ -415,6 +483,16 @@ extension RemoteServerMessage: Codable {
             try c.encode("sessionRenamed", forKey: .type)
             try c.encode(id, forKey: .sessionId)
             try c.encode(title, forKey: .title)
+        case .queueState(let id, let items, let steerUndoAvailable):
+            try c.encode("queueState", forKey: .type)
+            try c.encode(id, forKey: .sessionId)
+            try c.encode(items, forKey: .items)
+            try c.encode(steerUndoAvailable, forKey: .steerUndoAvailable)
+        case .queueEditRestored(let id, let itemId, let text):
+            try c.encode("queueEditRestored", forKey: .type)
+            try c.encode(id, forKey: .sessionId)
+            try c.encode(itemId, forKey: .itemId)
+            try c.encode(text, forKey: .text)
         case .error(let m): try c.encode("error", forKey: .type)
         try c.encode(m, forKey: .message)
         }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -315,7 +315,7 @@ struct RemoteProtocolTests {
     @Test func clientMessageDecodesSendPrompt() throws {
         let json = #"{"type":"sendPrompt","sessionId":"s1","text":"hello"}"#.data(using: .utf8)!
         let msg = try JSONDecoder().decode(RemoteClientMessage.self, from: json)
-        #expect(msg == .sendPrompt(sessionId: "s1", text: "hello", attachments: []))
+        #expect(msg == .sendPrompt(sessionId: "s1", text: "hello", attachments: [], intent: "auto"))
     }
 
     @Test func clientMessageDecodesTakeOverAndStop() throws {
@@ -343,7 +343,7 @@ struct RemoteProtocolTests {
 
     @Test func clientDriveVerbsRoundTrip() throws {
         #expect(try roundTrip(RemoteClientMessage.takeOver(sessionId: "s1")) == .takeOver(sessionId: "s1"))
-        #expect(try roundTrip(RemoteClientMessage.sendPrompt(sessionId: "s1", text: "hello", attachments: [])) == .sendPrompt(sessionId: "s1", text: "hello", attachments: []))
+        #expect(try roundTrip(RemoteClientMessage.sendPrompt(sessionId: "s1", text: "hello", attachments: [], intent: "auto")) == .sendPrompt(sessionId: "s1", text: "hello", attachments: [], intent: "auto"))
         #expect(try roundTrip(RemoteClientMessage.stop(sessionId: "s1")) == .stop(sessionId: "s1"))
     }
 
@@ -405,7 +405,8 @@ struct RemoteProtocolTests {
         let msg = RemoteClientMessage.sendPrompt(
             sessionId: "s1",
             text: "look",
-            attachments: [RemoteAttachment(name: "a.png", mimeType: "image/png", dataBase64: "AAAA")])
+            attachments: [RemoteAttachment(name: "a.png", mimeType: "image/png", dataBase64: "AAAA")],
+            intent: "auto")
         #expect(try roundTrip(msg) == msg)
     }
 
@@ -455,8 +456,87 @@ struct RemoteProtocolTests {
         #expect(!RemoteClientMessage.fetchOlder(sessionId: "s", beforeIndex: 0, limit: 1).isControl)
     }
 
+    @Test func clientMessageDecodesQueueVerbs() throws {
+        let force = #"{"type":"queueForceSend","sessionId":"s1","itemId":"i1"}"#.data(using: .utf8)!
+        #expect(try JSONDecoder().decode(RemoteClientMessage.self, from: force)
+            == .queueForceSend(sessionId: "s1", itemId: "i1"))
+
+        let remove = #"{"type":"queueRemove","sessionId":"s1","itemId":"i2"}"#.data(using: .utf8)!
+        #expect(try JSONDecoder().decode(RemoteClientMessage.self, from: remove)
+            == .queueRemove(sessionId: "s1", itemId: "i2"))
+
+        let retry = #"{"type":"queueRetry","sessionId":"s1","itemId":"i3"}"#.data(using: .utf8)!
+        #expect(try JSONDecoder().decode(RemoteClientMessage.self, from: retry)
+            == .queueRetry(sessionId: "s1", itemId: "i3"))
+
+        let edit = #"{"type":"queueEdit","sessionId":"s1","itemId":"i4"}"#.data(using: .utf8)!
+        #expect(try JSONDecoder().decode(RemoteClientMessage.self, from: edit)
+            == .queueEdit(sessionId: "s1", itemId: "i4"))
+
+        let clear = #"{"type":"queueClear","sessionId":"s1"}"#.data(using: .utf8)!
+        #expect(try JSONDecoder().decode(RemoteClientMessage.self, from: clear)
+            == .queueClear(sessionId: "s1"))
+
+        let undo = #"{"type":"queueSteerUndo","sessionId":"s1"}"#.data(using: .utf8)!
+        #expect(try JSONDecoder().decode(RemoteClientMessage.self, from: undo)
+            == .queueSteerUndo(sessionId: "s1"))
+    }
+
+    @Test func queueVerbsRoundTrip() throws {
+        let messages: [RemoteClientMessage] = [
+            .queueForceSend(sessionId: "s1", itemId: "i1"),
+            .queueRemove(sessionId: "s1", itemId: "i2"),
+            .queueRetry(sessionId: "s1", itemId: "i3"),
+            .queueEdit(sessionId: "s1", itemId: "i4"),
+            .queueClear(sessionId: "s1"),
+            .queueSteerUndo(sessionId: "s1"),
+        ]
+        for message in messages {
+            #expect(try roundTrip(message) == message)
+        }
+    }
+
+    @Test func sendPromptWithoutIntentDecodesAsAuto() throws {
+        let json = #"{"type":"sendPrompt","sessionId":"s1","text":"hi"}"#.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(RemoteClientMessage.self, from: json)
+        #expect(msg == .sendPrompt(sessionId: "s1", text: "hi", attachments: [], intent: "auto"))
+    }
+
+    @Test func sendPromptCarriesSteerIntent() throws {
+        let json = #"{"type":"sendPrompt","sessionId":"s1","text":"hi","intent":"steer"}"#.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(RemoteClientMessage.self, from: json)
+        #expect(msg == .sendPrompt(sessionId: "s1", text: "hi", attachments: [], intent: "steer"))
+        #expect(try roundTrip(msg) == msg)
+    }
+
+    @Test func queueStateRoundTrips() throws {
+        let state = RemoteServerMessage.queueState(
+            sessionId: "s1",
+            items: [
+                RemoteQueuedPrompt(id: "i1", text: "first", imageCount: 0, status: "sending", lastError: nil),
+                RemoteQueuedPrompt(id: "i2", text: "second", imageCount: 2, status: "pending", lastError: "boom"),
+            ],
+            steerUndoAvailable: true)
+        #expect(try roundTrip(state) == state)
+    }
+
+    @Test func queueEditRestoredRoundTrips() throws {
+        let restored = RemoteServerMessage.queueEditRestored(sessionId: "s1", itemId: "i1", text: "edit me")
+        #expect(try roundTrip(restored) == restored)
+    }
+
+    @Test func queueVerbsAreDriveOrdering() {
+        #expect(RemoteClientMessage.queueForceSend(sessionId: "s1", itemId: "i1").isDriveOrdering)
+        #expect(RemoteClientMessage.queueRemove(sessionId: "s1", itemId: "i1").isDriveOrdering)
+        #expect(RemoteClientMessage.queueRetry(sessionId: "s1", itemId: "i1").isDriveOrdering)
+        #expect(RemoteClientMessage.queueEdit(sessionId: "s1", itemId: "i1").isDriveOrdering)
+        #expect(RemoteClientMessage.queueClear(sessionId: "s1").isDriveOrdering)
+        #expect(RemoteClientMessage.queueSteerUndo(sessionId: "s1").isDriveOrdering)
+        #expect(!RemoteClientMessage.listSessions.isDriveOrdering)
+    }
+
     @Test func onlySendPromptAndTakeOverAreDriveOrdering() {
-        #expect(RemoteClientMessage.sendPrompt(sessionId: "s", text: "hi", attachments: []).isDriveOrdering)
+        #expect(RemoteClientMessage.sendPrompt(sessionId: "s", text: "hi", attachments: [], intent: "auto").isDriveOrdering)
         #expect(RemoteClientMessage.takeOver(sessionId: "s").isDriveOrdering)
         #expect(!RemoteClientMessage.subscribe(sessionId: "s").isDriveOrdering)
         #expect(!RemoteClientMessage.fetchOlder(sessionId: "s", beforeIndex: 0, limit: 1).isDriveOrdering)

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -513,8 +513,8 @@ struct RemoteProtocolTests {
         let state = RemoteServerMessage.queueState(
             sessionId: "s1",
             items: [
-                RemoteQueuedPrompt(id: "i1", text: "first", imageCount: 0, status: "sending", lastError: nil),
-                RemoteQueuedPrompt(id: "i2", text: "second", imageCount: 2, status: "pending", lastError: "boom"),
+                RemoteQueuedPrompt(id: "i1", text: "first", imageCount: 0, resourceCount: 0, status: "sending", lastError: nil),
+                RemoteQueuedPrompt(id: "i2", text: "second", imageCount: 2, resourceCount: 1, status: "pending", lastError: "boom"),
             ],
             steerUndoAvailable: true)
         #expect(try roundTrip(state) == state)

--- a/AlasTests/Remote/RemoteQueueProjectionTests.swift
+++ b/AlasTests/Remote/RemoteQueueProjectionTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct RemoteQueueProjectionTests {
+    private func item(
+        text: String? = nil,
+        imageURIs: [String] = [],
+        status: QueuedPrompt.Status = .pending,
+        lastError: String? = nil
+    ) -> QueuedPrompt {
+        var blocks: [ACPContentBlock] = []
+        if let text { blocks.append(.text(text)) }
+        for uri in imageURIs {
+            blocks.append(.image(data: "AAAA", uri: uri, mimeType: "image/png"))
+        }
+        return QueuedPrompt(blocks: blocks, status: status, lastError: lastError)
+    }
+
+    @Test func projectsPendingTextItem() {
+        let queued = item(text: "run the tests")
+        let projected = RemoteQueueProjection.project([queued])
+
+        #expect(projected.count == 1)
+        #expect(projected[0].id == queued.id.uuidString)
+        #expect(projected[0].text == "run the tests")
+        #expect(projected[0].imageCount == 0)
+        #expect(projected[0].status == "pending")
+        #expect(projected[0].lastError == nil)
+    }
+
+    @Test func projectsSendingStatusAndError() {
+        let sending = RemoteQueueProjection.project([item(text: "a", status: .sending)])
+        #expect(sending[0].status == "sending")
+
+        let errored = RemoteQueueProjection.project([item(text: "b", lastError: "boom")])
+        #expect(errored[0].status == "pending")
+        #expect(errored[0].lastError == "boom")
+    }
+
+    @Test func joinsMultipleTextBlocksAndCountsImages() {
+        let queued = QueuedPrompt(blocks: [
+            .text("first "),
+            .image(data: "AAAA", uri: "file:///a.png", mimeType: "image/png"),
+            .text("second"),
+            .image(data: "BBBB", uri: "file:///b.png", mimeType: "image/png"),
+        ])
+        let projected = RemoteQueueProjection.project([queued])
+
+        #expect(projected[0].text == "first second")
+        #expect(projected[0].imageCount == 2)
+    }
+
+    @Test func imageOnlyItemProjectsEmptyText() {
+        let projected = RemoteQueueProjection.project([item(imageURIs: ["file:///a.png"])])
+
+        #expect(projected[0].text.isEmpty)
+        #expect(projected[0].imageCount == 1)
+    }
+
+    @Test func neverLeaksImageBytes() throws {
+        let queued = item(text: "hi", imageURIs: ["file:///secret.png"])
+        let encoded = try JSONEncoder().encode(RemoteQueueProjection.project([queued]))
+        let json = String(data: encoded, encoding: .utf8)!
+
+        #expect(!json.contains("AAAA"))
+        #expect(!json.contains("secret.png"))
+    }
+
+    @Test func visibleCountExcludesSendingHead() {
+        let projected = RemoteQueueProjection.project([
+            item(text: "a", status: .sending),
+            item(text: "b"),
+            item(text: "c"),
+        ])
+        #expect(RemoteQueueProjection.visibleCount(projected) == 2)
+    }
+
+    @Test func plainTextFlattensTextAndMentions() {
+        let draft = ACPComposerDraft(segments: [
+            .text("look at "),
+            .mention(displayName: "App.swift", uri: "file:///App.swift"),
+            .text("please"),
+        ])
+        #expect(RemoteQueueProjection.plainText(from: draft) == "look at @App.swift please")
+    }
+
+    @Test func plainTextDropsImageSegments() {
+        let draft = ACPComposerDraft(segments: [
+            .text("hi"),
+            .image(uri: "file:///a.png", mimeType: "image/png"),
+        ])
+        #expect(RemoteQueueProjection.plainText(from: draft) == "hi")
+    }
+}

--- a/AlasTests/Remote/RemoteQueueProjectionTests.swift
+++ b/AlasTests/Remote/RemoteQueueProjectionTests.swift
@@ -25,6 +25,7 @@ struct RemoteQueueProjectionTests {
         #expect(projected[0].id == queued.id.uuidString)
         #expect(projected[0].text == "run the tests")
         #expect(projected[0].imageCount == 0)
+        #expect(projected[0].resourceCount == 0)
         #expect(projected[0].status == "pending")
         #expect(projected[0].lastError == nil)
     }
@@ -56,6 +57,45 @@ struct RemoteQueueProjectionTests {
 
         #expect(projected[0].text.isEmpty)
         #expect(projected[0].imageCount == 1)
+    }
+
+    @Test func countsResourceLinkBlocksIntoResourceCount() {
+        let queued = QueuedPrompt(blocks: [
+            .text("see "),
+            .resourceLink(uri: "file:///App.swift", name: "App.swift"),
+        ])
+        let projected = RemoteQueueProjection.project([queued])
+
+        #expect(projected[0].text == "see ")
+        #expect(projected[0].imageCount == 0)
+        #expect(projected[0].resourceCount == 1)
+    }
+
+    @Test func countsEmbeddedResourceBlocksIntoResourceCount() {
+        let queued = QueuedPrompt(blocks: [
+            .text("see "),
+            .resource(uri: "file:///notes.txt", mimeType: "text/plain", text: "notes"),
+        ])
+        let projected = RemoteQueueProjection.project([queued])
+
+        #expect(projected[0].text == "see ")
+        #expect(projected[0].imageCount == 0)
+        #expect(projected[0].resourceCount == 1)
+    }
+
+    @Test func mixedTextImageAndResourceItemProjectsAllThreeFields() {
+        let queued = QueuedPrompt(blocks: [
+            .text("look at "),
+            .image(data: "AAAA", uri: "file:///a.png", mimeType: "image/png"),
+            .resourceLink(uri: "file:///App.swift", name: "App.swift"),
+            .text(" and "),
+            .resource(uri: "file:///notes.txt", mimeType: "text/plain", text: "notes"),
+        ])
+        let projected = RemoteQueueProjection.project([queued])
+
+        #expect(projected[0].text == "look at  and ")
+        #expect(projected[0].imageCount == 1)
+        #expect(projected[0].resourceCount == 2)
     }
 
     @Test func neverLeaksImageBytes() throws {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -861,10 +861,10 @@ struct RemoteSessionGatewayTests {
     @Test func sendPromptRoutesOnlyWhenWriter() async {
         let provider = FakeSessionsProvider()
         let gw = RemoteSessionGateway(provider: provider) { _ in }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: [])) // not writer → ignored
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: [], intent: "auto")) // not writer → ignored
         #expect(provider.prompts.isEmpty)
         provider.writers.insert("s1")
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: []))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: [], intent: "auto"))
         #expect(provider.prompts.map(\.text) == ["hi"])
     }
 
@@ -872,9 +872,9 @@ struct RemoteSessionGatewayTests {
         let provider = FakeSessionsProvider()
         provider.writers.insert("s1")
         let gw = RemoteSessionGateway(provider: provider) { _ in }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "   \n  ", attachments: [])) // blank → ignored
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "   \n  ", attachments: [], intent: "auto")) // blank → ignored
         #expect(provider.prompts.isEmpty)
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "  hi  ", attachments: [])) // trimmed before forwarding
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "  hi  ", attachments: [], intent: "auto")) // trimmed before forwarding
         #expect(provider.prompts.map(\.text) == ["hi"])
     }
 
@@ -884,21 +884,21 @@ struct RemoteSessionGatewayTests {
         let provider = FakeSessionsProvider()
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: [])) // not writer
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: [], intent: "auto")) // not writer
         #expect(provider.prompts.isEmpty)
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
         // When we ARE the writer and the manager accepts, the prompt routes
         // and no rejection is sent.
         sent.removeAll()
         provider.writers.insert("s1")
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: []))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "hi", attachments: [], intent: "auto"))
         #expect(provider.prompts.map(\.text) == ["hi"])
         #expect(!sent.contains { if case .promptRejected = $0 { return true } else { return false } })
         // Writer, but the manager refuses the submit (e.g. needs auth) — the
         // client must still be told so it can restore the text.
         sent.removeAll()
         provider.sendPromptAccepts = false
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "later", attachments: []))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "later", attachments: [], intent: "auto"))
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
     }
 
@@ -1032,7 +1032,7 @@ struct RemoteSessionGatewayTests {
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
         let big = String(repeating: "A", count: 14_000_000)   // ~10.5MB decoded > cap
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: nil, mimeType: "image/png", dataBase64: big)]))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: nil, mimeType: "image/png", dataBase64: big)], intent: "auto"))
         #expect(provider.lastAttachments.isEmpty)
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
     }
@@ -1042,7 +1042,7 @@ struct RemoteSessionGatewayTests {
         provider.writers.insert("s1")
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: "f.txt", mimeType: "text/plain", dataBase64: "AAAA")]))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: "f.txt", mimeType: "text/plain", dataBase64: "AAAA")], intent: "auto"))
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
     }
 
@@ -1135,7 +1135,7 @@ struct RemoteSessionGatewayTests {
         let many = (0..<(RemoteSessionGateway.maxAttachmentCount + 1)).map { _ in
             RemoteAttachment(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")
         }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: many))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: many, intent: "auto"))
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
         #expect(provider.writtenAttachmentURLs.isEmpty)   // rejected before any write
     }
@@ -1147,7 +1147,7 @@ struct RemoteSessionGatewayTests {
         provider.writers.insert("s1")
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: "evil.png", mimeType: "image/png", dataBase64: "AAAAAAAAAAA=")]))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "x", attachments: [.init(name: "evil.png", mimeType: "image/png", dataBase64: "AAAAAAAAAAA=")], intent: "auto"))
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
         #expect(provider.writtenAttachmentURLs.isEmpty)
     }
@@ -1157,7 +1157,7 @@ struct RemoteSessionGatewayTests {
         provider.writers.insert("s1")
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")]))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")], intent: "auto"))
         #expect(provider.lastAttachments.count == 1)
         #expect(!sent.contains { if case .promptRejected = $0 { return true } else { return false } })
     }
@@ -1171,7 +1171,7 @@ struct RemoteSessionGatewayTests {
         provider.sendPromptAccepts = false
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")]))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")], intent: "auto"))
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
         #expect(!provider.writtenAttachmentURLs.isEmpty)
         for url in provider.writtenAttachmentURLs {
@@ -1189,7 +1189,7 @@ struct RemoteSessionGatewayTests {
         provider.sendPromptResultIsAsync = true
         var sent: [RemoteServerMessage] = []
         let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
-        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")]))
+        await gw.handle(.sendPrompt(sessionId: "s1", text: "look", attachments: [.init(name: "a.png", mimeType: "image/png", dataBase64: "iVBORw0KGgo=")], intent: "auto"))
         try await Task.sleep(nanoseconds: 30_000_000)   // let the async onResult land
         #expect(sent.contains(.promptRejected(sessionId: "s1")))
         #expect(!provider.writtenAttachmentURLs.isEmpty)

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -1978,4 +1978,40 @@ struct RemoteSessionGatewayTests {
         await gateway.handle(.queueForceSend(sessionId: id, itemId: itemId.uuidString))
         #expect(provider.queueForceSends.map(\.itemId) == [itemId])
     }
+
+    @Test func subscribeEmitsQueueStateEvenWhenQueueIsEmpty() async throws {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        provider.sessions[id] = try makeSessionWithAgentText("x")
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.subscribe(sessionId: id))
+
+        let states = sent.compactMap { message -> [RemoteQueuedPrompt]? in
+            if case .queueState(_, let items, _) = message { return items }
+            return nil
+        }
+        #expect(states == [[]])
+    }
+
+    @Test func subscribeProjectsExistingQueue() async throws {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        let session = try makeSessionWithAgentText("x")
+        session.queue = [QueuedPrompt(blocks: [.text("queued one")])]
+        provider.sessions[id] = session
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.subscribe(sessionId: id))
+
+        let items = sent.compactMap { message -> [RemoteQueuedPrompt]? in
+            if case .queueState(_, let items, _) = message { return items }
+            return nil
+        }.first
+        #expect(items?.count == 1)
+        #expect(items?.first?.text == "queued one")
+        #expect(items?.first?.status == "pending")
+    }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -32,6 +32,11 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var queueSteerUndos: [String] = []
     var steerPrompts: [(id: String, text: String)] = []
     var queueEditText: String?            // what queueEdit hands back
+    /// When set, `queueEdit` delegates to this real manager instead of
+    /// returning `queueEditText`, so a test can exercise the manager's own
+    /// guard logic (e.g. refusing an item with a mention/image) through the
+    /// gateway rather than a canned stub.
+    var manager: ACPSessionManager?
     var steerPromptAccepts = true
     var fullToolCallContents: [String: String] = [:]
     var fullToolCallContentCallCount = 0
@@ -160,8 +165,9 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     func queueForceSend(for id: String, itemId: UUID) { queueForceSends.append((id, itemId)) }
     func queueRemove(for id: String, itemId: UUID) { queueRemoves.append((id, itemId)) }
     func queueRetry(for id: String, itemId: UUID) { queueRetries.append((id, itemId)) }
-    func queueEdit(for id: String, itemId: UUID) -> String? {
+    func queueEdit(for id: String, itemId: UUID) async -> String? {
         queueEdits.append((id, itemId))
+        if let manager { return await manager.queueEdit(for: id, itemId: itemId) }
         return queueEditText
     }
     func queueClear(for id: String) { queueClears.append(id) }
@@ -2199,6 +2205,40 @@ struct RemoteSessionGatewayTests {
         await gateway.handle(.queueEdit(sessionId: id, itemId: UUID().uuidString))
 
         #expect(!sent.contains { if case .queueEditRestored = $0 { return true } else { return false } })
+    }
+
+    // Regression (codex review, PR #964): a queued item whose draft carries a
+    // mention (file reference) is just as unrepresentable in the plain-text
+    // web composer as one carrying an image. The web already hides Edit for
+    // these, but the manager must refuse the edit too, so a client that
+    // doesn't know the rule (or a hand-rolled one) can't cause the queued
+    // item's file context to be silently dropped. Routed through the real
+    // manager (not the plain stub) so this exercises the actual guard in
+    // `ACPSessionManager.queueEdit`, not a test double's approximation of it.
+    @Test func queueEditRefusesItemWithMentionAndLeavesItQueued() async throws {
+        let provider = FakeSessionsProvider()
+        let mgr = try makeManager()
+        provider.manager = mgr
+        let session = mgr.createSession(agentId: "claude")
+        provider.sessions[session.id] = session
+        provider.writers.insert(session.id)
+        #expect(await mgr.acquireWriterLease(sessionId: session.id) == true)
+
+        let draft = ACPComposerDraft(segments: [
+            .text("see "),
+            .mention(displayName: "App.swift", uri: "file:///App.swift"),
+        ])
+        session.enqueue(
+            blocks: [.text("see "), .resourceLink(uri: "file:///App.swift", name: "App.swift")],
+            draft: draft)
+        let itemId = session.queue[0].id
+
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gateway.handle(.queueEdit(sessionId: session.id, itemId: itemId.uuidString))
+
+        #expect(!sent.contains { if case .queueEditRestored = $0 { return true } else { return false } })
+        #expect(session.queue.map(\.id) == [itemId], "the item must remain queued, not be removed then discarded")
     }
 
     @Test func steerIntentRoutesToSteerPromptNotSendPrompt() async {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -24,6 +24,15 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var renamed: [(id: String, title: String)] = []
     var renameSucceeds = true
     var configs: [String: RemoteSessionConfig] = [:]
+    var queueForceSends: [(id: String, itemId: UUID)] = []
+    var queueRemoves: [(id: String, itemId: UUID)] = []
+    var queueRetries: [(id: String, itemId: UUID)] = []
+    var queueEdits: [(id: String, itemId: UUID)] = []
+    var queueClears: [String] = []
+    var queueSteerUndos: [String] = []
+    var steerPrompts: [(id: String, text: String)] = []
+    var queueEditText: String?            // what queueEdit hands back
+    var steerPromptAccepts = true
     var fullToolCallContents: [String: String] = [:]
     var fullToolCallContentCallCount = 0
     var sessionSummariesCallCount = 0
@@ -147,6 +156,21 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         return renameSucceeds
     }
     func sessionConfig(for id: String) -> RemoteSessionConfig? { configs[id] }
+
+    func queueForceSend(for id: String, itemId: UUID) { queueForceSends.append((id, itemId)) }
+    func queueRemove(for id: String, itemId: UUID) { queueRemoves.append((id, itemId)) }
+    func queueRetry(for id: String, itemId: UUID) { queueRetries.append((id, itemId)) }
+    func queueEdit(for id: String, itemId: UUID) -> String? {
+        queueEdits.append((id, itemId))
+        return queueEditText
+    }
+    func queueClear(for id: String) { queueClears.append(id) }
+    func queueSteerUndo(for id: String) { queueSteerUndos.append(id) }
+    func steerPrompt(for id: String, text: String, attachments: [ACPMessage.Attachment], onResult: @escaping @MainActor (Bool) -> Void) {
+        let accepted = writers.contains(id) && steerPromptAccepts
+        if accepted { steerPrompts.append((id, text)) }
+        onResult(accepted)
+    }
 }
 
 #if DEBUG
@@ -1938,5 +1962,20 @@ struct RemoteSessionGatewayTests {
         // The retry reuses the cache the first (superseded) attempt already
         // populated — no second real fetch needed.
         #expect(provider.fullToolCallContentCallCount == 1)
+    }
+
+    @Test func queueVerbsReachTheProviderOnlyForWriters() async {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        let itemId = UUID()
+
+        await gateway.handle(.queueForceSend(sessionId: id, itemId: itemId.uuidString))
+        #expect(provider.queueForceSends.isEmpty)
+
+        provider.writers.insert(id)
+        await gateway.handle(.queueForceSend(sessionId: id, itemId: itemId.uuidString))
+        #expect(provider.queueForceSends.map(\.itemId) == [itemId])
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -2014,4 +2014,25 @@ struct RemoteSessionGatewayTests {
         #expect(items?.first?.text == "queued one")
         #expect(items?.first?.status == "pending")
     }
+
+    @Test func resubscribeStillEmitsQueueStateWhenUnchanged() async throws {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        provider.sessions[id] = try makeSessionWithAgentText("x")
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        // First subscribe (e.g. one browser tab) populates lastQueue[id] with
+        // the same (empty) snapshot a second subscribe would compute — without
+        // `force: true` on the subscribe path, the second subscribe's send
+        // would be swallowed by the dedupe.
+        await gateway.handle(.subscribe(sessionId: id))
+        await gateway.handle(.subscribe(sessionId: id))
+
+        let states = sent.compactMap { message -> [RemoteQueuedPrompt]? in
+            if case .queueState(_, let items, _) = message { return items }
+            return nil
+        }
+        #expect(states == [[], []])
+    }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -2035,4 +2035,103 @@ struct RemoteSessionGatewayTests {
         }
         #expect(states == [[], []])
     }
+
+    @Test func allQueueVerbsRequireWriterLease() async {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        let itemId = UUID()
+        let gateway = RemoteSessionGateway(provider: provider) { _ in }
+
+        await gateway.handle(.queueRemove(sessionId: id, itemId: itemId.uuidString))
+        await gateway.handle(.queueRetry(sessionId: id, itemId: itemId.uuidString))
+        await gateway.handle(.queueEdit(sessionId: id, itemId: itemId.uuidString))
+        await gateway.handle(.queueClear(sessionId: id))
+        await gateway.handle(.queueSteerUndo(sessionId: id))
+
+        #expect(provider.queueRemoves.isEmpty)
+        #expect(provider.queueRetries.isEmpty)
+        #expect(provider.queueEdits.isEmpty)
+        #expect(provider.queueClears.isEmpty)
+        #expect(provider.queueSteerUndos.isEmpty)
+    }
+
+    @Test func queueVerbsReachProviderForWriter() async {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        provider.writers.insert(id)
+        let itemId = UUID()
+        let gateway = RemoteSessionGateway(provider: provider) { _ in }
+
+        await gateway.handle(.queueRemove(sessionId: id, itemId: itemId.uuidString))
+        await gateway.handle(.queueRetry(sessionId: id, itemId: itemId.uuidString))
+        await gateway.handle(.queueClear(sessionId: id))
+        await gateway.handle(.queueSteerUndo(sessionId: id))
+
+        #expect(provider.queueRemoves.map(\.itemId) == [itemId])
+        #expect(provider.queueRetries.map(\.itemId) == [itemId])
+        #expect(provider.queueClears == [id])
+        #expect(provider.queueSteerUndos == [id])
+    }
+
+    @Test func malformedItemIdIsIgnored() async {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        provider.writers.insert(id)
+        let gateway = RemoteSessionGateway(provider: provider) { _ in }
+
+        await gateway.handle(.queueRemove(sessionId: id, itemId: "not-a-uuid"))
+
+        #expect(provider.queueRemoves.isEmpty)
+    }
+
+    @Test func queueEditRepliesWithRestoredText() async {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        provider.writers.insert(id)
+        provider.queueEditText = "restore me"
+        let itemId = UUID()
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.queueEdit(sessionId: id, itemId: itemId.uuidString))
+
+        #expect(sent.contains(.queueEditRestored(sessionId: id, itemId: itemId.uuidString, text: "restore me")))
+    }
+
+    @Test func queueEditOnSendingItemRepliesWithNothing() async {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        provider.writers.insert(id)
+        provider.queueEditText = nil          // takeForEditing refused
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.queueEdit(sessionId: id, itemId: UUID().uuidString))
+
+        #expect(!sent.contains { if case .queueEditRestored = $0 { return true } else { return false } })
+    }
+
+    @Test func steerIntentRoutesToSteerPromptNotSendPrompt() async {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        provider.writers.insert(id)
+        let gateway = RemoteSessionGateway(provider: provider) { _ in }
+
+        await gateway.handle(.sendPrompt(sessionId: id, text: "redirect", attachments: [], intent: "steer"))
+
+        #expect(provider.steerPrompts.map(\.text) == ["redirect"])
+        #expect(provider.prompts.isEmpty)
+    }
+
+    @Test func autoIntentStillRoutesToSendPrompt() async {
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        provider.writers.insert(id)
+        let gateway = RemoteSessionGateway(provider: provider) { _ in }
+
+        await gateway.handle(.sendPrompt(sessionId: id, text: "queue me", attachments: [], intent: "auto"))
+
+        #expect(provider.prompts.map(\.text) == ["queue me"])
+        #expect(provider.steerPrompts.isEmpty)
+    }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -2036,6 +2036,96 @@ struct RemoteSessionGatewayTests {
         #expect(states == [[], []])
     }
 
+    @Test func queueMutationOnLiveSessionEmitsQueueState() async throws {
+        // The three existing queueState tests above only exercise the
+        // force:true subscribe path. This covers the load-bearing one: the
+        // emission inside the config-coalesce closure in observe(id:session:)
+        // that carries a live queue mutation (a real enqueue while the
+        // browser tab is already open) to the client.
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        let session = try makeSessionWithAgentText("x")
+        provider.sessions[id] = session
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gateway.handle(.subscribe(sessionId: id))
+        sent.removeAll()
+
+        let item = QueuedPrompt(blocks: [.text("queued one")])
+        session.queue = [item]                      // mutate the LIVE queue, not via subscribe
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let items = sent.compactMap { message -> [RemoteQueuedPrompt]? in
+            if case .queueState(_, let items, _) = message { return items }
+            return nil
+        }.last
+        let queued = try #require(items, "expected a queueState after mutating session.queue")
+        #expect(queued.count == 1)
+        #expect(queued.first?.id == item.id.uuidString)
+        #expect(queued.first?.text == "queued one")
+    }
+
+    @Test func reassigningIdenticalQueueValueDoesNotReemitQueueState() async throws {
+        // The dedupe in sendQueueState must hold on the live-mutation path
+        // too, not just be inert scaffolding — @Published fires
+        // objectWillChange on every assignment regardless of equality, so
+        // this exercises the gateway's own dedupe rather than Combine's.
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        let session = try makeSessionWithAgentText("x")
+        provider.sessions[id] = session
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gateway.handle(.subscribe(sessionId: id))
+
+        let item = QueuedPrompt(blocks: [.text("queued one")])
+        session.queue = [item]
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let countAfterMutation = sent.filter { if case .queueState = $0 { return true } else { return false } }.count
+        #expect(countAfterMutation == 2)   // force:true baseline at subscribe + the mutation above
+
+        session.queue = [item]             // reassign the identical value
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let countAfterReassign = sent.filter { if case .queueState = $0 { return true } else { return false } }.count
+        #expect(countAfterReassign == countAfterMutation)   // dedupe swallowed the no-op reassignment
+    }
+
+    @Test func steerUndoAvailableFlipEmitsQueueStateWithQueueUnchanged() async throws {
+        // Regression guard for RemoteQueueSnapshot: steerUndoAvailable can
+        // flip (a steer discards the queue, then the 5s undo window expires)
+        // while `items` stays exactly as-is (already emptied by the steer
+        // itself). Both transitions must independently reach the wire, or
+        // the client is left showing a stale "undo available" affordance.
+        // session.queue is never touched here, so a dedupe key that only
+        // looked at items would swallow both sends.
+        let provider = FakeSessionsProvider()
+        let id = "s1"
+        let session = try makeSessionWithAgentText("x")
+        provider.sessions[id] = session
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+        await gateway.handle(.subscribe(sessionId: id))
+        sent.removeAll()
+
+        let discardedSnapshot = [QueuedPrompt(blocks: [.text("discarded by steer")])]
+        session.steerUndo = .init(id: UUID(), snapshot: discardedSnapshot)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let afterSet = sent.compactMap { message -> Bool? in
+            if case .queueState(_, _, let steerUndoAvailable) = message { return steerUndoAvailable }
+            return nil
+        }
+        #expect(afterSet.last == true, "expected a queueState with steerUndoAvailable=true after arming the undo window")
+
+        session.steerUndo = nil   // the window expires; session.queue is untouched throughout
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let afterClear = sent.compactMap { message -> Bool? in
+            if case .queueState(_, _, let steerUndoAvailable) = message { return steerUndoAvailable }
+            return nil
+        }
+        #expect(afterClear.last == false, "expected a second queueState with steerUndoAvailable=false after the window closed")
+        #expect(afterClear.count == afterSet.count + 1, "both the arm and the clear must independently reach the wire")
+    }
+
     @Test func allQueueVerbsRequireWriterLease() async {
         let provider = FakeSessionsProvider()
         let id = "s1"

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -414,9 +414,24 @@ struct RemoteWebAssetTests {
         #expect(js.contains("🖼"))
     }
 
-    @Test func sendingQueueItemsExposeNoActions() throws {
+    // Regression (final branch review): native never renders a `.sending`
+    // queue item (ACPMessageList.shouldRenderQueueBubble returns false for
+    // it) — flushQueueIfIdle marks the head `.sending` while it's still in
+    // session.queue, and sendNow records the same prompt into the
+    // transcript, so a `.sending` bubble here would double-show that text
+    // for the whole duration of the queued turn. renderQueue() must filter
+    // `.sending` out before building any rows, not merely gate a row's
+    // actions/status on it.
+    @Test func sendingQueueItemsAreSkippedEntirely() throws {
         let js = try asset("app.js")
-        #expect(js.contains(#"const pending = item.status === "pending";"#))
+        let body = try #require(js.range(of: "function renderQueue() {").map { js[$0.lowerBound...].prefix(1250) })
+        #expect(body.contains(#"const visible = queueItems.filter(i => i.status !== "sending");"#))
+        #expect(body.contains("visible.forEach(item => box.appendChild(queuedRow(item)));"))
+        #expect(!body.contains("queueItems.forEach(item => box.appendChild(queuedRow(item)));"))
+        // queuedRow itself no longer branches on status — every row it builds
+        // is implicitly `.pending` since renderQueue() filters upstream.
+        #expect(!js.contains(#"item.status === "pending""#))
+        #expect(!js.contains("is-sending"))
     }
 
     @Test func queueParityBustsServiceWorkerAssetCache() throws {

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -382,6 +382,43 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"id="queue-badge" class="hidden""#))
     }
 
+    @Test func remoteWebRendersQueuedBubblesOutsideTheTranscriptScroller() throws {
+        let html = try asset("index.html")
+        let js = try asset("app.js")
+        let css = try asset("style.css")
+
+        #expect(html.contains(#"<div id="queued" class="hidden"></div>"#))
+        #expect(js.contains("function renderQueue()"))
+        #expect(js.contains(#"el("div", "queued-bubble")"#))
+        #expect(js.contains("function setQueuedOpen(id)"))
+        #expect(js.contains("function queueAction(type, itemId)"))
+        #expect(css.contains("#queued"))
+        #expect(css.contains(".queued-bubble"))
+        #expect(css.contains(".queued-actions"))
+    }
+
+    @Test func queuedBubblesDispatchEveryQueueVerb() throws {
+        let js = try asset("app.js")
+
+        #expect(js.contains(#""queueForceSend""#))
+        #expect(js.contains(#""queueRemove""#))
+        #expect(js.contains(#""queueRetry""#))
+        #expect(js.contains(#""queueEdit""#))
+        #expect(js.contains(#""queueClear""#))
+        #expect(js.contains(#"case "queueEditRestored""#))
+    }
+
+    @Test func queuedBubblesHideEditWhenTheItemCarriesImages() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("if (item.imageCount === 0)"))
+        #expect(js.contains("🖼"))
+    }
+
+    @Test func sendingQueueItemsExposeNoActions() throws {
+        let js = try asset("app.js")
+        #expect(js.contains(#"const pending = item.status === "pending";"#))
+    }
+
     @Test func queueParityBustsServiceWorkerAssetCache() throws {
         let html = try asset("index.html")
         let sw = try asset("sw.js")

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -354,6 +354,34 @@ struct RemoteWebAssetTests {
         #expect(js.contains("let steerUndoAvailable = false;"))
     }
 
+    // Regression (review, task 6): pendingAttachments feeds hasText in
+    // composerAction, but the mutation sites (attach picker, chip removal,
+    // restoreRejectedPrompt) only ever called renderChips(), never
+    // renderDriveBar() — so attaching or removing an image-only message's
+    // photo could leave Send/Queue stuck hidden until some unrelated event
+    // happened to recompute the button. renderChips is the common funnel for
+    // all three mutations, so the fix lives there.
+    @Test func renderChipsRecomputesComposerActionOnAttachmentChanges() throws {
+        let js = try asset("app.js")
+
+        let body = try #require(js.range(of: "function renderChips() {").map { js[$0.lowerBound...].prefix(900) })
+        let closingBrace = try #require(body.range(of: "\n}"))
+        #expect(body[..<closingBrace.lowerBound].contains("renderDriveBar(lastStreamingState);"))
+    }
+
+    // Regression (review, task 6): the CSS fix for `#queue-badge` (Finding 2)
+    // styles the badges purely by id, and renderQueueBadges selects by id
+    // too — so the `queue-badge` class on the badge spans no longer has any
+    // reader and must not linger as a dead attribute implying a styling
+    // mechanism that doesn't exist.
+    @Test func badgeSpansDoNotCarryTheVestigialQueueBadgeClass() throws {
+        let html = try asset("index.html")
+
+        #expect(!html.contains(#"class="queue-badge hidden""#))
+        #expect(html.contains(#"id="send-badge" class="hidden""#))
+        #expect(html.contains(#"id="queue-badge" class="hidden""#))
+    }
+
     @Test func queueParityBustsServiceWorkerAssetCache() throws {
         let html = try asset("index.html")
         let sw = try asset("sw.js")

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -429,4 +429,14 @@ struct RemoteWebAssetTests {
         #expect(sw.contains(#""/app.js?v=61""#))
         #expect(sw.contains(#""/style.css?v=39""#))
     }
+
+    @Test func remoteWebOffersUndoAfterASteerDiscardsTheQueue() throws {
+        let js = try asset("app.js")
+        let css = try asset("style.css")
+
+        #expect(js.contains("function steerUndoToast()"))
+        #expect(js.contains(#""queueSteerUndo""#))
+        #expect(js.contains("Queue cleared by steer"))
+        #expect(css.contains(".steer-undo"))
+    }
 }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -48,11 +48,11 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=60"#))
-        #expect(html.contains(#"/style.css?v=38"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v38";"#))
-        #expect(sw.contains(#""/app.js?v=60""#))
-        #expect(sw.contains(#""/style.css?v=38""#))
+        #expect(html.contains(#"/app.js?v=61"#))
+        #expect(html.contains(#"/style.css?v=39"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v39";"#))
+        #expect(sw.contains(#""/app.js?v=61""#))
+        #expect(sw.contains(#""/style.css?v=39""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -65,11 +65,11 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=60"#))
-        #expect(html.contains(#"/style.css?v=38"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v38";"#))
-        #expect(sw.contains(#""/app.js?v=60""#))
-        #expect(sw.contains(#""/style.css?v=38""#))
+        #expect(html.contains(#"/app.js?v=61"#))
+        #expect(html.contains(#"/style.css?v=39"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v39";"#))
+        #expect(sw.contains(#""/app.js?v=61""#))
+        #expect(sw.contains(#""/style.css?v=39""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -110,8 +110,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-state-active"))
         #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=60"))
-        #expect(html.contains("/style.css?v=38"))
+        #expect(html.contains("/app.js?v=61"))
+        #expect(html.contains("/style.css?v=39"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -136,8 +136,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=60""#))
-        #expect(sw.contains(#""/style.css?v=38""#))
+        #expect(sw.contains(#""/app.js?v=61""#))
+        #expect(sw.contains(#""/style.css?v=39""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {
@@ -285,9 +285,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v38"))
-        #expect(sw.contains("/app.js?v=60"))
-        #expect(html.contains("app.js?v=60"))
+        #expect(sw.contains("alas-remote-shell-v39"))
+        #expect(sw.contains("/app.js?v=61"))
+        #expect(html.contains("app.js?v=61"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -317,5 +317,51 @@ struct RemoteWebAssetTests {
         #expect(sw.contains(#"url.pathname.startsWith("/api/")"#))
         #expect(!sw.contains(#""/health","#))
         #expect(!sw.contains(#""/remote-info","#))
+    }
+
+    @Test func remoteWebDerivesComposerActionLikeNativePane() throws {
+        let js = try asset("app.js")
+
+        #expect(js.contains("function composerAction(streamingState, hasText)"))
+        #expect(js.contains(#"return hasText ? "send" : "hidden";"#))
+        #expect(js.contains(#"return hasText ? "queue" : "stop";"#))
+        #expect(js.contains("function queueBadgeCount()"))
+        #expect(js.contains("function submitPrompt(intent)"))
+        #expect(js.contains(#"intent: intent || "auto""#))
+    }
+
+    @Test func remoteWebRendersQueueSplitCapsule() throws {
+        let html = try asset("index.html")
+        let css = try asset("style.css")
+
+        #expect(html.contains(#"id="queue-capsule""#))
+        #expect(html.contains(#"id="queue-primary""#))
+        #expect(html.contains(#"id="queue-menu""#))
+        #expect(html.contains(#"id="queue-badge""#))
+        #expect(html.contains(#"id="steer-sheet""#))
+        #expect(html.contains(#"id="steer-now""#))
+        #expect(html.contains(#"id="steer-stop""#))
+        #expect(css.contains("#queue-capsule"))
+        #expect(css.contains("#queue-badge"))
+    }
+
+    @Test func remoteWebHandlesQueueStateMessage() throws {
+        let js = try asset("app.js")
+
+        #expect(js.contains(#"case "queueState""#))
+        #expect(js.contains("function applyQueueState(msg)"))
+        #expect(js.contains("let queueItems = [];"))
+        #expect(js.contains("let steerUndoAvailable = false;"))
+    }
+
+    @Test func queueParityBustsServiceWorkerAssetCache() throws {
+        let html = try asset("index.html")
+        let sw = try asset("sw.js")
+
+        #expect(html.contains(#"/app.js?v=61"#))
+        #expect(html.contains(#"/style.css?v=39"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v39";"#))
+        #expect(sw.contains(#""/app.js?v=61""#))
+        #expect(sw.contains(#""/style.css?v=39""#))
     }
 }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -410,8 +410,20 @@ struct RemoteWebAssetTests {
 
     @Test func queuedBubblesHideEditWhenTheItemCarriesImages() throws {
         let js = try asset("app.js")
-        #expect(js.contains("if (item.imageCount === 0)"))
         #expect(js.contains("🖼"))
+    }
+
+    // Regression (codex review, PR #964): the web client must never offer an
+    // action that would silently discard content it cannot represent. A
+    // queued item with a resource/file mention is just as lossy to edit as
+    // one with an image (the browser never gets the URI), so Edit must be
+    // gated on BOTH counts and the resource chip must be visible so the
+    // user can see why.
+    @Test func queuedBubblesHideEditWhenTheItemCarriesResources() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("if (item.imageCount === 0 && item.resourceCount === 0)"))
+        #expect(js.contains("📎"))
+        #expect(js.contains("queued-resources"))
     }
 
     // Regression (final branch review): native never renders a `.sending`


### PR DESCRIPTION
In the remote web client, queued and pending messages had no representation at all: while a turn was running the composer showed only a Stop button, so there was no way to enqueue a follow-up, see what was already queued, force-send an item, or remove one.

The queue engine was not missing. `sendPrompt` already routed through `ACPSessionManager.submit(intent: .auto)` → `ACPSubmitRoute.resolve`, which enqueues whenever the session is busy. Two things kept it out of reach: `renderDriveBar` hid the Send button entirely when busy, and no wire message ever reported the queue back. So this PR surfaces the existing engine rather than building a second one — every queue mutation delegates to the native call site the ACP pane already uses (`forceSendQueuedItem`, `removeFromQueue`, `takeForEditing`, `clearPendingQueue`, `steerUndo`, `submit`), so the `.sending`-head, persistence, and lease invariants are not duplicated for the remote path.

## What changed

**Projection** — `RemoteQueueProjection` flattens `QueuedPrompt` into a wire-safe `RemoteQueuedPrompt { id, text, imageCount, status, lastError }`. Image *count* only; bytes and URIs never reach the browser, and a test asserts it.

**Wire protocol** — six client verbs (`queueForceSend`, `queueRemove`, `queueRetry`, `queueEdit`, `queueClear`, `queueSteerUndo`), two server messages (`queueState`, `queueEditRestored`), and an `intent` field on `sendPrompt`. `intent` decodes via `decodeIfPresent ?? "auto"` so a browser running a stale cached client keeps working. All six verbs join `isDriveOrdering` so a following `stop` cannot overtake a queue mutation.

**Gateway** — `queueState` rides the existing coalesced `objectWillChange` subscription with its own dedupe, forced on subscribe so a freshly-opened session gets a baseline. Inbound verbs are writer-gated with auto-takeover, matching `sendPrompt`; `stop` keeps its deliberate un-gated emergency-brake carve-out.

**Web** — four-state composer button (`hidden`/`send`/`queue`/`stop`) ported from `ComposerAction.swift`, with a count badge and a split capsule whose chevron opens Steer/Stop. Queued bubbles render in their own strip above the composer with tap-to-reveal send-now / retry / edit / remove, an `N queued` + Clear header, and a steer-undo toast.

## Notable decisions

- **Queued bubbles live outside the transcript scroller**, unlike native. `#messages` is strictly index-ordered — `insertMessage` walks `dataset.index` and `applyPage` prepends backfilled pages with scroll anchoring — so un-indexed nodes would fight both routines. The strip also keeps the queue visible on a phone instead of scrolling away.
- **Tap-to-reveal instead of hover**, since phones have no hover.
- **Edit is hidden on image-bearing items.** The web client receives no image bytes, so editing such an item would silently discard attachments the user was never shown.
- **`.sending` items render nothing**, matching native: `ACPQueuedBubble`'s `.sending` branch is dead code behind `shouldRenderQueueBubble`. Rendering it would double-show every queued message for the whole turn, since `sendNow` records the prompt into the transcript while the item is still `.sending` in the queue.

## Testing

171 tests across `RemoteQueueProjectionTests`, `RemoteProtocolTests`, `RemoteSessionGatewayTests`, and `RemoteWebAssetTests`, including old-client `intent` back-compat, the writer gate on every verb, live queue-mutation emission, dedupe behaviour, and the `steerUndoAvailable` flip.

The web layer has no runtime harness in this repo — its coverage is structural assertions over the built assets, per the existing `RemoteWebAssetTests` pattern. **The queue UI has not yet been exercised in a real browser**; that check is still outstanding.

## Out of scope

Drag-to-reorder queued items, and full-fidelity images in queued bubbles (blocked on the authed attachment endpoint; bubbles show a placeholder for now).