### PR TITLE
feat(tabs): Add directional tab navigation shortcuts

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -281,6 +281,21 @@ struct AlasApp: App {
             .keyboardShortcut("t", modifiers: [.command, .shift])
             .disabled(!state.canReopenClosedTab)
             Divider()
+            Button("Select Previous Tab") {
+                NotificationCenter.default.post(
+                    name: .alasActivateAdjacentTab,
+                    object: CenterTabNavigationDirection.previous
+                )
+            }
+            .keyboardShortcut(state.shortcut(for: .selectPreviousTab))
+            Button("Select Next Tab") {
+                NotificationCenter.default.post(
+                    name: .alasActivateAdjacentTab,
+                    object: CenterTabNavigationDirection.next
+                )
+            }
+            .keyboardShortcut(state.shortcut(for: .selectNextTab))
+            Divider()
             Button("Select Tab 1") {
                 NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 1)
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4277,11 +4277,32 @@ final class AppState {
         )
         let index = number - 1
         guard composition.tabs.indices.contains(index) else { return nil }
-        let tabID = composition.tabs[index].id
+        return activateCenterTab(composition.tabs[index].id, worktreeId: worktreeId)
+    }
+
+    @discardableResult
+    func activateAdjacentCenterTab(
+        _ direction: CenterTabNavigationDirection,
+        worktreeId: String?
+    ) -> TabID? {
+        let worktreeTabs = worktreeId.map { tabs.tabs(forWorktree: $0) } ?? []
+        let composition = CenterTabComposition(
+            globalTabs: globalTabs.tabs,
+            worktreeTabs: worktreeTabs,
+            activeGlobalMissionTab: globalTabs.activeMissionTab(),
+            activeWorktreeTabId: worktreeId.flatMap { tabs.activeTabId(forWorktree: $0) }
+        )
+        guard let tabID = composition.adjacentTabID(in: direction) else { return nil }
+        return activateCenterTab(tabID, worktreeId: worktreeId)
+    }
+
+    private func activateCenterTab(_ tabID: TabID, worktreeId: String?) -> TabID? {
         if globalTabs.tabs.contains(where: { $0.id == tabID }) {
             globalTabs.activate(tabId: tabID)
         } else if let worktreeId {
             activateWorktreeCenterTab(worktreeId: worktreeId, tabId: tabID)
+        } else {
+            return nil
         }
         return tabID
     }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -836,7 +836,12 @@ private struct RootBaseHandlers: ViewModifier {
                     await state.reopenLastClosedTab()
                 }
             }
