### PR TITLE
refactor(changes): rename park changes to stash changes

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -352,7 +352,6 @@
 		3BB7766DF1D9BF15098432F5 /* CommitDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF335AB8B3061C889A348B3 /* CommitDetails.swift */; };
 		3C30C1EAE4786BB1BE42F994 /* ACPToolCallCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */; };
 		3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C1705E68E97111E85D83F3 /* RightPaneState.swift */; };
-		3C5797EAA86E4D493E1EEED8 /* ParkChangesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B7B0E241FE2BEAE4623BA1 /* ParkChangesSheet.swift */; };
 		3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */; };
 		3C8FAA4464E4D928F1DC6C91 /* session-new-response-with-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */; };
 		3C91EAB9AE55849DE5CF1BC7 /* DragOutSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99890AC2531648EB5E9716A8 /* DragOutSessionTests.swift */; };
@@ -1074,6 +1073,7 @@
 		B76AD708A9FD54304F84366A /* ImageFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F942D660C7ABA8542C77D /* ImageFileType.swift */; };
 		B785053315764F42E3601F15 /* UpdateProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF766C79A3F9F004A513D4D /* UpdateProgressSheet.swift */; };
 		B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */; };
+		B7C37289F04A218F12C803DB /* StashChangesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11281859D3CDA9DB8AF34D33 /* StashChangesSheet.swift */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
 		B7F21BA3E994F3A0990D4C06 /* ACPOrchestrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B90F0D59BBDA243D619B16 /* ACPOrchestrationStore.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
@@ -1622,6 +1622,7 @@
 		10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostCapabilities.swift; sourceTree = "<group>"; };
 		10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalMessages.swift; sourceTree = "<group>"; };
 		111B9EB86E55850C982CEEFA /* GGReorderSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGReorderSheet.swift; sourceTree = "<group>"; };
+		11281859D3CDA9DB8AF34D33 /* StashChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashChangesSheet.swift; sourceTree = "<group>"; };
 		11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClientTests.swift; sourceTree = "<group>"; };
 		11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTerminalLaunchTests.swift; sourceTree = "<group>"; };
 		11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateFocusMainWorktreeTests.swift; sourceTree = "<group>"; };
@@ -1637,7 +1638,6 @@
 		136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookEvent.swift; sourceTree = "<group>"; };
 		137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessorTests.swift; sourceTree = "<group>"; };
 		137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHookSettingsFile.swift; sourceTree = "<group>"; };
-		13B7B0E241FE2BEAE4623BA1 /* ParkChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParkChangesSheet.swift; sourceTree = "<group>"; };
 		14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabView.swift; sourceTree = "<group>"; };
 		141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconTests.swift; sourceTree = "<group>"; };
 		14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMergeConflictCodingTests.swift; sourceTree = "<group>"; };
@@ -3939,7 +3939,6 @@
 				F721FB733081A583D4053DDA /* FileTypeIconView.swift */,
 				542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */,
 				4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */,
-				13B7B0E241FE2BEAE4623BA1 /* ParkChangesSheet.swift */,
 				9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */,
 				F748F06725644571785BF658 /* PendingStashDrop.swift */,
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
@@ -3948,6 +3947,7 @@
 				9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */,
 				FE66950F2226F1182DCDD39A /* RightPaneView.swift */,
 				934BCC470703CF2DF2303357 /* SectionHeader.swift */,
+				11281859D3CDA9DB8AF34D33 /* StashChangesSheet.swift */,
 				40E8D8B829B3A7B0327CAFA1 /* StashesSectionView.swift */,
 				DDE8B45ECF898B83A616586D /* SubHeader.swift */,
 				9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */,
@@ -6366,7 +6366,6 @@
 				ACB0AD03C9DFD88A431E6BC5 /* OutdatedThreadsDrawer.swift in Sources */,
 				6635C1BBE700E46738D5648F /* PaneDragMath.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
-				3C5797EAA86E4D493E1EEED8 /* ParkChangesSheet.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
 				449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */,
 				F9FED997CCAD027FBBE36C1D /* PendingReview.swift in Sources */,
@@ -6547,6 +6546,7 @@
 				A06C59805BCD9D3200896932 /* StagedDiffLoader.swift in Sources */,
 				514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */,
 				899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */,
