### PR TITLE
feat(worktree): show worktree deletion progress

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1538,7 +1538,7 @@ final class AppState {
         })
         else { return nil }
         switch projectsManager.operationState(for: worktree.id) {
-        case nil, .deleteFailed:
+        case nil, .preparingDelete, .deleteFailed:
             return worktree
         case .creating, .deleting, .createFailed:
             return nil
@@ -1941,13 +1941,12 @@ final class AppState {
                 guard let self else { return [] }
                 // Match `RootView.selectedWorktree()`: hide creating /
                 // deleting / createFailed rows (the main pane returns nil
-                // for them) but keep deleteFailed selectable so the user
-                // can recover via keyboard nav, mirroring the sidebar.
+                // for them) but keep preflight and deleteFailed rows selectable.
                 return self.projectsManager.visibleWorktrees(projectId: projectId).filter {
                     switch self.projectsManager.operationState(for: $0.id) {
                     case .creating, .deleting, .createFailed:
                         return false
-                    case nil, .deleteFailed:
+                    case nil, .preparingDelete, .deleteFailed:
                         return true
                     }
                 }
@@ -6117,9 +6116,11 @@ final class AppState {
 
         let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
         let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
+        projectsManager.setOperationState(id: worktree.id, state: .preparingDelete)
 
         Task { @MainActor in
             let preflight = await Self.performDeletePreflight(worktreePath: worktree.path)
+            guard projectsManager.operationState(for: worktree.id) == .preparingDelete else { return }
             let confirmation = Self.deleteConfirmation(
                 branch: worktree.branch,
                 keepBranch: keepBranch,
@@ -6130,7 +6131,12 @@ final class AppState {
                 keepBranch: keepBranch,
                 preflight: preflight,
                 userConfirmed: confirmDeleteWorktree(confirmation)
-            ) else { return }
+            ) else {
+                if projectsManager.operationState(for: worktree.id) == .preparingDelete {
+                    projectsManager.setOperationState(id: worktree.id, state: nil)
+                }
+                return
+            }
 
             projectsManager.setOperationState(id: worktree.id, state: .deleting)
             await performDeleteWorktree(
@@ -8097,7 +8103,7 @@ extension AppState: RemoteSessionsProvider {
                 switch projectsManager.operationState(for: worktree.id) {
                 case .creating, .deleting, .createFailed:
                     continue
-                case nil, .deleteFailed:
+                case nil, .preparingDelete, .deleteFailed:
                     out.append(await remoteWorktreeOption(project: project, worktree: worktree))
                 }
             }
@@ -8122,7 +8128,7 @@ extension AppState: RemoteSessionsProvider {
         switch projectsManager.operationState(for: worktreeId) {
         case .creating, .deleting, .createFailed:
             return .failure("Worktree is no longer available.")
-        case nil, .deleteFailed:
+        case nil, .preparingDelete, .deleteFailed:
             break
         }
 

--- a/Alas/Sources/App/CenterSelectionState.swift
+++ b/Alas/Sources/App/CenterSelectionState.swift
@@ -28,6 +28,8 @@ struct CenterSelectionStateResolver {
         }
         if let op = projectsManager.operationState(for: id) {
             switch op {
+            case .preparingDelete:
+                break
             case .deleting:
                 if let wt = findWorktree(by: id) { return .deleting(wt) }
                 return .empty
@@ -64,7 +66,7 @@ struct CenterSelectionStateResolver {
                     switch op {
                     case .creating, .deleting, .createFailed:
                         return nil
-                    case .deleteFailed:
+                    case .preparingDelete, .deleteFailed:
                         break
                     }
                 }

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -37,6 +37,7 @@ struct ProjectUpdate: Equatable {
 
 enum WorktreeOperationState: Equatable {
     case creating
+    case preparingDelete
     case deleting
     /// The raw GG policy is retry metadata only; AppState removes its effective
     /// optimistic overlay before entering this state.
@@ -402,7 +403,7 @@ final class ProjectsManager {
                         reconciled.append(optimistic)
                     }
                 }
-            case .deleting:
+            case .preparingDelete, .deleting:
                 // If the row is gone from git, the deletion succeeded.
                 if !liveIds.contains(id) {
                     clearOperationIds.append(id)
@@ -517,9 +518,8 @@ final class ProjectsManager {
     ///
     /// Skips rows whose operation state is `.creating` or `.createFailed`:
     /// those rows show the user's intended branch name, not whatever git
-    /// has on disk yet. `.deleting` and `.deleteFailed` rows are still
-    /// updated — they correspond to real git worktrees with a pending UI
-    /// operation, so git's branch is still the truth.
+    /// has on disk yet. Delete-operation rows are still updated — they
+    /// correspond to real git worktrees, so git's branch is still the truth.
     @discardableResult
     func applyHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) -> Set<String> {
         guard var rows = worktreesByProject[projectId], !rows.isEmpty else { return [] }
@@ -534,7 +534,7 @@ final class ProjectsManager {
             if let op = worktreeOperationStates[rows[i].id] {
                 switch op {
                 case .creating, .createFailed: continue
-                case .deleting, .deleteFailed: break
+                case .preparingDelete, .deleting, .deleteFailed: break
                 }
             }
             if rows[i].branch != newBranch || rows[i].name != newBranch {

--- a/Alas/Sources/App/RightPaneSelectionState.swift
+++ b/Alas/Sources/App/RightPaneSelectionState.swift
@@ -28,6 +28,8 @@ struct RightPaneSelectionStateResolver {
         guard let wt = findWorktree(by: id) else { return .empty }
         if let op = projectsManager.operationState(for: wt.id) {
             switch op {
+            case .preparingDelete:
+                return .active(wt)
             case .creating:
                 return .creating(wt)
             case .deleting:

--- a/Alas/Sources/App/WorktreeCreationCompletion.swift
+++ b/Alas/Sources/App/WorktreeCreationCompletion.swift
@@ -30,7 +30,7 @@ enum WorktreeCreationCompletion {
             case .creating:
                 await sleep()
                 continue
-            case .deleting, .deleteFailed:
+            case .preparingDelete, .deleting, .deleteFailed:
                 return .failure(.init(message: "Worktree creation was interrupted."))
             case nil:
                 if let reconciledWorktree {

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -182,9 +182,8 @@ struct WorktreeRowView: View {
                 if operationState != nil {
                     HStack(spacing: 5) {
                         if Self.showsProgress(operationState: operationState) {
-                            ProgressView()
-                                .controlSize(.small)
-                                .tint(theme.color("warning"))
+                            Spinner(lineWidth: 1.5, duration: 0.7, color: theme.color("warning"))
+                                .frame(width: 10, height: 10)
                                 .accessibilityHidden(true)
                         }
                         Text(Self.statusText(for: operationState))

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -113,16 +113,17 @@ struct WorktreeRowView: View {
     let onSetGGWorktreeMode: (GGWorktreeMode) -> Void
     @Environment(\.theme) var theme
 
-    private var isPending: Bool {
+    nonisolated static func isPending(operationState: WorktreeOperationState?) -> Bool {
         switch operationState {
-        case .creating, .deleting: return true
+        case .creating, .preparingDelete, .deleting: return true
         default: return false
         }
     }
 
-    private var statusText: String {
+    nonisolated static func statusText(for operationState: WorktreeOperationState?) -> String {
         switch operationState {
         case .creating: return "Creating…"
+        case .preparingDelete: return "Preparing deletion…"
         case .deleting: return "Deleting…"
         case .createFailed(_, let msg, _, _): return "Create failed: \(msg.trimmedForDisplay)"
         case .deleteFailed(let msg): return "Delete failed: \(msg.trimmedForDisplay)"
@@ -130,11 +131,22 @@ struct WorktreeRowView: View {
         }
     }
 
+    nonisolated static func showsProgress(operationState: WorktreeOperationState?) -> Bool {
+        switch operationState {
+        case .preparingDelete, .deleting: return true
+        case .creating, .createFailed, .deleteFailed, .none: return false
+        }
+    }
+
+    private var isPending: Bool {
+        Self.isPending(operationState: operationState)
+    }
+
     private var errorMessage: String? {
         switch operationState {
         case .createFailed(_, let message, _, _), .deleteFailed(let message):
             return message
-        case .creating, .deleting, .none:
+        case .creating, .preparingDelete, .deleting, .none:
             return nil
         }
     }
@@ -168,11 +180,19 @@ struct WorktreeRowView: View {
                         .truncationMode(.tail)
                 }
                 if operationState != nil {
-                    Text(statusText)
-                        .font(.system(size: 10.5))
-                        .foregroundColor(theme.color("warning"))
-                        .lineLimit(2)
-                        .truncationMode(.tail)
+                    HStack(spacing: 5) {
+                        if Self.showsProgress(operationState: operationState) {
+                            ProgressView()
+                                .controlSize(.small)
+                                .tint(theme.color("warning"))
+                                .accessibilityHidden(true)
+                        }
+                        Text(Self.statusText(for: operationState))
+                            .font(.system(size: 10.5))
+                            .foregroundColor(theme.color("warning"))
+                            .lineLimit(2)
+                            .truncationMode(.tail)
+                    }
                 } else {
                     HStack(spacing: 8) {
                         Text(relative(worktree.lastActivity))

--- a/AlasTests/WorktreeRowHeightTests.swift
+++ b/AlasTests/WorktreeRowHeightTests.swift
@@ -28,6 +28,18 @@ struct WorktreeRowHeightTests {
         #expect(WorktreeRowView.pendingStackIndicatorColorToken() == "fg-faint")
     }
 
+    @Test func deletePhasesUsePendingProgressPresentation() {
+        #expect(WorktreeRowView.isPending(operationState: .preparingDelete))
+        #expect(WorktreeRowView.statusText(for: .preparingDelete) == "Preparing deletion…")
+        #expect(WorktreeRowView.showsProgress(operationState: .preparingDelete))
+
+        #expect(WorktreeRowView.isPending(operationState: .deleting))
+        #expect(WorktreeRowView.statusText(for: .deleting) == "Deleting…")
+        #expect(WorktreeRowView.showsProgress(operationState: .deleting))
+
+        #expect(!WorktreeRowView.showsProgress(operationState: .creating))
+    }
+
     @Test func rowHeightIsStableWithAndWithoutBadge() throws {
         let withoutBadge = try renderHeight(harnessSummary: nil)
         let withBadge = try renderHeight(harnessSummary: .init(


### PR DESCRIPTION
## Summary

- show a spinner and “Preparing deletion…” while delete preflight and hooks run
- keep the spinner visible with “Deleting…” after confirmation
- restore normal row state when deletion is cancelled and ignore stale preflight completions

## Why

Preparing a worktree deletion can take noticeable time in larger repositories, especially when hooks run. The sidebar previously gave no feedback until the confirmation dialog appeared.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/WorktreeRowHeightTests -quiet`

The full local suite was also attempted; an unrelated `MissionCoordinatorTests.restartAdvancesCreatingLegsIndependently()` failure reproduced independently and then stalled Xcode’s test runner.