### PR TITLE
fix(acp): hide workspace context from session titles

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -334,7 +334,7 @@ final class ACPSession: ObservableObject, Identifiable {
         didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         if titleSource == .placeholder {
-            let candidate = text
+            let candidate = Self.removingAlasWorkspaceContext(from: text)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .components(separatedBy: .newlines)
                 .joined(separator: " ")
@@ -345,6 +345,20 @@ final class ACPSession: ObservableObject, Identifiable {
                 titleSource = .generated
             }
         }
+    }
+
+    private static func removingAlasWorkspaceContext(from text: String) -> String {
+        var result = text
+        let openingTag = "<alas-workspace-context>"
+        let closingTag = "</alas-workspace-context>"
+        while let openingRange = result.range(of: openingTag),
+              let closingRange = result.range(
+                  of: closingTag,
+                  range: openingRange.upperBound..<result.endIndex
+              ) {
+            result.removeSubrange(openingRange.lowerBound..<closingRange.upperBound)
+        }
+        return result
     }
 
     /// Returns the set of transcript message indices that were appended or

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1031,6 +1031,33 @@ struct ACPSessionTests {
         else { Issue.record("expected user message") }
     }
 
+    @Test("generated title ignores Alas workspace context and uses the remaining prompt")
+    func generatedTitleIgnoresAlasWorkspaceContext() async {
+        let session = ACPSession(
+            id: "s",
+            agentId: "codex",
+            worktreeId: "w",
+            title: "New session",
+            titleSource: .placeholder
+        )
+        let prompt = """
+        <alas-workspace-context>
+        Private workspace metadata that should not become the title.
+        </alas-workspace-context>
+        Fix the session title inference
+        """
+
+        session.recordUserPrompt(text: prompt, attachments: [])
+
+        #expect(session.title == "Fix the session title inference")
+        #expect(session.titleSource == .generated)
+        if case .user(_, _, let text, _, _) = session.transcript.messages.first {
+            #expect(text == prompt)
+        } else {
+            Issue.record("expected the original prompt in the transcript")
+        }
+    }
+
     @Test("transcript tail following is runtime state")
     func transcriptTailFollowingDefaultsToEnabled() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")


### PR DESCRIPTION
## Summary

- exclude complete `<alas-workspace-context>` blocks from generated ACP session titles
- infer the title from the remaining user prompt while preserving the original transcript text
- add regression coverage for the injected-context case

## Verification

- `swiftformat Alas AlasTests --lint --reporter github-actions-log`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-remove-workspace-context-title-dd -quiet build ALAS_FFF_TARGET_ARCH=arm64`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-remove-workspace-context-title-dd test ALAS_FFF_TARGET_ARCH=arm64 -only-testing:AlasTests/ACPSessionTests -quiet`
- full test suite: 7,532 passed, 12 skipped, 0 failed before rebase; focused ACP suite passed again after rebasing onto `origin/main`