### PR TITLE
feat(acp): stabilize the AppKit transcript scrollbar

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -668,6 +668,7 @@
 		724CD1B1450DEC33DE6B0DE3 /* ComposerActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		725EDB42BF126786D99E359A /* CursorModelVariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F9063CCA0DA839EB342993 /* CursorModelVariants.swift */; };
+		72BFD5F8FC96F950F7995C1C /* ACPTranscriptLogicalScrollModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729B5F3498FF7388142DB9DD /* ACPTranscriptLogicalScrollModelTests.swift */; };
 		72CF403FFD14D75FC0DD15E3 /* MergeView3WayLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */; };
 		72EDB798775F24B86E8AD8DA /* ReviewChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
@@ -834,6 +835,7 @@
 		8ED9196CA54498198826E799 /* GGWorktreeMenuModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792D7045679FE1E12AAFA04 /* GGWorktreeMenuModelTests.swift */; };
 		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
+		8F5EA17127E27B25AA60D88B /* ACPTranscriptLogicalScrollModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6935E92CDED46890ABEABB6 /* ACPTranscriptLogicalScrollModel.swift */; };
 		8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */; };
 		8FA22790805C973E9EF64477 /* EditorLSPStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */; };
 		8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */; };
@@ -2197,6 +2199,7 @@
 		728F8E1DBF9DA86092C10AD0 /* ACPSessionOrchestrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinator.swift; sourceTree = "<group>"; };
 		7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateView.swift; sourceTree = "<group>"; };
 		72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiffTests.swift; sourceTree = "<group>"; };
+		729B5F3498FF7388142DB9DD /* ACPTranscriptLogicalScrollModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptLogicalScrollModelTests.swift; sourceTree = "<group>"; };
 		729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentModelTests.swift; sourceTree = "<group>"; };
 		72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAvatarPresetProviderTests.swift; sourceTree = "<group>"; };
 		730E9629FD89AA4BDCB3C57F /* RunScriptCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptCreation.swift; sourceTree = "<group>"; };
@@ -2559,6 +2562,7 @@
 		B5E898E9F7E2680132FF54D4 /* ACPSelectChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChip.swift; sourceTree = "<group>"; };
 		B65018D176CD2E52A3999CF0 /* AlasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackSummaryStore.swift; sourceTree = "<group>"; };
+		B6935E92CDED46890ABEABB6 /* ACPTranscriptLogicalScrollModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptLogicalScrollModel.swift; sourceTree = "<group>"; };
 		B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackCreateMode.swift; sourceTree = "<group>"; };
 		B6F6E707551671670D8CBA38 /* AgentLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLogoView.swift; sourceTree = "<group>"; };
 		B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSidebarContrastTests.swift; sourceTree = "<group>"; };
@@ -4081,6 +4085,7 @@
 				39B7BC45B64591618784F650 /* ACPSlashPickerTests.swift */,
 				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
+				729B5F3498FF7388142DB9DD /* ACPTranscriptLogicalScrollModelTests.swift */,
 				E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */,
 				E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */,
 				434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */,
