### PR TITLE
fix(acp): smooth transcript fling rebound

### DIFF
--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -751,7 +751,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 // queues several steps that land together as a single
                 // 60-150 row insertion measured in one synchronous pass.
                 pendingHeadStep = true
-                host.transcript.stepHeadBack()
+                host.transcript.stepHeadBack(boundTail: false)
             }
             if ACPTranscriptScroller.shouldStepTailForward(
                 visibleTail: host.transcript.visibleTailBound,
@@ -760,7 +760,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 threshold: threshold,
                 previousScrollY: previousY, newScrollY: newY
             ) {
-                host.transcript.stepTailForward(preserving: nil)
+                host.transcript.stepTailForward(preserving: nil, boundHead: false)
             }
 
             if !host.session.followsTranscriptTail {
@@ -915,7 +915,6 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             reconciler?.setFollowsTail(true)
             host.transcript.resetWindowToTail()
             host.onRememberScrollAnchor(nil, nil, true)
-            scroller?.scrollToBottom()
         }
 
         private func rememberCurrentAnchor() {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -97,6 +97,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// has been reconciled into the AppKit tiling map.
         private var pendingLogicalTargetId: String?
         private var isPendingLogicalResolutionScheduled = false
+        private let scrollSettleTimer: DebounceTimer
         /// Memoizes the window-sliced row list + its id → message-index
         /// lookup, keyed on (messages generation, window bounds) — the same
         /// cache the legacy list uses. `rememberCurrentAnchor` runs on every
@@ -108,6 +109,15 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         private let visibleRowsCache = ACPVisibleRowsCache()
 
         static let composerSpacerHeight: CGFloat = 220
+
+        init() {
+            scrollSettleTimer = DebounceTimer(
+                interval: ACPTranscriptScrollerReconciler.userScrollSuppressionWindow
+            )
+            scrollSettleTimer.onFire = { [weak self] in
+                self?.settleUserScroll()
+            }
+        }
 
         func attach(scroller: ACPTranscriptScrollerView, host: ACPTranscriptScroller) {
             self.scroller = scroller
@@ -663,6 +673,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // `repinsToTail(followsTail:wasFollowingTail:)`).
             reconciler.invalidatePendingAnchorRestore()
             reconciler.noteUserScroll()
+            scrollSettleTimer.poke()
 
             let event = NSApp.currentEvent
             let eventIsFresh = ACPUserScrollEvent.isFresh(
@@ -915,6 +926,29 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             reconciler?.setFollowsTail(true)
             host.transcript.resetWindowToTail()
             host.onRememberScrollAnchor(nil, nil, true)
+        }
+
+        /// Once a fling has stopped moving, restore the bounded render window
+        /// around the row being read. While it is active we deliberately keep
+        /// both edges so AppKit never has to reconcile a moving viewport with
+        /// rows disappearing behind it.
+        private func settleUserScroll() {
+            guard let host, let scroller else { return }
+            guard !scroller.isUserScrollActive else {
+                scrollSettleTimer.poke()
+                return
+            }
+            if host.session.followsTranscriptTail {
+                update(host: host)
+                return
+            }
+            guard host.transcript.visibleTailBound - host.transcript.visibleHead
+                    > ACPTranscript.maxVisibleRows,
+                  let globalIndex = currentTopGlobalMessageIndex(),
+                  let localIndex = host.transcript.localIndex(forGlobalIndex: globalIndex)
+            else { return }
+            host.transcript.setVisibleWindow(around: localIndex)
+            update(host: host)
         }
 
         private func rememberCurrentAnchor() {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -321,11 +321,10 @@ final class ACPTranscriptScrollerReconciler {
     /// behavior — streaming content accumulates below the viewport while the
     /// "go to newest" affordance stays hidden, because it keys off
     /// `session.followsTranscriptTail` which nothing has paused. The
-    /// suppression is therefore scoped to an ACTIVE GESTURE: the viewport
-    /// must be off the tail AND the user must have moved it within
-    /// `userScrollSuppressionWindow`. Once the gesture ends, an update
-    /// re-pins exactly as it always did, so the inconsistent state cannot
-    /// outlive the gesture that caused it.
+    /// suppression is therefore scoped to an ACTIVE GESTURE. This includes
+    /// elastic overrun at the bottom: `distanceFromBottom` is clamped to zero
+    /// there, but re-pinning would fight AppKit's rebound. Once the gesture
+    /// ends, an update re-pins exactly as it always did.
     ///
     /// "The user moved it" is `noteUserScroll()`, driven by the scroller's own
     /// programmatic/non-programmatic split, not by `NSApp.currentEvent` —
@@ -355,9 +354,6 @@ final class ACPTranscriptScrollerReconciler {
     private func repinsToTail(followsTail: Bool, wasFollowingTail: Bool) -> Bool {
         guard followsTail else { return false }
         if !wasFollowingTail { return true }
-        guard scroller.distanceFromBottom > ACPScrollDirectionClassifier.bottomTolerance else {
-            return true
-        }
         return !isUserScrollInFlight()
     }
 

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -91,6 +91,9 @@ final class ACPTranscriptScrollerView: NSScrollView {
 
     private var lastReportedY: CGFloat?
     private var programmaticAdjustmentDepth = 0
+    #if DEBUG
+    private(set) var scrollToBottomCallCountForTesting = 0
+    #endif
     private var boundsObserver: NSObjectProtocol?
     private var liveScrollObservers: [NSObjectProtocol] = []
 
@@ -322,6 +325,9 @@ final class ACPTranscriptScrollerView: NSScrollView {
     }
 
     func scrollToBottom() {
+        #if DEBUG
+        scrollToBottomCallCountForTesting += 1
+        #endif
         setScrollY(max(0, contentHeight - viewportHeight))
     }
 

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
@@ -123,6 +123,20 @@ struct ACPTranscriptScrollerLiveScrollTests {
         withExtendedLifetime(coordinator) {}
     }
 
+    @Test("a settled history fling compacts the temporary grow-only window")
+    func settledHistoryFlingCompactsWindow() async throws {
+        let (host, scroller, coordinator) = tailFollowingHost()
+        liveScroll(scroller, to: max(0, scroller.contentHeight - scroller.viewportHeight - 470))
+
+        try await Task.sleep(for: .milliseconds(600))
+
+        #expect(
+            host.transcript.visibleTailBound - host.transcript.visibleHead
+                <= ACPTranscript.maxVisibleRows
+        )
+        withExtendedLifetime(coordinator) {}
+    }
+
     @Test("live-scroll activity lapses after the gesture settles")
     func userScrollActivityLapses() {
         let (_, scroller, coordinator) = tailFollowingHost()

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -786,8 +786,8 @@ struct ACPTranscriptScrollerLogicalNavigationTests {
         #expect(scroller.distanceFromBottom < 1)
     }
 
-    @Test("AppKit head pagination discards the opposite page")
-    func headPaginationStaysBounded() throws {
+    @Test("AppKit head pagination keeps the opposite edge during a fling")
+    func headPaginationGrowsWithoutResettingTheWindow() throws {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         session.replaceTranscriptMessages(messages(200))
         session.transcript.setVisibleWindow(containing: 70)
@@ -799,8 +799,58 @@ struct ACPTranscriptScrollerLogicalNavigationTests {
 
         _ = coordinator // Retain the weak callback owner through the scroll.
         #expect(session.transcript.visibleHead == 40)
-        #expect(session.transcript.visibleTail == 130)
-        #expect(session.transcript.visibleTailBound - session.transcript.visibleHead == ACPTranscript.maxVisibleRows)
+        #expect(session.transcript.visibleTail == 160)
+        #expect(
+            session.transcript.visibleTailBound - session.transcript.visibleHead
+                == ACPTranscript.maxVisibleRows + ACPTranscript.tailWindow
+        )
+    }
+
+    @Test("AppKit tail pagination keeps the opposite edge during a fling")
+    func tailPaginationGrowsWithoutResettingTheWindow() throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.replaceTranscriptMessages(messages(200))
+        session.transcript.setVisibleWindow(containing: 40)
+        session.followsTranscriptTail = false
+        let (coordinator, scroller, _) = try attach(session: session)
+
+        let bottom = max(0, scroller.contentHeight - scroller.viewportHeight)
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: bottom - 1))
+        scroller.reflectScrolledClipView(scroller.contentView)
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: bottom))
+        scroller.reflectScrolledClipView(scroller.contentView)
+
+        _ = coordinator // Retain the weak callback owner through the scroll.
+        #expect(session.transcript.visibleHead == 40)
+        #expect(session.transcript.visibleTail == 160)
+        #expect(
+            session.transcript.visibleTailBound - session.transcript.visibleHead
+                == ACPTranscript.maxVisibleRows + ACPTranscript.tailWindow
+        )
+    }
+
+    @Test("reaching the live tail does not issue a programmatic scroll during rebound")
+    func reachingLiveTailDoesNotScrollProgrammatically() throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.replaceTranscriptMessages(messages(200))
+        session.transcript.resetWindowToTail()
+        session.transcript.freezeVisibleTail()
+        session.followsTranscriptTail = false
+        let (coordinator, scroller, _) = try attach(session: session)
+
+        NotificationCenter.default.post(
+            name: NSScrollView.willStartLiveScrollNotification, object: scroller
+        )
+        let bottom = max(0, scroller.contentHeight - scroller.viewportHeight)
+        let callsBefore = scroller.scrollToBottomCallCountForTesting
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: bottom - 1))
+        scroller.reflectScrolledClipView(scroller.contentView)
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: bottom))
+        scroller.reflectScrolledClipView(scroller.contentView)
+
+        #expect(session.followsTranscriptTail)
+        #expect(scroller.scrollToBottomCallCountForTesting == callsBefore)
+        _ = coordinator // Retain the weak callback owner through the scroll.
     }
 }
 

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -525,6 +525,20 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
         #expect(scroller.contentHeight == tiling.documentHeight)
     }
 
