### PR TITLE
feat(review): Sticky commit review revisions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -713,6 +713,7 @@
 		7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CA79B71B4AA72697392702 /* NumstatParser.swift */; };
 		7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B5B544A3432F8D8105268 /* SearchModel.swift */; };
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
+		7BB5B3A83C8D0CB185D2365E /* TrackedRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D35671971686B20DEA33CB /* TrackedRevision.swift */; };
 		7BBF0BCBD3121E1C20EF93CA /* ReviewReadinessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467E833E3CE05D82DB88C5C5 /* ReviewReadinessModel.swift */; };
 		7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */; };
 		7C286DF876CD8F71D07B6A93 /* WebSocketFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B22D5EBE7EDAC07C943C91D /* WebSocketFrame.swift */; };
@@ -1656,6 +1657,7 @@
 		169FC38D03727F34855EB521 /* AlasFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasFieldTests.swift; sourceTree = "<group>"; };
 		16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
+		16D35671971686B20DEA33CB /* TrackedRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevision.swift; sourceTree = "<group>"; };
 		178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerEditorPolicyTests.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -5346,6 +5348,7 @@
 				71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */,
 				BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */,
 				3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */,
+				16D35671971686B20DEA33CB /* TrackedRevision.swift */,
 			);
 			path = Commit;
 			sourceTree = "<group>";
@@ -6576,6 +6579,7 @@
 				5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */,
 				45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */,
 				AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */,
+				7BB5B3A83C8D0CB185D2365E /* TrackedRevision.swift in Sources */,
 				6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */,
 				5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */,
 				443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -994,6 +994,7 @@
 		AA0E67AEE21718BF9BEC7F13 /* RemoteFileAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0046CA3B9FF996E55A85D853 /* RemoteFileAccess.swift */; };
 		AA19B3B2B1CE418BFD6FD134 /* ACPElicitationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D906A11E19D165C7F5447E67 /* ACPElicitationCoordinatorTests.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
+		AA49692E8016430633CB4C33 /* FollowRevisionPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E17C2FF7553AEA01B535B1 /* FollowRevisionPrefill.swift */; };
 		AA69A96A8A26844CC6A47F09 /* RunScriptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1892610460CE642A24A4F322 /* RunScriptDialog.swift */; };
 		AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
@@ -1464,6 +1465,7 @@
 		F72AFDC819B805B3F1FFFB9A /* CommitReviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */; };
 		F73063B2384B650C227BD09E /* ACPHistorySidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */; };
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
+		F8501BB64D3150892C46D4B3 /* FollowRevisionPrefillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736203E6989B9E0200B93E0A /* FollowRevisionPrefillTests.swift */; };
 		F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FC38D03727F34855EB521 /* AlasFieldTests.swift */; };
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
 		F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */; };
@@ -2203,6 +2205,7 @@
 		72B788982A64A04D18889D25 /* ProjectAvatarPresetProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAvatarPresetProviderTests.swift; sourceTree = "<group>"; };
 		730E9629FD89AA4BDCB3C57F /* RunScriptCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptCreation.swift; sourceTree = "<group>"; };
 		73539FDFE4BDBD4D3B4DE546 /* ACPFirstRunConnectingPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPhase.swift; sourceTree = "<group>"; };
+		736203E6989B9E0200B93E0A /* FollowRevisionPrefillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowRevisionPrefillTests.swift; sourceTree = "<group>"; };
 		737A9A3D11EA28582CA5D061 /* ACPFirstRunConnectingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingView.swift; sourceTree = "<group>"; };
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
 		73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusOverridePicker.swift; sourceTree = "<group>"; };
@@ -2848,6 +2851,7 @@
 		E3AF2511A18895DBE494798E /* RunScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScript.swift; sourceTree = "<group>"; };
 		E3C49F11F34AA97B21936FC1 /* ACPElicitationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitationCoordinator.swift; sourceTree = "<group>"; };
 		E3CA4AD69CDACE0D41821742 /* WorktreeCreationCompletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCreationCompletion.swift; sourceTree = "<group>"; };
+		E3E17C2FF7553AEA01B535B1 /* FollowRevisionPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowRevisionPrefill.swift; sourceTree = "<group>"; };
 		E3F09E1DA9C67475445F4B63 /* RemoteFileStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileStatsTests.swift; sourceTree = "<group>"; };
 		E4128039056F417E483AB4DC /* DiffFeedbackLaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffFeedbackLaneTests.swift; sourceTree = "<group>"; };
 		E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderViewTests.swift; sourceTree = "<group>"; };
@@ -3373,6 +3377,7 @@
 				431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */,
 				2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */,
 				A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */,
+				736203E6989B9E0200B93E0A /* FollowRevisionPrefillTests.swift */,
 				B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */,
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */,
@@ -5347,6 +5352,7 @@
 				59DBB72EE97F0E906442919B /* CommitTabView.swift */,
 				71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */,
 				BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */,
+				E3E17C2FF7553AEA01B535B1 /* FollowRevisionPrefill.swift */,
 				3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */,
 				16D35671971686B20DEA33CB /* TrackedRevision.swift */,
 			);
@@ -6182,6 +6188,7 @@
 				4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */,
 				64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */,
 				9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */,
+				AA49692E8016430633CB4C33 /* FollowRevisionPrefill.swift in Sources */,
 				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
@@ -6942,6 +6949,7 @@
 				A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */,
 				DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */,
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
+				F8501BB64D3150892C46D4B3 /* FollowRevisionPrefillTests.swift in Sources */,
 				4DC40ADBDD5F113412B2087E /* ForkSourceBrokerService.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,

--- a/Alas/Sources/App/AlasActionService.swift
+++ b/Alas/Sources/App/AlasActionService.swift
@@ -556,7 +556,7 @@ struct AlasActionService {
         worktreePath: URL
     ) async -> FileIDNamespaceResolution {
         switch sessionID.sourceKind {
-        case .commit:
+        case .commit, .trackedCommit:
             return .resolved("commit")
         case .commitRange, .branch:
             return .resolved("range")

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3247,7 +3247,7 @@ final class AppState {
         switch tab {
         case .commit(let state):
             guard case .following(let revision) = state.revision,
-                  let accepted = revision.acceptingPendingCheckout()
+                  let accepted = revision.preparingPendingCheckoutAcceptance()
             else { return }
             _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
                 $0.revision = .following(accepted)
@@ -3327,6 +3327,11 @@ final class AppState {
                   now: Date()
               )
         else { return }
+        if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
+            let tab = tabs.openOrFocusReviewSession(worktreeId: worktreeID, record: existing)
+            activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
+            return
+        }
         persistReviewRetargeting(result, worktreeID: worktreeID, tabID: tabID)
     }
 
@@ -3334,7 +3339,7 @@ final class AppState {
         let store = ReviewSessionStore()
         guard let record = try? store.load(id: sessionID),
               case .trackedCommit(let revision) = record.target.payload,
-              let accepted = revision.acceptingPendingCheckout(),
+              let accepted = revision.preparingPendingCheckoutAcceptance(),
               let result = TrackedRevisionRetargeter.follow(
                   record: record,
                   revision: accepted,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -582,6 +582,7 @@ final class AppState {
     private var remoteProjectWatchers: [String: RemoteProjectGitWatcher] = [:]
     @ObservationIgnored
     private let projectGitWatcherFactory: @MainActor (URL) -> ProjectGitWatcher
+    private(set) var revisionChangeGenerations: [String: Int] = [:]
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
@@ -3105,6 +3106,7 @@ final class AppState {
             watcher.onHeadChanged = { [weak self] updates in
                 self?.handleProjectHeadUpdates(projectId: project.id, branchByWorktreePath: updates)
             }
+            watcher.onRevisionChanged = { [weak self] in self?.bumpRevisionGenerationForProject(projectId: project.id) }
             watcher.onTopologyChanged = { [weak self] in self?.handleProjectTopologyChange(projectId: project.id) }
             remoteProjectWatchers[project.id] = watcher
             watcher.start()
@@ -3113,6 +3115,7 @@ final class AppState {
         let watcher = projectGitWatcherFactory(URL(fileURLWithPath: project.path))
         let projectId = project.id
         watcher.onHeadChanged = { [weak self] map in self?.handleProjectHeadUpdates(projectId: projectId, branchByWorktreePath: map) }
+        watcher.onRevisionChanged = { [weak self] in self?.bumpRevisionGenerationForProject(projectId: projectId) }
         watcher.onTopologyChanged = { [weak self] in self?.handleProjectTopologyChange(projectId: projectId) }
         watcher.start()
         projectGitWatchers[projectId] = watcher
@@ -3137,12 +3140,37 @@ final class AppState {
     }
 
     func handleProjectHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) {
+        bumpRevisionGenerationForWorktreePaths(projectId: projectId, paths: Array(branchByWorktreePath.keys))
         let changedPaths = projectsManager.applyHeadUpdates(
             projectId: projectId,
             branchByWorktreePath: branchByWorktreePath
         )
         for path in changedPaths {
             GGStackSummaryStore.shared.summaries[path] = nil
+        }
+    }
+
+    func revisionChangeGeneration(worktreeID: String) -> Int {
+        revisionChangeGenerations[worktreeID, default: 0]
+    }
+
+    private func bumpRevisionGeneration(worktreeID: String) {
+        revisionChangeGenerations[worktreeID, default: 0] += 1
+    }
+
+    private func bumpRevisionGenerationForProject(projectId: String) {
+        for worktree in projectsManager.worktrees(projectId: projectId) {
+            bumpRevisionGeneration(worktreeID: worktree.id)
+        }
+    }
+
+    private func bumpRevisionGenerationForWorktreePaths(projectId: String, paths: [URL]) {
+        let affectedPaths = Set(paths.map { Self.canonicalWorktreePath($0.path) })
+        guard !affectedPaths.isEmpty else { return }
+        for worktree in projectsManager.worktrees(projectId: projectId) {
+            if affectedPaths.contains(Self.canonicalWorktreePath(worktree.path.path)) {
+                bumpRevisionGeneration(worktreeID: worktree.id)
+            }
         }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3279,6 +3279,8 @@ final class AppState {
         do {
             candidate = try await TrackedRevisionResolver.live.resolve(at: worktree.path, expression: expression)
         } catch {
+            guard isCurrentFollowRevisionRequest(worktreeID: worktreeID, requestKey: requestKey, requestGeneration: requestGeneration)
+            else { return }
             Self.showWarningAlert(
                 title: "Invalid Revision",
                 message: (error as NSError).localizedDescription
@@ -3291,12 +3293,16 @@ final class AppState {
             baselineHEAD: candidate.headSHA,
             resolvedSHA: candidate.sha
         ) else {
+            guard isCurrentFollowRevisionRequest(worktreeID: worktreeID, requestKey: requestKey, requestGeneration: requestGeneration)
+            else { return }
             Self.showWarningAlert(title: "Invalid Revision", message: "Revision expression must not be empty.")
             return
         }
-        guard followRevisionRequestGenerations[requestKey] == requestGeneration,
-              let tab = tabs.tabs(forWorktree: worktreeID).first(where: { followRevisionRequestKey(for: $0) == requestKey })
-        else { return }
+        guard isCurrentFollowRevisionRequest(worktreeID: worktreeID, requestKey: requestKey, requestGeneration: requestGeneration),
+              let tab = followRevisionRequestTab(worktreeID: worktreeID, requestKey: requestKey)
+        else {
+            return
+        }
 
         switch tab {
         case .commit:
@@ -3314,6 +3320,19 @@ final class AppState {
         let next = followRevisionRequestGenerations[key, default: 0] + 1
         followRevisionRequestGenerations[key] = next
         return next
+    }
+
+    private func isCurrentFollowRevisionRequest(
+        worktreeID: String,
+        requestKey: String,
+        requestGeneration: Int
+    ) -> Bool {
+        followRevisionRequestGenerations[requestKey] == requestGeneration &&
+            followRevisionRequestTab(worktreeID: worktreeID, requestKey: requestKey) != nil
+    }
+
+    private func followRevisionRequestTab(worktreeID: String, requestKey: String) -> Tab? {
+        tabs.tabs(forWorktree: worktreeID).first { followRevisionRequestKey(for: $0) == requestKey }
     }
 
     private func followRevisionRequestKey(worktreeID: String, tabID: TabID) -> String {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3189,7 +3189,7 @@ final class AppState {
             case .commit(let state):
                 guard case .following(let revision) = state.revision else { return }
                 _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
-                    $0.revision = .fixed(sha: revision.resolvedSHA)
+                    $0.fix(sha: revision.resolvedSHA)
                 }
             case .reviewSession(let state):
                 stopFollowingReviewSession(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID)
@@ -3242,7 +3242,7 @@ final class AppState {
         switch tab {
         case .commit:
             _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
-                $0.revision = .following(revision)
+                $0.follow(revision)
             }
         case .reviewSession(let state):
             followReviewSession(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID, revision: revision)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5115,6 +5115,7 @@ final class AppState {
             if case .acpSession(let s) = tab {
                 cleanupACPSession(worktreeId: worktreeId, sessionId: s.sessionId)
             }
+            invalidateFollowRevisionRequests(for: [tab])
         }
         tabs.close(worktreeId: worktreeId, tabId: tabId)
     }
@@ -5174,6 +5175,22 @@ final class AppState {
         }
     }
 
+    private func invalidateFollowRevisionRequests(for tabs: [Tab]) {
+        for tab in tabs {
+            switch tab {
+            case .commit, .reviewSession:
+                _ = bumpFollowRevisionRequestGeneration(followRevisionRequestKey(for: tab))
+            default:
+                continue
+            }
+        }
+    }
+
+    private func invalidateFollowRevisionRequests(allTabs: [Tab], closedIds: [TabID]) {
+        let closedSet = Set(closedIds)
+        invalidateFollowRevisionRequests(for: allTabs.filter { closedSet.contains($0.id) })
+    }
+
     /// Detach a single ACP session's runner and remove it from the
     /// worktree's manager. Different from `disposeACPManager`, which
     /// tears down the whole worktree's manager — this leaves the
@@ -5227,6 +5244,7 @@ final class AppState {
     func closeOtherTabs(worktreeId: String, keeping tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeOthers(worktreeId: worktreeId, keeping: tabId)
+        invalidateFollowRevisionRequests(allTabs: allTabs, closedIds: closed)
         cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
         cleanupACPSessions(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
@@ -5242,6 +5260,7 @@ final class AppState {
 
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = allTabs.map(\.id).filter(ids.contains)
+        invalidateFollowRevisionRequests(allTabs: allTabs, closedIds: closed)
         for id in closed {
             tabs.close(worktreeId: worktreeId, tabId: id)
         }
@@ -5386,6 +5405,7 @@ final class AppState {
         closedTabHistory.purge(worktreeID: worktreeId)
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeAll(worktreeId: worktreeId)
+        invalidateFollowRevisionRequests(allTabs: allTabs, closedIds: closed)
         cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
         disposeACPManager(for: worktreeId)
@@ -5398,6 +5418,7 @@ final class AppState {
     func closeTabsToLeft(worktreeId: String, of tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeToLeft(worktreeId: worktreeId, of: tabId)
+        invalidateFollowRevisionRequests(allTabs: allTabs, closedIds: closed)
         cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
         cleanupACPSessions(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
@@ -5406,6 +5427,7 @@ final class AppState {
     func closeTabsToRight(worktreeId: String, of tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeToRight(worktreeId: worktreeId, of: tabId)
+        invalidateFollowRevisionRequests(allTabs: allTabs, closedIds: closed)
         cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
         cleanupACPSessions(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3212,15 +3212,26 @@ final class AppState {
     }
 
     private func applyFollowRevision(worktreeID: String, tabID: TabID, expression: String) async {
-        guard let worktree = worktree(withId: worktreeID),
-              let candidate = try? await TrackedRevisionResolver.live.resolve(at: worktree.path, expression: expression),
-              let revision = TrackedRevision(
-                  expression: expression,
-                  baselineBranch: candidate.branch,
-                  resolvedSHA: candidate.sha
-              ),
-              let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })
-        else { return }
+        guard let worktree = worktree(withId: worktreeID) else { return }
+        let candidate: TrackedRevisionCandidate
+        do {
+            candidate = try await TrackedRevisionResolver.live.resolve(at: worktree.path, expression: expression)
+        } catch {
+            Self.showWarningAlert(
+                title: "Invalid Revision",
+                message: (error as NSError).localizedDescription
+            )
+            return
+        }
+        guard let revision = TrackedRevision(
+            expression: expression,
+            baselineBranch: candidate.branch,
+            resolvedSHA: candidate.sha
+        ) else {
+            Self.showWarningAlert(title: "Invalid Revision", message: "Revision expression must not be empty.")
+            return
+        }
+        guard let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID }) else { return }
 
         switch tab {
         case .commit:

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3377,17 +3377,19 @@ final class AppState {
               )
         else { return }
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
+            let merged = mergedReviewSession(existing: existing, source: record)
             do {
                 try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
-                try store.save(mergedReviewSession(existing: existing, source: record))
-                try store.delete(id: record.id)
+                try store.replace(id: record.id, with: merged)
                 invalidateFollowRevisionRequests(for: [tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })].compactMap { $0 })
                 tabs.close(worktreeId: worktreeID, tabId: tabID)
             } catch {
                 Self.showWarningAlert(title: "Could Not Update Review Target", message: error.localizedDescription)
                 return
             }
-            let tab = tabs.openOrFocusReviewSession(worktreeId: worktreeID, record: existing)
+            NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
+            bumpReviewSessionRetargetGeneration(sessionID: merged.id)
+            let tab = tabs.openOrFocusReviewSession(worktreeId: worktreeID, record: merged)
             activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
             return
         }
@@ -3404,17 +3406,19 @@ final class AppState {
               )
         else { return }
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
+            let merged = mergedReviewSession(existing: existing, source: record)
             do {
                 try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
-                try store.save(mergedReviewSession(existing: existing, source: record))
-                try store.delete(id: record.id)
+                try store.replace(id: record.id, with: merged)
                 invalidateFollowRevisionRequests(for: [tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })].compactMap { $0 })
                 tabs.close(worktreeId: worktreeID, tabId: tabID)
             } catch {
                 Self.showWarningAlert(title: "Could Not Update Review Target", message: error.localizedDescription)
                 return
             }
-            let tab = tabs.openOrFocusReviewSession(worktreeId: worktreeID, record: existing)
+            NotificationCenter.default.post(name: .alasReviewDraftCommentsDidChangeExternally, object: nil)
+            bumpReviewSessionRetargetGeneration(sessionID: merged.id)
+            let tab = tabs.openOrFocusReviewSession(worktreeId: worktreeID, record: merged)
             activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
             return
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3408,7 +3408,7 @@ final class AppState {
               )
         else { return }
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
-            let merged = mergedReviewSession(existing: existing, source: record)
+            let merged = mergedReviewSession(existing: existing, source: result.record)
             do {
                 let draftStore = ReviewDraftCommentStore()
                 let draftSnapshot = try draftStore.snapshot()
@@ -3444,7 +3444,7 @@ final class AppState {
               )
         else { return }
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
-            let merged = mergedReviewSession(existing: existing, source: record)
+            let merged = mergedReviewSession(existing: existing, source: result.record)
             do {
                 let draftStore = ReviewDraftCommentStore()
                 let draftSnapshot = try draftStore.snapshot()

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3371,6 +3371,15 @@ final class AppState {
               )
         else { return }
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
+            do {
+                try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
+                try store.delete(id: record.id)
+                invalidateFollowRevisionRequests(for: [tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })].compactMap { $0 })
+                tabs.close(worktreeId: worktreeID, tabId: tabID)
+            } catch {
+                Self.showWarningAlert(title: "Could Not Update Review Target", message: error.localizedDescription)
+                return
+            }
             let tab = tabs.openOrFocusReviewSession(worktreeId: worktreeID, record: existing)
             activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
             return
@@ -3388,6 +3397,15 @@ final class AppState {
               )
         else { return }
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
+            do {
+                try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
+                try store.delete(id: record.id)
+                invalidateFollowRevisionRequests(for: [tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })].compactMap { $0 })
+                tabs.close(worktreeId: worktreeID, tabId: tabID)
+            } catch {
+                Self.showWarningAlert(title: "Could Not Update Review Target", message: error.localizedDescription)
+                return
+            }
             let tab = tabs.openOrFocusReviewSession(worktreeId: worktreeID, record: existing)
             activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
             return

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -35,6 +35,37 @@ private struct MissingMissionRecoveryTarget: Equatable {
     }
 }
 
+enum ReviewSessionConsolidation {
+    static func merge(existing: ReviewSessionRecord, source: ReviewSessionRecord) -> ReviewSessionRecord {
+        var merged = existing
+        if merged.selectedFileID == nil {
+            merged.selectedFileID = source.selectedFileID
+        }
+        if merged.focusedCommentID == nil {
+            merged.focusedCommentID = source.focusedCommentID
+        }
+        if merged.handoffs.isEmpty {
+            merged.handoffs = source.handoffs
+        } else {
+            let existingHandoffIDs = Set(merged.handoffs.map(\.id))
+            merged.handoffs.append(contentsOf: source.handoffs.filter { !existingHandoffIDs.contains($0.id) })
+        }
+        if merged.lastSendError == nil {
+            merged.lastSendError = source.lastSendError
+        }
+        if merged.verdict == nil {
+            merged.verdict = source.verdict
+        }
+        if merged.verdict != nil {
+            merged.status = .reviewed
+        } else if merged.status == .active, source.status != .active {
+            merged.status = source.status
+        }
+        merged.updatedAt = max(merged.updatedAt, source.updatedAt)
+        return merged
+    }
+}
+
 @Observable
 @MainActor
 final class AppState {
@@ -3441,30 +3472,7 @@ final class AppState {
     }
 
     private func mergedReviewSession(existing: ReviewSessionRecord, source: ReviewSessionRecord) -> ReviewSessionRecord {
-        var merged = existing
-        if merged.selectedFileID == nil {
-            merged.selectedFileID = source.selectedFileID
-        }
-        if merged.focusedCommentID == nil {
-            merged.focusedCommentID = source.focusedCommentID
-        }
-        if merged.handoffs.isEmpty {
-            merged.handoffs = source.handoffs
-        } else {
-            let existingHandoffIDs = Set(merged.handoffs.map(\.id))
-            merged.handoffs.append(contentsOf: source.handoffs.filter { !existingHandoffIDs.contains($0.id) })
-        }
-        if merged.lastSendError == nil {
-            merged.lastSendError = source.lastSendError
-        }
-        if merged.verdict == nil {
-            merged.verdict = source.verdict
-        }
-        if merged.status == .active, source.status != .active {
-            merged.status = source.status
-        }
-        merged.updatedAt = max(merged.updatedAt, source.updatedAt)
-        return merged
+        ReviewSessionConsolidation.merge(existing: existing, source: source)
     }
 
     private func persistReviewRetargeting(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3357,20 +3357,28 @@ final class AppState {
     ) {
         let sessionStore = ReviewSessionStore()
         var savedRecord = false
-        let previousRecord = try? sessionStore.load(id: result.record.id)
+        let previousOldRecord = try? sessionStore.load(id: result.oldRecordID)
+        let previousNewRecord = try? sessionStore.load(id: result.record.id)
         do {
-            try sessionStore.save(result.record)
+            try sessionStore.replace(id: result.oldRecordID, with: result.record)
             savedRecord = true
             try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: result.newDraftSessionID)
             _ = tabs.updateReviewSession(worktreeId: worktreeID, tabId: tabID) {
-                $0.title = result.record.target.title
-                $0.selectedFileID = result.record.selectedFileID
-                $0.focusedCommentID = result.record.focusedCommentID
+                $0.retarget(to: result.record)
             }
             bumpReviewSessionRetargetGeneration(sessionID: result.record.id)
         } catch {
-            if savedRecord, let previousRecord {
-                try? sessionStore.save(previousRecord)
+            if savedRecord {
+                if let previousOldRecord {
+                    try? sessionStore.save(previousOldRecord)
+                }
+                if result.record.id != result.oldRecordID {
+                    if let previousNewRecord {
+                        try? sessionStore.save(previousNewRecord)
+                    } else {
+                        try? sessionStore.delete(id: result.record.id)
+                    }
+                }
             }
             Self.showWarningAlert(title: "Could Not Update Review Target", message: error.localizedDescription)
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3160,6 +3160,24 @@ final class AppState {
         }
     }
 
+    func promptFollowRevision(worktreeID: String, tabID: TabID, prefill: String? = nil) {
+        let alert = NSAlert()
+        alert.messageText = prefill == nil ? "Follow Revision" : "Edit Followed Revision"
+        alert.informativeText = "Enter a single Git revision expression, such as HEAD~3."
+        alert.addButton(withTitle: "Follow")
+        alert.addButton(withTitle: "Cancel")
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+        field.stringValue = prefill ?? "HEAD"
+        alert.accessoryView = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let expression = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !expression.isEmpty else {
+            Self.showWarningAlert(title: "Invalid Revision", message: "Revision expression must not be empty.")
+            return
+        }
+        followRevision(worktreeID: worktreeID, tabID: tabID, expression: expression)
+    }
+
     func stopFollowingRevision(worktreeID: String, tabID: TabID) {
         if let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID }) {
             switch tab {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3154,6 +3154,131 @@ final class AppState {
         revisionChangeGenerations[worktreeID, default: 0]
     }
 
+    func followRevision(worktreeID: String, tabID: TabID, expression: String) {
+        Task { @MainActor in
+            await applyFollowRevision(worktreeID: worktreeID, tabID: tabID, expression: expression)
+        }
+    }
+
+    func stopFollowingRevision(worktreeID: String, tabID: TabID) {
+        if let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID }) {
+            switch tab {
+            case .commit(let state):
+                guard case .following(let revision) = state.revision else { return }
+                _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
+                    $0.revision = .fixed(sha: revision.resolvedSHA)
+                }
+            case .reviewSession(let state):
+                stopFollowingReviewSession(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID)
+            default:
+                return
+            }
+        }
+    }
+
+    func acceptTrackedRevisionCheckout(worktreeID: String, tabID: TabID) {
+        guard let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID }) else { return }
+        switch tab {
+        case .commit(let state):
+            guard case .following(let revision) = state.revision,
+                  let accepted = revision.acceptingPendingCheckout()
+            else { return }
+            _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
+                $0.revision = .following(accepted)
+            }
+        case .reviewSession(let state):
+            acceptTrackedReviewSessionCheckout(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID)
+        default:
+            return
+        }
+    }
+
+    private func applyFollowRevision(worktreeID: String, tabID: TabID, expression: String) async {
+        guard let worktree = worktree(withId: worktreeID),
+              let candidate = try? await TrackedRevisionResolver.live.resolve(at: worktree.path, expression: expression),
+              let revision = TrackedRevision(
+                  expression: expression,
+                  baselineBranch: candidate.branch,
+                  resolvedSHA: candidate.sha
+              ),
+              let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })
+        else { return }
+
+        switch tab {
+        case .commit:
+            _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
+                $0.revision = .following(revision)
+            }
+        case .reviewSession(let state):
+            followReviewSession(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID, revision: revision)
+        default:
+            return
+        }
+    }
+
+    private func followReviewSession(
+        worktreeID: String,
+        tabID: TabID,
+        sessionID: ReviewSessionID,
+        revision: TrackedRevision
+    ) {
+        let store = ReviewSessionStore()
+        guard let record = try? store.load(id: sessionID),
+              let result = TrackedRevisionRetargeter.follow(
+                  record: record,
+                  revision: revision,
+                  title: "Review \(revision.expression)",
+                  now: Date()
+              )
+        else { return }
+        persistReviewRetargeting(result, worktreeID: worktreeID, tabID: tabID)
+    }
+
+    private func stopFollowingReviewSession(worktreeID: String, tabID: TabID, sessionID: ReviewSessionID) {
+        let store = ReviewSessionStore()
+        guard let record = try? store.load(id: sessionID),
+              let result = TrackedRevisionRetargeter.stop(
+                  record: record,
+                  title: "Review \(record.target.revisionDescription ?? "commit")",
+                  now: Date()
+              )
+        else { return }
+        persistReviewRetargeting(result, worktreeID: worktreeID, tabID: tabID)
+    }
+
+    private func acceptTrackedReviewSessionCheckout(worktreeID: String, tabID: TabID, sessionID: ReviewSessionID) {
+        let store = ReviewSessionStore()
+        guard let record = try? store.load(id: sessionID),
+              case .trackedCommit(let revision) = record.target.payload,
+              let accepted = revision.acceptingPendingCheckout(),
+              let result = TrackedRevisionRetargeter.follow(
+                  record: record,
+                  revision: accepted,
+                  title: "Review \(accepted.expression)",
+                  now: Date()
+              )
+        else { return }
+        persistReviewRetargeting(result, worktreeID: worktreeID, tabID: tabID)
+    }
+
+    private func persistReviewRetargeting(
+        _ result: TrackedRevisionRetargetingResult,
+        worktreeID: String,
+        tabID: TabID
+    ) {
+        do {
+            try ReviewSessionStore().save(result.record)
+            try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: result.newDraftSessionID)
+            _ = tabs.updateReviewSession(worktreeId: worktreeID, tabId: tabID) {
+                $0.title = result.record.target.title
+                $0.selectedFileID = result.record.selectedFileID
+                $0.focusedCommentID = result.record.focusedCommentID
+            }
+        } catch {
+            Self.showWarningAlert(title: "Could Not Update Review Target", message: error.localizedDescription)
+        }
+    }
+
     private func bumpRevisionGeneration(worktreeID: String) {
         revisionChangeGenerations[worktreeID, default: 0] += 1
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -584,6 +584,7 @@ final class AppState {
     private let projectGitWatcherFactory: @MainActor (URL) -> ProjectGitWatcher
     private(set) var revisionChangeGenerations: [String: Int] = [:]
     private(set) var reviewSessionRetargetGenerations: [String: Int] = [:]
+    private var followRevisionRequestGenerations: [String: Int] = [:]
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
@@ -3141,7 +3142,7 @@ final class AppState {
     }
 
     func handleProjectHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) {
-        bumpRevisionGenerationForWorktreePaths(projectId: projectId, paths: Array(branchByWorktreePath.keys))
+        bumpRevisionGenerationForProject(projectId: projectId)
         let changedPaths = projectsManager.applyHeadUpdates(
             projectId: projectId,
             branchByWorktreePath: branchByWorktreePath
@@ -3160,8 +3161,15 @@ final class AppState {
     }
 
     func followRevision(worktreeID: String, tabID: TabID, expression: String) {
+        let requestKey = followRevisionRequestKey(worktreeID: worktreeID, tabID: tabID)
+        let requestGeneration = bumpFollowRevisionRequestGeneration(requestKey)
         Task { @MainActor in
-            await applyFollowRevision(worktreeID: worktreeID, tabID: tabID, expression: expression)
+            await applyFollowRevision(
+                worktreeID: worktreeID,
+                requestKey: requestKey,
+                requestGeneration: requestGeneration,
+                expression: expression
+            )
         }
     }
 
@@ -3260,7 +3268,12 @@ final class AppState {
         }
     }
 
-    private func applyFollowRevision(worktreeID: String, tabID: TabID, expression: String) async {
+    private func applyFollowRevision(
+        worktreeID: String,
+        requestKey: String,
+        requestGeneration: Int,
+        expression: String
+    ) async {
         guard let worktree = worktree(withId: worktreeID) else { return }
         let candidate: TrackedRevisionCandidate
         do {
@@ -3281,17 +3294,43 @@ final class AppState {
             Self.showWarningAlert(title: "Invalid Revision", message: "Revision expression must not be empty.")
             return
         }
-        guard let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID }) else { return }
+        guard followRevisionRequestGenerations[requestKey] == requestGeneration,
+              let tab = tabs.tabs(forWorktree: worktreeID).first(where: { followRevisionRequestKey(for: $0) == requestKey })
+        else { return }
 
         switch tab {
         case .commit:
-            _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
+            _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tab.id) {
                 $0.follow(revision)
             }
         case .reviewSession(let state):
-            followReviewSession(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID, revision: revision)
+            followReviewSession(worktreeID: worktreeID, tabID: tab.id, sessionID: state.sessionID, revision: revision)
         default:
             return
+        }
+    }
+
+    private func bumpFollowRevisionRequestGeneration(_ key: String) -> Int {
+        let next = followRevisionRequestGenerations[key, default: 0] + 1
+        followRevisionRequestGenerations[key] = next
+        return next
+    }
+
+    private func followRevisionRequestKey(worktreeID: String, tabID: TabID) -> String {
+        guard let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID }) else {
+            return "\(worktreeID):\(tabID)"
+        }
+        return followRevisionRequestKey(for: tab)
+    }
+
+    private func followRevisionRequestKey(for tab: Tab) -> String {
+        switch tab {
+        case .commit(let state):
+            return "\(state.worktreeId):\(state.viewID)"
+        case .reviewSession(let state):
+            return "\(state.worktreeId):\(state.viewID)"
+        default:
+            return "\(tab.id)"
         }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3301,8 +3301,12 @@ final class AppState {
         worktreeID: String,
         tabID: TabID
     ) {
+        let sessionStore = ReviewSessionStore()
+        var savedRecord = false
+        let previousRecord = try? sessionStore.load(id: result.record.id)
         do {
-            try ReviewSessionStore().save(result.record)
+            try sessionStore.save(result.record)
+            savedRecord = true
             try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: result.newDraftSessionID)
             _ = tabs.updateReviewSession(worktreeId: worktreeID, tabId: tabID) {
                 $0.title = result.record.target.title
@@ -3311,6 +3315,9 @@ final class AppState {
             }
             bumpReviewSessionRetargetGeneration(sessionID: result.record.id)
         } catch {
+            if savedRecord, let previousRecord {
+                try? sessionStore.save(previousRecord)
+            }
             Self.showWarningAlert(title: "Could Not Update Review Target", message: error.localizedDescription)
         }
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3239,10 +3239,12 @@ final class AppState {
             switch tab {
             case .commit(let state):
                 guard case .following(let revision) = state.revision else { return }
+                _ = bumpFollowRevisionRequestGeneration(followRevisionRequestKey(for: tab))
                 _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
                     $0.fix(sha: revision.resolvedSHA)
                 }
             case .reviewSession(let state):
+                _ = bumpFollowRevisionRequestGeneration(followRevisionRequestKey(for: tab))
                 stopFollowingReviewSession(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID)
             default:
                 return

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3109,7 +3109,10 @@ final class AppState {
                 self?.handleProjectHeadUpdates(projectId: project.id, branchByWorktreePath: updates)
             }
             watcher.onRevisionChanged = { [weak self] in self?.bumpRevisionGenerationForProject(projectId: project.id) }
-            watcher.onTopologyChanged = { [weak self] in self?.handleProjectTopologyChange(projectId: project.id) }
+            watcher.onTopologyChanged = { [weak self] in
+                self?.bumpRevisionGenerationForProject(projectId: project.id)
+                self?.handleProjectTopologyChange(projectId: project.id)
+            }
             remoteProjectWatchers[project.id] = watcher
             watcher.start()
             return
@@ -3118,7 +3121,10 @@ final class AppState {
         let projectId = project.id
         watcher.onHeadChanged = { [weak self] map in self?.handleProjectHeadUpdates(projectId: projectId, branchByWorktreePath: map) }
         watcher.onRevisionChanged = { [weak self] in self?.bumpRevisionGenerationForProject(projectId: projectId) }
-        watcher.onTopologyChanged = { [weak self] in self?.handleProjectTopologyChange(projectId: projectId) }
+        watcher.onTopologyChanged = { [weak self] in
+            self?.bumpRevisionGenerationForProject(projectId: projectId)
+            self?.handleProjectTopologyChange(projectId: projectId)
+        }
         watcher.start()
         projectGitWatchers[projectId] = watcher
     }
@@ -3373,6 +3379,7 @@ final class AppState {
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
             do {
                 try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
+                try store.save(mergedReviewSession(existing: existing, source: record))
                 try store.delete(id: record.id)
                 invalidateFollowRevisionRequests(for: [tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })].compactMap { $0 })
                 tabs.close(worktreeId: worktreeID, tabId: tabID)
@@ -3399,6 +3406,7 @@ final class AppState {
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
             do {
                 try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
+                try store.save(mergedReviewSession(existing: existing, source: record))
                 try store.delete(id: record.id)
                 invalidateFollowRevisionRequests(for: [tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })].compactMap { $0 })
                 tabs.close(worktreeId: worktreeID, tabId: tabID)
@@ -3426,6 +3434,33 @@ final class AppState {
               )
         else { return }
         persistReviewRetargeting(result, worktreeID: worktreeID, tabID: tabID)
+    }
+
+    private func mergedReviewSession(existing: ReviewSessionRecord, source: ReviewSessionRecord) -> ReviewSessionRecord {
+        var merged = existing
+        if merged.selectedFileID == nil {
+            merged.selectedFileID = source.selectedFileID
+        }
+        if merged.focusedCommentID == nil {
+            merged.focusedCommentID = source.focusedCommentID
+        }
+        if merged.handoffs.isEmpty {
+            merged.handoffs = source.handoffs
+        } else {
+            let existingHandoffIDs = Set(merged.handoffs.map(\.id))
+            merged.handoffs.append(contentsOf: source.handoffs.filter { !existingHandoffIDs.contains($0.id) })
+        }
+        if merged.lastSendError == nil {
+            merged.lastSendError = source.lastSendError
+        }
+        if merged.verdict == nil {
+            merged.verdict = source.verdict
+        }
+        if merged.status == .active, source.status != .active {
+            merged.status = source.status
+        }
+        merged.updatedAt = max(merged.updatedAt, source.updatedAt)
+        return merged
     }
 
     private func persistReviewRetargeting(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7419,7 +7419,7 @@ final class AppState {
         }
 
         let existing = tabs.tabs(forWorktree: worktree.id).first { tab in
-            if case .commit(let state) = tab { return state.sha == commit.sha }
+            if case .commit(let state) = tab { return state.fixedSHA == commit.sha }
             return false
         }
         if let existing {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -583,6 +583,7 @@ final class AppState {
     @ObservationIgnored
     private let projectGitWatcherFactory: @MainActor (URL) -> ProjectGitWatcher
     private(set) var revisionChangeGenerations: [String: Int] = [:]
+    private(set) var reviewSessionRetargetGenerations: [String: Int] = [:]
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
@@ -3154,6 +3155,10 @@ final class AppState {
         revisionChangeGenerations[worktreeID, default: 0]
     }
 
+    func reviewSessionRetargetGeneration(sessionID: ReviewSessionID) -> Int {
+        reviewSessionRetargetGenerations[sessionID.rawValue, default: 0]
+    }
+
     func followRevision(worktreeID: String, tabID: TabID, expression: String) {
         Task { @MainActor in
             await applyFollowRevision(worktreeID: worktreeID, tabID: tabID, expression: expression)
@@ -3204,6 +3209,7 @@ final class AppState {
             _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
                 $0.revision = .following(accepted)
             }
+            bumpRevisionGeneration(worktreeID: worktreeID)
         case .reviewSession(let state):
             acceptTrackedReviewSessionCheckout(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID)
         default:
@@ -3303,9 +3309,14 @@ final class AppState {
                 $0.selectedFileID = result.record.selectedFileID
                 $0.focusedCommentID = result.record.focusedCommentID
             }
+            bumpReviewSessionRetargetGeneration(sessionID: result.record.id)
         } catch {
             Self.showWarningAlert(title: "Could Not Update Review Target", message: error.localizedDescription)
         }
+    }
+
+    private func bumpReviewSessionRetargetGeneration(sessionID: ReviewSessionID) {
+        reviewSessionRetargetGenerations[sessionID.rawValue, default: 0] += 1
     }
 
     private func bumpRevisionGeneration(worktreeID: String) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3410,8 +3410,15 @@ final class AppState {
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
             let merged = mergedReviewSession(existing: existing, source: record)
             do {
-                try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
-                try store.replace(id: record.id, with: merged)
+                let draftStore = ReviewDraftCommentStore()
+                let draftSnapshot = try draftStore.snapshot()
+                try draftStore.migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
+                do {
+                    try store.replace(id: record.id, with: merged)
+                } catch {
+                    try? draftStore.restore(draftSnapshot)
+                    throw error
+                }
                 invalidateFollowRevisionRequests(for: [tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })].compactMap { $0 })
                 tabs.close(worktreeId: worktreeID, tabId: tabID)
             } catch {
@@ -3439,8 +3446,15 @@ final class AppState {
         if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
             let merged = mergedReviewSession(existing: existing, source: record)
             do {
-                try ReviewDraftCommentStore().migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
-                try store.replace(id: record.id, with: merged)
+                let draftStore = ReviewDraftCommentStore()
+                let draftSnapshot = try draftStore.snapshot()
+                try draftStore.migrate(from: result.oldDraftSessionID, to: existing.target.draftSessionID)
+                do {
+                    try store.replace(id: record.id, with: merged)
+                } catch {
+                    try? draftStore.restore(draftSnapshot)
+                    throw error
+                }
                 invalidateFollowRevisionRequests(for: [tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID })].compactMap { $0 })
                 tabs.close(worktreeId: worktreeID, tabId: tabID)
             } catch {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3232,6 +3232,7 @@ final class AppState {
         guard let revision = TrackedRevision(
             expression: expression,
             baselineBranch: candidate.branch,
+            baselineHEAD: candidate.headSHA,
             resolvedSHA: candidate.sha
         ) else {
             Self.showWarningAlert(title: "Invalid Revision", message: "Revision expression must not be empty.")
@@ -3266,6 +3267,11 @@ final class AppState {
                   now: Date()
               )
         else { return }
+        if let existing = try? store.findActive(targetID: result.record.target.id, excluding: record.id) {
+            let tab = tabs.openOrFocusReviewSession(worktreeId: worktreeID, record: existing)
+            activateWorktreeCenterTab(worktreeId: worktreeID, tabId: tab.id)
+            return
+        }
         persistReviewRetargeting(result, worktreeID: worktreeID, tabID: tabID)
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3211,6 +3211,8 @@ final class AppState {
     }
 
     func promptFollowRevision(worktreeID: String, tabID: TabID, prefill: String? = nil) {
+        let requestKey = followRevisionRequestKey(worktreeID: worktreeID, tabID: tabID)
+        let requestGeneration = bumpFollowRevisionRequestGeneration(requestKey)
         Task { @MainActor in
             let resolvedPrefill: String?
             if let prefill {
@@ -3218,6 +3220,11 @@ final class AppState {
             } else {
                 resolvedPrefill = await suggestedFollowRevisionPrefill(worktreeID: worktreeID, tabID: tabID)
             }
+            guard isCurrentFollowRevisionRequest(
+                worktreeID: worktreeID,
+                requestKey: requestKey,
+                requestGeneration: requestGeneration
+            ) else { return }
             presentFollowRevisionPrompt(worktreeID: worktreeID, tabID: tabID, prefill: resolvedPrefill, isEditing: prefill != nil)
         }
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3166,13 +3166,25 @@ final class AppState {
     }
 
     func promptFollowRevision(worktreeID: String, tabID: TabID, prefill: String? = nil) {
+        Task { @MainActor in
+            let resolvedPrefill: String?
+            if let prefill {
+                resolvedPrefill = prefill
+            } else {
+                resolvedPrefill = await suggestedFollowRevisionPrefill(worktreeID: worktreeID, tabID: tabID)
+            }
+            presentFollowRevisionPrompt(worktreeID: worktreeID, tabID: tabID, prefill: resolvedPrefill, isEditing: prefill != nil)
+        }
+    }
+
+    private func presentFollowRevisionPrompt(worktreeID: String, tabID: TabID, prefill: String?, isEditing: Bool) {
         let alert = NSAlert()
-        alert.messageText = prefill == nil ? "Follow Revision" : "Edit Followed Revision"
+        alert.messageText = isEditing ? "Edit Followed Revision" : "Follow Revision"
         alert.informativeText = "Enter a single Git revision expression, such as HEAD~3."
         alert.addButton(withTitle: "Follow")
         alert.addButton(withTitle: "Cancel")
         let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
-        field.stringValue = prefill ?? "HEAD"
+        field.stringValue = prefill ?? ""
         alert.accessoryView = field
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         let expression = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -3181,6 +3193,37 @@ final class AppState {
             return
         }
         followRevision(worktreeID: worktreeID, tabID: tabID, expression: expression)
+    }
+
+    private func suggestedFollowRevisionPrefill(worktreeID: String, tabID: TabID) async -> String? {
+        guard let worktree = worktree(withId: worktreeID),
+              let displayedSHA = displayedCommitSHA(worktreeID: worktreeID, tabID: tabID)
+        else { return nil }
+        let result = try? await Process.git(
+            ["rev-list", "--first-parent", "--max-count=200", "HEAD"],
+            cwd: worktree.path
+        )
+        guard result?.exitCode == 0 else { return nil }
+        let firstParentSHAs = result?.stdout
+            .split(whereSeparator: \.isNewline)
+            .map(String.init) ?? []
+        return FollowRevisionPrefill.expression(displayedSHA: displayedSHA, firstParentSHAs: firstParentSHAs)
+    }
+
+    private func displayedCommitSHA(worktreeID: String, tabID: TabID) -> String? {
+        guard let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID }) else { return nil }
+        switch tab {
+        case .commit(let state):
+            return state.sha
+        case .reviewSession(let state):
+            let record = try? ReviewSessionStore().load(id: state.sessionID)
+            if case .commit(let sha) = record?.target.payload {
+                return sha
+            }
+            return nil
+        default:
+            return nil
+        }
     }
 
     func stopFollowingRevision(worktreeID: String, tabID: TabID) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3296,11 +3296,13 @@ final class AppState {
             guard case .following(let revision) = state.revision,
                   let accepted = revision.preparingPendingCheckoutAcceptance()
             else { return }
+            _ = bumpFollowRevisionRequestGeneration(followRevisionRequestKey(for: tab))
             _ = tabs.updateCommit(worktreeId: worktreeID, tabId: tabID) {
                 $0.revision = .following(accepted)
             }
             bumpRevisionGeneration(worktreeID: worktreeID)
         case .reviewSession(let state):
+            _ = bumpFollowRevisionRequestGeneration(followRevisionRequestKey(for: tab))
             acceptTrackedReviewSessionCheckout(worktreeID: worktreeID, tabID: tabID, sessionID: state.sessionID)
         default:
             return

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -332,7 +332,7 @@ struct RootView: View {
 
     private func openOrFocusCommit(worktree: Worktree, commit: CommitInfo) {
         let existing = state.tabs.tabs(forWorktree: worktree.id).first { tab in
-            if case .commit(let s) = tab { return s.sha == commit.sha } else { return false }
+            if case .commit(let s) = tab { return s.fixedSHA == commit.sha } else { return false }
         }
         if let existing {
             state.tabs.activate(worktreeId: worktree.id, tabId: existing.id)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -147,6 +147,19 @@ struct CenterPaneView: View {
                     }
                     FileSystemOpen.reveal(url: url)
                 },
+                onFollowRevision: { id in
+                    state.promptFollowRevision(worktreeID: worktree.id, tabID: id)
+                },
+                onEditRevision: { id in
+                    let prefill: String? = {
+                        guard case .commit(let s)? = tabs.first(where: { $0.id == id }) else { return nil }
+                        return s.revision.tracked?.expression
+                    }()
+                    state.promptFollowRevision(worktreeID: worktree.id, tabID: id, prefill: prefill)
+                },
+                onStopFollowingRevision: { id in
+                    state.stopFollowingRevision(worktreeID: worktree.id, tabID: id)
+                },
                 systemActionsEnabled: !worktree.path.isRemoteAlasPath,
                 onRenameTerminal: { id in
                     state.renameTerminalTab(worktreeId: worktree.id, tabId: id)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -314,11 +314,11 @@ struct CenterPaneView: View {
                     case .commit(let s):
                         CommitTabView(
                             worktreePath: worktree.path,
-                            sha: s.sha,
+                            tabState: s,
                             worktreeId: worktree.id,
                             appState: state
                         )
-                        .id(s.sha)
+                        .id(s.id)
                     case .commitEditor(let s):
                         CommitEditorTabView(
                             worktreePath: worktree.path,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -418,7 +418,7 @@ struct CenterPaneView: View {
                             tabState: sessionState,
                             appState: state
                         )
-                        .id(sessionState.id)
+                        .id(sessionState.viewID)
                     case .mission(let missionState):
                         MissionTabView(
                             state: state,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -147,13 +147,46 @@ struct CenterPaneView: View {
                     }
                     FileSystemOpen.reveal(url: url)
                 },
+                revisionFollowCapability: { tab in
+                    switch tab {
+                    case .commit(let state):
+                        return RevisionFollowCapability(
+                            isSupported: true,
+                            isFollowing: state.revision.tracked != nil
+                        )
+                    case .reviewSession(let state):
+                        let record = try? ReviewSessionStore().load(id: state.sessionID)
+                        guard record?.target.kind == .commit else {
+                            return RevisionFollowCapability(isSupported: false, isFollowing: false)
+                        }
+                        let isFollowing: Bool
+                        if case .trackedCommit = record?.target.payload {
+                            isFollowing = true
+                        } else {
+                            isFollowing = false
+                        }
+                        return RevisionFollowCapability(isSupported: true, isFollowing: isFollowing)
+                    default:
+                        return RevisionFollowCapability(isSupported: false, isFollowing: false)
+                    }
+                },
                 onFollowRevision: { id in
                     state.promptFollowRevision(worktreeID: worktree.id, tabID: id)
                 },
                 onEditRevision: { id in
                     let prefill: String? = {
-                        guard case .commit(let s)? = tabs.first(where: { $0.id == id }) else { return nil }
-                        return s.revision.tracked?.expression
+                        switch tabs.first(where: { $0.id == id }) {
+                        case .commit(let s):
+                            return s.revision.tracked?.expression
+                        case .reviewSession(let s):
+                            let record = try? ReviewSessionStore().load(id: s.sessionID)
+                            if case .trackedCommit(let revision) = record?.target.payload {
+                                return revision.expression
+                            }
+                            return nil
+                        default:
+                            return nil
+                        }
                     }()
                     state.promptFollowRevision(worktreeID: worktree.id, tabID: id, prefill: prefill)
                 },

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -156,7 +156,7 @@ struct CenterPaneView: View {
                         )
                     case .reviewSession(let state):
                         let record = try? ReviewSessionStore().load(id: state.sessionID)
-                        guard record?.target.kind == .commit else {
+                        guard record?.target.kind == .commit || record?.target.kind == .trackedCommit else {
                             return RevisionFollowCapability(isSupported: false, isFollowing: false)
                         }
                         let isFollowing: Bool

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -364,7 +364,7 @@ struct CenterPaneView: View {
                             worktreeId: worktree.id,
                             appState: state
                         )
-                        .id(s.id)
+                        .id(s.viewID)
                     case .commitEditor(let s):
                         CommitEditorTabView(
                             worktreePath: worktree.path,

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -13,6 +13,7 @@ struct CommitHeaderView: View {
     var onEditRevision: (() -> Void)?
     var onStopFollowingRevision: (() -> Void)?
     var onAcceptPendingCheckout: (() -> Void)?
+    var onRetryRevision: (() -> Void)?
 
     @Environment(\.theme) private var theme
     @StateObject private var copyFeedback = CopyFeedbackState()
@@ -138,6 +139,12 @@ struct CommitHeaderView: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .accessibilityIdentifier("commit-revision-error")
+                if let onRetryRevision {
+                    Button("Retry", action: onRetryRevision)
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .accessibilityIdentifier("commit-revision-error-retry")
+                }
             }
 
             Spacer(minLength: 8)

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -5,6 +5,14 @@ struct CommitHeaderView: View {
 
     let details: CommitDetails
     @Binding var expanded: Bool
+    var revisionExpression: String?
+    var pendingCheckout: TrackedRevisionCandidate?
+    var isRefreshingRevision = false
+    var revisionError: String?
+    var onFollowRevision: (() -> Void)?
+    var onEditRevision: (() -> Void)?
+    var onStopFollowingRevision: (() -> Void)?
+    var onAcceptPendingCheckout: (() -> Void)?
 
     @Environment(\.theme) private var theme
     @StateObject private var copyFeedback = CopyFeedbackState()
@@ -13,6 +21,10 @@ struct CommitHeaderView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             compactRow
+            if showsRevisionRow {
+                revisionRow
+                    .padding(.top, 8)
+            }
             if expanded {
                 ScrollView(.vertical) {
                     expandedBlock
@@ -25,6 +37,14 @@ struct CommitHeaderView: View {
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
         .copyFeedbackOverlay(message: copyFeedback.message)
+    }
+
+    private var showsRevisionRow: Bool {
+        revisionExpression != nil ||
+            pendingCheckout != nil ||
+            isRefreshingRevision ||
+            revisionError != nil ||
+            onFollowRevision != nil
     }
 
     private var compactRow: some View {
@@ -72,6 +92,76 @@ struct CommitHeaderView: View {
         .onTapGesture { expanded.toggle() }
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel("Toggle commit details")
+    }
+
+    private var revisionRow: some View {
+        HStack(spacing: 8) {
+            if let revisionExpression {
+                Text("\(revisionExpression) -> \(details.info.shortSha)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .accessibilityIdentifier("commit-revision-following-label")
+            } else if onFollowRevision != nil {
+                Text("Fixed commit")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-muted"))
+            }
+
+            if isRefreshingRevision {
+                Text("Refreshing")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .accessibilityIdentifier("commit-revision-updating")
+            }
+
+            if let pendingCheckout {
+                Text("Paused on checkout to \(pendingCheckout.branch)")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("warn"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .accessibilityIdentifier("commit-revision-pending-checkout")
+                Button("Update") {
+                    onAcceptPendingCheckout?()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .accessibilityIdentifier("commit-revision-accept-checkout")
+            }
+
+            if let revisionError, !revisionError.isEmpty {
+                Text(revisionError)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("del"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .accessibilityIdentifier("commit-revision-error")
+            }
+
+            Spacer(minLength: 8)
+
+            if revisionExpression == nil, let onFollowRevision {
+                Button("Follow Revision…", action: onFollowRevision)
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("commit-revision-follow")
+            } else {
+                if let onEditRevision {
+                    Button("Edit…", action: onEditRevision)
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .accessibilityIdentifier("commit-revision-edit")
+                }
+                if let onStopFollowingRevision {
+                    Button("Stop", action: onStopFollowingRevision)
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .accessibilityIdentifier("commit-revision-stop")
+                }
+            }
+        }
     }
 
     private var expandedBlock: some View {

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct CommitTabView: View {
     let worktreePath: URL
-    let sha: String
+    let tabState: CommitTabState
     let worktreeId: String
     @Bindable var appState: AppState
 
@@ -28,6 +28,16 @@ struct CommitTabView: View {
     @Environment(\.theme) private var theme
     private let git = GitService()
     private let reviewLoader = CommitReviewLoader()
+    private let revisionResolver = TrackedRevisionResolver.live
+
+    private var sha: String { tabState.sha }
+
+    private var loadTaskID: String {
+        if let tracked = tabState.revision.tracked {
+            return "\(tabState.id):\(tracked.expression):\(appState.revisionChangeGeneration(worktreeID: worktreeId))"
+        }
+        return "\(tabState.id):\(sha)"
+    }
 
     private var diffPreferences: DiffPreferenceBindings {
         DiffPreferenceBindings(
@@ -79,7 +89,7 @@ struct CommitTabView: View {
                 Color.clear
             }
         }
-        .task(id: sha) { await loadDetails() }
+        .task(id: loadTaskID) { await loadDetails() }
     }
 
     @ViewBuilder
@@ -107,7 +117,7 @@ struct CommitTabView: View {
                     .multilineTextAlignment(.center)
                     .lineLimit(4)
                 AlasButton(title: "Retry", style: .subtle) {
-                    Task { await loadReviewSession(details: details) }
+                    Task { await loadDetails() }
                 }
             }
             .padding(24)
@@ -166,7 +176,7 @@ struct CommitTabView: View {
                     target: Self.reviewSessionTarget(
                         worktreeID: worktreeId,
                         repositoryPath: worktreePath,
-                        sha: sha,
+                        sha: details.info.sha,
                         title: details.info.subject
                     )
                 )
@@ -178,14 +188,17 @@ struct CommitTabView: View {
     }
 
     private func loadDetails() async {
-        let requestedKey = sha
+        let requestedKey = loadTaskID
         activeDetailsKey = requestedKey
-        loadingDetails = true
+        loadingDetails = details == nil
         detailsError = nil
-        details = nil
-        reviewSession = nil
+        if details == nil {
+            reviewSession = nil
+        }
         reviewSessionError = nil
-        selectedReviewFileID = nil
+        if details == nil {
+            selectedReviewFileID = nil
+        }
         activeReviewKey = nil
         activeReviewID = UUID()
         loadingReviewSession = false
@@ -194,21 +207,44 @@ struct CommitTabView: View {
             if activeDetailsKey == requestedKey { loadingDetails = false }
         }
         do {
-            let d = try await git.commitDetails(at: worktreePath, sha: sha)
+            let resolved = try await resolvedRevisionForLoad()
+            guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
+            let d = try await git.commitDetails(at: worktreePath, sha: resolved.sha)
+            guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
+            let loaded = try await loadReviewSession(details: d, sha: resolved.sha)
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
             self.details = d
-            await loadReviewSession(details: d)
+            publishReviewSession(loaded, preservingSelectionByPathFrom: selectedReviewFileID)
+            if let tracked = resolved.trackedRevision {
+                appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {
+                    $0.revision = .following(tracked)
+                    $0.title = d.info.subject
+                }
+            }
         } catch {
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
             self.detailsError = (error as NSError).localizedDescription
         }
     }
 
-    private func loadReviewSession(details: CommitDetails) async {
-        guard CommitReviewLoadIdentity.isCurrent(details: details, currentDetails: self.details, sha: sha) else {
-            return
+    private func resolvedRevisionForLoad() async throws -> (sha: String, trackedRevision: TrackedRevision?) {
+        guard case .following(let tracked) = tabState.revision else {
+            return (tabState.sha, nil)
         }
-        let requestedToken = CommitReviewLoadToken.next(key: reviewKey(details: details))
+        let candidate = try await revisionResolver.resolve(at: worktreePath, expression: tracked.expression)
+        switch TrackedRevisionPolicy.evaluate(current: tracked, candidate: candidate) {
+        case .unchanged(let revision), .follow(let revision):
+            return (revision.resolvedSHA, revision)
+        case .pause(let revision):
+            appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {
+                $0.revision = .following(revision)
+            }
+            return (tracked.resolvedSHA, nil)
+        }
+    }
+
+    private func loadReviewSession(details: CommitDetails, sha: String) async throws -> DiffReviewLoadedSession {
+        let requestedToken = CommitReviewLoadToken.next(key: reviewKey(details: details, sha: sha))
         activeReviewKey = requestedToken.key
         activeReviewID = requestedToken.id
         loadingReviewSession = true
@@ -229,22 +265,29 @@ struct CommitTabView: View {
             )
             guard
                 !Task.isCancelled,
-                requestedToken.isActive(activeKey: activeReviewKey, activeID: activeReviewID),
-                CommitReviewLoadIdentity.isCurrent(details: details, currentDetails: self.details, sha: sha)
-            else { return }
-            reviewSession = loaded
-            selectedReviewFileID = selectedReviewFileID.flatMap { selected in
-                loaded.summary.files.contains { $0.id == selected } ? selected : loaded.summary.files.first?.id
-            } ?? loaded.summary.files.first?.id
+                requestedToken.isActive(activeKey: activeReviewKey, activeID: activeReviewID)
+            else { throw CancellationError() }
+            return loaded
         } catch is CancellationError {
+            throw CancellationError()
         } catch {
             guard
                 !Task.isCancelled,
-                requestedToken.isActive(activeKey: activeReviewKey, activeID: activeReviewID),
-                CommitReviewLoadIdentity.isCurrent(details: details, currentDetails: self.details, sha: sha)
-            else { return }
+                requestedToken.isActive(activeKey: activeReviewKey, activeID: activeReviewID)
+            else { throw CancellationError() }
             reviewSessionError = (error as NSError).localizedDescription
+            throw error
         }
+    }
+
+    private func publishReviewSession(
+        _ loaded: DiffReviewLoadedSession,
+        preservingSelectionByPathFrom previousSelection: DiffReviewFileID?
+    ) {
+        reviewSession = loaded
+        selectedReviewFileID = previousSelection.flatMap { selected in
+            loaded.summary.files.first { $0.path == selected.path }?.id
+        } ?? loaded.summary.files.first?.id
     }
 
     private func openFileAction(for path: String) -> (() -> Void)? {
@@ -258,7 +301,7 @@ struct CommitTabView: View {
         }
     }
 
-    private func reviewKey(details: CommitDetails) -> String {
+    private func reviewKey(details: CommitDetails, sha: String) -> String {
         let fileKey = details.files
             .map { file in
                 [

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -226,7 +226,11 @@ struct CommitTabView: View {
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
             let d = try await git.commitDetails(at: worktreePath, sha: resolved.sha)
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
-            let loaded = try await loadReviewSession(details: d, sha: resolved.sha)
+            let loaded = try await loadReviewSession(
+                details: d,
+                sha: resolved.sha,
+                preservesPublishedSession: isTrackedRefresh
+            )
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
             self.details = d
             publishReviewSession(loaded, preservingSelectionByPathFrom: selectedReviewFileID)
@@ -258,16 +262,24 @@ struct CommitTabView: View {
         }
     }
 
-    private func loadReviewSession(details: CommitDetails, sha: String) async throws -> DiffReviewLoadedSession {
+    private func loadReviewSession(
+        details: CommitDetails,
+        sha: String,
+        preservesPublishedSession: Bool = false
+    ) async throws -> DiffReviewLoadedSession {
         let requestedToken = CommitReviewLoadToken.next(key: reviewKey(details: details, sha: sha))
         activeReviewKey = requestedToken.key
         activeReviewID = requestedToken.id
-        loadingReviewSession = true
+        if !preservesPublishedSession {
+            loadingReviewSession = true
+            reviewSession = nil
+        }
         reviewSessionError = nil
-        reviewSession = nil
         defer {
             if requestedToken.isActive(activeKey: activeReviewKey, activeID: activeReviewID) {
-                loadingReviewSession = false
+                if !preservesPublishedSession {
+                    loadingReviewSession = false
+                }
                 activeReviewKey = nil
             }
         }
@@ -290,7 +302,9 @@ struct CommitTabView: View {
                 !Task.isCancelled,
                 requestedToken.isActive(activeKey: activeReviewKey, activeID: activeReviewID)
             else { throw CancellationError() }
-            reviewSessionError = (error as NSError).localizedDescription
+            if !preservesPublishedSession {
+                reviewSessionError = (error as NSError).localizedDescription
+            }
             throw error
         }
     }

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -223,7 +223,20 @@ struct CommitTabView: View {
             if activeDetailsKey == requestedKey { isRefreshingTrackedRevision = false }
         }
         do {
-            let resolved = try await resolvedRevisionForLoad()
+            let resolved: (
+                sha: String,
+                trackedRevision: TrackedRevision?,
+                reusesCurrentSnapshot: Bool
+            )
+            let refreshError: String?
+            do {
+                resolved = try await resolvedRevisionForLoad()
+                refreshError = nil
+            } catch {
+                guard case .following(let tracked) = tabState.revision else { throw error }
+                resolved = (tracked.resolvedSHA, nil, false)
+                refreshError = error.localizedDescription
+            }
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
             if resolved.reusesCurrentSnapshot {
                 if let tracked = resolved.trackedRevision {
@@ -242,6 +255,7 @@ struct CommitTabView: View {
             )
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
             self.details = d
+            detailsError = refreshError
             publishReviewSession(loaded, preservingSelectionByPathFrom: selectedReviewFileID)
             if let tracked = resolved.trackedRevision {
                 appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -77,7 +77,8 @@ struct CommitTabView: View {
                     onFollowRevision: { appState.promptFollowRevision(worktreeID: worktreeId, tabID: tabState.id) },
                     onEditRevision: editFollowedRevision,
                     onStopFollowingRevision: stopFollowingRevision,
-                    onAcceptPendingCheckout: acceptPendingCheckout
+                    onAcceptPendingCheckout: acceptPendingCheckout,
+                    onRetryRevision: retryRevisionRefresh
                 )
                 commitReviewContent(details: details)
             } else if loadingDetails {
@@ -377,6 +378,10 @@ struct CommitTabView: View {
     @MainActor
     private func acceptPendingCheckout() {
         appState.acceptTrackedRevisionCheckout(worktreeID: worktreeId, tabID: tabState.id)
+    }
+
+    private func retryRevisionRefresh() {
+        Task { await loadDetails() }
     }
 }
 

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -11,6 +11,7 @@ struct CommitTabView: View {
     @State private var loadingDetails = true
     @State private var detailsError: String?
     @State private var activeDetailsKey: String?
+    @State private var activeDetailsID = UUID()
 
     @State private var reviewSession: DiffReviewLoadedSession?
     @State private var loadingReviewSession = false
@@ -201,8 +202,9 @@ struct CommitTabView: View {
     }
 
     private func loadDetails() async {
-        let requestedKey = loadTaskID
-        activeDetailsKey = requestedKey
+        let requestedToken = CommitReviewLoadToken.next(key: loadTaskID)
+        activeDetailsKey = requestedToken.key
+        activeDetailsID = requestedToken.id
         let isTrackedRefresh = tabState.revision.tracked != nil && details != nil
         loadingDetails = details == nil
         isRefreshingTrackedRevision = isTrackedRefresh
@@ -219,8 +221,10 @@ struct CommitTabView: View {
         loadingReviewSession = false
         headerExpanded = true
         defer {
-            if activeDetailsKey == requestedKey { loadingDetails = false }
-            if activeDetailsKey == requestedKey { isRefreshingTrackedRevision = false }
+            if requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) {
+                loadingDetails = false
+                isRefreshingTrackedRevision = false
+            }
         }
         do {
             let resolved: (
@@ -237,7 +241,7 @@ struct CommitTabView: View {
                 resolved = (tracked.resolvedSHA, nil, false)
                 refreshError = error.localizedDescription
             }
-            guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
+            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return }
             if resolved.reusesCurrentSnapshot {
                 if let tracked = resolved.trackedRevision {
                     appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {
@@ -247,13 +251,13 @@ struct CommitTabView: View {
                 return
             }
             let d = try await git.commitDetails(at: worktreePath, sha: resolved.sha)
-            guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
+            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return }
             let loaded = try await loadReviewSession(
                 details: d,
                 sha: resolved.sha,
                 preservesPublishedSession: isTrackedRefresh
             )
-            guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
+            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return }
             self.details = d
             detailsError = refreshError
             publishReviewSession(loaded, preservingSelectionByPathFrom: selectedReviewFileID)
@@ -264,7 +268,7 @@ struct CommitTabView: View {
                 }
             }
         } catch {
-            guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
+            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return }
             self.detailsError = (error as NSError).localizedDescription
         }
     }

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -24,6 +24,7 @@ struct CommitTabView: View {
     @State private var reviewSessionLaunchError: String?
     @State private var wrapLines = false
     @State private var showWhitespace = false
+    @State private var isRefreshingTrackedRevision = false
 
     @Environment(\.theme) private var theme
     private let git = GitService()
@@ -66,7 +67,18 @@ struct CommitTabView: View {
     var body: some View {
         VStack(spacing: 0) {
             if let details {
-                CommitHeaderView(details: details, expanded: $headerExpanded)
+                CommitHeaderView(
+                    details: details,
+                    expanded: $headerExpanded,
+                    revisionExpression: tabState.revision.tracked?.expression,
+                    pendingCheckout: tabState.revision.tracked?.pendingCheckout,
+                    isRefreshingRevision: isRefreshingTrackedRevision,
+                    revisionError: detailsError,
+                    onFollowRevision: { appState.promptFollowRevision(worktreeID: worktreeId, tabID: tabState.id) },
+                    onEditRevision: editFollowedRevision,
+                    onStopFollowingRevision: stopFollowingRevision,
+                    onAcceptPendingCheckout: acceptPendingCheckout
+                )
                 commitReviewContent(details: details)
             } else if loadingDetails {
                 Spinner()
@@ -190,7 +202,9 @@ struct CommitTabView: View {
     private func loadDetails() async {
         let requestedKey = loadTaskID
         activeDetailsKey = requestedKey
+        let isTrackedRefresh = tabState.revision.tracked != nil && details != nil
         loadingDetails = details == nil
+        isRefreshingTrackedRevision = isTrackedRefresh
         detailsError = nil
         if details == nil {
             reviewSession = nil
@@ -205,6 +219,7 @@ struct CommitTabView: View {
         headerExpanded = true
         defer {
             if activeDetailsKey == requestedKey { loadingDetails = false }
+            if activeDetailsKey == requestedKey { isRefreshingTrackedRevision = false }
         }
         do {
             let resolved = try await resolvedRevisionForLoad()
@@ -329,6 +344,25 @@ struct CommitTabView: View {
             },
             onFailure: { reviewSessionLaunchError = $0.localizedDescription }
         )
+    }
+
+    @MainActor
+    private func editFollowedRevision() {
+        appState.promptFollowRevision(
+            worktreeID: worktreeId,
+            tabID: tabState.id,
+            prefill: tabState.revision.tracked?.expression
+        )
+    }
+
+    @MainActor
+    private func stopFollowingRevision() {
+        appState.stopFollowingRevision(worktreeID: worktreeId, tabID: tabState.id)
+    }
+
+    @MainActor
+    private func acceptPendingCheckout() {
+        appState.acceptTrackedRevisionCheckout(worktreeID: worktreeId, tabID: tabState.id)
     }
 }
 

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -205,7 +205,12 @@ struct CommitTabView: View {
         let requestedToken = CommitReviewLoadToken.next(key: loadTaskID)
         activeDetailsKey = requestedToken.key
         activeDetailsID = requestedToken.id
-        let isTrackedRefresh = tabState.revision.tracked != nil && details != nil
+        let preservesCurrentSnapshot = CommitReviewLoadIdentity.preservesPublishedSession(
+            details: details,
+            sha: tabState.sha,
+            hasReviewSession: reviewSession != nil
+        )
+        let isTrackedRefresh = (tabState.revision.tracked != nil || preservesCurrentSnapshot) && details != nil
         loadingDetails = details == nil
         isRefreshingTrackedRevision = isTrackedRefresh
         detailsError = nil
@@ -434,6 +439,10 @@ struct CommitReviewLoadToken: Equatable {
 enum CommitReviewLoadIdentity {
     static func isCurrent(details: CommitDetails, currentDetails: CommitDetails?, sha: String) -> Bool {
         details.info.sha == sha && currentDetails?.info.sha == details.info.sha
+    }
+
+    static func preservesPublishedSession(details: CommitDetails?, sha: String, hasReviewSession: Bool) -> Bool {
+        details?.info.sha == sha && hasReviewSession
     }
 }
 

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -225,6 +225,14 @@ struct CommitTabView: View {
         do {
             let resolved = try await resolvedRevisionForLoad()
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
+            if resolved.reusesCurrentSnapshot {
+                if let tracked = resolved.trackedRevision {
+                    appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {
+                        $0.revision = .following(tracked)
+                    }
+                }
+                return
+            }
             let d = try await git.commitDetails(at: worktreePath, sha: resolved.sha)
             guard !Task.isCancelled, activeDetailsKey == requestedKey else { return }
             let loaded = try await loadReviewSession(
@@ -247,19 +255,26 @@ struct CommitTabView: View {
         }
     }
 
-    private func resolvedRevisionForLoad() async throws -> (sha: String, trackedRevision: TrackedRevision?) {
+    private func resolvedRevisionForLoad() async throws -> (
+        sha: String,
+        trackedRevision: TrackedRevision?,
+        reusesCurrentSnapshot: Bool
+    ) {
         guard case .following(let tracked) = tabState.revision else {
-            return (tabState.sha, nil)
+            return (tabState.sha, nil, false)
         }
         let candidate = try await revisionResolver.resolve(at: worktreePath, expression: tracked.expression)
         switch TrackedRevisionPolicy.evaluate(current: tracked, candidate: candidate) {
-        case .unchanged(let revision), .follow(let revision):
-            return (revision.resolvedSHA, revision)
+        case .unchanged(let revision):
+            let canReuseSnapshot = details?.info.sha == revision.resolvedSHA && reviewSession != nil
+            return (revision.resolvedSHA, revision, canReuseSnapshot)
+        case .follow(let revision):
+            return (revision.resolvedSHA, revision, false)
         case .pause(let revision):
             appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {
                 $0.revision = .following(revision)
             }
-            return (tracked.resolvedSHA, nil)
+            return (tracked.resolvedSHA, nil, false)
         }
     }
 

--- a/Alas/Sources/Center/Commit/FollowRevisionPrefill.swift
+++ b/Alas/Sources/Center/Commit/FollowRevisionPrefill.swift
@@ -1,0 +1,6 @@
+enum FollowRevisionPrefill {
+    static func expression(displayedSHA: String, firstParentSHAs: [String]) -> String? {
+        guard let offset = firstParentSHAs.firstIndex(of: displayedSHA) else { return nil }
+        return offset == 0 ? "HEAD" : "HEAD~\(offset)"
+    }
+}

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -212,6 +212,7 @@ private extension TrackedRevision {
 
 struct TrackedRevisionRetargetingResult {
     let record: ReviewSessionRecord
+    let oldRecordID: ReviewSessionID
     let oldDraftSessionID: ReviewDraftSessionID
     let newDraftSessionID: ReviewDraftSessionID
 }
@@ -233,6 +234,7 @@ enum TrackedRevisionRetargeter {
                     resolvedSHAChanged: oldRevision.resolvedSHA != revision.resolvedSHA,
                     now: now
                 ),
+                oldRecordID: record.id,
                 oldDraftSessionID: oldDraftSessionID,
                 newDraftSessionID: target.draftSessionID
             )
@@ -249,6 +251,7 @@ enum TrackedRevisionRetargeter {
                 resolvedSHAChanged: oldSHA != revision.resolvedSHA,
                 now: now
             ),
+            oldRecordID: record.id,
             oldDraftSessionID: record.target.draftSessionID,
             newDraftSessionID: target.draftSessionID
         )
@@ -262,6 +265,7 @@ enum TrackedRevisionRetargeter {
         guard let target = record.target.freezingTrackedRevision(title: title) else { return nil }
         return TrackedRevisionRetargetingResult(
             record: record.retargetingCommit(to: target, resolvedSHAChanged: false, now: now),
+            oldRecordID: record.id,
             oldDraftSessionID: record.target.draftSessionID,
             newDraftSessionID: target.draftSessionID
         )

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -52,7 +52,24 @@ struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
     }
 
     var dependsOnWorktreeHEAD: Bool {
-        expression.hasPrefix("HEAD") || expression.hasPrefix("@")
+        Self.usesWorktreeHEADAlias(expression)
+    }
+
+    static func usesWorktreeHEADAlias(_ expression: String) -> Bool {
+        let expression = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        if expression == "HEAD" || expression == "@" { return true }
+        if expression.hasPrefix("HEAD") {
+            return isSupportedHEADSuffix(expression.dropFirst("HEAD".count))
+        }
+        if expression.hasPrefix("@") {
+            return isSupportedHEADSuffix(expression.dropFirst("@".count))
+        }
+        return false
+    }
+
+    fileprivate static func isSupportedHEADSuffix(_ suffix: Substring) -> Bool {
+        guard let first = suffix.first else { return false }
+        return first == "~" || first == "^" || first == "{" || suffix.hasPrefix("@{")
     }
 
     func resolving(_ candidate: TrackedRevisionCandidate) -> Self {
@@ -113,9 +130,15 @@ struct TrackedRevisionResolver {
             let startingBranch = try await branch(worktreePath)
             let startingHEAD = try await resolve(worktreePath, "HEAD")
             let pinnedExpression: String
-            if expression.hasPrefix("HEAD") {
+            if expression == "HEAD" {
+                pinnedExpression = startingHEAD
+            } else if expression.hasPrefix("HEAD"),
+                      TrackedRevision.isSupportedHEADSuffix(expression.dropFirst("HEAD".count)) {
                 pinnedExpression = startingHEAD + expression.dropFirst("HEAD".count)
-            } else if expression.hasPrefix("@") {
+            } else if expression == "@" {
+                pinnedExpression = startingHEAD
+            } else if expression.hasPrefix("@"),
+                      TrackedRevision.isSupportedHEADSuffix(expression.dropFirst("@".count)) {
                 pinnedExpression = startingHEAD + expression.dropFirst("@".count)
             } else {
                 pinnedExpression = expression

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -261,9 +261,6 @@ private extension TrackedRevision {
     static func isStableReflogSelector(_ selector: String) -> Bool {
         guard !selector.isEmpty else { return false }
         let lowercased = selector.lowercased()
-        if lowercased == "upstream" || lowercased == "u" {
-            return true
-        }
         if selector.allSatisfy(\.isNumber) { return true }
         if selector.first == "-", selector.dropFirst().allSatisfy(\.isNumber) {
             return true

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -3,27 +3,54 @@ import Foundation
 struct TrackedRevisionCandidate: Codable, Equatable, Hashable, Sendable {
     let branch: String
     let sha: String
+    let headSHA: String
+
+    private enum CodingKeys: String, CodingKey {
+        case branch
+        case sha
+        case headSHA
+    }
+
+    init(branch: String, sha: String, headSHA: String? = nil) {
+        self.branch = branch
+        self.sha = sha
+        self.headSHA = headSHA ?? sha
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let branch = try container.decode(String.self, forKey: .branch)
+        let sha = try container.decode(String.self, forKey: .sha)
+        self.init(
+            branch: branch,
+            sha: sha,
+            headSHA: try container.decodeIfPresent(String.self, forKey: .headSHA)
+        )
+    }
 }
 
 struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
     let expression: String
     var baselineBranch: String
+    var baselineHEAD: String
     var resolvedSHA: String
     var pendingCheckout: TrackedRevisionCandidate?
 
     private enum CodingKeys: String, CodingKey {
         case expression
         case baselineBranch
+        case baselineHEAD
         case resolvedSHA
         case pendingCheckout
     }
 
-    init?(expression: String, baselineBranch: String, resolvedSHA: String) {
+    init?(expression: String, baselineBranch: String, baselineHEAD: String? = nil, resolvedSHA: String) {
         let expression = expression.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !expression.isEmpty else { return nil }
 
         self.expression = expression
         self.baselineBranch = baselineBranch
+        self.baselineHEAD = baselineHEAD ?? resolvedSHA
         self.resolvedSHA = resolvedSHA
         self.pendingCheckout = nil
     }
@@ -32,10 +59,12 @@ struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let expression = try container.decode(String.self, forKey: .expression)
         let baselineBranch = try container.decode(String.self, forKey: .baselineBranch)
+        let baselineHEAD = try container.decodeIfPresent(String.self, forKey: .baselineHEAD)
         let resolvedSHA = try container.decode(String.self, forKey: .resolvedSHA)
         guard var revision = Self(
             expression: expression,
             baselineBranch: baselineBranch,
+            baselineHEAD: baselineHEAD,
             resolvedSHA: resolvedSHA
         ) else {
             throw DecodingError.dataCorruptedError(
@@ -75,6 +104,7 @@ struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
     func resolving(_ candidate: TrackedRevisionCandidate) -> Self {
         var revision = self
         revision.baselineBranch = candidate.branch
+        revision.baselineHEAD = candidate.headSHA
         revision.resolvedSHA = candidate.sha
         revision.pendingCheckout = nil
         return revision
@@ -107,11 +137,21 @@ enum TrackedRevisionPolicy {
             return .unchanged(current.resolving(candidate))
         }
 
-        guard current.dependsOnWorktreeHEAD, candidate.branch != current.baselineBranch else {
+        guard current.dependsOnWorktreeHEAD else {
             return .follow(current.resolving(candidate))
         }
 
-        return .pause(current.withPendingCheckout(candidate))
+        if candidate.branch != current.baselineBranch {
+            return .pause(current.withPendingCheckout(candidate))
+        }
+
+        if current.baselineBranch.isEmpty,
+           candidate.branch.isEmpty,
+           candidate.headSHA != current.baselineHEAD {
+            return .pause(current.withPendingCheckout(candidate))
+        }
+
+        return .follow(current.resolving(candidate))
     }
 }
 
@@ -147,7 +187,7 @@ struct TrackedRevisionResolver {
             let endingBranch = try await branch(worktreePath)
             let endingHEAD = try await resolve(worktreePath, "HEAD")
             if startingBranch == endingBranch, startingHEAD == endingHEAD {
-                return TrackedRevisionCandidate(branch: endingBranch, sha: resolvedSHA)
+                return TrackedRevisionCandidate(branch: endingBranch, sha: resolvedSHA, headSHA: endingHEAD)
             }
             try Task.checkCancellation()
         }

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -133,12 +133,12 @@ struct TrackedRevisionResolver {
             if expression == "HEAD" {
                 pinnedExpression = startingHEAD
             } else if expression.hasPrefix("HEAD"),
-                      TrackedRevision.isSupportedHEADSuffix(expression.dropFirst("HEAD".count)) {
+                      TrackedRevision.shouldPinHEADSuffix(expression.dropFirst("HEAD".count)) {
                 pinnedExpression = startingHEAD + expression.dropFirst("HEAD".count)
             } else if expression == "@" {
                 pinnedExpression = startingHEAD
             } else if expression.hasPrefix("@"),
-                      TrackedRevision.isSupportedHEADSuffix(expression.dropFirst("@".count)) {
+                      TrackedRevision.shouldPinHEADSuffix(expression.dropFirst("@".count)) {
                 pinnedExpression = startingHEAD + expression.dropFirst("@".count)
             } else {
                 pinnedExpression = expression
@@ -151,6 +151,13 @@ struct TrackedRevisionResolver {
             }
             try Task.checkCancellation()
         }
+    }
+}
+
+private extension TrackedRevision {
+    static func shouldPinHEADSuffix(_ suffix: Substring) -> Bool {
+        guard let first = suffix.first else { return false }
+        return first == "~" || first == "^"
     }
 }
 

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -168,13 +168,13 @@ enum TrackedRevisionRetargeter {
         now: Date
     ) -> TrackedRevisionRetargetingResult? {
         guard case .commit(let oldSHA) = record.target.payload else {
-            guard case .trackedCommit = record.target.payload else { return nil }
+            guard case .trackedCommit(let oldRevision) = record.target.payload else { return nil }
             let oldDraftSessionID = record.target.draftSessionID
             let target = record.target.updatingTrackedRevision(revision, title: title)
             return TrackedRevisionRetargetingResult(
                 record: record.retargetingCommit(
                     to: target,
-                    resolvedSHAChanged: record.target.revisionDescription != target.revisionDescription,
+                    resolvedSHAChanged: oldRevision.resolvedSHA != revision.resolvedSHA,
                     now: now
                 ),
                 oldDraftSessionID: oldDraftSessionID,

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -130,3 +130,61 @@ struct TrackedRevisionResolver {
         }
     }
 }
+
+struct TrackedRevisionRetargetingResult {
+    let record: ReviewSessionRecord
+    let oldDraftSessionID: ReviewDraftSessionID
+    let newDraftSessionID: ReviewDraftSessionID
+}
+
+enum TrackedRevisionRetargeter {
+    static func follow(
+        record: ReviewSessionRecord,
+        revision: TrackedRevision,
+        title: String,
+        now: Date
+    ) -> TrackedRevisionRetargetingResult? {
+        guard case .commit(let oldSHA) = record.target.payload else {
+            guard case .trackedCommit = record.target.payload else { return nil }
+            let oldDraftSessionID = record.target.draftSessionID
+            let target = record.target.updatingTrackedRevision(revision, title: title)
+            return TrackedRevisionRetargetingResult(
+                record: record.retargetingCommit(
+                    to: target,
+                    resolvedSHAChanged: record.target.revisionDescription != target.revisionDescription,
+                    now: now
+                ),
+                oldDraftSessionID: oldDraftSessionID,
+                newDraftSessionID: target.draftSessionID
+            )
+        }
+        let target = ReviewSessionTarget.trackedCommit(
+            worktreeID: record.target.worktreeID,
+            repositoryPath: record.target.repositoryPath,
+            revision: revision,
+            title: title
+        )
+        return TrackedRevisionRetargetingResult(
+            record: record.retargetingCommit(
+                to: target,
+                resolvedSHAChanged: oldSHA != revision.resolvedSHA,
+                now: now
+            ),
+            oldDraftSessionID: record.target.draftSessionID,
+            newDraftSessionID: target.draftSessionID
+        )
+    }
+
+    static func stop(
+        record: ReviewSessionRecord,
+        title: String,
+        now: Date
+    ) -> TrackedRevisionRetargetingResult? {
+        guard let target = record.target.freezingTrackedRevision(title: title) else { return nil }
+        return TrackedRevisionRetargetingResult(
+            record: record.retargetingCommit(to: target, resolvedSHAChanged: false, now: now),
+            oldDraftSessionID: record.target.draftSessionID,
+            newDraftSessionID: target.draftSessionID
+        )
+    }
+}

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -175,18 +175,30 @@ struct TrackedRevisionResolver {
 
     func resolve(at worktreePath: URL, expression: String) async throws -> TrackedRevisionCandidate {
         let expression = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let selector = TrackedRevision.timeRelativeReflogSelector(in: expression) {
+            throw TrackedRevisionResolverError.unsupportedTimeRelativeReflogExpression(selector)
+        }
+        let dependsOnWorktreeHEAD = TrackedRevision.usesWorktreeHEADAlias(expression)
         while true {
             let startingBranch = try await branch(worktreePath)
-            let startingHEAD = try await resolve(worktreePath, "HEAD")
+            let startingHEAD: String?
+            do {
+                startingHEAD = try await resolve(worktreePath, "HEAD")
+            } catch {
+                guard !dependsOnWorktreeHEAD else { throw error }
+                startingHEAD = nil
+            }
             let pinnedExpression: String
-            if expression == "HEAD" {
+            if expression == "HEAD", let startingHEAD {
                 pinnedExpression = startingHEAD
             } else if expression.hasPrefix("HEAD"),
+                      let startingHEAD,
                       TrackedRevision.shouldPinHEADSuffix(expression.dropFirst("HEAD".count)) {
                 pinnedExpression = startingHEAD + expression.dropFirst("HEAD".count)
-            } else if expression == "@" {
+            } else if expression == "@", let startingHEAD {
                 pinnedExpression = startingHEAD
             } else if expression.hasPrefix("@"),
+                      let startingHEAD,
                       TrackedRevision.shouldPinHEADSuffix(expression.dropFirst("@".count)) {
                 pinnedExpression = startingHEAD + expression.dropFirst("@".count)
             } else {
@@ -194,11 +206,28 @@ struct TrackedRevisionResolver {
             }
             let resolvedSHA = try await resolve(worktreePath, String(pinnedExpression))
             let endingBranch = try await branch(worktreePath)
-            let endingHEAD = try await resolve(worktreePath, "HEAD")
+            let endingHEAD: String?
+            do {
+                endingHEAD = try await resolve(worktreePath, "HEAD")
+            } catch {
+                guard !dependsOnWorktreeHEAD else { throw error }
+                endingHEAD = nil
+            }
             if startingBranch == endingBranch, startingHEAD == endingHEAD {
-                return TrackedRevisionCandidate(branch: endingBranch, sha: resolvedSHA, headSHA: endingHEAD)
+                return TrackedRevisionCandidate(branch: endingBranch, sha: resolvedSHA, headSHA: endingHEAD ?? "")
             }
             try Task.checkCancellation()
+        }
+    }
+}
+
+enum TrackedRevisionResolverError: LocalizedError, Equatable {
+    case unsupportedTimeRelativeReflogExpression(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedTimeRelativeReflogExpression(let selector):
+            "Time-relative reflog expressions like @{\(selector)} are not supported for followed revisions."
         }
     }
 }
@@ -207,6 +236,35 @@ private extension TrackedRevision {
     static func shouldPinHEADSuffix(_ suffix: Substring) -> Bool {
         guard let first = suffix.first else { return false }
         return first == "~" || first == "^"
+    }
+
+    static func timeRelativeReflogSelector(in expression: String) -> String? {
+        var searchStart = expression.startIndex
+        while let openRange = expression.range(of: "@{", range: searchStart..<expression.endIndex) {
+            guard let closeIndex = expression[openRange.upperBound...].firstIndex(of: "}") else {
+                return nil
+            }
+            let selector = String(expression[openRange.upperBound..<closeIndex])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !isStableReflogSelector(selector) {
+                return selector
+            }
+            searchStart = expression.index(after: closeIndex)
+        }
+        return nil
+    }
+
+    static func isStableReflogSelector(_ selector: String) -> Bool {
+        guard !selector.isEmpty else { return false }
+        let lowercased = selector.lowercased()
+        if lowercased == "upstream" || lowercased == "u" || lowercased == "push" {
+            return true
+        }
+        if selector.allSatisfy(\.isNumber) { return true }
+        if selector.first == "-", selector.dropFirst().allSatisfy(\.isNumber) {
+            return true
+        }
+        return false
     }
 }
 

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -175,8 +175,8 @@ struct TrackedRevisionResolver {
 
     func resolve(at worktreePath: URL, expression: String) async throws -> TrackedRevisionCandidate {
         let expression = expression.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let selector = TrackedRevision.timeRelativeReflogSelector(in: expression) {
-            throw TrackedRevisionResolverError.unsupportedTimeRelativeReflogExpression(selector)
+        if let selector = TrackedRevision.unsupportedReflogSelector(in: expression) {
+            throw TrackedRevisionResolverError.unsupportedReflogExpression(selector)
         }
         let dependsOnWorktreeHEAD = TrackedRevision.usesWorktreeHEADAlias(expression)
         while true {
@@ -222,12 +222,16 @@ struct TrackedRevisionResolver {
 }
 
 enum TrackedRevisionResolverError: LocalizedError, Equatable {
-    case unsupportedTimeRelativeReflogExpression(String)
+    case unsupportedReflogExpression(String)
 
     var errorDescription: String? {
         switch self {
-        case .unsupportedTimeRelativeReflogExpression(let selector):
-            "Time-relative reflog expressions like @{\(selector)} are not supported for followed revisions."
+        case .unsupportedReflogExpression(let selector):
+            if selector.lowercased() == "push" {
+                "Followed revisions do not support @{push}; use an explicit remote-tracking ref instead."
+            } else {
+                "Time-relative reflog expressions like @{\(selector)} are not supported for followed revisions."
+            }
         }
     }
 }
@@ -238,7 +242,7 @@ private extension TrackedRevision {
         return first == "~" || first == "^"
     }
 
-    static func timeRelativeReflogSelector(in expression: String) -> String? {
+    static func unsupportedReflogSelector(in expression: String) -> String? {
         var searchStart = expression.startIndex
         while let openRange = expression.range(of: "@{", range: searchStart..<expression.endIndex) {
             guard let closeIndex = expression[openRange.upperBound...].firstIndex(of: "}") else {
@@ -257,7 +261,7 @@ private extension TrackedRevision {
     static func isStableReflogSelector(_ selector: String) -> Bool {
         guard !selector.isEmpty else { return false }
         let lowercased = selector.lowercased()
-        if lowercased == "upstream" || lowercased == "u" || lowercased == "push" {
+        if lowercased == "upstream" || lowercased == "u" {
             return true
         }
         if selector.allSatisfy(\.isNumber) { return true }

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+struct TrackedRevisionCandidate: Codable, Equatable, Hashable, Sendable {
+    let branch: String
+    let sha: String
+}
+
+struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
+    let expression: String
+    var baselineBranch: String
+    var resolvedSHA: String
+    var pendingCheckout: TrackedRevisionCandidate?
+
+    private enum CodingKeys: String, CodingKey {
+        case expression
+        case baselineBranch
+        case resolvedSHA
+        case pendingCheckout
+    }
+
+    init?(expression: String, baselineBranch: String, resolvedSHA: String) {
+        let expression = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !expression.isEmpty else { return nil }
+
+        self.expression = expression
+        self.baselineBranch = baselineBranch
+        self.resolvedSHA = resolvedSHA
+        self.pendingCheckout = nil
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let expression = try container.decode(String.self, forKey: .expression)
+        let baselineBranch = try container.decode(String.self, forKey: .baselineBranch)
+        let resolvedSHA = try container.decode(String.self, forKey: .resolvedSHA)
+        guard var revision = Self(
+            expression: expression,
+            baselineBranch: baselineBranch,
+            resolvedSHA: resolvedSHA
+        ) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .expression,
+                in: container,
+                debugDescription: "Tracked revision expression must not be empty."
+            )
+        }
+        revision.pendingCheckout = try container.decodeIfPresent(
+            TrackedRevisionCandidate.self,
+            forKey: .pendingCheckout
+        )
+        self = revision
+    }
+
+    var dependsOnWorktreeHEAD: Bool {
+        expression.hasPrefix("HEAD") || expression.hasPrefix("@")
+    }
+
+    func resolving(_ candidate: TrackedRevisionCandidate) -> Self {
+        var revision = self
+        revision.baselineBranch = candidate.branch
+        revision.resolvedSHA = candidate.sha
+        revision.pendingCheckout = nil
+        return revision
+    }
+
+    func withPendingCheckout(_ candidate: TrackedRevisionCandidate) -> Self {
+        var revision = self
+        revision.pendingCheckout = candidate
+        return revision
+    }
+
+    func acceptingPendingCheckout() -> Self? {
+        guard let pendingCheckout else { return nil }
+        return resolving(pendingCheckout)
+    }
+}
+
+enum TrackedRevisionTransition: Equatable {
+    case unchanged(TrackedRevision)
+    case follow(TrackedRevision)
+    case pause(TrackedRevision)
+}
+
+enum TrackedRevisionPolicy {
+    static func evaluate(
+        current: TrackedRevision,
+        candidate: TrackedRevisionCandidate
+    ) -> TrackedRevisionTransition {
+        guard candidate.sha != current.resolvedSHA else {
+            return .unchanged(current.resolving(candidate))
+        }
+
+        guard current.dependsOnWorktreeHEAD, candidate.branch != current.baselineBranch else {
+            return .follow(current.resolving(candidate))
+        }
+
+        return .pause(current.withPendingCheckout(candidate))
+    }
+}
+
+struct TrackedRevisionResolver {
+    var resolve: (URL, String) async throws -> String
+    var branch: (URL) async throws -> String
+
+    static let live = TrackedRevisionResolver(
+        resolve: { try await GitService().resolveRevision(at: $0, ref: $1) },
+        branch: { try await GitService().currentBranch(worktreePath: $0) }
+    )
+
+    func resolve(at worktreePath: URL, expression: String) async throws -> TrackedRevisionCandidate {
+        let expression = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        while true {
+            let startingBranch = try await branch(worktreePath)
+            let startingHEAD = try await resolve(worktreePath, "HEAD")
+            let pinnedExpression: String
+            if expression.hasPrefix("HEAD") {
+                pinnedExpression = startingHEAD + expression.dropFirst("HEAD".count)
+            } else if expression.hasPrefix("@") {
+                pinnedExpression = startingHEAD + expression.dropFirst("@".count)
+            } else {
+                pinnedExpression = expression
+            }
+            let resolvedSHA = try await resolve(worktreePath, String(pinnedExpression))
+            let endingBranch = try await branch(worktreePath)
+            let endingHEAD = try await resolve(worktreePath, "HEAD")
+            if startingBranch == endingBranch, startingHEAD == endingHEAD {
+                return TrackedRevisionCandidate(branch: endingBranch, sha: resolvedSHA)
+            }
+            try Task.checkCancellation()
+        }
+    }
+}

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -120,6 +120,15 @@ struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
         guard let pendingCheckout else { return nil }
         return resolving(pendingCheckout)
     }
+
+    func preparingPendingCheckoutAcceptance() -> Self? {
+        guard let pendingCheckout else { return nil }
+        var revision = self
+        revision.baselineBranch = pendingCheckout.branch
+        revision.baselineHEAD = pendingCheckout.headSHA
+        revision.pendingCheckout = nil
+        return revision
+    }
 }
 
 enum TrackedRevisionTransition: Equatable {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
@@ -63,6 +63,28 @@ struct ReviewDraftCommentStore {
         try store.write(snapshot, to: url)
     }
 
+    func migrate(from sourceID: ReviewDraftSessionID, to targetID: ReviewDraftSessionID) throws {
+        guard sourceID != targetID else { return }
+        var snapshot = try readSnapshot()
+        let moved = snapshot.commentsBySessionID.removeValue(forKey: sourceID.rawValue) ?? []
+        guard !moved.isEmpty else {
+            try store.write(snapshot, to: url)
+            return
+        }
+
+        var mergedByID: [String: ReviewDraftComment] = [:]
+        for comment in snapshot.commentsBySessionID[targetID.rawValue] ?? [] {
+            mergedByID[comment.id] = comment
+        }
+        for comment in moved {
+            var rekeyed = comment
+            rekeyed.sessionID = targetID
+            mergedByID[rekeyed.id] = rekeyed
+        }
+        snapshot.commentsBySessionID[targetID.rawValue] = Array(mergedByID.values)
+        try store.write(snapshot, to: url)
+    }
+
     private func readSnapshot() throws -> Snapshot {
         try store.readIfExists(Snapshot.self, from: url) ?? Snapshot(commentsBySessionID: [:])
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
@@ -19,6 +19,15 @@ struct ReviewDraftCommentStore {
         return snapshot.commentsBySessionID.values.flatMap { $0 }.sorted(by: sortComments)
     }
 
+    func snapshot() throws -> ReviewDraftCommentStoreSnapshot {
+        let snapshot = try readSnapshot()
+        return ReviewDraftCommentStoreSnapshot(commentsBySessionID: snapshot.commentsBySessionID)
+    }
+
+    func restore(_ saved: ReviewDraftCommentStoreSnapshot) throws {
+        try store.write(Snapshot(commentsBySessionID: saved.commentsBySessionID), to: url)
+    }
+
     func find(commentID: String) throws -> ReviewDraftComment? {
         let snapshot = try readSnapshot()
         for comments in snapshot.commentsBySessionID.values {
@@ -108,4 +117,8 @@ struct ReviewDraftCommentStore {
     private struct Snapshot: Codable, Equatable {
         var commentsBySessionID: [String: [ReviewDraftComment]]
     }
+}
+
+struct ReviewDraftCommentStoreSnapshot: Equatable {
+    fileprivate var commentsBySessionID: [String: [ReviewDraftComment]]
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ReviewDraftSourceKind: String, Codable, Equatable, Hashable, Sendable {
     case localChanges = "local-changes"
     case commit
+    case trackedCommit = "tracked-commit"
     case commitRange = "commit-range"
     case draftCommit = "draft-commit"
     case branch
@@ -40,6 +41,10 @@ struct ReviewDraftSessionID: Codable, Equatable, Hashable, Sendable, RawRepresen
 
     static func commit(worktreeID: String, repositoryPath: URL, sha: String) -> Self {
         make(.commit, [worktreeID, repositoryPath.standardizedFileURL.path, sha])
+    }
+
+    static func trackedCommit(worktreeID: String, repositoryPath: URL, expression: String) -> Self {
+        make(.trackedCommit, [worktreeID, repositoryPath.standardizedFileURL.path, expression])
     }
 
     static func commitRange(worktreeID: String, repositoryPath: URL, base: String, head: String) -> Self {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -14,6 +14,22 @@ struct ReviewSessionLoadedContext {
     let session: DiffReviewLoadedSession
     let feedbackTarget: ReviewFeedbackTarget
     let providerContext: ReviewSessionProviderContext?
+
+    func replacingFeedbackTarget(for target: ReviewSessionTarget) -> ReviewSessionLoadedContext {
+        ReviewSessionLoadedContext(
+            session: session,
+            feedbackTarget: ReviewFeedbackTarget(
+                title: target.title,
+                repositoryPath: target.repositoryPath.path,
+                providerDescription: target.providerDescription,
+                sourceDescription: target.sourceDescription,
+                sessionDescription: "Review session: \(target.title)",
+                revisionDescription: target.revisionDescription,
+                priorHandoffDescription: nil
+            ),
+            providerContext: providerContext
+        )
+    }
 }
 
 enum ReviewSessionLauncher {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift
@@ -101,7 +101,13 @@ struct ReviewSessionLoader {
                 return filterLocalChanges(session, scope: .staged)
             },
             commit: { target in
-                guard case .commit(let sha) = target.payload else {
+                let sha: String
+                switch target.payload {
+                case .commit(let commitSHA):
+                    sha = commitSHA
+                case .trackedCommit(let revision):
+                    sha = revision.resolvedSHA
+                default:
                     throw ReviewSessionLoaderError.unsupportedTarget
                 }
                 let details = try await git.commitDetails(at: target.repositoryPath, sha: sha)
@@ -245,6 +251,9 @@ struct ReviewSessionLoader {
             session = try await draftCommit(target)
             providerContext = nil
         case .commit:
+            session = try await commit(target)
+            providerContext = nil
+        case .trackedCommit:
             session = try await commit(target)
             providerContext = nil
         case .commitRange:

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -386,7 +386,7 @@ struct ReviewFeedbackHandoff: Codable, Equatable, Identifiable, Sendable {
 }
 
 struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
-    let id: ReviewSessionID
+    var id: ReviewSessionID
     var target: ReviewSessionTarget
     var selectedFileID: DiffReviewFileID?
     var focusedCommentID: String?
@@ -474,6 +474,9 @@ struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
         now: Date
     ) -> ReviewSessionRecord {
         var record = self
+        if target.id != self.target.id {
+            record.id = Self.retargetedID(sourceID: id, targetID: target.id)
+        }
         record.target = target
         if resolvedSHAChanged {
             record.status = .active
@@ -481,5 +484,9 @@ struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
         }
         record.updatedAt = now
         return record
+    }
+
+    private static func retargetedID(sourceID: ReviewSessionID, targetID: ReviewSessionID) -> ReviewSessionID {
+        ReviewSessionID(rawValue: "\(targetID.rawValue)\u{1f}retargeted\u{1f}\(sourceID.rawValue)")
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -9,6 +9,7 @@ enum ReviewSessionTargetKind: String, Codable, Equatable, Hashable, Sendable {
     case localChanges = "local-changes"
     case draftCommit = "draft-commit"
     case commit
+    case trackedCommit = "tracked-commit"
     case commitRange = "commit-range"
     case branch
     case reviewRequest = "review-request"
@@ -85,6 +86,56 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
             revisionDescription: sha,
             draftSessionID: .commit(worktreeID: worktreeID, repositoryPath: repositoryPath, sha: sha),
             payload: .commit(sha: sha)
+        )
+    }
+
+    static func trackedCommit(
+        worktreeID: String,
+        repositoryPath: URL,
+        revision: TrackedRevision,
+        title: String
+    ) -> Self {
+        let path = standardizedPath(repositoryPath)
+        let revisionDescription = "\(revision.expression) -> \(revision.resolvedSHA)"
+        return ReviewSessionTarget(
+            id: makeID(.trackedCommit, [worktreeID, path, revision.expression]),
+            kind: .trackedCommit,
+            worktreeID: worktreeID,
+            repositoryPath: standardizedURL(repositoryPath),
+            title: title,
+            sourceDescription: "Commit \(revisionDescription)",
+            providerDescription: nil,
+            providerURL: nil,
+            revisionDescription: revisionDescription,
+            draftSessionID: .trackedCommit(
+                worktreeID: worktreeID,
+                repositoryPath: repositoryPath,
+                expression: revision.expression
+            ),
+            payload: .trackedCommit(revision)
+        )
+    }
+
+    func updatingTrackedRevision(
+        _ revision: TrackedRevision,
+        title: String
+    ) -> ReviewSessionTarget {
+        guard case .trackedCommit = payload else { return self }
+        return .trackedCommit(
+            worktreeID: worktreeID,
+            repositoryPath: repositoryPath,
+            revision: revision,
+            title: title
+        )
+    }
+
+    func freezingTrackedRevision(title: String) -> ReviewSessionTarget? {
+        guard case .trackedCommit(let revision) = payload else { return nil }
+        return .commit(
+            worktreeID: worktreeID,
+            repositoryPath: repositoryPath,
+            sha: revision.resolvedSHA,
+            title: title
         )
     }
 
@@ -239,6 +290,7 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
         case localChanges(scope: ReviewDraftLocalChangesScope)
         case draftCommit
         case commit(sha: String)
+        case trackedCommit(TrackedRevision)
         case commitRange(base: String, head: String)
         case branch(base: String, head: String)
         case reviewRequest(provider: CodeHostKind, host: String, repositorySlug: String, number: Int, headSHA: String?)
@@ -254,6 +306,9 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
             case .commit(let sha):
                 hasher.combine(2)
                 hasher.combine(sha)
+            case .trackedCommit(let revision):
+                hasher.combine(7)
+                hasher.combine(revision)
             case .commitRange(let base, let head):
                 hasher.combine(3)
                 hasher.combine(base)
@@ -409,6 +464,21 @@ struct ReviewSessionRecord: Codable, Equatable, Identifiable, Sendable {
     func focusingComment(_ commentID: String?, now: Date) -> ReviewSessionRecord {
         var record = self
         record.focusedCommentID = commentID
+        record.updatedAt = now
+        return record
+    }
+
+    func retargetingCommit(
+        to target: ReviewSessionTarget,
+        resolvedSHAChanged: Bool,
+        now: Date
+    ) -> ReviewSessionRecord {
+        var record = self
+        record.target = target
+        if resolvedSHAChanged {
+            record.status = .active
+            record.verdict = nil
+        }
         record.updatedAt = now
         return record
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
@@ -40,6 +40,21 @@ struct ReviewSessionStore {
         try store.write(snapshot, to: url)
     }
 
+    func replace(id oldID: ReviewSessionID, with record: ReviewSessionRecord) throws {
+        var snapshot = try readSnapshot()
+        if oldID != record.id {
+            snapshot.recordsByID[oldID.rawValue] = nil
+        }
+        snapshot.recordsByID[record.id.rawValue] = record
+        try store.write(snapshot, to: url)
+    }
+
+    func delete(id: ReviewSessionID) throws {
+        var snapshot = try readSnapshot()
+        snapshot.recordsByID[id.rawValue] = nil
+        try store.write(snapshot, to: url)
+    }
+
     private func readSnapshot() throws -> Snapshot {
         try store.readIfExists(Snapshot.self, from: url) ?? Snapshot(recordsByID: [:])
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
@@ -14,8 +14,16 @@ struct ReviewSessionStore {
         if let record = snapshot.recordsByID[id.rawValue] {
             return record
         }
-        guard let replacementID = snapshot.replacementIDsByOldID[id.rawValue] else { return nil }
-        return snapshot.recordsByID[replacementID]
+        var currentID = id.rawValue
+        var seen: Set<String> = []
+        while let replacementID = snapshot.replacementIDsByOldID[currentID],
+              seen.insert(currentID).inserted {
+            if let record = snapshot.recordsByID[replacementID] {
+                return record
+            }
+            currentID = replacementID
+        }
+        return nil
     }
 
     func list(worktreeID: String) throws -> [ReviewSessionRecord] {
@@ -49,6 +57,9 @@ struct ReviewSessionStore {
         if oldID != record.id {
             snapshot.recordsByID[oldID.rawValue] = nil
             snapshot.replacementIDsByOldID[oldID.rawValue] = record.id.rawValue
+            for (alias, replacementID) in snapshot.replacementIDsByOldID where replacementID == oldID.rawValue {
+                snapshot.replacementIDsByOldID[alias] = record.id.rawValue
+            }
         }
         snapshot.recordsByID[record.id.rawValue] = record
         try store.write(snapshot, to: url)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
@@ -11,7 +11,11 @@ struct ReviewSessionStore {
 
     func load(id: ReviewSessionID) throws -> ReviewSessionRecord? {
         let snapshot = try readSnapshot()
-        return snapshot.recordsByID[id.rawValue]
+        if let record = snapshot.recordsByID[id.rawValue] {
+            return record
+        }
+        guard let replacementID = snapshot.replacementIDsByOldID[id.rawValue] else { return nil }
+        return snapshot.recordsByID[replacementID]
     }
 
     func list(worktreeID: String) throws -> [ReviewSessionRecord] {
@@ -44,6 +48,7 @@ struct ReviewSessionStore {
         var snapshot = try readSnapshot()
         if oldID != record.id {
             snapshot.recordsByID[oldID.rawValue] = nil
+            snapshot.replacementIDsByOldID[oldID.rawValue] = record.id.rawValue
         }
         snapshot.recordsByID[record.id.rawValue] = record
         try store.write(snapshot, to: url)
@@ -52,11 +57,12 @@ struct ReviewSessionStore {
     func delete(id: ReviewSessionID) throws {
         var snapshot = try readSnapshot()
         snapshot.recordsByID[id.rawValue] = nil
+        snapshot.replacementIDsByOldID[id.rawValue] = nil
         try store.write(snapshot, to: url)
     }
 
     private func readSnapshot() throws -> Snapshot {
-        try store.readIfExists(Snapshot.self, from: url) ?? Snapshot(recordsByID: [:])
+        try store.readIfExists(Snapshot.self, from: url) ?? Snapshot(recordsByID: [:], replacementIDsByOldID: [:])
     }
 
     private func sortSessions(_ lhs: ReviewSessionRecord, _ rhs: ReviewSessionRecord) -> Bool {
@@ -68,5 +74,20 @@ struct ReviewSessionStore {
 
     private struct Snapshot: Codable, Equatable {
         var recordsByID: [String: ReviewSessionRecord]
+        var replacementIDsByOldID: [String: String] = [:]
+
+        init(recordsByID: [String: ReviewSessionRecord], replacementIDsByOldID: [String: String] = [:]) {
+            self.recordsByID = recordsByID
+            self.replacementIDsByOldID = replacementIDsByOldID
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            recordsByID = try container.decode([String: ReviewSessionRecord].self, forKey: .recordsByID)
+            replacementIDsByOldID = try container.decodeIfPresent(
+                [String: String].self,
+                forKey: .replacementIDsByOldID
+            ) ?? [:]
+        }
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
@@ -21,10 +21,15 @@ struct ReviewSessionStore {
             .sorted(by: sortSessions)
     }
 
-    func findActive(targetID: ReviewSessionID) throws -> ReviewSessionRecord? {
+    func findActive(targetID: ReviewSessionID, excluding excludedID: ReviewSessionID? = nil) throws -> ReviewSessionRecord? {
         let snapshot = try readSnapshot()
         return snapshot.recordsByID.values
-            .filter { $0.target.id == targetID && $0.status != .archived && $0.status != .reviewed }
+            .filter {
+                $0.target.id == targetID &&
+                    $0.id != excludedID &&
+                    $0.status != .archived &&
+                    $0.status != .reviewed
+            }
             .sorted(by: sortSessions)
             .first
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionStore.swift
@@ -26,6 +26,20 @@ struct ReviewSessionStore {
         return nil
     }
 
+    func loadReplacement(for id: ReviewSessionID) throws -> ReviewSessionRecord? {
+        let snapshot = try readSnapshot()
+        var currentID = id.rawValue
+        var seen: Set<String> = []
+        while let replacementID = snapshot.replacementIDsByOldID[currentID],
+              seen.insert(currentID).inserted {
+            if let record = snapshot.recordsByID[replacementID] {
+                return record
+            }
+            currentID = replacementID
+        }
+        return nil
+    }
+
     func list(worktreeID: String) throws -> [ReviewSessionRecord] {
         let snapshot = try readSnapshot()
         return snapshot.recordsByID.values

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -203,6 +203,9 @@ struct ReviewSessionTabView: View {
                 record = refreshed
             }
         }
+        .onChange(of: tabState.sessionID) { _, _ in
+            rekeyDraftControllerForCurrentSession()
+        }
     }
 
     private var loadTaskID: String {
@@ -744,6 +747,14 @@ struct ReviewSessionTabView: View {
         } catch {
             // Draft comment load failures stay non-blocking; the controller keeps the error.
         }
+    }
+
+    private func rekeyDraftControllerForCurrentSession() {
+        guard persistsState,
+              let refreshed = try? sessionStore.load(id: tabState.sessionID)
+        else { return }
+        record = refreshed
+        loadDraftCommentController(for: refreshed)
     }
 
     private func draftCommentActions(for loaded: ReviewSessionLoadedContext) -> ReviewDraftCommentActions {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -619,6 +619,7 @@ struct ReviewSessionTabView: View {
                     try sessionStore.save(refreshedRecord)
                 }
                 record = refreshedRecord
+                self.loaded = loaded.replacingFeedbackTarget(for: refreshedRecord.target)
                 loadError = refreshError
                 loadDraftCommentController(for: refreshedRecord)
                 isLoading = false

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -216,29 +216,34 @@ struct ReviewSessionTabView: View {
     }
 
     private var header: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "text.badge.checkmark")
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(theme.color("accent"))
-            VStack(alignment: .leading, spacing: 2) {
-                Text(record?.target.title ?? tabState.title)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(theme.color("fg"))
-                    .lineLimit(1)
-                    .accessibilityLabel(record?.target.title ?? tabState.title)
-                if let sourceDescription = record?.target.sourceDescription {
-                    Text(sourceDescription)
-                        .font(.system(size: 11))
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                Image(systemName: "text.badge.checkmark")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(theme.color("accent"))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(record?.target.title ?? tabState.title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(1)
+                        .accessibilityLabel(record?.target.title ?? tabState.title)
+                    if let sourceDescription = record?.target.sourceDescription {
+                        Text(sourceDescription)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("fg-muted"))
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 12)
+                if let providerDescription = record?.target.providerDescription {
+                    Text(providerDescription)
+                        .font(.system(size: 11, weight: .medium))
                         .foregroundColor(theme.color("fg-muted"))
                         .lineLimit(1)
                 }
             }
-            Spacer(minLength: 12)
-            if let providerDescription = record?.target.providerDescription {
-                Text(providerDescription)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(theme.color("fg-muted"))
-                    .lineLimit(1)
+            if showsTrackedRevisionRow {
+                trackedRevisionRow
             }
         }
         .padding(.horizontal, 14)
@@ -250,6 +255,94 @@ struct ReviewSessionTabView: View {
                 label: record?.target.title ?? tabState.title
             )
         )
+    }
+
+    private var trackedRevision: TrackedRevision? {
+        guard case .trackedCommit(let revision) = record?.target.payload else { return nil }
+        return revision
+    }
+
+    private var showsTrackedRevisionRow: Bool {
+        trackedRevision != nil || record?.target.kind == .commit
+    }
+
+    private var trackedRevisionRow: some View {
+        HStack(spacing: 8) {
+            if let revision = trackedRevision {
+                Text("\(revision.expression) -> \(String(revision.resolvedSHA.prefix(10)))")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .accessibilityIdentifier("review-session-revision-following-label")
+
+                if let pending = revision.pendingCheckout {
+                    Text("Paused on checkout to \(pending.branch)")
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("warn"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .accessibilityIdentifier("review-session-revision-pending-checkout")
+                    Button("Update") {
+                        acceptPendingCheckout()
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("review-session-revision-accept-checkout")
+                }
+            } else {
+                Text("Fixed commit review")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-muted"))
+            }
+
+            Spacer(minLength: 8)
+
+            if trackedRevision == nil {
+                Button("Follow Revision…") {
+                    promptFollowRevision(prefill: nil)
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .accessibilityIdentifier("review-session-revision-follow")
+            } else {
+                Button("Edit…") {
+                    promptFollowRevision(prefill: trackedRevision?.expression)
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .accessibilityIdentifier("review-session-revision-edit")
+
+                Button("Stop") {
+                    stopFollowingRevision()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .accessibilityIdentifier("review-session-revision-stop")
+            }
+        }
+    }
+
+    @MainActor
+    private func promptFollowRevision(prefill: String?) {
+        guard let worktree, let appState else { return }
+        appState.promptFollowRevision(
+            worktreeID: worktree.id,
+            tabID: tabState.id,
+            prefill: prefill
+        )
+    }
+
+    @MainActor
+    private func stopFollowingRevision() {
+        guard let worktree, let appState else { return }
+        appState.stopFollowingRevision(worktreeID: worktree.id, tabID: tabState.id)
+    }
+
+    @MainActor
+    private func acceptPendingCheckout() {
+        guard let worktree, let appState else { return }
+        appState.acceptTrackedRevisionCheckout(worktreeID: worktree.id, tabID: tabState.id)
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -1156,7 +1156,9 @@ struct ReviewSessionTabView: View {
 
     private func recordSessionSendFailure(_ error: Error) {
         guard let visibleRecord = record else { return }
-        var current = (try? sessionStore.load(id: visibleRecord.id)) ?? visibleRecord
+        var current = (try? sessionStore.loadReplacement(for: visibleRecord.id))
+            ?? (try? sessionStore.load(id: visibleRecord.id))
+            ?? visibleRecord
         current.lastSendError = "Failed to send to agent: \(error.localizedDescription)"
         current.updatedAt = now()
         record = current
@@ -1281,7 +1283,9 @@ enum ReviewSessionHandoffPersistence {
         }
 
         do {
-            let current = try sessionStore.load(id: handoff.sessionID) ?? currentRecord
+            let current = try sessionStore.loadReplacement(for: handoff.sessionID)
+                ?? sessionStore.load(id: handoff.sessionID)
+                ?? currentRecord
             guard let current else { return nil }
             let updated = current.recording(handoff: handoff)
             try sessionStore.save(updated)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -206,7 +206,13 @@ struct ReviewSessionTabView: View {
     }
 
     private var loadTaskID: String {
-        "\(tabState.sessionID.rawValue):\(loadGeneration)"
+        let revisionGeneration: Int
+        if let appState, case .trackedCommit = record?.target.payload {
+            revisionGeneration = appState.revisionChangeGeneration(worktreeID: tabState.worktreeId)
+        } else {
+            revisionGeneration = 0
+        }
+        return "\(tabState.sessionID.rawValue):\(loadGeneration):\(revisionGeneration)"
     }
 
     private var header: some View {
@@ -441,9 +447,8 @@ struct ReviewSessionTabView: View {
 
     private func beginLoadReviewSession() -> ReviewSessionTabLoadToken {
         let token = loadCoordinator.begin()
-        isLoading = true
+        isLoading = loaded == nil
         loadError = nil
-        loaded = nil
         return token
     }
 
@@ -453,16 +458,28 @@ struct ReviewSessionTabView: View {
                 throw ReviewSessionTabError.missingSession(tabState.sessionID)
             }
 
-            let loadedContext = try await loader.load(target: storedRecord.target)
+            let resolvedRecord = try await resolveTrackedRecordForLoad(storedRecord)
+            guard loadCoordinator.canPublish(token) else { return }
+            if resolvedRecord.record.target != storedRecord.target {
+                try sessionStore.save(resolvedRecord.record)
+            }
+            guard !resolvedRecord.paused else {
+                record = resolvedRecord.record
+                isLoading = false
+                loadCoordinator.finish(token)
+                return
+            }
+
+            let loadedContext = try await loader.load(target: resolvedRecord.record.target)
             guard loadCoordinator.canPublish(token) else { return }
 
             publishInitialLoad(
                 ReviewSessionTabLoadPublication.initial(
-                    record: storedRecord,
+                    record: resolvedRecord.record,
                     loaded: loadedContext
                 )
             )
-            loadDraftCommentController(for: storedRecord)
+            loadDraftCommentController(for: resolvedRecord.record)
             isLoading = false
             loadCoordinator.finish(token)
         } catch is CancellationError {
@@ -474,6 +491,50 @@ struct ReviewSessionTabView: View {
             loadError = error.localizedDescription
             isLoading = false
             loadCoordinator.finish(token)
+        }
+    }
+
+    private func resolveTrackedRecordForLoad(
+        _ storedRecord: ReviewSessionRecord
+    ) async throws -> (record: ReviewSessionRecord, paused: Bool) {
+        guard let worktree, case .trackedCommit(let revision) = storedRecord.target.payload else {
+            return (storedRecord, false)
+        }
+        let candidate = try await TrackedRevisionResolver.live.resolve(
+            at: worktree.path,
+            expression: revision.expression
+        )
+        switch TrackedRevisionPolicy.evaluate(current: revision, candidate: candidate) {
+        case .unchanged(let updated):
+            let target = storedRecord.target.updatingTrackedRevision(updated, title: storedRecord.target.title)
+            return (
+                storedRecord.retargetingCommit(
+                    to: target,
+                    resolvedSHAChanged: false,
+                    now: now()
+                ),
+                false
+            )
+        case .follow(let updated):
+            let target = storedRecord.target.updatingTrackedRevision(updated, title: "Review \(updated.expression)")
+            return (
+                storedRecord.retargetingCommit(
+                    to: target,
+                    resolvedSHAChanged: true,
+                    now: now()
+                ),
+                false
+            )
+        case .pause(let updated):
+            let target = storedRecord.target.updatingTrackedRevision(updated, title: storedRecord.target.title)
+            return (
+                storedRecord.retargetingCommit(
+                    to: target,
+                    resolvedSHAChanged: false,
+                    now: now()
+                ),
+                true
+            )
         }
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -212,7 +212,8 @@ struct ReviewSessionTabView: View {
         } else {
             revisionGeneration = 0
         }
-        return "\(tabState.sessionID.rawValue):\(loadGeneration):\(revisionGeneration)"
+        let retargetGeneration = appState?.reviewSessionRetargetGeneration(sessionID: tabState.sessionID) ?? 0
+        return "\(tabState.sessionID.rawValue):\(loadGeneration):\(revisionGeneration):\(retargetGeneration)"
     }
 
     private var header: some View {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -593,16 +593,10 @@ struct ReviewSessionTabView: View {
             if resolvedRecord.paused, resolvedRecord.record.target != storedRecord.target {
                 try sessionStore.save(resolvedRecord.record)
             }
-            guard !resolvedRecord.paused else {
-                record = resolvedRecord.record
-                isLoading = false
-                loadCoordinator.finish(token)
-                return
-            }
 
             let loadedContext = try await loader.load(target: resolvedRecord.record.target)
             guard loadCoordinator.canPublish(token) else { return }
-            if resolvedRecord.record.target != storedRecord.target {
+            if !resolvedRecord.paused, resolvedRecord.record.target != storedRecord.target {
                 try sessionStore.save(resolvedRecord.record)
             }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -588,7 +588,16 @@ struct ReviewSessionTabView: View {
                 throw ReviewSessionTabError.missingSession(tabState.sessionID)
             }
 
-            let resolvedRecord = try await resolveTrackedRecordForLoad(storedRecord)
+            let resolvedRecord: (record: ReviewSessionRecord, paused: Bool)
+            let refreshError: String?
+            do {
+                resolvedRecord = try await resolveTrackedRecordForLoad(storedRecord)
+                refreshError = nil
+            } catch {
+                guard case .trackedCommit = storedRecord.target.payload else { throw error }
+                resolvedRecord = (storedRecord, false)
+                refreshError = error.localizedDescription
+            }
             guard loadCoordinator.canPublish(token) else { return }
             if resolvedRecord.paused, resolvedRecord.record.target != storedRecord.target {
                 try sessionStore.save(resolvedRecord.record)
@@ -606,6 +615,7 @@ struct ReviewSessionTabView: View {
                     loaded: loadedContext
                 )
             )
+            loadError = refreshError
             loadDraftCommentController(for: resolvedRecord.record)
             isLoading = false
             loadCoordinator.finish(token)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -1155,7 +1155,8 @@ struct ReviewSessionTabView: View {
     }
 
     private func recordSessionSendFailure(_ error: Error) {
-        guard var current = record else { return }
+        guard let visibleRecord = record else { return }
+        var current = (try? sessionStore.load(id: visibleRecord.id)) ?? visibleRecord
         current.lastSendError = "Failed to send to agent: \(error.localizedDescription)"
         current.updatedAt = now()
         record = current

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -608,6 +608,7 @@ struct ReviewSessionTabView: View {
                 }
                 record = refreshedRecord
                 loadError = refreshError
+                loadDraftCommentController(for: refreshedRecord)
                 isLoading = false
                 loadCoordinator.finish(token)
                 return
@@ -655,6 +656,11 @@ struct ReviewSessionTabView: View {
         merged.focusedCommentID = latestRecord.focusedCommentID
         merged.handoffs = latestRecord.handoffs
         merged.lastSendError = latestRecord.lastSendError
+        if trackedResolvedSHA(in: latestRecord) == trackedResolvedSHA(in: refreshedRecord) {
+            merged.status = latestRecord.status
+            merged.verdict = latestRecord.verdict
+            merged.updatedAt = latestRecord.updatedAt
+        }
         return merged
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -599,24 +599,38 @@ struct ReviewSessionTabView: View {
                 refreshError = error.localizedDescription
             }
             guard loadCoordinator.canPublish(token) else { return }
-            if resolvedRecord.paused, resolvedRecord.record.target != storedRecord.target {
-                try sessionStore.save(resolvedRecord.record)
+            var refreshedRecord = mergeLatestMutableFields(into: resolvedRecord.record, fallback: storedRecord)
+            if let loaded,
+               trackedResolvedSHA(in: record) == trackedResolvedSHA(in: refreshedRecord),
+               case .trackedCommit = refreshedRecord.target.payload {
+                if refreshedRecord.target != storedRecord.target {
+                    try sessionStore.save(refreshedRecord)
+                }
+                record = refreshedRecord
+                loadError = refreshError
+                isLoading = false
+                loadCoordinator.finish(token)
+                return
+            }
+            if resolvedRecord.paused, refreshedRecord.target != storedRecord.target {
+                try sessionStore.save(refreshedRecord)
             }
 
-            let loadedContext = try await loader.load(target: resolvedRecord.record.target)
+            let loadedContext = try await loader.load(target: refreshedRecord.target)
             guard loadCoordinator.canPublish(token) else { return }
-            if !resolvedRecord.paused, resolvedRecord.record.target != storedRecord.target {
-                try sessionStore.save(resolvedRecord.record)
+            refreshedRecord = mergeLatestMutableFields(into: refreshedRecord, fallback: storedRecord)
+            if !resolvedRecord.paused, refreshedRecord.target != storedRecord.target {
+                try sessionStore.save(refreshedRecord)
             }
 
             publishInitialLoad(
                 ReviewSessionTabLoadPublication.initial(
-                    record: resolvedRecord.record,
+                    record: refreshedRecord,
                     loaded: loadedContext
                 )
             )
             loadError = refreshError
-            loadDraftCommentController(for: resolvedRecord.record)
+            loadDraftCommentController(for: refreshedRecord)
             isLoading = false
             loadCoordinator.finish(token)
         } catch is CancellationError {
@@ -629,6 +643,24 @@ struct ReviewSessionTabView: View {
             isLoading = false
             loadCoordinator.finish(token)
         }
+    }
+
+    private func mergeLatestMutableFields(
+        into refreshedRecord: ReviewSessionRecord,
+        fallback: ReviewSessionRecord
+    ) -> ReviewSessionRecord {
+        let latestRecord = (try? sessionStore.load(id: refreshedRecord.id)) ?? fallback
+        var merged = refreshedRecord
+        merged.selectedFileID = latestRecord.selectedFileID
+        merged.focusedCommentID = latestRecord.focusedCommentID
+        merged.handoffs = latestRecord.handoffs
+        merged.lastSendError = latestRecord.lastSendError
+        return merged
+    }
+
+    private func trackedResolvedSHA(in record: ReviewSessionRecord?) -> String? {
+        guard case .trackedCommit(let revision) = record?.target.payload else { return nil }
+        return revision.resolvedSHA
     }
 
     private func resolveTrackedRecordForLoad(

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -747,12 +747,17 @@ struct ReviewSessionTabView: View {
     }
 
     private func draftCommentActions(for loaded: ReviewSessionLoadedContext) -> ReviewDraftCommentActions {
+        let handoffOriginRecordID = record?.id
         var actions = ReviewDraftWorkspaceActions.make(
             controller: draftCommentController,
             sender: feedbackSender,
             sessionID: tabState.sessionID,
-            recordHandoff: recordSessionHandoff,
-            recordSendFailure: recordSessionSendFailure,
+            recordHandoff: { handoff in
+                recordSessionHandoff(handoff, originRecordID: handoffOriginRecordID)
+            },
+            recordSendFailure: { error in
+                recordSessionSendFailure(error, originRecordID: handoffOriginRecordID)
+            },
             worktreeID: persistsState ? tabState.worktreeId : nil,
             now: now,
             sessionStore: { sessionStore }
@@ -1144,30 +1149,27 @@ struct ReviewSessionTabView: View {
         )
     }
 
-    private func recordSessionHandoff(_ handoff: ReviewFeedbackHandoff) {
+    private func recordSessionHandoff(_ handoff: ReviewFeedbackHandoff, originRecordID: ReviewSessionID?) {
         record = ReviewSessionHandoffPersistence.record(
             handoff,
             currentRecord: record,
+            originRecordID: originRecordID,
             sessionStore: sessionStore,
             persistsState: persistsState,
             now: now
         )
     }
 
-    private func recordSessionSendFailure(_ error: Error) {
+    private func recordSessionSendFailure(_ error: Error, originRecordID: ReviewSessionID?) {
         guard let visibleRecord = record else { return }
-        var current = (try? sessionStore.loadReplacement(for: visibleRecord.id))
-            ?? (try? sessionStore.load(id: visibleRecord.id))
-            ?? visibleRecord
-        current.lastSendError = "Failed to send to agent: \(error.localizedDescription)"
-        current.updatedAt = now()
-        record = current
-        guard persistsState else { return }
-        do {
-            try sessionStore.save(current)
-        } catch {
-            // Visible send failure state is already set; failure to persist that state is non-blocking.
-        }
+        record = ReviewSessionHandoffPersistence.recordSendFailure(
+            error,
+            currentRecord: visibleRecord,
+            originRecordID: originRecordID,
+            sessionStore: sessionStore,
+            persistsState: persistsState,
+            now: now
+        )
     }
 
     private func selectDraftComment(_ comment: ReviewDraftComment) {
@@ -1274,6 +1276,7 @@ enum ReviewSessionHandoffPersistence {
     static func record(
         _ handoff: ReviewFeedbackHandoff,
         currentRecord: ReviewSessionRecord?,
+        originRecordID: ReviewSessionID? = nil,
         sessionStore: ReviewSessionStore,
         persistsState: Bool,
         now: () -> Date
@@ -1283,9 +1286,12 @@ enum ReviewSessionHandoffPersistence {
         }
 
         do {
-            let current = try sessionStore.loadReplacement(for: handoff.sessionID)
-                ?? sessionStore.load(id: handoff.sessionID)
-                ?? currentRecord
+            let current = try operationRecord(
+                sessionID: handoff.sessionID,
+                currentRecord: currentRecord,
+                originRecordID: originRecordID,
+                sessionStore: sessionStore
+            )
             guard let current else { return nil }
             let updated = current.recording(handoff: handoff)
             try sessionStore.save(updated)
@@ -1296,6 +1302,53 @@ enum ReviewSessionHandoffPersistence {
             visibleRecord.updatedAt = now()
             return visibleRecord
         }
+    }
+
+    @MainActor
+    static func recordSendFailure(
+        _ error: Error,
+        currentRecord: ReviewSessionRecord,
+        originRecordID: ReviewSessionID? = nil,
+        sessionStore: ReviewSessionStore,
+        persistsState: Bool,
+        now: () -> Date
+    ) -> ReviewSessionRecord {
+        let sessionID = originRecordID ?? currentRecord.id
+        let current = (try? operationRecord(
+            sessionID: sessionID,
+            currentRecord: currentRecord,
+            originRecordID: originRecordID,
+            sessionStore: sessionStore
+        )) ?? currentRecord
+        var updated = current
+        updated.lastSendError = "Failed to send to agent: \(error.localizedDescription)"
+        updated.updatedAt = now()
+        guard persistsState else { return updated }
+        do {
+            try sessionStore.save(updated)
+        } catch {
+            // Visible send failure state is already set; failure to persist that state is non-blocking.
+        }
+        return updated
+    }
+
+    private static func operationRecord(
+        sessionID: ReviewSessionID,
+        currentRecord: ReviewSessionRecord?,
+        originRecordID: ReviewSessionID?,
+        sessionStore: ReviewSessionStore
+    ) throws -> ReviewSessionRecord? {
+        let direct = try sessionStore.load(id: sessionID)
+        let replacement = try sessionStore.loadReplacement(for: sessionID)
+        if let currentRecord {
+            if currentRecord.id == originRecordID || currentRecord.id == sessionID {
+                return direct ?? currentRecord
+            }
+            if currentRecord.id == replacement?.id {
+                return replacement
+            }
+        }
+        return replacement ?? direct ?? currentRecord
     }
 }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -351,13 +351,22 @@ struct ReviewSessionTabView: View {
         if isLoading {
             stateView(title: "Loading review session...", detail: nil, color: theme.color("fg-dim"), showsRetry: false)
         } else if let loaded, loaded.session.files.isEmpty {
-            stateView(title: "No files to review", detail: "This review session has no file diffs.", color: theme.color("fg-dim"), showsRetry: false)
+            emptyReviewState()
         } else if let loaded {
             reviewSurface(loaded)
         } else if let loadError {
             stateView(title: "Could not load review session", detail: loadError, color: theme.color("del"), showsRetry: loadsOnAppear)
         } else {
             stateView(title: "No review session loaded", detail: nil, color: theme.color("fg-dim"), showsRetry: false)
+        }
+    }
+
+    private func emptyReviewState() -> some View {
+        VStack(spacing: 0) {
+            if let loadError, !loadError.isEmpty {
+                trackedRefreshErrorBanner(loadError)
+            }
+            stateView(title: "No files to review", detail: "This review session has no file diffs.", color: theme.color("fg-dim"), showsRetry: false)
         }
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -73,6 +73,7 @@ struct ReviewSessionTabView: View {
     @Environment(\.theme) private var theme
     @State private var record: ReviewSessionRecord?
     @State private var loaded: ReviewSessionLoadedContext?
+    @State private var loadedTrackedResolvedSHA: String?
     @State private var isLoading = false
     @State private var loadError: String?
     @State private var selectedFileID: DiffReviewFileID?
@@ -139,6 +140,7 @@ struct ReviewSessionTabView: View {
         self.now = now
         self._record = State(initialValue: record)
         self._loaded = State(initialValue: loaded)
+        self._loadedTrackedResolvedSHA = State(initialValue: Self.trackedResolvedSHA(in: record))
         self._selectedFileID = State(initialValue: record?.selectedFileID ?? tabState.selectedFileID)
         self._focusedDraftCommentID = State(initialValue: record?.focusedCommentID ?? tabState.focusedCommentID)
         if let record {
@@ -613,13 +615,16 @@ struct ReviewSessionTabView: View {
             guard loadCoordinator.canPublish(token) else { return }
             var refreshedRecord = mergeLatestMutableFields(into: resolvedRecord.record, fallback: storedRecord)
             if let loaded,
-               trackedResolvedSHA(in: record) == trackedResolvedSHA(in: refreshedRecord),
-               case .trackedCommit = refreshedRecord.target.payload {
+               Self.canReuseLoadedTrackedDiff(
+                   loadedTrackedResolvedSHA: loadedTrackedResolvedSHA,
+                   refreshedRecord: refreshedRecord
+               ) {
                 if refreshedRecord.target != storedRecord.target {
                     try sessionStore.save(refreshedRecord)
                 }
                 record = refreshedRecord
                 self.loaded = loaded.replacingFeedbackTarget(for: refreshedRecord.target)
+                loadedTrackedResolvedSHA = Self.trackedResolvedSHA(in: refreshedRecord)
                 loadError = refreshError
                 loadDraftCommentController(for: refreshedRecord)
                 isLoading = false
@@ -669,7 +674,7 @@ struct ReviewSessionTabView: View {
         merged.focusedCommentID = latestRecord.focusedCommentID
         merged.handoffs = latestRecord.handoffs
         merged.lastSendError = latestRecord.lastSendError
-        if trackedResolvedSHA(in: latestRecord) == trackedResolvedSHA(in: refreshedRecord) {
+        if Self.trackedResolvedSHA(in: latestRecord) == Self.trackedResolvedSHA(in: refreshedRecord) {
             merged.status = latestRecord.status
             merged.verdict = latestRecord.verdict
             merged.updatedAt = latestRecord.updatedAt
@@ -677,7 +682,15 @@ struct ReviewSessionTabView: View {
         return merged
     }
 
-    private func trackedResolvedSHA(in record: ReviewSessionRecord?) -> String? {
+    static func canReuseLoadedTrackedDiff(
+        loadedTrackedResolvedSHA: String?,
+        refreshedRecord: ReviewSessionRecord
+    ) -> Bool {
+        guard case .trackedCommit = refreshedRecord.target.payload else { return false }
+        return loadedTrackedResolvedSHA == trackedResolvedSHA(in: refreshedRecord)
+    }
+
+    private static func trackedResolvedSHA(in record: ReviewSessionRecord?) -> String? {
         guard case .trackedCommit(let revision) = record?.target.payload else { return nil }
         return revision.resolvedSHA
     }
@@ -729,6 +742,7 @@ struct ReviewSessionTabView: View {
     private func publishInitialLoad(_ publication: ReviewSessionTabLoadPublication) {
         record = publication.record
         loaded = publication.loaded
+        loadedTrackedResolvedSHA = Self.trackedResolvedSHA(in: publication.record)
         selectedFileID = publication.selectedFileID
         focusedDraftCommentID = publication.focusedDraftCommentID
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -349,12 +349,12 @@ struct ReviewSessionTabView: View {
     private var content: some View {
         if isLoading {
             stateView(title: "Loading review session...", detail: nil, color: theme.color("fg-dim"), showsRetry: false)
-        } else if let loadError {
-            stateView(title: "Could not load review session", detail: loadError, color: theme.color("del"), showsRetry: loadsOnAppear)
         } else if let loaded, loaded.session.files.isEmpty {
             stateView(title: "No files to review", detail: "This review session has no file diffs.", color: theme.color("fg-dim"), showsRetry: false)
         } else if let loaded {
             reviewSurface(loaded)
+        } else if let loadError {
+            stateView(title: "Could not load review session", detail: loadError, color: theme.color("del"), showsRetry: loadsOnAppear)
         } else {
             stateView(title: "No review session loaded", detail: nil, color: theme.color("fg-dim"), showsRetry: false)
         }
@@ -388,6 +388,9 @@ struct ReviewSessionTabView: View {
             if let providerPublishError, !providerPublishError.isEmpty {
                 providerErrorBanner(providerPublishError)
             }
+            if let loadError, !loadError.isEmpty {
+                trackedRefreshErrorBanner(loadError)
+            }
             DiffReviewSurface(
                 session: loaded.session,
                 selectedFileID: Binding(
@@ -420,6 +423,39 @@ struct ReviewSessionTabView: View {
             )
             .environment(\.reviewDraftSummaryRailStatus, ReviewDraftSummaryRailStatus(record: record))
         }
+    }
+
+    private func trackedRefreshErrorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.color("del"))
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg"))
+                .lineLimit(2)
+            Spacer(minLength: 8)
+            Button("Retry") {
+                loadGeneration += 1
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .accessibilityIdentifier("review-session-revision-error-retry")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("del").opacity(0.08))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.color("line"))
+                .frame(height: 1)
+        }
+        .background(
+            DiffReviewAccessibilityMarker(
+                identifier: "review-session-revision-error",
+                label: message
+            )
+        )
     }
 
     private func providerErrorBanner(_ message: String) -> some View {
@@ -553,7 +589,7 @@ struct ReviewSessionTabView: View {
 
             let resolvedRecord = try await resolveTrackedRecordForLoad(storedRecord)
             guard loadCoordinator.canPublish(token) else { return }
-            if resolvedRecord.record.target != storedRecord.target {
+            if resolvedRecord.paused, resolvedRecord.record.target != storedRecord.target {
                 try sessionStore.save(resolvedRecord.record)
             }
             guard !resolvedRecord.paused else {
@@ -565,6 +601,9 @@ struct ReviewSessionTabView: View {
 
             let loadedContext = try await loader.load(target: resolvedRecord.record.target)
             guard loadCoordinator.canPublish(token) else { return }
+            if resolvedRecord.record.target != storedRecord.target {
+                try sessionStore.save(resolvedRecord.record)
+            }
 
             publishInitialLoad(
                 ReviewSessionTabLoadPublication.initial(

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -281,9 +281,9 @@ struct FileHistoryTabState: Codable, Equatable, Identifiable {
 }
 
 struct ReviewSessionTabState: Codable, Equatable, Identifiable {
-    let id: TabID
+    var id: TabID
     let worktreeId: String
-    let sessionID: ReviewSessionID
+    var sessionID: ReviewSessionID
     var title: String
     var selectedFileID: DiffReviewFileID?
     var focusedCommentID: String?
@@ -295,6 +295,14 @@ struct ReviewSessionTabState: Codable, Equatable, Identifiable {
         self.title = record.target.title
         self.selectedFileID = record.selectedFileID
         self.focusedCommentID = record.focusedCommentID
+    }
+
+    mutating func retarget(to record: ReviewSessionRecord) {
+        id = "review-session:\(record.id.rawValue)"
+        sessionID = record.id
+        title = record.target.title
+        selectedFileID = record.selectedFileID
+        focusedCommentID = record.focusedCommentID
     }
 }
 

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -401,6 +401,11 @@ struct CommitTabState: Codable, Equatable, Identifiable {
 
     var sha: String { revision.resolvedSHA }
 
+    var fixedSHA: String? {
+        guard case .fixed(let sha) = revision else { return nil }
+        return sha
+    }
+
     init(worktreeId: String, sha: String, title: String) {
         self.id = Self.fixedID(worktreeId: worktreeId, sha: sha)
         self.worktreeId = worktreeId

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -388,12 +388,14 @@ enum CommitRevision: Codable, Equatable, Hashable, Sendable {
 struct CommitTabState: Codable, Equatable, Identifiable {
     var id: TabID
     let worktreeId: String
+    var viewID: TabID
     var revision: CommitRevision
     var title: String
 
     private enum CodingKeys: String, CodingKey {
         case id
         case worktreeId
+        case viewID
         case revision
         case sha
         case title
@@ -409,6 +411,7 @@ struct CommitTabState: Codable, Equatable, Identifiable {
     init(worktreeId: String, sha: String, title: String) {
         self.id = Self.fixedID(worktreeId: worktreeId, sha: sha)
         self.worktreeId = worktreeId
+        self.viewID = id
         self.revision = .fixed(sha: sha)
         self.title = title
     }
@@ -416,6 +419,7 @@ struct CommitTabState: Codable, Equatable, Identifiable {
     init(worktreeId: String, trackedRevision: TrackedRevision, title: String) {
         self.id = Self.trackedID(worktreeId: worktreeId, expression: trackedRevision.expression)
         self.worktreeId = worktreeId
+        self.viewID = id
         self.revision = .following(trackedRevision)
         self.title = title
     }
@@ -424,6 +428,7 @@ struct CommitTabState: Codable, Equatable, Identifiable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(TabID.self, forKey: .id)
         worktreeId = try container.decode(String.self, forKey: .worktreeId)
+        viewID = try container.decodeIfPresent(TabID.self, forKey: .viewID) ?? id
         title = try container.decode(String.self, forKey: .title)
         if let decodedRevision = try container.decodeIfPresent(CommitRevision.self, forKey: .revision) {
             revision = decodedRevision
@@ -436,6 +441,7 @@ struct CommitTabState: Codable, Equatable, Identifiable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(worktreeId, forKey: .worktreeId)
+        try container.encode(viewID, forKey: .viewID)
         try container.encode(revision, forKey: .revision)
         try container.encode(sha, forKey: .sha)
         try container.encode(title, forKey: .title)

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -283,18 +283,41 @@ struct FileHistoryTabState: Codable, Equatable, Identifiable {
 struct ReviewSessionTabState: Codable, Equatable, Identifiable {
     var id: TabID
     let worktreeId: String
+    var viewID: TabID
     var sessionID: ReviewSessionID
     var title: String
     var selectedFileID: DiffReviewFileID?
     var focusedCommentID: String?
 
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case worktreeId
+        case viewID
+        case sessionID
+        case title
+        case selectedFileID
+        case focusedCommentID
+    }
+
     init(worktreeId: String, record: ReviewSessionRecord) {
         self.id = "review-session:\(record.id.rawValue)"
         self.worktreeId = worktreeId
+        self.viewID = id
         self.sessionID = record.id
         self.title = record.target.title
         self.selectedFileID = record.selectedFileID
         self.focusedCommentID = record.focusedCommentID
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(TabID.self, forKey: .id)
+        worktreeId = try container.decode(String.self, forKey: .worktreeId)
+        viewID = try container.decodeIfPresent(TabID.self, forKey: .viewID) ?? id
+        sessionID = try container.decode(ReviewSessionID.self, forKey: .sessionID)
+        title = try container.decode(String.self, forKey: .title)
+        selectedFileID = try container.decodeIfPresent(DiffReviewFileID.self, forKey: .selectedFileID)
+        focusedCommentID = try container.decodeIfPresent(String.self, forKey: .focusedCommentID)
     }
 
     mutating func retarget(to record: ReviewSessionRecord) {

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -132,6 +132,24 @@ enum Tab: Codable, Equatable, Identifiable {
         }
     }
 
+    var supportsRevisionFollowActions: Bool {
+        switch self {
+        case .commit, .reviewSession:
+            true
+        default:
+            false
+        }
+    }
+
+    var isFollowingRevision: Bool {
+        switch self {
+        case .commit(let state):
+            state.revision.tracked != nil
+        default:
+            false
+        }
+    }
+
     var relativeFilePath: String? {
         switch self {
         case .editor(let s):       return s.isExternal ? nil : s.relativePath

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 typealias TabID = String
@@ -337,17 +338,82 @@ struct ReviewPRTabState: Codable, Equatable, Identifiable {
     }
 }
 
+enum CommitRevision: Codable, Equatable, Hashable, Sendable {
+    case fixed(sha: String)
+    case following(TrackedRevision)
+
+    var resolvedSHA: String {
+        switch self {
+        case .fixed(let sha):
+            sha
+        case .following(let revision):
+            revision.resolvedSHA
+        }
+    }
+
+    var tracked: TrackedRevision? {
+        if case .following(let revision) = self {
+            return revision
+        }
+        return nil
+    }
+}
+
 struct CommitTabState: Codable, Equatable, Identifiable {
     let id: TabID
     let worktreeId: String
-    let sha: String
-    let title: String
+    var revision: CommitRevision
+    var title: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case worktreeId
+        case revision
+        case sha
+        case title
+    }
+
+    var sha: String { revision.resolvedSHA }
 
     init(worktreeId: String, sha: String, title: String) {
         self.id = "commit:\(worktreeId):\(sha)"
         self.worktreeId = worktreeId
-        self.sha = sha
+        self.revision = .fixed(sha: sha)
         self.title = title
+    }
+
+    init(worktreeId: String, trackedRevision: TrackedRevision, title: String) {
+        self.id = "commit:\(worktreeId):tracked:\(Self.trackedIDDigest(for: trackedRevision.expression))"
+        self.worktreeId = worktreeId
+        self.revision = .following(trackedRevision)
+        self.title = title
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(TabID.self, forKey: .id)
+        worktreeId = try container.decode(String.self, forKey: .worktreeId)
+        title = try container.decode(String.self, forKey: .title)
+        if let decodedRevision = try container.decodeIfPresent(CommitRevision.self, forKey: .revision) {
+            revision = decodedRevision
+        } else {
+            revision = .fixed(sha: try container.decode(String.self, forKey: .sha))
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(worktreeId, forKey: .worktreeId)
+        try container.encode(revision, forKey: .revision)
+        try container.encode(sha, forKey: .sha)
+        try container.encode(title, forKey: .title)
+    }
+
+    private static func trackedIDDigest(for expression: String) -> String {
+        SHA256.hash(data: Data(expression.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 }
 

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -378,7 +378,7 @@ enum CommitRevision: Codable, Equatable, Hashable, Sendable {
 }
 
 struct CommitTabState: Codable, Equatable, Identifiable {
-    let id: TabID
+    var id: TabID
     let worktreeId: String
     var revision: CommitRevision
     var title: String
@@ -394,14 +394,14 @@ struct CommitTabState: Codable, Equatable, Identifiable {
     var sha: String { revision.resolvedSHA }
 
     init(worktreeId: String, sha: String, title: String) {
-        self.id = "commit:\(worktreeId):\(sha)"
+        self.id = Self.fixedID(worktreeId: worktreeId, sha: sha)
         self.worktreeId = worktreeId
         self.revision = .fixed(sha: sha)
         self.title = title
     }
 
     init(worktreeId: String, trackedRevision: TrackedRevision, title: String) {
-        self.id = "commit:\(worktreeId):tracked:\(Self.trackedIDDigest(for: trackedRevision.expression))"
+        self.id = Self.trackedID(worktreeId: worktreeId, expression: trackedRevision.expression)
         self.worktreeId = worktreeId
         self.revision = .following(trackedRevision)
         self.title = title
@@ -426,6 +426,24 @@ struct CommitTabState: Codable, Equatable, Identifiable {
         try container.encode(revision, forKey: .revision)
         try container.encode(sha, forKey: .sha)
         try container.encode(title, forKey: .title)
+    }
+
+    mutating func follow(_ revision: TrackedRevision) {
+        id = Self.trackedID(worktreeId: worktreeId, expression: revision.expression)
+        self.revision = .following(revision)
+    }
+
+    mutating func fix(sha: String) {
+        id = Self.fixedID(worktreeId: worktreeId, sha: sha)
+        revision = .fixed(sha: sha)
+    }
+
+    private static func fixedID(worktreeId: String, sha: String) -> String {
+        "commit:\(worktreeId):\(sha)"
+    }
+
+    private static func trackedID(worktreeId: String, expression: String) -> String {
+        "commit:\(worktreeId):tracked:\(trackedIDDigest(for: expression))"
     }
 
     private static func trackedIDDigest(for expression: String) -> String {

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -18,6 +18,9 @@ struct TabBarView: View {
     let onCopyRelativePath: (TabID) -> Void
     let onOpenWithSystem: (TabID) -> Void
     let onRevealInFinder: (TabID) -> Void
+    var revisionFollowCapability: (Tab) -> RevisionFollowCapability = { tab in
+        RevisionFollowCapability(tab: tab)
+    }
     var onFollowRevision: (TabID) -> Void = { _ in }
     var onEditRevision: (TabID) -> Void = { _ in }
     var onStopFollowingRevision: (TabID) -> Void = { _ in }
@@ -159,15 +162,16 @@ struct TabBarView: View {
                 Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
                 Divider()
             }
-            if tab.supportsRevisionFollowActions {
-                Button(tab.isFollowingRevision ? "Edit Followed Revision…" : "Follow Revision…") {
-                    if tab.isFollowingRevision {
+            let revisionCapability = revisionFollowCapability(tab)
+            if revisionCapability.isSupported {
+                Button(revisionCapability.isFollowing ? "Edit Followed Revision…" : "Follow Revision…") {
+                    if revisionCapability.isFollowing {
                         onEditRevision(tab.id)
                     } else {
                         onFollowRevision(tab.id)
                     }
                 }
-                if tab.isFollowingRevision {
+                if revisionCapability.isFollowing {
                     Button("Stop Following Revision") { onStopFollowingRevision(tab.id) }
                 }
                 Divider()
@@ -201,6 +205,23 @@ struct TabBarView: View {
         } else {
             proxy.scrollTo(activeId, anchor: .center)
         }
+    }
+}
+
+struct RevisionFollowCapability: Equatable {
+    let isSupported: Bool
+    let isFollowing: Bool
+
+    init(isSupported: Bool, isFollowing: Bool) {
+        self.isSupported = isSupported
+        self.isFollowing = isFollowing
+    }
+
+    init(tab: Tab) {
+        self.init(
+            isSupported: tab.supportsRevisionFollowActions,
+            isFollowing: tab.isFollowingRevision
+        )
     }
 }
 

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -18,6 +18,9 @@ struct TabBarView: View {
     let onCopyRelativePath: (TabID) -> Void
     let onOpenWithSystem: (TabID) -> Void
     let onRevealInFinder: (TabID) -> Void
+    var onFollowRevision: (TabID) -> Void = { _ in }
+    var onEditRevision: (TabID) -> Void = { _ in }
+    var onStopFollowingRevision: (TabID) -> Void = { _ in }
     /// Whether system-open / reveal-in-Finder actions are available for this
     /// worktree. False for remote worktrees (local `NSWorkspace` can't touch
     /// them); the menu items are hidden when this is false so users don't see
@@ -154,6 +157,19 @@ struct TabBarView: View {
                 Button("Rename…") { onRenameACPSession(tab.id) }
                 Button("Copy Session as Markdown") { onCopyACPSession(tab.id) }
                 Button("Save Session as Markdown…") { onExportACPSession(tab.id) }
+                Divider()
+            }
+            if tab.supportsRevisionFollowActions {
+                Button(tab.isFollowingRevision ? "Edit Followed Revision…" : "Follow Revision…") {
+                    if tab.isFollowingRevision {
+                        onEditRevision(tab.id)
+                    } else {
+                        onFollowRevision(tab.id)
+                    }
+                }
+                if tab.isFollowingRevision {
+                    Button("Stop Following Revision") { onStopFollowingRevision(tab.id) }
+                }
                 Divider()
             }
             Button("Close") { onClose(tab.id) }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1058,6 +1058,15 @@ final class TabsManager {
         else { return nil }
         mutate(&state)
         let tab = Tab.reviewSession(state)
+        if tab.id != tabId,
+           let existingIdx = file.tabs.firstIndex(where: { $0.id == tab.id && $0.id != tabId }) {
+            let existing = file.tabs[existingIdx]
+            file.tabs.remove(at: idx)
+            file.activeTabId = existing.id
+            byWorktree[worktreeId] = file
+            persist(worktreeId)
+            return existing
+        }
         file.tabs[idx] = tab
         if file.activeTabId == tabId {
             file.activeTabId = tab.id

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1059,6 +1059,9 @@ final class TabsManager {
         mutate(&state)
         let tab = Tab.reviewSession(state)
         file.tabs[idx] = tab
+        if file.activeTabId == tabId {
+            file.activeTabId = tab.id
+        }
         byWorktree[worktreeId] = file
         persist(worktreeId)
         return tab

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -754,6 +754,9 @@ final class TabsManager {
         mutate(&state)
         let tab = Tab.commit(state)
         file.tabs[idx] = tab
+        if file.activeTabId == tabId {
+            file.activeTabId = tab.id
+        }
         byWorktree[worktreeId] = file
         persist(worktreeId)
         return tab

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -742,6 +742,24 @@ final class TabsManager {
     }
 
     @discardableResult
+    func updateCommit(
+        worktreeId: String,
+        tabId: TabID,
+        mutate: (inout CommitTabState) -> Void
+    ) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .commit(var state) = file.tabs[idx]
+        else { return nil }
+        mutate(&state)
+        let tab = Tab.commit(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
+    @discardableResult
     func openCommitEditor(
         worktreeId: String,
         baseRef: String,

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -753,6 +753,15 @@ final class TabsManager {
         else { return nil }
         mutate(&state)
         let tab = Tab.commit(state)
+        if tab.id != tabId,
+           let existingIdx = file.tabs.firstIndex(where: { $0.id == tab.id && $0.id != tabId }) {
+            let existing = file.tabs[existingIdx]
+            file.tabs.remove(at: idx)
+            file.activeTabId = existing.id
+            byWorktree[worktreeId] = file
+            persist(worktreeId)
+            return existing
+        }
         file.tabs[idx] = tab
         if file.activeTabId == tabId {
             file.activeTabId = tab.id

--- a/Alas/Sources/Dialogs/ReviewTarget/AppState+ReviewPalette.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/AppState+ReviewPalette.swift
@@ -98,6 +98,9 @@ extension AppState {
             resolveRevision: { worktree, ref in
                 try await GitService().resolveRevision(at: worktree.path, ref: ref)
             },
+            currentBranch: { worktree in
+                try await GitService().currentBranch(worktreePath: worktree.path)
+            },
             headSHA: { worktree in
                 try await GitService().headSHA(at: worktree.path)
             },

--- a/Alas/Sources/Dialogs/ReviewTarget/AppState+ReviewPalette.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/AppState+ReviewPalette.swift
@@ -101,6 +101,9 @@ extension AppState {
             currentBranch: { worktree in
                 try await GitService().currentBranch(worktreePath: worktree.path)
             },
+            resolveTrackedRevision: { worktree, expression in
+                try await TrackedRevisionResolver.live.resolve(at: worktree.path, expression: expression)
+            },
             headSHA: { worktree in
                 try await GitService().headSHA(at: worktree.path)
             },

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
@@ -275,7 +275,7 @@ struct ReviewTargetDialog: View {
                 .padding(.bottom, 3)
         case .message(let text):
             messageRow(text)
-        case .followedRevision(let expression, let resolvedSHA, let branch):
+        case .followedRevision(let expression, let resolvedSHA, let branch, _):
             followedRevisionRow(
                 expression: expression,
                 resolvedSHA: resolvedSHA,

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
@@ -52,6 +52,12 @@ struct ReviewTargetDialog: View {
                     await model.loadTargets(environment: environment)
                 }
             }
+            .task(id: validationTaskKey) {
+                guard case .targets = model.level else { return }
+                try? await Task.sleep(nanoseconds: 180_000_000)
+                guard !Task.isCancelled else { return }
+                await model.validateRevisionQuery(environment: environment)
+            }
         }
     }
 
@@ -64,6 +70,15 @@ struct ReviewTargetDialog: View {
         switch model.level {
         case .worktrees: return "worktrees"
         case .targets(let worktree): return "targets:\(worktree.id)"
+        }
+    }
+
+    private var validationTaskKey: String {
+        switch model.level {
+        case .worktrees:
+            return "revision-validation:worktrees"
+        case .targets(let worktree):
+            return "revision-validation:\(worktree.id):\(model.query)"
         }
     }
 
@@ -260,6 +275,24 @@ struct ReviewTargetDialog: View {
                 .padding(.bottom, 3)
         case .message(let text):
             messageRow(text)
+        case .followedRevision(let expression, let resolvedSHA, let branch):
+            followedRevisionRow(
+                expression: expression,
+                resolvedSHA: resolvedSHA,
+                branch: branch,
+                isSelected: isSelected
+            )
+            .onTapGesture {
+                model.setSelectedIndex(index, selectable: selectable)
+                Task { await model.activateSelection(environment: environment) }
+            }
+            .onHover { hovering in
+                guard hovering else { return }
+                let current = NSEvent.mouseLocation
+                if lastHoverLocation == current { return }
+                lastHoverLocation = current
+                model.setSelectedIndex(index, selectable: selectable)
+            }
         case .commit(let commit):
             commitRow(commit, isSelected: isSelected, selectedCommit: selectedCommit)
                 .onTapGesture {
@@ -336,6 +369,33 @@ struct ReviewTargetDialog: View {
             Text(name)
                 .font(.system(size: 12))
                 .foregroundColor(theme.color("fg"))
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+        .background(isSelected ? theme.color("accent-soft") : Color.clear)
+        .contentShape(Rectangle())
+    }
+
+    private func followedRevisionRow(
+        expression: String,
+        resolvedSHA: String,
+        branch: String,
+        isSelected: Bool
+    ) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "pin")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-muted"))
+            VStack(alignment: .leading, spacing: 1) {
+                Text(expression)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                Text("\(String(resolvedSHA.prefix(10))) · \(branch)")
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
             Spacer()
         }
         .padding(.horizontal, 14)

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteEnvironment.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteEnvironment.swift
@@ -8,6 +8,7 @@ struct ReviewTargetPaletteEnvironment {
     var loadCommitsAhead: (Worktree) async throws -> (commits: [CommitInfo], comparisonRef: String?)
     var loadBranches: (Worktree) async throws -> [String]
     var resolveRevision: (Worktree, String) async throws -> String
+    var currentBranch: (Worktree) async throws -> String
     var headSHA: (Worktree) async throws -> String
     /// Opens the review session and closes the palette. The worktree is the
     /// session's host — callers switch the app's active worktree to it.

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteEnvironment.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteEnvironment.swift
@@ -9,6 +9,7 @@ struct ReviewTargetPaletteEnvironment {
     var loadBranches: (Worktree) async throws -> [String]
     var resolveRevision: (Worktree, String) async throws -> String
     var currentBranch: (Worktree) async throws -> String
+    var resolveTrackedRevision: (Worktree, String) async throws -> TrackedRevisionCandidate
     var headSHA: (Worktree) async throws -> String
     /// Opens the review session and closes the palette. The worktree is the
     /// session's host — callers switch the app's active worktree to it.

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -24,13 +24,14 @@ final class ReviewTargetPaletteModel {
 
     enum TargetRow: Equatable {
         case header(String)
+        case followedRevision(expression: String, resolvedSHA: String, branch: String)
         case commit(CommitInfo)
         case branch(String)
         case message(String)
 
         var isSelectable: Bool {
             switch self {
-            case .commit, .branch: return true
+            case .followedRevision, .commit, .branch: return true
             case .header, .message: return false
             }
         }
@@ -42,6 +43,8 @@ final class ReviewTargetPaletteModel {
         var stableId: String {
             switch self {
             case .header(let title):  return "header:\(title)"
+            case .followedRevision(let expression, let resolvedSHA, let branch):
+                return "followed:\(expression):\(resolvedSHA):\(branch)"
             case .commit(let commit): return "commit:\(commit.sha)"
             case .branch(let name):   return "branch:\(name)"
             case .message(let text):  return "message:\(text)"
@@ -62,6 +65,8 @@ final class ReviewTargetPaletteModel {
             // of the first matching commit/branch. Level 1 has no header
             // rows, so 0 is already a real, selectable entry there.
             if case .targets = level {
+                followedRevisionRow = nil
+                revisionValidationError = nil
                 setSelectedIndex(0, selectable: targetRows().map(\.isSelectable))
             } else {
                 selectedIndex = 0
@@ -85,6 +90,9 @@ final class ReviewTargetPaletteModel {
     private(set) var branches: [String] = []
     private(set) var isLoadingTargets = false
     private(set) var targetsError: String?
+    private(set) var followedRevisionRow: TargetRow?
+    private(set) var revisionValidationError: String?
+    private var revisionValidationToken = UUID()
 
     // MARK: - Lifecycle
 
@@ -114,6 +122,8 @@ final class ReviewTargetPaletteModel {
         branches = []
         targetsError = nil
         isLoadingTargets = false
+        followedRevisionRow = nil
+        revisionValidationError = nil
         aheadCounts = [:]
         comparisonRefs = [:]
     }
@@ -163,7 +173,12 @@ final class ReviewTargetPaletteModel {
         guard case .targets = level else { return [] }
         if isLoadingTargets { return [.message("Loading commits…")] }
         if let targetsError { return [.message(targetsError)] }
-        var rows: [TargetRow] = [.header("Commits")]
+        var rows: [TargetRow] = []
+        if let followedRevisionRow {
+            rows.append(.header("Followed Revision"))
+            rows.append(followedRevisionRow)
+        }
+        rows.append(.header("Commits"))
         let filteredCommits = ReviewScopeSelection.filteredCommits(commits, query: query)
         if filteredCommits.isEmpty {
             rows.append(.message(
@@ -181,6 +196,9 @@ final class ReviewTargetPaletteModel {
         if !filteredBranches.isEmpty {
             rows.append(.header("Branches"))
             rows.append(contentsOf: filteredBranches.map(TargetRow.branch))
+        }
+        if let revisionValidationError, rows.filter(\.isSelectable).isEmpty {
+            rows.append(.message(revisionValidationError))
         }
         return rows
     }
@@ -222,7 +240,7 @@ final class ReviewTargetPaletteModel {
                 return true
             case .header, .message:
                 nextIndex += step
-            case .branch:
+            case .followedRevision, .branch:
                 return true
             }
         }
@@ -386,6 +404,14 @@ final class ReviewTargetPaletteModel {
             let rows = targetRows()
             guard rows.indices.contains(selectedIndex) else { return }
             switch rows[selectedIndex] {
+            case .followedRevision(let expression, let resolvedSHA, let branch):
+                launchFollowedRevision(
+                    expression: expression,
+                    resolvedSHA: resolvedSHA,
+                    branch: branch,
+                    worktree: worktree,
+                    environment: env
+                )
             case .commit(let commit):
                 launchCommitSelection(commit, worktree: worktree, environment: env)
             case .branch(let name):
@@ -393,6 +419,35 @@ final class ReviewTargetPaletteModel {
             case .header, .message:
                 break
             }
+        }
+    }
+
+    func validateRevisionQuery(environment env: ReviewTargetPaletteEnvironment) async {
+        guard case .targets(let worktree) = level else { return }
+        let expression = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        revisionValidationToken = UUID()
+        let token = revisionValidationToken
+        followedRevisionRow = nil
+        revisionValidationError = nil
+        guard !expression.isEmpty else { return }
+        do {
+            async let sha = env.resolveRevision(worktree, expression)
+            async let branch = env.currentBranch(worktree)
+            let (resolvedSHA, currentBranch) = try await (sha, branch)
+            guard revisionValidationToken == token,
+                  query.trimmingCharacters(in: .whitespacesAndNewlines) == expression,
+                  case .targets(let current) = level,
+                  current.id == worktree.id
+            else { return }
+            followedRevisionRow = .followedRevision(
+                expression: expression,
+                resolvedSHA: resolvedSHA,
+                branch: currentBranch
+            )
+            setSelectedIndex(0, selectable: targetRows().map(\.isSelectable))
+        } catch {
+            guard revisionValidationToken == token else { return }
+            revisionValidationError = "Could not resolve \(expression): \(error.localizedDescription)"
         }
     }
 
@@ -456,6 +511,29 @@ final class ReviewTargetPaletteModel {
         } catch {
             launchError = "Could not resolve \(name): \(error.localizedDescription)"
         }
+    }
+
+    private func launchFollowedRevision(
+        expression: String,
+        resolvedSHA: String,
+        branch: String,
+        worktree: Worktree,
+        environment env: ReviewTargetPaletteEnvironment
+    ) {
+        guard let revision = TrackedRevision(
+            expression: expression,
+            baselineBranch: branch,
+            resolvedSHA: resolvedSHA
+        ) else { return }
+        env.openTarget(
+            ReviewSessionTarget.trackedCommit(
+                worktreeID: worktree.id,
+                repositoryPath: worktree.path,
+                revision: revision,
+                title: "Review \(revision.expression)"
+            ),
+            worktree
+        )
     }
 
     // Commits arrive newest-first (git log order); "older" = larger index.

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -410,12 +410,9 @@ final class ReviewTargetPaletteModel {
             let rows = targetRows()
             guard rows.indices.contains(selectedIndex) else { return }
             switch rows[selectedIndex] {
-            case .followedRevision(let expression, let resolvedSHA, let branch, let headSHA):
-                launchFollowedRevision(
+            case .followedRevision(let expression, _, _, _):
+                await launchFollowedRevision(
                     expression: expression,
-                    resolvedSHA: resolvedSHA,
-                    branch: branch,
-                    headSHA: headSHA,
                     worktree: worktree,
                     environment: env
                 )
@@ -539,17 +536,21 @@ final class ReviewTargetPaletteModel {
 
     private func launchFollowedRevision(
         expression: String,
-        resolvedSHA: String,
-        branch: String,
-        headSHA: String,
         worktree: Worktree,
         environment env: ReviewTargetPaletteEnvironment
-    ) {
+    ) async {
+        let candidate: TrackedRevisionCandidate
+        do {
+            candidate = try await env.resolveTrackedRevision(worktree, expression)
+        } catch {
+            launchError = "Could not resolve \(expression): \(error.localizedDescription)"
+            return
+        }
         guard let revision = TrackedRevision(
             expression: expression,
-            baselineBranch: branch,
-            baselineHEAD: headSHA,
-            resolvedSHA: resolvedSHA
+            baselineBranch: candidate.branch,
+            baselineHEAD: candidate.headSHA,
+            resolvedSHA: candidate.sha
         ) else { return }
         env.openTarget(
             ReviewSessionTarget.trackedCommit(

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -437,16 +437,34 @@ final class ReviewTargetPaletteModel {
                   case .targets(let current) = level,
                   current.id == worktree.id
             else { return }
+            let previousSelection = targetRows().indices.contains(selectedIndex) ? targetRows()[selectedIndex] : nil
             followedRevisionRow = .followedRevision(
                 expression: expression,
                 resolvedSHA: candidate.sha,
                 branch: candidate.branch
             )
-            setSelectedIndex(0, selectable: targetRows().map(\.isSelectable))
+            preserveSelectionAfterRevisionValidation(previousSelection: previousSelection)
         } catch {
             guard revisionValidationToken == token else { return }
             revisionValidationError = "Could not resolve \(expression): \(error.localizedDescription)"
         }
+    }
+
+    private func preserveSelectionAfterRevisionValidation(previousSelection: TargetRow?) {
+        let rows = targetRows()
+        let selectable = rows.map(\.isSelectable)
+        let selectableIndexes = selectable.indices.filter { selectable[$0] }
+        if selectableIndexes.count == 1 {
+            setSelectedIndex(selectableIndexes[0], selectable: selectable)
+            return
+        }
+        if let previousSelection,
+           let preservedIndex = rows.firstIndex(of: previousSelection),
+           selectable[preservedIndex] {
+            selectedIndex = preservedIndex
+            return
+        }
+        setSelectedIndex(selectedIndex, selectable: selectable)
     }
 
     private func launchFullRange(

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -24,7 +24,7 @@ final class ReviewTargetPaletteModel {
 
     enum TargetRow: Equatable {
         case header(String)
-        case followedRevision(expression: String, resolvedSHA: String, branch: String)
+        case followedRevision(expression: String, resolvedSHA: String, branch: String, headSHA: String)
         case commit(CommitInfo)
         case branch(String)
         case message(String)
@@ -43,8 +43,8 @@ final class ReviewTargetPaletteModel {
         var stableId: String {
             switch self {
             case .header(let title):  return "header:\(title)"
-            case .followedRevision(let expression, let resolvedSHA, let branch):
-                return "followed:\(expression):\(resolvedSHA):\(branch)"
+            case .followedRevision(let expression, let resolvedSHA, let branch, let headSHA):
+                return "followed:\(expression):\(resolvedSHA):\(branch):\(headSHA)"
             case .commit(let commit): return "commit:\(commit.sha)"
             case .branch(let name):   return "branch:\(name)"
             case .message(let text):  return "message:\(text)"
@@ -404,11 +404,12 @@ final class ReviewTargetPaletteModel {
             let rows = targetRows()
             guard rows.indices.contains(selectedIndex) else { return }
             switch rows[selectedIndex] {
-            case .followedRevision(let expression, let resolvedSHA, let branch):
+            case .followedRevision(let expression, let resolvedSHA, let branch, let headSHA):
                 launchFollowedRevision(
                     expression: expression,
                     resolvedSHA: resolvedSHA,
                     branch: branch,
+                    headSHA: headSHA,
                     worktree: worktree,
                     environment: env
                 )
@@ -441,7 +442,8 @@ final class ReviewTargetPaletteModel {
             followedRevisionRow = .followedRevision(
                 expression: expression,
                 resolvedSHA: candidate.sha,
-                branch: candidate.branch
+                branch: candidate.branch,
+                headSHA: candidate.headSHA
             )
             preserveSelectionAfterRevisionValidation(previousSelection: previousSelection)
         } catch {
@@ -533,12 +535,14 @@ final class ReviewTargetPaletteModel {
         expression: String,
         resolvedSHA: String,
         branch: String,
+        headSHA: String,
         worktree: Worktree,
         environment env: ReviewTargetPaletteEnvironment
     ) {
         guard let revision = TrackedRevision(
             expression: expression,
             baselineBranch: branch,
+            baselineHEAD: headSHA,
             resolvedSHA: resolvedSHA
         ) else { return }
         env.openTarget(

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -172,11 +172,14 @@ final class ReviewTargetPaletteModel {
     func targetRows() -> [TargetRow] {
         guard case .targets = level else { return [] }
         if isLoadingTargets { return [.message("Loading commits…")] }
-        if let targetsError { return [.message(targetsError)] }
         var rows: [TargetRow] = []
         if let followedRevisionRow {
             rows.append(.header("Followed Revision"))
             rows.append(followedRevisionRow)
+        }
+        if let targetsError {
+            rows.append(.message(targetsError))
+            return rows
         }
         rows.append(.header("Commits"))
         let filteredCommits = ReviewScopeSelection.filteredCommits(commits, query: query)

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -173,7 +173,10 @@ final class ReviewTargetPaletteModel {
         guard case .targets = level else { return [] }
         if isLoadingTargets { return [.message("Loading commits…")] }
         var rows: [TargetRow] = []
-        if let followedRevisionRow {
+        let revisionExpression = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let followedRevisionRow,
+           case .followedRevision(let expression, _, _, _) = followedRevisionRow,
+           expression == revisionExpression {
             rows.append(.header("Followed Revision"))
             rows.append(followedRevisionRow)
         }

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -431,9 +431,7 @@ final class ReviewTargetPaletteModel {
         revisionValidationError = nil
         guard !expression.isEmpty else { return }
         do {
-            async let sha = env.resolveRevision(worktree, expression)
-            async let branch = env.currentBranch(worktree)
-            let (resolvedSHA, currentBranch) = try await (sha, branch)
+            let candidate = try await env.resolveTrackedRevision(worktree, expression)
             guard revisionValidationToken == token,
                   query.trimmingCharacters(in: .whitespacesAndNewlines) == expression,
                   case .targets(let current) = level,
@@ -441,8 +439,8 @@ final class ReviewTargetPaletteModel {
             else { return }
             followedRevisionRow = .followedRevision(
                 expression: expression,
-                resolvedSHA: resolvedSHA,
-                branch: currentBranch
+                resolvedSHA: candidate.sha,
+                branch: candidate.branch
             )
             setSelectedIndex(0, selectable: targetRows().map(\.isSelectable))
         } catch {

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -369,18 +369,16 @@ final class RemoteProjectGitWatcher {
             .split(whereSeparator: \.isNewline)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-            .sorted()
             .joined(separator: "\n")
     }
 
     nonisolated static func revisionConfigSignature(pathOutputs: [String: String]) -> String {
-        pathOutputs
-            .flatMap { path, output in
-                upstreamConfigSignature(from: output)
+        pathOutputs.keys.sorted()
+            .flatMap { path in
+                upstreamConfigSignature(from: pathOutputs[path] ?? "")
                     .split(whereSeparator: \.isNewline)
                     .map { "\(path):\($0)" }
             }
-            .sorted()
             .joined(separator: "\n")
     }
 

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -226,7 +226,7 @@ final class RemoteProjectGitWatcher {
 
     private func pollReflogOutput() async -> String {
         let result = try? await Process.git(
-            ["reflog", "show", "--all", "--format=%H %gD"],
+            ["reflog", "show", "--all", "--max-count=256", "--format=%H %gD"],
             cwd: projectPath
         )
         guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -197,20 +197,37 @@ final class RemoteProjectGitWatcher {
             }
             .sorted { $0.key < $1.key }
         for (pathKey, path) in worktreePaths {
-            for ref in Self.revisionPseudoRefs {
-                let probe = try? await Process.git(
-                    ["rev-parse", "--verify", "-q", "\(ref)^{commit}"],
-                    cwd: path
-                )
-                guard let probe, !RemoteExec.isConnectionFailure(exitCode: probe.exitCode) else {
-                    return nil
-                }
-                pseudoRefCommits["\(pathKey):\(ref)"] = probe.exitCode == 0
-                    ? probe.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-                    : ""
+            guard let commits = await pollPseudoRefCommits(at: path) else { return nil }
+            for (ref, commit) in commits {
+                pseudoRefCommits["\(pathKey):\(ref)"] = commit
             }
         }
         return Self.sharedRefsSignature(showRefOutput: result.stdout, pseudoRefCommits: pseudoRefCommits)
+    }
+
+    private func pollPseudoRefCommits(at path: URL) async -> [String: String]? {
+        let refs = Self.revisionPseudoRefs
+        let stdin = refs.map { "\($0)^{commit}" }.joined(separator: "\n") + "\n"
+        let result = try? await Process.git(
+            ["cat-file", "--batch-check=%(objectname)"],
+            cwd: path,
+            stdin: stdin
+        )
+        guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+            return nil
+        }
+        guard result.exitCode == 0 else { return Dictionary(uniqueKeysWithValues: refs.map { ($0, "") }) }
+        let lines = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
+        var commits: [String: String] = [:]
+        for (idx, ref) in refs.enumerated() {
+            guard lines.indices.contains(idx) else {
+                commits[ref] = ""
+                continue
+            }
+            let line = lines[idx].trimmingCharacters(in: .whitespacesAndNewlines)
+            commits[ref] = line.contains(" missing") ? "" : line
+        }
+        return commits
     }
 
     deinit { pollTask?.cancel() }

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -217,7 +217,7 @@ final class RemoteProjectGitWatcher {
         var pathOutputs: [String: String] = [:]
         for (pathKey, path) in worktreePaths {
             let result = try? await Process.git(
-                ["config", "--get-regexp", #"^(branch\..*\.(remote|merge|pushRemote)|remote\.pushDefault|push\.default)$"#],
+                ["config", "--get-regexp", Self.revisionConfigPattern],
                 cwd: path
             )
             guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
@@ -318,6 +318,9 @@ final class RemoteProjectGitWatcher {
             .sorted()
             .joined(separator: "\n")
     }
+
+    nonisolated static let revisionConfigPattern =
+        #"^(branch\..*\.(remote|merge|pushremote)|remote\.pushdefault|push\.default|remote\..*\.push)$"#
 
     nonisolated static func reflogSignature(from output: String) -> String {
         let lines = output

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CryptoKit
 import Foundation
 
 enum RemotePollCadence {
@@ -190,14 +191,14 @@ final class RemoteProjectGitWatcher {
             return nil
         }
         guard result.exitCode == 0 || result.exitCode == 1 else { return nil }
-        let upstreamConfigOutput = await pollUpstreamConfigOutput()
-        let reflogOutput = await pollReflogOutput()
-        var pseudoRefCommits: [String: String] = [:]
         let worktreePaths = ([projectPath] + entries.map { URL(fileURLWithPath: $0.path) })
             .reduce(into: [String: URL]()) { pathsByKey, path in
                 pathsByKey[path.standardizedFileURL.path] = path
             }
             .sorted { $0.key < $1.key }
+        let revisionConfigOutput = await pollRevisionConfigOutput(worktreePaths: worktreePaths)
+        let reflogSignature = await pollReflogSignature()
+        var pseudoRefCommits: [String: String] = [:]
         for (pathKey, path) in worktreePaths {
             guard let commits = await pollPseudoRefCommits(at: path) else { return nil }
             for (ref, commit) in commits {
@@ -206,34 +207,50 @@ final class RemoteProjectGitWatcher {
         }
         return Self.sharedRefsSignature(
             showRefOutput: result.stdout,
-            upstreamConfigOutput: upstreamConfigOutput,
-            reflogOutput: reflogOutput,
+            revisionConfigOutput: revisionConfigOutput,
+            reflogSignature: reflogSignature,
             pseudoRefCommits: pseudoRefCommits
         )
     }
 
-    private func pollUpstreamConfigOutput() async -> String {
-        let result = try? await Process.git(
-            ["config", "--get-regexp", #"^(branch\..*\.(remote|merge|pushRemote)|remote\.pushDefault|push\.default)$"#],
-            cwd: projectPath
-        )
-        guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
-            return ""
+    private func pollRevisionConfigOutput(worktreePaths: [(key: String, value: URL)]) async -> String {
+        var pathOutputs: [String: String] = [:]
+        for (pathKey, path) in worktreePaths {
+            let result = try? await Process.git(
+                ["config", "--get-regexp", #"^(branch\..*\.(remote|merge|pushRemote)|remote\.pushDefault|push\.default)$"#],
+                cwd: path
+            )
+            guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+                continue
+            }
+            guard result.exitCode == 0 || result.exitCode == 1 else { continue }
+            pathOutputs[pathKey] = result.stdout
         }
-        guard result.exitCode == 0 || result.exitCode == 1 else { return "" }
-        return Self.upstreamConfigSignature(from: result.stdout)
+        return Self.revisionConfigSignature(pathOutputs: pathOutputs)
     }
 
-    private func pollReflogOutput() async -> String {
-        let result = try? await Process.git(
-            ["reflog", "show", "--all", "--max-count=256", "--format=%H %gD"],
-            cwd: projectPath
-        )
+    private func pollReflogSignature() async -> String {
+        let result: ProcessResult?
+        if let host {
+            result = try? await RemoteExec.run(
+                host: host,
+                cwd: projectPath.path,
+                command: Self.reflogDigestCommand()
+            )
+        } else {
+            result = try? await Process.git(
+                ["reflog", "show", "--all", "--format=%H %gD"],
+                cwd: projectPath
+            )
+        }
         guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
             return ""
         }
         guard result.exitCode == 0 || result.exitCode == 1 else { return "" }
-        return result.stdout
+        guard host != nil else {
+            return Self.reflogSignature(from: result.stdout)
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func pollPseudoRefCommits(at path: URL) async -> [String: String]? {
@@ -265,16 +282,16 @@ final class RemoteProjectGitWatcher {
 
     nonisolated static func sharedRefsSignature(
         showRefOutput: String,
-        upstreamConfigOutput: String = "",
-        reflogOutput: String = "",
+        revisionConfigOutput: String = "",
+        reflogSignature: String = "",
         pseudoRefCommits: [String: String]
     ) -> String {
         var signature = showRefOutput
-        if !upstreamConfigOutput.isEmpty {
-            signature += "\nconfig:\(upstreamConfigOutput)"
+        if !revisionConfigOutput.isEmpty {
+            signature += "\nconfig:\(revisionConfigOutput)"
         }
-        if !reflogOutput.isEmpty {
-            signature += "\nreflog:\(reflogOutput)"
+        if !reflogSignature.isEmpty {
+            signature += "\nreflog:\(reflogSignature)"
         }
         for key in pseudoRefCommits.keys.sorted() {
             signature += "\n\(key):\(pseudoRefCommits[key] ?? "")"
@@ -289,6 +306,46 @@ final class RemoteProjectGitWatcher {
             .filter { !$0.isEmpty }
             .sorted()
             .joined(separator: "\n")
+    }
+
+    nonisolated static func revisionConfigSignature(pathOutputs: [String: String]) -> String {
+        pathOutputs
+            .flatMap { path, output in
+                upstreamConfigSignature(from: output)
+                    .split(whereSeparator: \.isNewline)
+                    .map { "\(path):\($0)" }
+            }
+            .sorted()
+            .joined(separator: "\n")
+    }
+
+    nonisolated static func reflogSignature(from output: String) -> String {
+        let lines = output
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+        let digest = SHA256.hash(data: Data(output.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "entries=\(lines.count);sha=\(digest)"
+    }
+
+    nonisolated static func reflogDigestCommand() -> String {
+        """
+        status=0
+        out=$(git reflog show --all --format='%H %gD') || status=$?
+        if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
+          exit "$status"
+        fi
+        if command -v shasum >/dev/null 2>&1; then
+          digest=$(printf '%s\\n' "$out" | shasum -a 256 | awk '{print $1}')
+        elif command -v sha256sum >/dev/null 2>&1; then
+          digest=$(printf '%s\\n' "$out" | sha256sum | awk '{print $1}')
+        else
+          digest=$(printf '%s\\n' "$out" | cksum | awk '{print $1 ":" $2}')
+        fi
+        count=$(printf '%s\\n' "$out" | sed '/^$/d' | wc -l | awk '{print $1}')
+        printf 'entries=%s;sha=%s\\n' "$count" "$digest"
+        """
     }
 
     nonisolated static let revisionPseudoRefs = [

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -131,8 +131,8 @@ final class RemoteProjectGitWatcher {
         if let host { RemoteHostStatusStore.shared.reportSuccess(host: host) }
         guard result.exitCode == 0 else { return true }
 
-        let sharedRefsSignature = await pollSharedRefsSignature()
         let entries = RemoteWorktreePoll.parse(porcelain: result.stdout)
+        let sharedRefsSignature = await pollSharedRefsSignature(entries: entries)
         defer {
             lastEntries = entries
             if let sharedRefsSignature {
@@ -184,22 +184,31 @@ final class RemoteProjectGitWatcher {
         )
     }
 
-    private func pollSharedRefsSignature() async -> String? {
+    private func pollSharedRefsSignature(entries: [RemoteWorktreePollEntry]) async -> String? {
         let result = try? await Process.git(["show-ref", "--head"], cwd: projectPath)
         guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
             return nil
         }
         guard result.exitCode == 0 || result.exitCode == 1 else { return nil }
         var pseudoRefCommits: [String: String] = [:]
-        for ref in Self.revisionPseudoRefs {
-            let probe = try? await Process.git(
-                ["rev-parse", "--verify", "-q", "\(ref)^{commit}"],
-                cwd: projectPath
-            )
-            guard let probe, !RemoteExec.isConnectionFailure(exitCode: probe.exitCode) else {
-                return nil
+        let worktreePaths = ([projectPath] + entries.map { URL(fileURLWithPath: $0.path) })
+            .reduce(into: [String: URL]()) { pathsByKey, path in
+                pathsByKey[path.standardizedFileURL.path] = path
             }
-            pseudoRefCommits[ref] = probe.exitCode == 0 ? probe.stdout.trimmingCharacters(in: .whitespacesAndNewlines) : ""
+            .sorted { $0.key < $1.key }
+        for (pathKey, path) in worktreePaths {
+            for ref in Self.revisionPseudoRefs {
+                let probe = try? await Process.git(
+                    ["rev-parse", "--verify", "-q", "\(ref)^{commit}"],
+                    cwd: path
+                )
+                guard let probe, !RemoteExec.isConnectionFailure(exitCode: probe.exitCode) else {
+                    return nil
+                }
+                pseudoRefCommits["\(pathKey):\(ref)"] = probe.exitCode == 0
+                    ? probe.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                    : ""
+            }
         }
         return Self.sharedRefsSignature(showRefOutput: result.stdout, pseudoRefCommits: pseudoRefCommits)
     }
@@ -211,8 +220,8 @@ final class RemoteProjectGitWatcher {
         pseudoRefCommits: [String: String]
     ) -> String {
         var signature = showRefOutput
-        for ref in revisionPseudoRefs {
-            signature += "\n\(ref):\(pseudoRefCommits[ref] ?? "")"
+        for key in pseudoRefCommits.keys.sorted() {
+            signature += "\n\(key):\(pseudoRefCommits[key] ?? "")"
         }
         return signature
     }

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -46,6 +46,7 @@ final class RemoteProjectGitWatcher {
     private var pollTask: Task<Void, Never>?
     private var helperSession: RemoteHelperWatchSession?
     private var lastEntries: [RemoteWorktreePollEntry]?
+    private var lastSharedRefsSignature: String?
     private var tickGate = RemoteProjectGitTickGate()
 
     init(projectPath: URL) {
@@ -130,8 +131,18 @@ final class RemoteProjectGitWatcher {
         if let host { RemoteHostStatusStore.shared.reportSuccess(host: host) }
         guard result.exitCode == 0 else { return true }
 
+        let sharedRefsSignature = await pollSharedRefsSignature()
         let entries = RemoteWorktreePoll.parse(porcelain: result.stdout)
-        defer { lastEntries = entries }
+        defer {
+            lastEntries = entries
+            if let sharedRefsSignature {
+                lastSharedRefsSignature = sharedRefsSignature
+            }
+        }
+        var sharedRefsMoved = false
+        if let sharedRefsSignature {
+            sharedRefsMoved = lastSharedRefsSignature != nil && lastSharedRefsSignature != sharedRefsSignature
+        }
         guard lastEntries != nil else {
             onTopologyChanged?()
             return true
@@ -144,9 +155,18 @@ final class RemoteProjectGitWatcher {
                 (URL(fileURLWithPath: $0.key), $0.value)
             }))
         }
-        if delta.headMoved { onRevisionChanged?() }
+        if delta.headMoved || sharedRefsMoved { onRevisionChanged?() }
         if delta.topologyChanged { onTopologyChanged?() }
         return true
+    }
+
+    private func pollSharedRefsSignature() async -> String? {
+        let result = try? await Process.git(["show-ref", "--head"], cwd: projectPath)
+        guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+            return nil
+        }
+        guard result.exitCode == 0 || result.exitCode == 1 else { return nil }
+        return result.stdout
     }
 
     deinit { pollTask?.cancel() }

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -212,7 +212,7 @@ final class RemoteProjectGitWatcher {
 
     private func pollUpstreamConfigOutput() async -> String {
         let result = try? await Process.git(
-            ["config", "--get-regexp", #"^branch\..*\.(remote|merge)$"#],
+            ["config", "--get-regexp", #"^(branch\..*\.(remote|merge|pushRemote)|remote\.pushDefault|push\.default)$"#],
             cwd: projectPath
         )
         guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -147,17 +147,41 @@ final class RemoteProjectGitWatcher {
             onTopologyChanged?()
             return true
         }
-        guard let old = lastEntries, let delta = RemoteWorktreePoll.classify(old: old, new: entries) else {
-            return true
-        }
-        if !delta.branchLabelsByPath.isEmpty {
-            onHeadChanged?(Dictionary(uniqueKeysWithValues: delta.branchLabelsByPath.map {
+        let events = Self.events(old: lastEntries, new: entries, sharedRefsMoved: sharedRefsMoved)
+        if !events.branchLabelsByPath.isEmpty {
+            onHeadChanged?(Dictionary(uniqueKeysWithValues: events.branchLabelsByPath.map {
                 (URL(fileURLWithPath: $0.key), $0.value)
             }))
         }
-        if delta.headMoved || sharedRefsMoved { onRevisionChanged?() }
-        if delta.topologyChanged { onTopologyChanged?() }
+        if events.revisionChanged { onRevisionChanged?() }
+        if events.topologyChanged { onTopologyChanged?() }
         return true
+    }
+
+    nonisolated static func events(
+        old: [RemoteWorktreePollEntry]?,
+        new: [RemoteWorktreePollEntry],
+        sharedRefsMoved: Bool
+    ) -> RemoteProjectGitWatcherEvents {
+        guard let old else {
+            return RemoteProjectGitWatcherEvents(
+                branchLabelsByPath: [:],
+                revisionChanged: sharedRefsMoved,
+                topologyChanged: true
+            )
+        }
+        guard let delta = RemoteWorktreePoll.classify(old: old, new: new) else {
+            return RemoteProjectGitWatcherEvents(
+                branchLabelsByPath: [:],
+                revisionChanged: sharedRefsMoved,
+                topologyChanged: false
+            )
+        }
+        return RemoteProjectGitWatcherEvents(
+            branchLabelsByPath: delta.branchLabelsByPath,
+            revisionChanged: delta.headMoved || sharedRefsMoved,
+            topologyChanged: delta.topologyChanged
+        )
     }
 
     private func pollSharedRefsSignature() async -> String? {
@@ -170,4 +194,10 @@ final class RemoteProjectGitWatcher {
     }
 
     deinit { pollTask?.cancel() }
+}
+
+struct RemoteProjectGitWatcherEvents: Equatable {
+    var branchLabelsByPath: [String: String]
+    var revisionChanged: Bool
+    var topologyChanged: Bool
 }

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -190,6 +190,7 @@ final class RemoteProjectGitWatcher {
             return nil
         }
         guard result.exitCode == 0 || result.exitCode == 1 else { return nil }
+        let upstreamConfigOutput = await pollUpstreamConfigOutput()
         var pseudoRefCommits: [String: String] = [:]
         let worktreePaths = ([projectPath] + entries.map { URL(fileURLWithPath: $0.path) })
             .reduce(into: [String: URL]()) { pathsByKey, path in
@@ -202,7 +203,23 @@ final class RemoteProjectGitWatcher {
                 pseudoRefCommits["\(pathKey):\(ref)"] = commit
             }
         }
-        return Self.sharedRefsSignature(showRefOutput: result.stdout, pseudoRefCommits: pseudoRefCommits)
+        return Self.sharedRefsSignature(
+            showRefOutput: result.stdout,
+            upstreamConfigOutput: upstreamConfigOutput,
+            pseudoRefCommits: pseudoRefCommits
+        )
+    }
+
+    private func pollUpstreamConfigOutput() async -> String {
+        let result = try? await Process.git(
+            ["config", "--get-regexp", #"^branch\..*\.(remote|merge)$"#],
+            cwd: projectPath
+        )
+        guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+            return ""
+        }
+        guard result.exitCode == 0 || result.exitCode == 1 else { return "" }
+        return Self.upstreamConfigSignature(from: result.stdout)
     }
 
     private func pollPseudoRefCommits(at path: URL) async -> [String: String]? {
@@ -234,13 +251,26 @@ final class RemoteProjectGitWatcher {
 
     nonisolated static func sharedRefsSignature(
         showRefOutput: String,
+        upstreamConfigOutput: String = "",
         pseudoRefCommits: [String: String]
     ) -> String {
         var signature = showRefOutput
+        if !upstreamConfigOutput.isEmpty {
+            signature += "\nconfig:\(upstreamConfigOutput)"
+        }
         for key in pseudoRefCommits.keys.sorted() {
             signature += "\n\(key):\(pseudoRefCommits[key] ?? "")"
         }
         return signature
+    }
+
+    nonisolated static func upstreamConfigSignature(from output: String) -> String {
+        output
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .sorted()
+            .joined(separator: "\n")
     }
 
     nonisolated static let revisionPseudoRefs = [

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -443,6 +443,10 @@ final class RemoteProjectGitWatcher {
         if let grafts = try? String(contentsOf: graftsURL, encoding: .utf8) {
             output.append("info/grafts \(shallowSignature(from: grafts))")
         }
+        let alternatesURL = gitDir.appendingPathComponent("objects").appendingPathComponent("info").appendingPathComponent("alternates")
+        if let alternates = try? String(contentsOf: alternatesURL, encoding: .utf8) {
+            output.append("objects/info/alternates \(shallowSignature(from: alternates))")
+        }
         return output
         .sorted()
         .joined(separator: "\n")
@@ -519,6 +523,19 @@ final class RemoteProjectGitWatcher {
             fi
             count=$(printf '%s\\n' "$out" | sed '/^$/d' | wc -l | awk '{print $1}')
             printf 'info/grafts entries=%s;sha=%s\\n' "$count" "$digest"
+          fi
+          alternates="$git_dir/objects/info/alternates"
+          if [ -f "$alternates" ]; then
+            out=$(cat "$alternates" 2>/dev/null || true)
+            if command -v shasum >/dev/null 2>&1; then
+              digest=$(printf '%s\\n' "$out" | shasum -a 256 | awk '{print $1}')
+            elif command -v sha256sum >/dev/null 2>&1; then
+              digest=$(printf '%s\\n' "$out" | sha256sum | awk '{print $1}')
+            else
+              digest=$(printf '%s\\n' "$out" | cksum | awk '{print $1 ":" $2}')
+            fi
+            count=$(printf '%s\\n' "$out" | sed '/^$/d' | wc -l | awk '{print $1}')
+            printf 'objects/info/alternates entries=%s;sha=%s\\n' "$count" "$digest"
           fi
         } | sort
         """

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -144,6 +144,7 @@ final class RemoteProjectGitWatcher {
                 (URL(fileURLWithPath: $0.key), $0.value)
             }))
         }
+        if delta.headMoved { onRevisionChanged?() }
         if delta.topologyChanged { onTopologyChanged?() }
         return true
     }

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -411,7 +411,7 @@ final class RemoteProjectGitWatcher {
     }
 
     nonisolated static let revisionConfigPattern =
-        #"^(branch\..*\.(remote|merge|pushremote)|remote\.pushdefault|push\.default|remote\..*\.push)$"#
+        #"^(branch\..*\.(remote|merge|pushremote)|remote\.pushdefault|push\.default|remote\..*\.(fetch|push))$"#
 
     nonisolated static func customTopLevelRefsOutput(at worktreePath: URL) async -> String {
         guard let gitDirResult = try? await Process.git(

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -190,10 +190,42 @@ final class RemoteProjectGitWatcher {
             return nil
         }
         guard result.exitCode == 0 || result.exitCode == 1 else { return nil }
-        return result.stdout
+        var pseudoRefCommits: [String: String] = [:]
+        for ref in Self.revisionPseudoRefs {
+            let probe = try? await Process.git(
+                ["rev-parse", "--verify", "-q", "\(ref)^{commit}"],
+                cwd: projectPath
+            )
+            guard let probe, !RemoteExec.isConnectionFailure(exitCode: probe.exitCode) else {
+                return nil
+            }
+            pseudoRefCommits[ref] = probe.exitCode == 0 ? probe.stdout.trimmingCharacters(in: .whitespacesAndNewlines) : ""
+        }
+        return Self.sharedRefsSignature(showRefOutput: result.stdout, pseudoRefCommits: pseudoRefCommits)
     }
 
     deinit { pollTask?.cancel() }
+
+    nonisolated static func sharedRefsSignature(
+        showRefOutput: String,
+        pseudoRefCommits: [String: String]
+    ) -> String {
+        var signature = showRefOutput
+        for ref in revisionPseudoRefs {
+            signature += "\n\(ref):\(pseudoRefCommits[ref] ?? "")"
+        }
+        return signature
+    }
+
+    nonisolated static let revisionPseudoRefs = [
+        "AUTO_MERGE",
+        "CHERRY_PICK_HEAD",
+        "FETCH_HEAD",
+        "MERGE_HEAD",
+        "ORIG_HEAD",
+        "REBASE_HEAD",
+        "REVERT_HEAD",
+    ]
 }
 
 struct RemoteProjectGitWatcherEvents: Equatable {

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -197,6 +197,7 @@ final class RemoteProjectGitWatcher {
             }
             .sorted { $0.key < $1.key }
         let revisionConfigOutput = await pollRevisionConfigOutput(worktreePaths: worktreePaths)
+        let privateRefsOutput = await pollPrivateRefsOutput(worktreePaths: worktreePaths)
         let reflogSignature = await pollReflogSignature()
         var pseudoRefCommits: [String: String] = [:]
         for (pathKey, path) in worktreePaths {
@@ -208,6 +209,7 @@ final class RemoteProjectGitWatcher {
         return Self.sharedRefsSignature(
             showRefOutput: result.stdout,
             revisionConfigOutput: revisionConfigOutput,
+            privateRefsOutput: privateRefsOutput,
             reflogSignature: reflogSignature,
             pseudoRefCommits: pseudoRefCommits
         )
@@ -227,6 +229,28 @@ final class RemoteProjectGitWatcher {
             pathOutputs[pathKey] = result.stdout
         }
         return Self.revisionConfigSignature(pathOutputs: pathOutputs)
+    }
+
+    private func pollPrivateRefsOutput(worktreePaths: [(key: String, value: URL)]) async -> String {
+        var pathOutputs: [String: String] = [:]
+        for (pathKey, path) in worktreePaths {
+            let result = try? await Process.git(
+                [
+                    "for-each-ref",
+                    "--format=%(objectname) %(refname)",
+                    "refs/worktree",
+                    "refs/bisect",
+                    "refs/rewritten",
+                ],
+                cwd: path
+            )
+            guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+                continue
+            }
+            guard result.exitCode == 0 else { continue }
+            pathOutputs[pathKey] = result.stdout
+        }
+        return Self.privateRefsSignature(pathOutputs: pathOutputs)
     }
 
     private func pollReflogSignature() async -> String {
@@ -283,12 +307,16 @@ final class RemoteProjectGitWatcher {
     nonisolated static func sharedRefsSignature(
         showRefOutput: String,
         revisionConfigOutput: String = "",
+        privateRefsOutput: String = "",
         reflogSignature: String = "",
         pseudoRefCommits: [String: String]
     ) -> String {
         var signature = showRefOutput
         if !revisionConfigOutput.isEmpty {
             signature += "\nconfig:\(revisionConfigOutput)"
+        }
+        if !privateRefsOutput.isEmpty {
+            signature += "\nprivate-refs:\(privateRefsOutput)"
         }
         if !reflogSignature.isEmpty {
             signature += "\nreflog:\(reflogSignature)"
@@ -313,6 +341,19 @@ final class RemoteProjectGitWatcher {
             .flatMap { path, output in
                 upstreamConfigSignature(from: output)
                     .split(whereSeparator: \.isNewline)
+                    .map { "\(path):\($0)" }
+            }
+            .sorted()
+            .joined(separator: "\n")
+    }
+
+    nonisolated static func privateRefsSignature(pathOutputs: [String: String]) -> String {
+        pathOutputs
+            .flatMap { path, output in
+                output
+                    .split(whereSeparator: \.isNewline)
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
                     .map { "\(path):\($0)" }
             }
             .sorted()

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -423,9 +423,12 @@ final class RemoteProjectGitWatcher {
             let name = url.lastPathComponent
             guard !nonRevisionTopLevelRefNames.contains(name),
                   (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true,
-                  let contents = try? String(contentsOf: url, encoding: .utf8),
-                  isTopLevelRevisionContent(contents)
+                  let contents = try? String(contentsOf: url, encoding: .utf8)
             else { return nil }
+            if name == "shallow" {
+                return "shallow \(shallowSignature(from: contents))"
+            }
+            guard isTopLevelRevisionContent(contents) else { return nil }
             return "\(name) \(contents.trimmingCharacters(in: .whitespacesAndNewlines))"
         }
         .sorted()
@@ -472,6 +475,19 @@ final class RemoteProjectGitWatcher {
             \(ignored)) continue ;;
           esac
           IFS= read -r line < "$path" || line=
+          if [ "$name" = shallow ]; then
+            out=$(cat "$path" 2>/dev/null || true)
+            if command -v shasum >/dev/null 2>&1; then
+              digest=$(printf '%s\\n' "$out" | shasum -a 256 | awk '{print $1}')
+            elif command -v sha256sum >/dev/null 2>&1; then
+              digest=$(printf '%s\\n' "$out" | sha256sum | awk '{print $1}')
+            else
+              digest=$(printf '%s\\n' "$out" | cksum | awk '{print $1 ":" $2}')
+            fi
+            count=$(printf '%s\\n' "$out" | sed '/^$/d' | wc -l | awk '{print $1}')
+            printf 'shallow entries=%s;sha=%s\\n' "$count" "$digest"
+            continue
+          fi
           case "$line" in
             "ref: refs/"*) printf '%s %s\\n' "$name" "$line" ;;
             *) printf '%s' "$line" | grep -Eq '^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$' && printf '%s %s\\n' "$name" "$line" ;;
@@ -490,6 +506,16 @@ final class RemoteProjectGitWatcher {
             return true
         }
         return (line.count == 40 || line.count == 64) && line.allSatisfy(\.isHexDigit)
+    }
+
+    nonisolated static func shallowSignature(from output: String) -> String {
+        let lines = output
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+        let digest = SHA256.hash(data: Data(output.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "entries=\(lines.count);sha=\(digest)"
     }
 
     nonisolated static let nonRevisionTopLevelRefNames: Set<String> = [

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -64,9 +64,12 @@ final class RemoteProjectGitWatcher {
                 kinds: [.git]
             )
             session.onEvent = { [weak self] event in
-                guard event.kind == .git else { return }
+                let action = Self.helperEventAction(for: event)
+                guard action.runTick else { return }
                 Task { @MainActor in
-                    self?.onRevisionChanged?()
+                    if action.bumpRevisionImmediately {
+                        self?.onRevisionChanged?()
+                    }
                     _ = await self?.runTick()
                 }
             }
@@ -182,6 +185,13 @@ final class RemoteProjectGitWatcher {
             branchLabelsByPath: delta.branchLabelsByPath,
             revisionChanged: delta.headMoved || sharedRefsMoved,
             topologyChanged: delta.topologyChanged
+        )
+    }
+
+    nonisolated static func helperEventAction(for event: RemoteHelperWatchEvent) -> RemoteProjectGitWatcherHelperEventAction {
+        RemoteProjectGitWatcherHelperEventAction(
+            runTick: event.kind == .git,
+            bumpRevisionImmediately: false
         )
     }
 
@@ -556,4 +566,9 @@ struct RemoteProjectGitWatcherEvents: Equatable {
     var branchLabelsByPath: [String: String]
     var revisionChanged: Bool
     var topologyChanged: Bool
+}
+
+struct RemoteProjectGitWatcherHelperEventAction: Equatable {
+    var runTick: Bool
+    var bumpRevisionImmediately: Bool
 }

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -197,6 +197,7 @@ final class RemoteProjectGitWatcher {
             }
             .sorted { $0.key < $1.key }
         let revisionConfigOutput = await pollRevisionConfigOutput(worktreePaths: worktreePaths)
+        let customTopLevelRefsOutput = await pollCustomTopLevelRefsOutput(worktreePaths: worktreePaths)
         let privateRefsOutput = await pollPrivateRefsOutput(worktreePaths: worktreePaths)
         let reflogSignature = await pollReflogSignature()
         var pseudoRefCommits: [String: String] = [:]
@@ -209,6 +210,7 @@ final class RemoteProjectGitWatcher {
         return Self.sharedRefsSignature(
             showRefOutput: result.stdout,
             revisionConfigOutput: revisionConfigOutput,
+            customTopLevelRefsOutput: customTopLevelRefsOutput,
             privateRefsOutput: privateRefsOutput,
             reflogSignature: reflogSignature,
             pseudoRefCommits: pseudoRefCommits
@@ -229,6 +231,27 @@ final class RemoteProjectGitWatcher {
             pathOutputs[pathKey] = result.stdout
         }
         return Self.revisionConfigSignature(pathOutputs: pathOutputs)
+    }
+
+    private func pollCustomTopLevelRefsOutput(worktreePaths: [(key: String, value: URL)]) async -> String {
+        var pathOutputs: [String: String] = [:]
+        for (pathKey, path) in worktreePaths {
+            if let host {
+                let result = try? await RemoteExec.run(
+                    host: host,
+                    cwd: path.path,
+                    command: Self.customTopLevelRefsCommand()
+                )
+                guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+                    continue
+                }
+                guard result.exitCode == 0 else { continue }
+                pathOutputs[pathKey] = result.stdout
+            } else {
+                pathOutputs[pathKey] = await Self.customTopLevelRefsOutput(at: path)
+            }
+        }
+        return Self.topLevelRefsSignature(pathOutputs: pathOutputs)
     }
 
     private func pollPrivateRefsOutput(worktreePaths: [(key: String, value: URL)]) async -> String {
@@ -307,6 +330,7 @@ final class RemoteProjectGitWatcher {
     nonisolated static func sharedRefsSignature(
         showRefOutput: String,
         revisionConfigOutput: String = "",
+        customTopLevelRefsOutput: String = "",
         privateRefsOutput: String = "",
         reflogSignature: String = "",
         pseudoRefCommits: [String: String]
@@ -314,6 +338,9 @@ final class RemoteProjectGitWatcher {
         var signature = showRefOutput
         if !revisionConfigOutput.isEmpty {
             signature += "\nconfig:\(revisionConfigOutput)"
+        }
+        if !customTopLevelRefsOutput.isEmpty {
+            signature += "\ntop-level-refs:\(customTopLevelRefsOutput)"
         }
         if !privateRefsOutput.isEmpty {
             signature += "\nprivate-refs:\(privateRefsOutput)"
@@ -347,6 +374,19 @@ final class RemoteProjectGitWatcher {
             .joined(separator: "\n")
     }
 
+    nonisolated static func topLevelRefsSignature(pathOutputs: [String: String]) -> String {
+        pathOutputs
+            .flatMap { path, output in
+                output
+                    .split(whereSeparator: \.isNewline)
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                    .map { "\(path):\($0)" }
+            }
+            .sorted()
+            .joined(separator: "\n")
+    }
+
     nonisolated static func privateRefsSignature(pathOutputs: [String: String]) -> String {
         pathOutputs
             .flatMap { path, output in
@@ -362,6 +402,35 @@ final class RemoteProjectGitWatcher {
 
     nonisolated static let revisionConfigPattern =
         #"^(branch\..*\.(remote|merge|pushremote)|remote\.pushdefault|push\.default|remote\..*\.push)$"#
+
+    nonisolated static func customTopLevelRefsOutput(at worktreePath: URL) async -> String {
+        guard let gitDirResult = try? await Process.git(
+            ["rev-parse", "--absolute-git-dir"],
+            cwd: worktreePath
+        ),
+            gitDirResult.exitCode == 0
+        else { return "" }
+        let gitDirPath = gitDirResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !gitDirPath.isEmpty else { return "" }
+        let gitDir = URL(fileURLWithPath: gitDirPath)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: gitDir,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )
+        else { return "" }
+        return entries.compactMap { url -> String? in
+            let name = url.lastPathComponent
+            guard !nonRevisionTopLevelRefNames.contains(name),
+                  (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true,
+                  let contents = try? String(contentsOf: url, encoding: .utf8),
+                  isTopLevelRevisionContent(contents)
+            else { return nil }
+            return "\(name) \(contents.trimmingCharacters(in: .whitespacesAndNewlines))"
+        }
+        .sorted()
+        .joined(separator: "\n")
+    }
 
     nonisolated static func reflogSignature(from output: String) -> String {
         let lines = output
@@ -391,6 +460,60 @@ final class RemoteProjectGitWatcher {
         printf 'entries=%s;sha=%s\\n' "$count" "$digest"
         """
     }
+
+    nonisolated static func customTopLevelRefsCommand() -> String {
+        let ignored = nonRevisionTopLevelRefNames.sorted().joined(separator: "|")
+        return """
+        git_dir=$(git rev-parse --absolute-git-dir) || exit $?
+        [ -d "$git_dir" ] || exit 0
+        find "$git_dir" -maxdepth 1 -type f -print | while IFS= read -r path; do
+          name=${path##*/}
+          case "$name" in
+            \(ignored)) continue ;;
+          esac
+          IFS= read -r line < "$path" || line=
+          case "$line" in
+            "ref: refs/"*) printf '%s %s\\n' "$name" "$line" ;;
+            *) printf '%s' "$line" | grep -Eq '^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$' && printf '%s %s\\n' "$name" "$line" ;;
+          esac
+        done | sort
+        """
+    }
+
+    nonisolated static func isTopLevelRevisionContent(_ contents: String) -> Bool {
+        let line = contents
+            .split(whereSeparator: \.isNewline)
+            .first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if line.hasPrefix("ref: refs/") {
+            return true
+        }
+        return (line.count == 40 || line.count == 64) && line.allSatisfy(\.isHexDigit)
+    }
+
+    nonisolated static let nonRevisionTopLevelRefNames: Set<String> = [
+        "branches",
+        "COMMIT_EDITMSG",
+        "commondir",
+        "config",
+        "config.worktree",
+        "description",
+        "gc.log",
+        "gitdir",
+        "hooks",
+        "index",
+        "info",
+        "logs",
+        "MERGE_MSG",
+        "modules",
+        "objects",
+        "packed-refs",
+        "refs",
+        "SQUASH_MSG",
+        "TAG_EDITMSG",
+        "worktrees",
+    ]
 
     nonisolated static let revisionPseudoRefs = [
         "AUTO_MERGE",

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -38,6 +38,7 @@ struct RemoteProjectGitTickGate {
 @MainActor
 final class RemoteProjectGitWatcher {
     var onHeadChanged: (([URL: String]) -> Void)?
+    var onRevisionChanged: (() -> Void)?
     var onTopologyChanged: (() -> Void)?
 
     private let projectPath: URL
@@ -62,7 +63,10 @@ final class RemoteProjectGitWatcher {
             )
             session.onEvent = { [weak self] event in
                 guard event.kind == .git else { return }
-                Task { @MainActor in _ = await self?.runTick() }
+                Task { @MainActor in
+                    self?.onRevisionChanged?()
+                    _ = await self?.runTick()
+                }
             }
             session.onAvailabilityChanged = { [weak self] _ in
                 self?.restartPolling()

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -429,7 +429,7 @@ final class RemoteProjectGitWatcher {
             options: [.skipsHiddenFiles]
         )
         else { return "" }
-        return entries.compactMap { url -> String? in
+        var output = entries.compactMap { url -> String? in
             let name = url.lastPathComponent
             guard !nonRevisionTopLevelRefNames.contains(name),
                   (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true,
@@ -441,6 +441,11 @@ final class RemoteProjectGitWatcher {
             guard isTopLevelRevisionContent(contents) else { return nil }
             return "\(name) \(contents.trimmingCharacters(in: .whitespacesAndNewlines))"
         }
+        let graftsURL = gitDir.appendingPathComponent("info").appendingPathComponent("grafts")
+        if let grafts = try? String(contentsOf: graftsURL, encoding: .utf8) {
+            output.append("info/grafts \(shallowSignature(from: grafts))")
+        }
+        return output
         .sorted()
         .joined(separator: "\n")
     }
@@ -479,14 +484,34 @@ final class RemoteProjectGitWatcher {
         return """
         git_dir=$(git rev-parse --absolute-git-dir) || exit $?
         [ -d "$git_dir" ] || exit 0
-        find "$git_dir" -maxdepth 1 -type f -print | while IFS= read -r path; do
-          name=${path##*/}
-          case "$name" in
-            \(ignored)) continue ;;
-          esac
-          IFS= read -r line < "$path" || line=
-          if [ "$name" = shallow ]; then
-            out=$(cat "$path" 2>/dev/null || true)
+        {
+          find "$git_dir" -maxdepth 1 -type f -print | while IFS= read -r path; do
+            name=${path##*/}
+            case "$name" in
+              \(ignored)) continue ;;
+            esac
+            IFS= read -r line < "$path" || line=
+            if [ "$name" = shallow ]; then
+              out=$(cat "$path" 2>/dev/null || true)
+              if command -v shasum >/dev/null 2>&1; then
+                digest=$(printf '%s\\n' "$out" | shasum -a 256 | awk '{print $1}')
+              elif command -v sha256sum >/dev/null 2>&1; then
+                digest=$(printf '%s\\n' "$out" | sha256sum | awk '{print $1}')
+              else
+                digest=$(printf '%s\\n' "$out" | cksum | awk '{print $1 ":" $2}')
+              fi
+              count=$(printf '%s\\n' "$out" | sed '/^$/d' | wc -l | awk '{print $1}')
+              printf 'shallow entries=%s;sha=%s\\n' "$count" "$digest"
+              continue
+            fi
+            case "$line" in
+              "ref: refs/"*) printf '%s %s\\n' "$name" "$line" ;;
+              *) printf '%s' "$line" | grep -Eq '^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$' && printf '%s %s\\n' "$name" "$line" ;;
+            esac
+          done
+          grafts="$git_dir/info/grafts"
+          if [ -f "$grafts" ]; then
+            out=$(cat "$grafts" 2>/dev/null || true)
             if command -v shasum >/dev/null 2>&1; then
               digest=$(printf '%s\\n' "$out" | shasum -a 256 | awk '{print $1}')
             elif command -v sha256sum >/dev/null 2>&1; then
@@ -495,14 +520,9 @@ final class RemoteProjectGitWatcher {
               digest=$(printf '%s\\n' "$out" | cksum | awk '{print $1 ":" $2}')
             fi
             count=$(printf '%s\\n' "$out" | sed '/^$/d' | wc -l | awk '{print $1}')
-            printf 'shallow entries=%s;sha=%s\\n' "$count" "$digest"
-            continue
+            printf 'info/grafts entries=%s;sha=%s\\n' "$count" "$digest"
           fi
-          case "$line" in
-            "ref: refs/"*) printf '%s %s\\n' "$name" "$line" ;;
-            *) printf '%s' "$line" | grep -Eq '^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$' && printf '%s %s\\n' "$name" "$line" ;;
-          esac
-        done | sort
+        } | sort
         """
     }
 

--- a/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
+++ b/Alas/Sources/SSH/RemoteProjectGitWatcher.swift
@@ -191,6 +191,7 @@ final class RemoteProjectGitWatcher {
         }
         guard result.exitCode == 0 || result.exitCode == 1 else { return nil }
         let upstreamConfigOutput = await pollUpstreamConfigOutput()
+        let reflogOutput = await pollReflogOutput()
         var pseudoRefCommits: [String: String] = [:]
         let worktreePaths = ([projectPath] + entries.map { URL(fileURLWithPath: $0.path) })
             .reduce(into: [String: URL]()) { pathsByKey, path in
@@ -206,6 +207,7 @@ final class RemoteProjectGitWatcher {
         return Self.sharedRefsSignature(
             showRefOutput: result.stdout,
             upstreamConfigOutput: upstreamConfigOutput,
+            reflogOutput: reflogOutput,
             pseudoRefCommits: pseudoRefCommits
         )
     }
@@ -220,6 +222,18 @@ final class RemoteProjectGitWatcher {
         }
         guard result.exitCode == 0 || result.exitCode == 1 else { return "" }
         return Self.upstreamConfigSignature(from: result.stdout)
+    }
+
+    private func pollReflogOutput() async -> String {
+        let result = try? await Process.git(
+            ["reflog", "show", "--all", "--format=%H %gD"],
+            cwd: projectPath
+        )
+        guard let result, !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+            return ""
+        }
+        guard result.exitCode == 0 || result.exitCode == 1 else { return "" }
+        return result.stdout
     }
 
     private func pollPseudoRefCommits(at path: URL) async -> [String: String]? {
@@ -252,11 +266,15 @@ final class RemoteProjectGitWatcher {
     nonisolated static func sharedRefsSignature(
         showRefOutput: String,
         upstreamConfigOutput: String = "",
+        reflogOutput: String = "",
         pseudoRefCommits: [String: String]
     ) -> String {
         var signature = showRefOutput
         if !upstreamConfigOutput.isEmpty {
             signature += "\nconfig:\(upstreamConfigOutput)"
+        }
+        if !reflogOutput.isEmpty {
+            signature += "\nreflog:\(reflogOutput)"
         }
         for key in pseudoRefCommits.keys.sorted() {
             signature += "\n\(key):\(pseudoRefCommits[key] ?? "")"

--- a/Alas/Sources/SSH/RemoteWorktreePoll.swift
+++ b/Alas/Sources/SSH/RemoteWorktreePoll.swift
@@ -10,6 +10,8 @@ struct RemoteWorktreePollEntry: Equatable {
 struct RemoteWorktreePollDelta: Equatable {
     /// Worktree path to display branch label, for `applyHeadUpdates`.
     let branchLabelsByPath: [String: String]
+    /// True when any existing worktree HEAD moved.
+    let headMoved: Bool
     /// True when worktrees were added/removed or any HEAD moved.
     let topologyChanged: Bool
 }
@@ -80,6 +82,7 @@ enum RemoteWorktreePoll {
 
         return RemoteWorktreePollDelta(
             branchLabelsByPath: branchLabelsByPath,
+            headMoved: headMoved,
             topologyChanged: pathSetChanged || headMoved
         )
     }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -64,6 +64,12 @@ enum GitEventFilter {
             if parts.count == 3 && Self.revisionPseudoRefs.contains(parts[2]) {
                 return .revisionChange
             }
+            if parts.count == 3 && parts[2] == "config.worktree" {
+                return .revisionChange
+            }
+            if parts.count >= 4 && parts[2] == "logs" {
+                return .revisionChange
+            }
             return .other
         }
 

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -70,6 +70,9 @@ enum GitEventFilter {
             if parts.count >= 4 && parts[2] == "logs" {
                 return .revisionChange
             }
+            if parts.count >= 4 && parts[2] == "refs" {
+                return .revisionChange
+            }
             return .other
         }
 

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -7,6 +7,7 @@ import Foundation
 enum GitEventCategory: Equatable {
     case ignored                  // *.lock under .git/ — mid-write, never react
     case headChange(URL)          // worktree root whose HEAD just changed
+    case revisionChange           // shared refs moved; tracked revisions may resolve differently
     case topologyChange           // .git/worktrees/ contents changed
     case other                    // unrelated event, caller decides
 }
@@ -64,14 +65,8 @@ enum GitEventFilter {
 
         if rel == "worktrees" { return .topologyChange }
 
-        // Branch ref updates: refs/heads/<...> and the consolidated packed-refs
-        // file both reflect commit/checkout/reset/pull activity. Route through
-        // the topology debouncer so refreshWorktrees re-reads lastActivity from
-        // the updated ref file mtimes and re-applies ordering. (For the linked
-        // worktree HEAD case we already short-circuit via `worktrees/<name>/HEAD`
-        // above; this branch covers the shared branch refs.)
-        if rel == "packed-refs" || rel.hasPrefix("refs/heads/") {
-            return .topologyChange
+        if rel == "packed-refs" || rel.hasPrefix("refs/") {
+            return .revisionChange
         }
 
         return .other

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -87,6 +87,9 @@ enum GitEventFilter {
         if rel == "shallow" {
             return .revisionChange
         }
+        if rel == "info/grafts" {
+            return .revisionChange
+        }
         if rel == "logs/HEAD" || rel.hasPrefix("logs/refs/") {
             return .revisionChange
         }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -123,7 +123,7 @@ enum GitEventFilter {
         guard let contents = try? String(contentsOfFile: eventPath, encoding: .utf8) else {
             return true
         }
-        return contents.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("ref: refs/")
+        return isTopLevelRevisionContent(contents)
     }
 
     private static let nonRevisionTopLevelNames: Set<String> = [
@@ -148,4 +148,16 @@ enum GitEventFilter {
         "TAG_EDITMSG",
         "worktrees",
     ]
+
+    private static func isTopLevelRevisionContent(_ contents: String) -> Bool {
+        let line = contents
+            .split(whereSeparator: \.isNewline)
+            .first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if line.hasPrefix("ref: refs/") {
+            return true
+        }
+        return (line.count == 40 || line.count == 64) && line.allSatisfy(\.isHexDigit)
+    }
 }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -84,6 +84,9 @@ enum GitEventFilter {
         if rel == "config" || rel == "config.worktree" {
             return .revisionChange
         }
+        if rel == "shallow" {
+            return .revisionChange
+        }
         if rel == "logs/HEAD" || rel.hasPrefix("logs/refs/") {
             return .revisionChange
         }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -8,6 +8,7 @@ enum GitEventCategory: Equatable {
     case ignored                  // *.lock under .git/ — mid-write, never react
     case headChange(URL)          // worktree root whose HEAD just changed
     case revisionChange           // shared refs moved; tracked revisions may resolve differently
+    case revisionAndTopologyChange
     case topologyChange           // .git/worktrees/ contents changed
     case other                    // unrelated event, caller decides
 }
@@ -65,7 +66,13 @@ enum GitEventFilter {
 
         if rel == "worktrees" { return .topologyChange }
 
-        if rel == "packed-refs" || rel.hasPrefix("refs/") {
+        if rel == "packed-refs" {
+            return .revisionChange
+        }
+        if rel.hasPrefix("refs/heads/") {
+            return .revisionAndTopologyChange
+        }
+        if rel.hasPrefix("refs/") {
             return .revisionChange
         }
 

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -90,6 +90,9 @@ enum GitEventFilter {
         if rel == "info/grafts" {
             return .revisionChange
         }
+        if rel == "objects/info/alternates" {
+            return .revisionChange
+        }
         if rel == "logs/HEAD" || rel.hasPrefix("logs/refs/") {
             return .revisionChange
         }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -61,6 +61,9 @@ enum GitEventFilter {
                 let worktreeRoot = URL(fileURLWithPath: gitlink).deletingLastPathComponent()
                 return .headChange(worktreeRoot.standardizedFileURL)
             }
+            if parts.count == 3 && Self.revisionPseudoRefs.contains(parts[2]) {
+                return .revisionChange
+            }
             return .other
         }
 

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -69,6 +69,9 @@ enum GitEventFilter {
         if rel == "packed-refs" {
             return .revisionChange
         }
+        if Self.revisionPseudoRefs.contains(rel) {
+            return .revisionChange
+        }
         if rel.hasPrefix("refs/heads/") {
             return .revisionAndTopologyChange
         }
@@ -78,4 +81,14 @@ enum GitEventFilter {
 
         return .other
     }
+
+    private static let revisionPseudoRefs: Set<String> = [
+        "AUTO_MERGE",
+        "CHERRY_PICK_HEAD",
+        "FETCH_HEAD",
+        "MERGE_HEAD",
+        "ORIG_HEAD",
+        "REBASE_HEAD",
+        "REVERT_HEAD",
+    ]
 }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -79,7 +79,7 @@ enum GitEventFilter {
         if rel == "worktrees" { return .topologyChange }
 
         if rel == "packed-refs" {
-            return .revisionChange
+            return .revisionAndTopologyChange
         }
         if rel == "config" || rel == "config.worktree" {
             return .revisionChange

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -75,6 +75,9 @@ enum GitEventFilter {
         if rel == "config" {
             return .revisionChange
         }
+        if rel == "logs/HEAD" || rel.hasPrefix("logs/refs/") {
+            return .revisionChange
+        }
         if Self.revisionPseudoRefs.contains(rel) {
             return .revisionChange
         }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -90,6 +90,9 @@ enum GitEventFilter {
         if Self.revisionPseudoRefs.contains(rel) {
             return .revisionChange
         }
+        if isTopLevelSymbolicRevision(eventPath: eventPath, relativePath: rel) {
+            return .revisionChange
+        }
         if rel.hasPrefix("refs/heads/") {
             return .revisionAndTopologyChange
         }
@@ -109,4 +112,12 @@ enum GitEventFilter {
         "REBASE_HEAD",
         "REVERT_HEAD",
     ]
+
+    private static func isTopLevelSymbolicRevision(eventPath: String, relativePath: String) -> Bool {
+        guard !relativePath.isEmpty,
+              !relativePath.contains("/"),
+              let contents = try? String(contentsOfFile: eventPath, encoding: .utf8)
+        else { return false }
+        return contents.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("ref: refs/")
+    }
 }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -115,9 +115,37 @@ enum GitEventFilter {
 
     private static func isTopLevelSymbolicRevision(eventPath: String, relativePath: String) -> Bool {
         guard !relativePath.isEmpty,
-              !relativePath.contains("/"),
-              let contents = try? String(contentsOfFile: eventPath, encoding: .utf8)
+              !relativePath.contains("/")
         else { return false }
+        if nonRevisionTopLevelNames.contains(relativePath) {
+            return false
+        }
+        guard let contents = try? String(contentsOfFile: eventPath, encoding: .utf8) else {
+            return true
+        }
         return contents.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("ref: refs/")
     }
+
+    private static let nonRevisionTopLevelNames: Set<String> = [
+        "branches",
+        "COMMIT_EDITMSG",
+        "commondir",
+        "config",
+        "config.worktree",
+        "description",
+        "gc.log",
+        "gitdir",
+        "hooks",
+        "index",
+        "info",
+        "logs",
+        "MERGE_MSG",
+        "modules",
+        "objects",
+        "packed-refs",
+        "refs",
+        "SQUASH_MSG",
+        "TAG_EDITMSG",
+        "worktrees",
+    ]
 }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -78,7 +78,7 @@ enum GitEventFilter {
         if rel == "packed-refs" {
             return .revisionChange
         }
-        if rel == "config" {
+        if rel == "config" || rel == "config.worktree" {
             return .revisionChange
         }
         if rel == "logs/HEAD" || rel.hasPrefix("logs/refs/") {

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -72,6 +72,9 @@ enum GitEventFilter {
         if rel == "packed-refs" {
             return .revisionChange
         }
+        if rel == "config" {
+            return .revisionChange
+        }
         if Self.revisionPseudoRefs.contains(rel) {
             return .revisionChange
         }

--- a/Alas/Sources/Watch/ProjectGitWatcher.swift
+++ b/Alas/Sources/Watch/ProjectGitWatcher.swift
@@ -16,10 +16,11 @@ private final class ProjectGitWatcherStreamContext {
 
 private struct ProjectGitWatcherStreamBatch {
     var headFiles: Set<URL> = []
+    var sawRevision = false
     var sawTopology = false
 
     var hasChanges: Bool {
-        !headFiles.isEmpty || sawTopology
+        !headFiles.isEmpty || sawRevision || sawTopology
     }
 }
 
@@ -41,6 +42,7 @@ final class ProjectGitWatcher {
     }()
 
     var onHeadChanged: (([URL: String]) -> Void)?
+    var onRevisionChanged: (() -> Void)?
     var onTopologyChanged: (() -> Void)?
 
     private let repoPath: URL
@@ -282,6 +284,8 @@ final class ProjectGitWatcher {
                 continue
             case .headChange:
                 batch.headFiles.insert(URL(fileURLWithPath: path).standardizedFileURL)
+            case .revisionChange:
+                batch.sawRevision = true
             case .topologyChange:
                 batch.sawTopology = true
             }
@@ -294,6 +298,9 @@ final class ProjectGitWatcher {
         if !batch.headFiles.isEmpty {
             pendingHeadFiles.formUnion(batch.headFiles)
             headDebouncer.poke()
+        }
+        if batch.sawRevision {
+            onRevisionChanged?()
         }
         if batch.sawTopology {
             topologyDebouncer.poke()

--- a/Alas/Sources/Watch/ProjectGitWatcher.swift
+++ b/Alas/Sources/Watch/ProjectGitWatcher.swift
@@ -286,6 +286,9 @@ final class ProjectGitWatcher {
                 batch.headFiles.insert(URL(fileURLWithPath: path).standardizedFileURL)
             case .revisionChange:
                 batch.sawRevision = true
+            case .revisionAndTopologyChange:
+                batch.sawRevision = true
+                batch.sawTopology = true
             case .topologyChange:
                 batch.sawTopology = true
             }

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -216,6 +216,7 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
         || relative == "config.worktree"
         || relative == "packed-refs"
         || relative == "refs/stash"
+        || relative == "shallow"
         || relative == "logs/HEAD"
         || relative.starts_with("logs/refs/")
         || relative.starts_with("refs/")
@@ -374,6 +375,7 @@ mod tests {
         ));
         assert!(is_relevant_git_path(&root.join(".git/refs/tags/v1"), &info));
         assert!(is_relevant_git_path(&root.join(".git/refs/stash"), &info));
+        assert!(is_relevant_git_path(&root.join(".git/shallow"), &info));
         assert!(is_relevant_git_path(&root.join(".git/logs/HEAD"), &info));
         assert!(is_relevant_git_path(
             &root.join(".git/logs/refs/stash"),

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -211,6 +211,7 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
     let relative = relative.to_string_lossy();
     let relative = relative.trim_matches('/');
     if relative == "config"
+        || relative == "config.worktree"
         || relative == "packed-refs"
         || relative == "refs/stash"
         || relative == "logs/HEAD"
@@ -315,6 +316,10 @@ mod tests {
         assert!(is_relevant_git_path(&root.join(".git/ORIG_HEAD"), &info));
         assert!(is_relevant_git_path(&root.join(".git/AUTO_MERGE"), &info));
         assert!(is_relevant_git_path(&root.join(".git/config"), &info));
+        assert!(is_relevant_git_path(
+            &root.join(".git/config.worktree"),
+            &info
+        ));
         assert!(is_relevant_git_path(
             &root.join(".git/refs/remotes/origin/main"),
             &info

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -217,6 +217,7 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
         || relative == "packed-refs"
         || relative == "refs/stash"
         || relative == "shallow"
+        || relative == "info/grafts"
         || relative == "logs/HEAD"
         || relative.starts_with("logs/refs/")
         || relative.starts_with("refs/")
@@ -376,6 +377,7 @@ mod tests {
         assert!(is_relevant_git_path(&root.join(".git/refs/tags/v1"), &info));
         assert!(is_relevant_git_path(&root.join(".git/refs/stash"), &info));
         assert!(is_relevant_git_path(&root.join(".git/shallow"), &info));
+        assert!(is_relevant_git_path(&root.join(".git/info/grafts"), &info));
         assert!(is_relevant_git_path(&root.join(".git/logs/HEAD"), &info));
         assert!(is_relevant_git_path(
             &root.join(".git/logs/refs/stash"),

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -213,7 +213,8 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
     if relative == "config"
         || relative == "packed-refs"
         || relative == "refs/stash"
-        || relative == "logs/refs/stash"
+        || relative == "logs/HEAD"
+        || relative.starts_with("logs/refs/")
         || relative.starts_with("refs/")
         || is_revision_pseudo_ref(relative)
     {
@@ -318,8 +319,17 @@ mod tests {
         ));
         assert!(is_relevant_git_path(&root.join(".git/refs/tags/v1"), &info));
         assert!(is_relevant_git_path(&root.join(".git/refs/stash"), &info));
+        assert!(is_relevant_git_path(&root.join(".git/logs/HEAD"), &info));
         assert!(is_relevant_git_path(
             &root.join(".git/logs/refs/stash"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/logs/refs/heads/main"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/logs/refs/tags/v1"),
             &info
         ));
         assert!(is_relevant_git_path(&root.join(".git/packed-refs"), &info));

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -195,10 +195,9 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
     if let Ok(relative) = path.strip_prefix(&info.worktree_dir) {
         let relative = relative.to_string_lossy();
         let relative = relative.trim_matches('/');
-        if matches!(
-            relative,
-            "HEAD" | "index" | "MERGE_HEAD" | "CHERRY_PICK_HEAD" | "REVERT_HEAD" | "REBASE_HEAD"
-        ) || relative == "rebase-merge"
+        if matches!(relative, "HEAD" | "index")
+            || is_revision_pseudo_ref(relative)
+            || relative == "rebase-merge"
             || relative.starts_with("rebase-merge/")
             || relative == "rebase-apply"
             || relative.starts_with("rebase-apply/")
@@ -211,12 +210,12 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
     };
     let relative = relative.to_string_lossy();
     let relative = relative.trim_matches('/');
-    if relative == "FETCH_HEAD"
+    if relative == "config"
         || relative == "packed-refs"
         || relative == "refs/stash"
         || relative == "logs/refs/stash"
-        || relative.starts_with("refs/heads/")
-        || relative.starts_with("refs/remotes/")
+        || relative.starts_with("refs/")
+        || is_revision_pseudo_ref(relative)
     {
         return true;
     }
@@ -225,9 +224,24 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
     }
     if let Some(rest) = relative.strip_prefix("worktrees/") {
         let parts: Vec<_> = rest.split('/').filter(|part| !part.is_empty()).collect();
-        return parts.len() == 1 || (parts.len() == 2 && parts[1] == "HEAD");
+        return parts.len() == 1
+            || (parts.len() == 2 && (parts[1] == "HEAD" || is_revision_pseudo_ref(parts[1])))
+            || (parts.len() >= 2 && (parts[1] == "rebase-merge" || parts[1] == "rebase-apply"));
     }
     false
+}
+
+fn is_revision_pseudo_ref(relative: &str) -> bool {
+    matches!(
+        relative,
+        "AUTO_MERGE"
+            | "CHERRY_PICK_HEAD"
+            | "FETCH_HEAD"
+            | "MERGE_HEAD"
+            | "ORIG_HEAD"
+            | "REBASE_HEAD"
+            | "REVERT_HEAD"
+    )
 }
 
 #[cfg(test)]
@@ -295,10 +309,14 @@ mod tests {
             &info
         ));
         assert!(is_relevant_git_path(&root.join(".git/FETCH_HEAD"), &info));
+        assert!(is_relevant_git_path(&root.join(".git/ORIG_HEAD"), &info));
+        assert!(is_relevant_git_path(&root.join(".git/AUTO_MERGE"), &info));
+        assert!(is_relevant_git_path(&root.join(".git/config"), &info));
         assert!(is_relevant_git_path(
             &root.join(".git/refs/remotes/origin/main"),
             &info
         ));
+        assert!(is_relevant_git_path(&root.join(".git/refs/tags/v1"), &info));
         assert!(is_relevant_git_path(&root.join(".git/refs/stash"), &info));
         assert!(is_relevant_git_path(
             &root.join(".git/logs/refs/stash"),
@@ -325,6 +343,14 @@ mod tests {
         ));
         assert!(is_relevant_git_path(
             &root.join(".git/worktrees/feature/CHERRY_PICK_HEAD"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/ORIG_HEAD"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/FETCH_HEAD"),
             &info
         ));
         assert!(is_relevant_git_path(

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -226,7 +226,9 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
     if let Some(rest) = relative.strip_prefix("worktrees/") {
         let parts: Vec<_> = rest.split('/').filter(|part| !part.is_empty()).collect();
         return parts.len() == 1
+            || (parts.len() == 2 && parts[1] == "config.worktree")
             || (parts.len() == 2 && (parts[1] == "HEAD" || is_revision_pseudo_ref(parts[1])))
+            || (parts.len() >= 3 && parts[1] == "logs")
             || (parts.len() >= 2 && (parts[1] == "rebase-merge" || parts[1] == "rebase-apply"));
     }
     false
@@ -361,6 +363,18 @@ mod tests {
         ));
         assert!(is_relevant_git_path(
             &root.join(".git/worktrees/feature/FETCH_HEAD"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/config.worktree"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/logs/HEAD"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/logs/refs/heads/topic"),
             &info
         ));
         assert!(is_relevant_git_path(

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -197,6 +197,7 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
         let relative = relative.trim_matches('/');
         if matches!(relative, "HEAD" | "index")
             || is_revision_pseudo_ref(relative)
+            || is_top_level_symbolic_revision(path, relative)
             || relative.starts_with("refs/")
             || relative == "rebase-merge"
             || relative.starts_with("rebase-merge/")
@@ -248,6 +249,15 @@ fn is_revision_pseudo_ref(relative: &str) -> bool {
             | "REBASE_HEAD"
             | "REVERT_HEAD"
     )
+}
+
+fn is_top_level_symbolic_revision(path: &Path, relative: &str) -> bool {
+    if relative.is_empty() || relative.contains('/') {
+        return false;
+    }
+    std::fs::read_to_string(path)
+        .map(|contents| contents.trim().starts_with("ref: refs/"))
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -346,6 +356,30 @@ mod tests {
         assert!(is_relevant_git_path(&root.join(".git/MERGE_HEAD"), &info));
         assert!(!is_relevant_git_path(&root.join(".git/index.lock"), &info));
         assert!(!is_relevant_git_path(&root.join("src/main.rs"), &info));
+    }
+
+    #[test]
+    fn top_level_symbolic_refs_are_git_events() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-symbolic-ref-{}-{nonce}",
+            std::process::id(),
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let git_dir = root.join(".git");
+        std::fs::create_dir_all(&git_dir).expect("git dir");
+        let symbolic = git_dir.join("FOO");
+        std::fs::write(&symbolic, "ref: refs/heads/main\n").expect("symbolic ref");
+        let non_ref = git_dir.join("BAR");
+        std::fs::write(&non_ref, "not a ref\n").expect("non ref");
+        let info = git_info(&root);
+
+        assert!(is_relevant_git_path(&symbolic, &info));
+        assert!(!is_relevant_git_path(&non_ref, &info));
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -218,6 +218,7 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
         || relative == "refs/stash"
         || relative == "shallow"
         || relative == "info/grafts"
+        || relative == "objects/info/alternates"
         || relative == "logs/HEAD"
         || relative.starts_with("logs/refs/")
         || relative.starts_with("refs/")
@@ -378,6 +379,10 @@ mod tests {
         assert!(is_relevant_git_path(&root.join(".git/refs/stash"), &info));
         assert!(is_relevant_git_path(&root.join(".git/shallow"), &info));
         assert!(is_relevant_git_path(&root.join(".git/info/grafts"), &info));
+        assert!(is_relevant_git_path(
+            &root.join(".git/objects/info/alternates"),
+            &info
+        ));
         assert!(is_relevant_git_path(&root.join(".git/logs/HEAD"), &info));
         assert!(is_relevant_git_path(
             &root.join(".git/logs/refs/stash"),

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -197,6 +197,7 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
         let relative = relative.trim_matches('/');
         if matches!(relative, "HEAD" | "index")
             || is_revision_pseudo_ref(relative)
+            || relative.starts_with("refs/")
             || relative == "rebase-merge"
             || relative.starts_with("rebase-merge/")
             || relative == "rebase-apply"
@@ -230,6 +231,7 @@ fn is_relevant_git_path(path: &Path, info: &GitInfo) -> bool {
             || (parts.len() == 2 && parts[1] == "config.worktree")
             || (parts.len() == 2 && (parts[1] == "HEAD" || is_revision_pseudo_ref(parts[1])))
             || (parts.len() >= 3 && parts[1] == "logs")
+            || (parts.len() >= 3 && parts[1] == "refs")
             || (parts.len() >= 2 && (parts[1] == "rebase-merge" || parts[1] == "rebase-apply"));
     }
     false
@@ -380,6 +382,18 @@ mod tests {
         ));
         assert!(is_relevant_git_path(
             &root.join(".git/worktrees/feature/logs/refs/heads/topic"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/refs/worktree/follow"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/refs/bisect/good-abc"),
+            &info
+        ));
+        assert!(is_relevant_git_path(
+            &root.join(".git/worktrees/feature/refs/rewritten/main"),
             &info
         ));
         assert!(is_relevant_git_path(

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -255,9 +255,38 @@ fn is_top_level_symbolic_revision(path: &Path, relative: &str) -> bool {
     if relative.is_empty() || relative.contains('/') {
         return false;
     }
+    if is_non_revision_top_level_name(relative) {
+        return false;
+    }
     std::fs::read_to_string(path)
         .map(|contents| contents.trim().starts_with("ref: refs/"))
-        .unwrap_or(false)
+        .unwrap_or(true)
+}
+
+fn is_non_revision_top_level_name(relative: &str) -> bool {
+    matches!(
+        relative,
+        "branches"
+            | "COMMIT_EDITMSG"
+            | "commondir"
+            | "config"
+            | "config.worktree"
+            | "description"
+            | "gc.log"
+            | "gitdir"
+            | "hooks"
+            | "index"
+            | "info"
+            | "logs"
+            | "MERGE_MSG"
+            | "modules"
+            | "objects"
+            | "packed-refs"
+            | "refs"
+            | "SQUASH_MSG"
+            | "TAG_EDITMSG"
+            | "worktrees"
+    )
 }
 
 #[cfg(test)]
@@ -375,10 +404,12 @@ mod tests {
         std::fs::write(&symbolic, "ref: refs/heads/main\n").expect("symbolic ref");
         let non_ref = git_dir.join("BAR");
         std::fs::write(&non_ref, "not a ref\n").expect("non ref");
+        let deleted_symbolic = git_dir.join("DELETED_FOO");
         let info = git_info(&root);
 
         assert!(is_relevant_git_path(&symbolic, &info));
         assert!(!is_relevant_git_path(&non_ref, &info));
+        assert!(is_relevant_git_path(&deleted_symbolic, &info));
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/AlasHelper/src/watch.rs
+++ b/AlasHelper/src/watch.rs
@@ -259,8 +259,15 @@ fn is_top_level_symbolic_revision(path: &Path, relative: &str) -> bool {
         return false;
     }
     std::fs::read_to_string(path)
-        .map(|contents| contents.trim().starts_with("ref: refs/"))
+        .map(|contents| is_top_level_revision_content(&contents))
         .unwrap_or(true)
+}
+
+fn is_top_level_revision_content(contents: &str) -> bool {
+    let line = contents.lines().next().unwrap_or("").trim();
+    line.starts_with("ref: refs/")
+        || ((line.len() == 40 || line.len() == 64)
+            && line.chars().all(|char| char.is_ascii_hexdigit()))
 }
 
 fn is_non_revision_top_level_name(relative: &str) -> bool {
@@ -402,12 +409,15 @@ mod tests {
         std::fs::create_dir_all(&git_dir).expect("git dir");
         let symbolic = git_dir.join("FOO");
         std::fs::write(&symbolic, "ref: refs/heads/main\n").expect("symbolic ref");
+        let direct = git_dir.join("DIRECT");
+        std::fs::write(&direct, "0123456789abcdef0123456789abcdef01234567\n").expect("direct ref");
         let non_ref = git_dir.join("BAR");
         std::fs::write(&non_ref, "not a ref\n").expect("non ref");
         let deleted_symbolic = git_dir.join("DELETED_FOO");
         let info = git_info(&root);
 
         assert!(is_relevant_git_path(&symbolic, &info));
+        assert!(is_relevant_git_path(&direct, &info));
         assert!(!is_relevant_git_path(&non_ref, &info));
         assert!(is_relevant_git_path(&deleted_symbolic, &info));
         let _ = std::fs::remove_dir_all(&root);

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -229,6 +229,37 @@ struct CommitTabStateTests {
         #expect(retargeted.record.verdict == record.verdict)
     }
 
+    @Test func trackedRevisionRetargeterRekeysRecordsWhenTargetChanges() throws {
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "source",
+            title: "Source"
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD~2",
+            baselineBranch: "feature",
+            resolvedSHA: "tracked"
+        ))
+
+        let retargeted = try #require(TrackedRevisionRetargeter.follow(
+            record: record,
+            revision: revision,
+            title: "Review HEAD~2",
+            now: Date(timeIntervalSince1970: 2)
+        ))
+
+        #expect(retargeted.oldRecordID == record.id)
+        #expect(retargeted.record.id != record.id)
+        #expect(retargeted.record.id.rawValue.contains(retargeted.record.target.id.rawValue))
+    }
+
     @Test func trackedRevisionDecodingNormalizesExpressionAndPreservesPendingCheckout() throws {
         let json = """
         {

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -86,7 +86,7 @@ struct CommitTabStateTests {
             expression: "  HEAD~3  ", baselineBranch: "feature", resolvedSHA: "old"
         ))
         let headAlias = try #require(TrackedRevision(
-            expression: " \n@{upstream}", baselineBranch: "feature", resolvedSHA: "old"
+            expression: " \n@{0}", baselineBranch: "feature", resolvedSHA: "old"
         ))
         let namedRef = try #require(TrackedRevision(
             expression: " topic~2 ", baselineBranch: "feature", resolvedSHA: "old"
@@ -127,23 +127,29 @@ struct CommitTabStateTests {
         }
     }
 
-    @Test func resolverRejectsPushReflogSelector() async throws {
+    @Test func resolverRejectsConfigDependentReflogSelectors() async throws {
         let resolver = TrackedRevisionResolver(
             resolve: { _, _ in
-                Issue.record("@{push} should be rejected before resolving")
+                Issue.record("config-dependent selectors should be rejected before resolving")
                 return "unused"
             },
             branch: { _ in
-                Issue.record("@{push} should be rejected before reading branch")
+                Issue.record("config-dependent selectors should be rejected before reading branch")
                 return "unused"
             }
         )
 
-        do {
-            _ = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "@{push}")
-            Issue.record("Expected @{push} selector to throw")
-        } catch let error as TrackedRevisionResolverError {
-            #expect(error == .unsupportedReflogExpression("push"))
+        for (expression, selector) in [
+            ("@{push}", "push"),
+            ("@{upstream}", "upstream"),
+            ("@{u}", "u"),
+        ] {
+            do {
+                _ = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: expression)
+                Issue.record("Expected \(expression) selector to throw")
+            } catch let error as TrackedRevisionResolverError {
+                #expect(error == .unsupportedReflogExpression(selector))
+            }
         }
     }
 

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -60,11 +60,19 @@ struct CommitTabStateTests {
         let namedRef = try #require(TrackedRevision(
             expression: " topic~2 ", baselineBranch: "feature", resolvedSHA: "old"
         ))
+        let headPrefixRef = try #require(TrackedRevision(
+            expression: "HEAD-feature", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+        let atPrefixRef = try #require(TrackedRevision(
+            expression: "@feature", baselineBranch: "feature", resolvedSHA: "old"
+        ))
 
         #expect(headRelative.expression == "HEAD~3")
         #expect(headRelative.dependsOnWorktreeHEAD)
         #expect(headAlias.dependsOnWorktreeHEAD)
         #expect(!namedRef.dependsOnWorktreeHEAD)
+        #expect(!headPrefixRef.dependsOnWorktreeHEAD)
+        #expect(!atPrefixRef.dependsOnWorktreeHEAD)
         #expect(TrackedRevision(expression: " \n ", baselineBranch: "feature", resolvedSHA: "old") == nil)
     }
 

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -120,6 +120,43 @@ struct CommitTabStateTests {
         #expect(current.acceptingPendingCheckout() == nil)
     }
 
+    @Test func trackedRevisionRetargeterFollowsAndStopsReviewRecords() throws {
+        let fixedTarget = ReviewSessionTarget.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "aaa",
+            title: "Review aaa"
+        )
+        let record = ReviewSessionRecord(
+            id: fixedTarget.id,
+            target: fixedTarget,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "bbb"
+        ))
+
+        let followed = try #require(TrackedRevisionRetargeter.follow(
+            record: record,
+            revision: revision,
+            title: "Review HEAD~2",
+            now: Date(timeIntervalSince1970: 2)
+        ))
+        let stopped = try #require(TrackedRevisionRetargeter.stop(
+            record: followed.record,
+            title: "Review bbb",
+            now: Date(timeIntervalSince1970: 3)
+        ))
+
+        #expect(followed.oldDraftSessionID == fixedTarget.draftSessionID)
+        #expect(followed.newDraftSessionID == followed.record.target.draftSessionID)
+        #expect(followed.record.target.draftSessionID.sourceKind == .trackedCommit)
+        #expect(stopped.oldDraftSessionID == followed.record.target.draftSessionID)
+        #expect(stopped.newDraftSessionID.sourceKind == .commit)
+        #expect(stopped.record.target.payload == .commit(sha: "bbb"))
+    }
+
     @Test func trackedRevisionDecodingNormalizesExpressionAndPreservesPendingCheckout() throws {
         let json = """
         {

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -3,6 +3,15 @@ import Foundation
 @testable import Alas
 
 struct CommitTabStateTests {
+    @Test func legacyCommitJSONDecodesAsFixedRevision() throws {
+        let json = #"{"id":"commit:wt:abc","worktreeId":"wt","sha":"abc","title":"Old"}"#
+
+        let state = try JSONDecoder().decode(CommitTabState.self, from: Data(json.utf8))
+
+        #expect(state.revision == .fixed(sha: "abc"))
+        #expect(state.id == "commit:wt:abc")
+    }
+
     @Test func idIsStablePerWorktreeAndSha() {
         let a = CommitTabState(worktreeId: "wt-1", sha: "a3f2c1d", title: "x")
         let b = CommitTabState(worktreeId: "wt-1", sha: "a3f2c1d", title: "different title")
@@ -23,6 +32,22 @@ struct CommitTabStateTests {
         #expect(r.worktreeId == "wt-1")
         #expect(r.sha == "deadbeefcafebabe")
         #expect(r.title == "fix: foo")
+    }
+
+    @Test func followedRevisionRoundTrips() throws {
+        let tracked = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "deadbeef"
+        ))
+        let state = CommitTabState(worktreeId: "wt", trackedRevision: tracked, title: "Follow HEAD")
+
+        let decoded = try JSONDecoder().decode(
+            CommitTabState.self,
+            from: JSONEncoder().encode(state)
+        )
+
+        #expect(decoded == state)
+        #expect(decoded.revision == .following(tracked))
+        #expect(decoded.sha == "deadbeef")
     }
 
     @Test func trackedRevisionTrimsExpressionAndClassifiesHEADDependence() throws {

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -24,4 +24,230 @@ struct CommitTabStateTests {
         #expect(r.sha == "deadbeefcafebabe")
         #expect(r.title == "fix: foo")
     }
+
+    @Test func trackedRevisionTrimsExpressionAndClassifiesHEADDependence() throws {
+        let headRelative = try #require(TrackedRevision(
+            expression: "  HEAD~3  ", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+        let headAlias = try #require(TrackedRevision(
+            expression: " \n@{upstream}", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+        let namedRef = try #require(TrackedRevision(
+            expression: " topic~2 ", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+
+        #expect(headRelative.expression == "HEAD~3")
+        #expect(headRelative.dependsOnWorktreeHEAD)
+        #expect(headAlias.dependsOnWorktreeHEAD)
+        #expect(!namedRef.dependsOnWorktreeHEAD)
+        #expect(TrackedRevision(expression: " \n ", baselineBranch: "feature", resolvedSHA: "old") == nil)
+    }
+
+    @Test func headRelativeRevisionFollowsMovementOnSameBranch() throws {
+        let current = try #require(TrackedRevision(
+            expression: "HEAD~3", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+        let candidate = TrackedRevisionCandidate(branch: "feature", sha: "new")
+
+        #expect(TrackedRevisionPolicy.evaluate(current: current, candidate: candidate)
+            == .follow(current.resolving(candidate)))
+    }
+
+    @Test func headRelativeRevisionPausesWhenBranchChanges() throws {
+        let current = try #require(TrackedRevision(
+            expression: " HEAD~3 ", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+        let candidate = TrackedRevisionCandidate(branch: "main", sha: "new")
+
+        #expect(TrackedRevisionPolicy.evaluate(current: current, candidate: candidate)
+            == .pause(current.withPendingCheckout(candidate)))
+    }
+
+    @Test func namedRefFollowsAcrossUnrelatedCheckout() throws {
+        let current = try #require(TrackedRevision(
+            expression: "topic~2", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+        let candidate = TrackedRevisionCandidate(branch: "main", sha: "new")
+
+        #expect(TrackedRevisionPolicy.evaluate(current: current, candidate: candidate)
+            == .follow(current.resolving(candidate)))
+    }
+
+    @Test func unchangedSHAMetadataRefreshesWithoutReloading() throws {
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD~3", baselineBranch: "feature", resolvedSHA: "same"
+        ))
+        let current = revision.withPendingCheckout(TrackedRevisionCandidate(branch: "main", sha: "other"))
+        let candidate = TrackedRevisionCandidate(branch: "main", sha: "same")
+
+        #expect(TrackedRevisionPolicy.evaluate(current: current, candidate: candidate)
+            == .unchanged(current.resolving(candidate)))
+    }
+
+    @Test func acceptingPendingCheckoutAdoptsPendingRevision() throws {
+        let current = try #require(TrackedRevision(
+            expression: "HEAD~3", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+        let candidate = TrackedRevisionCandidate(branch: "main", sha: "new")
+
+        #expect(current.withPendingCheckout(candidate).acceptingPendingCheckout()
+            == current.resolving(candidate))
+        #expect(current.acceptingPendingCheckout() == nil)
+    }
+
+    @Test func trackedRevisionDecodingNormalizesExpressionAndPreservesPendingCheckout() throws {
+        let json = """
+        {
+          "expression": "  HEAD~2  ",
+          "baselineBranch": "feature",
+          "resolvedSHA": "old",
+          "pendingCheckout": { "branch": "main", "sha": "new" }
+        }
+        """
+
+        let revision = try JSONDecoder().decode(TrackedRevision.self, from: Data(json.utf8))
+
+        #expect(revision.expression == "HEAD~2")
+        #expect(revision.pendingCheckout == TrackedRevisionCandidate(branch: "main", sha: "new"))
+        #expect(try JSONDecoder().decode(TrackedRevision.self, from: JSONEncoder().encode(revision)) == revision)
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(TrackedRevision.self, from: Data("""
+            { "expression": "  ", "baselineBranch": "feature", "resolvedSHA": "old" }
+            """.utf8))
+        }
+    }
+
+    @Test func trackedRevisionResolverRetriesWhenCheckoutInterleavesResolution() async throws {
+        let sequence = RevisionSnapshotSequence(
+            branches: ["feature", "main", "main", "main"],
+            heads: ["feature-head", "main-head", "main-head", "main-head"],
+            shas: ["feature-sha", "main-sha"]
+        )
+        let resolver = TrackedRevisionResolver(
+            resolve: { _, ref in await sequence.nextSHA(for: ref) },
+            branch: { _ in await sequence.nextBranch() }
+        )
+
+        let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "HEAD~2")
+
+        #expect(candidate == TrackedRevisionCandidate(branch: "main", sha: "main-sha"))
+    }
+
+    @Test func trackedRevisionResolverPinsHEADRelativeExpressionAcrossTrueABA() async throws {
+        let sequence = MixedCheckoutRevisionSequence()
+        let resolver = TrackedRevisionResolver(
+            resolve: { _, ref in await sequence.resolve(ref) },
+            branch: { _ in "feature" }
+        )
+
+        let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "HEAD~2")
+
+        #expect(candidate == TrackedRevisionCandidate(branch: "feature", sha: "feature-expression-sha"))
+        #expect(await sequence.requestedRefs == ["HEAD", "feature-head~2", "HEAD"])
+    }
+
+    @Test func trackedRevisionResolverTrimsBeforePinningHEADRelativeExpression() async throws {
+        let sequence = PinnedExpressionSequence(
+            rawExpression: "  HEAD^  ",
+            pinnedExpression: "feature-head^"
+        )
+        let resolver = TrackedRevisionResolver(
+            resolve: { _, ref in await sequence.resolve(ref) },
+            branch: { _ in "feature" }
+        )
+
+        let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "  HEAD^  ")
+
+        #expect(candidate == TrackedRevisionCandidate(branch: "feature", sha: "feature-expression-sha"))
+        #expect(await sequence.requestedRefs == ["HEAD", "feature-head^", "HEAD"])
+    }
+
+    @Test func trackedRevisionResolverPinsHEADAliasRelativeExpressionAcrossTrueABA() async throws {
+        let sequence = PinnedExpressionSequence(
+            rawExpression: "@~2",
+            pinnedExpression: "feature-head~2"
+        )
+        let resolver = TrackedRevisionResolver(
+            resolve: { _, ref in await sequence.resolve(ref) },
+            branch: { _ in "feature" }
+        )
+
+        let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "@~2")
+
+        #expect(candidate == TrackedRevisionCandidate(branch: "feature", sha: "feature-expression-sha"))
+        #expect(await sequence.requestedRefs == ["HEAD", "feature-head~2", "HEAD"])
+    }
+}
+
+private actor MixedCheckoutRevisionSequence {
+    private(set) var requestedRefs: [String] = []
+
+    func resolve(_ ref: String) -> String {
+        requestedRefs.append(ref)
+        switch ref {
+        case "HEAD":
+            return "feature-head"
+        case "HEAD~2":
+            // Simulates resolving the raw expression after HEAD moved to main,
+            // then returning to feature before validation.
+            return "main-expression-sha"
+        case "feature-head~2":
+            return "feature-expression-sha"
+        default:
+            Issue.record("Unexpected revision expression: \(ref)")
+            return "unexpected"
+        }
+    }
+}
+
+private actor PinnedExpressionSequence {
+    private let rawExpression: String
+    private let pinnedExpression: String
+    private(set) var requestedRefs: [String] = []
+
+    init(rawExpression: String, pinnedExpression: String) {
+        self.rawExpression = rawExpression
+        self.pinnedExpression = pinnedExpression
+    }
+
+    func resolve(_ ref: String) -> String {
+        requestedRefs.append(ref)
+        switch ref {
+        case "HEAD":
+            return "feature-head"
+        case pinnedExpression:
+            return "feature-expression-sha"
+        case rawExpression:
+            // Simulates resolving the raw expression after HEAD moved to main,
+            // then returning to feature before validation.
+            return "main-expression-sha"
+        default:
+            Issue.record("Unexpected revision expression: \(ref)")
+            return "unexpected"
+        }
+    }
+}
+
+private actor RevisionSnapshotSequence {
+    private var branches: [String]
+    private var heads: [String]
+    private var shas: [String]
+
+    init(
+        branches: [String],
+        heads: [String] = [],
+        shas: [String]
+    ) {
+        self.branches = branches
+        self.heads = heads
+        self.shas = shas
+    }
+
+    func nextBranch() -> String {
+        branches.removeFirst()
+    }
+
+    func nextSHA(for ref: String) -> String {
+        ref == "HEAD" ? heads.removeFirst() : shas.removeFirst()
+    }
 }

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -96,6 +96,16 @@ struct CommitTabStateTests {
             == .pause(current.withPendingCheckout(candidate)))
     }
 
+    @Test func headRelativeRevisionPausesWhenDetachedHeadChanges() throws {
+        let current = try #require(TrackedRevision(
+            expression: "HEAD~3", baselineBranch: "", baselineHEAD: "detached-old", resolvedSHA: "old"
+        ))
+        let candidate = TrackedRevisionCandidate(branch: "", sha: "new", headSHA: "detached-new")
+
+        #expect(TrackedRevisionPolicy.evaluate(current: current, candidate: candidate)
+            == .pause(current.withPendingCheckout(candidate)))
+    }
+
     @Test func namedRefFollowsAcrossUnrelatedCheckout() throws {
         let current = try #require(TrackedRevision(
             expression: "topic~2", baselineBranch: "feature", resolvedSHA: "old"
@@ -237,7 +247,7 @@ struct CommitTabStateTests {
 
         let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "HEAD~2")
 
-        #expect(candidate == TrackedRevisionCandidate(branch: "main", sha: "main-sha"))
+        #expect(candidate == TrackedRevisionCandidate(branch: "main", sha: "main-sha", headSHA: "main-head"))
     }
 
     @Test func trackedRevisionResolverPinsHEADRelativeExpressionAcrossTrueABA() async throws {
@@ -249,7 +259,11 @@ struct CommitTabStateTests {
 
         let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "HEAD~2")
 
-        #expect(candidate == TrackedRevisionCandidate(branch: "feature", sha: "feature-expression-sha"))
+        #expect(candidate == TrackedRevisionCandidate(
+            branch: "feature",
+            sha: "feature-expression-sha",
+            headSHA: "feature-head"
+        ))
         #expect(await sequence.requestedRefs == ["HEAD", "feature-head~2", "HEAD"])
     }
 
@@ -265,7 +279,11 @@ struct CommitTabStateTests {
 
         let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "  HEAD^  ")
 
-        #expect(candidate == TrackedRevisionCandidate(branch: "feature", sha: "feature-expression-sha"))
+        #expect(candidate == TrackedRevisionCandidate(
+            branch: "feature",
+            sha: "feature-expression-sha",
+            headSHA: "feature-head"
+        ))
         #expect(await sequence.requestedRefs == ["HEAD", "feature-head^", "HEAD"])
     }
 
@@ -281,7 +299,11 @@ struct CommitTabStateTests {
 
         let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "@~2")
 
-        #expect(candidate == TrackedRevisionCandidate(branch: "feature", sha: "feature-expression-sha"))
+        #expect(candidate == TrackedRevisionCandidate(
+            branch: "feature",
+            sha: "feature-expression-sha",
+            headSHA: "feature-head"
+        ))
         #expect(await sequence.requestedRefs == ["HEAD", "feature-head~2", "HEAD"])
     }
 }

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -10,6 +10,7 @@ struct CommitTabStateTests {
 
         #expect(state.revision == .fixed(sha: "abc"))
         #expect(state.id == "commit:wt:abc")
+        #expect(state.viewID == "commit:wt:abc")
     }
 
     @Test func idIsStablePerWorktreeAndSha() {
@@ -30,6 +31,7 @@ struct CommitTabStateTests {
         }
         #expect(r.id == s.id)
         #expect(r.worktreeId == "wt-1")
+        #expect(r.viewID == s.viewID)
         #expect(r.sha == "deadbeefcafebabe")
         #expect(r.title == "fix: foo")
     }
@@ -61,6 +63,22 @@ struct CommitTabStateTests {
         #expect(fixed.fixedSHA == "deadbeef")
         #expect(followed.sha == "deadbeef")
         #expect(followed.fixedSHA == nil)
+    }
+
+    @Test func commitViewIDSurvivesFollowAndFixRekeys() throws {
+        var state = CommitTabState(worktreeId: "wt", sha: "old", title: "Old")
+        let viewID = state.viewID
+        let tracked = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "new"
+        ))
+
+        state.follow(tracked)
+        #expect(state.id != viewID)
+        #expect(state.viewID == viewID)
+
+        state.fix(sha: "new")
+        #expect(state.id == "commit:wt:new")
+        #expect(state.viewID == viewID)
     }
 
     @Test func trackedRevisionTrimsExpressionAndClassifiesHEADDependence() throws {

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -165,6 +165,43 @@ struct CommitTabStateTests {
         #expect(stopped.record.target.payload == .commit(sha: "bbb"))
     }
 
+    @Test func trackedRevisionRetargeterPreservesVerdictWhenExpressionChangesOnly() throws {
+        let original = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "bbb"
+        ))
+        let edited = try #require(TrackedRevision(
+            expression: "topic", baselineBranch: "feature", resolvedSHA: "bbb"
+        ))
+        let target = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            revision: original,
+            title: "Review HEAD~2"
+        )
+        let record = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            status: .reviewed,
+            verdict: ReviewSessionVerdict(
+                verdict: .approve,
+                summary: "Same bytes",
+                reviewedAt: Date(timeIntervalSince1970: 1)
+            ),
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+
+        let retargeted = try #require(TrackedRevisionRetargeter.follow(
+            record: record,
+            revision: edited,
+            title: "Review topic",
+            now: Date(timeIntervalSince1970: 2)
+        ))
+
+        #expect(retargeted.record.status == .reviewed)
+        #expect(retargeted.record.verdict == record.verdict)
+    }
+
     @Test func trackedRevisionDecodingNormalizesExpressionAndPreservesPendingCheckout() throws {
         let json = """
         {

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -123,7 +123,27 @@ struct CommitTabStateTests {
             _ = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "HEAD@{5 minutes ago}")
             Issue.record("Expected time-relative reflog selector to throw")
         } catch let error as TrackedRevisionResolverError {
-            #expect(error == .unsupportedTimeRelativeReflogExpression("5 minutes ago"))
+            #expect(error == .unsupportedReflogExpression("5 minutes ago"))
+        }
+    }
+
+    @Test func resolverRejectsPushReflogSelector() async throws {
+        let resolver = TrackedRevisionResolver(
+            resolve: { _, _ in
+                Issue.record("@{push} should be rejected before resolving")
+                return "unused"
+            },
+            branch: { _ in
+                Issue.record("@{push} should be rejected before reading branch")
+                return "unused"
+            }
+        )
+
+        do {
+            _ = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "@{push}")
+            Issue.record("Expected @{push} selector to throw")
+        } catch let error as TrackedRevisionResolverError {
+            #expect(error == .unsupportedReflogExpression("push"))
         }
     }
 

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -48,6 +48,19 @@ struct CommitTabStateTests {
         #expect(decoded == state)
         #expect(decoded.revision == .following(tracked))
         #expect(decoded.sha == "deadbeef")
+        #expect(decoded.fixedSHA == nil)
+    }
+
+    @Test func fixedSHAOnlyMatchesImmutableCommitRevisions() throws {
+        let fixed = CommitTabState(worktreeId: "wt", sha: "deadbeef", title: "Fixed")
+        let tracked = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "deadbeef"
+        ))
+        let followed = CommitTabState(worktreeId: "wt", trackedRevision: tracked, title: "Follow")
+
+        #expect(fixed.fixedSHA == "deadbeef")
+        #expect(followed.sha == "deadbeef")
+        #expect(followed.fixedSHA == nil)
     }
 
     @Test func trackedRevisionTrimsExpressionAndClassifiesHEADDependence() throws {

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -138,6 +138,23 @@ struct CommitTabStateTests {
         #expect(current.acceptingPendingCheckout() == nil)
     }
 
+    @Test func preparingPendingCheckoutAcceptancePreservesDisplayedSHA() throws {
+        let current = try #require(TrackedRevision(
+            expression: "HEAD~3",
+            baselineBranch: "feature",
+            baselineHEAD: "feature-head",
+            resolvedSHA: "old"
+        ))
+        let candidate = TrackedRevisionCandidate(branch: "main", sha: "new", headSHA: "main-head")
+
+        let prepared = try #require(current.withPendingCheckout(candidate).preparingPendingCheckoutAcceptance())
+
+        #expect(prepared.baselineBranch == "main")
+        #expect(prepared.baselineHEAD == "main-head")
+        #expect(prepared.resolvedSHA == "old")
+        #expect(prepared.pendingCheckout == nil)
+    }
+
     @Test func trackedRevisionRetargeterFollowsAndStopsReviewRecords() throws {
         let fixedTarget = ReviewSessionTarget.commit(
             worktreeID: "wt",

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -107,6 +107,41 @@ struct CommitTabStateTests {
         #expect(TrackedRevision(expression: " \n ", baselineBranch: "feature", resolvedSHA: "old") == nil)
     }
 
+    @Test func resolverRejectsTimeRelativeReflogExpressions() async throws {
+        let resolver = TrackedRevisionResolver(
+            resolve: { _, _ in
+                Issue.record("time-relative selector should be rejected before resolving")
+                return "unused"
+            },
+            branch: { _ in
+                Issue.record("time-relative selector should be rejected before reading branch")
+                return "unused"
+            }
+        )
+
+        do {
+            _ = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "HEAD@{5 minutes ago}")
+            Issue.record("Expected time-relative reflog selector to throw")
+        } catch let error as TrackedRevisionResolverError {
+            #expect(error == .unsupportedTimeRelativeReflogExpression("5 minutes ago"))
+        }
+    }
+
+    @Test func resolverAllowsHeadIndependentRevisionOnUnbornBranch() async throws {
+        let resolver = TrackedRevisionResolver(
+            resolve: { _, ref in
+                if ref == "HEAD" { throw ResolverTestError.missingHEAD }
+                if ref == "v1.0" { return "tag-sha" }
+                throw ResolverTestError.unexpectedRef(ref)
+            },
+            branch: { _ in "orphan" }
+        )
+
+        let candidate = try await resolver.resolve(at: URL(fileURLWithPath: "/repo"), expression: "v1.0")
+
+        #expect(candidate == TrackedRevisionCandidate(branch: "orphan", sha: "tag-sha", headSHA: ""))
+    }
+
     @Test func headRelativeRevisionFollowsMovementOnSameBranch() throws {
         let current = try #require(TrackedRevision(
             expression: "HEAD~3", baselineBranch: "feature", resolvedSHA: "old"
@@ -458,4 +493,9 @@ private actor RevisionSnapshotSequence {
     func nextSHA(for ref: String) -> String {
         ref == "HEAD" ? heads.removeFirst() : shas.removeFirst()
     }
+}
+
+private enum ResolverTestError: Error, Equatable {
+    case missingHEAD
+    case unexpectedRef(String)
 }

--- a/AlasTests/CommitTabViewTests.swift
+++ b/AlasTests/CommitTabViewTests.swift
@@ -220,6 +220,31 @@ struct CommitTabViewTests {
         #expect(newer.isActive(activeKey: newer.key, activeID: newer.id))
     }
 
+    @Test func commitReviewLoadIdentityPreservesPublishedSessionForSameSHA() {
+        let current = details(sha: "current-sha")
+
+        #expect(CommitReviewLoadIdentity.preservesPublishedSession(
+            details: current,
+            sha: "current-sha",
+            hasReviewSession: true
+        ))
+        #expect(!CommitReviewLoadIdentity.preservesPublishedSession(
+            details: current,
+            sha: "other-sha",
+            hasReviewSession: true
+        ))
+        #expect(!CommitReviewLoadIdentity.preservesPublishedSession(
+            details: current,
+            sha: "current-sha",
+            hasReviewSession: false
+        ))
+        #expect(!CommitReviewLoadIdentity.preservesPublishedSession(
+            details: nil,
+            sha: "current-sha",
+            hasReviewSession: true
+        ))
+    }
+
     @Test func commitReviewContentStateShowsLoadingForNonEmptyCommitWithoutSession() {
         #expect(CommitReviewContentState.resolve(
             detailsFileCount: 1,

--- a/AlasTests/FollowRevisionPrefillTests.swift
+++ b/AlasTests/FollowRevisionPrefillTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import Alas
+
+struct FollowRevisionPrefillTests {
+    @Test func derivesHeadForDisplayedTip() {
+        #expect(FollowRevisionPrefill.expression(
+            displayedSHA: "tip",
+            firstParentSHAs: ["tip", "parent"]
+        ) == "HEAD")
+    }
+
+    @Test func derivesHeadOffsetForDisplayedAncestor() {
+        #expect(FollowRevisionPrefill.expression(
+            displayedSHA: "grandparent",
+            firstParentSHAs: ["tip", "parent", "grandparent"]
+        ) == "HEAD~2")
+    }
+
+    @Test func leavesUnrelatedDisplayedCommitBlank() {
+        #expect(FollowRevisionPrefill.expression(
+            displayedSHA: "side-commit",
+            firstParentSHAs: ["tip", "parent", "grandparent"]
+        ) == nil)
+    }
+}

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -102,6 +102,21 @@ struct GitEventFilterTests {
         ) == .revisionChange)
     }
 
+    @Test func reflogUpdatesAreRevisionChanges() {
+        let cases = [
+            "/repo/.git/logs/HEAD",
+            "/repo/.git/logs/refs/heads/main",
+            "/repo/.git/logs/refs/tags/v1",
+        ]
+        for path in cases {
+            #expect(GitEventFilter.classify(
+                eventPath: path,
+                gitDir: gitDir,
+                worktreeRoot: worktreeRoot
+            ) == .revisionChange)
+        }
+    }
+
     @Test func pseudoRefsAcceptedByRevisionResolverAreRevisionChanges() {
         let cases = [
             "FETCH_HEAD",

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -169,6 +169,21 @@ struct GitEventFilterTests {
         }
     }
 
+    @Test func linkedWorktreePrivateRefsAreRevisionChanges() {
+        let cases = [
+            "/repo/.git/worktrees/feat/refs/worktree/follow",
+            "/repo/.git/worktrees/feat/refs/bisect/good-abc",
+            "/repo/.git/worktrees/feat/refs/rewritten/main",
+        ]
+        for path in cases {
+            #expect(GitEventFilter.classify(
+                eventPath: path,
+                gitDir: gitDir,
+                worktreeRoot: worktreeRoot
+            ) == .revisionChange)
+        }
+    }
+
     @Test func refsTagsAreRevisionChangesOnly() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/refs/tags/v1",

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -100,6 +100,11 @@ struct GitEventFilterTests {
             gitDir: gitDir,
             worktreeRoot: worktreeRoot
         ) == .revisionChange)
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/config.worktree",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .revisionChange)
     }
 
     @Test func reflogUpdatesAreRevisionChanges() {

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -141,6 +141,29 @@ struct GitEventFilterTests {
         }
     }
 
+    @Test func topLevelSymbolicRevisionIsRevisionChange() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-symbolic-ref-\(UUID().uuidString)")
+        let gitDir = tmp.appendingPathComponent(".git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let symbolicRef = gitDir.appendingPathComponent("FOO")
+        try "ref: refs/heads/main\n".write(to: symbolicRef, atomically: true, encoding: .utf8)
+        let nonRef = gitDir.appendingPathComponent("BAR")
+        try "not a ref\n".write(to: nonRef, atomically: true, encoding: .utf8)
+
+        #expect(GitEventFilter.classify(
+            eventPath: symbolicRef.path,
+            gitDir: gitDir,
+            worktreeRoot: tmp
+        ) == .revisionChange)
+        #expect(GitEventFilter.classify(
+            eventPath: nonRef.path,
+            gitDir: gitDir,
+            worktreeRoot: tmp
+        ) == .other)
+    }
+
     @Test func linkedWorktreePseudoRefsAreRevisionChanges() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/worktrees/feat/REBASE_HEAD",

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -115,6 +115,14 @@ struct GitEventFilterTests {
         ) == .revisionChange)
     }
 
+    @Test func graftAncestryUpdateIsRevisionChange() {
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/info/grafts",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .revisionChange)
+    }
+
     @Test func reflogUpdatesAreRevisionChanges() {
         let cases = [
             "/repo/.git/logs/HEAD",

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -74,34 +74,33 @@ struct GitEventFilterTests {
         }
     }
 
-    @Test func branchRefUpdateIsTopology() {
+    @Test func branchRefUpdateIsRevisionAndTopology() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/refs/heads/main",
             gitDir: gitDir,
             worktreeRoot: worktreeRoot
-        ) == .topologyChange)
+        ) == .revisionAndTopologyChange)
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/refs/heads/feature/foo",
             gitDir: gitDir,
             worktreeRoot: worktreeRoot
-        ) == .topologyChange)
+        ) == .revisionAndTopologyChange)
     }
 
-    @Test func packedRefsUpdateIsTopology() {
+    @Test func packedRefsUpdateIsRevisionChange() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/packed-refs",
             gitDir: gitDir,
             worktreeRoot: worktreeRoot
-        ) == .topologyChange)
+        ) == .revisionChange)
     }
 
-    @Test func refsTagsAreNotTopology() {
-        // Tag refs aren't activity signals for the worktree sort.
+    @Test func refsTagsAreRevisionChangesOnly() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/refs/tags/v1",
             gitDir: gitDir,
             worktreeRoot: worktreeRoot
-        ) == .other)
+        ) == .revisionChange)
     }
 
     @Test func ignoresPathsOutsideGitDir() {

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -149,12 +149,19 @@ struct GitEventFilterTests {
         defer { try? FileManager.default.removeItem(at: tmp) }
         let symbolicRef = gitDir.appendingPathComponent("FOO")
         try "ref: refs/heads/main\n".write(to: symbolicRef, atomically: true, encoding: .utf8)
+        let directRef = gitDir.appendingPathComponent("DIRECT")
+        try "0123456789abcdef0123456789abcdef01234567\n".write(to: directRef, atomically: true, encoding: .utf8)
         let nonRef = gitDir.appendingPathComponent("BAR")
         try "not a ref\n".write(to: nonRef, atomically: true, encoding: .utf8)
         let deletedSymbolicRef = gitDir.appendingPathComponent("DELETED_FOO")
 
         #expect(GitEventFilter.classify(
             eventPath: symbolicRef.path,
+            gitDir: gitDir,
+            worktreeRoot: tmp
+        ) == .revisionChange)
+        #expect(GitEventFilter.classify(
+            eventPath: directRef.path,
             gitDir: gitDir,
             worktreeRoot: tmp
         ) == .revisionChange)

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -95,6 +95,25 @@ struct GitEventFilterTests {
         ) == .revisionChange)
     }
 
+    @Test func pseudoRefsAcceptedByRevisionResolverAreRevisionChanges() {
+        let cases = [
+            "FETCH_HEAD",
+            "REBASE_HEAD",
+            "MERGE_HEAD",
+            "CHERRY_PICK_HEAD",
+            "REVERT_HEAD",
+            "ORIG_HEAD",
+            "AUTO_MERGE",
+        ]
+        for ref in cases {
+            #expect(GitEventFilter.classify(
+                eventPath: "/repo/.git/\(ref)",
+                gitDir: gitDir,
+                worktreeRoot: worktreeRoot
+            ) == .revisionChange)
+        }
+    }
+
     @Test func refsTagsAreRevisionChangesOnly() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/refs/tags/v1",

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -65,7 +65,6 @@ struct GitEventFilterTests {
     @Test func ignoresUnrelatedPathsUnderGitDir() {
         let cases = [
             "/repo/.git/objects/pack/pack-abc.pack",
-            "/repo/.git/config",
             "/repo/.git/worktrees/feat/locked",
         ]
         for path in cases {
@@ -90,6 +89,14 @@ struct GitEventFilterTests {
     @Test func packedRefsUpdateIsRevisionChange() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/packed-refs",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .revisionChange)
+    }
+
+    @Test func configUpdateIsRevisionChange() {
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/config",
             gitDir: gitDir,
             worktreeRoot: worktreeRoot
         ) == .revisionChange)

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -107,6 +107,14 @@ struct GitEventFilterTests {
         ) == .revisionChange)
     }
 
+    @Test func shallowBoundaryUpdateIsRevisionChange() {
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/shallow",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .revisionChange)
+    }
+
     @Test func reflogUpdatesAreRevisionChanges() {
         let cases = [
             "/repo/.git/logs/HEAD",

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -151,6 +151,7 @@ struct GitEventFilterTests {
         try "ref: refs/heads/main\n".write(to: symbolicRef, atomically: true, encoding: .utf8)
         let nonRef = gitDir.appendingPathComponent("BAR")
         try "not a ref\n".write(to: nonRef, atomically: true, encoding: .utf8)
+        let deletedSymbolicRef = gitDir.appendingPathComponent("DELETED_FOO")
 
         #expect(GitEventFilter.classify(
             eventPath: symbolicRef.path,
@@ -159,6 +160,16 @@ struct GitEventFilterTests {
         ) == .revisionChange)
         #expect(GitEventFilter.classify(
             eventPath: nonRef.path,
+            gitDir: gitDir,
+            worktreeRoot: tmp
+        ) == .other)
+        #expect(GitEventFilter.classify(
+            eventPath: deletedSymbolicRef.path,
+            gitDir: gitDir,
+            worktreeRoot: tmp
+        ) == .revisionChange)
+        #expect(GitEventFilter.classify(
+            eventPath: gitDir.appendingPathComponent("index").path,
             gitDir: gitDir,
             worktreeRoot: tmp
         ) == .other)

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -123,6 +123,14 @@ struct GitEventFilterTests {
         ) == .revisionChange)
     }
 
+    @Test func alternateObjectDatabaseUpdateIsRevisionChange() {
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/objects/info/alternates",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .revisionChange)
+    }
+
     @Test func reflogUpdatesAreRevisionChanges() {
         let cases = [
             "/repo/.git/logs/HEAD",

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -149,6 +149,21 @@ struct GitEventFilterTests {
         ) == .revisionChange)
     }
 
+    @Test func linkedWorktreeConfigAndReflogsAreRevisionChanges() {
+        let cases = [
+            "/repo/.git/worktrees/feat/config.worktree",
+            "/repo/.git/worktrees/feat/logs/HEAD",
+            "/repo/.git/worktrees/feat/logs/refs/heads/topic",
+        ]
+        for path in cases {
+            #expect(GitEventFilter.classify(
+                eventPath: path,
+                gitDir: gitDir,
+                worktreeRoot: worktreeRoot
+            ) == .revisionChange)
+        }
+    }
+
     @Test func refsTagsAreRevisionChangesOnly() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/refs/tags/v1",

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -86,12 +86,12 @@ struct GitEventFilterTests {
         ) == .revisionAndTopologyChange)
     }
 
-    @Test func packedRefsUpdateIsRevisionChange() {
+    @Test func packedRefsUpdateIsRevisionAndTopologyChange() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/packed-refs",
             gitDir: gitDir,
             worktreeRoot: worktreeRoot
-        ) == .revisionChange)
+        ) == .revisionAndTopologyChange)
     }
 
     @Test func configUpdateIsRevisionChange() {

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -114,6 +114,19 @@ struct GitEventFilterTests {
         }
     }
 
+    @Test func linkedWorktreePseudoRefsAreRevisionChanges() {
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/worktrees/feat/REBASE_HEAD",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .revisionChange)
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/worktrees/feat/FETCH_HEAD",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .revisionChange)
+    }
+
     @Test func refsTagsAreRevisionChangesOnly() {
         #expect(GitEventFilter.classify(
             eventPath: "/repo/.git/refs/tags/v1",

--- a/AlasTests/ProjectGitWatcherTests.swift
+++ b/AlasTests/ProjectGitWatcherTests.swift
@@ -91,7 +91,7 @@ struct ProjectGitWatcherTests {
         #expect(topologyFires == 1)
     }
 
-    @Test func sharedRefsTriggerRevisionCallback() async throws {
+    @Test func sharedRefsTriggerRevisionAndLocalBranchTopologyCallbacks() async throws {
         let (gitDir, _) = try setupRepo()
         defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }
 
@@ -112,7 +112,7 @@ struct ProjectGitWatcherTests {
 
         #expect(headFires == 0)
         #expect(revisionFires == 1)
-        #expect(topologyFires == 0)
+        #expect(topologyFires == 1)
     }
 
     @Test func mixedBatchClearsHeadInFavorOfTopology() async throws {

--- a/AlasTests/ProjectGitWatcherTests.swift
+++ b/AlasTests/ProjectGitWatcherTests.swift
@@ -115,6 +115,28 @@ struct ProjectGitWatcherTests {
         #expect(topologyFires == 1)
     }
 
+    @Test func packedRefsTriggerRevisionAndTopologyCallbacks() async throws {
+        let (gitDir, _) = try setupRepo()
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let watcher = makeWatcher(gitDir: gitDir)
+        var headFires = 0
+        var revisionFires = 0
+        var topologyFires = 0
+        watcher.onHeadChanged = { _ in headFires += 1 }
+        watcher.onRevisionChanged = { revisionFires += 1 }
+        watcher.onTopologyChanged = { topologyFires += 1 }
+
+        watcher.processEvents([
+            gitDir.appendingPathComponent("packed-refs").path,
+        ])
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        #expect(headFires == 0)
+        #expect(revisionFires == 1)
+        #expect(topologyFires == 1)
+    }
+
     @Test func mixedBatchClearsHeadInFavorOfTopology() async throws {
         let (gitDir, _) = try setupRepo()
         defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }

--- a/AlasTests/ProjectGitWatcherTests.swift
+++ b/AlasTests/ProjectGitWatcherTests.swift
@@ -91,6 +91,30 @@ struct ProjectGitWatcherTests {
         #expect(topologyFires == 1)
     }
 
+    @Test func sharedRefsTriggerRevisionCallback() async throws {
+        let (gitDir, _) = try setupRepo()
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let watcher = makeWatcher(gitDir: gitDir)
+        var headFires = 0
+        var revisionFires = 0
+        var topologyFires = 0
+        watcher.onHeadChanged = { _ in headFires += 1 }
+        watcher.onRevisionChanged = { revisionFires += 1 }
+        watcher.onTopologyChanged = { topologyFires += 1 }
+
+        watcher.processEvents([
+            gitDir.appendingPathComponent("refs/heads/main").path,
+            gitDir.appendingPathComponent("refs/remotes/origin/main").path,
+            gitDir.appendingPathComponent("refs/tags/v1").path,
+        ])
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        #expect(headFires == 0)
+        #expect(revisionFires == 1)
+        #expect(topologyFires == 0)
+    }
+
     @Test func mixedBatchClearsHeadInFavorOfTopology() async throws {
         let (gitDir, _) = try setupRepo()
         defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -4,6 +4,18 @@ import Foundation
 
 @MainActor
 struct ProjectsManagerHeadUpdatesTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        var projectsFile: ProjectsFile
+
+        func write<T: Encodable>(_ value: T, to url: URL) throws {}
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? {
+            if type == ProjectsFile.self { return projectsFile as? T }
+            if type == AppConfig.self { return AppConfig.defaults as? T }
+            return nil
+        }
+    }
+
     private func makeManager() -> (ProjectsManager, ProjectConfig) {
         let project = ProjectConfig(
             id: "p1",
@@ -130,5 +142,29 @@ struct ProjectsManagerHeadUpdatesTests {
             branchByWorktreePath: [URL(fileURLWithPath: "/x"): "y"]
         )
         // No crash, no state change. Nothing to assert beyond that.
+    }
+
+    @Test func appStateHeadUpdatesInvalidateFollowersAcrossProject() {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let main = wt(path: "/repo", branch: "main")
+        let linked = wt(path: "/wts/feature", branch: "feature")
+        seed(state.projectsManager, projectId: project.id, [main, linked])
+
+        state.handleProjectHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [main.path: "main-updated"]
+        )
+
+        #expect(state.revisionChangeGeneration(worktreeID: main.id) == 1)
+        #expect(state.revisionChangeGeneration(worktreeID: linked.id) == 1)
+        #expect(state.projectsManager.worktrees(projectId: project.id).first { $0.id == main.id }?.branch == "main-updated")
+        #expect(state.projectsManager.worktrees(projectId: project.id).first { $0.id == linked.id }?.branch == "feature")
     }
 }

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -153,6 +153,46 @@ return value + other
         #expect(try store.load(sessionID: session).isEmpty)
     }
 
+    @Test func migrateMovesAndRekeysDrafts() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let oldID = ReviewDraftSessionID.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "aaa"
+        )
+        let newID = ReviewDraftSessionID.trackedCommit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            expression: "HEAD~3"
+        )
+        let existing = makeComment(
+            id: "draft-1",
+            session: newID,
+            startLine: 8,
+            endLine: nil,
+            createdAt: Date(timeIntervalSince1970: 8)
+        )
+        let moved = makeComment(
+            id: "draft-1",
+            session: oldID,
+            startLine: 4,
+            endLine: nil,
+            createdAt: Date(timeIntervalSince1970: 10)
+        )
+
+        try store.save(existing)
+        try store.save(moved)
+        try store.migrate(from: oldID, to: newID)
+
+        #expect(try store.load(sessionID: oldID).isEmpty)
+        let rekeyed = try #require(store.load(sessionID: newID).single)
+        #expect(rekeyed.sessionID == newID)
+        #expect(rekeyed.startLine == 4)
+    }
+
     @Test @MainActor func controllerMarksDraftPublishedAndRecordsProviderErrors() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -193,6 +193,46 @@ return value + other
         #expect(rekeyed.startLine == 4)
     }
 
+    @Test func snapshotRestorePreservesDraftsAfterMigration() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("review-draft-comments.json")
+        let store = ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        let oldID = ReviewDraftSessionID.commit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "aaa"
+        )
+        let newID = ReviewDraftSessionID.trackedCommit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            expression: "HEAD~3"
+        )
+        let source = makeComment(
+            id: "draft-1",
+            session: oldID,
+            startLine: 4,
+            endLine: nil,
+            createdAt: Date(timeIntervalSince1970: 10)
+        )
+        let destination = makeComment(
+            id: "draft-2",
+            session: newID,
+            startLine: 8,
+            endLine: nil,
+            createdAt: Date(timeIntervalSince1970: 11)
+        )
+
+        try store.save(source)
+        try store.save(destination)
+        let snapshot = try store.snapshot()
+        try store.migrate(from: oldID, to: newID)
+        try store.restore(snapshot)
+
+        #expect(try store.load(sessionID: oldID) == [source])
+        #expect(try store.load(sessionID: newID) == [destination])
+    }
+
     @Test @MainActor func controllerMarksDraftPublishedAndRecordsProviderErrors() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -135,6 +135,49 @@ struct ReviewSessionLoaderTests {
         #expect(loaded.feedbackTarget.revisionDescription == "HEAD~3 -> bbb")
     }
 
+    @Test func loadedContextCanRefreshTargetDependentFeedbackMetadata() throws {
+        let original = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            revision: try #require(TrackedRevision(
+                expression: "HEAD~3",
+                baselineBranch: "main",
+                resolvedSHA: "bbb"
+            )),
+            title: "Review HEAD~3"
+        )
+        let edited = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            revision: try #require(TrackedRevision(
+                expression: "main~2",
+                baselineBranch: "main",
+                resolvedSHA: "bbb"
+            )),
+            title: "Review main~2"
+        )
+        let session = DiffReviewLoadedSession(files: [], summary: DiffReviewSessionModel(files: [], groupsEnabled: false))
+        let loaded = ReviewSessionLoadedContext(
+            session: session,
+            feedbackTarget: ReviewFeedbackTarget(
+                title: original.title,
+                repositoryPath: original.repositoryPath.path,
+                providerDescription: original.providerDescription,
+                sourceDescription: original.sourceDescription,
+                revisionDescription: original.revisionDescription
+            ),
+            providerContext: nil
+        )
+
+        let refreshed = loaded.replacingFeedbackTarget(for: edited)
+
+        #expect(refreshed.session.files.count == loaded.session.files.count)
+        #expect(refreshed.session.summary.fileCount == loaded.session.summary.fileCount)
+        #expect(refreshed.feedbackTarget.title == "Review main~2")
+        #expect(refreshed.feedbackTarget.sourceDescription == "Commit main~2 -> bbb")
+        #expect(refreshed.feedbackTarget.revisionDescription == "main~2 -> bbb")
+    }
+
     @MainActor
     @Test func productionLoaderPassesResolvedSHAForTrackedCommit() async throws {
         let repo = FileManager.default.temporaryDirectory

--- a/AlasTests/ReviewSessionLoaderTests.swift
+++ b/AlasTests/ReviewSessionLoaderTests.swift
@@ -106,6 +106,76 @@ struct ReviewSessionLoaderTests {
         #expect(loaded.feedbackTarget.sourceDescription == "Commit deadbeef")
     }
 
+    @Test func trackedCommitLoaderUsesResolvedSHAAndFeedbackDescription() async throws {
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD~3", baselineBranch: "feature", resolvedSHA: "bbb"
+        ))
+        let target = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            revision: revision,
+            title: "Review HEAD~3"
+        )
+        var loadedPayload: ReviewSessionTarget.Payload?
+        let loader = ReviewSessionLoader(
+            commit: { target in
+                loadedPayload = target.payload
+                guard case .trackedCommit(let loadedRevision) = target.payload else {
+                    throw ReviewSessionLoaderError.unsupportedTarget
+                }
+                #expect(loadedRevision.resolvedSHA == "bbb")
+                return DiffReviewLoadedSession(files: [], summary: DiffReviewSessionModel(files: [], groupsEnabled: false))
+            }
+        )
+
+        let loaded = try await loader.load(target: target)
+
+        #expect(loadedPayload == .trackedCommit(revision))
+        #expect(loaded.feedbackTarget.sourceDescription == "Commit HEAD~3 -> bbb")
+        #expect(loaded.feedbackTarget.revisionDescription == "HEAD~3 -> bbb")
+    }
+
+    @MainActor
+    @Test func productionLoaderPassesResolvedSHAForTrackedCommit() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-review-session-loader-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "Test User"], cwd: repo)
+        try "a\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "first"], cwd: repo)
+        let sha = try await GitService().resolveRevision(at: repo, ref: "HEAD")
+        let worktree = Worktree(
+            id: Worktree.makeId(path: repo),
+            projectId: "project-1",
+            name: "main",
+            branch: "main",
+            path: repo,
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD", baselineBranch: "main", resolvedSHA: sha
+        ))
+        let target = ReviewSessionTarget.trackedCommit(
+            worktreeID: worktree.id,
+            repositoryPath: repo,
+            revision: revision,
+            title: "Review HEAD"
+        )
+        let loader = ReviewSessionLoader.production(
+            appState: AppState(store: MemoryStore()),
+            worktree: worktree
+        )
+
+        let loaded = try await loader.load(target: target)
+
+        #expect(loaded.feedbackTarget.revisionDescription == "HEAD -> \(sha)")
+    }
+
     @MainActor
     @Test func productionLoaderLoadsProviderReviewRequestWithProviderContext() async throws {
         let repo = FileManager.default.temporaryDirectory

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -4,6 +4,39 @@ import Testing
 
 @Suite("Review session models")
 struct ReviewSessionModelsTests {
+    @Test func consolidationMergesVerdictWithReviewedStatus() {
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc",
+            title: "Review abc"
+        )
+        let existing = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            status: .sent,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 2)
+        )
+        let source = ReviewSessionRecord(
+            id: ReviewSessionID(rawValue: "source"),
+            target: target,
+            status: .reviewed,
+            verdict: ReviewSessionVerdict(
+                verdict: .approve,
+                summary: "Looks good",
+                reviewedAt: .init(timeIntervalSince1970: 3)
+            ),
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 4)
+        )
+
+        let merged = ReviewSessionConsolidation.merge(existing: existing, source: source)
+
+        #expect(merged.verdict == source.verdict)
+        #expect(merged.status == .reviewed)
+    }
+
     @Test func localChangesTargetDerivesStableIDs() {
         let repositoryPath = URL(fileURLWithPath: "/repo")
         let target = ReviewSessionTarget.localChanges(

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -297,4 +297,57 @@ struct ReviewSessionModelsTests {
         #expect(unchanged.status == .reviewed)
         #expect(unchanged.verdict == reviewed.verdict)
     }
+
+    @Test func consolidationUsesRetargetedRecordStateAfterRevisionMoves() throws {
+        let repositoryPath = URL(fileURLWithPath: "/repo")
+        let sourceTarget = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            sha: "aaa",
+            title: "Review aaa"
+        )
+        let movedRevision = try #require(TrackedRevision(
+            expression: "HEAD~3",
+            baselineBranch: "feature",
+            resolvedSHA: "bbb"
+        ))
+        let destinationTarget = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            revision: movedRevision,
+            title: "Review HEAD~3"
+        )
+        let source = ReviewSessionRecord(
+            id: sourceTarget.id,
+            target: sourceTarget,
+            status: .reviewed,
+            verdict: ReviewSessionVerdict(
+                verdict: .approve,
+                summary: "Old bytes were good",
+                reviewedAt: Date(timeIntervalSince1970: 40)
+            ),
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 40)
+        )
+        let existing = ReviewSessionRecord(
+            id: destinationTarget.id,
+            target: destinationTarget,
+            status: .sent,
+            createdAt: Date(timeIntervalSince1970: 20),
+            updatedAt: Date(timeIntervalSince1970: 30)
+        )
+        let result = try #require(TrackedRevisionRetargeter.follow(
+            record: source,
+            revision: movedRevision,
+            title: "Review HEAD~3",
+            now: Date(timeIntervalSince1970: 50)
+        ))
+
+        let merged = ReviewSessionConsolidation.merge(existing: existing, source: result.record)
+
+        #expect(result.record.verdict == nil)
+        #expect(result.record.status == .active)
+        #expect(merged.verdict == nil)
+        #expect(merged.status == .sent)
+    }
 }

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -73,6 +73,33 @@ struct ReviewSessionModelsTests {
         #expect(branch.sourceDescription == "Branch feature against main")
     }
 
+    @Test func trackedCommitIdentityUsesExpressionNotResolvedSHA() throws {
+        let repositoryPath = URL(fileURLWithPath: "/repo/../repo")
+        let revision = try #require(TrackedRevision(
+            expression: " HEAD~3 ", baselineBranch: "feature", resolvedSHA: "aaa"
+        ))
+        let first = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            revision: revision,
+            title: "Review HEAD~3"
+        )
+        let moved = revision.resolving(.init(branch: "feature", sha: "bbb"))
+        let second = first.updatingTrackedRevision(moved, title: "Review rewritten commit")
+
+        #expect(first.kind == .trackedCommit)
+        #expect(first.id == second.id)
+        #expect(first.draftSessionID == second.draftSessionID)
+        #expect(first.draftSessionID == .trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            expression: "HEAD~3"
+        ))
+        #expect(second.revisionDescription == "HEAD~3 -> bbb")
+        #expect(second.sourceDescription == "Commit HEAD~3 -> bbb")
+        #expect(second.freezingTrackedRevision(title: "Fixed")?.payload == .commit(sha: "bbb"))
+    }
+
     @Test func draftReviewRequestTargetUsesRepositoryPathDraftID() {
         let repositoryPath = URL(fileURLWithPath: "/repo")
         let target = ReviewSessionTarget.draftReviewRequest(
@@ -180,5 +207,61 @@ struct ReviewSessionModelsTests {
         ))
         #expect(reviewed.updatedAt == Date(timeIntervalSince1970: 20))
         #expect(reviewed.markedAddressed(now: Date(timeIntervalSince1970: 30)).status == .reviewed)
+    }
+
+    @Test func retargetingTrackedCommitReopensVerdictAndPreservesHandoffs() throws {
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD~3", baselineBranch: "feature", resolvedSHA: "aaa"
+        ))
+        let target = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            revision: revision,
+            title: "Review HEAD~3"
+        )
+        let handoff = ReviewFeedbackHandoff(
+            id: "handoff-1",
+            sessionID: target.id,
+            commentIDs: ["comment-1"],
+            target: .existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex"),
+            createdAt: Date(timeIntervalSince1970: 30),
+            promptRevision: "rev-1",
+            status: .sent
+        )
+        let reviewed = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            status: .reviewed,
+            verdict: ReviewSessionVerdict(
+                verdict: .approve,
+                summary: "Looks good",
+                reviewedAt: Date(timeIntervalSince1970: 40)
+            ),
+            handoffs: [handoff],
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 40)
+        )
+        let movedTarget = target.updatingTrackedRevision(
+            revision.resolving(.init(branch: "feature", sha: "bbb")),
+            title: "Review rewritten commit"
+        )
+
+        let moved = reviewed.retargetingCommit(
+            to: movedTarget,
+            resolvedSHAChanged: true,
+            now: Date(timeIntervalSince1970: 50)
+        )
+        let unchanged = reviewed.retargetingCommit(
+            to: target,
+            resolvedSHAChanged: false,
+            now: Date(timeIntervalSince1970: 60)
+        )
+
+        #expect(moved.status == .active)
+        #expect(moved.verdict == nil)
+        #expect(moved.handoffs == reviewed.handoffs)
+        #expect(moved.updatedAt == Date(timeIntervalSince1970: 50))
+        #expect(unchanged.status == .reviewed)
+        #expect(unchanged.verdict == reviewed.verdict)
     }
 }

--- a/AlasTests/ReviewSessionStoreTests.swift
+++ b/AlasTests/ReviewSessionStoreTests.swift
@@ -136,6 +136,22 @@ struct ReviewSessionStoreTests {
         #expect(try store.findActive(targetID: target.id, excluding: ReviewSessionID(rawValue: "missing")) == current)
     }
 
+    @Test func replaceRemovesOldRecordIDWhenRetargetingRekeys() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let source = makeRecord(id: "source", worktreeID: "wt-1", updatedAt: 1)
+        var retargeted = source
+        retargeted.id = ReviewSessionID(rawValue: "retargeted")
+
+        try store.save(source)
+        try store.replace(id: source.id, with: retargeted)
+
+        #expect(try store.load(id: source.id) == nil)
+        #expect(try store.load(id: retargeted.id) == retargeted)
+    }
+
     private func makeRecord(id: String, worktreeID: String, updatedAt: TimeInterval) -> ReviewSessionRecord {
         let target = ReviewSessionTarget.commit(
             worktreeID: worktreeID,

--- a/AlasTests/ReviewSessionStoreTests.swift
+++ b/AlasTests/ReviewSessionStoreTests.swift
@@ -152,6 +152,26 @@ struct ReviewSessionStoreTests {
         #expect(try store.load(id: retargeted.id) == retargeted)
     }
 
+    @Test func replaceRewritesExistingAliasesTransitively() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let source = makeRecord(id: "source", worktreeID: "wt-1", updatedAt: 1)
+        var middle = source
+        middle.id = ReviewSessionID(rawValue: "middle")
+        var final = source
+        final.id = ReviewSessionID(rawValue: "final")
+
+        try store.save(source)
+        try store.replace(id: source.id, with: middle)
+        try store.replace(id: middle.id, with: final)
+
+        #expect(try store.load(id: source.id) == final)
+        #expect(try store.load(id: middle.id) == final)
+        #expect(try store.load(id: final.id) == final)
+    }
+
     private func makeRecord(id: String, worktreeID: String, updatedAt: TimeInterval) -> ReviewSessionRecord {
         let target = ReviewSessionTarget.commit(
             worktreeID: worktreeID,

--- a/AlasTests/ReviewSessionStoreTests.swift
+++ b/AlasTests/ReviewSessionStoreTests.swift
@@ -172,6 +172,26 @@ struct ReviewSessionStoreTests {
         #expect(try store.load(id: final.id) == final)
     }
 
+    @Test func replacementLookupStaysAuthoritativeAfterOldIDReuse() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let source = makeRecord(id: "source", worktreeID: "wt-1", updatedAt: 1)
+        var retargeted = source
+        retargeted.id = ReviewSessionID(rawValue: "retargeted")
+        retargeted.updatedAt = Date(timeIntervalSince1970: 2)
+        var reopened = source
+        reopened.updatedAt = Date(timeIntervalSince1970: 3)
+
+        try store.save(source)
+        try store.replace(id: source.id, with: retargeted)
+        try store.save(reopened)
+
+        #expect(try store.load(id: source.id) == reopened)
+        #expect(try store.loadReplacement(for: source.id) == retargeted)
+    }
+
     private func makeRecord(id: String, worktreeID: String, updatedAt: TimeInterval) -> ReviewSessionRecord {
         let target = ReviewSessionTarget.commit(
             worktreeID: worktreeID,

--- a/AlasTests/ReviewSessionStoreTests.swift
+++ b/AlasTests/ReviewSessionStoreTests.swift
@@ -172,6 +172,24 @@ struct ReviewSessionStoreTests {
         #expect(try store.load(id: final.id) == final)
     }
 
+    @Test func replaceCanAliasSourceToExistingDestination() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let source = makeRecord(id: "source", worktreeID: "wt-1", updatedAt: 1)
+        var destination = makeRecord(id: "destination", worktreeID: "wt-1", updatedAt: 2)
+        destination.selectedFileID = DiffReviewFileID(namespace: "commit", path: "Merged.swift")
+
+        try store.save(source)
+        try store.save(makeRecord(id: "destination", worktreeID: "wt-1", updatedAt: 1))
+        try store.replace(id: source.id, with: destination)
+
+        #expect(try store.load(id: source.id) == destination)
+        #expect(try store.loadReplacement(for: source.id) == destination)
+        #expect(try store.load(id: destination.id) == destination)
+    }
+
     @Test func replacementLookupStaysAuthoritativeAfterOldIDReuse() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewSessionStoreTests.swift
+++ b/AlasTests/ReviewSessionStoreTests.swift
@@ -148,7 +148,7 @@ struct ReviewSessionStoreTests {
         try store.save(source)
         try store.replace(id: source.id, with: retargeted)
 
-        #expect(try store.load(id: source.id) == nil)
+        #expect(try store.load(id: source.id) == retargeted)
         #expect(try store.load(id: retargeted.id) == retargeted)
     }
 

--- a/AlasTests/ReviewSessionStoreTests.swift
+++ b/AlasTests/ReviewSessionStoreTests.swift
@@ -99,6 +99,43 @@ struct ReviewSessionStoreTests {
         #expect(try store.findActive(targetID: target.id) == record)
     }
 
+    @Test func findActiveCanExcludeCurrentRetargetedSession() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD~2",
+            baselineBranch: "feature",
+            baselineHEAD: "head",
+            resolvedSHA: "sha"
+        ))
+        let target = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            revision: revision,
+            title: "Review HEAD~2"
+        )
+        let existing = ReviewSessionRecord(
+            id: ReviewSessionID(rawValue: "existing"),
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+        let current = ReviewSessionRecord(
+            id: ReviewSessionID(rawValue: "current"),
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 3),
+            updatedAt: Date(timeIntervalSince1970: 4)
+        )
+        try store.save(existing)
+        try store.save(current)
+
+        #expect(try store.findActive(targetID: target.id, excluding: current.id) == existing)
+        #expect(try store.findActive(targetID: target.id, excluding: existing.id) == current)
+        #expect(try store.findActive(targetID: target.id, excluding: ReviewSessionID(rawValue: "missing")) == current)
+    }
+
     private func makeRecord(id: String, worktreeID: String, updatedAt: TimeInterval) -> ReviewSessionRecord {
         let target = ReviewSessionTarget.commit(
             worktreeID: worktreeID,

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -65,6 +65,37 @@ struct ReviewSessionTabViewTests {
         #expect(!coordinator.canPublish(older))
     }
 
+    @Test func loadedTrackedDiffReuseComparesLoadedRevision() throws {
+        let oldRevision = try #require(TrackedRevision(
+            expression: "HEAD~3",
+            baselineBranch: "feature",
+            resolvedSHA: "aaa"
+        ))
+        let newRevision = oldRevision.resolving(.init(branch: "feature", sha: "bbb"))
+        let oldTarget = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            revision: oldRevision,
+            title: "Review HEAD~3"
+        )
+        let newTarget = oldTarget.updatingTrackedRevision(newRevision, title: "Review HEAD~3")
+        let refreshed = ReviewSessionRecord(
+            id: newTarget.id,
+            target: newTarget,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 2)
+        )
+
+        #expect(!ReviewSessionTabView.canReuseLoadedTrackedDiff(
+            loadedTrackedResolvedSHA: "aaa",
+            refreshedRecord: refreshed
+        ))
+        #expect(ReviewSessionTabView.canReuseLoadedTrackedDiff(
+            loadedTrackedResolvedSHA: "bbb",
+            refreshedRecord: refreshed
+        ))
+    }
+
     @Test func rendersLoadedSessionTitleAndSummaryRail() throws {
         let target = ReviewSessionTarget.localChanges(
             worktreeID: "wt-1",

--- a/AlasTests/ReviewSessionTabViewTests.swift
+++ b/AlasTests/ReviewSessionTabViewTests.swift
@@ -223,6 +223,103 @@ struct ReviewSessionTabViewTests {
         #expect(recursiveDescription(host).contains("Sent to agent, but failed to save handoff record: save failed"))
     }
 
+    @Test func handoffFromReopenedSessionDoesNotFollowStaleReplacementAlias() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let source = Self.record(id: "source", sha: "source", updatedAt: 1)
+        var retargeted = source
+        retargeted.id = ReviewSessionID(rawValue: "retargeted")
+        retargeted.target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "retargeted",
+            title: "Review retargeted"
+        )
+        retargeted.updatedAt = Date(timeIntervalSince1970: 2)
+        var reopened = source
+        reopened.updatedAt = Date(timeIntervalSince1970: 3)
+        let handoff = Self.handoff(sessionID: source.id)
+
+        try store.save(source)
+        try store.replace(id: source.id, with: retargeted)
+        try store.save(reopened)
+
+        let updated = ReviewSessionHandoffPersistence.record(
+            handoff,
+            currentRecord: reopened,
+            originRecordID: source.id,
+            sessionStore: store,
+            persistsState: true,
+            now: { Date(timeIntervalSince1970: 4) }
+        )
+
+        #expect(updated?.id == source.id)
+        #expect(try store.load(id: source.id)?.handoffs == [handoff])
+        #expect(try store.loadReplacement(for: source.id)?.handoffs.isEmpty == true)
+    }
+
+    @Test func handoffStartedBeforeRetargetStillFollowsReplacementAlias() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let source = Self.record(id: "source", sha: "source", updatedAt: 1)
+        var retargeted = source
+        retargeted.id = ReviewSessionID(rawValue: "retargeted")
+        retargeted.updatedAt = Date(timeIntervalSince1970: 2)
+        var reopened = source
+        reopened.updatedAt = Date(timeIntervalSince1970: 3)
+        let handoff = Self.handoff(sessionID: source.id)
+
+        try store.save(source)
+        try store.replace(id: source.id, with: retargeted)
+        try store.save(reopened)
+
+        let updated = ReviewSessionHandoffPersistence.record(
+            handoff,
+            currentRecord: retargeted,
+            originRecordID: source.id,
+            sessionStore: store,
+            persistsState: true,
+            now: { Date(timeIntervalSince1970: 4) }
+        )
+
+        #expect(updated?.id == retargeted.id)
+        #expect(try store.loadReplacement(for: source.id)?.handoffs == [handoff])
+        #expect(try store.load(id: source.id)?.handoffs.isEmpty == true)
+    }
+
+    @Test func sendFailureFromReopenedSessionDoesNotFollowStaleReplacementAlias() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+        let source = Self.record(id: "source", sha: "source", updatedAt: 1)
+        var retargeted = source
+        retargeted.id = ReviewSessionID(rawValue: "retargeted")
+        var reopened = source
+        reopened.updatedAt = Date(timeIntervalSince1970: 3)
+
+        try store.save(source)
+        try store.replace(id: source.id, with: retargeted)
+        try store.save(reopened)
+
+        let updated = ReviewSessionHandoffPersistence.recordSendFailure(
+            TestPersistenceError(),
+            currentRecord: reopened,
+            originRecordID: source.id,
+            sessionStore: store,
+            persistsState: true,
+            now: { Date(timeIntervalSince1970: 4) }
+        )
+
+        #expect(updated.id == source.id)
+        #expect(try store.load(id: source.id)?.lastSendError == "Failed to send to agent: save failed")
+        #expect(try store.loadReplacement(for: source.id)?.lastSendError == nil)
+    }
+
     @Test func providerMutationControllerPublishesDraftsAndMarksResults() async throws {
         let sessionID = ReviewDraftSessionID.reviewRequest(
             worktreeID: "wt",
@@ -1776,6 +1873,33 @@ struct ReviewSessionTabViewTests {
                 warnings: mutationWarnings
             )
         }
+    }
+
+    private static func record(id: String, sha: String, updatedAt: TimeInterval) -> ReviewSessionRecord {
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: sha,
+            title: "Review \(sha)"
+        )
+        return ReviewSessionRecord(
+            id: ReviewSessionID(rawValue: id),
+            target: target,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: updatedAt)
+        )
+    }
+
+    private static func handoff(sessionID: ReviewSessionID) -> ReviewFeedbackHandoff {
+        ReviewFeedbackHandoff(
+            id: "handoff-1",
+            sessionID: sessionID,
+            commentIDs: ["draft-1"],
+            target: .existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex"),
+            createdAt: Date(timeIntervalSince1970: 30),
+            promptRevision: "revision-1",
+            status: .sent
+        )
     }
 
     private struct TestPersistenceError: LocalizedError {

--- a/AlasTests/ReviewTargetPaletteModelTests.swift
+++ b/AlasTests/ReviewTargetPaletteModelTests.swift
@@ -36,9 +36,31 @@ struct ReviewTargetPaletteModelTests {
             loadCommitsAhead: { _ in (commits, comparisonRef) },
             loadBranches: { _ in branches },
             resolveRevision: { _, ref in "resolved-\(ref)" },
+            currentBranch: { _ in "feature" },
             headSHA: { _ in "head-sha" },
             openTarget: onOpen
         )
+    }
+
+    @Test func exactRevisionQueryLaunchesTrackedCommit() async throws {
+        let model = ReviewTargetPaletteModel()
+        let w = worktree("feature")
+        var opened: ReviewSessionTarget?
+        let env = environment(worktrees: [w], branches: [], onOpen: { target, _ in opened = target })
+        model.open(prefill: w)
+        await model.loadTargets(environment: env)
+
+        model.query = "HEAD~3"
+        await model.validateRevisionQuery(environment: env)
+
+        #expect(model.targetRows().contains(.followedRevision(
+            expression: "HEAD~3",
+            resolvedSHA: "resolved-HEAD~3",
+            branch: "feature"
+        )))
+        await model.activateSelection(environment: env)
+        #expect(opened?.kind == .trackedCommit)
+        #expect(opened?.revisionDescription == "HEAD~3 -> resolved-HEAD~3")
     }
 
     @Test func worktreeEntriesPutCurrentFirstThenAlpha() {

--- a/AlasTests/ReviewTargetPaletteModelTests.swift
+++ b/AlasTests/ReviewTargetPaletteModelTests.swift
@@ -67,6 +67,32 @@ struct ReviewTargetPaletteModelTests {
         #expect(opened?.revisionDescription == "HEAD~3 -> resolved-HEAD~3")
     }
 
+    @Test func revisionActivationReResolvesCachedFollowedRow() async throws {
+        let model = ReviewTargetPaletteModel()
+        let w = worktree("feature")
+        var opened: ReviewSessionTarget?
+        var resolution = TrackedRevisionCandidate(branch: "feature", sha: "old-head", headSHA: "old-head")
+        var env = environment(worktrees: [w], branches: [], onOpen: { target, _ in opened = target })
+        env.resolveTrackedRevision = { _, _ in resolution }
+        model.open(prefill: w)
+        await model.loadTargets(environment: env)
+
+        model.query = "HEAD"
+        await model.validateRevisionQuery(environment: env)
+        resolution = TrackedRevisionCandidate(branch: "other", sha: "new-head", headSHA: "new-head")
+
+        await model.activateSelection(environment: env)
+
+        #expect(opened?.kind == .trackedCommit)
+        #expect(opened?.revisionDescription == "HEAD -> new-head")
+        #expect(opened?.payload == .trackedCommit(try #require(TrackedRevision(
+            expression: "HEAD",
+            baselineBranch: "other",
+            baselineHEAD: "new-head",
+            resolvedSHA: "new-head"
+        ))))
+    }
+
     @Test func worktreeEntriesPutCurrentFirstThenAlpha() {
         let model = ReviewTargetPaletteModel()
         model.open()

--- a/AlasTests/ReviewTargetPaletteModelTests.swift
+++ b/AlasTests/ReviewTargetPaletteModelTests.swift
@@ -278,6 +278,44 @@ struct ReviewTargetPaletteModelTests {
         #expect(opened?.payload == .branch(base: "resolved-main", head: "head-sha"))
     }
 
+    @Test func revisionValidationPreservesExistingBranchSelection() async {
+        let model = ReviewTargetPaletteModel()
+        model.open(prefill: worktree("feature"))
+        let env = environment(commits: [], branches: ["main"])
+        await model.loadTargets(environment: env)
+        model.query = "main"
+        #expect(model.targetRows().contains(.branch("main")))
+        #expect(model.selectedIndex == 3)
+
+        await model.validateRevisionQuery(environment: env)
+
+        #expect(model.targetRows()[1] == .followedRevision(
+            expression: "main",
+            resolvedSHA: "resolved-main",
+            branch: "feature"
+        ))
+        #expect(model.selectedIndex == 5)
+        #expect(model.targetRows()[model.selectedIndex] == .branch("main"))
+    }
+
+    @Test func revisionValidationSelectsFollowedRowWhenItIsTheOnlySelectableTarget() async {
+        let model = ReviewTargetPaletteModel()
+        model.open(prefill: worktree("feature"))
+        let env = environment(commits: [], branches: [])
+        await model.loadTargets(environment: env)
+        model.query = "HEAD~3"
+
+        await model.validateRevisionQuery(environment: env)
+
+        #expect(model.targetRows() == [
+            .header("Followed Revision"),
+            .followedRevision(expression: "HEAD~3", resolvedSHA: "resolved-HEAD~3", branch: "feature"),
+            .header("Commits"),
+            .message("No commits ahead of the base branch"),
+        ])
+        #expect(model.selectedIndex == 1)
+    }
+
     @Test func backReturnsToWorktreesAndResetsQueryAndAnchor() {
         let model = ReviewTargetPaletteModel()
         model.open()

--- a/AlasTests/ReviewTargetPaletteModelTests.swift
+++ b/AlasTests/ReviewTargetPaletteModelTests.swift
@@ -59,7 +59,8 @@ struct ReviewTargetPaletteModelTests {
         #expect(model.targetRows().contains(.followedRevision(
             expression: "HEAD~3",
             resolvedSHA: "resolved-HEAD~3",
-            branch: "feature"
+            branch: "feature",
+            headSHA: "resolved-HEAD~3"
         )))
         await model.activateSelection(environment: env)
         #expect(opened?.kind == .trackedCommit)
@@ -292,7 +293,8 @@ struct ReviewTargetPaletteModelTests {
         #expect(model.targetRows()[1] == .followedRevision(
             expression: "main",
             resolvedSHA: "resolved-main",
-            branch: "feature"
+            branch: "feature",
+            headSHA: "resolved-main"
         ))
         #expect(model.selectedIndex == 5)
         #expect(model.targetRows()[model.selectedIndex] == .branch("main"))
@@ -309,7 +311,12 @@ struct ReviewTargetPaletteModelTests {
 
         #expect(model.targetRows() == [
             .header("Followed Revision"),
-            .followedRevision(expression: "HEAD~3", resolvedSHA: "resolved-HEAD~3", branch: "feature"),
+            .followedRevision(
+                expression: "HEAD~3",
+                resolvedSHA: "resolved-HEAD~3",
+                branch: "feature",
+                headSHA: "resolved-HEAD~3"
+            ),
             .header("Commits"),
             .message("No commits ahead of the base branch"),
         ])

--- a/AlasTests/ReviewTargetPaletteModelTests.swift
+++ b/AlasTests/ReviewTargetPaletteModelTests.swift
@@ -352,4 +352,28 @@ struct ReviewTargetPaletteModelTests {
         await model.loadTargets(environment: env)
         #expect(model.targetRows() == [.message("Could not load commits: boom")])
     }
+
+    @Test func targetRowsShowsFollowedRevisionWhenTargetLoadingFails() async {
+        let model = ReviewTargetPaletteModel()
+        model.open(prefill: worktree("feature"))
+        struct Boom: Error, LocalizedError { var errorDescription: String? { "boom" } }
+        var env = environment()
+        env.loadCommitsAhead = { _ in throw Boom() }
+        await model.loadTargets(environment: env)
+        model.query = "HEAD~3"
+
+        await model.validateRevisionQuery(environment: env)
+
+        #expect(model.targetRows() == [
+            .header("Followed Revision"),
+            .followedRevision(
+                expression: "HEAD~3",
+                resolvedSHA: "resolved-HEAD~3",
+                branch: "feature",
+                headSHA: "resolved-HEAD~3"
+            ),
+            .message("Could not load commits: boom"),
+        ])
+        #expect(model.selectedIndex == 1)
+    }
 }

--- a/AlasTests/ReviewTargetPaletteModelTests.swift
+++ b/AlasTests/ReviewTargetPaletteModelTests.swift
@@ -37,6 +37,9 @@ struct ReviewTargetPaletteModelTests {
             loadBranches: { _ in branches },
             resolveRevision: { _, ref in "resolved-\(ref)" },
             currentBranch: { _ in "feature" },
+            resolveTrackedRevision: { _, expression in
+                TrackedRevisionCandidate(branch: "feature", sha: "resolved-\(expression)")
+            },
             headSHA: { _ in "head-sha" },
             openTarget: onOpen
         )

--- a/AlasTests/ReviewTargetPaletteModelTests.swift
+++ b/AlasTests/ReviewTargetPaletteModelTests.swift
@@ -323,6 +323,31 @@ struct ReviewTargetPaletteModelTests {
         #expect(model.selectedIndex == 1)
     }
 
+    @Test func queryChangeClearsPreviousFollowedRevisionBeforeDebounce() async {
+        let model = ReviewTargetPaletteModel()
+        model.open(prefill: worktree("feature"))
+        let env = environment(commits: [], branches: [])
+        await model.loadTargets(environment: env)
+        model.query = "HEAD~3"
+        await model.validateRevisionQuery(environment: env)
+        #expect(model.targetRows().contains(.followedRevision(
+            expression: "HEAD~3",
+            resolvedSHA: "resolved-HEAD~3",
+            branch: "feature",
+            headSHA: "resolved-HEAD~3"
+        )))
+
+        model.query = "HEAD~4"
+
+        #expect(!model.targetRows().contains(.followedRevision(
+            expression: "HEAD~3",
+            resolvedSHA: "resolved-HEAD~3",
+            branch: "feature",
+            headSHA: "resolved-HEAD~3"
+        )))
+        #expect(model.targetRows().filter(\.isSelectable).isEmpty)
+    }
+
     @Test func backReturnsToWorktreesAndResetsQueryAndAnchor() {
         let model = ReviewTargetPaletteModel()
         model.open()

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -196,7 +196,7 @@ struct RemoteWorktreePollTests {
         #expect(command.contains("info/grafts entries"))
     }
 
-    @Test func sharedRefsSignatureIncludesSortedUpstreamConfig() {
+    @Test func sharedRefsSignatureIncludesOrderedUpstreamConfig() {
         let config = """
         branch.feature.merge refs/heads/main
         branch.feature.remote origin
@@ -216,6 +216,12 @@ struct RemoteWorktreePollTests {
         branch.feature.merge refs/heads/main
         branch.feature.remote origin
         remote.origin.fetch +refs/heads/main:refs/remotes/fork/main
+        """
+        let duplicateOrderChanged = """
+        branch.feature.merge refs/heads/main
+        branch.feature.remote fork
+        branch.feature.remote origin
+        remote.origin.fetch +refs/heads/main:refs/remotes/origin/main
         """
         let pushChanged = """
         branch.feature.merge refs/heads/main
@@ -252,11 +258,17 @@ struct RemoteWorktreePollTests {
             revisionConfigOutput: RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: ["/srv/repo": fetchChanged]),
             pseudoRefCommits: [:]
         )
+        let duplicateReordered = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            revisionConfigOutput: RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: ["/srv/repo": duplicateOrderChanged]),
+            pseudoRefCommits: [:]
+        )
 
-        #expect(first == same)
+        #expect(first != same)
         #expect(first != second)
         #expect(first != pushed)
         #expect(first != fetched)
+        #expect(first != duplicateReordered)
         #expect(first.contains("config:/srv/repo:branch.feature.merge refs/heads/main"))
         #expect(first.contains("remote.origin.fetch +refs/heads/main:refs/remotes/origin/main"))
         #expect(pushed.contains("branch.feature.pushremote fork"))

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -45,6 +45,7 @@ struct RemoteWorktreePollTests {
         let delta = RemoteWorktreePoll.classify(old: old, new: new)
         #expect(delta == RemoteWorktreePollDelta(
             branchLabelsByPath: ["/srv/wt/feature": "other"],
+            headMoved: false,
             topologyChanged: false
         ))
     }
@@ -66,7 +67,11 @@ struct RemoteWorktreePollTests {
             branch: new[0].branch
         )
         let delta = RemoteWorktreePoll.classify(old: old, new: new)
-        #expect(delta == RemoteWorktreePollDelta(branchLabelsByPath: [:], topologyChanged: true))
+        #expect(delta == RemoteWorktreePollDelta(
+            branchLabelsByPath: [:],
+            headMoved: true,
+            topologyChanged: true
+        ))
     }
 
     @Test func addedOrRemovedWorktreeYieldsTopologyChange() {

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -138,6 +138,22 @@ struct RemoteWorktreePollTests {
         #expect(signature.contains("/repo/worktrees/feat:REBASE_HEAD:rebase-sha"))
     }
 
+    @Test func sharedRefsSignatureIncludesSortedPrivateWorktreeRefs() {
+        let privateRefs = RemoteProjectGitWatcher.privateRefsSignature(pathOutputs: [
+            "/srv/repo": "bbb refs/worktree/follow\n",
+            "/srv/wt/feature": "aaa refs/rewritten/main\nccc refs/bisect/good-abc\n",
+        ])
+        let signature = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            privateRefsOutput: privateRefs,
+            pseudoRefCommits: [:]
+        )
+
+        #expect(signature.contains("private-refs:/srv/repo:bbb refs/worktree/follow"))
+        #expect(signature.contains("/srv/wt/feature:aaa refs/rewritten/main"))
+        #expect(signature.contains("/srv/wt/feature:ccc refs/bisect/good-abc"))
+    }
+
     @Test func sharedRefsSignatureIncludesSortedUpstreamConfig() {
         let config = """
         branch.feature.merge refs/heads/main

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -153,10 +153,11 @@ struct RemoteWorktreePollTests {
         """
         let pushChanged = """
         branch.feature.merge refs/heads/main
-        branch.feature.pushRemote fork
+        branch.feature.pushremote fork
         branch.feature.remote origin
         push.default current
-        remote.pushDefault origin
+        remote.fork.push refs/heads/feature:refs/heads/feature
+        remote.pushdefault origin
         """
 
         let first = RemoteProjectGitWatcher.sharedRefsSignature(
@@ -184,9 +185,19 @@ struct RemoteWorktreePollTests {
         #expect(first != second)
         #expect(first != pushed)
         #expect(first.contains("config:/srv/repo:branch.feature.merge refs/heads/main"))
-        #expect(pushed.contains("branch.feature.pushRemote fork"))
-        #expect(pushed.contains("remote.pushDefault origin"))
+        #expect(pushed.contains("branch.feature.pushremote fork"))
+        #expect(pushed.contains("remote.fork.push refs/heads/feature:refs/heads/feature"))
+        #expect(pushed.contains("remote.pushdefault origin"))
         #expect(pushed.contains("push.default current"))
+    }
+
+    @Test func revisionConfigPatternMatchesGitCanonicalPushKeys() throws {
+        let regex = try Regex(RemoteProjectGitWatcher.revisionConfigPattern)
+        #expect("branch.feature.pushremote".wholeMatch(of: regex) != nil)
+        #expect("remote.pushdefault".wholeMatch(of: regex) != nil)
+        #expect("remote.fork.push".wholeMatch(of: regex) != nil)
+        #expect("branch.feature.pushRemote".wholeMatch(of: regex) == nil)
+        #expect("remote.pushDefault".wholeMatch(of: regex) == nil)
     }
 
     @Test func revisionConfigSignatureQualifiesEachWorktreePath() {

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -156,7 +156,7 @@ struct RemoteWorktreePollTests {
 
     @Test func sharedRefsSignatureIncludesCustomTopLevelRefs() {
         let topLevelRefs = RemoteProjectGitWatcher.topLevelRefsSignature(pathOutputs: [
-            "/srv/repo": "FOO ref: refs/heads/main\nDIRECT 0123456789abcdef0123456789abcdef01234567\n",
+            "/srv/repo": "FOO ref: refs/heads/main\nDIRECT 0123456789abcdef0123456789abcdef01234567\nshallow entries=1;sha=abc\n",
             "/srv/wt/feature": "BAR ref: refs/heads/feature\n",
         ])
         let signature = RemoteProjectGitWatcher.sharedRefsSignature(
@@ -167,6 +167,7 @@ struct RemoteWorktreePollTests {
 
         #expect(signature.contains("top-level-refs:/srv/repo:DIRECT 0123456789abcdef0123456789abcdef01234567"))
         #expect(signature.contains("/srv/repo:FOO ref: refs/heads/main"))
+        #expect(signature.contains("/srv/repo:shallow entries=1;sha=abc"))
         #expect(signature.contains("/srv/wt/feature:BAR ref: refs/heads/feature"))
     }
 
@@ -176,6 +177,7 @@ struct RemoteWorktreePollTests {
         #expect(command.contains("ref: refs/"))
         #expect(command.contains("0-9a-fA-F"))
         #expect(command.contains("packed-refs"))
+        #expect(command.contains("shallow entries"))
     }
 
     @Test func sharedRefsSignatureIncludesSortedUpstreamConfig() {

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -137,4 +137,39 @@ struct RemoteWorktreePollTests {
         #expect(signature.contains("/repo:FETCH_HEAD:fetch-sha"))
         #expect(signature.contains("/repo/worktrees/feat:REBASE_HEAD:rebase-sha"))
     }
+
+    @Test func sharedRefsSignatureIncludesSortedUpstreamConfig() {
+        let config = """
+        branch.feature.merge refs/heads/main
+        branch.feature.remote origin
+        """
+        let reordered = """
+        branch.feature.remote origin
+        branch.feature.merge refs/heads/main
+        """
+        let changed = """
+        branch.feature.merge refs/heads/next
+        branch.feature.remote origin
+        """
+
+        let first = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: config),
+            pseudoRefCommits: [:]
+        )
+        let same = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: reordered),
+            pseudoRefCommits: [:]
+        )
+        let second = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: changed),
+            pseudoRefCommits: [:]
+        )
+
+        #expect(first == same)
+        #expect(first != second)
+        #expect(first.contains("config:branch.feature.merge refs/heads/main"))
+    }
 }

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -170,7 +170,7 @@ struct RemoteWorktreePollTests {
 
     @Test func sharedRefsSignatureIncludesCustomTopLevelRefs() {
         let topLevelRefs = RemoteProjectGitWatcher.topLevelRefsSignature(pathOutputs: [
-            "/srv/repo": "FOO ref: refs/heads/main\nDIRECT 0123456789abcdef0123456789abcdef01234567\nshallow entries=1;sha=abc\n",
+            "/srv/repo": "FOO ref: refs/heads/main\nDIRECT 0123456789abcdef0123456789abcdef01234567\nshallow entries=1;sha=abc\ninfo/grafts entries=1;sha=def\n",
             "/srv/wt/feature": "BAR ref: refs/heads/feature\n",
         ])
         let signature = RemoteProjectGitWatcher.sharedRefsSignature(
@@ -182,6 +182,7 @@ struct RemoteWorktreePollTests {
         #expect(signature.contains("top-level-refs:/srv/repo:DIRECT 0123456789abcdef0123456789abcdef01234567"))
         #expect(signature.contains("/srv/repo:FOO ref: refs/heads/main"))
         #expect(signature.contains("/srv/repo:shallow entries=1;sha=abc"))
+        #expect(signature.contains("/srv/repo:info/grafts entries=1;sha=def"))
         #expect(signature.contains("/srv/wt/feature:BAR ref: refs/heads/feature"))
     }
 
@@ -192,6 +193,7 @@ struct RemoteWorktreePollTests {
         #expect(command.contains("0-9a-fA-F"))
         #expect(command.contains("packed-refs"))
         #expect(command.contains("shallow entries"))
+        #expect(command.contains("info/grafts entries"))
     }
 
     @Test func sharedRefsSignatureIncludesSortedUpstreamConfig() {

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -188,4 +188,21 @@ struct RemoteWorktreePollTests {
         #expect(pushed.contains("remote.pushDefault origin"))
         #expect(pushed.contains("push.default current"))
     }
+
+    @Test func sharedRefsSignatureIncludesReflogOutput() {
+        let first = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            reflogOutput: "abc HEAD@{0}\ndef HEAD@{1}\n",
+            pseudoRefCommits: [:]
+        )
+        let second = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            reflogOutput: "abc HEAD@{0}\n",
+            pseudoRefCommits: [:]
+        )
+
+        #expect(first != second)
+        #expect(first.contains("reflog:abc HEAD@{0}"))
+        #expect(first.contains("def HEAD@{1}"))
+    }
 }

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -97,4 +97,30 @@ struct RemoteWorktreePollTests {
         #expect(secondBegin)
         #expect(!finalFinishReleases)
     }
+
+    @Test func watcherEventsDispatchSharedRefsWhenWorktreesAreUnchanged() {
+        let entries = RemoteWorktreePoll.parse(porcelain: porcelain)
+        let events = RemoteProjectGitWatcher.events(old: entries, new: entries, sharedRefsMoved: true)
+        #expect(events == RemoteProjectGitWatcherEvents(
+            branchLabelsByPath: [:],
+            revisionChanged: true,
+            topologyChanged: false
+        ))
+    }
+
+    @Test func watcherEventsMergeHeadAndSharedRefChanges() {
+        let old = RemoteWorktreePoll.parse(porcelain: porcelain)
+        var new = old
+        new[1] = RemoteWorktreePollEntry(
+            path: new[1].path,
+            head: "9999999999999999999999999999999999999999",
+            branch: new[1].branch
+        )
+        let events = RemoteProjectGitWatcher.events(old: old, new: new, sharedRefsMoved: true)
+        #expect(events == RemoteProjectGitWatcherEvents(
+            branchLabelsByPath: [:],
+            revisionChanged: true,
+            topologyChanged: true
+        ))
+    }
 }

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -154,6 +154,30 @@ struct RemoteWorktreePollTests {
         #expect(signature.contains("/srv/wt/feature:ccc refs/bisect/good-abc"))
     }
 
+    @Test func sharedRefsSignatureIncludesCustomTopLevelRefs() {
+        let topLevelRefs = RemoteProjectGitWatcher.topLevelRefsSignature(pathOutputs: [
+            "/srv/repo": "FOO ref: refs/heads/main\nDIRECT 0123456789abcdef0123456789abcdef01234567\n",
+            "/srv/wt/feature": "BAR ref: refs/heads/feature\n",
+        ])
+        let signature = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            customTopLevelRefsOutput: topLevelRefs,
+            pseudoRefCommits: [:]
+        )
+
+        #expect(signature.contains("top-level-refs:/srv/repo:DIRECT 0123456789abcdef0123456789abcdef01234567"))
+        #expect(signature.contains("/srv/repo:FOO ref: refs/heads/main"))
+        #expect(signature.contains("/srv/wt/feature:BAR ref: refs/heads/feature"))
+    }
+
+    @Test func customTopLevelRefsCommandScansAbsoluteGitDir() {
+        let command = RemoteProjectGitWatcher.customTopLevelRefsCommand()
+        #expect(command.contains("git rev-parse --absolute-git-dir"))
+        #expect(command.contains("ref: refs/"))
+        #expect(command.contains("0-9a-fA-F"))
+        #expect(command.contains("packed-refs"))
+    }
+
     @Test func sharedRefsSignatureIncludesSortedUpstreamConfig() {
         let config = """
         branch.feature.merge refs/heads/main

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -161,48 +161,75 @@ struct RemoteWorktreePollTests {
 
         let first = RemoteProjectGitWatcher.sharedRefsSignature(
             showRefOutput: "abc refs/heads/main\n",
-            upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: config),
+            revisionConfigOutput: RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: ["/srv/repo": config]),
             pseudoRefCommits: [:]
         )
         let same = RemoteProjectGitWatcher.sharedRefsSignature(
             showRefOutput: "abc refs/heads/main\n",
-            upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: reordered),
+            revisionConfigOutput: RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: ["/srv/repo": reordered]),
             pseudoRefCommits: [:]
         )
         let second = RemoteProjectGitWatcher.sharedRefsSignature(
             showRefOutput: "abc refs/heads/main\n",
-            upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: changed),
+            revisionConfigOutput: RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: ["/srv/repo": changed]),
             pseudoRefCommits: [:]
         )
         let pushed = RemoteProjectGitWatcher.sharedRefsSignature(
             showRefOutput: "abc refs/heads/main\n",
-            upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: pushChanged),
+            revisionConfigOutput: RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: ["/srv/repo": pushChanged]),
             pseudoRefCommits: [:]
         )
 
         #expect(first == same)
         #expect(first != second)
         #expect(first != pushed)
-        #expect(first.contains("config:branch.feature.merge refs/heads/main"))
+        #expect(first.contains("config:/srv/repo:branch.feature.merge refs/heads/main"))
         #expect(pushed.contains("branch.feature.pushRemote fork"))
         #expect(pushed.contains("remote.pushDefault origin"))
         #expect(pushed.contains("push.default current"))
     }
 
-    @Test func sharedRefsSignatureIncludesReflogOutput() {
+    @Test func revisionConfigSignatureQualifiesEachWorktreePath() {
+        let main = """
+        branch.feature.merge refs/heads/main
+        branch.feature.remote origin
+        """
+        let linked = """
+        branch.feature.merge refs/heads/linked
+        branch.feature.remote origin
+        """
+
+        let signature = RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: [
+            "/srv/repo": main,
+            "/srv/repo-linked": linked,
+        ])
+
+        #expect(signature.contains("/srv/repo:branch.feature.merge refs/heads/main"))
+        #expect(signature.contains("/srv/repo-linked:branch.feature.merge refs/heads/linked"))
+    }
+
+    @Test func sharedRefsSignatureIncludesCompleteReflogSignature() {
+        let full = RemoteProjectGitWatcher.reflogSignature(from: "abc HEAD@{0}\ndef HEAD@{1}\n")
+        let shortened = RemoteProjectGitWatcher.reflogSignature(from: "abc HEAD@{0}\n")
         let first = RemoteProjectGitWatcher.sharedRefsSignature(
             showRefOutput: "abc refs/heads/main\n",
-            reflogOutput: "abc HEAD@{0}\ndef HEAD@{1}\n",
+            reflogSignature: full,
             pseudoRefCommits: [:]
         )
         let second = RemoteProjectGitWatcher.sharedRefsSignature(
             showRefOutput: "abc refs/heads/main\n",
-            reflogOutput: "abc HEAD@{0}\n",
+            reflogSignature: shortened,
             pseudoRefCommits: [:]
         )
 
         #expect(first != second)
-        #expect(first.contains("reflog:abc HEAD@{0}"))
-        #expect(first.contains("def HEAD@{1}"))
+        #expect(first.contains("reflog:entries=2;sha="))
+    }
+
+    @Test func reflogDigestCommandCoversCompleteReflog() {
+        let command = RemoteProjectGitWatcher.reflogDigestCommand()
+        #expect(command.contains("git reflog show --all --format='%H %gD'"))
+        #expect(!command.contains("--max-count"))
+        #expect(command.contains("shasum -a 256") || command.contains("sha256sum"))
     }
 }

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -198,19 +198,28 @@ struct RemoteWorktreePollTests {
         let config = """
         branch.feature.merge refs/heads/main
         branch.feature.remote origin
+        remote.origin.fetch +refs/heads/main:refs/remotes/origin/main
         """
         let reordered = """
+        remote.origin.fetch +refs/heads/main:refs/remotes/origin/main
         branch.feature.remote origin
         branch.feature.merge refs/heads/main
         """
         let changed = """
         branch.feature.merge refs/heads/next
         branch.feature.remote origin
+        remote.origin.fetch +refs/heads/main:refs/remotes/origin/main
+        """
+        let fetchChanged = """
+        branch.feature.merge refs/heads/main
+        branch.feature.remote origin
+        remote.origin.fetch +refs/heads/main:refs/remotes/fork/main
         """
         let pushChanged = """
         branch.feature.merge refs/heads/main
         branch.feature.pushremote fork
         branch.feature.remote origin
+        remote.origin.fetch +refs/heads/main:refs/remotes/origin/main
         push.default current
         remote.fork.push refs/heads/feature:refs/heads/feature
         remote.pushdefault origin
@@ -236,21 +245,29 @@ struct RemoteWorktreePollTests {
             revisionConfigOutput: RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: ["/srv/repo": pushChanged]),
             pseudoRefCommits: [:]
         )
+        let fetched = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            revisionConfigOutput: RemoteProjectGitWatcher.revisionConfigSignature(pathOutputs: ["/srv/repo": fetchChanged]),
+            pseudoRefCommits: [:]
+        )
 
         #expect(first == same)
         #expect(first != second)
         #expect(first != pushed)
+        #expect(first != fetched)
         #expect(first.contains("config:/srv/repo:branch.feature.merge refs/heads/main"))
+        #expect(first.contains("remote.origin.fetch +refs/heads/main:refs/remotes/origin/main"))
         #expect(pushed.contains("branch.feature.pushremote fork"))
         #expect(pushed.contains("remote.fork.push refs/heads/feature:refs/heads/feature"))
         #expect(pushed.contains("remote.pushdefault origin"))
         #expect(pushed.contains("push.default current"))
     }
 
-    @Test func revisionConfigPatternMatchesGitCanonicalPushKeys() throws {
+    @Test func revisionConfigPatternMatchesGitCanonicalRevisionKeys() throws {
         let regex = try Regex(RemoteProjectGitWatcher.revisionConfigPattern)
         #expect("branch.feature.pushremote".wholeMatch(of: regex) != nil)
         #expect("remote.pushdefault".wholeMatch(of: regex) != nil)
+        #expect("remote.origin.fetch".wholeMatch(of: regex) != nil)
         #expect("remote.fork.push".wholeMatch(of: regex) != nil)
         #expect("branch.feature.pushRemote".wholeMatch(of: regex) == nil)
         #expect("remote.pushDefault".wholeMatch(of: regex) == nil)

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -108,6 +108,20 @@ struct RemoteWorktreePollTests {
         ))
     }
 
+    @Test func helperGitEventsOnlyRequestAuthoritativeTick() {
+        let event = RemoteHelperWatchEvent(
+            subscriptionId: "sub",
+            root: "/srv/repo",
+            kind: .git,
+            paths: ["/srv/repo/.git/index"]
+        )
+
+        #expect(RemoteProjectGitWatcher.helperEventAction(for: event) == RemoteProjectGitWatcherHelperEventAction(
+            runTick: true,
+            bumpRevisionImmediately: false
+        ))
+    }
+
     @Test func watcherEventsMergeHeadAndSharedRefChanges() {
         let old = RemoteWorktreePoll.parse(porcelain: porcelain)
         var new = old

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -170,7 +170,7 @@ struct RemoteWorktreePollTests {
 
     @Test func sharedRefsSignatureIncludesCustomTopLevelRefs() {
         let topLevelRefs = RemoteProjectGitWatcher.topLevelRefsSignature(pathOutputs: [
-            "/srv/repo": "FOO ref: refs/heads/main\nDIRECT 0123456789abcdef0123456789abcdef01234567\nshallow entries=1;sha=abc\ninfo/grafts entries=1;sha=def\n",
+            "/srv/repo": "FOO ref: refs/heads/main\nDIRECT 0123456789abcdef0123456789abcdef01234567\nshallow entries=1;sha=abc\ninfo/grafts entries=1;sha=def\nobjects/info/alternates entries=1;sha=ghi\n",
             "/srv/wt/feature": "BAR ref: refs/heads/feature\n",
         ])
         let signature = RemoteProjectGitWatcher.sharedRefsSignature(
@@ -183,6 +183,7 @@ struct RemoteWorktreePollTests {
         #expect(signature.contains("/srv/repo:FOO ref: refs/heads/main"))
         #expect(signature.contains("/srv/repo:shallow entries=1;sha=abc"))
         #expect(signature.contains("/srv/repo:info/grafts entries=1;sha=def"))
+        #expect(signature.contains("/srv/repo:objects/info/alternates entries=1;sha=ghi"))
         #expect(signature.contains("/srv/wt/feature:BAR ref: refs/heads/feature"))
     }
 
@@ -194,6 +195,7 @@ struct RemoteWorktreePollTests {
         #expect(command.contains("packed-refs"))
         #expect(command.contains("shallow entries"))
         #expect(command.contains("info/grafts entries"))
+        #expect(command.contains("objects/info/alternates entries"))
     }
 
     @Test func sharedRefsSignatureIncludesOrderedUpstreamConfig() {

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -151,6 +151,13 @@ struct RemoteWorktreePollTests {
         branch.feature.merge refs/heads/next
         branch.feature.remote origin
         """
+        let pushChanged = """
+        branch.feature.merge refs/heads/main
+        branch.feature.pushRemote fork
+        branch.feature.remote origin
+        push.default current
+        remote.pushDefault origin
+        """
 
         let first = RemoteProjectGitWatcher.sharedRefsSignature(
             showRefOutput: "abc refs/heads/main\n",
@@ -167,9 +174,18 @@ struct RemoteWorktreePollTests {
             upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: changed),
             pseudoRefCommits: [:]
         )
+        let pushed = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            upstreamConfigOutput: RemoteProjectGitWatcher.upstreamConfigSignature(from: pushChanged),
+            pseudoRefCommits: [:]
+        )
 
         #expect(first == same)
         #expect(first != second)
+        #expect(first != pushed)
         #expect(first.contains("config:branch.feature.merge refs/heads/main"))
+        #expect(pushed.contains("branch.feature.pushRemote fork"))
+        #expect(pushed.contains("remote.pushDefault origin"))
+        #expect(pushed.contains("push.default current"))
     }
 }

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -128,13 +128,13 @@ struct RemoteWorktreePollTests {
         let signature = RemoteProjectGitWatcher.sharedRefsSignature(
             showRefOutput: "abc refs/heads/main\n",
             pseudoRefCommits: [
-                "FETCH_HEAD": "fetch-sha",
-                "REBASE_HEAD": "rebase-sha",
+                "/repo:FETCH_HEAD": "fetch-sha",
+                "/repo/worktrees/feat:REBASE_HEAD": "rebase-sha",
             ]
         )
 
         #expect(signature.contains("abc refs/heads/main"))
-        #expect(signature.contains("FETCH_HEAD:fetch-sha"))
-        #expect(signature.contains("REBASE_HEAD:rebase-sha"))
+        #expect(signature.contains("/repo:FETCH_HEAD:fetch-sha"))
+        #expect(signature.contains("/repo/worktrees/feat:REBASE_HEAD:rebase-sha"))
     }
 }

--- a/AlasTests/SSH/RemoteWorktreePollTests.swift
+++ b/AlasTests/SSH/RemoteWorktreePollTests.swift
@@ -123,4 +123,18 @@ struct RemoteWorktreePollTests {
             topologyChanged: true
         ))
     }
+
+    @Test func sharedRefsSignatureIncludesPseudoRefs() {
+        let signature = RemoteProjectGitWatcher.sharedRefsSignature(
+            showRefOutput: "abc refs/heads/main\n",
+            pseudoRefCommits: [
+                "FETCH_HEAD": "fetch-sha",
+                "REBASE_HEAD": "rebase-sha",
+            ]
+        )
+
+        #expect(signature.contains("abc refs/heads/main"))
+        #expect(signature.contains("FETCH_HEAD:fetch-sha"))
+        #expect(signature.contains("REBASE_HEAD:rebase-sha"))
+    }
 }

--- a/AlasTests/TabsManagerReviewSessionTests.swift
+++ b/AlasTests/TabsManagerReviewSessionTests.swift
@@ -55,6 +55,36 @@ struct TabsManagerReviewSessionTests {
         #expect(state.selectedFileID == DiffReviewFileID(namespace: "commit", path: "A.swift"))
     }
 
+    @Test func openOrFocusReviewSessionRefreshesExistingDestinationState() {
+        var manager = TabsManager()
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "abc",
+            title: "Review abc"
+        )
+        let initial = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 1)
+        )
+        _ = manager.openOrFocusReviewSession(worktreeId: "wt-1", record: initial)
+
+        var merged = initial
+        merged.selectedFileID = DiffReviewFileID(namespace: "commit", path: "Merged.swift")
+        merged.focusedCommentID = "comment-1"
+        let refreshed = manager.openOrFocusReviewSession(worktreeId: "wt-1", record: merged)
+
+        guard case .reviewSession(let state) = refreshed else {
+            Issue.record("Expected review session tab")
+            return
+        }
+        #expect(state.selectedFileID == DiffReviewFileID(namespace: "commit", path: "Merged.swift"))
+        #expect(state.focusedCommentID == "comment-1")
+        #expect(manager.tabs(forWorktree: "wt-1").count == 1)
+    }
+
     @Test func reviewSessionViewIDSurvivesRetargeting() throws {
         let repositoryPath = URL(fileURLWithPath: "/repo")
         let fixedTarget = ReviewSessionTarget.commit(

--- a/AlasTests/TabsManagerReviewSessionTests.swift
+++ b/AlasTests/TabsManagerReviewSessionTests.swift
@@ -55,6 +55,62 @@ struct TabsManagerReviewSessionTests {
         #expect(state.selectedFileID == DiffReviewFileID(namespace: "commit", path: "A.swift"))
     }
 
+    @Test func reviewSessionViewIDSurvivesRetargeting() throws {
+        let repositoryPath = URL(fileURLWithPath: "/repo")
+        let fixedTarget = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            sha: "old",
+            title: "Review old"
+        )
+        let tracked = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "new"
+        ))
+        let trackedTarget = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            revision: tracked,
+            title: "Review HEAD~2"
+        )
+        var state = ReviewSessionTabState(
+            worktreeId: "wt-1",
+            record: ReviewSessionRecord(
+                id: fixedTarget.id,
+                target: fixedTarget,
+                createdAt: .init(timeIntervalSince1970: 1),
+                updatedAt: .init(timeIntervalSince1970: 1)
+            )
+        )
+        let viewID = state.viewID
+
+        state.retarget(to: ReviewSessionRecord(
+            id: trackedTarget.id,
+            target: trackedTarget,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 2)
+        ))
+
+        #expect(state.id != viewID)
+        #expect(state.viewID == viewID)
+    }
+
+    @Test func legacyReviewSessionTabDecodeUsesIDAsViewID() throws {
+        let json = """
+        {
+          "id": "review-session:old",
+          "worktreeId": "wt-1",
+          "sessionID": "old",
+          "title": "Review old"
+        }
+        """
+
+        let state = try JSONDecoder().decode(ReviewSessionTabState.self, from: Data(json.utf8))
+
+        #expect(state.id == "review-session:old")
+        #expect(state.viewID == "review-session:old")
+        #expect(state.sessionID == ReviewSessionID(rawValue: "old"))
+    }
+
     @Test func retargetingReviewSessionCoalescesExistingDestinationTab() throws {
         var manager = TabsManager()
         let repositoryPath = URL(fileURLWithPath: "/repo")

--- a/AlasTests/TabsManagerReviewSessionTests.swift
+++ b/AlasTests/TabsManagerReviewSessionTests.swift
@@ -54,4 +54,56 @@ struct TabsManagerReviewSessionTests {
         }
         #expect(state.selectedFileID == DiffReviewFileID(namespace: "commit", path: "A.swift"))
     }
+
+    @Test func retargetingReviewSessionCoalescesExistingDestinationTab() throws {
+        var manager = TabsManager()
+        let repositoryPath = URL(fileURLWithPath: "/repo")
+        let fixedTarget = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            sha: "old",
+            title: "Review old"
+        )
+        let tracked = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "new"
+        ))
+        let trackedTarget = ReviewSessionTarget.trackedCommit(
+            worktreeID: "wt-1",
+            repositoryPath: repositoryPath,
+            revision: tracked,
+            title: "Review HEAD~2"
+        )
+        let existing = manager.openOrFocusReviewSession(
+            worktreeId: "wt-1",
+            record: ReviewSessionRecord(
+                id: trackedTarget.id,
+                target: trackedTarget,
+                status: .reviewed,
+                createdAt: .init(timeIntervalSince1970: 1),
+                updatedAt: .init(timeIntervalSince1970: 2)
+            )
+        )
+        let source = manager.openOrFocusReviewSession(
+            worktreeId: "wt-1",
+            record: ReviewSessionRecord(
+                id: fixedTarget.id,
+                target: fixedTarget,
+                createdAt: .init(timeIntervalSince1970: 3),
+                updatedAt: .init(timeIntervalSince1970: 4)
+            )
+        )
+
+        let result = manager.updateReviewSession(worktreeId: "wt-1", tabId: source.id) { state in
+            state.retarget(to: ReviewSessionRecord(
+                id: trackedTarget.id,
+                target: trackedTarget,
+                createdAt: .init(timeIntervalSince1970: 3),
+                updatedAt: .init(timeIntervalSince1970: 5)
+            ))
+        }
+
+        #expect(result?.id == existing.id)
+        #expect(manager.tabs(forWorktree: "wt-1").map(\.id) == [existing.id])
+        #expect(manager.activeTabId(forWorktree: "wt-1") == existing.id)
+    }
 }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -929,6 +929,50 @@ struct TabsManagerTests {
         #expect(state.revision == .fixed(sha: "new"))
         #expect(state.title == "New subject")
     }
+
+    @Test func trackedCommitRekeyFocusesExistingTrackedDestination() throws {
+        let worktreeId = "tabs-manager-tracked-commit-rekey-existing-tracked"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let first = manager.appendCommit(worktreeId: worktreeId, sha: "one", title: "One")
+        let second = manager.appendCommit(worktreeId: worktreeId, sha: "two", title: "Two")
+        let tracked = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "tracked-sha"
+        ))
+        let existing = manager.updateCommit(worktreeId: worktreeId, tabId: first.id) {
+            $0.follow(tracked)
+        }
+
+        let result = manager.updateCommit(worktreeId: worktreeId, tabId: second.id) {
+            $0.follow(tracked)
+        }
+
+        #expect(result?.id == existing?.id)
+        #expect(manager.tabs(forWorktree: worktreeId).map(\.id) == [try #require(existing?.id)])
+        #expect(manager.activeTabId(forWorktree: worktreeId) == existing?.id)
+    }
+
+    @Test func trackedCommitRekeyFocusesExistingFixedDestination() throws {
+        let worktreeId = "tabs-manager-tracked-commit-rekey-existing-fixed"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let fixed = manager.appendCommit(worktreeId: worktreeId, sha: "target", title: "Target")
+        let followedSource = manager.appendCommit(worktreeId: worktreeId, sha: "source", title: "Source")
+        let tracked = try #require(TrackedRevision(
+            expression: "HEAD", baselineBranch: "feature", resolvedSHA: "target"
+        ))
+        let followed = manager.updateCommit(worktreeId: worktreeId, tabId: followedSource.id) {
+            $0.follow(tracked)
+        }
+
+        let result = manager.updateCommit(worktreeId: worktreeId, tabId: try #require(followed?.id)) {
+            $0.fix(sha: "target")
+        }
+
+        #expect(result?.id == fixed.id)
+        #expect(manager.tabs(forWorktree: worktreeId).map(\.id) == [fixed.id])
+        #expect(manager.activeTabId(forWorktree: worktreeId) == fixed.id)
+    }
 }
 
 private struct RestoreMemoryStore: PersistenceStoreProtocol {

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -893,7 +893,7 @@ struct TabsManagerTests {
         #expect(mgr.commitEditorTab(worktreeId: worktreeId, currentSha: "ffffffffffffffffffffffffffffffffffffffff")?.id == descendant.id)
     }
 
-    @Test func trackedCommitUpdatePreservesTabIdentityAndOrder() throws {
+    @Test func trackedCommitUpdateRekeysTabIdentityAndPreservesOrder() throws {
         let worktreeId = "tabs-manager-tracked-commit-update"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
         let manager = TabsManager()
@@ -905,16 +905,23 @@ struct TabsManagerTests {
         ))
 
         let followed = manager.updateCommit(worktreeId: worktreeId, tabId: originalID) {
-            $0.revision = .following(tracked.resolving(.init(branch: "feature", sha: "new")))
+            $0.follow(tracked.resolving(.init(branch: "feature", sha: "new")))
             $0.title = "New subject"
         }
-        let stopped = manager.updateCommit(worktreeId: worktreeId, tabId: originalID) {
-            $0.revision = .fixed(sha: "new")
+        let followedID = try #require(followed?.id)
+        let reopenedOriginal = manager.appendCommit(worktreeId: worktreeId, sha: "old", title: "Old subject")
+        let stopped = manager.updateCommit(worktreeId: worktreeId, tabId: followedID) {
+            $0.fix(sha: "new")
         }
 
-        #expect(followed?.id == originalID)
-        #expect(stopped?.id == originalID)
-        #expect(manager.tabs(forWorktree: worktreeId).map(\.id) == [originalID, second.id])
+        #expect(followedID != originalID)
+        #expect(reopenedOriginal.id == originalID)
+        #expect(stopped?.id == "commit:\(worktreeId):new")
+        #expect(manager.tabs(forWorktree: worktreeId).map(\.id) == [
+            "commit:\(worktreeId):new",
+            second.id,
+            originalID,
+        ])
         guard case .commit(let state) = manager.tabs(forWorktree: worktreeId)[0] else {
             Issue.record("Expected commit tab")
             return

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -892,6 +892,36 @@ struct TabsManagerTests {
         #expect(mgr.commitEditorTab(worktreeId: worktreeId, currentSha: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")?.id == target.id)
         #expect(mgr.commitEditorTab(worktreeId: worktreeId, currentSha: "ffffffffffffffffffffffffffffffffffffffff")?.id == descendant.id)
     }
+
+    @Test func trackedCommitUpdatePreservesTabIdentityAndOrder() throws {
+        let worktreeId = "tabs-manager-tracked-commit-update"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let first = manager.appendCommit(worktreeId: worktreeId, sha: "old", title: "Old subject")
+        let second = manager.appendTerminal(worktreeId: worktreeId, title: "Other", sessionId: "other")
+        let originalID = first.id
+        let tracked = try #require(TrackedRevision(
+            expression: "HEAD~2", baselineBranch: "feature", resolvedSHA: "old"
+        ))
+
+        let followed = manager.updateCommit(worktreeId: worktreeId, tabId: originalID) {
+            $0.revision = .following(tracked.resolving(.init(branch: "feature", sha: "new")))
+            $0.title = "New subject"
+        }
+        let stopped = manager.updateCommit(worktreeId: worktreeId, tabId: originalID) {
+            $0.revision = .fixed(sha: "new")
+        }
+
+        #expect(followed?.id == originalID)
+        #expect(stopped?.id == originalID)
+        #expect(manager.tabs(forWorktree: worktreeId).map(\.id) == [originalID, second.id])
+        guard case .commit(let state) = manager.tabs(forWorktree: worktreeId)[0] else {
+            Issue.record("Expected commit tab")
+            return
+        }
+        #expect(state.revision == .fixed(sha: "new"))
+        #expect(state.title == "New subject")
+    }
 }
 
 private struct RestoreMemoryStore: PersistenceStoreProtocol {

--- a/docs/superpowers/plans/2026-08-05-sticky-commit-revisions.md
+++ b/docs/superpowers/plans/2026-08-05-sticky-commit-revisions.md
@@ -1,0 +1,741 @@
+# Sticky Commit Revisions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let commit-detail tabs and dedicated commit review sessions follow a logical single-commit Git expression while loading and displaying only immutable resolved snapshots.
+
+**Architecture:** A shared `TrackedRevision` model owns the expression, branch baseline, last complete SHA, and pending checkout candidate. Existing Git watchers publish a per-worktree generation; commit and review views resolve on that signal, load the candidate SHA in a guarded shadow generation, and atomically publish only complete snapshots. Fixed-SHA targets keep their existing persistence and behavior.
+
+**Tech Stack:** Swift 5.9+, SwiftUI/AppKit on macOS, Swift Observation, Swift Testing, XcodeGen, existing `GitService`, `TabsManager`, and review-session persistence.
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Accept one Git commit-ish expression; ranges and branch-comparison reviews remain immutable.
+- Normalize expressions only by trimming leading and trailing whitespace.
+- Do not add per-tab polling or new dependencies.
+- Keep the last complete snapshot visible during refresh and after resolution/load failures.
+- Pause only HEAD-dependent expressions on a branch checkout; named refs keep following independently.
+- Preserve drafts and handoff history, but clear the verdict and return to `active` when the resolved SHA changes.
+- Preserve legacy fixed-SHA decoding and behavior.
+- Tests use Swift Testing (`import Testing`), not XCTest.
+
+---
+
+### Task 1: Tracked revision domain model and transition policy
+
+**Files:**
+- Create: `Alas/Sources/Center/Commit/TrackedRevision.swift`
+- Modify: `AlasTests/CommitTabStateTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: `GitService.resolveRevision(at:ref:)` and `GitService.currentBranch(worktreePath:)`.
+- Produces: `TrackedRevision`, `TrackedRevisionCandidate`, `TrackedRevisionTransition`, `TrackedRevisionPolicy.evaluate(current:candidate:)`, and `TrackedRevisionResolver.resolve(at:expression:)`.
+
+- [ ] **Step 1: Write failing model and policy tests**
+
+Add tests covering whitespace trimming, HEAD-dependency classification, same-branch movement, named-ref movement across checkout, HEAD checkout pause, unchanged SHA metadata refresh, and pending checkout acceptance:
+
+```swift
+@Test func headRelativeRevisionPausesWhenBranchChanges() throws {
+    let current = try #require(TrackedRevision(
+        expression: " HEAD~3 ", baselineBranch: "feature",
+        resolvedSHA: "old"
+    ))
+    let candidate = TrackedRevisionCandidate(branch: "main", sha: "new")
+
+    #expect(TrackedRevisionPolicy.evaluate(current: current, candidate: candidate)
+        == .pause(current.withPendingCheckout(candidate)))
+}
+
+@Test func namedRefFollowsAcrossUnrelatedCheckout() throws {
+    let current = try #require(TrackedRevision(
+        expression: "topic~2", baselineBranch: "feature",
+        resolvedSHA: "old"
+    ))
+    let candidate = TrackedRevisionCandidate(branch: "main", sha: "new")
+
+    #expect(TrackedRevisionPolicy.evaluate(current: current, candidate: candidate)
+        == .follow(current.resolving(candidate)))
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/CommitTabStateTests test
+```
+
+Expected: compilation fails because the tracked-revision types do not exist.
+
+- [ ] **Step 3: Implement the shared model and live resolver**
+
+Create the following contract:
+
+```swift
+struct TrackedRevisionCandidate: Codable, Equatable, Hashable, Sendable {
+    let branch: String
+    let sha: String
+}
+
+struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
+    let expression: String
+    var baselineBranch: String
+    var resolvedSHA: String
+    var pendingCheckout: TrackedRevisionCandidate?
+
+    init?(expression: String, baselineBranch: String, resolvedSHA: String)
+    var dependsOnWorktreeHEAD: Bool { get }
+    func resolving(_ candidate: TrackedRevisionCandidate) -> Self
+    func withPendingCheckout(_ candidate: TrackedRevisionCandidate) -> Self
+    func acceptingPendingCheckout() -> Self?
+}
+
+enum TrackedRevisionTransition: Equatable {
+    case unchanged(TrackedRevision)
+    case follow(TrackedRevision)
+    case pause(TrackedRevision)
+}
+
+enum TrackedRevisionPolicy {
+    static func evaluate(
+        current: TrackedRevision,
+        candidate: TrackedRevisionCandidate
+    ) -> TrackedRevisionTransition
+}
+
+struct TrackedRevisionResolver {
+    var resolve: (URL, String) async throws -> String
+    var branch: (URL) async throws -> String
+
+    static let live = TrackedRevisionResolver(
+        resolve: { try await GitService().resolveRevision(at: $0, ref: $1) },
+        branch: { try await GitService().currentBranch(worktreePath: $0) }
+    )
+
+    func resolve(at worktreePath: URL, expression: String) async throws
+        -> TrackedRevisionCandidate
+}
+```
+
+`dependsOnWorktreeHEAD` recognizes expressions beginning with `HEAD` or `@` after trimming. `evaluate` pauses only when that flag is true, the branch changed, and the SHA changed. A same-SHA candidate clears pending state and adopts the candidate branch without reloading.
+
+- [ ] **Step 4: Regenerate the project and rerun tests**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/CommitTabStateTests test
+```
+
+Expected: all `CommitTabStateTests` pass.
+
+- [ ] **Step 5: Commit the domain model**
+
+```bash
+git add Alas/Sources/Center/Commit/TrackedRevision.swift \
+  AlasTests/CommitTabStateTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(review): add tracked revision model"
+```
+
+---
+
+### Task 2: Persist fixed and followed commit tabs with stable identity
+
+**Files:**
+- Modify: `Alas/Sources/Center/Tab.swift`
+- Modify: `Alas/Sources/Center/TabsManager.swift`
+- Modify: `AlasTests/CommitTabStateTests.swift`
+- Modify: `AlasTests/TabsManagerTests.swift`
+
+**Interfaces:**
+- Consumes: `TrackedRevision` from Task 1.
+- Produces: `CommitRevision`, stable `CommitTabState`, and `TabsManager.updateCommit(worktreeId:tabId:mutate:)`.
+
+- [ ] **Step 1: Add failing persistence and manager tests**
+
+Cover legacy JSON decoding, a followed round-trip, stable ID across SHA movement and stopping, and mutation without tab reorder:
+
+```swift
+@Test func legacyCommitJSONDecodesAsFixedRevision() throws {
+    let json = #"{"id":"commit:wt:abc","worktreeId":"wt","sha":"abc","title":"Old"}"#
+    let state = try JSONDecoder().decode(CommitTabState.self, from: Data(json.utf8))
+    #expect(state.revision == .fixed(sha: "abc"))
+    #expect(state.id == "commit:wt:abc")
+}
+
+@Test func trackedCommitUpdatePreservesTabIdentityAndOrder() {
+    let originalID = manager.tabs(forWorktree: "wt")[0].id
+    _ = manager.updateCommit(worktreeId: "wt", tabId: originalID) {
+        $0.revision = .following(tracked.resolving(.init(branch: "feature", sha: "new")))
+        $0.title = "new Subject"
+    }
+    #expect(manager.tabs(forWorktree: "wt")[0].id == originalID)
+}
+```
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/CommitTabStateTests \
+  -only-testing:AlasTests/TabsManagerTests test
+```
+
+Expected: tests fail because `CommitRevision` and `updateCommit` are missing.
+
+- [ ] **Step 3: Implement custom Codable compatibility and stable updates**
+
+Replace the immutable SHA-only state with:
+
+```swift
+enum CommitRevision: Codable, Equatable, Hashable, Sendable {
+    case fixed(sha: String)
+    case following(TrackedRevision)
+
+    var resolvedSHA: String { get }
+    var tracked: TrackedRevision? { get }
+}
+
+struct CommitTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    var revision: CommitRevision
+    var title: String
+
+    var sha: String { revision.resolvedSHA }
+    init(worktreeId: String, sha: String, title: String)
+    init(worktreeId: String, trackedRevision: TrackedRevision, title: String)
+}
+```
+
+Use a custom decoder that reads `revision` when present and otherwise maps the legacy `sha` key to `.fixed`. Encode `revision` and retain `sha` as a compatibility mirror for downgrade resilience. The tracked initializer derives a deterministic initial ID from worktree plus a SHA-256 digest of the expression; subsequent mutations retain the stored ID.
+
+Add:
+
+```swift
+@discardableResult
+func updateCommit(
+    worktreeId: String,
+    tabId: TabID,
+    mutate: (inout CommitTabState) -> Void
+) -> Tab?
+```
+
+Persist once after replacing the matching `.commit` element. Update commit open/focus searches to compare `state.sha`, not IDs.
+
+- [ ] **Step 4: Rerun focused tests**
+
+Expected: both suites pass, including the unchanged legacy ID assertions.
+
+- [ ] **Step 5: Commit commit-tab persistence**
+
+```bash
+git add Alas/Sources/Center/Tab.swift Alas/Sources/Center/TabsManager.swift \
+  AlasTests/CommitTabStateTests.swift AlasTests/TabsManagerTests.swift
+git commit -m "feat(review): persist followed commit tabs"
+```
+
+---
+
+### Task 3: Add tracked commit review targets and atomic draft migration
+
+**Files:**
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift`
+- Modify: `AlasTests/ReviewDraftCommentStoreTests.swift`
+- Modify: `AlasTests/ReviewSessionModelsTests.swift`
+- Modify: `AlasTests/ReviewSessionLoaderTests.swift`
+
+**Interfaces:**
+- Consumes: `TrackedRevision` and existing commit review loader.
+- Produces: `.trackedCommit`, `ReviewDraftSessionID.trackedCommit(...)`, `ReviewDraftCommentStore.migrate(from:to:)`, and record retarget helpers.
+
+- [ ] **Step 1: Write failing target, migration, and loader tests**
+
+```swift
+@Test func trackedCommitIdentityUsesExpressionNotResolvedSHA() throws {
+    let revision = try #require(TrackedRevision(
+        expression: "HEAD~3", baselineBranch: "feature", resolvedSHA: "aaa"
+    ))
+    let first = ReviewSessionTarget.trackedCommit(
+        worktreeID: "wt", repositoryPath: URL(fileURLWithPath: "/repo"),
+        revision: revision, title: "Review HEAD~3"
+    )
+    let second = first.updatingTrackedRevision(
+        revision.resolving(.init(branch: "feature", sha: "bbb")),
+        title: "Review rewritten commit"
+    )
+    #expect(first.id == second.id)
+    #expect(first.draftSessionID == second.draftSessionID)
+}
+
+@Test func migrateMovesAndRekeysDraftsInOneWrite() throws {
+    try store.save(comment(sessionID: oldID, id: "draft-1"))
+    try store.migrate(from: oldID, to: newID)
+    #expect(try store.load(sessionID: oldID).isEmpty)
+    #expect(try store.load(sessionID: newID).single?.sessionID == newID)
+}
+```
+
+Also assert that moving from resolved SHA `aaa` to `bbb` clears `verdict`, sets `status = .active`, preserves handoffs, and that `ReviewSessionLoader` passes only `bbb` to its commit loader.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/ReviewDraftCommentStoreTests \
+  -only-testing:AlasTests/ReviewSessionModelsTests \
+  -only-testing:AlasTests/ReviewSessionLoaderTests test
+```
+
+- [ ] **Step 3: Implement tracked review identity and migration**
+
+Add `.trackedCommit` to `ReviewDraftSourceKind`, `ReviewSessionTargetKind`, and `ReviewSessionTarget.Payload`. Define:
+
+```swift
+static func trackedCommit(
+    worktreeID: String,
+    repositoryPath: URL,
+    revision: TrackedRevision,
+    title: String
+) -> ReviewSessionTarget
+
+func updatingTrackedRevision(
+    _ revision: TrackedRevision,
+    title: String
+) -> ReviewSessionTarget
+
+func freezingTrackedRevision(title: String) -> ReviewSessionTarget?
+```
+
+The target and draft IDs use the normalized expression and never the resolved SHA. `revisionDescription` is `"<expression> -> <sha>"`; `sourceDescription` uses the same unambiguous pair.
+
+Add record behavior:
+
+```swift
+func retargetingCommit(
+    to target: ReviewSessionTarget,
+    resolvedSHAChanged: Bool,
+    now: Date
+) -> ReviewSessionRecord
+```
+
+When `resolvedSHAChanged` is true, clear `verdict`, set `status = .active`, preserve handoffs, and update `updatedAt`.
+
+Implement `ReviewDraftCommentStore.migrate(from:to:)` by reading one snapshot, removing the source array, rewriting every moved comment's `sessionID`, merging by comment ID with the moved value winning, then writing once.
+
+Route `.trackedCommit` through the existing commit loader using only `revision.resolvedSHA`.
+
+- [ ] **Step 4: Rerun focused tests**
+
+Expected: all three suites pass.
+
+- [ ] **Step 5: Commit tracked review persistence**
+
+```bash
+git add Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift \
+  Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift \
+  Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift \
+  Alas/Sources/Center/ReviewWorkspace/ReviewSessionLoader.swift \
+  AlasTests/ReviewDraftCommentStoreTests.swift AlasTests/ReviewSessionModelsTests.swift \
+  AlasTests/ReviewSessionLoaderTests.swift
+git commit -m "feat(review): add followed review targets"
+```
+
+---
+
+### Task 4: Publish Git revision-change generations from existing watchers
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/Watch/GitEventFilter.swift`
+- Modify: `Alas/Sources/SSH/RemoteProjectGitWatcher.swift`
+- Modify: `AlasTests/AppStateCleanupTests.swift`
+- Modify: `AlasTests/ProjectGitWatcherTests.swift`
+- Modify: `AlasTests/SSH/RemoteWorktreePollTests.swift`
+
+**Interfaces:**
+- Consumes: existing `ProjectGitWatcher` and `RemoteProjectGitWatcher` callbacks.
+- Produces: `AppState.revisionChangeGeneration(worktreeID:)` and internal generation bump helpers.
+
+- [ ] **Step 1: Add failing generation tests**
+
+Test that a worktree HEAD callback bumps only matching worktrees, while shared-ref movement bumps every worktree in the project. Expand `GitEventFilter` coverage so `refs/heads`, `refs/remotes`, and `refs/tags` all signal a revision change. Test that repeated callbacks monotonically increase, remote HEAD movement takes the topology path, and a remote helper Git event can signal revision movement even when `git worktree list` is otherwise unchanged.
+
+```swift
+@Test func headUpdateAdvancesMatchingWorktreeRevisionGeneration() async throws {
+    let before = state.revisionChangeGeneration(worktreeID: worktree.id)
+    state.handleProjectHeadUpdates(
+        projectId: project.id,
+        branchByWorktreePath: [worktree.path: worktree.branch]
+    )
+    #expect(state.revisionChangeGeneration(worktreeID: worktree.id) == before + 1)
+}
+```
+
+- [ ] **Step 2: Run focused watcher tests and verify failure**
+
+Run the three suites with `rtk xcodebuild ... test`; expect missing generation APIs.
+
+- [ ] **Step 3: Implement observable per-worktree generations**
+
+Add an observable dictionary and accessor:
+
+```swift
+private(set) var revisionChangeGenerations: [String: Int] = [:]
+
+func revisionChangeGeneration(worktreeID: String) -> Int {
+    revisionChangeGenerations[worktreeID, default: 0]
+}
+```
+
+In `handleProjectHeadUpdates`, canonicalize callback paths, bump every matching worktree even when its branch label did not change, then retain the existing sidebar/GG invalidation behavior. Treat every non-lock path under `refs/` as a shared revision change and bump all current worktrees for the project before the existing asynchronous topology refresh; newly discovered worktrees start at zero.
+
+Add `RemoteProjectGitWatcher.onRevisionChanged`. Invoke it for remote-helper `.git` events before the reconciliation tick, and wire it in `AppState` to bump all project worktree generations without forcing a second topology refresh. Remote poll HEAD deltas retain their existing topology callback, which also bumps generations.
+
+- [ ] **Step 4: Rerun watcher tests**
+
+Expected: focused local and remote watcher suites pass.
+
+- [ ] **Step 5: Commit watcher generation wiring**
+
+```bash
+git add Alas/Sources/App/AppState.swift Alas/Sources/Watch/GitEventFilter.swift \
+  Alas/Sources/SSH/RemoteProjectGitWatcher.swift AlasTests/AppStateCleanupTests.swift \
+  AlasTests/ProjectGitWatcherTests.swift AlasTests/SSH/RemoteWorktreePollTests.swift
+git commit -m "feat(review): signal tracked revision changes"
+```
+
+---
+
+### Task 5: Centralize follow, edit, stop, and checkout-accept actions
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `Alas/Sources/Center/TabBarView.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Modify: `Alas/Sources/Center/Commit/TrackedRevision.swift`
+- Modify: `AlasTests/CommitTabStateTests.swift`
+- Modify: `AlasTests/TabsManagerReviewSessionTests.swift`
+
+**Interfaces:**
+- Consumes: `TabsManager.updateCommit`, tracked review target helpers, and draft migration.
+- Produces: `AppState.followRevision(worktreeID:tabID:expression:)`, `stopFollowingRevision(worktreeID:tabID:)`, `acceptTrackedRevisionCheckout(worktreeID:tabID:)`, and tab-context actions.
+
+- [ ] **Step 1: Write failing retarget action tests**
+
+Test the pure mutation seam for both tab kinds: fixed commit to followed, followed expression edit, followed commit to fixed, fixed review to followed with draft migration IDs, and pending checkout acceptance. Verify invalid/blank expressions leave state untouched.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run `CommitTabStateTests` and `TabsManagerReviewSessionTests`; expect missing action helpers.
+
+- [ ] **Step 3: Implement testable mutation helpers and AppKit prompt**
+
+Add a helper returning explicit persistence work:
+
+```swift
+struct TrackedRevisionRetargetingResult {
+    let record: ReviewSessionRecord
+    let oldDraftSessionID: ReviewDraftSessionID
+    let newDraftSessionID: ReviewDraftSessionID
+}
+
+enum TrackedRevisionRetargeter {
+    static func follow(
+        record: ReviewSessionRecord,
+        revision: TrackedRevision,
+        title: String,
+        now: Date
+    ) -> TrackedRevisionRetargetingResult?
+
+    static func stop(
+        record: ReviewSessionRecord,
+        title: String,
+        now: Date
+    ) -> TrackedRevisionRetargetingResult?
+}
+```
+
+AppState resolves the entered expression first, then applies either a commit-tab mutation or the review record + draft migration + tab title update. Use an `NSAlert` with one text field for header/context-menu entry; show validation failures with the existing warning alert path. Prefill an existing expression when editing and a first-parent `HEAD~N` suggestion when `GitService` can prove the displayed SHA equals that expression.
+
+- [ ] **Step 4: Add tab-bar context actions**
+
+Extend `TabBarView` with `onFollowRevision`, `onEditRevision`, and `onStopFollowingRevision` callbacks. Show these only for `.commit` and commit-kind `.reviewSession` tabs; the review-session capability is determined from its current record in `CenterPaneView`. Mirror the same AppState methods used by pane headers.
+
+- [ ] **Step 5: Rerun focused tests**
+
+Expected: retargeting and persistence tests pass.
+
+- [ ] **Step 6: Commit revision actions**
+
+```bash
+git add Alas/Sources/App/AppState.swift Alas/Sources/Center/TabBarView.swift \
+  Alas/Sources/Center/CenterPaneView.swift Alas/Sources/Center/Commit/TrackedRevision.swift \
+  AlasTests/CommitTabStateTests.swift AlasTests/TabsManagerReviewSessionTests.swift
+git commit -m "feat(review): add revision follow actions"
+```
+
+---
+
+### Task 6: Make commit-detail tabs refresh atomically
+
+**Files:**
+- Modify: `Alas/Sources/Center/Commit/CommitTabView.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Modify: `AlasTests/CommitTabViewTests.swift`
+
+**Interfaces:**
+- Consumes: `CommitTabState`, `TrackedRevisionResolver`, watcher generation, and AppState actions.
+- Produces: guarded `CommitTabSnapshot`, updating/error presentation, and checkout banner behavior.
+
+- [ ] **Step 1: Add failing publication and presentation tests**
+
+Define tests for: old snapshot retained while updating; candidate details and review session published together; stale load token rejected; selection retained by matching file path; failure retains the old snapshot; pending checkout exposes accept/stop actions; fixed tabs never resolve on generation changes.
+
+```swift
+@Test func trackedPublicationRetainsSelectionByPath() {
+    let publication = CommitTabRefreshPublication.make(
+        previousSelection: .init(namespace: "commit", path: "A.swift"),
+        snapshot: snapshot(paths: ["A.swift", "B.swift"])
+    )
+    #expect(publication.selectedFileID?.path == "A.swift")
+}
+```
+
+- [ ] **Step 2: Run `CommitTabViewTests` and verify failure**
+
+- [ ] **Step 3: Refactor the view around a complete immutable snapshot**
+
+Pass `tabState: CommitTabState` instead of a bare SHA. Add:
+
+```swift
+struct CommitTabSnapshot {
+    let sha: String
+    let details: CommitDetails
+    let reviewSession: DiffReviewLoadedSession
+}
+```
+
+Load details and review content into locals, then publish one snapshot only if the generation token remains active. Initial fixed tabs may show the existing full-page spinner; followed refreshes retain the prior snapshot and show `commit-revision-updating` in the header. Resolution/load failures show a nonblocking `commit-revision-error` banner with Retry, Edit, and Stop.
+
+The task identity includes tab ID, tracked expression, and `appState.revisionChangeGeneration(worktreeID:)`. Evaluate `TrackedRevisionPolicy` before loading. Persist pause metadata immediately; persist a new resolved SHA/title only after its complete snapshot loads.
+
+- [ ] **Step 4: Add header follow controls and checkout banner**
+
+Fixed headers call `followRevision`; followed headers show the expression, short SHA, Edit, and Stop. Pending checkout shows Update to new branch and Stop. Add stable accessibility identifiers for all controls.
+
+- [ ] **Step 5: Update center-pane identity and rerun tests**
+
+Render `CommitTabView(tabState:s, ...)` with `.id(s.id)`, never `.id(s.sha)`, so a rewrite does not recreate tab-local UI state.
+
+Expected: `CommitTabViewTests` pass.
+
+- [ ] **Step 6: Commit atomic commit-tab refresh**
+
+```bash
+git add Alas/Sources/Center/Commit/CommitTabView.swift \
+  Alas/Sources/Center/CenterPaneView.swift AlasTests/CommitTabViewTests.swift
+git commit -m "feat(review): refresh followed commit tabs"
+```
+
+---
+
+### Task 7: Make dedicated review sessions refresh atomically
+
+**Files:**
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift`
+- Modify: `Alas/Sources/Center/TabsManager.swift`
+- Modify: `AlasTests/ReviewSessionTabViewTests.swift`
+- Modify: `AlasTests/TabsManagerReviewSessionTests.swift`
+
+**Interfaces:**
+- Consumes: tracked target helpers, `ReviewSessionLoader`, resolver policy, draft migration, and watcher generation.
+- Produces: tracked-session shadow reload, verdict reset, continuity publication, and tracked review header/banner.
+
+- [ ] **Step 1: Add failing tracked-session refresh tests**
+
+Cover same-branch follow, unchanged resolution, checkout pause, old loaded context retained during refresh/error, out-of-order suppression, file selection retention, draft controller stability, verdict reset, and title/tab-state persistence.
+
+```swift
+@Test func movingTrackedReviewReopensVerdictAndPreservesHandoffs() throws {
+    let updated = reviewedRecord.retargetingCommit(
+        to: movedTarget,
+        resolvedSHAChanged: true,
+        now: Date(timeIntervalSince1970: 50)
+    )
+    #expect(updated.status == .active)
+    #expect(updated.verdict == nil)
+    #expect(updated.handoffs == reviewedRecord.handoffs)
+}
+```
+
+- [ ] **Step 2: Run review-session suites and verify failure**
+
+- [ ] **Step 3: Resolve before load and publish a complete generation**
+
+Include the worktree revision generation in `loadTaskID` only for tracked commit targets. Split initial-empty loading from tracked-refresh loading so `beginLoadReviewSession` does not clear `loaded` during a refresh. For `.follow`, build the candidate target in memory, call `loader.load(target:)`, then atomically:
+
+1. retarget and save the record,
+2. update the tab title/selection,
+3. publish the new loaded context,
+4. keep the same draft controller because the logical draft ID is unchanged.
+
+For `.pause`, save pending metadata without replacing loaded content. For resolution/load failure, retain loaded content and show a tracked error banner; on first reopen, load the persisted last-resolved SHA even if revalidation fails so the last snapshot is recoverable.
+
+- [ ] **Step 4: Add tracked header and checkout/error banners**
+
+Mirror the commit-tab actions and identifiers. Feedback target text must use `expression -> resolvedSHA`. Retry increments the existing load generation.
+
+- [ ] **Step 5: Rerun focused review-session tests**
+
+Expected: `ReviewSessionTabViewTests` and `TabsManagerReviewSessionTests` pass.
+
+- [ ] **Step 6: Commit tracked review refresh**
+
+```bash
+git add Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift \
+  Alas/Sources/Center/TabsManager.swift AlasTests/ReviewSessionTabViewTests.swift \
+  AlasTests/TabsManagerReviewSessionTests.swift
+git commit -m "feat(review): refresh followed review sessions"
+```
+
+---
+
+### Task 8: Open followed revisions from the review palette
+
+**Files:**
+- Modify: `Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteEnvironment.swift`
+- Modify: `Alas/Sources/Dialogs/ReviewTarget/AppState+ReviewPalette.swift`
+- Modify: `Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift`
+- Modify: `Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift`
+- Modify: `AlasTests/ReviewTargetPaletteModelTests.swift`
+
+**Interfaces:**
+- Consumes: live resolver and `ReviewSessionTarget.trackedCommit`.
+- Produces: debounced exact-query validation and `.followedRevision` palette rows.
+
+- [ ] **Step 1: Add failing palette tests**
+
+Test valid exact expression, invalid expression, stale async result suppression, commit-filter rows retained, selection snapping to the followed row when it is the only result, and activation opening a tracked target.
+
+```swift
+@Test func exactRevisionQueryLaunchesTrackedCommit() async throws {
+    model.query = "HEAD~3"
+    await model.validateRevisionQuery(environment: env)
+    #expect(model.targetRows().contains(.followedRevision(
+        expression: "HEAD~3", resolvedSHA: "resolved-HEAD~3", branch: "feature"
+    )))
+    await model.activateSelection(environment: env)
+    #expect(opened?.kind == .trackedCommit)
+}
+```
+
+- [ ] **Step 2: Run `ReviewTargetPaletteModelTests` and verify failure**
+
+- [ ] **Step 3: Implement validation state and row activation**
+
+Add `currentBranch` to the environment. Add a selectable row:
+
+```swift
+case followedRevision(expression: String, resolvedSHA: String, branch: String)
+```
+
+`validateRevisionQuery` trims the exact query, captures a validation token, resolves SHA and branch concurrently, and publishes only if the token and query still match. Do not hide ordinary fuzzy commit/branch matches. Activation builds `TrackedRevision` and opens `ReviewSessionTarget.trackedCommit` titled `Review <expression>`.
+
+- [ ] **Step 4: Wire debounced validation and presentation**
+
+Start validation from a query-keyed task in `ReviewTargetDialog` after a short cancellation-aware debounce. Render a pin icon, expression, and resolved short SHA. Surface validation errors only when no normal target rows match, avoiding noisy errors during ordinary fuzzy search.
+
+- [ ] **Step 5: Rerun palette tests**
+
+Expected: all existing and new palette tests pass.
+
+- [ ] **Step 6: Commit palette entry**
+
+```bash
+git add Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteEnvironment.swift \
+  Alas/Sources/Dialogs/ReviewTarget/AppState+ReviewPalette.swift \
+  Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift \
+  Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift \
+  AlasTests/ReviewTargetPaletteModelTests.swift
+git commit -m "feat(review): open followed revisions from palette"
+```
+
+---
+
+### Task 9: Integration regression pass and required verification
+
+**Files:**
+- Verify: all tracked-revision, commit-tab, review-session, watcher, palette, and persistence suites.
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: a fully verified feature with no unrelated behavior changes.
+
+- [ ] **Step 1: Run all focused suites together**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/CommitTabStateTests \
+  -only-testing:AlasTests/CommitTabViewTests \
+  -only-testing:AlasTests/TabsManagerTests \
+  -only-testing:AlasTests/TabsManagerReviewSessionTests \
+  -only-testing:AlasTests/ReviewDraftCommentStoreTests \
+  -only-testing:AlasTests/ReviewSessionModelsTests \
+  -only-testing:AlasTests/ReviewSessionLoaderTests \
+  -only-testing:AlasTests/ReviewSessionTabViewTests \
+  -only-testing:AlasTests/ReviewTargetPaletteModelTests \
+  -only-testing:AlasTests/ProjectGitWatcherTests test
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run formatting and repository checks**
+
+```bash
+swiftformat --lint Alas/Sources AlasTests
+git diff --check
+```
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 3: Regenerate and run the required build**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: generation and build succeed. Commit `Alas.xcodeproj/project.pbxproj` if regeneration changes it.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: full suite passes. If an unrelated known flaky test fails, rerun that test in isolation and report both results without claiming a clean full-suite pass.
+
+- [ ] **Step 5: Review the final diff and commit verification fixes**
+
+```bash
+git status --short
+git diff --stat 1b07a6c6..HEAD
+git diff --check 1b07a6c6..HEAD
+```
+
+Confirm that no CLI/MCP, range-review, hosted-review, draft-commit, or commit-editor behavior changed. Commit only real verification fixes with a focused message; do not create an empty verification commit.

--- a/docs/superpowers/specs/2026-08-05-sticky-commit-revisions-design.md
+++ b/docs/superpowers/specs/2026-08-05-sticky-commit-revisions-design.md
@@ -1,0 +1,219 @@
+# Sticky Commit Revision Tracking Design
+
+## Context
+
+Commit-detail tabs and dedicated commit review sessions currently persist an
+immutable commit SHA. This is correct for historical inspection, but it makes
+iterative review awkward: amending or rebasing replaces commits while an open
+tab continues to show the old object.
+
+Users should be able to follow a logical single-commit revision such as
+`HEAD`, `HEAD~3`, a local branch, or a tag. The logical expression must remain
+stable while Alas loads each resolved commit as an immutable snapshot. Fixed
+SHA tabs must keep their existing behavior.
+
+## Goals
+
+- Support followed revisions in commit-detail tabs and dedicated review
+  sessions.
+- Let users create a followed revision from an open tab or the review target
+  palette.
+- Follow same-branch amend, rebase, reset, and named-ref movement
+  automatically.
+- Preserve tab position and review continuity while the resolved SHA changes.
+- Keep the last complete snapshot visible until the replacement is fully
+  loaded.
+- Pause before following an affected `HEAD` expression across a branch
+  checkout.
+- Persist pins and their review state across app restarts.
+
+## Non-Goals
+
+- Tracked commit ranges or branch-comparison reviews.
+- Changes to hosted PR/MR, draft-commit, or commit-editor targets.
+- CLI or MCP contract changes.
+- Per-tab polling for Git changes.
+- Rewriting comment anchors with content-based fuzzy matching.
+
+## Model and Identity
+
+Add a shared Codable tracked-revision value containing:
+
+- the user-authored expression, normalized only by trimming whitespace
+- the branch baseline used to distinguish same-branch rewrites from checkout
+- the last completely loaded SHA
+- an optional pending checkout candidate
+
+A fixed commit remains an immutable SHA. A followed commit keeps logical
+identity separate from its resolved snapshot:
+
+- the expression owns tab/session identity and review continuity
+- the resolved SHA owns commit metadata, diffs, images, and context snapshots
+
+Commit tabs gain a stable persisted tab ID plus fixed-or-followed revision
+state. Changing the resolved SHA must not change the tab ID, order, or active
+selection.
+
+Commit review sessions similarly separate their logical target identity from
+the resolved commit snapshot. A followed session and its draft namespace are
+keyed by worktree, repository, and normalized expression. Loaders receive only
+the resolved immutable SHA.
+
+Legacy persisted commit tabs and review sessions decode as fixed-SHA targets
+with their existing identity and behavior. Converting a fixed review into a
+followed review, editing its expression, or stopping following atomically
+migrates its draft comments to the new logical namespace without changing the
+open session's continuity.
+
+## Entry and Presentation
+
+Both commit-detail and review-session headers expose revision tracking:
+
+- fixed tabs offer **Follow revision...**
+- followed tabs show **Following `<expression>`** and the resolved short SHA
+- followed tabs offer **Edit revision...** and **Stop following**
+- the tab context menu mirrors these actions
+
+The revision editor accepts any single expression that `git rev-parse
+--verify <expression>^{commit}` resolves. Raw SHAs are valid but naturally do
+not move. When the displayed commit is on HEAD's first-parent chain, the editor
+suggests `HEAD` or `HEAD~N`; otherwise it starts without a relative suggestion.
+
+Stopping following freezes the tab at its last complete SHA. It does not close,
+move, or replace the visible tab.
+
+The review target palette keeps its current commit and branch filtering. For a
+nonempty query, it also validates the exact query asynchronously and, when it
+resolves, presents a selectable **Follow revision `<expression>`** row. Commit
+ranges continue to create immutable range targets.
+
+Tab titles follow the loaded snapshot's subject while preserving a visible pin
+indicator. Review headers and feedback context show both the expression and
+resolved short SHA so the displayed bytes are never ambiguous.
+
+## Resolution and Refresh Flow
+
+AppState exposes a shared revision-change generation keyed by worktree. The
+existing local and remote Git watchers advance it for HEAD or local-ref
+movement. This avoids adding a watcher or polling loop per tab.
+
+When a followed tab is visible or its worktree generation changes:
+
+1. Resolve the expression and current branch.
+2. If the SHA is unchanged, publish no UI or persistence change.
+3. If the branch baseline is unchanged, begin loading the candidate SHA.
+4. Load commit details and every diff/image/context provider against that exact
+   immutable SHA in a new generation.
+5. Publish metadata, diff content, resolved SHA, and title atomically only when
+   the complete generation succeeds and is still current.
+
+The prior snapshot remains interactive during resolution and loading. A small
+updating indicator communicates background work without replacing the pane
+with a spinner. Selection is retained by file path when the file still exists;
+otherwise it falls back through the review surface's normal selection rules.
+
+Resolution and load operations are cancellable and generation-guarded. An old
+completion cannot overwrite a newer Git event, edited expression, accepted
+checkout, stopped pin, or closed tab.
+
+Inactive tabs do not poll. They revalidate when activated or when an already
+instantiated view observes the shared generation.
+
+## Checkout Safety
+
+If the worktree branch changes and the expression resolves to a different SHA,
+Alas keeps the last complete snapshot and pauses following. The tab presents a
+banner with:
+
+- **Update to new branch**, which accepts the candidate branch as the new
+  baseline and loads its resolved commit
+- **Stop following**, which freezes the prior complete SHA
+
+Named expressions whose resolution is independent of the checked-out branch
+continue following their own ref. A branch switch that does not change the
+expression's resolved SHA requires no confirmation.
+
+The branch baseline and pending checkout candidate persist. Reopening the app
+revalidates before changing content and restores the confirmation state when
+needed.
+
+## Review Continuity
+
+When a followed review moves to a new SHA, preserve:
+
+- draft comments and replies
+- comment resolution state
+- feedback handoff history
+- selected file where its path still exists
+- rail collapse, layout, wrapping, and whitespace state
+
+Existing path/side/line placement reattaches comments when the anchor remains
+visible. Comments whose old line no longer maps stay visible at file level;
+comments for absent files remain represented by the review summary's orphan
+handling.
+
+A verdict applies to one resolved snapshot. Moving to a new SHA clears the
+verdict and returns the session to `active`, while retaining historical
+handoffs. Feedback produced after movement includes both the expression and
+resolved SHA.
+
+## Failure Behavior
+
+An invalid expression cannot create or replace a pin. Validation errors remain
+in the revision editor or palette.
+
+If an established expression later stops resolving, or its replacement fails
+to load, Alas keeps the last complete snapshot and presents a nonblocking error
+with **Retry**, **Edit revision...**, and **Stop following**. Interrupted rebases,
+deleted refs, shallow history, and remote connection failures all use this
+behavior.
+
+Persistence is committed only with a successful complete generation or an
+explicit user action. A partially loaded candidate must never be labeled as the
+current resolved snapshot.
+
+## Testing
+
+Model and persistence tests cover:
+
+- legacy fixed-SHA decoding
+- stable followed identities and restart round-trips
+- expression trimming and fixed-versus-followed deduplication
+- draft migration when following, editing, or stopping
+- pending checkout persistence
+
+Resolver and coordinator tests cover:
+
+- unchanged resolutions
+- same-branch amend, rebase, and reset movement
+- named-ref movement
+- checkout pause, accept, and stop
+- deleted or temporarily invalid refs
+- cancellation and out-of-order completion suppression
+
+Commit-tab and review-session tests cover:
+
+- retaining the old snapshot during refresh
+- atomic metadata and diff publication
+- selection retention by file path
+- comment placement and orphan fallback
+- verdict reset to `active`
+- retry and edit recovery
+
+Palette and header tests cover validation, the synthetic followed-revision row,
+`HEAD~N` suggestions, follow/edit/stop actions, errors, and accessibility
+labels. Watcher tests cover local ref changes and remote HEAD movement without
+per-tab polling.
+
+Acceptance scenarios are:
+
+- fixed SHA tabs never move
+- `HEAD` follows an amend
+- `HEAD~3` follows a rebase
+- checkout pauses an affected HEAD-relative pin
+- accepting checkout follows the new branch
+- a broken expression retains the last good diff
+- closing and reopening preserves the pin and review drafts
+
+Verification runs focused Swift Testing suites first, then `xcodegen`, the
+required macOS build, and the full test suite.


### PR DESCRIPTION
## Summary
- Add tracked revision persistence for commit and review-session tabs.
- Refresh followed commit/review tabs from Git revision-change generations while retaining the last complete snapshot.
- Add palette, tab-menu, and pane-header actions for following, editing, stopping, and accepting checkout-paused revisions.

## Verification
- rtk xcodegen
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build\n- focused tracked-revision regression suite: CommitTabStateTests, CommitTabViewTests, TabsManagerTests, TabsManagerReviewSessionTests, ReviewDraftCommentStoreTests, ReviewSessionModelsTests, ReviewSessionLoaderTests, ReviewSessionTabViewTests, ReviewTargetPaletteModelTests, ProjectGitWatcherTests, CommitHeaderViewTests, TouchTargetSmokeTests\n- rtk swiftformat --lint .\n- rtk git diff --check 4f55edc9..HEAD\n\nFull local suite note: attempted twice; the run stalled before XCTest output and was interrupted locally. CI should provide the full-suite signal.