+				B7C37289F04A218F12C803DB /* StashChangesSheet.swift in Sources */,
 				7374C72F780CEE12E81997B9 /* StashDiffTabView.swift in Sources */,
 				40345C2068BFBF42B5C629B0 /* StashesSectionView.swift in Sources */,
 				EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */,

--- a/Alas/Sources/Git/GitService+Stash.swift
+++ b/Alas/Sources/Git/GitService+Stash.swift
@@ -128,7 +128,7 @@ extension GitService {
         }
 
         let result = try await Process.git(args, cwd: worktreePath)
-        return Self.stashOperationResult(result, fallback: "Could not park changes.")
+        return Self.stashOperationResult(result, fallback: "Could not stash changes.")
     }
 
     func stashFiles(worktreePath: URL, stash: GitStash) async throws -> [GitStashFile] {

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -281,8 +281,8 @@ struct ChangesTabView: View {
                     )
                 },
                 onDiscardFile: { file in rps.requestDiscardFile(path: file.path) },
-                onParkChanges: { rps.requestParkChanges() },
-                parkChangesDisabled: rps.mergeOp.current != nil || rps.stashOperationInFlight,
+                onStashChanges: { rps.requestStashChanges() },
+                stashChangesDisabled: rps.mergeOp.current != nil || rps.stashOperationInFlight,
                 isOpenFileEnabled: { file in
                     DiffOpenFileAvailability.isAvailable(
                         worktreePath: rps.worktree.path,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -50,7 +50,7 @@ final class RightPaneState: GGSplitCommitServicing {
     var expandedStashRefs: Set<String> = []
     var stashFilesByRef: [String: [GitStashFile]] = [:]
     var loadingStashRefs: Set<String> = []
-    var pendingParkChanges: Bool = false
+    var pendingStashChanges: Bool = false
     var pendingStashDrop: PendingStashDrop? = nil
     private(set) var stashOperationInFlight: Bool = false
     private(set) var hasLoadedSnapshot: Bool = false
@@ -1564,7 +1564,7 @@ final class RightPaneState: GGSplitCommitServicing {
         expandedStashRefs = []
         stashFilesByRef = [:]
         loadingStashRefs = []
-        pendingParkChanges = false
+        pendingStashChanges = false
         pendingStashDrop = nil
         stashOperationInFlight = false
         indexFingerprint = ""
@@ -2414,18 +2414,18 @@ final class RightPaneState: GGSplitCommitServicing {
         }
     }
 
-    func requestParkChanges() {
+    func requestStashChanges() {
         guard !changes.isEmpty, mergeOp.current == nil, !stashOperationInFlight else { return }
-        pendingParkChanges = true
+        pendingStashChanges = true
     }
 
-    func cancelParkChanges() {
-        pendingParkChanges = false
+    func cancelStashChanges() {
+        pendingStashChanges = false
     }
 
-    func parkChanges(message: String, includeUntracked: Bool) {
-        guard pendingParkChanges, !stashOperationInFlight else { return }
-        pendingParkChanges = false
+    func stashChanges(message: String, includeUntracked: Bool) {
+        guard pendingStashChanges, !stashOperationInFlight else { return }
+        pendingStashChanges = false
         stashOperationInFlight = true
         sidebarError = nil
         Task { @MainActor in

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -148,15 +148,15 @@ struct RightPaneView: View {
                 )
                 .sheet(
                     isPresented: Binding(
-                        get: { rps.pendingParkChanges },
-                        set: { if !$0 { rps.cancelParkChanges() } }
+                        get: { rps.pendingStashChanges },
+                        set: { if !$0 { rps.cancelStashChanges() } }
                     )
                 ) {
-                    ParkChangesSheet(
-                        onPark: { message, includeUntracked in
-                            rps.parkChanges(message: message, includeUntracked: includeUntracked)
+                    StashChangesSheet(
+                        onStash: { message, includeUntracked in
+                            rps.stashChanges(message: message, includeUntracked: includeUntracked)
                         },
-                        onCancel: { rps.cancelParkChanges() }
+                        onCancel: { rps.cancelStashChanges() }
                     )
                 }
                 .alert(

--- a/Alas/Sources/Right/StashChangesSheet.swift
+++ b/Alas/Sources/Right/StashChangesSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-struct ParkChangesSheet: View {
-    let onPark: (String, Bool) -> Void
+struct StashChangesSheet: View {
+    let onStash: (String, Bool) -> Void
     let onCancel: () -> Void
 
     @Environment(\.theme) private var theme
@@ -10,7 +10,7 @@ struct ParkChangesSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Park Changes")
+            Text("Stash Changes")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(theme.color("fg"))
             Text("Move current working-tree changes into a git stash.")
@@ -20,7 +20,7 @@ struct ParkChangesSheet: View {
                 text: $message,
                 placeholder: "Optional message",
                 focusOnAppear: true,
-                onSubmit: { onPark(message, includeUntracked) }
+                onSubmit: { onStash(message, includeUntracked) }
             )
             Toggle("Include untracked files", isOn: $includeUntracked)
                 .toggleStyle(.checkbox)
@@ -28,8 +28,8 @@ struct ParkChangesSheet: View {
             HStack {
                 Spacer()
                 Button("Cancel", action: onCancel)
-                Button("Park Changes") {
-                    onPark(message, includeUntracked)
+                Button("Stash Changes") {
+                    onStash(message, includeUntracked)
                 }
                 .keyboardShortcut(.defaultAction)
             }

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -18,8 +18,8 @@ struct WorkingTreeSectionView: View {
     var onCompareWithHEAD: ((ChangedFile) -> Void)? = nil
     var onFileHistory:     ((ChangedFile) -> Void)? = nil
     var onDiscardFile:     ((ChangedFile) -> Void)? = nil
-    var onParkChanges:     (() -> Void)? = nil
-    var parkChangesDisabled: Bool = false
+    var onStashChanges:     (() -> Void)? = nil
+    var stashChangesDisabled: Bool = false
     var isOpenFileEnabled: ((ChangedFile) -> Bool)? = nil
     var dragPayload: ((ChangedFile) -> DragOutPayload?)? = nil
 
@@ -74,10 +74,10 @@ struct WorkingTreeSectionView: View {
                     }
                 }
                 if !changes.isEmpty {
-                    Button("Park Changes…") {
-                        onParkChanges?()
+                    Button("Stash Changes…") {
+                        onStashChanges?()
                     }
-                    .disabled(parkChangesDisabled || changes.isEmpty || onParkChanges == nil)
+                    .disabled(stashChangesDisabled || changes.isEmpty || onStashChanges == nil)
                     Divider()
                 }
                 Button("Discard all working tree changes…", role: .destructive) {

--- a/docs/superpowers/specs/2026-08-05-stash-changes-terminology-design.md
+++ b/docs/superpowers/specs/2026-08-05-stash-changes-terminology-design.md
@@ -1,0 +1,30 @@
+# Stash Changes Terminology Design
+
+## Goal
+
+Make the working-tree action clearly communicate that it creates a Git stash by replacing its stash-specific “park” terminology with “stash.”
+
+## Scope
+
+- Change the working-tree context-menu action from “Park Changes…” to “Stash Changes…”.
+- Change the sheet title and confirmation button from “Park Changes” to “Stash Changes”.
+- Change the stash creation fallback error to “Could not stash changes.”
+- Rename stash-specific Swift files, types, state, callbacks, and methods from `Park…`/`park…` to `Stash…`/`stash…`.
+- Keep the existing explanatory text, options, Git command, and behavior unchanged.
+
+Occurrences of “park,” “parked,” or “parking” that describe suspended tasks, continuations, processes, or viewport positions are unrelated and remain unchanged. No stash-specific “unpark” terminology currently exists.
+
+## Components and Data Flow
+
+The existing working-tree menu continues to request presentation of the existing sheet. Submitting the sheet continues to pass the optional message and untracked-files choice through right-pane state to `GitService.pushStash`. Only the names presented to users and the stash-specific Swift identifiers along this path change.
+
+## Error Handling
+
+Existing error propagation is unchanged. Only the empty-output fallback for a failed stash push changes from park terminology to stash terminology.
+
+## Verification
+
+- Do not add a new unit-test seam solely for static UI copy. Verify the exact new strings and the absence of stash-semantic park terminology with source searches; let compilation cover renamed Swift symbols.
+- Search production code and tests to confirm no stash-semantic `park` or `unpark` occurrences remain.
+- Regenerate the Xcode project because the Swift source file is renamed.
+- Run the required macOS build and test commands.


### PR DESCRIPTION
## Summary

- Rename the working-tree stash action from “Park Changes” to “Stash Changes”.
- Rename stash-specific Swift symbols and the sheet file to match the UI terminology.
- Keep the underlying `git stash push` behavior and options unchanged.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Full local macOS test suite is in progress; GitHub CI is pending.