@@ -4427,6 +4432,7 @@
 		7AED40BA76EA092B0B29D83D /* Scroller */ = {
 			isa = PBXGroup;
 			children = (
+				B6935E92CDED46890ABEABB6 /* ACPTranscriptLogicalScrollModel.swift */,
 				A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */,
 				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
 				ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */,
@@ -5959,6 +5965,7 @@
 				303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */,
 				8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */,
 				9983414D08DCAB87919FB804 /* ACPTranscriptChangeLog.swift in Sources */,
+				8F5EA17127E27B25AA60D88B /* ACPTranscriptLogicalScrollModel.swift in Sources */,
 				C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */,
 				95E01DC5A933FCC077399762 /* ACPTranscriptRowHostingPool.swift in Sources */,
 				62A80BDF7373A108DCF07512 /* ACPTranscriptRowHostingView.swift in Sources */,
@@ -6750,6 +6757,7 @@
 				1C2C949642E10060172AB1BA /* ACPToolCallPresentationTests.swift in Sources */,
 				F3249EE6574B3C7FC9FED0B1 /* ACPTranscriptChangeLogTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,
+				72BFD5F8FC96F950F7995C1C /* ACPTranscriptLogicalScrollModelTests.swift in Sources */,
 				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,
 				6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */,
 				F22A776D791ABA7A584B4C18 /* ACPTranscriptMessageIndexTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1183,8 +1183,11 @@ final class ACPSession: ObservableObject, Identifiable {
         transcript.completedOutputBoundaryMessageIds.removeAll()
     }
 
-    func replaceTranscriptMessages(_ messages: [ACPMessage]) {
-        transcript.replaceMessages(with: messagesPreservingToolCallContentRevisions(messages))
+    func replaceTranscriptMessages(_ messages: [ACPMessage], messageIndexOffset: Int = 0) {
+        transcript.replaceMessages(
+            with: messagesPreservingToolCallContentRevisions(messages),
+            messageIndexOffset: messageIndexOffset
+        )
     }
 
     private func messagesPreservingToolCallContentRevisions(_ messages: [ACPMessage]) -> [ACPMessage] {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -931,7 +931,7 @@ final class ACPSessionManager: ObservableObject {
         for i in tailStart..<total {
             tail.append(wires[i].toMessage())
         }
-        session.replaceTranscriptMessages(tail)
+        session.replaceTranscriptMessages(tail, messageIndexOffset: tailStart)
         session.transcript.visibleHead = 0
         if markCompletedBoundary {
             // Seed completedOutputBoundaryMessageIds from loaded history so

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -79,6 +79,16 @@ final class ACPTranscript: ObservableObject {
     /// async load is still running.
     @Published var isBackfillingOlderMessages: Bool = false
 
+    /// Number of known persisted messages that precede `messages[0]` while
+    /// tail-first hydration is still materialising the older prefix. This is
+    /// deliberately non-published: mutation entry points update it before
+    /// publishing the corresponding `messages` change, so observers always
+    /// see one coherent local/global index mapping.
+    private(set) var messageIndexOffset: Int = 0
+
+    /// Total known transcript extent even during the tail-only first paint.
+    var logicalMessageCount: Int { messageIndexOffset + messages.count }
+
     /// Render window: `ACPMessageList` draws `messages[visibleHead..<visibleTail]`.
     /// Reset to `max(0, messages.count - tailWindow)` after hydration so
     /// long transcripts paint quickly; user can scroll up or click the
@@ -169,14 +179,27 @@ final class ACPTranscript: ObservableObject {
         messages[index] = message
     }
 
-    func replaceMessages(with newMessages: [ACPMessage]) {
+    func replaceMessages(with newMessages: [ACPMessage], messageIndexOffset: Int = 0) {
+        self.messageIndexOffset = max(0, messageIndexOffset)
         messages = newMessages
     }
 
     func prependMessages(_ older: [ACPMessage]) {
         guard !older.isEmpty else { return }
+        messageIndexOffset = max(0, messageIndexOffset - older.count)
         pendingMessagesMutation = .prepend(count: older.count)
         messages.insert(contentsOf: older, at: 0)
+    }
+
+    func globalIndex(forLocalIndex index: Int) -> Int? {
+        guard messages.indices.contains(index) else { return nil }
+        return messageIndexOffset + index
+    }
+
+    func localIndex(forGlobalIndex index: Int) -> Int? {
+        let localIndex = index - messageIndexOffset
+        guard messages.indices.contains(localIndex) else { return nil }
+        return localIndex
     }
 
     func messageIndex(messageId: String, kind: TextMessageKind) -> Int? {
@@ -524,6 +547,21 @@ final class ACPTranscript: ObservableObject {
         let head = max(0, min(index, messages.count))
         let tail = min(messages.count, head + Self.maxVisibleRows)
         setVisibleWindow(head: head, tail: tail)
+    }
+
+    /// Select a full bounded window around a navigation target, with one
+    /// page of older context when available. Near either transcript edge the
+    /// window shifts inward instead of shrinking.
+    func setVisibleWindow(around index: Int) {
+        guard !messages.isEmpty else {
+            setVisibleWindow(head: 0, tail: 0)
+            return
+        }
+        let target = max(0, min(index, messages.count - 1))
+        let latestHead = max(0, messages.count - Self.maxVisibleRows)
+        let preferredHead = max(0, target - Self.tailWindow)
+        let head = min(preferredHead, latestHead)
+        setVisibleWindow(head: head, tail: min(messages.count, head + Self.maxVisibleRows))
     }
 
     /// Move the render window head, dropping markdown caches for any message

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptLogicalScrollModel.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptLogicalScrollModel.swift
@@ -1,0 +1,55 @@
+import CoreGraphics
+
+/// Maps a variable-height transcript onto a stable, message-index-based
+/// scrollbar range. Render-window membership and measured row heights are
+/// intentionally absent from this model, so paging cannot resize the thumb.
+enum ACPTranscriptLogicalScrollModel {
+    static let logicalPointsPerMessage: CGFloat = 96
+
+    struct Metrics: Equatable {
+        let value: Double
+        let knobProportion: CGFloat
+        let logicalViewportMessages: CGFloat
+    }
+
+    static func metrics(
+        totalCount: Int,
+        viewportHeight: CGFloat,
+        topGlobalIndex: Int,
+        isAtTail: Bool
+    ) -> Metrics {
+        let count = max(0, totalCount)
+        let viewportMessages = logicalViewportMessages(viewportHeight: viewportHeight)
+        let knobProportion = count == 0 ? 1 : min(1, viewportMessages / CGFloat(count))
+        let maximumTopIndex = max(0, CGFloat(count) - viewportMessages)
+        let value: Double
+        if maximumTopIndex == 0 {
+            value = 0
+        } else if isAtTail {
+            value = 1
+        } else {
+            value = Double(min(max(CGFloat(topGlobalIndex), 0), maximumTopIndex) / maximumTopIndex)
+        }
+        return Metrics(
+            value: value,
+            knobProportion: knobProportion,
+            logicalViewportMessages: viewportMessages
+        )
+    }
+
+    static func targetGlobalIndex(
+        value: Double,
+        totalCount: Int,
+        viewportHeight: CGFloat
+    ) -> Int {
+        let count = max(0, totalCount)
+        let viewportMessages = logicalViewportMessages(viewportHeight: viewportHeight)
+        let maximumTopIndex = max(0, CGFloat(count) - viewportMessages)
+        let clampedValue = min(max(value, 0), 1)
+        return Int((CGFloat(clampedValue) * maximumTopIndex).rounded())
+    }
+
+    private static func logicalViewportMessages(viewportHeight: CGFloat) -> CGFloat {
+        max(1, max(0, viewportHeight) / logicalPointsPerMessage)
+    }
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -90,6 +90,13 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// Set when a head step has been requested and cleared by the next
         /// `update(host:)`. See `handleScroll`'s head-step block.
         private var pendingHeadStep = false
+        /// Global message index selected by a logical scrollbar release that
+        /// still lies in tail-first hydration's unmaterialized prefix.
+        private var pendingLogicalTargetGlobalIndex: Int?
+        /// Stable id to align at the viewport top after its bounded window
+        /// has been reconciled into the AppKit tiling map.
+        private var pendingLogicalTargetId: String?
+        private var isPendingLogicalResolutionScheduled = false
         /// Memoizes the window-sliced row list + its id → message-index
         /// lookup, keyed on (messages generation, window bounds) — the same
         /// cache the legacy list uses. `rememberCurrentAnchor` runs on every
@@ -119,6 +126,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             }
             scroller.onViewportHeightChange = { [weak self] in
                 self?.reconcileForViewportHeightChange()
+            }
+            scroller.onLogicalScrollCommit = { [weak self] value in
+                self?.commitLogicalScroll(value: value)
             }
             update(host: host)
         }
@@ -213,10 +223,12 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 scroller?.scrollToBottom()
             }
             reconciler.layoutMountedRows()
+            syncLogicalScrollerMetrics()
         }
 
         func update(host: ACPTranscriptScroller) {
             self.host = host
+            schedulePendingLogicalTargetResolutionIfPossible()
             // Re-apply unconditionally: `reconciler.apply` itself early-
             // returns and records nothing for a non-positive width (host
             // view not yet laid out), so skipping this call based on any
@@ -237,6 +249,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // (or, at width 0, will be re-requested by the next scroll tick).
             pendingHeadStep = false
             restoreInitialPositionIfNeeded()
+            alignPendingLogicalTargetIfPossible()
+            syncLogicalScrollerMetrics()
         }
 
         // MARK: row specs
@@ -630,6 +644,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 if !reconciler.isApplyingSpecs {
                     reconciler.layoutMountedRows()
                 }
+                syncLogicalScrollerMetrics()
                 return
             }
 
@@ -729,7 +744,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 // queues several steps that land together as a single
                 // 60-150 row insertion measured in one synchronous pass.
                 pendingHeadStep = true
-                host.transcript.stepHeadBack(boundTail: false)
+                host.transcript.stepHeadBack()
             }
             if ACPTranscriptScroller.shouldStepTailForward(
                 visibleTail: host.transcript.visibleTailBound,
@@ -738,12 +753,140 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 threshold: threshold,
                 previousScrollY: previousY, newScrollY: newY
             ) {
-                host.transcript.stepTailForward(preserving: nil, boundHead: false)
+                host.transcript.stepTailForward(preserving: nil)
             }
 
             if !host.session.followsTranscriptTail {
                 rememberCurrentAnchor()
             }
+            syncLogicalScrollerMetrics()
+        }
+
+        private func commitLogicalScroll(value: Double) {
+            guard let host, let scroller, host.transcript.logicalMessageCount > 0 else { return }
+            if value >= 1 - Double.ulpOfOne {
+                pendingLogicalTargetGlobalIndex = nil
+                pendingLogicalTargetId = nil
+                host.session.followsTranscriptTail = true
+                reconciler?.setFollowsTail(true)
+                host.transcript.resetWindowToTail()
+                host.onRememberScrollAnchor(nil, nil, true)
+                update(host: host)
+                scroller.scrollToBottom()
+                syncLogicalScrollerMetrics()
+                return
+            }
+
+            if host.session.followsTranscriptTail {
+                pauseTailFollow()
+            } else {
+                reconciler?.setFollowsTail(false)
+                host.transcript.freezeVisibleTail()
+            }
+            let target = ACPTranscriptLogicalScrollModel.targetGlobalIndex(
+                value: value,
+                totalCount: host.transcript.logicalMessageCount,
+                viewportHeight: scroller.viewportHeight
+            )
+            pendingLogicalTargetGlobalIndex = target
+            if resolvePendingLogicalTargetIfPossible() {
+                update(host: host)
+            } else {
+                syncLogicalScrollerMetrics()
+            }
+        }
+
+        /// Returns true when the pending global target is materialized and a
+        /// bounded local window has been selected for the next reconcile.
+        @discardableResult
+        private func resolvePendingLogicalTargetIfPossible() -> Bool {
+            guard let host, let target = pendingLogicalTargetGlobalIndex else { return false }
+            let count = host.transcript.logicalMessageCount
+            guard count > 0 else {
+                pendingLogicalTargetGlobalIndex = nil
+                return false
+            }
+            let clampedTarget = min(max(0, target), count - 1)
+            pendingLogicalTargetGlobalIndex = clampedTarget
+            guard let localIndex = host.transcript.localIndex(forGlobalIndex: clampedTarget) else {
+                return false
+            }
+            pendingLogicalTargetGlobalIndex = nil
+            pendingLogicalTargetId = host.transcript.stableId(
+                for: host.transcript.messages[localIndex]
+            )
+            host.transcript.setVisibleWindow(around: localIndex)
+            return true
+        }
+
+        /// `update(host:)` is called from `updateNSView`; selecting a new
+        /// published render window synchronously inside that boundary would
+        /// mutate SwiftUI-observed state during view reconciliation. Once
+        /// backfill makes a queued target available, resolve it on the next
+        /// main-actor turn instead.
+        private func schedulePendingLogicalTargetResolutionIfPossible() {
+            guard !isPendingLogicalResolutionScheduled,
+                  let host,
+                  let target = pendingLogicalTargetGlobalIndex,
+                  host.transcript.localIndex(forGlobalIndex: target) != nil
+            else { return }
+            isPendingLogicalResolutionScheduled = true
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.isPendingLogicalResolutionScheduled = false
+                guard let host = self.host,
+                      self.resolvePendingLogicalTargetIfPossible()
+                else { return }
+                self.update(host: host)
+            }
+        }
+
+        private func alignPendingLogicalTargetIfPossible() {
+            guard let id = pendingLogicalTargetId,
+                  let row = tiling.row(withId: id),
+                  let scroller
+            else { return }
+            scroller.setScrollY(row.minY)
+            pendingLogicalTargetId = nil
+            rememberCurrentAnchor()
+        }
+
+        private func syncLogicalScrollerMetrics() {
+            guard let host, let scroller else { return }
+            let topGlobalIndex = pendingLogicalTargetGlobalIndex
+                ?? currentTopGlobalMessageIndex()
+                ?? host.transcript.globalIndex(forLocalIndex: host.transcript.visibleHead)
+                ?? 0
+            scroller.setLogicalScrollerMetrics(ACPTranscriptLogicalScrollModel.metrics(
+                totalCount: host.transcript.logicalMessageCount,
+                viewportHeight: scroller.viewportHeight,
+                topGlobalIndex: topGlobalIndex,
+                isAtTail: host.session.followsTranscriptTail
+            ))
+        }
+
+        private func currentTopGlobalMessageIndex() -> Int? {
+            guard let host, let scroller,
+                  let anchorId = tiling.nearestNonSyntheticRowId(
+                      to: scroller.scrollY,
+                      syntheticIdPrefix: ACPTranscriptScrollerReconciler.syntheticIdPrefix
+                  )
+            else { return nil }
+            let lookup = visibleRowsCache.lookup(
+                generation: host.transcript.messagesGeneration,
+                head: host.transcript.visibleHead,
+                tail: host.transcript.visibleTailBound,
+                build: {
+                    ACPMessageList.visibleRows(
+                        messages: host.transcript.messages,
+                        visibleHead: host.transcript.visibleHead,
+                        visibleTail: host.transcript.visibleTailBound,
+                        stableId: { host.transcript.stableId(for: $0) }
+                    )
+                }
+            )
+            guard let localIndex = lookup.transcriptIndex(for: anchorId) else { return nil }
+            return host.transcript.globalIndex(forLocalIndex: localIndex)
         }
 
         private func pauseTailFollow() {
@@ -868,6 +1011,18 @@ struct ACPTranscriptScroller: NSViewRepresentable {
 
         var mountedRowCountForTesting: Int {
             reconciler?.mountedRowIdsForTesting.count ?? 0
+        }
+
+        var pendingLogicalTargetGlobalIndexForTesting: Int? {
+            pendingLogicalTargetGlobalIndex
+        }
+
+        var topVisibleMessageIdForTesting: String? {
+            guard let scroller else { return nil }
+            return tiling.nearestNonSyntheticRowId(
+                to: scroller.scrollY,
+                syntheticIdPrefix: ACPTranscriptScrollerReconciler.syntheticIdPrefix
+            )
         }
         #endif
     }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -648,6 +648,13 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 return
             }
 
+            // A wheel/trackpad move after a logical release is newer user
+            // intent. Do not let a queued jump into not-yet-materialized
+            // history revive when a later backfill makes its target
+            // available and teleport the viewport away from this position.
+            pendingLogicalTargetGlobalIndex = nil
+            pendingLogicalTargetId = nil
+
             // This tick is the user moving the viewport, not us. Two things
             // follow from that: a row that vanished from an earlier update is
             // no longer worth restoring to if it comes back (see

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -950,7 +950,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                     )
                 }
             )
-            host.onRememberScrollAnchor(anchorId, lookup.transcriptIndex(for: anchorId), false)
+            let globalIndex = lookup.transcriptIndex(for: anchorId)
+                .flatMap { host.transcript.globalIndex(forLocalIndex: $0) }
+            host.onRememberScrollAnchor(anchorId, globalIndex, false)
         }
 
         /// Runs once per Coordinator lifetime, but only actually latches

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -7,6 +7,34 @@ final class ACPTranscriptDocumentView: NSView {
     override var isFlipped: Bool { true }
 }
 
+/// Native scroller whose thumb extent is owned by the transcript's logical
+/// full-history range rather than by NSScrollView's bounded physical window.
+/// NSScrollView remains free to drive the control value during ordinary
+/// scrolling and knob tracking; only its physical knob-proportion writes are
+/// rejected after logical metrics have been installed.
+@MainActor
+final class ACPTranscriptLogicalScroller: NSScroller {
+    private var logicalKnobProportion: CGFloat?
+
+    override class var isCompatibleWithOverlayScrollers: Bool {
+        self == ACPTranscriptLogicalScroller.self
+    }
+
+    override var knobProportion: CGFloat {
+        get { logicalKnobProportion ?? super.knobProportion }
+        set {
+            guard logicalKnobProportion == nil else { return }
+            super.knobProportion = newValue
+        }
+    }
+
+    func setLogicalKnobProportion(_ proportion: CGFloat) {
+        let clamped = min(max(proportion, 0), 1)
+        logicalKnobProportion = clamped
+        super.knobProportion = clamped
+    }
+}
+
 /// The transcript's NSScrollView. Exposes the one primitive SwiftUI's
 /// ScrollView can't provide on macOS 26: synchronous scroll-offset
 /// adjustment in the same pass as a content mutation (`applyPrepend`), so
@@ -120,6 +148,7 @@ final class ACPTranscriptScrollerView: NSScrollView {
         super.init(frame: frameRect)
         drawsBackground = false
         hasVerticalScroller = true
+        verticalScroller = ACPTranscriptLogicalScroller()
         hasHorizontalScroller = false
         verticalScroller?.isContinuous = false
         verticalScroller?.target = self
@@ -266,7 +295,11 @@ final class ACPTranscriptScrollerView: NSScrollView {
     private func applyLogicalScrollerMetrics() {
         guard let logicalScrollerMetrics, let verticalScroller else { return }
         verticalScroller.doubleValue = logicalScrollerMetrics.value
-        verticalScroller.knobProportion = logicalScrollerMetrics.knobProportion
+        if let logicalScroller = verticalScroller as? ACPTranscriptLogicalScroller {
+            logicalScroller.setLogicalKnobProportion(logicalScrollerMetrics.knobProportion)
+        } else {
+            verticalScroller.knobProportion = logicalScrollerMetrics.knobProportion
+        }
     }
 
     @objc private func commitLogicalScroll(_ sender: NSScroller) {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -16,6 +16,8 @@ final class ACPTranscriptDocumentView: NSView {
 final class ACPTranscriptScrollerView: NSScrollView {
     let flippedDocumentView = ACPTranscriptDocumentView()
     var onScroll: ((_ previousY: CGFloat?, _ newY: CGFloat, _ viewportHeight: CGFloat, _ contentHeight: CGFloat, _ isProgrammatic: Bool) -> Void)?
+    var onLogicalScrollCommit: ((Double) -> Void)?
+    private var logicalScrollerMetrics: ACPTranscriptLogicalScrollModel.Metrics?
 
     /// Fired from `layout()` whenever `contentView.bounds.width` differs
     /// from the last width reported — including the very first non-zero
@@ -119,6 +121,9 @@ final class ACPTranscriptScrollerView: NSScrollView {
         drawsBackground = false
         hasVerticalScroller = true
         hasHorizontalScroller = false
+        verticalScroller?.isContinuous = false
+        verticalScroller?.target = self
+        verticalScroller?.action = #selector(commitLogicalScroll(_:))
         automaticallyAdjustsContentInsets = false
         documentView = flippedDocumentView
         flippedDocumentView.frame = NSRect(x: 0, y: 0, width: frameRect.width, height: 0)
@@ -204,6 +209,7 @@ final class ACPTranscriptScrollerView: NSScrollView {
         } else {
             onViewportHeightChange?()
         }
+        applyLogicalScrollerMetrics()
     }
 
     var scrollY: CGFloat { contentView.bounds.origin.y }
@@ -218,6 +224,7 @@ final class ACPTranscriptScrollerView: NSScrollView {
         performProgrammatic {
             flippedDocumentView.frame.size.height = height
         }
+        applyLogicalScrollerMetrics()
     }
 
     /// Grow the document by prepended content and shift the scroll offset by
@@ -237,6 +244,7 @@ final class ACPTranscriptScrollerView: NSScrollView {
             contentView.setBoundsOrigin(NSPoint(x: origin.x, y: clampedScrollY(origin.y + delta)))
             reflectScrolledClipView(contentView)
         }
+        applyLogicalScrollerMetrics()
     }
 
     func setScrollY(_ y: CGFloat) {
@@ -247,6 +255,22 @@ final class ACPTranscriptScrollerView: NSScrollView {
             contentView.setBoundsOrigin(NSPoint(x: contentView.bounds.origin.x, y: clamped))
             reflectScrolledClipView(contentView)
         }
+        applyLogicalScrollerMetrics()
+    }
+
+    func setLogicalScrollerMetrics(_ metrics: ACPTranscriptLogicalScrollModel.Metrics) {
+        logicalScrollerMetrics = metrics
+        applyLogicalScrollerMetrics()
+    }
+
+    private func applyLogicalScrollerMetrics() {
+        guard let logicalScrollerMetrics, let verticalScroller else { return }
+        verticalScroller.doubleValue = logicalScrollerMetrics.value
+        verticalScroller.knobProportion = logicalScrollerMetrics.knobProportion
+    }
+
+    @objc private func commitLogicalScroll(_ sender: NSScroller) {
+        onLogicalScrollCommit?(sender.doubleValue)
     }
 
     /// The scrollable range's clamp, shared by every programmatic offset
@@ -272,5 +296,6 @@ final class ACPTranscriptScrollerView: NSScrollView {
         lastReportedY = newY
         let maxY = max(0, contentHeight - viewportHeight)
         onScroll?(previous, newY, viewportHeight, contentHeight, programmaticAdjustmentDepth > 0)
+        applyLogicalScrollerMetrics()
     }
 }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -241,6 +241,15 @@ final class ACPTranscriptScrollerView: NSScrollView {
         applyLogicalScrollerMetrics()
     }
 
+    override func reflectScrolledClipView(_ cView: NSClipView) {
+        super.reflectScrolledClipView(cView)
+        // NSScrollView reflects the bounded physical document on every
+        // ordinary scroll tick. The transcript scrollbar represents the
+        // full logical history instead, so those metrics may be used
+        // internally but must not remain visible on the native scroller.
+        applyLogicalScrollerMetrics()
+    }
+
     var scrollY: CGFloat { contentView.bounds.origin.y }
     var viewportHeight: CGFloat { contentView.bounds.height }
     var contentHeight: CGFloat { flippedDocumentView.frame.height }

--- a/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
@@ -22,6 +22,64 @@ struct ACPTranscriptWindowTests {
         #expect(t.visibleHead == 0)
     }
 
+    @Test("tail-first history exposes stable global message indices")
+    func tailFirstHistoryExposesGlobalIndices() {
+        let t = ACPTranscript()
+        let tail = (0..<30).map { index in
+            ACPMessage.systemNotice(id: UUID(), text: "m\(index + 170)")
+        }
+
+        t.replaceMessages(with: tail, messageIndexOffset: 170)
+
+        #expect(t.messageIndexOffset == 170)
+        #expect(t.logicalMessageCount == 200)
+        #expect(t.globalIndex(forLocalIndex: 0) == 170)
+        #expect(t.globalIndex(forLocalIndex: 29) == 199)
+        #expect(t.globalIndex(forLocalIndex: 30) == nil)
+        #expect(t.localIndex(forGlobalIndex: 169) == nil)
+        #expect(t.localIndex(forGlobalIndex: 170) == 0)
+        #expect(t.localIndex(forGlobalIndex: 199) == 29)
+        #expect(t.localIndex(forGlobalIndex: 200) == nil)
+    }
+
+    @Test("backfill prepend preserves the logical history extent")
+    func backfillPrependPreservesLogicalExtent() {
+        let t = ACPTranscript()
+        let tail = (0..<30).map { index in
+            ACPMessage.systemNotice(id: UUID(), text: "m\(index + 170)")
+        }
+        let older = (0..<170).map { index in
+            ACPMessage.systemNotice(id: UUID(), text: "m\(index)")
+        }
+        t.replaceMessages(with: tail, messageIndexOffset: 170)
+
+        t.prependMessages(older)
+
+        #expect(t.messageIndexOffset == 0)
+        #expect(t.logicalMessageCount == 200)
+        #expect(t.globalIndex(forLocalIndex: 170) == 170)
+    }
+
+    @Test("target windows preload one page and remain full near either end")
+    func targetWindowsRemainBounded() {
+        let t = ACPTranscript()
+        t.messages = (0..<200).map { index in
+            .systemNotice(id: UUID(), text: "m\(index)")
+        }
+
+        t.setVisibleWindow(around: 100)
+        #expect(t.visibleHead == 70)
+        #expect(t.visibleTail == 160)
+
+        t.setVisibleWindow(around: 10)
+        #expect(t.visibleHead == 0)
+        #expect(t.visibleTail == 90)
+
+        t.setVisibleWindow(around: 190)
+        #expect(t.visibleHead == 110)
+        #expect(t.visibleTail == 200)
+    }
+
     @Test("resetWindowToTail computes initial head")
     func resetForLongTranscript() {
         let t = ACPTranscript()

--- a/AlasTests/ACP/UI/ACPTranscriptLogicalScrollModelTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptLogicalScrollModelTests.swift
@@ -1,0 +1,107 @@
+import CoreGraphics
+import Testing
+
+@testable import Alas
+
+@Suite("ACP transcript logical scroll model")
+struct ACPTranscriptLogicalScrollModelTests {
+    @Test("empty and viewport-sized histories are not scrollable")
+    func nonScrollableHistories() {
+        let empty = ACPTranscriptLogicalScrollModel.metrics(
+            totalCount: 0,
+            viewportHeight: 960,
+            topGlobalIndex: 0,
+            isAtTail: false
+        )
+        #expect(empty.value == 0)
+        #expect(empty.knobProportion == 1)
+        #expect(empty.logicalViewportMessages == 10)
+
+        let short = ACPTranscriptLogicalScrollModel.metrics(
+            totalCount: 5,
+            viewportHeight: 960,
+            topGlobalIndex: 3,
+            isAtTail: false
+        )
+        #expect(short.value == 0)
+        #expect(short.knobProportion == 1)
+        #expect(ACPTranscriptLogicalScrollModel.targetGlobalIndex(
+            value: 0.75,
+            totalCount: 5,
+            viewportHeight: 960
+        ) == 0)
+    }
+
+    @Test("thumb metrics represent message-index progress")
+    func messageIndexProgress() {
+        let top = ACPTranscriptLogicalScrollModel.metrics(
+            totalCount: 200,
+            viewportHeight: 960,
+            topGlobalIndex: 0,
+            isAtTail: false
+        )
+        #expect(top.value == 0)
+        #expect(top.knobProportion == 0.05)
+        #expect(top.logicalViewportMessages == 10)
+
+        let middle = ACPTranscriptLogicalScrollModel.metrics(
+            totalCount: 200,
+            viewportHeight: 960,
+            topGlobalIndex: 95,
+            isAtTail: false
+        )
+        #expect(middle.value == 0.5)
+        #expect(middle.knobProportion == top.knobProportion)
+
+        let tail = ACPTranscriptLogicalScrollModel.metrics(
+            totalCount: 200,
+            viewportHeight: 960,
+            topGlobalIndex: 120,
+            isAtTail: true
+        )
+        #expect(tail.value == 1)
+        #expect(tail.knobProportion == top.knobProportion)
+    }
+
+    @Test("release values map to clamped global top indices")
+    func releaseMapping() {
+        #expect(ACPTranscriptLogicalScrollModel.targetGlobalIndex(
+            value: -1,
+            totalCount: 200,
+            viewportHeight: 960
+        ) == 0)
+        #expect(ACPTranscriptLogicalScrollModel.targetGlobalIndex(
+            value: 0.5,
+            totalCount: 200,
+            viewportHeight: 960
+        ) == 95)
+        #expect(ACPTranscriptLogicalScrollModel.targetGlobalIndex(
+            value: 2,
+            totalCount: 200,
+            viewportHeight: 960
+        ) == 190)
+    }
+
+    @Test("viewport resize and genuine count growth update only logical range")
+    func rangeChanges() {
+        let taller = ACPTranscriptLogicalScrollModel.metrics(
+            totalCount: 200,
+            viewportHeight: 1920,
+            topGlobalIndex: 90,
+            isAtTail: false
+        )
+        #expect(taller.logicalViewportMessages == 20)
+        #expect(taller.knobProportion == 0.1)
+        #expect(taller.value == 0.5)
+
+        let grown = ACPTranscriptLogicalScrollModel.metrics(
+            totalCount: 400,
+            viewportHeight: 960,
+            topGlobalIndex: 95,
+            isAtTail: false
+        )
+        #expect(grown.logicalViewportMessages == 10)
+        #expect(grown.knobProportion == 0.025)
+        #expect(abs(grown.value - (95.0 / 390.0)) < 0.000_001)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -707,6 +707,38 @@ struct ACPTranscriptScrollerLogicalNavigationTests {
         #expect(coordinator.topVisibleMessageIdForTesting == allMessages[49].stableId)
     }
 
+    @Test("a later user scroll cancels a queued hydration jump")
+    func userScrollCancelsQueuedHydrationJump() async throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let allMessages = messages(200)
+        session.replaceTranscriptMessages(Array(allMessages.suffix(30)), messageIndexOffset: 170)
+        session.transcript.visibleHead = 0
+        session.transcript.visibleTail = nil
+        session.followsTranscriptTail = true
+        let (coordinator, scroller, nativeScroller) = try attach(session: session)
+
+        commit(0.25, through: nativeScroller)
+        #expect(coordinator.pendingLogicalTargetGlobalIndexForTesting == 49)
+
+        // A wheel/trackpad scroll in the materialized tail is newer user
+        // intent than the queued release into unhydrated history.
+        scroller.contentView.setBoundsOrigin(NSPoint(
+            x: 0,
+            y: max(0, scroller.scrollY - 10)
+        ))
+        scroller.reflectScrolledClipView(scroller.contentView)
+        #expect(coordinator.pendingLogicalTargetGlobalIndexForTesting == nil)
+
+        session.prependTranscriptMessages(Array(allMessages.prefix(170)))
+        coordinator.update(host: makeHost(session: session))
+        await Task.yield()
+
+        // Backfill keeps the currently viewed tail window instead of
+        // reviving the stale jump to message 49.
+        #expect(session.transcript.visibleHead == 170)
+        #expect(session.transcript.visibleTailBound == 200)
+    }
+
     @Test("releasing at the logical end resumes the live tail")
     func tailJump() throws {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -10,7 +10,8 @@ import Testing
 private func makeHost(
     session: ACPSession = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t"),
     contentMaxWidth: CGFloat = 800,
-    typography: ACPChatTypography = .default
+    typography: ACPChatTypography = .default,
+    onRememberScrollAnchor: @escaping (String?, Int?, Bool) -> Void = { _, _, _ in }
 ) -> ACPTranscriptScroller {
     ACPTranscriptScroller(
         session: session,
@@ -23,7 +24,7 @@ private func makeHost(
         forkTargets: [],
         onFork: { _, _ in },
         rememberedScrollAnchor: { nil },
-        onRememberScrollAnchor: { _, _, _ in },
+        onRememberScrollAnchor: onRememberScrollAnchor,
         onOpenTranscriptLink: { _ in true },
         policy: nil,
         scopeKey: "scope",
@@ -722,10 +723,7 @@ struct ACPTranscriptScrollerLogicalNavigationTests {
 
         // A wheel/trackpad scroll in the materialized tail is newer user
         // intent than the queued release into unhydrated history.
-        scroller.contentView.setBoundsOrigin(NSPoint(
-            x: 0,
-            y: max(0, scroller.scrollY - 10)
-        ))
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: 0))
         scroller.reflectScrolledClipView(scroller.contentView)
         #expect(coordinator.pendingLogicalTargetGlobalIndexForTesting == nil)
 
@@ -737,6 +735,38 @@ struct ACPTranscriptScrollerLogicalNavigationTests {
         // reviving the stale jump to message 49.
         #expect(session.transcript.visibleHead == 170)
         #expect(session.transcript.visibleTailBound == 200)
+    }
+
+    @Test("tail-only scrolling remembers a global anchor index")
+    func tailOnlyScrollRemembersGlobalAnchorIndex() throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let allMessages = messages(200)
+        session.replaceTranscriptMessages(Array(allMessages.suffix(30)), messageIndexOffset: 170)
+        session.transcript.visibleHead = 0
+        session.transcript.visibleTail = nil
+        session.followsTranscriptTail = false
+        var remembered: (id: String?, index: Int?, followsTail: Bool)?
+        let host = makeHost(session: session) { id, index, followsTail in
+            remembered = (id, index, followsTail)
+        }
+        let scroller = ACPTranscriptScrollerView(
+            frame: NSRect(x: 0, y: 0, width: 600, height: 400)
+        )
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: 0))
+        scroller.reflectScrolledClipView(scroller.contentView)
+
+        let anchor = try #require(remembered)
+        let anchorId = try #require(anchor.id)
+        let anchorIndex = try #require(anchor.index)
+        let localIndex = try #require(
+            session.transcript.messages.firstIndex { $0.stableId == anchorId }
+        )
+        #expect(anchorIndex == 170 + localIndex)
+        #expect(!anchor.followsTail)
     }
 
     @Test("releasing at the logical end resumes the live tail")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -631,6 +631,117 @@ struct ACPTranscriptScrollerViewportHeightReconciliationTests {
     }
 }
 
+@MainActor
+@Suite("ACPTranscriptScroller logical navigation")
+struct ACPTranscriptScrollerLogicalNavigationTests {
+    private func messages(_ count: Int) -> [ACPMessage] {
+        (0..<count).map { index in
+            .systemNotice(id: UUID(), text: "message \(index)")
+        }
+    }
+
+    private func attach(
+        session: ACPSession,
+        size: NSSize = NSSize(width: 600, height: 400)
+    ) throws -> (ACPTranscriptScroller.Coordinator, ACPTranscriptScrollerView, NSScroller) {
+        let host = makeHost(session: session)
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(origin: .zero, size: size))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        return (coordinator, scroller, try #require(scroller.verticalScroller))
+    }
+
+    private func commit(_ value: Double, through scroller: NSScroller) {
+        scroller.doubleValue = value
+        _ = scroller.sendAction(scroller.action, to: scroller.target)
+    }
+
+    @Test("a released historical position swaps a bounded window and aligns its target")
+    func loadedHistoricalJump() throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let allMessages = messages(200)
+        session.replaceTranscriptMessages(allMessages)
+        session.transcript.resetWindowToTail()
+        session.followsTranscriptTail = true
+        let (coordinator, _, nativeScroller) = try attach(session: session)
+
+        commit(0.5, through: nativeScroller)
+
+        // 400pt / 96pt leaves a maximum logical top of 195.833; halfway
+        // rounds to global/local message 98. One 30-row page is preloaded.
+        #expect(!session.followsTranscriptTail)
+        #expect(session.transcript.visibleHead == 68)
+        #expect(session.transcript.visibleTail == 158)
+        #expect(coordinator.pendingLogicalTargetGlobalIndexForTesting == nil)
+        #expect(coordinator.topVisibleMessageIdForTesting == allMessages[98].stableId)
+    }
+
+    @Test("a release into the unmaterialized prefix waits for backfill")
+    func queuedHydrationJump() async throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let allMessages = messages(200)
+        session.replaceTranscriptMessages(Array(allMessages.suffix(30)), messageIndexOffset: 170)
+        session.transcript.visibleHead = 0
+        session.transcript.visibleTail = nil
+        session.followsTranscriptTail = true
+        let (coordinator, _, nativeScroller) = try attach(session: session)
+
+        commit(0.25, through: nativeScroller)
+
+        #expect(!session.followsTranscriptTail)
+        #expect(coordinator.pendingLogicalTargetGlobalIndexForTesting == 49)
+
+        session.prependTranscriptMessages(Array(allMessages.prefix(170)))
+        coordinator.update(host: makeHost(session: session))
+
+        // `update(host:)` is the NSViewRepresentable update boundary in
+        // production. Resolving must defer its published window mutation
+        // until that synchronous update has returned.
+        #expect(coordinator.pendingLogicalTargetGlobalIndexForTesting == 49)
+        await Task.yield()
+
+        #expect(coordinator.pendingLogicalTargetGlobalIndexForTesting == nil)
+        #expect(session.transcript.visibleHead == 19)
+        #expect(session.transcript.visibleTail == 109)
+        #expect(coordinator.topVisibleMessageIdForTesting == allMessages[49].stableId)
+    }
+
+    @Test("releasing at the logical end resumes the live tail")
+    func tailJump() throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.replaceTranscriptMessages(messages(200))
+        session.transcript.setVisibleWindow(containing: 40)
+        session.followsTranscriptTail = false
+        let (coordinator, scroller, nativeScroller) = try attach(session: session)
+
+        commit(1, through: nativeScroller)
+
+        _ = coordinator // Retain the weak callback owner through the action.
+        #expect(session.followsTranscriptTail)
+        #expect(session.transcript.visibleHead == 170)
+        #expect(session.transcript.visibleTail == nil)
+        #expect(scroller.distanceFromBottom < 1)
+    }
+
+    @Test("AppKit head pagination discards the opposite page")
+    func headPaginationStaysBounded() throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.replaceTranscriptMessages(messages(200))
+        session.transcript.setVisibleWindow(containing: 70)
+        session.followsTranscriptTail = false
+        let (coordinator, scroller, _) = try attach(session: session)
+
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: 0))
+        scroller.reflectScrolledClipView(scroller.contentView)
+
+        _ = coordinator // Retain the weak callback owner through the scroll.
+        #expect(session.transcript.visibleHead == 40)
+        #expect(session.transcript.visibleTail == 130)
+        #expect(session.transcript.visibleTailBound - session.transcript.visibleHead == ACPTranscript.maxVisibleRows)
+    }
+}
+
 @Suite("ACPTranscriptScroller policies")
 struct ACPTranscriptScrollerPolicyTests {
     @Test("head step fires near the top when older rows exist")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
@@ -132,6 +132,25 @@ struct ACPTranscriptScrollerViewTests {
         #expect(abs(verticalScroller.knobProportion - 0.1) < 0.000_001)
     }
 
+    @Test("ordinary scroll reflection preserves the logical transcript position")
+    func scrollReflectionPreservesLogicalPosition() throws {
+        let s = scroller()
+        let verticalScroller = try #require(s.verticalScroller)
+        s.setLogicalScrollerMetrics(.init(
+            value: 0.25,
+            knobProportion: 0.1,
+            logicalViewportMessages: 10
+        ))
+
+        // NSScrollView reflects the bounded physical document on every
+        // wheel/trackpad tick. That reflection must not replace the logical
+        // full-transcript position supplied by the coordinator.
+        s.contentView.setBoundsOrigin(NSPoint(x: 0, y: 3000))
+        s.reflectScrolledClipView(s.contentView)
+
+        #expect(abs(verticalScroller.doubleValue - 0.25) < 0.000_001)
+    }
+
     /// `onContentWidthChange` is the hook `ACPTranscriptScroller.Coordinator`
     /// uses to reconcile after a real width arrives from AppKit's own layout
     /// pass, without any accompanying SwiftUI model update (P1 finding,

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
@@ -84,6 +84,36 @@ struct ACPTranscriptScrollerViewTests {
         #expect(!reports.contains { !$0.programmatic })
     }
 
+    @Test("logical native scroller commits only when AppKit sends its action")
+    func logicalScrollerCommitsOnAction() throws {
+        let s = scroller()
+        let verticalScroller = try #require(s.verticalScroller)
+        var committedValues: [Double] = []
+        s.onLogicalScrollCommit = { committedValues.append($0) }
+
+        #expect(!verticalScroller.isContinuous)
+        s.setLogicalScrollerMetrics(.init(
+            value: 0.25,
+            knobProportion: 0.1,
+            logicalViewportMessages: 10
+        ))
+        #expect(abs(verticalScroller.doubleValue - 0.25) < 0.000_001)
+        #expect(abs(verticalScroller.knobProportion - 0.1) < 0.000_001)
+
+        // A physical document move makes NSScrollView reflect its own
+        // bounded range, but our logical metrics must win immediately.
+        s.setScrollY(1000)
+        #expect(abs(verticalScroller.doubleValue - 0.25) < 0.000_001)
+        #expect(abs(verticalScroller.knobProportion - 0.1) < 0.000_001)
+
+        // Knob tracking changes the control value without navigating. A
+        // non-continuous NSScroller sends its action only when tracking ends.
+        verticalScroller.doubleValue = 0.75
+        #expect(committedValues.isEmpty)
+        _ = verticalScroller.sendAction(verticalScroller.action, to: verticalScroller.target)
+        #expect(committedValues == [0.75])
+    }
+
     /// `onContentWidthChange` is the hook `ACPTranscriptScroller.Coordinator`
     /// uses to reconcile after a real width arrives from AppKit's own layout
     /// pass, without any accompanying SwiftUI model update (P1 finding,

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
@@ -114,6 +114,24 @@ struct ACPTranscriptScrollerViewTests {
         #expect(committedValues == [0.75])
     }
 
+    @Test("physical scroll metrics cannot replace the logical knob proportion")
+    func physicalMetricsCannotReplaceLogicalKnobProportion() throws {
+        let s = scroller()
+        let verticalScroller = try #require(s.verticalScroller)
+        s.setLogicalScrollerMetrics(.init(
+            value: 0.25,
+            knobProportion: 0.1,
+            logicalViewportMessages: 10
+        ))
+
+        // NSScrollView writes the bounded physical document proportion on
+        // ordinary scroll ticks. Once logical metrics are active, that
+        // upstream write must not resize the transcript thumb.
+        verticalScroller.knobProportion = 0.8
+
+        #expect(abs(verticalScroller.knobProportion - 0.1) < 0.000_001)
+    }
+
     /// `onContentWidthChange` is the hook `ACPTranscriptScroller.Coordinator`
     /// uses to reconcile after a real width arrives from AppKit's own layout
     /// pass, without any accompanying SwiftUI model update (P1 finding,

--- a/docs/superpowers/plans/2026-08-05-appkit-transcript-logical-scrollbar.md
+++ b/docs/superpowers/plans/2026-08-05-appkit-transcript-logical-scrollbar.md
@@ -1,0 +1,190 @@
+# AppKit Transcript Logical Scrollbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the AppKit ACP transcript a stable, transcript-wide native scrollbar while rendering no more than the existing 90-message window.
+
+**Architecture:** Keep the measured AppKit document bounded and decouple the native `NSScroller` metrics from its pixel height. A pure logical-scroll model maps global message indices to native knob values; `ACPTranscript` supplies a tail-hydration index offset; the AppKit coordinator commits a bounded page jump only after the user releases the scroller.
+
+**Tech Stack:** Swift 5.9+, AppKit `NSScrollView`/`NSScroller`, SwiftUI hosting, Observation via Combine, Swift Testing.
+
+## Global Constraints
+
+- Apply only to the feature-flagged AppKit transcript; do not change the legacy SwiftUI scrollbar behavior.
+- Use 96 logical points per message and the existing 30-row page / 90-row maximum window.
+- Preserve native AppKit scrollbar appearance, accessibility, track clicks, wheel scrolling, and tail-follow behavior.
+- Keep persisted schemas and wire formats unchanged.
+- Keep code, comments, logs, and UI strings in English.
+
+---
+
+### Task 1: Logical history indices and bounded target windows
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Session/ACPTranscript.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- Test: `AlasTests/ACP/Session/ACPTranscriptWindowTests.swift`
+
+**Interfaces:**
+- Produces: `ACPTranscript.messageIndexOffset: Int`, `logicalMessageCount: Int`, `globalIndex(forLocalIndex:)`, `localIndex(forGlobalIndex:)`, `setVisibleWindow(around:)`.
+- Consumes: existing `tailWindow`, `maxVisibleRows`, `setVisibleWindow(head:tail:)`, and tail-first hydration/prepend paths.
+
+- [ ] **Step 1: Add failing transcript-index tests**
+
+  Add Swift Testing cases proving that a 30-message materialized tail with offset 170 reports 200 logical messages, maps local index 0 to global 170, rejects global 169 as unavailable, and maps global 199 to local 29. Add cases proving `setVisibleWindow(around: 100)` selects `70..<160`, while targets near either end clamp the window to `0..<90` and `110..<200`.
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+  Run:
+
+  ```bash
+  ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTranscriptWindowTests test
+  ```
+
+  Expected: compilation fails because the logical-index API does not exist.
+
+- [ ] **Step 3: Implement logical indices atomically with transcript publication**
+
+  Add a non-published, `private(set)` message-index offset defaulting to zero. Set it before replacing the initial hydrated tail, decrement it before a prepend publishes the expanded `messages` array, and reset it for ordinary full replacements. Derive the logical count as `messageIndexOffset + messages.count`; make conversions bounds-checked. Implement `setVisibleWindow(around:)` so the target has up to `tailWindow` older rows preloaded and the result never exceeds `maxVisibleRows`.
+
+- [ ] **Step 4: Run the transcript tests and confirm success**
+
+  Run the focused command from Step 2. Expected: all `ACPTranscriptWindowTests` pass.
+
+- [ ] **Step 5: Commit the transcript model slice**
+
+  ```bash
+  git add Alas/Sources/ACP/Session/ACPTranscript.swift Alas/Sources/ACP/Session/ACPSessionManager.swift AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
+  git commit -m "feat(acp): expose logical transcript history indices"
+  ```
+
+### Task 2: Pure logical scrollbar mapping
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/Scroller/ACPTranscriptLogicalScrollModel.swift`
+- Create: `AlasTests/ACP/UI/ACPTranscriptLogicalScrollModelTests.swift`
+
+**Interfaces:**
+- Produces: `ACPTranscriptLogicalScrollModel` with `logicalPointsPerMessage = 96`, `metrics(totalCount:viewportHeight:topGlobalIndex:isAtTail:)`, and `targetGlobalIndex(value:totalCount:viewportHeight:)`.
+- Consumes: global indices from Task 1.
+
+- [ ] **Step 1: Add failing pure mapping tests**
+
+  Cover empty and short transcripts, top and bottom endpoints, midpoint rounding/clamping, viewport resizing, and genuine count growth. Assert that changing rendered-window membership or measured pixel heights is not an input and therefore cannot change knob proportion or value for identical logical inputs.
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+  Run:
+
+  ```bash
+  ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTranscriptLogicalScrollModelTests test
+  ```
+
+  Expected: compilation fails because the model does not exist.
+
+- [ ] **Step 3: Implement the pure model**
+
+  Define an equatable `Metrics` value containing normalized `value`, `knobProportion`, and `logicalViewportMessages`. Compute the logical viewport as `max(1, viewportHeight / 96)`, clamp the knob to `0...1`, force tail-follow to value `1`, and map release values across `max(0, totalCount - logicalViewportMessages)`.
+
+- [ ] **Step 4: Regenerate the project and run the focused tests**
+
+  Run `rtk xcodegen`, then the command from Step 2. Expected: tests pass and the new source/test files belong to their targets.
+
+- [ ] **Step 5: Commit the logical model slice**
+
+  ```bash
+  git add project.yml Alas.xcodeproj Alas/Sources/ACP/UI/Scroller/ACPTranscriptLogicalScrollModel.swift AlasTests/ACP/UI/ACPTranscriptLogicalScrollModelTests.swift
+  git commit -m "feat(acp): add logical transcript scrollbar metrics"
+  ```
+
+### Task 3: Native release-to-jump AppKit coordination
+
+**Files:**
+- Modify: `Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift`
+- Modify: `Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift`
+- Test: `AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift`
+- Test: `AlasTests/ACP/UI/ACPTranscriptScrollerScrollBackTests.swift`
+
+**Interfaces:**
+- Consumes: Task 1 logical indices/window selection and Task 2 metrics/mapping.
+- Produces: `ACPTranscriptScrollerView.onLogicalScrollCommit`, `setLogicalScrollerMetrics(_:)`, coordinator pending-target resolution, and bounded AppKit pagination.
+
+- [ ] **Step 1: Add failing native-policy tests**
+
+  Assert the installed vertical `NSScroller` is non-continuous; logical metrics override physical document metrics; intermediate value changes do not navigate; a commit maps to and aligns a loaded historical row; value `1` restores tail-follow; an unavailable pre-backfill target remains pending and resolves after prepend; and repeated head/tail steps never exceed `maxVisibleRows`.
+
+- [ ] **Step 2: Run focused AppKit tests and confirm failure**
+
+  Run:
+
+  ```bash
+  ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTranscriptScrollerPolicyTests -only-testing:AlasTests/ACPTranscriptScrollerScrollBackTests test
+  ```
+
+  Expected: compilation or assertions fail because logical scroller coordination is absent.
+
+- [ ] **Step 3: Install and maintain logical native metrics**
+
+  Keep a native vertical `NSScroller`, set `isContinuous = false`, and route its action to a release callback without custom drawing. After every physical scroll report, layout, and host update, overwrite its value and knob proportion from the pure logical model so `reflectScrolledClipView` cannot leak bounded-document metrics to the user.
+
+- [ ] **Step 4: Implement loaded and queued page jumps**
+
+  In the coordinator, special-case a committed value of `1` to reset the tail window, scroll to bottom after reconciliation, and resume tail-follow. For historical values, pause/freeze tail-follow, convert the global target to a local index, select a bounded window around it, and retain the target stable id until the next apply can align that row at the viewport top. If conversion fails because the global target precedes `messageIndexOffset`, retain the global index and retry on subsequent transcript updates; clamp against the current logical count before retrying.
+
+- [ ] **Step 5: Bound wheel and trackpad pagination**
+
+  Replace the AppKit-only unbounded `stepHeadBack(boundTail: false)` and `stepTailForward(..., boundHead: false)` calls with bounded window steps. Keep the existing reconciler anchor capture/restore and pending-head-step latch so simultaneous insertion/removal does not move the visible row or enqueue duplicate pages.
+
+- [ ] **Step 6: Run focused tests and fix regressions**
+
+  Run the command from Step 2 plus:
+
+  ```bash
+  ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPTranscriptWindowTests -only-testing:AlasTests/ACPTranscriptScrollerReconcilerTests test
+  ```
+
+  Expected: all selected suites pass.
+
+- [ ] **Step 7: Commit AppKit integration**
+
+  ```bash
+  git add Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift AlasTests/ACP/UI/ACPTranscriptScrollerScrollBackTests.swift
+  git commit -m "feat(acp): stabilize the AppKit transcript scrollbar"
+  ```
+
+### Task 4: Full verification
+
+**Files:**
+- Modify only files required by concrete failures attributable to this change.
+
+**Interfaces:**
+- Consumes: Tasks 1-3.
+- Produces: a fully verified AppKit-only feature with no new public persistence or wire contract.
+
+- [ ] **Step 1: Regenerate and inspect generated-project drift**
+
+  Run `rtk xcodegen` and `git status --short`. Commit generated files only if source membership changed them.
+
+- [ ] **Step 2: Run formatting lint**
+
+  Run the repository SwiftFormat lint command and correct only violations introduced by this branch.
+
+- [ ] **Step 3: Run the required quiet build**
+
+  ```bash
+  ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+  ```
+
+  Expected: exit status 0.
+
+- [ ] **Step 4: Run the complete required test suite**
+
+  ```bash
+  ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+  ```
+
+  Expected: exit status 0 with no failures attributable to this change.
+
+- [ ] **Step 5: Review the final diff and commit verification fixes**
+
+  Confirm the legacy SwiftUI path and persistence schema are untouched, no render window exceeds 90 messages, and no placeholders or agent attribution appear. Commit any necessary verification fixes with a focused conventional message.

--- a/docs/superpowers/specs/2026-08-05-appkit-transcript-logical-scrollbar-design.md
+++ b/docs/superpowers/specs/2026-08-05-appkit-transcript-logical-scrollbar-design.md
@@ -1,0 +1,58 @@
+# AppKit Transcript Logical Scrollbar Design
+
+## Goal
+
+Make the AppKit ACP transcript scrollbar behave as though the whole known
+transcript is present, while continuing to render and measure only a bounded
+message window. Revealing or discarding existing-history pages must not resize
+the scrollbar thumb.
+
+## Behavior
+
+The native vertical `NSScroller` represents logical message progress rather
+than the pixel height of the currently rendered document. One message occupies
+a fixed 96-point logical extent. The thumb proportion is derived from the
+viewport height and the total known message count; its value is derived from
+the global index of the top visible message. Consequently, swapping pages of
+variable-height content cannot change the logical range.
+
+The scroller is non-continuous. Its knob moves normally while the user drags,
+but the transcript navigates only when tracking ends. A released position maps
+to a global top-message index. The AppKit path selects a bounded 90-message
+window with up to one 30-message page before the target, then aligns the target
+message with the viewport top. Releasing at the bottom restores the live tail
+window and tail-follow; every historical target pauses tail-follow.
+
+Wheel and trackpad pagination also keep the render window bounded. Revealing a
+30-message page at one edge discards the opposite page, while the existing
+reconciler anchor preservation prevents visible movement.
+
+## Tail-first Hydration
+
+On reopen, the transcript initially materializes only its last 30 messages.
+`ACPTranscript` will retain the number of known messages preceding its current
+array as a global index offset. `offset + messages.count` therefore exposes the
+full logical count before older message objects have been constructed.
+
+If a scrollbar release targets that unmaterialized prefix, the AppKit
+coordinator records the global target. The existing backfill continues; after
+its prepend makes the target available, the coordinator selects and aligns the
+requested window. A changed count clamps the target, and destroying the
+coordinator discards it.
+
+## Boundaries
+
+This applies only to the feature-flagged AppKit transcript path. The legacy
+SwiftUI list, persisted session schema, and wire formats remain unchanged.
+Genuine newly appended messages extend the logical range normally. Logical
+progress intentionally weights every message equally, regardless of rendered
+height.
+
+## Verification
+
+Pure tests cover logical knob metrics and release-position mapping. Transcript
+tests cover global/local index conversion and bounded target windows. AppKit
+coordinator tests cover release-only jumps, queued hydration targets,
+tail-follow transitions, bounded bidirectional pagination, and visual-anchor
+preservation. Existing scroll-back, scrollbar-click, resize, hydration, and
+tail-follow tests remain regression gates.


### PR DESCRIPTION
## Summary

- model the AppKit ACP transcript scrollbar against the full logical message history
- keep thumb size and position stable while bounded render windows page in both directions
- commit direct scrollbar navigation on release and queue jumps that target unhydrated history
- preserve the legacy SwiftUI transcript path unchanged

## Verification

- `xcodegen`
- `swiftformat Alas AlasTests --lint`
- focused ACP transcript/scroller suite: 52 tests passed
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -quiet build`