### PR TITLE
fix(gg): recover cancelled stack refreshes

### DIFF
--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -983,6 +983,33 @@ final class RightPaneState: GGSplitCommitServicing {
             await reconcileGGUndoCandidateIfNeeded()
             return
         }
+        let previousStack = ggStack
+        let previousKey = ggStackCommitsKey
+        let previousLoadState = ggStackLoadState
+        let previousSummary = GGStackSummaryStore.shared.summaries[worktree.path.path]
+        defer {
+            if Task.isCancelled,
+               snapshotGeneration == snapshotInvalidationGeneration,
+               refreshGeneration == ggStackRefreshGeneration,
+               ggStackLoadState == .loading {
+                let canRestorePreviousSnapshot = previousKey == key
+                    && key == currentGGStackCommitsKey
+                    && (previousLoadState == .loaded || previousLoadState == .empty)
+                if canRestorePreviousSnapshot {
+                    ggStack = previousStack
+                    ggStackCommitsKey = previousKey
+                    ggStackLoadState = previousLoadState
+                    GGStackSummaryStore.shared.summaries[worktree.path.path] = previousSummary
+                } else {
+                    ggStack = nil
+                    ggStackCommitsKey = nil
+                    ggStackLoadState = .failed(
+                        "Stack refresh was interrupted. Retry to load it again."
+                    )
+                    GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+                }
+            }
+        }
         ggStackLoadState = .loading
         ggStackCommitsKey = nil
         if ggStack != nil { ggStack = nil }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -1329,6 +1329,127 @@ struct RightPaneGGStackTests {
         #expect(runner.callCount == 2)
     }
 