-        let g = fReopenClosedTab
+        let gAdjacent = fReopenClosedTab
+            .onReceive(NotificationCenter.default.publisher(for: .alasActivateAdjacentTab)) { notification in
+                guard let direction = notification.object as? CenterTabNavigationDirection else { return }
+                state.activateAdjacentCenterTab(direction, worktreeId: selectedWorktree()?.id)
+            }
+        let g = gAdjacent
             .onReceive(NotificationCenter.default.publisher(for: .alasActivateTabByNumber)) { notification in
                 guard let number = notification.object as? Int else { return }
                 state.activateCenterTabNumber(number, worktreeId: selectedWorktree()?.id)
@@ -1001,6 +1006,7 @@ extension Notification.Name {
     static let alasOpenAgentLauncher = Notification.Name("AlasOpenAgentLauncher")
     static let alasCloseTab        = Notification.Name("AlasCloseTab")
     static let alasReopenClosedTab = Notification.Name("AlasReopenClosedTab")
+    static let alasActivateAdjacentTab = Notification.Name("AlasActivateAdjacentTab")
     static let alasActivateTabByNumber = Notification.Name("AlasActivateTabByNumber")
     static let alasOpenSettings    = Notification.Name("AlasOpenSettings")
     static let alasOpenSearch      = Notification.Name("AlasOpenSearch")

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -1,6 +1,11 @@
 import AppKit
 import SwiftUI
 
+enum CenterTabNavigationDirection: Sendable {
+    case previous
+    case next
+}
+
 struct CenterTabComposition {
     let tabs: [Tab]
     let activeId: TabID?
@@ -16,6 +21,19 @@ struct CenterTabComposition {
             return .mission(mission)
         } + worktreeTabs
         activeId = activeGlobalMissionTab?.id ?? activeWorktreeTabId
+    }
+
+    func adjacentTabID(in direction: CenterTabNavigationDirection) -> TabID? {
+        guard tabs.count > 1,
+              let activeId,
+              let activeIndex = tabs.firstIndex(where: { $0.id == activeId }) else { return nil }
+        let offset: Int
+        switch direction {
+        case .previous: offset = -1
+        case .next: offset = 1
+        }
+        let targetIndex = (activeIndex + offset + tabs.count) % tabs.count
+        return tabs[targetIndex].id
     }
 }
 

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -16,7 +16,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     // Global
     case searchFiles, switchRepository, findAndReplace, replaceInEditor, toggleSidebar, toggleRightPane,
          createProject, newWorktree, focusMainWorktree, newTerminalTab, launchAgentTerminal, launchAgentChat,
-         openReviewPalette, runScript, increaseFontSize, decreaseFontSize, resetFontSize
+         openReviewPalette, runScript, selectPreviousTab, selectNextTab,
+         increaseFontSize, decreaseFontSize, resetFontSize
     // Code editor
     case splitSelectionIntoLines, toggleMarkdownPreview, commitInComposer
     // Terminal
@@ -28,7 +29,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         switch self {
         case .searchFiles, .switchRepository, .findAndReplace, .replaceInEditor, .toggleSidebar, .toggleRightPane,
              .createProject, .newWorktree, .focusMainWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
-             .openReviewPalette, .runScript, .increaseFontSize, .decreaseFontSize, .resetFontSize:
+             .openReviewPalette, .runScript, .selectPreviousTab, .selectNextTab,
+             .increaseFontSize, .decreaseFontSize, .resetFontSize:
             return .global
         case .splitSelectionIntoLines, .toggleMarkdownPreview:
             return .codeEditor
@@ -57,6 +59,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .launchAgentChat:          return "Launch Agent Chat"
         case .openReviewPalette:        return "Review Worktree"
         case .runScript:                return "Run Script"
+        case .selectPreviousTab:        return "Select Previous Tab"
+        case .selectNextTab:            return "Select Next Tab"
         case .increaseFontSize:         return "Increase Font Size"
         case .decreaseFontSize:         return "Decrease Font Size"
         case .resetFontSize:            return "Reset Font Size"
@@ -120,6 +124,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .launchAgentChat:          return .init(key: "t",          modifiers: [.command, .option, .shift])
         case .openReviewPalette:        return .init(key: "r",          modifiers: [.command, .shift])
         case .runScript:                return .init(key: "r",          modifiers: [.command])
+        case .selectPreviousTab:        return .init(key: "tab",        modifiers: [.control, .shift])
+        case .selectNextTab:            return .init(key: "tab",        modifiers: [.control])
         case .increaseFontSize:         return .init(key: "=",          modifiers: [.command])
         case .decreaseFontSize:         return .init(key: "-",          modifiers: [.command])
         case .resetFontSize:            return .init(key: "0",          modifiers: [.command])

--- a/AlasTests/AppStatePersistenceTests.swift
+++ b/AlasTests/AppStatePersistenceTests.swift
@@ -439,6 +439,28 @@ struct AppStatePersistenceTests {
         #expect(fixture.state.tabs.tabs(forWorktree: fixture.otherWorktree.id) == [terminal])
     }
 
+    @Test func adjacentCenterTabNavigationCrossesOwnershipBoundaries() throws {
+        let fixture = try MissionGlobalNavigationFixture(includeWorktree: true)
+        let terminal = fixture.state.tabs.appendTerminal(
+            worktreeId: fixture.otherWorktree.id,
+            title: "Shell",
+            sessionId: "session-1"
+        )
+        fixture.state.globalTabs.openOrFocusMission(
+            missionID: fixture.aggregate.mission.id,
+            title: fixture.aggregate.mission.title
+        )
+
+        #expect(fixture.state.activateAdjacentCenterTab(.next, worktreeId: fixture.otherWorktree.id) == terminal.id)
+        #expect(fixture.state.globalTabs.activeMissionTab() == nil)
+
+        #expect(fixture.state.activateAdjacentCenterTab(.next, worktreeId: fixture.otherWorktree.id) == MissionTabState.fixture.id)
+        #expect(fixture.state.globalTabs.activeMissionTab() == .fixture)
+
+        #expect(fixture.state.activateAdjacentCenterTab(.previous, worktreeId: fixture.otherWorktree.id) == terminal.id)
+        #expect(fixture.state.globalTabs.activeMissionTab() == nil)
+    }
+
     @Test func reloadTabsPreservesGlobalMissionWhenWorktreeIsMissing() throws {
         let fixture = try MissionGlobalNavigationFixture(includeWorktree: false)
         fixture.state.globalTabs.openOrFocusMission(

--- a/AlasTests/CenterSelectionStateResolverTests.swift
+++ b/AlasTests/CenterSelectionStateResolverTests.swift
@@ -24,6 +24,69 @@ struct CenterSelectionStateResolverTests {
         #expect(composition.activeId == mission.id)
     }
 
+    @Test func adjacentTabsFollowVisualOrderAndWrap() {
+        let mission = MissionTabState.fixture
+        let firstTerminal = Tab.terminal(TerminalTabState(
+            id: "terminal-1",
+            title: "First Terminal",
+            sessionId: "session-1"
+        ))
+        let secondTerminal = Tab.terminal(TerminalTabState(
+            id: "terminal-2",
+            title: "Second Terminal",
+            sessionId: "session-2"
+        ))
+
+        let fromMission = CenterTabComposition(
+            globalTabs: [.mission(mission)],
+            worktreeTabs: [firstTerminal, secondTerminal],
+            activeGlobalMissionTab: mission,
+            activeWorktreeTabId: firstTerminal.id
+        )
+        #expect(fromMission.adjacentTabID(in: .next) == firstTerminal.id)
+        #expect(fromMission.adjacentTabID(in: .previous) == secondTerminal.id)
+
+        let fromLastTerminal = CenterTabComposition(
+            globalTabs: [.mission(mission)],
+            worktreeTabs: [firstTerminal, secondTerminal],
+            activeGlobalMissionTab: nil,
+            activeWorktreeTabId: secondTerminal.id
+        )
+        #expect(fromLastTerminal.adjacentTabID(in: .next) == mission.id)
+        #expect(fromLastTerminal.adjacentTabID(in: .previous) == firstTerminal.id)
+    }
+
+    @Test func adjacentTabIsUnavailableWithoutAValidChoice() {
+        let terminal = Tab.terminal(TerminalTabState(
+            id: "terminal-1",
+            title: "Terminal",
+            sessionId: "session-1"
+        ))
+
+        let empty = CenterTabComposition(
+            globalTabs: [],
+            worktreeTabs: [],
+            activeGlobalMissionTab: nil,
+            activeWorktreeTabId: nil
+        )
+        let single = CenterTabComposition(
+            globalTabs: [],
+            worktreeTabs: [terminal],
+            activeGlobalMissionTab: nil,
+            activeWorktreeTabId: terminal.id
+        )
+        let missingActive = CenterTabComposition(
+            globalTabs: [],
+            worktreeTabs: [terminal, .mission(.fixture)],
+            activeGlobalMissionTab: nil,
+            activeWorktreeTabId: "missing-tab"
+        )
+
+        #expect(empty.adjacentTabID(in: .next) == nil)
+        #expect(single.adjacentTabID(in: .next) == nil)
+        #expect(missingActive.adjacentTabID(in: .previous) == nil)
+    }
+
     @Test func bulkClosurePlanUsesTheComposedTabOrder() {
         let firstMission = MissionTabState.fixture
         let secondMission = MissionTabState(

--- a/AlasTests/ShortcutActionTests.swift
+++ b/AlasTests/ShortcutActionTests.swift
@@ -34,6 +34,8 @@ struct ShortcutActionTests {
             (.launchAgentChat,      "t",          [.command, .option, .shift]),
             (.openReviewPalette,    "r",          [.command, .shift]),
             (.runScript,            "r",          [.command]),
+            (.selectPreviousTab,    "tab",        [.control, .shift]),
+            (.selectNextTab,        "tab",        [.control]),
             (.increaseFontSize,     "=",          [.command]),
             (.decreaseFontSize,     "-",          [.command]),
             (.resetFontSize,        "0",          [.command]),
@@ -62,7 +64,8 @@ struct ShortcutActionTests {
         let global: Set<ShortcutAction> = [
             .searchFiles, .switchRepository, .findAndReplace, .replaceInEditor, .toggleSidebar, .toggleRightPane,
             .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
-            .openReviewPalette, .runScript, .focusMainWorktree, .increaseFontSize, .decreaseFontSize, .resetFontSize,
+            .openReviewPalette, .runScript, .selectPreviousTab, .selectNextTab, .focusMainWorktree,
+            .increaseFontSize, .decreaseFontSize, .resetFontSize,
         ]
         let codeEditor: Set<ShortcutAction> = [
             .splitSelectionIntoLines, .toggleMarkdownPreview,

--- a/AlasTests/ShortcutReservationsTests.swift
+++ b/AlasTests/ShortcutReservationsTests.swift
@@ -19,6 +19,23 @@ struct ShortcutReservationsTests {
         #expect(ShortcutReservations.defaultReserved.contains(.init(key: "r", modifiers: [.command])))
     }
 
+    @Test func adjacentTabBindingsAreDynamicallyReserved() {
+        let next = ShortcutBinding(key: "tab", modifiers: [.control])
+        let previous = ShortcutBinding(key: "tab", modifiers: [.control, .shift])
+        #expect(ShortcutReservations.defaultReserved.contains(next))
+        #expect(ShortcutReservations.defaultReserved.contains(previous))
+
+        var config = AppConfig.defaults
+        let replacement = ShortcutBinding(key: "tab", modifiers: [.control, .option])
+        config.shortcutOverrides[ShortcutAction.selectNextTab.rawValue] = .some(replacement)
+        config.shortcutOverrides[ShortcutAction.selectPreviousTab.rawValue] = .some(nil)
+
+        let reserved = ShortcutReservations.snapshot(from: config)
+        #expect(reserved.contains(replacement))
+        #expect(!reserved.contains(next))
+        #expect(!reserved.contains(previous))
+    }
+
     @Test func defaultsIncludeStandardsAndTabSwitchers() {
         let reserved = ShortcutReservations.defaultReserved
         // ⌘W (Close Tab), ⌘⇧T (Reopen Closed Tab), and ⌘1..⌘9 stay reserved


### PR DESCRIPTION
## Summary

- add configurable Select Next Tab and Select Previous Tab actions
- navigate in visual tab order with wraparound across Mission and worktree tabs
- reserve active bindings from focused terminals while releasing overridden or disabled chords
- expose both actions in the View menu alongside numbered tab selection

## User impact

Users can move through tabs with Control-Tab and Control-Shift-Tab by default, and can customize or disable both shortcuts in Settings.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- targeted navigation and shortcut tests
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test` (7,502 tests; pass)
- independent read-only code review: ready to merge, no findings