### PR TITLE
fix(stacks): Hide Stacked Diffs Mode menu when gg is globally disabled

### DIFF
--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -17,7 +17,8 @@ struct GGWorktreeMenuModel: Equatable {
         isEffectiveActive = context.isActive
         showsStatusIndicator = context.isActive && !hasStackSummary
         let contextIsRemote = context == .inactive(reason: .remoteProject)
-        isVisible = !isRemoteWorktree && !contextIsRemote
+        let isGloballyDisabled = context == .inactive(reason: .masterDisabled)
+        isVisible = !isRemoteWorktree && !contextIsRemote && !isGloballyDisabled
 
         guard !isRemoteWorktree else {
             inactiveExplanation = nil

--- a/AlasTests/GGWorktreeMenuModelTests.swift
+++ b/AlasTests/GGWorktreeMenuModelTests.swift
@@ -55,12 +55,13 @@ struct GGWorktreeMenuModelTests {
         #expect(model.inactiveExplanation == "gg is not installed.")
     }
 
-    @Test func globalDisableHasUsefulExplanation() {
+    @Test func globalDisableHidesMenuAndHasUsefulExplanation() {
         let model = menuModel(
             selectedMode: .on,
             context: .inactive(reason: .masterDisabled)
         )
 
+        #expect(!model.isVisible)
         #expect(model.inactiveExplanation == "Stacked diffs are disabled in Settings.")
     }
 


### PR DESCRIPTION
When stacked diffs are turned off in Settings (`.masterDisabled`), the worktree context menu still showed an empty "Stacked Diffs Mode >" entry. This change hides the entire menu section in that case, matching the existing behavior for remote worktrees and projects.

Changes:
- `GGWorktreeMenuModel.isVisible` now returns `false` when the context is `.inactive(reason: .masterDisabled)`.
- Updated the existing test to assert that the menu is hidden when gg is globally disabled.

Verification:
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build` passes.
- Full test suite: 7,732 tests, 0 failures.