### PR TITLE
fix(code): add Kotlin LSP install recipe

### DIFF
--- a/Alas/Sources/Code/LSP/RecommendedLanguageCatalog.swift
+++ b/Alas/Sources/Code/LSP/RecommendedLanguageCatalog.swift
@@ -170,10 +170,9 @@ enum RecommendedLanguageCatalog {
             displayName: "Kotlin",
             masonId: nil,
             aliasOf: nil,
-            // kotlin-lsp (JetBrains) is distributed via GitHub releases only — out of scope.
-            // kotlin-language-server (community/fwcd) is a different server and would not
-            // satisfy the LanguageServerRegistry spawn expectation for "kotlin-lsp".
-            recipes: []
+            recipes: [
+                InstallRecipe(installer: .brew, package: "JetBrains/utils/kotlin-lsp"),
+            ]
         ),
     ]
 

--- a/AlasTests/Code/LSP/InstallNudgeResolverTests.swift
+++ b/AlasTests/Code/LSP/InstallNudgeResolverTests.swift
@@ -95,12 +95,12 @@ struct InstallNudgeResolverTests {
             dismissedInstallNudges: [],
             installerHost: InstallerHost(detected: [.brew: DetectedInstaller(kind: .brew, executable: "/opt/homebrew/bin/brew")]),
             masonSnapshot: MasonSnapshot(packages: [
-                package(id: "kotlin-language-server", languageId: "kotlin", extensions: ["kt", "kts"], command: "kotlin-language-server")
+                package(id: "clangd", languageId: "c", extensions: ["c"], command: "clangd")
             ]),
             availabilityStatus: { _ in .notInstalled }
         )
 
-        let nudge = resolver.nudgeData(forAbsolutePath: "/tmp/Main.kt")
+        let nudge = resolver.nudgeData(forAbsolutePath: "/tmp/main.c")
 
         #expect(nudge == nil)
     }

--- a/AlasTests/Code/LSP/RecommendedLanguageCatalogTests.swift
+++ b/AlasTests/Code/LSP/RecommendedLanguageCatalogTests.swift
@@ -96,4 +96,12 @@ struct RecommendedLanguageCatalogTests {
         let goRecipe = entry?.resolvedRecipes.first(where: { $0.installer == .go })
         #expect(goRecipe?.package == "golang.org/x/tools/gopls")
     }
+
+    @Test("kotlin entry installs JetBrains kotlin-lsp with Homebrew")
+    func kotlinRecipe() {
+        let entry = RecommendedLanguageCatalog.entry(forLanguage: "kotlin")
+        #expect(entry?.resolvedRecipes == [
+            InstallRecipe(installer: .brew, package: "JetBrains/utils/kotlin-lsp"),
+        ])
+    }
 }


### PR DESCRIPTION
## Summary

- add the official JetBrains Homebrew recipe for `kotlin-lsp`
- show the existing Install affordance for Kotlin in Settings → Code → Languages
- update catalog and install-nudge regression coverage

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- full test suite: 7,534 passed, 12 skipped, 0 failed
- focused tests after rebase: 22 passed, 0 failed
- SwiftFormat lint: 0/3 files require formatting
- `git diff --check`