### PR TITLE
perf(changes): smooth long commit list scrolling

### DIFF
--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -79,6 +79,15 @@ struct BehindChip: View {
 }
 
 struct CommitsSectionView: View {
+    struct CommitRowBatch: Identifiable {
+        let range: Range<Int>
+        let id: [String]
+    }
+
+    /// Keep the pinned outer stack's child count low without eagerly building
+    /// an entire long history when a batch enters the viewport.
+    static let rowBatchSize = 8
+
     let commits: [CommitInfo]
     let olderCommits: [CommitInfo]
     let comparisonRef: String?
@@ -161,6 +170,19 @@ struct CommitsSectionView: View {
         ggStack?.name ?? "Commits"
     }
 
+    static func rowBatches(count: Int) -> [Range<Int>] {
+        guard count > 0 else { return [] }
+        return stride(from: 0, to: count, by: rowBatchSize).map { start in
+            start ..< min(start + rowBatchSize, count)
+        }
+    }
+
+    static func rowBatches(for commits: [CommitInfo]) -> [CommitRowBatch] {
+        rowBatches(count: commits.count).map { range in
+            CommitRowBatch(range: range, id: commits[range].map(\.sha))
+        }
+    }
+
     static func ggRowMutationsEnabled(
         inFlightAction: GGStackActionKind?,
         mergeOperation: MergeOperation?,
@@ -182,26 +204,30 @@ struct CommitsSectionView: View {
     private var expandedBody: some View {
         // 1. Worktree commits ("your work") OR today's empty placeholder.
         if !commits.isEmpty {
-                ForEach(Array(commits.enumerated()), id: \.element.id) { idx, commit in
-                CommitRow(
-                    commit: commit,
-                    isLast: idx == commits.count - 1 && olderCommits.isEmpty,
-                    onSelect: { onSelect(commit) },
-                    onCopySHA: { onCopySHA(commit) },
-                    onCopyMessage: { Clipboard.copy(commit.fullMessage) },
-                    onOpenRemote: rps.commitsNeedPush ? nil : openRemoteAction(for: commit, remote: rps.primaryCommitRemote),
-                    onEdit: { onEdit(commit) },
-                    onReview: { onReview(commit) },
-                    onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
-                    onRevert: { rps.runRevert(sha: commit.sha) },
-                    ggMenu: ggMenu(for: commit),
-                    onGGAction: { action in onGGAction(action, commit) },
-                    onGGOpenPR: ggOpenReviewRequestAction(for: commit).map { action in
-                        { onGGAction(action, commit) }
-                    },
-                    stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),
-                    codeHostKind: stackCodeHostKind
-                )
+            ForEach(Self.rowBatches(for: commits)) { batch in
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(commits[batch.range]) { commit in
+                        CommitRow(
+                            commit: commit,
+                            isLast: commit.id == commits.last?.id && olderCommits.isEmpty,
+                            onSelect: { onSelect(commit) },
+                            onCopySHA: { onCopySHA(commit) },
+                            onCopyMessage: { Clipboard.copy(commit.fullMessage) },
+                            onOpenRemote: rps.commitsNeedPush ? nil : openRemoteAction(for: commit, remote: rps.primaryCommitRemote),
+                            onEdit: { onEdit(commit) },
+                            onReview: { onReview(commit) },
+                            onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
+                            onRevert: { rps.runRevert(sha: commit.sha) },
+                            ggMenu: ggMenu(for: commit),
+                            onGGAction: { action in onGGAction(action, commit) },
+                            onGGOpenPR: ggOpenReviewRequestAction(for: commit).map { action in
+                                { onGGAction(action, commit) }
+                            },
+                            stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),
+                            codeHostKind: stackCodeHostKind
+                        )
+                    }
+                }
             }
         } else if olderCommits.isEmpty {
             emptyPlaceholder
@@ -215,19 +241,23 @@ struct CommitsSectionView: View {
 
         // 3. Older commits — dimmed when comparisonRef exists, plain when not.
         if !olderCommits.isEmpty {
-                ForEach(Array(olderCommits.enumerated()), id: \.element.id) { idx, commit in
-                CommitRow(
-                    commit: commit,
-                    isLast: idx == olderCommits.count - 1,
-                    isHistorical: comparisonRef != nil,
-                    onSelect: { onSelect(commit) },
-                    onCopySHA: { onCopySHA(commit) },
-                    onCopyMessage: { Clipboard.copy(commit.fullMessage) },
-                    onOpenRemote: openRemoteAction(for: commit, remote: rps.commitRemote),
-                    onReview: { onReview(commit) },
-                    onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
-                    onRevert: { rps.runRevert(sha: commit.sha) }
-                )
+            ForEach(Self.rowBatches(for: olderCommits)) { batch in
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(olderCommits[batch.range]) { commit in
+                        CommitRow(
+                            commit: commit,
+                            isLast: commit.id == olderCommits.last?.id,
+                            isHistorical: comparisonRef != nil,
+                            onSelect: { onSelect(commit) },
+                            onCopySHA: { onCopySHA(commit) },
+                            onCopyMessage: { Clipboard.copy(commit.fullMessage) },
+                            onOpenRemote: openRemoteAction(for: commit, remote: rps.commitRemote),
+                            onReview: { onReview(commit) },
+                            onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
+                            onRevert: { rps.runRevert(sha: commit.sha) }
+                        )
+                    }
+                }
             }
         }
 

--- a/AlasTests/CommitsSectionTitleTests.swift
+++ b/AlasTests/CommitsSectionTitleTests.swift
@@ -2,6 +2,46 @@ import Testing
 @testable import Alas
 
 struct CommitsSectionTitleTests {
+    @Test func commitRowsAreSplitIntoSmallContiguousBatches() {
+        let batches = CommitsSectionView.rowBatches(count: 40)
+
+        #expect(batches.count == 5)
+        #expect(batches.allSatisfy { $0.count <= CommitsSectionView.rowBatchSize })
+        #expect(batches.flatMap(Array.init) == Array(0 ..< 40))
+    }
+
+    @Test func commitRowBatchesHandleEmptyAndPartialLists() {
+        #expect(CommitsSectionView.rowBatches(count: 0).isEmpty)
+        #expect(CommitsSectionView.rowBatches(count: 10) == [0 ..< 8, 8 ..< 10])
+    }
+
+    @Test func commitRowBatchIdentityTracksCommitContent() {
+        let original = (0 ..< CommitsSectionView.rowBatchSize).map { commit(sha: "commit-\($0)") }
+        var refreshed = original
+        refreshed[3] = commit(sha: "replacement")
+
+        let originalBatch = try! #require(CommitsSectionView.rowBatches(for: original).first)
+        let refreshedBatch = try! #require(CommitsSectionView.rowBatches(for: refreshed).first)
+
+        #expect(originalBatch.range == refreshedBatch.range)
+        #expect(originalBatch.id != refreshedBatch.id)
+    }
+
+    private func commit(sha: String) -> CommitInfo {
+        CommitInfo(
+            sha: sha,
+            shortSha: String(sha.prefix(7)),
+            author: "Author",
+            authorInitials: "A",
+            date: .now,
+            subject: "Subject",
+            conventionalTag: nil,
+            filesChanged: 0,
+            insertions: 0,
+            deletions: 0
+        )
+    }
+
     private func stack(name: String = "nacho/stack") -> GGStack {
         GGStack(
             name: name, base: "main", totalCommits: 1, syncedCommits: 1,


### PR DESCRIPTION
## Summary

- batch commit rows in groups of eight so the Changes tab's pinned outer stack manages far fewer direct children for long histories
- preserve commit SHA identity, row actions, and commit-rail end-state behavior across batches
- add regression coverage for batch sizing, ordering, empty histories, and partial batches

## Verification

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-changes-tab-perf-final -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-changes-tab-perf-final -only-testing:AlasTests/CommitsSectionTitleTests -only-testing:AlasTests/CommitRowTests test` (15 tests passed)
- `rtk swiftformat --lint Alas/Sources/Right/CommitsSectionView.swift AlasTests/CommitsSectionTitleTests.swift`
- `git diff --check`