+    @Test("remeasureRow does not clamp the bottom while a user scroll is settling")
+    func remeasureRowDoesNotRepinDuringUserScrollSettle() {
+        let (reconciler, scroller, _, _) = makeStackWithPool()
+        let specs = (0..<10).map { spec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: true)
+        #expect(scroller.distanceFromBottom < 1)
+        let callsBefore = scroller.scrollToBottomCallCountForTesting
+
+        reconciler.noteUserScroll()
+        reconciler.remeasureRow(id: "r9")
+
+        #expect(scroller.scrollToBottomCallCountForTesting == callsBefore)
+    }
+
     @Test("remeasureRow does not re-pin once tail-follow is paused, even before the next apply")
     func remeasureRowDoesNotRepinAfterTailFollowPaused() {
         // The window this closes: a user scrolls up, the scroll handler


### PR DESCRIPTION
## Summary
- Keep native AppKit transcript pagination grow-only during wheel and trackpad flings.
- Avoid tail-follow re-pins while AppKit settles its elastic bottom rebound.

## Root cause
The 0.14.2 logical-scrollbar change bounded both window edges during a fling, forcing a reconciler reset. At the live tail, remeasured rows could also call `scrollToBottom()` during elastic settling.

## Validation
- Manual ACP transcript fling test at both edges
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (7,653 tests / 698 suites)