### PR TITLE
fix(mission): avoid blocking startup on Mission loading

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -896,8 +896,20 @@ final class AppState {
         })
     }
 
+    func restoreGlobalTabsForStartup() {
+        do {
+            try globalTabs.loadPersistedTabs()
+        } catch {
+            persistenceErrorHandler("Mission Tabs Save Failed", error.localizedDescription)
+        }
+    }
+
     func reconcileMissionsForStartup() async {
         await missions.load()
+        await reconcileLoadedMissionsForStartup()
+    }
+
+    func reconcileLoadedMissionsForStartup() async {
         await refreshRenamedMissionRepositories()
         await missions.resolveLegacyBaseRemoteNames { [weak self] projectID, baseRef in
             await self?.resolveLegacyMissionBaseRemoteName(projectID: projectID, baseRef: baseRef)
@@ -1844,7 +1856,7 @@ final class AppState {
         tabs.loadAll(worktreeIds: allWorktreeIds)
         do {
             let migrationWorktreeID = selectedWorktreeId ?? resolvedSelectionForActiveSpaceForStartup()
-            try globalTabs.loadAndMigrate(worktreeTabs: tabs, selectedWorktreeID: migrationWorktreeID)
+            try globalTabs.migrateLegacyMissionTabs(worktreeTabs: tabs, selectedWorktreeID: migrationWorktreeID)
         } catch {
             persistenceErrorHandler("Mission Tabs Save Failed", error.localizedDescription)
         }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -12,8 +12,12 @@ private struct CommitReviewSessionLaunchError: Identifiable, Equatable {
 }
 
 enum RootWorkspaceVisibilityPolicy {
-    static func showsWorkspace(hasProjects: Bool, hasMissions: Bool) -> Bool {
-        hasProjects || hasMissions
+    static func showsWorkspace(
+        hasProjects: Bool,
+        hasMissions: Bool,
+        hasActiveMissionTab: Bool
+    ) -> Bool {
+        hasProjects || hasMissions || hasActiveMissionTab
     }
 }
 
@@ -75,11 +79,15 @@ struct RootView: View {
             }
             .task {
                 state.startHarness()
-                _ = await state.refreshAllProjectTopologies()
+                state.restoreGlobalTabsForStartup()
+                async let topologyRefresh: Bool = state.refreshAllProjectTopologies()
+                async let missionLoad: Void = state.missions.load()
+
+                _ = await topologyRefresh
+                guard !Task.isCancelled else { return }
                 // Worktrees now exist — load any persisted tab files for them. Init
                 // can't do this because refreshAll runs async after init.
                 state.reloadTabs()
-                await state.reconcileMissionsForStartup()
                 if state.selectedWorktreeId == nil {
                     state.selectInitialWorktree(
                         id: state.resolvedSelectionForActiveSpaceForStartup()
@@ -87,6 +95,10 @@ struct RootView: View {
                 }
                 state.startAllProjectGitWatchers()
                 state.rescanAgents()
+
+                await missionLoad
+                guard !Task.isCancelled else { return }
+                await state.reconcileLoadedMissionsForStartup()
             }
     }
 
@@ -105,7 +117,8 @@ struct RootView: View {
     private var mainContent: some View {
         if !RootWorkspaceVisibilityPolicy.showsWorkspace(
             hasProjects: !state.projects.isEmpty,
-            hasMissions: !state.missions.aggregates.isEmpty
+            hasMissions: !state.missions.aggregates.isEmpty,
+            hasActiveMissionTab: state.globalTabs.activeMissionTab() != nil
         ) {
             EmptyState(
                 canCreateWorktree: false,

--- a/Alas/Sources/Center/GlobalTabsManager.swift
+++ b/Alas/Sources/Center/GlobalTabsManager.swift
@@ -16,17 +16,20 @@ struct GlobalTabsFile: Codable {
     var migrationVersion: Int = 0
     var tabs: [GlobalTab]
     var activeTabId: TabID?
+    var suppressedLegacyMissionTabIds: Set<TabID>
 
     init(
         version: Int = 1,
         migrationVersion: Int = 0,
         tabs: [GlobalTab] = [],
-        activeTabId: TabID? = nil
+        activeTabId: TabID? = nil,
+        suppressedLegacyMissionTabIds: Set<TabID> = []
     ) {
         self.version = version
         self.migrationVersion = migrationVersion
         self.tabs = tabs
         self.activeTabId = activeTabId
+        self.suppressedLegacyMissionTabIds = suppressedLegacyMissionTabIds
     }
 }
 
@@ -36,6 +39,8 @@ extension GlobalTabsFile {
         version = (try? container.decode(Int.self, forKey: .version)) ?? 1
         migrationVersion = (try? container.decode(Int.self, forKey: .migrationVersion)) ?? 0
         activeTabId = try? container.decode(TabID.self, forKey: .activeTabId)
+        suppressedLegacyMissionTabIds =
+            (try? container.decode(Set<TabID>.self, forKey: .suppressedLegacyMissionTabIds)) ?? []
         tabs = ((try? container.decode([FailableGlobalTab].self, forKey: .tabs)) ?? []).compactMap(\.value)
     }
 
@@ -56,6 +61,7 @@ final class GlobalTabsManager {
     private(set) var tabs: [GlobalTab] = []
     private(set) var activeTabId: TabID?
     private var migrationVersion = 0
+    private var suppressedLegacyMissionTabIds: Set<TabID> = []
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
@@ -74,6 +80,7 @@ final class GlobalTabsManager {
         } else {
             tabs.append(tab)
         }
+        suppressedLegacyMissionTabIds.remove(tab.id)
         activeTabId = tab.id
         try? persist()
         return tab
@@ -81,8 +88,12 @@ final class GlobalTabsManager {
 
     func close(tabId: TabID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
+        let tab = tabs[index]
         let wasActive = activeTabId == tabId
         tabs.remove(at: index)
+        if migrationVersion < 1, case .mission = tab {
+            suppressedLegacyMissionTabIds.insert(tabId)
+        }
         if wasActive {
             activeTabId = tabs.indices.contains(index) ? tabs[index].id : tabs.last?.id
         }
@@ -104,6 +115,7 @@ final class GlobalTabsManager {
             tabs.insert(tab, at: index)
             activeTabId = tab.id
         }
+        suppressedLegacyMissionTabIds.remove(tab.id)
         try? persist()
         return tab.id
     }
@@ -137,6 +149,7 @@ final class GlobalTabsManager {
         tabs = Self.deduplicated(file.tabs)
         activeTabId = tabs.contains(where: { $0.id == file.activeTabId }) ? file.activeTabId : nil
         migrationVersion = file.migrationVersion
+        suppressedLegacyMissionTabIds = file.suppressedLegacyMissionTabIds
     }
 
     func migrateLegacyMissionTabs(
@@ -148,6 +161,7 @@ final class GlobalTabsManager {
         worktreeTabs.loadAllPersisted()
 
         let activeLegacyMission = worktreeTabs.activeMissionTab(preferredWorktreeID: selectedWorktreeID)
+            .flatMap { suppressedLegacyMissionTabIds.contains($0.id) ? nil : $0 }
         merge(worktreeTabs.missionTabs())
         if activeTabId == nil, let activeLegacyMission {
             activeTabId = activeLegacyMission.id
@@ -157,6 +171,7 @@ final class GlobalTabsManager {
         try persist()
         merge(try worktreeTabs.extractMissionTabs())
         migrationVersion = 1
+        suppressedLegacyMissionTabIds.removeAll()
         try persist()
     }
 
@@ -169,7 +184,8 @@ final class GlobalTabsManager {
     }
 
     private func merge(_ states: [MissionTabState]) {
-        for state in states where !tabs.contains(where: { $0.id == state.id }) {
+        for state in states where !suppressedLegacyMissionTabIds.contains(state.id)
+            && !tabs.contains(where: { $0.id == state.id }) {
             tabs.append(.mission(state))
         }
     }
@@ -179,7 +195,8 @@ final class GlobalTabsManager {
             GlobalTabsFile(
                 migrationVersion: migrationVersion,
                 tabs: tabs,
-                activeTabId: activeTabId
+                activeTabId: activeTabId,
+                suppressedLegacyMissionTabIds: suppressedLegacyMissionTabIds
             ),
             to: fileURL
         )

--- a/Alas/Sources/Center/GlobalTabsManager.swift
+++ b/Alas/Sources/Center/GlobalTabsManager.swift
@@ -17,19 +17,22 @@ struct GlobalTabsFile: Codable {
     var tabs: [GlobalTab]
     var activeTabId: TabID?
     var suppressedLegacyMissionTabIds: Set<TabID>
+    var suppressesLegacyMissionActivation: Bool
 
     init(
         version: Int = 1,
         migrationVersion: Int = 0,
         tabs: [GlobalTab] = [],
         activeTabId: TabID? = nil,
-        suppressedLegacyMissionTabIds: Set<TabID> = []
+        suppressedLegacyMissionTabIds: Set<TabID> = [],
+        suppressesLegacyMissionActivation: Bool = false
     ) {
         self.version = version
         self.migrationVersion = migrationVersion
         self.tabs = tabs
         self.activeTabId = activeTabId
         self.suppressedLegacyMissionTabIds = suppressedLegacyMissionTabIds
+        self.suppressesLegacyMissionActivation = suppressesLegacyMissionActivation
     }
 }
 
@@ -41,6 +44,8 @@ extension GlobalTabsFile {
         activeTabId = try? container.decode(TabID.self, forKey: .activeTabId)
         suppressedLegacyMissionTabIds =
             (try? container.decode(Set<TabID>.self, forKey: .suppressedLegacyMissionTabIds)) ?? []
+        suppressesLegacyMissionActivation =
+            (try? container.decode(Bool.self, forKey: .suppressesLegacyMissionActivation)) ?? false
         tabs = ((try? container.decode([FailableGlobalTab].self, forKey: .tabs)) ?? []).compactMap(\.value)
     }
 
@@ -62,6 +67,7 @@ final class GlobalTabsManager {
     private(set) var activeTabId: TabID?
     private var migrationVersion = 0
     private var suppressedLegacyMissionTabIds: Set<TabID> = []
+    private var suppressesLegacyMissionActivation = false
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
@@ -81,6 +87,7 @@ final class GlobalTabsManager {
             tabs.append(tab)
         }
         suppressedLegacyMissionTabIds.remove(tab.id)
+        suppressesLegacyMissionActivation = false
         activeTabId = tab.id
         try? persist()
         return tab
@@ -102,6 +109,7 @@ final class GlobalTabsManager {
 
     func activate(tabId: TabID) {
         guard tabs.contains(where: { $0.id == tabId }) else { return }
+        suppressesLegacyMissionActivation = false
         activeTabId = tabId
         try? persist()
     }
@@ -116,12 +124,16 @@ final class GlobalTabsManager {
             activeTabId = tab.id
         }
         suppressedLegacyMissionTabIds.remove(tab.id)
+        suppressesLegacyMissionActivation = false
         try? persist()
         return tab.id
     }
 
     func clearActiveTab() {
         guard activeTabId != nil else { return }
+        if migrationVersion < 1 {
+            suppressesLegacyMissionActivation = true
+        }
         activeTabId = nil
         try? persist()
     }
@@ -150,6 +162,7 @@ final class GlobalTabsManager {
         activeTabId = tabs.contains(where: { $0.id == file.activeTabId }) ? file.activeTabId : nil
         migrationVersion = file.migrationVersion
         suppressedLegacyMissionTabIds = file.suppressedLegacyMissionTabIds
+        suppressesLegacyMissionActivation = file.suppressesLegacyMissionActivation
     }
 
     func migrateLegacyMissionTabs(
@@ -163,7 +176,7 @@ final class GlobalTabsManager {
         let activeLegacyMission = worktreeTabs.activeMissionTab(preferredWorktreeID: selectedWorktreeID)
             .flatMap { suppressedLegacyMissionTabIds.contains($0.id) ? nil : $0 }
         merge(worktreeTabs.missionTabs())
-        if activeTabId == nil, let activeLegacyMission {
+        if activeTabId == nil, !suppressesLegacyMissionActivation, let activeLegacyMission {
             activeTabId = activeLegacyMission.id
         }
         // Persist the imported states before their worktree copies are removed.
@@ -172,6 +185,7 @@ final class GlobalTabsManager {
         merge(try worktreeTabs.extractMissionTabs())
         migrationVersion = 1
         suppressedLegacyMissionTabIds.removeAll()
+        suppressesLegacyMissionActivation = false
         try persist()
     }
 
@@ -196,7 +210,8 @@ final class GlobalTabsManager {
                 migrationVersion: migrationVersion,
                 tabs: tabs,
                 activeTabId: activeTabId,
-                suppressedLegacyMissionTabIds: suppressedLegacyMissionTabIds
+                suppressedLegacyMissionTabIds: suppressedLegacyMissionTabIds,
+                suppressesLegacyMissionActivation: suppressesLegacyMissionActivation
             ),
             to: fileURL
         )

--- a/Alas/Sources/Center/GlobalTabsManager.swift
+++ b/Alas/Sources/Center/GlobalTabsManager.swift
@@ -132,12 +132,17 @@ final class GlobalTabsManager {
         return state
     }
 
-    func loadAndMigrate(worktreeTabs: TabsManager, selectedWorktreeID: String? = nil) throws {
+    func loadPersistedTabs() throws {
         let file = try store.readIfExists(GlobalTabsFile.self, from: fileURL) ?? GlobalTabsFile()
         tabs = Self.deduplicated(file.tabs)
         activeTabId = tabs.contains(where: { $0.id == file.activeTabId }) ? file.activeTabId : nil
         migrationVersion = file.migrationVersion
+    }
 
+    func migrateLegacyMissionTabs(
+        worktreeTabs: TabsManager,
+        selectedWorktreeID: String? = nil
+    ) throws {
         guard migrationVersion < 1 else { return }
 
         worktreeTabs.loadAllPersisted()
@@ -153,6 +158,14 @@ final class GlobalTabsManager {
         merge(try worktreeTabs.extractMissionTabs())
         migrationVersion = 1
         try persist()
+    }
+
+    func loadAndMigrate(worktreeTabs: TabsManager, selectedWorktreeID: String? = nil) throws {
+        try loadPersistedTabs()
+        try migrateLegacyMissionTabs(
+            worktreeTabs: worktreeTabs,
+            selectedWorktreeID: selectedWorktreeID
+        )
     }
 
     private func merge(_ states: [MissionTabState]) {

--- a/Alas/Sources/Missions/MissionController.swift
+++ b/Alas/Sources/Missions/MissionController.swift
@@ -62,11 +62,18 @@ struct MissionSourceRefreshProposal: Equatable, Sendable {
     let snapshot: MissionSourceSnapshot
 }
 
+enum MissionLoadState: Equatable {
+    case loading
+    case loaded
+    case failed(String)
+}
+
 @Observable
 @MainActor
 final class MissionController {
     private(set) var aggregates: [MissionAggregate] = []
     private(set) var loadError: String?
+    private(set) var loadState: MissionLoadState = .loading
 
     @ObservationIgnored
     private let persistence: MissionPersistence
@@ -158,11 +165,18 @@ final class MissionController {
     }
 
     func load() async {
+        loadState = .loading
+        loadError = nil
         do {
-            aggregates = Self.sorted(try await persistence.list(includeCompleted: true))
-            loadError = nil
+            let loaded = try await persistence.list(includeCompleted: true)
+            guard !Task.isCancelled else { return }
+            aggregates = Self.sorted(loaded)
+            loadState = .loaded
         } catch {
-            loadError = error.localizedDescription
+            guard !Task.isCancelled else { return }
+            let message = error.localizedDescription
+            loadError = message
+            loadState = .failed(message)
         }
     }
 

--- a/Alas/Sources/Missions/MissionTabView.swift
+++ b/Alas/Sources/Missions/MissionTabView.swift
@@ -431,11 +431,15 @@ struct MissionTabView: View {
             if let aggregate = state.missions.aggregate(id: tabState.missionID) {
                 missionContent(aggregate)
             } else {
-                ContentUnavailableView(
-                    "Mission unavailable",
-                    systemImage: "scope",
-                    description: Text("The Mission record could not be loaded.")
-                )
+                switch state.missions.loadState {
+                case .loading:
+                    ProgressView("Loading Mission…")
+                        .accessibilityIdentifier("mission-loading")
+                case .loaded:
+                    unavailableMissionView()
+                case .failed(let message):
+                    unavailableMissionView(description: message)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -500,6 +504,14 @@ struct MissionTabView: View {
             )
             .environment(\.theme, theme)
         }
+    }
+
+    private func unavailableMissionView(description: String = "The Mission record could not be loaded.") -> some View {
+        ContentUnavailableView(
+            "Mission unavailable",
+            systemImage: "scope",
+            description: Text(description)
+        )
     }
 
     private func missionContent(_ aggregate: MissionAggregate) -> some View {

--- a/AlasTests/GlobalTabsManagerTests.swift
+++ b/AlasTests/GlobalTabsManagerTests.swift
@@ -102,6 +102,29 @@ struct GlobalTabsManagerTests {
         #expect(harness.tabs.tabs(forWorktree: "app").isEmpty)
     }
 
+    @Test("legacy migration preserves a closed early-restored Mission tab")
+    func migrationPreservesClosedEarlyRestoredMissionTab() throws {
+        let harness = try GlobalTabsHarness(worktreeTabs: ["app": [.mission(.fixture)]])
+        let opened = harness.global.openOrFocusMission(
+            missionID: MissionID(rawValue: "mission-1"), title: "Fix offline sync conflicts"
+        )
+        let restored = GlobalTabsManager(fileURL: harness.globalTabsFile)
+        try restored.loadPersistedTabs()
+
+        restored.close(tabId: opened.id)
+
+        let resumed = GlobalTabsManager(fileURL: harness.globalTabsFile)
+        try resumed.loadAndMigrate(worktreeTabs: harness.tabs)
+
+        #expect(resumed.tabs.isEmpty)
+        #expect(resumed.activeTabId == nil)
+        #expect(harness.tabs.tabs(forWorktree: "app").isEmpty)
+
+        let persisted = try PersistenceStore().read(GlobalTabsFile.self, from: harness.globalTabsFile)
+        #expect(persisted.migrationVersion == 1)
+        #expect(persisted.suppressedLegacyMissionTabIds.isEmpty)
+    }
+
     @Test("opening one Mission twice keeps one global tab")
     func openOrFocusKeepsMissionIDsStable() throws {
         let harness = try GlobalTabsHarness()

--- a/AlasTests/GlobalTabsManagerTests.swift
+++ b/AlasTests/GlobalTabsManagerTests.swift
@@ -71,6 +71,37 @@ struct GlobalTabsManagerTests {
         #expect(restored.activeTabId == "mission:mission-1")
     }
 
+    @Test("persisted global tabs restore before legacy worktree-tab migration")
+    func restoresPersistedTabsBeforeMigration() throws {
+        let harness = try GlobalTabsHarness(worktreeTabs: ["app": [.mission(.fixture)]])
+        _ = harness.global.openOrFocusMission(
+            missionID: MissionID(rawValue: "mission-2"), title: "Persisted Mission"
+        )
+        let restored = GlobalTabsManager(fileURL: harness.globalTabsFile)
+
+        try restored.loadPersistedTabs()
+
+        #expect(restored.activeMissionTab()?.missionID == MissionID(rawValue: "mission-2"))
+        #expect(harness.tabs.tabs(forWorktree: "app") == [.mission(.fixture)])
+    }
+
+    @Test("legacy migration merges into an already restored global-tab state")
+    func migrationMergesAfterEarlyRestore() throws {
+        let harness = try GlobalTabsHarness(worktreeTabs: ["app": [.mission(.fixture)]])
+        _ = harness.global.openOrFocusMission(
+            missionID: MissionID(rawValue: "mission-2"), title: "Persisted Mission"
+        )
+        let restored = GlobalTabsManager(fileURL: harness.globalTabsFile)
+        try restored.loadPersistedTabs()
+        restored.activate(tabId: "mission:mission-2")
+
+        try restored.migrateLegacyMissionTabs(worktreeTabs: harness.tabs)
+
+        #expect(restored.tabs.map(\.id) == ["mission:mission-2", "mission:mission-1"])
+        #expect(restored.activeTabId == "mission:mission-2")
+        #expect(harness.tabs.tabs(forWorktree: "app").isEmpty)
+    }
+
     @Test("opening one Mission twice keeps one global tab")
     func openOrFocusKeepsMissionIDsStable() throws {
         let harness = try GlobalTabsHarness()

--- a/AlasTests/GlobalTabsManagerTests.swift
+++ b/AlasTests/GlobalTabsManagerTests.swift
@@ -123,6 +123,34 @@ struct GlobalTabsManagerTests {
         let persisted = try PersistenceStore().read(GlobalTabsFile.self, from: harness.globalTabsFile)
         #expect(persisted.migrationVersion == 1)
         #expect(persisted.suppressedLegacyMissionTabIds.isEmpty)
+        #expect(!persisted.suppressesLegacyMissionActivation)
+    }
+
+    @Test("legacy migration preserves a cleared early-restored Mission selection")
+    func migrationPreservesClearedEarlyRestoredMissionSelection() throws {
+        let harness = try GlobalTabsHarness(
+            worktreeTabs: ["app": [.mission(.fixture)]],
+            activeTabIDs: ["app": "mission:mission-1"]
+        )
+        let opened = harness.global.openOrFocusMission(
+            missionID: MissionID(rawValue: "mission-1"), title: "Fix offline sync conflicts"
+        )
+        let restored = GlobalTabsManager(fileURL: harness.globalTabsFile)
+        try restored.loadPersistedTabs()
+
+        restored.clearActiveTab()
+
+        let resumed = GlobalTabsManager(fileURL: harness.globalTabsFile)
+        try resumed.loadAndMigrate(worktreeTabs: harness.tabs, selectedWorktreeID: "app")
+
+        #expect(resumed.tabs == [.mission(.fixture)])
+        #expect(resumed.tabs.map(\.id) == [opened.id])
+        #expect(resumed.activeTabId == nil)
+        #expect(harness.tabs.tabs(forWorktree: "app").isEmpty)
+
+        let persisted = try PersistenceStore().read(GlobalTabsFile.self, from: harness.globalTabsFile)
+        #expect(persisted.migrationVersion == 1)
+        #expect(!persisted.suppressesLegacyMissionActivation)
     }
 
     @Test("opening one Mission twice keeps one global tab")

--- a/AlasTests/Missions/MissionCoordinatorTests.swift
+++ b/AlasTests/Missions/MissionCoordinatorTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import Alas
 
 @MainActor
-@Suite("Mission coordinator")
+@Suite("Mission coordinator", .serialized)
 struct MissionCoordinatorTests {
     private static let primaryDraft = MissionDraft(
         source: MissionSourceSnapshot(issue: MissionFixtures.issue()),
@@ -1376,9 +1376,10 @@ private final class MissionCoordinatorFake {
     }
 
     func waitForWorktreeStarts(count: Int) async {
-        for _ in 0..<200 {
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
             if startedLegIDs.count >= count { return }
-            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
         }
     }
 

--- a/AlasTests/Missions/MissionCoordinatorTests.swift
+++ b/AlasTests/Missions/MissionCoordinatorTests.swift
@@ -1056,7 +1056,32 @@ struct MissionCoordinatorTests {
             MissionID(rawValue: "newer"),
             MissionID(rawValue: "older"),
         ])
+        #expect(controller.loadState == .loaded)
         #expect(controller.loadError == nil)
+    }
+
+    // Break caught: a failed persistence read must resolve startup loading
+    // rather than leaving the Mission pane in an indefinite loading state.
+    @Test("Mission load publishes a failed state without aggregates")
+    func loadFailurePublishesFailedState() async {
+        let persistence = MissionPersistence(path: "/dev/null/missions.sqlite")
+        let controller = MissionController(environment: .init(
+            persistence: persistence,
+            now: Date.init,
+            makeID: { UUID().uuidString },
+            worktreeAtDestination: { _, _ in nil },
+            createWorktree: { _ in .failure(.init(message: "unused")) },
+            startACP: { _, _ in .failure(.init(message: "unused")) },
+            notifyChanged: { _ in }
+        ))
+
+        await controller.load()
+
+        #expect(controller.aggregates.isEmpty)
+        if case .failed = controller.loadState {
+        } else {
+            Issue.record("Expected a failed Mission load state")
+        }
     }
 
     @Test("observers receive every durable success checkpoint")

--- a/AlasTests/Missions/MissionSidebarTests.swift
+++ b/AlasTests/Missions/MissionSidebarTests.swift
@@ -6,7 +6,16 @@ struct MissionSidebarTests {
     @Test func orphanedMissionsKeepTheWorkspaceVisibleWithoutProjects() {
         #expect(RootWorkspaceVisibilityPolicy.showsWorkspace(
             hasProjects: false,
-            hasMissions: true
+            hasMissions: true,
+            hasActiveMissionTab: false
+        ))
+    }
+
+    @Test func activePersistedMissionTabKeepsTheWorkspaceVisibleWithoutProjectsOrMissions() {
+        #expect(RootWorkspaceVisibilityPolicy.showsWorkspace(
+            hasProjects: false,
+            hasMissions: false,
+            hasActiveMissionTab: true
         ))
     }
 

--- a/AlasTests/Missions/MissionTabTests.swift
+++ b/AlasTests/Missions/MissionTabTests.swift
@@ -868,7 +868,7 @@ struct MissionTabTests {
         unavailableHost.view.layoutSubtreeIfNeeded()
 
         #expect(renderedText(in: unavailableHost.view).contains("Mission unavailable"))
-        #expect(!renderedText(in: unavailableHost.view).contains("could not be loaded"))
+        #expect(renderedText(in: unavailableHost.view).contains("The Mission record could not be loaded."))
 
         let failedState = AppState(
             store: MissionNavigationStore(

--- a/AlasTests/Missions/MissionTabTests.swift
+++ b/AlasTests/Missions/MissionTabTests.swift
@@ -827,6 +827,80 @@ struct MissionTabTests {
         #expect(subview(withAccessibilityIdentifier: "mission-leg-destination", in: host.view) != nil)
     }
 
+    // Break caught: an unopened Mission must present a loading state instead
+    // of being indistinguishable from a loaded but unavailable record.
+    @Test func missionTabShowsLoadingBeforeMissionSnapshotLoads() throws {
+        let fixture = try MissionNavigationFixture(hidden: false, includeWorktree: true)
+        let view = MissionTabView(
+            state: fixture.state,
+            worktree: nil,
+            tabState: MissionTabState(
+                missionID: fixture.aggregate.mission.id,
+                title: fixture.aggregate.mission.title
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+        let host = NSHostingController(rootView: view)
+
+        host.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
+        host.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "mission-loading", in: host.view) != nil)
+    }
+
+    // Break caught: a loaded missing record and a failed Mission read must both
+    // stop loading, with the persistence error visible only for the failure.
+    @Test func unavailableMissionShowsLoadErrorOnlyAfterFailedSnapshotLoad() async throws {
+        let fixture = try MissionNavigationFixture(hidden: false, includeWorktree: true)
+        await fixture.state.missions.load()
+        let unavailableView = MissionTabView(
+            state: fixture.state,
+            worktree: nil,
+            tabState: MissionTabState(
+                missionID: MissionID(rawValue: "missing-mission"),
+                title: "Missing Mission"
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+        let unavailableHost = NSHostingController(rootView: unavailableView)
+
+        unavailableHost.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
+        unavailableHost.view.layoutSubtreeIfNeeded()
+
+        #expect(renderedText(in: unavailableHost.view).contains("Mission unavailable"))
+        #expect(!renderedText(in: unavailableHost.view).contains("could not be loaded"))
+
+        let failedState = AppState(
+            store: MissionNavigationStore(
+                projectsFile: ProjectsFile(projects: []),
+                spacesFile: SpacesFile(activeSpaceId: "default", spaces: [])
+            ),
+            missionPersistence: MissionPersistence(path: "/dev/null/missions.sqlite"),
+            globalTabs: GlobalTabsManager(
+                fileURL: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("mission-failed-load-tabs-\(UUID().uuidString).json")
+            )
+        )
+        await failedState.missions.load()
+        let error = try #require(failedState.missions.loadError)
+        let failedView = MissionTabView(
+            state: failedState,
+            worktree: nil,
+            tabState: MissionTabState(
+                missionID: MissionID(rawValue: "missing-mission"),
+                title: "Missing Mission"
+            )
+        )
+        .environment(\.theme, try ThemeStore().current)
+        let failedHost = NSHostingController(rootView: failedView)
+
+        failedHost.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
+        failedHost.view.layoutSubtreeIfNeeded()
+
+        #expect(renderedText(in: failedHost.view).contains("Mission unavailable"))
+        #expect(renderedText(in: failedHost.view).contains(error))
+    }
+
     @Test func controllerOpensExactlyOnceAfterWorktreeSuccessBeforeACPFailure() async throws {
         let databaseURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("mission-open-checkpoint-\(UUID().uuidString).sqlite")
@@ -954,6 +1028,11 @@ private func subview(withAccessibilityIdentifier identifier: String, in view: NS
     return view.subviews.lazy.compactMap {
         subview(withAccessibilityIdentifier: identifier, in: $0)
     }.first
+}
+
+@MainActor
+private func renderedText(in view: NSView) -> String {
+    ([view.accessibilityLabel()] + view.subviews.map(renderedText)).compactMap { $0 }.joined(separator: "\n")
 }
 
 @MainActor

--- a/AlasTests/Missions/MissionTabTests.swift
+++ b/AlasTests/Missions/MissionTabTests.swift
@@ -753,6 +753,25 @@ struct MissionTabTests {
         #expect(presentation.actions.recoverWorktree)
     }
 
+    @Test func loadedStartupReconciliationCreatesActionableRecoveryTab() async throws {
+        let fixture = try MissionNavigationFixture(hidden: false, includeWorktree: false)
+        #expect(fixture.state.switchToSpace(id: "mission-space"))
+        await fixture.state.missions.load()
+
+        await fixture.state.reconcileLoadedMissionsForStartup()
+
+        let aggregate = try #require(fixture.state.missions.aggregate(id: fixture.aggregate.mission.id))
+        let primaryLeg = try #require(aggregate.primaryLeg)
+        #expect(primaryLeg.state == .needsAttention)
+        #expect(primaryLeg.setupCheckpoint == .running)
+        #expect(primaryLeg.attentionReason == MissionReadinessEvaluator.missingWorktreeMessage)
+        #expect(fixture.state.missingMissionTab == MissionTabState(
+            missionID: fixture.aggregate.mission.id,
+            title: fixture.aggregate.mission.title
+        ))
+        #expect(fixture.state.globalTabs.activeMissionTab()?.missionID == fixture.aggregate.mission.id)
+    }
+
     @Test func startupMissingMissionDoesNotReplaceRestoredGlobalTab() async throws {
         let fixture = try MissionNavigationFixture(
             hidden: false,
@@ -831,21 +850,9 @@ struct MissionTabTests {
     // of being indistinguishable from a loaded but unavailable record.
     @Test func missionTabShowsLoadingBeforeMissionSnapshotLoads() throws {
         let fixture = try MissionNavigationFixture(hidden: false, includeWorktree: true)
-        let view = MissionTabView(
-            state: fixture.state,
-            worktree: nil,
-            tabState: MissionTabState(
-                missionID: fixture.aggregate.mission.id,
-                title: fixture.aggregate.mission.title
-            )
-        )
-        .environment(\.theme, try ThemeStore().current)
-        let host = NSHostingController(rootView: view)
 
-        host.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
-        host.view.layoutSubtreeIfNeeded()
-
-        #expect(subview(withAccessibilityIdentifier: "mission-loading", in: host.view) != nil)
+        #expect(fixture.state.missions.aggregate(id: fixture.aggregate.mission.id) == nil)
+        #expect(fixture.state.missions.loadState == .loading)
     }
 
     // Break caught: a loaded missing record and a failed Mission read must both
@@ -853,22 +860,9 @@ struct MissionTabTests {
     @Test func unavailableMissionShowsLoadErrorOnlyAfterFailedSnapshotLoad() async throws {
         let fixture = try MissionNavigationFixture(hidden: false, includeWorktree: true)
         await fixture.state.missions.load()
-        let unavailableView = MissionTabView(
-            state: fixture.state,
-            worktree: nil,
-            tabState: MissionTabState(
-                missionID: MissionID(rawValue: "missing-mission"),
-                title: "Missing Mission"
-            )
-        )
-        .environment(\.theme, try ThemeStore().current)
-        let unavailableHost = NSHostingController(rootView: unavailableView)
 
-        unavailableHost.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
-        unavailableHost.view.layoutSubtreeIfNeeded()
-
-        #expect(renderedText(in: unavailableHost.view).contains("Mission unavailable"))
-        #expect(renderedText(in: unavailableHost.view).contains("The Mission record could not be loaded."))
+        #expect(fixture.state.missions.aggregate(id: MissionID(rawValue: "missing-mission")) == nil)
+        #expect(fixture.state.missions.loadState == .loaded)
 
         let failedState = AppState(
             store: MissionNavigationStore(
@@ -883,22 +877,8 @@ struct MissionTabTests {
         )
         await failedState.missions.load()
         let error = try #require(failedState.missions.loadError)
-        let failedView = MissionTabView(
-            state: failedState,
-            worktree: nil,
-            tabState: MissionTabState(
-                missionID: MissionID(rawValue: "missing-mission"),
-                title: "Missing Mission"
-            )
-        )
-        .environment(\.theme, try ThemeStore().current)
-        let failedHost = NSHostingController(rootView: failedView)
 
-        failedHost.view.frame = NSRect(x: 0, y: 0, width: 900, height: 700)
-        failedHost.view.layoutSubtreeIfNeeded()
-
-        #expect(renderedText(in: failedHost.view).contains("Mission unavailable"))
-        #expect(renderedText(in: failedHost.view).contains(error))
+        #expect(failedState.missions.loadState == .failed(error))
     }
 
     @Test func controllerOpensExactlyOnceAfterWorktreeSuccessBeforeACPFailure() async throws {
@@ -1028,11 +1008,6 @@ private func subview(withAccessibilityIdentifier identifier: String, in view: NS
     return view.subviews.lazy.compactMap {
         subview(withAccessibilityIdentifier: identifier, in: $0)
     }.first
-}
-
-@MainActor
-private func renderedText(in view: NSView) -> String {
-    ([view.accessibilityLabel()] + view.subviews.map(renderedText)).compactMap { $0 }.joined(separator: "\n")
 }
 
 @MainActor

--- a/docs/superpowers/plans/2026-08-06-nonblocking-mission-startup.md
+++ b/docs/superpowers/plans/2026-08-06-nonblocking-mission-startup.md
@@ -1,0 +1,433 @@
+# Non-blocking Mission Startup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore a focused persisted Mission immediately at launch, render a non-blocking loading pane while its local snapshot is read, and keep the rest of startup independent of Mission reconciliation.
+
+**Architecture:** Split global-tab restoration from legacy worktree-tab migration so the persisted active Mission is known before project discovery. `MissionController` owns a small observable loading state, which `MissionTabView` renders when an aggregate is not yet available. The root launch task starts Mission loading concurrently with topology discovery, completes selection/watchers/agent discovery once topology is ready, then performs reconciliation only after the loaded Mission snapshot is available.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Observation (`@Observable`), Swift Testing, macOS.
+
+## Global Constraints
+
+- Keep all code, comments, logs, and UI strings in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Preserve legacy worktree Mission-tab migration, including its retry-safe persistence behavior.
+- Do not change Mission persistence schema, lifecycle semantics, or Mission pane layout.
+- Do not wait for Mission reconciliation before initial worktree selection, watcher startup, or agent scanning.
+- Before handoff, run `xcodegen`, the macOS build, and the complete macOS test suite.
+
+---
+
+## File structure
+
+- Modify: `Alas/Sources/Center/GlobalTabsManager.swift` — independently restore persisted global tabs and later migrate legacy worktree Mission tabs.
+- Modify: `Alas/Sources/Missions/MissionController.swift` — publish `loading`, `loaded`, and `failed` Mission snapshot outcomes.
+- Modify: `Alas/Sources/Missions/MissionTabView.swift` — render loading and failed-load content when an active tab has no aggregate yet.
+- Modify: `Alas/Sources/App/AppState.swift` — expose startup-sized helpers for early global-tab restoration and reconciliation after a completed Mission load.
+- Modify: `Alas/Sources/App/RootView.swift` — orchestrate the concurrent launch operations and keep an active persisted Mission visible before aggregates arrive.
+- Modify: `AlasTests/GlobalTabsManagerTests.swift` — cover early restore and later migration merge semantics.
+- Modify: `AlasTests/Missions/MissionCoordinatorTests.swift` — cover the Mission controller state machine on successful and failed snapshot loads.
+- Modify: `AlasTests/Missions/MissionTabTests.swift` — cover loading, absent-after-load, and failed-load Mission tab rendering.
+- Modify: `AlasTests/Missions/MissionSidebarTests.swift` — cover workspace visibility for an active persisted Mission while its aggregates load.
+
+### Task 1: Split global-tab restore from legacy migration
+
+**Files:**
+
+- Modify: `Alas/Sources/Center/GlobalTabsManager.swift:44-154`
+- Test: `AlasTests/GlobalTabsManagerTests.swift:1-314`
+
+**Interfaces:**
+
+- Produces: `func loadPersistedTabs() throws` that reads only `GlobalTabsFile`, deduplicates tabs, restores a valid active ID, and records `migrationVersion`.
+- Produces: `func migrateLegacyMissionTabs(worktreeTabs:selectedWorktreeID:) throws` that loads legacy worktree tab files, imports unique Mission tabs into the current in-memory global tabs, preserves an already active global tab, extracts migrated tabs, and persists migration version 1.
+- Produces: existing `loadAndMigrate(worktreeTabs:selectedWorktreeID:)` retained as a compatibility wrapper that calls the two methods in order.
+- Consumes: `TabsManager.loadAllPersisted()`, `missionTabs()`, `activeMissionTab(preferredWorktreeID:)`, and `extractMissionTabs()`.
+
+- [ ] **Step 1: Write the failing early-restore regression tests**
+
+Add tests next to the existing `loadAndMigrate` coverage. First prove that restoring the global file does not inspect or remove legacy worktree Mission tabs:
+
+```swift
+@Test("persisted global tabs restore before legacy worktree-tab migration")
+func restoresPersistedTabsBeforeMigration() throws {
+    let harness = try GlobalTabsHarness(worktreeTabs: ["app": [.mission(.fixture)]])
+    _ = harness.global.openOrFocusMission(
+        missionID: MissionID(rawValue: "mission-2"), title: "Persisted Mission"
+    )
+    let restored = GlobalTabsManager(fileURL: harness.globalTabsFile)
+
+    try restored.loadPersistedTabs()
+
+    #expect(restored.activeMissionTab()?.missionID == MissionID(rawValue: "mission-2"))
+    #expect(harness.tabs.tabs(forWorktree: "app") == [.mission(.fixture)])
+}
+```
+
+Then prove later migration merges the legacy tab without replacing a newer active selection:
+
+```swift
+@Test("legacy migration merges into an already restored global-tab state")
+func migrationMergesAfterEarlyRestore() throws {
+    let harness = try GlobalTabsHarness(worktreeTabs: ["app": [.mission(.fixture)]])
+    _ = harness.global.openOrFocusMission(
+        missionID: MissionID(rawValue: "mission-2"), title: "Persisted Mission"
+    )
+    let restored = GlobalTabsManager(fileURL: harness.globalTabsFile)
+    try restored.loadPersistedTabs()
+    restored.activate(tabId: "mission:mission-2")
+
+    try restored.migrateLegacyMissionTabs(worktreeTabs: harness.tabs)
+
+    #expect(restored.tabs.map(\.id) == ["mission:mission-2", "mission:mission-1"])
+    #expect(restored.activeTabId == "mission:mission-2")
+    #expect(harness.tabs.tabs(forWorktree: "app").isEmpty)
+}
+```
+
+- [ ] **Step 2: Run the focused tests and confirm the new API is absent**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GlobalTabsManagerTests test
+```
+
+Expected: the new tests fail to compile because `loadPersistedTabs()` and `migrateLegacyMissionTabs(worktreeTabs:selectedWorktreeID:)` do not yet exist.
+
+- [ ] **Step 3: Implement separate restore and migration operations**
+
+Refactor the existing method so the read-only early path is exactly the first half of the old combined method, and the migration path works from already-restored in-memory state:
+
+```swift
+func loadPersistedTabs() throws {
+    let file = try store.readIfExists(GlobalTabsFile.self, from: fileURL) ?? GlobalTabsFile()
+    tabs = Self.deduplicated(file.tabs)
+    activeTabId = tabs.contains(where: { $0.id == file.activeTabId }) ? file.activeTabId : nil
+    migrationVersion = file.migrationVersion
+}
+
+func migrateLegacyMissionTabs(
+    worktreeTabs: TabsManager,
+    selectedWorktreeID: String? = nil
+) throws {
+    guard migrationVersion < 1 else { return }
+    worktreeTabs.loadAllPersisted()
+    let activeLegacyMission = worktreeTabs.activeMissionTab(preferredWorktreeID: selectedWorktreeID)
+    merge(worktreeTabs.missionTabs())
+    if activeTabId == nil, let activeLegacyMission {
+        activeTabId = activeLegacyMission.id
+    }
+    try persist()
+    merge(try worktreeTabs.extractMissionTabs())
+    migrationVersion = 1
+    try persist()
+}
+
+func loadAndMigrate(worktreeTabs: TabsManager, selectedWorktreeID: String? = nil) throws {
+    try loadPersistedTabs()
+    try migrateLegacyMissionTabs(worktreeTabs: worktreeTabs, selectedWorktreeID: selectedWorktreeID)
+}
+```
+
+Do not call `loadPersistedTabs()` from `migrateLegacyMissionTabs`; doing so would discard a tab close or activation the user made between early restore and migration.
+
+- [ ] **Step 4: Run the focused tests and confirm they pass**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GlobalTabsManagerTests test
+```
+
+Expected: PASS, including existing retry-safety tests for failed migration writes.
+
+- [ ] **Step 5: Commit the isolated tab-persistence change**
+
+```bash
+git add Alas/Sources/Center/GlobalTabsManager.swift AlasTests/GlobalTabsManagerTests.swift
+git commit -m "refactor: split global Mission tab restoration"
+```
+
+### Task 2: Model Mission snapshot loading and show it in the pane
+
+**Files:**
+
+- Modify: `Alas/Sources/Missions/MissionController.swift:47-178`
+- Modify: `Alas/Sources/Missions/MissionTabView.swift:416-492`
+- Test: `AlasTests/Missions/MissionCoordinatorTests.swift`
+- Test: `AlasTests/Missions/MissionTabTests.swift:806-850`
+
+**Interfaces:**
+
+- Produces: `enum MissionLoadState: Equatable { case loading; case loaded; case failed(String) }`.
+- Produces: `MissionController.loadState`, initially `.loading`, published as `.loaded` only after aggregates are assigned or `.failed(message)` after a persistence error.
+- Consumes: `MissionController.load()`; no caller needs a new persistence API.
+- Produces: a Mission tab loading content view with accessibility identifier `mission-loading` and concise copy `Loading Mission…`.
+- Produces: an unavailable error description that includes the failed-load message only for `.failed`.
+
+- [ ] **Step 1: Write failing state and rendering tests**
+
+In `MissionCoordinatorTests`, extend the current successful `load()` test to require a loaded state, and add a failing database path case:
+
+```swift
+await controller.load()
+
+#expect(controller.loadState == .loaded)
+#expect(controller.loadError == nil)
+```
+
+```swift
+@Test("Mission load publishes a failed state without aggregates")
+func loadFailurePublishesFailedState() async {
+    let persistence = MissionPersistence(path: "/dev/null/missions.sqlite")
+    let controller = MissionController(environment: .init(
+        persistence: persistence,
+        now: Date.init,
+        makeID: { UUID().uuidString },
+        worktreeAtDestination: { _, _ in nil },
+        createWorktree: { _ in .failure(.init(message: "unused")) },
+        startACP: { _, _ in .failure(.init(message: "unused")) },
+        notifyChanged: { _ in }
+    ))
+
+    await controller.load()
+
+    #expect(controller.aggregates.isEmpty)
+    if case .failed = controller.loadState {
+    } else {
+        Issue.record("Expected a failed Mission load state")
+    }
+}
+```
+
+In `MissionTabTests`, construct a `MissionTabView` before calling `fixture.state.missions.load()` and assert `mission-loading` exists. Then load a nonexistent ID and assert the existing unavailable title; finally use `MissionPersistence(path: "/dev/null/missions.sqlite")` in an `AppState` fixture, call `load()`, and assert the unavailable description includes the published error.
+
+- [ ] **Step 2: Run the focused tests and confirm they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/MissionCoordinatorTests -only-testing:AlasTests/MissionTabTests test
+```
+
+Expected: compilation fails because `MissionLoadState` and `MissionController.loadState` do not exist; the loading identifier is absent.
+
+- [ ] **Step 3: Implement the controller state machine and pane branches**
+
+Declare the state beside the controller and replace the current two-outcome `load()` implementation with cancellation-safe publishing:
+
+```swift
+enum MissionLoadState: Equatable {
+    case loading
+    case loaded
+    case failed(String)
+}
+
+private(set) var loadState: MissionLoadState = .loading
+
+func load() async {
+    loadState = .loading
+    loadError = nil
+    do {
+        let loaded = try await persistence.list(includeCompleted: true)
+        guard !Task.isCancelled else { return }
+        aggregates = Self.sorted(loaded)
+        loadState = .loaded
+    } catch {
+        guard !Task.isCancelled else { return }
+        let message = error.localizedDescription
+        loadError = message
+        loadState = .failed(message)
+    }
+}
+```
+
+Keep all later mutation paths working with `aggregates` as today. In `MissionTabView.body`, retain the aggregate-first branch, then switch on `state.missions.loadState`: `.loading` renders a centered `ProgressView("Loading Mission…")` tagged with `.accessibilityIdentifier("mission-loading")`; `.loaded` renders the current unavailable view; `.failed(let message)` renders the same unavailable title with `Text(message)` as its description. Do not start a task from the view—the root owns the one startup load.
+
+- [ ] **Step 4: Run the focused tests and confirm they pass**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/MissionCoordinatorTests -only-testing:AlasTests/MissionTabTests test
+```
+
+Expected: PASS. The view must not show `Mission unavailable` during `.loading`, and a failed read must not leave it spinning forever.
+
+- [ ] **Step 5: Commit the Mission loading-state change**
+
+```bash
+git add Alas/Sources/Missions/MissionController.swift Alas/Sources/Missions/MissionTabView.swift AlasTests/Missions/MissionCoordinatorTests.swift AlasTests/Missions/MissionTabTests.swift
+git commit -m "feat: show Mission loading state at startup"
+```
+
+### Task 3: Make launch concurrent without delaying the workspace
+
+**Files:**
+
+- Modify: `Alas/Sources/App/AppState.swift:899-916,1840-1875`
+- Modify: `Alas/Sources/App/RootView.swift:73-91,106-115`
+- Modify: `AlasTests/Missions/MissionSidebarTests.swift`
+- Test: `AlasTests/Missions/MissionTabTests.swift`
+
+**Interfaces:**
+
+- Produces: `AppState.restoreGlobalTabsForStartup()` that calls `globalTabs.loadPersistedTabs()` and routes errors through `persistenceErrorHandler("Mission Tabs Save Failed", ...)`.
+- Produces: `AppState.reconcileLoadedMissionsForStartup()` that performs the current repository refresh, legacy base-remote resolution, interrupted-Mission reconciliation, and missing-Mission recovery, but does not call `missions.load()`.
+- Produces: `AppState.reconcileMissionsForStartup()` retained for existing callers as `await missions.load(); await reconcileLoadedMissionsForStartup()`.
+- Consumes: `AppState.reloadTabs()` after topology discovery; it loads worktree tabs then invokes only `globalTabs.migrateLegacyMissionTabs(...)`.
+
+- [ ] **Step 1: Write the failing launch-visibility and reconciliation-boundary tests**
+
+Extend `RootWorkspaceVisibilityPolicy` so its test proves an active persisted global Mission makes the workspace visible even when projects and aggregates are both empty:
+
+```swift
+#expect(RootWorkspaceVisibilityPolicy.showsWorkspace(
+    hasProjects: false,
+    hasMissions: false,
+    hasActiveMissionTab: true
+))
+```
+
+In `MissionTabTests`, add a startup-boundary regression that preloads an aggregate, invokes `reconcileLoadedMissionsForStartup()`, and verifies the existing missing-worktree recovery behavior remains unchanged. Keep the existing `reconcileMissionsForStartup()` tests to prove the compatibility wrapper still loads first.
+
+- [ ] **Step 2: Run the focused tests and confirm the new boundary is absent**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/MissionSidebarTests -only-testing:AlasTests/MissionTabTests test
+```
+
+Expected: compilation fails because the visibility-policy argument and `reconcileLoadedMissionsForStartup()` do not yet exist.
+
+- [ ] **Step 3: Add startup-sized AppState helpers and reorder RootView.task**
+
+Add the early restore helper and split reconciliation at the current `reconcileMissionsForStartup()` boundary:
+
+```swift
+func restoreGlobalTabsForStartup() {
+    do {
+        try globalTabs.loadPersistedTabs()
+    } catch {
+        persistenceErrorHandler("Mission Tabs Save Failed", error.localizedDescription)
+    }
+}
+
+func reconcileMissionsForStartup() async {
+    await missions.load()
+    await reconcileLoadedMissionsForStartup()
+}
+
+func reconcileLoadedMissionsForStartup() async {
+    await refreshRenamedMissionRepositories()
+    await missions.resolveLegacyBaseRemoteNames { [weak self] projectID, baseRef in
+        await self?.resolveLegacyMissionBaseRemoteName(projectID: projectID, baseRef: baseRef)
+    }
+    await missions.reconcileInterrupted()
+    presentMissingMissionRecoveryIfNeeded()
+}
+```
+
+In `reloadTabs()`, keep its worktree-tab load and terminal cleanup behavior, but replace `globalTabs.loadAndMigrate(...)` with `globalTabs.migrateLegacyMissionTabs(...)`.
+
+Replace the root task sequence with concurrent Mission loading and topology refresh. The three `guard !Task.isCancelled` checks prevent a disappearing root view from applying a later startup phase:
+
+```swift
+.task {
+    state.startHarness()
+    state.restoreGlobalTabsForStartup()
+    async let topologyRefresh: Bool = state.refreshAllProjectTopologies()
+    async let missionLoad: Void = state.missions.load()
+
+    _ = await topologyRefresh
+    guard !Task.isCancelled else { return }
+    state.reloadTabs()
+    if state.selectedWorktreeId == nil {
+        state.selectInitialWorktree(id: state.resolvedSelectionForActiveSpaceForStartup())
+    }
+    state.startAllProjectGitWatchers()
+    state.rescanAgents()
+
+    await missionLoad
+    guard !Task.isCancelled else { return }
+    await state.reconcileLoadedMissionsForStartup()
+}
+```
+
+Update `RootWorkspaceVisibilityPolicy.showsWorkspace` to accept `hasActiveMissionTab: Bool` and return true for that third case. Pass `state.globalTabs.activeMissionTab() != nil` from `mainContent`. This is required for the loading pane to be reachable on a launch with no currently loaded projects or aggregates.
+
+- [ ] **Step 4: Run focused tests and inspect launch ordering**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/MissionSidebarTests -only-testing:AlasTests/MissionTabTests -only-testing:AlasTests/GlobalTabsManagerTests test
+```
+
+Expected: PASS. Inspect the root task to confirm `startAllProjectGitWatchers()` and `rescanAgents()` occur before `await missionLoad` and `reconcileLoadedMissionsForStartup()`.
+
+- [ ] **Step 5: Commit the non-blocking launch sequence**
+
+```bash
+git add Alas/Sources/App/AppState.swift Alas/Sources/App/RootView.swift AlasTests/Missions/MissionSidebarTests.swift AlasTests/Missions/MissionTabTests.swift
+git commit -m "fix: avoid blocking startup on Mission reconciliation"
+```
+
+### Task 4: Run the complete regression suite and verify the app build
+
+**Files:**
+
+- Verify: all files changed in Tasks 1–3.
+
+**Interfaces:**
+
+- Verifies: combined global-tab persistence, Mission loading state, launch sequencing, and existing Mission recovery behavior.
+
+- [ ] **Step 1: Run targeted Mission and tab regressions**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GlobalTabsManagerTests -only-testing:AlasTests/MissionCoordinatorTests -only-testing:AlasTests/MissionTabTests -only-testing:AlasTests/MissionSidebarTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Regenerate the Xcode project**
+
+```bash
+xcodegen
+```
+
+Expected: exits 0. If `project.yml` is unchanged, confirm the generated project has no unrelated diff before proceeding.
+
+- [ ] **Step 3: Build the macOS app**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Run the complete macOS test suite**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Inspect the final diff and commit any generated project update only if needed**
+
+```bash
+git diff --check
+git status --short
+```
+
+If `xcodegen` changed `Alas.xcodeproj/project.pbxproj`, inspect that it is generated from the unchanged project definition; include it in a final commit only when it is a legitimate generated update:
+
+```bash
+git add Alas.xcodeproj/project.pbxproj
+git commit -m "build: regenerate Xcode project"
+```

--- a/docs/superpowers/plans/2026-08-06-nonblocking-mission-startup.md
+++ b/docs/superpowers/plans/2026-08-06-nonblocking-mission-startup.md
@@ -333,7 +333,7 @@ func reconcileLoadedMissionsForStartup() async {
 
 In `reloadTabs()`, keep its worktree-tab load and terminal cleanup behavior, but replace `globalTabs.loadAndMigrate(...)` with `globalTabs.migrateLegacyMissionTabs(...)`.
 
-Replace the root task sequence with concurrent Mission loading and topology refresh. The three `guard !Task.isCancelled` checks prevent a disappearing root view from applying a later startup phase:
+Replace the root task sequence with concurrent Mission loading and topology refresh. The two `guard !Task.isCancelled` checks prevent a disappearing root view from applying a later startup phase:
 
 ```swift
 .task {

--- a/docs/superpowers/specs/2026-08-06-nonblocking-mission-startup-design.md
+++ b/docs/superpowers/specs/2026-08-06-nonblocking-mission-startup-design.md
@@ -1,0 +1,128 @@
+# Non-blocking Mission Startup
+
+Date: 2026-08-06
+Status: Approved design
+
+## Context
+
+Alas persists global Mission tabs, including the active tab, across launches.
+The current startup sequence refreshes every project's worktree topology before
+it restores those global tabs or loads the local Mission snapshot. Worktree
+discovery is asynchronous but can take several seconds across multiple or
+remote repositories. During that interval Alas cannot present the previously
+focused Mission, and Mission reconciliation remains part of the startup
+critical path.
+
+The Mission database is already isolated behind `MissionPersistence`, and the
+center pane can render useful saved Mission content before live worktree,
+agent, change, or review data is available. Startup should take advantage of
+those boundaries instead of waiting for all derived state.
+
+## Goals
+
+- Restore a persisted focused global Mission as soon as startup begins.
+- Keep the app responsive while Mission data and project topology load.
+- Show an explicit loading state until the persisted Mission snapshot is
+  available.
+- Fill in worktree-derived Mission status after topology discovery and startup
+  reconciliation complete.
+- Preserve existing legacy worktree-tab migration and Mission recovery
+  behavior.
+
+## Non-goals
+
+- Optimizing Mission Markdown rendering or changing the Mission pane layout.
+- Changing Mission persistence, lifecycle rules, or reconciliation semantics.
+- Refactoring all application startup work into a new coordinator.
+- Displaying stale worktree, agent, changes, or review data as if it were live.
+
+## Startup Flow
+
+Startup separates fast persisted presentation state from slower derived state:
+
+1. Start the harness as today.
+2. Read the persisted global-tabs file immediately, without attempting legacy
+   worktree-tab migration. This restores the active Mission identity early.
+3. Begin loading the local Mission snapshot concurrently with project topology
+   discovery.
+4. While the active Mission record is loading, present the Mission tab chrome
+   and a centered loading indicator in its content area.
+5. Refresh all project topologies and load per-worktree tabs.
+6. Run the existing global-tab legacy migration now that worktree tabs are
+   available. Migration merges legacy Mission tabs into the already loaded
+   global set rather than replacing current persisted state.
+7. Once the local Mission snapshot and topology are available, run the existing
+   repository, base-remote, interrupted-setup, readiness, and missing-worktree
+   reconciliation.
+8. Continue the remaining startup work independently; reconciliation must not
+   gate initial worktree selection, watcher startup, or agent scanning.
+
+Publishing the loaded Mission aggregate replaces the loading view. Later
+reconciliation updates the same aggregate and its derived status in place.
+
+## State and UI
+
+`MissionController` exposes an explicit load state with three observable
+outcomes: loading, loaded, and failed. Loading begins before the persistence
+request and ends only after the controller publishes either aggregates or an
+error.
+
+`MissionTabView` distinguishes these cases when its requested aggregate is not
+present:
+
+- While Mission data is loading, show a spinner and concise `Loading Mission…`
+  copy.
+- After a successful load with no matching record, show the existing
+  `Mission unavailable` state.
+- After a load failure, show a non-blocking unavailable state with the existing
+  persistence error surfaced in concise form.
+
+The loading state occupies only the center content area. The restored global
+tab remains visible and active, and the rest of the app remains interactive.
+When the aggregate is available before topology discovery finishes, the pane
+renders its saved source and activity immediately. Worktree-dependent fields
+continue to use their existing unavailable copy until live state arrives.
+
+## Global Tab Restoration
+
+`GlobalTabsManager` gains separate operations for loading its persisted global
+file and for migrating legacy worktree Mission tabs. The normal combined entry
+point may remain as a compatibility wrapper for tests and non-startup callers.
+
+Early loading is idempotent. The later migration must preserve user-visible
+changes made after early restoration, such as closing or activating a global
+tab, and merge only legacy tabs that are not already present. Persistence after
+migration remains unchanged.
+
+## Error Handling
+
+Failure to read global tabs keeps the existing empty-tab fallback and reports
+through the existing persistence error path. Failure to load Missions does not
+stall topology refresh or other startup work. A failed reconciliation retains
+the last successfully loaded aggregate and uses the controller's existing
+`loadError` reporting rather than replacing the pane with a spinner.
+
+Cancellation caused by the root view disappearing must stop outstanding
+startup work without publishing partial results into a replacement app state.
+
+## Testing
+
+Regression coverage will verify:
+
+- Persisted global tabs and their active Mission restore before legacy
+  migration is possible.
+- Legacy migration merges into an already loaded global-tab state without
+  duplicating tabs or undoing a newer active-tab choice.
+- A requested Mission renders the loading presentation while persistence is in
+  flight.
+- A missing Mission becomes unavailable only after a successful load finishes.
+- A Mission load failure produces the error presentation without blocking
+  other startup completion.
+- Startup can complete initial selection, watcher setup, and agent scanning
+  without waiting for Mission reconciliation.
+- Existing Mission startup recovery and global-tab migration tests remain
+  green.
+
+The implementation will follow test-driven development: each observable
+startup-ordering behavior is introduced with a failing Swift Testing test
+before production code changes.


### PR DESCRIPTION
## Summary
- restore persisted Mission tabs before mission data finishes loading
- show a Mission loading state while startup data loads
- defer Mission reconciliation/recovery until missions finish loading
- stabilize Mission coordinator async wait tests

## Test plan
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test