+    @Test func cancelledSameKeyReloadRestoresPreviousStableStack() async throws {
+        let worktree = makeWorktree()
+        defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }
+        let result = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture,
+            stderr: ""
+        )
+        let cancelledResult = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture.replacingOccurrences(
+                of: "agent-inbox",
+                with: "cancelled-response"
+            ),
+            stderr: ""
+        )
+        let runner = ControlledStackGGRunner(
+            stackResults: [("agent-inbox", result), ("cancelled-response", cancelledResult)],
+            suspendedCalls: [2]
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [
+            commit(sha: String(repeating: "q", count: 40), stackShaped: true),
+        ]
+
+        await state.refreshGGStack()
+        let stableKey = try #require(state.ggStackCommitsKey)
+        let stableSummary = try #require(GGStackSummaryStore.shared.summaries[worktree.path.path])
+
+        let refresh = Task { @MainActor in
+            await state.refreshGGStack(forceRemote: true)
+        }
+        await runner.waitUntilCall(2)
+        #expect(state.ggStackLoadState == .loading)
+
+        refresh.cancel()
+        await runner.complete(call: 2)
+        await refresh.value
+
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(state.ggStack?.name != "cancelled-response")
+        #expect(state.ggStackCommitsKey == stableKey)
+        #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == stableSummary)
+    }
+
+    @Test func cancelledRefreshWithChangedLiveKeyDoesNotRestorePreviousStack() async {
+        let worktree = makeWorktree()
+        defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }
+        let result = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture,
+            stderr: ""
+        )
+        let runner = ControlledStackGGRunner(
+            stackResults: [("agent-inbox", result), ("agent-inbox", result)],
+            suspendedCalls: [2]
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.currentBranch = "nacho/old-stack"
+        state.ggStackSourceCommits = [
+            commit(sha: String(repeating: "s", count: 40), stackShaped: true),
+        ]
+        await state.refreshGGStack()
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] != nil)
+
+        let refresh = Task { @MainActor in
+            await state.refreshGGStack(forceRemote: true)
+        }
+        await runner.waitUntilCall(2)
+        state.currentBranch = "nacho/new-stack"
+        state.ggStackSourceCommits = [
+            commit(sha: String(repeating: "t", count: 40), stackShaped: true),
+        ]
+
+        refresh.cancel()
+        await runner.complete(call: 2)
+        await refresh.value
+
+        #expect(state.ggStackLoadState == .failed("Stack refresh was interrupted. Retry to load it again."))
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackCommitsKey == nil)
+        #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
+    }
+
+    @Test func cancelledFirstStackLoadBecomesRetryableFailure() async {
+        let worktree = makeWorktree()
+        let result = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture,
+            stderr: ""
+        )
+        let runner = ControlledStackGGRunner(
+            stackResults: [("agent-inbox", result)],
+            suspendedCalls: [1]
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [
+            commit(sha: String(repeating: "r", count: 40), stackShaped: true),
+        ]
+
+        let refresh = Task { @MainActor in await state.refreshGGStack() }
+        await runner.waitUntilCall(1)
+        #expect(state.ggStackLoadState == .loading)
+
+        refresh.cancel()
+        await runner.complete(call: 1)
+        await refresh.value
+
+        #expect(state.ggStackLoadState == .failed("Stack refresh was interrupted. Retry to load it again."))
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackCommitsKey == nil)
+    }
+
     @Test func changedKeyLoadingInvalidatesOldCacheAndSuspendsUndoUntilReconciled() async throws {
         let worktree = makeWorktree()
         try FileManager.default.createDirectory(

--- a/docs/superpowers/plans/2026-08-06-gg-stack-refresh-cancellation.md
+++ b/docs/superpowers/plans/2026-08-06-gg-stack-refresh-cancellation.md
@@ -1,0 +1,183 @@
+# GG Stack Refresh Cancellation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure a cancelled GG stack reload cannot leave the stacked-diffs drawer displaying `Loading` indefinitely.
+
+**Architecture:** Keep cancellation recovery inside `RightPaneState.refreshGGStack`, where refresh-generation and snapshot-generation ownership are already enforced. Capture the prior stable stack presentation before clearing it; if the current load is cancelled without being superseded, restore a same-key stable snapshot or publish a retryable failure.
+
+**Tech Stack:** Swift 5.9+, Swift Concurrency, Observation, Swift Testing, SwiftUI/macOS, XcodeGen/Xcode.
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Do not change successful, inactive-context, non-cancellation failure, or superseded-refresh behavior.
+- Never display a stack snapshot under a different branch/context/commit key.
+- Do not change GG sync streaming or GG command timeouts.
+
+---
+
+### Task 1: Make cancellation terminal without publishing stale stack data
+
+**Files:**
+- Modify: `AlasTests/RightPaneGGStackTests.swift:1332`
+- Modify: `Alas/Sources/Right/RightPaneState.swift:953-1047`
+
+**Interfaces:**
+- Consumes: `RightPaneState.refreshGGStack(forceRemote:)`, `ggStackRefreshGeneration`, `snapshotInvalidationGeneration`, `GGStackLoadState`, `GGStackSummaryStore`.
+- Produces: Cancellation recovery within `refreshGGStack(forceRemote:)`; no new public API.
+
+- [ ] **Step 1: Add failing cancellation regression tests**
+
+Add these tests near the existing refresh-generation tests in `RightPaneGGStackTests`:
+
+```swift
+@Test func cancelledSameKeyReloadRestoresPreviousStableStack() async throws {
+    let worktree = makeWorktree()
+    defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }
+    let result = ProcessResult(
+        exitCode: 0,
+        stdout: GGStackModelsTests.fixture,
+        stderr: ""
+    )
+    let runner = ControlledStackGGRunner(
+        stackResults: [("agent-inbox", result), ("agent-inbox", result)],
+        suspendedCalls: [2]
+    )
+    let state = RightPaneState(worktree: worktree, baseBranch: "main")
+    state.ggService = GGService(runner: runner)
+    state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+    state.ggStackSourceCommits = [
+        commit(sha: String(repeating: "q", count: 40), stackShaped: true),
+    ]
+
+    await state.refreshGGStack()
+    let stableKey = try #require(state.ggStackCommitsKey)
+    let stableSummary = try #require(GGStackSummaryStore.shared.summaries[worktree.path.path])
+
+    let refresh = Task { @MainActor in
+        await state.refreshGGStack(forceRemote: true)
+    }
+    await runner.waitUntilCall(2)
+    #expect(state.ggStackLoadState == .loading)
+
+    refresh.cancel()
+    await runner.complete(call: 2)
+    await refresh.value
+
+    #expect(state.ggStackLoadState == .loaded)
+    #expect(state.ggStack?.name == "agent-inbox")
+    #expect(state.ggStackCommitsKey == stableKey)
+    #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == stableSummary)
+}
+
+@Test func cancelledFirstStackLoadBecomesRetryableFailure() async {
+    let worktree = makeWorktree()
+    let result = ProcessResult(
+        exitCode: 0,
+        stdout: GGStackModelsTests.fixture,
+        stderr: ""
+    )
+    let runner = ControlledStackGGRunner(
+        stackResults: [("agent-inbox", result)],
+        suspendedCalls: [1]
+    )
+    let state = RightPaneState(worktree: worktree, baseBranch: "main")
+    state.ggService = GGService(runner: runner)
+    state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+    state.ggStackSourceCommits = [
+        commit(sha: String(repeating: "r", count: 40), stackShaped: true),
+    ]
+
+    let refresh = Task { @MainActor in await state.refreshGGStack() }
+    await runner.waitUntilCall(1)
+    #expect(state.ggStackLoadState == .loading)
+
+    refresh.cancel()
+    await runner.complete(call: 1)
+    await refresh.value
+
+    #expect(state.ggStackLoadState == .failed("Stack refresh was interrupted. Retry to load it again."))
+    #expect(state.ggStack == nil)
+    #expect(state.ggStackCommitsKey == nil)
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/RightPaneGGStackTests/cancelledSameKeyReloadRestoresPreviousStableStack \
+  -only-testing:AlasTests/RightPaneGGStackTests/cancelledFirstStackLoadBecomesRetryableFailure
+```
+
+Expected: both tests fail because `ggStackLoadState` remains `.loading`; the same-key test also observes a nil stack, cache key, and summary.
+
+- [ ] **Step 3: Implement ownership-aware cancellation recovery**
+
+Immediately after the unchanged-key guard in `refreshGGStack(forceRemote:)`, capture the previous stable presentation and install a `defer` before switching to `.loading`:
+
+```swift
+let previousStack = ggStack
+let previousKey = ggStackCommitsKey
+let previousLoadState = ggStackLoadState
+let previousSummary = GGStackSummaryStore.shared.summaries[worktree.path.path]
+defer {
+    if Task.isCancelled,
+       snapshotGeneration == snapshotInvalidationGeneration,
+       refreshGeneration == ggStackRefreshGeneration,
+       ggStackLoadState == .loading {
+        let canRestorePreviousSnapshot = previousKey == key
+            && (previousLoadState == .loaded || previousLoadState == .empty)
+        if canRestorePreviousSnapshot {
+            ggStack = previousStack
+            ggStackCommitsKey = previousKey
+            ggStackLoadState = previousLoadState
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = previousSummary
+        } else {
+            ggStack = nil
+            ggStackCommitsKey = nil
+            ggStackLoadState = .failed(
+                "Stack refresh was interrupted. Retry to load it again."
+            )
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+        }
+    }
+}
+```
+
+Keep the existing `Task.isCancelled` checks in the success and catch paths. They prevent normal result publication; the `defer` now supplies the missing terminal transition only when this refresh still owns `.loading`.
+
+- [ ] **Step 4: Run focused GG stack tests and verify GREEN**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/RightPaneGGStackTests
+```
+
+Expected: all `RightPaneGGStackTests` pass, including existing stale-generation and changed-key tests.
+
+- [ ] **Step 5: Regenerate and run project verification**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+git diff --check
+```
+
+Expected: XcodeGen succeeds without unintended project changes; build and all tests pass; `git diff --check` reports no errors.
+
+- [ ] **Step 6: Commit the tested fix**
+
+```bash
+git add Alas/Sources/Right/RightPaneState.swift AlasTests/RightPaneGGStackTests.swift
+git commit -m "fix(gg): resolve cancelled stack refreshes"
+```

--- a/docs/superpowers/specs/2026-08-06-gg-stack-refresh-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-06-gg-stack-refresh-cancellation-design.md
@@ -1,0 +1,44 @@
+# GG Stack Refresh Cancellation Design
+
+## Problem
+
+The stacked-diffs drawer can remain on its `Loading` placeholder indefinitely after a sync or another refresh trigger. `RightPaneState.refreshGGStack` clears the cached stack and sets `ggStackLoadState` to `.loading` before awaiting `gg ls --json`. When that task is cancelled, both its success and error paths return without publishing another load state. If no newer refresh completes, the drawer has no transition out of `.loading`.
+
+## Design
+
+Treat cancellation as a terminal result only when the cancelled refresh still owns the current GG refresh generation and the surrounding right-pane snapshot has not been invalidated.
+
+Before starting the load, retain the previous stack, cache key, load state, and published summary. If the load is cancelled while it is still current:
+
+- Restore the previous snapshot when it was successfully loaded for the same branch/context/commit key.
+- Otherwise publish `.failed` with a concise interruption message, keep the cache key unset, clear stack-derived summary state, and preserve the existing Retry path.
+
+A refresh superseded by a newer GG refresh must not publish cancellation recovery. The existing refresh-generation guard remains authoritative. A refresh superseded by `markSnapshotUnknown()` must also remain silent because that invalidation owns the replacement state.
+
+This design does not change successful loads, command failures, inactive contexts, or the policy that prevents a stack loaded for one key from being shown under another key.
+
+## Data Flow
+
+1. Capture the last stable GG stack snapshot.
+2. Mark the current snapshot as loading and invoke `gg ls --json`.
+3. On success, publish the new stack as today.
+4. On a non-cancellation failure, publish the existing `.failed` state as today.
+5. On cancellation, first verify refresh and snapshot ownership, then restore a matching stable snapshot or publish an interruptible failure with Retry.
+
+## Testing
+
+Add a Swift Testing regression test using the controlled GG runner:
+
+1. Load a stable stack successfully.
+2. Start and suspend a forced reload for the same key.
+3. Verify the drawer state becomes `.loading`.
+4. Cancel and complete the suspended reload without starting a successor.
+5. Verify the prior loaded stack, cache key, load state, and summary are restored.
+
+Add a second assertion path for a cancelled first load or changed-key load, verifying it becomes `.failed` rather than remaining `.loading`. Existing stale-refresh tests continue to prove that an older cancellation cannot overwrite a newer successful refresh.
+
+## Out of Scope
+
+- Changing the ten-minute timeout used by mutating GG commands.
+- Altering `gg sync` streaming or progress presentation.
+- Retrying cancelled refreshes automatically while a pane is inactive.


### PR DESCRIPTION
## Summary

- Prevents the GG stack drawer from remaining in `Loading` when an in-flight stack refresh is cancelled.
- Restores the prior stable stack only when its key still matches the live branch and commit identity.
- Shows a retryable failure instead of stale stack data for first-load or changed-key cancellations.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination "platform=macOS" -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination "platform=macOS" -quiet test` (7,664 passed, 12 skipped)
- Codex review: thumbs up