### PR TITLE
fix(commit): keep short details non-scrollable

### DIFF
--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -27,10 +27,13 @@ struct CommitHeaderView: View {
                     .padding(.top, 8)
             }
             if expanded {
-                ScrollView(.vertical) {
+                ViewThatFits(in: .vertical) {
                     expandedBlock
+                        .fixedSize(horizontal: false, vertical: true)
+                    ScrollView(.vertical) {
+                        expandedBlock
+                    }
                 }
-                .fixedSize(horizontal: false, vertical: true)
                 .frame(maxHeight: Self.maxExpandedHeight)
             }
         }

--- a/AlasTests/CommitHeaderViewTests.swift
+++ b/AlasTests/CommitHeaderViewTests.swift
@@ -98,6 +98,16 @@ struct CommitHeaderViewTests {
         #expect(size.height <= CommitHeaderView.maxExpandedHeight + 40)
     }
 
+    @Test func expandedHeaderOnlyMakesOverflowingDetailsScrollable() {
+        let shortController = hostExpandedHeader(body: "Short body")
+        let longBody = Array(repeating: "A long commit message line", count: 100)
+            .joined(separator: "\n")
+        let longController = hostExpandedHeader(body: longBody)
+
+        #expect(shortController.view.descendantScrollViews().isEmpty)
+        #expect(longController.view.descendantScrollViews().count == 1)
+    }
+
     @Test func headerRowHasButtonAccessibilityTrait() {
         let details = makeDetails(body: "Body")
         var expanded = false
@@ -107,5 +117,24 @@ struct CommitHeaderViewTests {
         let controller = NSHostingController(rootView: view)
         controller.view.layoutSubtreeIfNeeded()
         #expect(controller.view != nil)
+    }
+
+    private func hostExpandedHeader(body: String) -> NSHostingController<some View> {
+        let view = CommitHeaderView(details: makeDetails(body: body), expanded: .constant(true))
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        return controller
+    }
+}
+
+private extension NSView {
+    func descendantScrollViews() -> [NSScrollView] {
+        var result = [self].compactMap { $0 as? NSScrollView }
+        for subview in subviews {
+            result.append(contentsOf: subview.descendantScrollViews())
+        }
+        return result
     }
 }


### PR DESCRIPTION
## Summary

- render short expanded commit details at their intrinsic wrapped height
- keep the 180-point cap and vertical scrolling only for overflowing details
- add coverage for both the intrinsic and overflowing layouts

## Verification

- `swiftformat Alas AlasTests --lint --reporter github-actions-log`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (7,534 passed, 12 skipped, 0 failed)