### PR TITLE
fix(changes): stage optimistically

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1260,6 +1260,7 @@
 		D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */; };
 		D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */; };
 		D49FD01D96C6B00C3683FBCA /* ChatPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D2C54087C4501C3E7793FE /* ChatPane.swift */; };
+		D4C9B03A011D0692D6C97CB8 /* RightPaneOptimisticStageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C91EC7522F31BF41F062610 /* RightPaneOptimisticStageTests.swift */; };
 		D4DE0AC014387E216A904D2E /* ReviewTargetPaletteModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2506BDBA9F67B6516CE2BEF /* ReviewTargetPaletteModelTests.swift */; };
 		D4E6BD88D38563AF45E79C83 /* RightPaneGGLandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */; };
 		D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */; };
@@ -1778,6 +1779,7 @@
 		2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoader.swift; sourceTree = "<group>"; };
 		2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryTests.swift; sourceTree = "<group>"; };
 		2C84E444E25F7DDBE30FB824 /* ReviewFeedbackBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewFeedbackBundleTests.swift; sourceTree = "<group>"; };
+		2C91EC7522F31BF41F062610 /* RightPaneOptimisticStageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneOptimisticStageTests.swift; sourceTree = "<group>"; };
 		2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconTests.swift; sourceTree = "<group>"; };
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPillState.swift; sourceTree = "<group>"; };
@@ -3507,6 +3509,7 @@
 				F6512F4CA47764514D593C1B /* RevisionSnapshotCacheTests.swift */,
 				94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */,
 				BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */,
+				2C91EC7522F31BF41F062610 /* RightPaneOptimisticStageTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */,
@@ -7206,6 +7209,7 @@
 				652C66E1DA5C28C6FD1B5132 /* RevisionSnapshotCacheTests.swift in Sources */,
 				D4E6BD88D38563AF45E79C83 /* RightPaneGGLandTests.swift in Sources */,
 				4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */,
+				D4C9B03A011D0692D6C97CB8 /* RightPaneOptimisticStageTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				019EE52A9C64CF5D15AD9AF2 /* RightPaneStateContentFingerprintTests.swift in Sources */,

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -13,7 +13,7 @@ struct ChangesTabView: View {
     }
 
     private var nonConflictChanges: [ChangedFile] {
-        rps.changes.filter { $0.conflict == nil }
+        rps.displayChanges.filter { $0.conflict == nil }
     }
 
     private var preparationModel: ChangesPreparationModel {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -35,6 +35,15 @@ private struct SyncFetchTarget: Hashable {
     let branch: String
 }
 
+private struct PendingStageMutation: Identifiable {
+    let id = UUID()
+    let paths: Set<String>
+    let gitPaths: [String]
+    let target: ChangeStage
+    var hasAppliedGitMutation = false
+    var minimumRefreshGeneration = 0
+}
+
 @Observable
 @MainActor
 final class RightPaneState: GGSplitCommitServicing {
@@ -55,8 +64,13 @@ final class RightPaneState: GGSplitCommitServicing {
     private(set) var stashOperationInFlight: Bool = false
     private(set) var hasLoadedSnapshot: Bool = false
     var displayChanges: [ChangedFile] {
-        hasLoadedSnapshot ? changes : []
+        guard hasLoadedSnapshot else { return [] }
+        return Self.applyingStageMutations(
+            pendingStageMutations.map { (paths: $0.paths, target: $0.target) },
+            to: changes
+        )
     }
+    private var pendingStageMutations: [PendingStageMutation] = []
     /// Increments whenever `refresh()` publishes a new change list. This
     /// catches same-line unstaged edits whose add/delete totals stay constant.
     /// It is now guarded by an effective-change fingerprint so no-op
@@ -342,13 +356,19 @@ final class RightPaneState: GGSplitCommitServicing {
     private var refreshInFlight = false
 
     @ObservationIgnored
+    private var refreshGeneration = 0
+
+    @ObservationIgnored
     private var refreshRerunRequested = false
 
     @ObservationIgnored
     private var refreshRerunRequiresReviewLoopRemote = false
 
     @ObservationIgnored
-    private var refreshWaiters: [CheckedContinuation<Void, Never>] = []
+    private var refreshWaiters: [CheckedContinuation<Bool, Never>] = []
+
+    @ObservationIgnored
+    private var stageMutationWorker: Task<Void, Never>? = nil
 
     @ObservationIgnored
     private var lastReviewLoopRemoteRefreshAt: Date?
@@ -694,39 +714,40 @@ final class RightPaneState: GGSplitCommitServicing {
         baseCommits?.count ?? displayCommits.count
     }
 
+    @discardableResult
     @MainActor
-    func refresh(forceReviewLoopRemote: Bool = false) async {
+    func refresh(forceReviewLoopRemote: Bool = false) async -> Bool {
         if refreshInFlight {
             refreshRerunRequested = true
             refreshRerunRequiresReviewLoopRemote = refreshRerunRequiresReviewLoopRemote || forceReviewLoopRemote
-            await withCheckedContinuation { continuation in
+            return await withCheckedContinuation { continuation in
                 refreshWaiters.append(continuation)
             }
-            return
         }
 
         refreshInFlight = true
-        defer {
-            refreshInFlight = false
-            let waiters = refreshWaiters
-            refreshWaiters = []
-            for waiter in waiters {
-                waiter.resume()
-            }
-        }
-
         var forceRemoteRefresh = forceReviewLoopRemote
+        var refreshed = false
         repeat {
             forceRemoteRefresh = forceRemoteRefresh || refreshRerunRequiresReviewLoopRemote
             refreshRerunRequested = false
             refreshRerunRequiresReviewLoopRemote = false
-            await performRefresh(forceReviewLoopRemote: forceRemoteRefresh)
+            refreshed = await performRefresh(forceReviewLoopRemote: forceRemoteRefresh)
             forceRemoteRefresh = false
         } while refreshRerunRequested
+        refreshInFlight = false
+        let waiters = refreshWaiters
+        refreshWaiters = []
+        for waiter in waiters {
+            waiter.resume(returning: refreshed)
+        }
+        return refreshed
     }
 
     @MainActor
-    private func performRefresh(forceReviewLoopRemote: Bool) async {
+    private func performRefresh(forceReviewLoopRemote: Bool) async -> Bool {
+        refreshGeneration += 1
+        let currentRefreshGeneration = refreshGeneration
         let reviewLoopInspection = reviewLoop.beginLocalInspection()
         let snapshotGeneration = snapshotInvalidationGeneration
         loading = true
@@ -806,7 +827,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 workingTreeContentFingerprint: workingTreeContentFingerprint
             )
             guard snapshotGeneration == snapshotInvalidationGeneration else {
-                return
+                return false
             }
             // Watcher-driven refreshes fire continuously while agents or
             // builds write into the worktree. @Observable invalidates every
@@ -816,6 +837,9 @@ final class RightPaneState: GGSplitCommitServicing {
             // diff live-lock: docs/plans/2026-07-09-draft-commit-diff-livelock-fix.md).
             if self.upstreamRef != resolvedUpstream?.ref { self.upstreamRef = resolvedUpstream?.ref }
             if self.changes != entries { self.changes = entries }
+            pendingStageMutations.removeAll {
+                $0.hasAppliedGitMutation && $0.minimumRefreshGeneration <= currentRefreshGeneration
+            }
             self.reconcileStashCaches(with: stashes)
             if self.stashes != stashes { self.stashes = stashes }
             if self.lastChangesFingerprint != newChangesFingerprint {
@@ -893,10 +917,11 @@ final class RightPaneState: GGSplitCommitServicing {
             if previousReviewRequestFingerprint != currentReviewRequestFingerprint {
                 changesGeneration += 1
             }
+            return true
         } catch {
             reviewLoop.failLocalRefresh(reviewLoopInspection, error: error)
             guard snapshotGeneration == snapshotInvalidationGeneration else {
-                return
+                return false
             }
             sidebarError = error.localizedDescription
             hasLoadedSnapshot = true
@@ -906,6 +931,7 @@ final class RightPaneState: GGSplitCommitServicing {
             // `self.changes` at its last successful value, which presented as
             // an empty Changes pane when the very first refresh failed.
             logger.error("refresh failed for worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return false
         }
     }
 
@@ -1850,6 +1876,28 @@ final class RightPaneState: GGSplitCommitServicing {
         return "\(base)\u{0000}\(workingTreeContentFingerprint)"
     }
 
+    nonisolated static func applyingStageMutations(
+        _ mutations: [(paths: Set<String>, target: ChangeStage)],
+        to changes: [ChangedFile]
+    ) -> [ChangedFile] {
+        mutations.reduce(changes) { projected, mutation in
+            projected.map { file in
+                guard mutation.paths.contains(file.path), file.stage != mutation.target else {
+                    return file
+                }
+                return ChangedFile(
+                    path: file.path,
+                    status: file.status,
+                    stage: mutation.target,
+                    add: file.add,
+                    del: file.del,
+                    renameFrom: file.renameFrom,
+                    conflict: file.conflict
+                )
+            }
+        }
+    }
+
     func invalidateFileTreeChildLoadsForRefresh() {
         fileTreeGeneration += 1
         loadedFileTreeChildPaths = [""]
@@ -1859,21 +1907,10 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     func toggleStage(_ file: ChangedFile) {
-        sidebarError = nil
-        Task { @MainActor in
-            do {
-                if file.stage == .staged {
-                    // For a staged rename, include the original path so both
-                    // sides of the rename are restored to the working tree;
-                    // otherwise the deletion of the old path remains staged.
-                    try await git.unstage(worktreePath: worktree.path, files: Self.unstagePaths(for: file))
-                } else {
-                    try await git.stage(worktreePath: worktree.path, files: [file.path])
-                }
-            } catch {
-                self.sidebarError = (error as NSError).localizedDescription
-            }
-            await self.refresh()
+        if file.stage == .staged {
+            unstageAll([file])
+        } else {
+            stageAll([file])
         }
     }
 
@@ -2214,23 +2251,55 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     func stageAll(_ files: [ChangedFile]) {
-        let paths = files.map(\.path)
-        sidebarError = nil
-        Task { @MainActor in
-            do { try await git.stageAll(worktreePath: worktree.path, files: paths) }
-            catch { self.sidebarError = (error as NSError).localizedDescription }
-            await self.refresh()
-        }
+        enqueueStageMutation(files: files, target: .staged, gitPaths: files.map(\.path))
     }
 
     func unstageAll(_ files: [ChangedFile]) {
-        let paths = files.flatMap(Self.unstagePaths(for:))
+        enqueueStageMutation(
+            files: files,
+            target: .unstaged,
+            gitPaths: files.flatMap(Self.unstagePaths(for:))
+        )
+    }
+
+    private func enqueueStageMutation(
+        files: [ChangedFile],
+        target: ChangeStage,
+        gitPaths: [String]
+    ) {
+        guard !files.isEmpty else { return }
         sidebarError = nil
-        Task { @MainActor in
-            do { try await git.unstageAll(worktreePath: worktree.path, files: paths) }
-            catch { self.sidebarError = (error as NSError).localizedDescription }
-            await self.refresh()
+        pendingStageMutations.append(PendingStageMutation(
+            paths: Set(files.map(\.path)),
+            gitPaths: gitPaths,
+            target: target
+        ))
+        guard stageMutationWorker == nil else { return }
+        stageMutationWorker = Task { @MainActor [weak self] in
+            await self?.runStageMutationQueue()
         }
+    }
+
+    private func runStageMutationQueue() async {
+        while let mutation = pendingStageMutations.first(where: { !$0.hasAppliedGitMutation }) {
+            do {
+                if mutation.target == .staged {
+                    try await git.stageAll(worktreePath: worktree.path, files: mutation.gitPaths)
+                } else {
+                    try await git.unstageAll(worktreePath: worktree.path, files: mutation.gitPaths)
+                }
+                if let index = pendingStageMutations.firstIndex(where: { $0.id == mutation.id }) {
+                    pendingStageMutations[index].hasAppliedGitMutation = true
+                    pendingStageMutations[index].minimumRefreshGeneration = refreshGeneration + 1
+                }
+                await refresh()
+            } catch {
+                pendingStageMutations.removeAll { $0.id == mutation.id }
+                sidebarError = (error as NSError).localizedDescription
+                await refresh()
+            }
+        }
+        stageMutationWorker = nil
     }
 
     func requestDiscardFile(path: String) {

--- a/AlasTests/RightPaneOptimisticStageTests.swift
+++ b/AlasTests/RightPaneOptimisticStageTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct RightPaneOptimisticStageTests {
+    @Test func stageAndUnstageProjectImmediately() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = makeState(at: repo)
+        await state.refresh()
+
+        let unstaged = try #require(state.changes.first { $0.path == "file.txt" })
+        state.stageAll([unstaged])
+        #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .staged)
+
+        try await waitUntil {
+            state.changes.first { $0.path == "file.txt" }?.stage == .staged
+        }
+        let staged = try #require(state.changes.first { $0.path == "file.txt" })
+        state.unstageAll([staged])
+        #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .unstaged)
+    }
+
+    @Test func orderedMutationsUseLatestStageForOverlappingPaths() {
+        let changes = [changedFile("file.txt", stage: .unstaged)]
+
+        let projected = RightPaneState.applyingStageMutations(
+            [
+                (paths: ["file.txt"], target: .staged),
+                (paths: ["file.txt"], target: .unstaged),
+            ],
+            to: changes
+        )
+
+        #expect(projected == changes)
+    }
+
+    @Test func mutationProjectsEveryEntryForItsPathAndLeavesOthersUnchanged() {
+        let changes = [
+            changedFile("mixed.txt", stage: .staged, add: 2),
+            changedFile("mixed.txt", stage: .unstaged, del: 3),
+            changedFile("other.txt", stage: .unstaged),
+        ]
+
+        let projected = RightPaneState.applyingStageMutations(
+            [(paths: ["mixed.txt"], target: .staged)],
+            to: changes
+        )
+
+        #expect(projected.filter { $0.path == "mixed.txt" }.allSatisfy { $0.stage == .staged })
+        #expect(projected.first { $0.path == "other.txt" }?.stage == .unstaged)
+    }
+
+    @Test func failedStageRollsBackToAuthoritativeChanges() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = makeState(at: repo)
+        await state.refresh()
+        let file = try #require(state.changes.first { $0.path == "file.txt" })
+        try Data().write(to: repo.appendingPathComponent(".git/index.lock"))
+
+        state.stageAll([file])
+        #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .staged)
+
+        try await waitUntil { state.sidebarError != nil }
+        #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .unstaged)
+    }
+
+    private func makeRepo() async throws -> URL {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-optimistic-stage-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "Test"], cwd: repo)
+        try "base\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "file.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        try "changed\n".write(to: repo.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        return repo
+    }
+
+    private func makeState(at path: URL) -> RightPaneState {
+        RightPaneState(
+            worktree: Worktree(
+                id: Worktree.makeId(path: path),
+                projectId: "project",
+                name: "test",
+                branch: "main",
+                path: path,
+                status: .clean,
+                lastActivity: Date()
+            ),
+            baseBranch: "main"
+        )
+    }
+
+    private func changedFile(
+        _ path: String,
+        stage: ChangeStage,
+        add: Int = 0,
+        del: Int = 0
+    ) -> ChangedFile {
+        ChangedFile(
+            path: path,
+            status: "M",
+            stage: stage,
+            add: add,
+            del: del,
+            renameFrom: nil
+        )
+    }
+
+    private func waitUntil(_ condition: () -> Bool) async throws {
+        for _ in 0..<100 {
+            if condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("Condition was not met before timeout")
+    }
+}

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -312,4 +312,14 @@ struct RightPaneStateBaseBranchTests {
         #expect(state.sidebarError != nil)
         #expect(state.displayChanges.isEmpty)
     }
+
+    @Test func refreshReportsFailureWhenSnapshotDoesNotPublish() async {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-missing-worktree-\(UUID().uuidString)")
+        let state = RightPaneState(worktree: makeWorktree(at: tmp, branch: "main"), baseBranch: "main")
+
+        let refreshed = await state.refresh()
+
+        #expect(!refreshed)
+    }
 }


### PR DESCRIPTION
## Summary

- update staging controls immediately while Git runs
- serialize rapid stage/unstage actions and roll back failures
- cover optimistic projection, ordering, and rollback behavior

## Why

The Changes tab waited for Git and a refresh before showing a stage-state change, making every control feel delayed.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (7,654 tests)