### PR TITLE
feat(review): migrate diff panes to AppKit scroller

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -560,6 +560,7 @@
 		5A0AE37CBA893BD09558C27E /* CIStatusStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FAF07CCA81D986D1C30D05 /* CIStatusStrip.swift */; };
 		5ABD7DF29A68C38C8AA9EF37 /* MermaidRenderServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A107DA120039DD59C4F5CDD7 /* MermaidRenderServiceTests.swift */; };
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
+		5B2E19E0AE25DC4FA27332A3 /* AppKitDiffReviewRowPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF2F144BCF7B1A9460131EC /* AppKitDiffReviewRowPlan.swift */; };
 		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
 		5BB2FF7F9DFFFEF75CA508A2 /* RemoteLSPLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89D9FFAC80BDE46A651A0F /* RemoteLSPLauncherTests.swift */; };
 		5C15CCD6E7D896DEFA533C82 /* BuiltInAlasMCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7BEEA16E15CB254BD84F5F /* BuiltInAlasMCP.swift */; };
@@ -1127,6 +1128,7 @@
 		BB7A00188B3BD4C729E0D8E6 /* RemoteTranscriptSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */; };
 		BB924C35D21B87B46A47C5FA /* ACPAdapterTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818B29F6B58D4FFC80603AAD /* ACPAdapterTarget.swift */; };
 		BBACA7DCC1EFA6D55AEB38CE /* ACPMCPStatusControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1936C815E64C7DB204340469 /* ACPMCPStatusControl.swift */; };
+		BBCC834135D0915CAEED5A4C /* AppKitDiffReviewRowPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11202D7ACC80F782AE48CD81 /* AppKitDiffReviewRowPlanTests.swift */; };
 		BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */; };
@@ -1649,6 +1651,7 @@
 		10B3615A1591964AB1C9E524 /* RemoteHostCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostCapabilities.swift; sourceTree = "<group>"; };
 		10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalMessages.swift; sourceTree = "<group>"; };
 		111B9EB86E55850C982CEEFA /* GGReorderSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGReorderSheet.swift; sourceTree = "<group>"; };
+		11202D7ACC80F782AE48CD81 /* AppKitDiffReviewRowPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewRowPlanTests.swift; sourceTree = "<group>"; };
 		11281859D3CDA9DB8AF34D33 /* StashChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashChangesSheet.swift; sourceTree = "<group>"; };
 		11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClientTests.swift; sourceTree = "<group>"; };
 		11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTerminalLaunchTests.swift; sourceTree = "<group>"; };
@@ -2103,6 +2106,7 @@
 		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
 		5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayPreferences.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
+		5CF2F144BCF7B1A9460131EC /* AppKitDiffReviewRowPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewRowPlan.swift; sourceTree = "<group>"; };
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5D60B1F5C752C6936F36CB04 /* AddMissionLegDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionLegDialog.swift; sourceTree = "<group>"; };
 		5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchBackend.swift; sourceTree = "<group>"; };
@@ -5180,6 +5184,7 @@
 			isa = PBXGroup;
 			children = (
 				5E4EE1C8C8564C2920CC8DAF /* AppKitDiffReviewPresentationState.swift */,
+				5CF2F144BCF7B1A9460131EC /* AppKitDiffReviewRowPlan.swift */,
 				CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */,
 				65B5815D9BE36D3F835B5456 /* DiffReviewFileSection.swift */,
 				980DF534CC718ACEB60FCB6F /* DiffReviewImageProvider.swift */,
@@ -5379,6 +5384,7 @@
 			children = (
 				A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */,
 				1686C9F25D69FDDC4A4A21FF /* Diff */,
+				F49FC1F7280807BA9B8075E0 /* DiffReview */,
 				A43DE0BBE093A618267071AD /* Review */,
 			);
 			path = Center;
@@ -5471,6 +5477,14 @@
 				FEC68B05B719B9235865027F /* ThreePaneSizing.swift */,
 			);
 			path = Layout;
+			sourceTree = "<group>";
+		};
+		F49FC1F7280807BA9B8075E0 /* DiffReview */ = {
+			isa = PBXGroup;
+			children = (
+				11202D7ACC80F782AE48CD81 /* AppKitDiffReviewRowPlanTests.swift */,
+			);
+			path = DiffReview;
 			sourceTree = "<group>";
 		};
 		F4E7F552A9A004DB7193809A /* SQLiteKit */ = {
@@ -6117,6 +6131,7 @@
 				F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */,
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
 				534E1DFA40F7F467F82D900E /* AppKitDiffReviewPresentationState.swift in Sources */,
+				5B2E19E0AE25DC4FA27332A3 /* AppKitDiffReviewRowPlan.swift in Sources */,
 				1E830E480ED505750BFC8881 /* AppKitDiffRowHostingPool.swift in Sources */,
 				AE21069C36D87EB089423687 /* AppKitDiffRowHostingView.swift in Sources */,
 				B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */,
@@ -6923,6 +6938,7 @@
 				FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				3B925198F948BE8054662C43 /* AppKitDiffReviewPresentationStateTests.swift in Sources */,
+				BBCC834135D0915CAEED5A4C /* AppKitDiffReviewRowPlanTests.swift in Sources */,
 				3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */,
 				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
 				92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1031,6 +1031,7 @@
 		AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */; };
 		AE21069C36D87EB089423687 /* AppKitDiffRowHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741EFB94AD886324DBC73C72 /* AppKitDiffRowHostingView.swift */; };
 		AE5BC95F30EE46ED0DE74F23 /* WorkingTreeChangeGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */; };
+		AE780E8AB5BDB8E7D5BD5146 /* AppKitDiffScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CEF76FBF31C0DA4B19B692 /* AppKitDiffScroller.swift */; };
 		AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */; };
 		AF071864CA8C882F74753E39 /* ACPToolCallPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710BC995453481F445E2ECF /* ACPToolCallPresentation.swift */; };
 		AF2263B61D95A8BFF0972E93 /* AgentHookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */; };
@@ -1342,6 +1343,7 @@
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		DF93C8550C7A78C2A03CF56A /* ReviewEvidenceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF257B37B6E9EA4D97C67D4 /* ReviewEvidenceModel.swift */; };
 		DFA62A97A39B75AD9C7D4DC3 /* DragOutActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FE8C7594DE6CD4038A2113 /* DragOutActivationTests.swift */; };
+		DFCDEE99657971BB74AD9A06 /* AppKitDiffScrollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7624AEF61C42B615FBC76B71 /* AppKitDiffScrollerTests.swift */; };
 		DFD997286ABB95FBEA6A3AF2 /* ACPWorktreeSessionBootstrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B9DC1F684C319AFDB497B6 /* ACPWorktreeSessionBootstrapper.swift */; };
 		E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C511B229168DDEA87173A41 /* GGInboxStore.swift */; };
 		E099FB5101ED328389233B35 /* MermaidDiagramLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */; };
@@ -2240,6 +2242,7 @@
 		75D19208F2DE728FB5D6F8FF /* ClosedTabHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabHistoryTests.swift; sourceTree = "<group>"; };
 		75DFDC1BD30B1D1CC469D54C /* ZmxEnvTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxEnvTests.swift; sourceTree = "<group>"; };
 		7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManager.swift; sourceTree = "<group>"; };
+		7624AEF61C42B615FBC76B71 /* AppKitDiffScrollerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerTests.swift; sourceTree = "<group>"; };
 		764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ReviewLoop.swift"; sourceTree = "<group>"; };
 		768D12909DD5233659AC4E03 /* RepoGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupView.swift; sourceTree = "<group>"; };
 		76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolverTests.swift; sourceTree = "<group>"; };
@@ -2814,6 +2817,7 @@
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatus.swift; sourceTree = "<group>"; };
 		D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerEditorPolicy.swift; sourceTree = "<group>"; };
+		D9CEF76FBF31C0DA4B19B692 /* AppKitDiffScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScroller.swift; sourceTree = "<group>"; };
 		D9E6D61B213F3378243B4A26 /* AlasField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasField.swift; sourceTree = "<group>"; };
 		DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabViewTests.swift; sourceTree = "<group>"; };
 		DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRow.swift; sourceTree = "<group>"; };
@@ -4050,6 +4054,7 @@
 				02207D1F1F421F2E19CD90D0 /* AppKitDiffRowHostingPool.swift */,
 				741EFB94AD886324DBC73C72 /* AppKitDiffRowHostingView.swift */,
 				A4E9E696C1C8F5817524752F /* AppKitDiffRowSpec.swift */,
+				D9CEF76FBF31C0DA4B19B692 /* AppKitDiffScroller.swift */,
 				62376559E51E6DAE99840D03 /* AppKitDiffScrollerFlag.swift */,
 				BC2967A37F842D09F43063F3 /* AppKitDiffScrollerReconciler.swift */,
 				C0CD19EC130ED5EFACD84176 /* AppKitDiffScrollView.swift */,
@@ -5471,6 +5476,7 @@
 				CB13AAAE5C140D3A47CEC44F /* AppKitDiffRowHostingPoolTests.swift */,
 				D97D9F58350601898307089A /* AppKitDiffScrollerFlagTests.swift */,
 				3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */,
+				7624AEF61C42B615FBC76B71 /* AppKitDiffScrollerTests.swift */,
 				4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */,
 			);
 			path = Scroller;
@@ -6099,6 +6105,7 @@
 				AE21069C36D87EB089423687 /* AppKitDiffRowHostingView.swift in Sources */,
 				B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */,
 				DACFC0DB20E71EB91E74F19D /* AppKitDiffScrollView.swift in Sources */,
+				AE780E8AB5BDB8E7D5BD5146 /* AppKitDiffScroller.swift in Sources */,
 				0808A4FCD6525B4C2BBAF0B5 /* AppKitDiffScrollerFlag.swift in Sources */,
 				A3655FEDF6C5E3C128401DA7 /* AppKitDiffScrollerReconciler.swift in Sources */,
 				A0012CF058E580908B5348BC /* AppKitDiffTilingController.swift in Sources */,
@@ -6901,6 +6908,7 @@
 				3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */,
 				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
 				92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */,
+				DFCDEE99657971BB74AD9A06 /* AppKitDiffScrollerTests.swift in Sources */,
 				7AD9F8BC899393522EF92C48 /* AppKitDiffTilingControllerTests.swift in Sources */,
 				A2340CCA2AA5C39B27545EA6 /* AppQuitActionTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */; };
 		1E5EA96E9798649521CE1427 /* ACPAdapterInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */; };
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
+		1E830E480ED505750BFC8881 /* AppKitDiffRowHostingPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02207D1F1F421F2E19CD90D0 /* AppKitDiffRowHostingPool.swift */; };
 		1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */; };
 		1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */; };
 		1ED78A36E993D85D0DD1E3CC /* ACPSessionUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */; };
@@ -352,6 +353,7 @@
 		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
 		3BB7766DF1D9BF15098432F5 /* CommitDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF335AB8B3061C889A348B3 /* CommitDetails.swift */; };
 		3C30C1EAE4786BB1BE42F994 /* ACPToolCallCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */; };
+		3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB13AAAE5C140D3A47CEC44F /* AppKitDiffRowHostingPoolTests.swift */; };
 		3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C1705E68E97111E85D83F3 /* RightPaneState.swift */; };
 		3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */; };
 		3C8FAA4464E4D928F1DC6C91 /* session-new-response-with-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */; };
@@ -1025,6 +1027,7 @@
 		ADF6D3B634D9CCA17D7884EC /* PiACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */; };
 		AE0939D43A4ED88536500D9E /* AgentPathResolveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D904085EDE14D7C09A6BC9A /* AgentPathResolveTests.swift */; };
 		AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */; };
+		AE21069C36D87EB089423687 /* AppKitDiffRowHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741EFB94AD886324DBC73C72 /* AppKitDiffRowHostingView.swift */; };
 		AE5BC95F30EE46ED0DE74F23 /* WorkingTreeChangeGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D32294F9B916DFAFF5E9A6F /* WorkingTreeChangeGroup.swift */; };
 		AEB565CDE2F5AEAE088A1A79 /* ACPChatLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */; };
 		AF071864CA8C882F74753E39 /* ACPToolCallPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710BC995453481F445E2ECF /* ACPToolCallPresentation.swift */; };
@@ -1555,6 +1558,7 @@
 		01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioTerminalDispatchTests.swift; sourceTree = "<group>"; };
 		01F0314E357190EF2A1F861B /* CodexInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstaller.swift; sourceTree = "<group>"; };
 		02161104BA524379A359CB2D /* SidebarChromeTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarChromeTheme.swift; sourceTree = "<group>"; };
+		02207D1F1F421F2E19CD90D0 /* AppKitDiffRowHostingPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffRowHostingPool.swift; sourceTree = "<group>"; };
 		02347E4D2EA79A5CB8DF82DC /* session-update-current-model.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-current-model.json"; sourceTree = "<group>"; };
 		023D0843198D3386919147FF /* SQLiteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteError.swift; sourceTree = "<group>"; };
 		0240C5961343C3042D865570 /* GeneralPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPane.swift; sourceTree = "<group>"; };
@@ -2222,6 +2226,7 @@
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
 		73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusOverridePicker.swift; sourceTree = "<group>"; };
 		73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapper.swift; sourceTree = "<group>"; };
+		741EFB94AD886324DBC73C72 /* AppKitDiffRowHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffRowHostingView.swift; sourceTree = "<group>"; };
 		743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolver.swift; sourceTree = "<group>"; };
 		749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSingleResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		74D394D40BC9060833DD640A /* LSPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstaller.swift; sourceTree = "<group>"; };
@@ -2710,6 +2715,7 @@
 		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
 		CB020862232495EC1C5ECBEA /* WindowAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearance.swift; sourceTree = "<group>"; };
 		CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerProjectOrderingTests.swift; sourceTree = "<group>"; };
+		CB13AAAE5C140D3A47CEC44F /* AppKitDiffRowHostingPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffRowHostingPoolTests.swift; sourceTree = "<group>"; };
 		CB2EB554CB6AF797545DB95D /* HeadReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReader.swift; sourceTree = "<group>"; };
 		CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPaneTests.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -4035,6 +4041,8 @@
 		448F7BA39D19D1EE3458017B /* Scroller */ = {
 			isa = PBXGroup;
 			children = (
+				02207D1F1F421F2E19CD90D0 /* AppKitDiffRowHostingPool.swift */,
+				741EFB94AD886324DBC73C72 /* AppKitDiffRowHostingView.swift */,
 				A4E9E696C1C8F5817524752F /* AppKitDiffRowSpec.swift */,
 				62376559E51E6DAE99840D03 /* AppKitDiffScrollerFlag.swift */,
 				89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */,
@@ -5452,6 +5460,7 @@
 		F4EACD28D4B915771D0F40DE /* Scroller */ = {
 			isa = PBXGroup;
 			children = (
+				CB13AAAE5C140D3A47CEC44F /* AppKitDiffRowHostingPoolTests.swift */,
 				D97D9F58350601898307089A /* AppKitDiffScrollerFlagTests.swift */,
 				4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */,
 			);
@@ -6077,6 +6086,8 @@
 				214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */,
 				F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */,
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
+				1E830E480ED505750BFC8881 /* AppKitDiffRowHostingPool.swift in Sources */,
+				AE21069C36D87EB089423687 /* AppKitDiffRowHostingView.swift in Sources */,
 				B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */,
 				0808A4FCD6525B4C2BBAF0B5 /* AppKitDiffScrollerFlag.swift in Sources */,
 				A0012CF058E580908B5348BC /* AppKitDiffTilingController.swift in Sources */,
@@ -6876,6 +6887,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
+				3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */,
 				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
 				7AD9F8BC899393522EF92C48 /* AppKitDiffTilingControllerTests.swift in Sources */,
 				A2340CCA2AA5C39B27545EA6 /* AppQuitActionTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */; };
 		30604716147E0B9C558244F3 /* ACPSessionOrchestrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD63F297F7735AD9E1841ACF /* ACPSessionOrchestrationPolicy.swift */; };
 		3068E2E9A175FD2430C684D1 /* DiffPaneAppKitScrollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AB88006D9C1857616D5035 /* DiffPaneAppKitScrollerTests.swift */; };
+		308CDBB267D8A16BF7AA8008 /* AppKitDiffReviewScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7861A044BEFFC09DBF61E06B /* AppKitDiffReviewScroller.swift */; };
 		30A03E2F26084723538C97BB /* SSHConfigParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2641F3E2016CE8C83E75BA5D /* SSHConfigParser.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
@@ -459,6 +460,7 @@
 		48EFAD2DE1F112D72B5F9FAC /* AgentPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37987D5884297401F95478D3 /* AgentPathTests.swift */; };
 		490CB816CBED69EC7C886497 /* GGInboxModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */; };
 		4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F1C71C2574B1077964E5E1 /* ACPPermissionDecisionLogTests.swift */; };
+		4977422707F8C79E2BD5E337 /* AppKitDiffReviewScrollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6C1F946AC7EC621C5A8A59 /* AppKitDiffReviewScrollerTests.swift */; };
 		497D21A67A062CE6282008CD /* PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295319DB8544C170DDD6328D /* PathsTests.swift */; };
 		49A112CA4183D8FAEA84294A /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 0714DCAA9EC181C239773440 /* TreeSitterBash */; };
 		49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */; };
@@ -2096,6 +2098,7 @@
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteZmxInstaller.swift; sourceTree = "<group>"; };
 		5B5EA9E4B728B9C4FDA2E104 /* MCPRegistrationRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPRegistrationRegistry.swift; sourceTree = "<group>"; };
+		5B6C1F946AC7EC621C5A8A59 /* AppKitDiffReviewScrollerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewScrollerTests.swift; sourceTree = "<group>"; };
 		5B72D621D704CB5B2CCA82C6 /* RemoteAppStateAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAppStateAccessTests.swift; sourceTree = "<group>"; };
 		5B7B8B82A8D4F5B1F1DF1731 /* DiffReviewRenderContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderContext.swift; sourceTree = "<group>"; };
 		5B9261D66BAD364C3EEAB4DA /* AppConfigHarnessMCPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigHarnessMCPTests.swift; sourceTree = "<group>"; };
@@ -2264,6 +2267,7 @@
 		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
 		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = .build/ghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
 		784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecentsTests.swift; sourceTree = "<group>"; };
+		7861A044BEFFC09DBF61E06B /* AppKitDiffReviewScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewScroller.swift; sourceTree = "<group>"; };
 		78B20E30E45C7EBE078A54F9 /* MissionPromptBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionPromptBuilderTests.swift; sourceTree = "<group>"; };
 		78FFB4147D92264DEEB09DB7 /* MissionTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionTabTests.swift; sourceTree = "<group>"; };
 		792BD8DAE4AAED201252C9E2 /* ProjectMCPServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerTests.swift; sourceTree = "<group>"; };
@@ -5185,6 +5189,7 @@
 			children = (
 				5E4EE1C8C8564C2920CC8DAF /* AppKitDiffReviewPresentationState.swift */,
 				5CF2F144BCF7B1A9460131EC /* AppKitDiffReviewRowPlan.swift */,
+				7861A044BEFFC09DBF61E06B /* AppKitDiffReviewScroller.swift */,
 				CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */,
 				65B5815D9BE36D3F835B5456 /* DiffReviewFileSection.swift */,
 				980DF534CC718ACEB60FCB6F /* DiffReviewImageProvider.swift */,
@@ -5483,6 +5488,7 @@
 			isa = PBXGroup;
 			children = (
 				11202D7ACC80F782AE48CD81 /* AppKitDiffReviewRowPlanTests.swift */,
+				5B6C1F946AC7EC621C5A8A59 /* AppKitDiffReviewScrollerTests.swift */,
 			);
 			path = DiffReview;
 			sourceTree = "<group>";
@@ -6132,6 +6138,7 @@
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
 				534E1DFA40F7F467F82D900E /* AppKitDiffReviewPresentationState.swift in Sources */,
 				5B2E19E0AE25DC4FA27332A3 /* AppKitDiffReviewRowPlan.swift in Sources */,
+				308CDBB267D8A16BF7AA8008 /* AppKitDiffReviewScroller.swift in Sources */,
 				1E830E480ED505750BFC8881 /* AppKitDiffRowHostingPool.swift in Sources */,
 				AE21069C36D87EB089423687 /* AppKitDiffRowHostingView.swift in Sources */,
 				B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */,
@@ -6939,6 +6946,7 @@
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				3B925198F948BE8054662C43 /* AppKitDiffReviewPresentationStateTests.swift in Sources */,
 				BBCC834135D0915CAEED5A4C /* AppKitDiffReviewRowPlanTests.swift in Sources */,
+				4977422707F8C79E2BD5E337 /* AppKitDiffReviewScrollerTests.swift in Sources */,
 				3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */,
 				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
 				92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */; };
 		3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */; };
 		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
+		3B925198F948BE8054662C43 /* AppKitDiffReviewPresentationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBEC713703928ABF1942645D /* AppKitDiffReviewPresentationStateTests.swift */; };
 		3BB7766DF1D9BF15098432F5 /* CommitDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF335AB8B3061C889A348B3 /* CommitDetails.swift */; };
 		3C30C1EAE4786BB1BE42F994 /* ACPToolCallCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */; };
 		3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB13AAAE5C140D3A47CEC44F /* AppKitDiffRowHostingPoolTests.swift */; };
@@ -512,6 +513,7 @@
 		52AB869F9071103FD1649552 /* RemoteHostStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */; };
 		52D1F226CE8DB1967977D3F3 /* ACPQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */; };
 		52E3CDEB14242DB611348EEA /* WorktreeSortMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DEBCFA106423E38276E9C2 /* WorktreeSortMenu.swift */; };
+		534E1DFA40F7F467F82D900E /* AppKitDiffReviewPresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4EE1C8C8564C2920CC8DAF /* AppKitDiffReviewPresentationState.swift */; };
 		5426DC977050AACBCBDA37E9 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */; };
 		542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */; };
 		551C15188490062DFC77A479 /* MemorySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */; };
@@ -2112,6 +2114,7 @@
 		5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolver.swift; sourceTree = "<group>"; };
 		5DEE18D06DCB7DE3C8C8D91A /* EditorBufferExternalEditableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferExternalEditableTests.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
+		5E4EE1C8C8564C2920CC8DAF /* AppKitDiffReviewPresentationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewPresentationState.swift; sourceTree = "<group>"; };
 		5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionCheckerTests.swift; sourceTree = "<group>"; };
 		5F128D8543DA5FC5C39C22E9 /* ACPPermissionDecisionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionDecisionLog.swift; sourceTree = "<group>"; };
 		5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentity.swift; sourceTree = "<group>"; };
@@ -2938,6 +2941,7 @@
 		EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigFilesTests.swift; sourceTree = "<group>"; };
 		EBD68C6A69930BE0F9437AAE /* RemoteMessageWireJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessageWireJSON.swift; sourceTree = "<group>"; };
 		EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfUpdaterTests.swift; sourceTree = "<group>"; };
+		EBEC713703928ABF1942645D /* AppKitDiffReviewPresentationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewPresentationStateTests.swift; sourceTree = "<group>"; };
 		EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionByteAccounting.swift; sourceTree = "<group>"; };
 		EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkPersistenceTests.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
@@ -3318,6 +3322,7 @@
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
+				EBEC713703928ABF1942645D /* AppKitDiffReviewPresentationStateTests.swift */,
 				FD2672B5B84D96BDDE9D80A0 /* AppQuitActionTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
 				08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */,
@@ -5174,6 +5179,7 @@
 		C96401D17E1C5E3A5F55212E /* DiffReview */ = {
 			isa = PBXGroup;
 			children = (
+				5E4EE1C8C8564C2920CC8DAF /* AppKitDiffReviewPresentationState.swift */,
 				CD6385E6DE02E97B0041616F /* DiffReviewContextProvider.swift */,
 				65B5815D9BE36D3F835B5456 /* DiffReviewFileSection.swift */,
 				980DF534CC718ACEB60FCB6F /* DiffReviewImageProvider.swift */,
@@ -6110,6 +6116,7 @@
 				214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */,
 				F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */,
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
+				534E1DFA40F7F467F82D900E /* AppKitDiffReviewPresentationState.swift in Sources */,
 				1E830E480ED505750BFC8881 /* AppKitDiffRowHostingPool.swift in Sources */,
 				AE21069C36D87EB089423687 /* AppKitDiffRowHostingView.swift in Sources */,
 				B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */,
@@ -6915,6 +6922,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
+				3B925198F948BE8054662C43 /* AppKitDiffReviewPresentationStateTests.swift in Sources */,
 				3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */,
 				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
 				92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		44F6A0601A9F27FC09DB8387 /* BeautifulMermaid in Frameworks */ = {isa = PBXBuildFile; productRef = F1692E6406C1269703621C3B /* BeautifulMermaid */; };
 		45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC15742E7423AE2F3A203A /* ACPSessionInfoUpdateDecodeTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
+		45662ECAA60BB27895E0B0EB /* DiffPaneRowPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831DF53F0548536E919CA30 /* DiffPaneRowPlanTests.swift */; };
 		45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC68B05B719B9235865027F /* ThreePaneSizing.swift */; };
 		45B3616A459480A78A5004E8 /* ImageDiffPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */; };
 		45EEE2F32712FDEE392A9707 /* ZmxEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E0BB32D1A3B26473464A0F /* ZmxEnv.swift */; };
@@ -475,6 +476,7 @@
 		4DC40ADBDD5F113412B2087E /* ForkSourceBrokerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730AFD7C822A7A17A5F2637 /* ForkSourceBrokerService.swift */; };
 		4DEFF78597731750310ABE00 /* RemoteHelperWatchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F17DE68E81565014FC9454 /* RemoteHelperWatchSession.swift */; };
 		4DF50D8995FBF711085A40AF /* ReviewThreadMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CEB6C5C076B4147D587909 /* ReviewThreadMutations.swift */; };
+		4E06212EA28C05F474BB4A8D /* DiffPaneRowPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E0512A6C9A3BE43C8B796F /* DiffPaneRowPlan.swift */; };
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
 		4E352BDC87A204DE2912F54F /* ACPHarnessBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */; };
 		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
@@ -1742,6 +1744,7 @@
 		2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageWireTests.swift; sourceTree = "<group>"; };
 		246A2AF26902AB36730A4F44 /* GGUndoMarkerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGUndoMarkerStoreTests.swift; sourceTree = "<group>"; };
 		246D436645310B14BB2874A5 /* NewMissionDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMissionDialog.swift; sourceTree = "<group>"; };
+		24E0512A6C9A3BE43C8B796F /* DiffPaneRowPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneRowPlan.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
 		256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayoutTests.swift; sourceTree = "<group>"; };
 		25B1ED890A8A45244572D8A3 /* RightPaneStatePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStatePullTests.swift; sourceTree = "<group>"; };
@@ -2807,6 +2810,7 @@
 		D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewScrollSpy.swift; sourceTree = "<group>"; };
 		D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailability.swift; sourceTree = "<group>"; };
 		D7860DF249939BC7FC1EBD76 /* GGStackDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackDrawer.swift; sourceTree = "<group>"; };
+		D831DF53F0548536E919CA30 /* DiffPaneRowPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneRowPlanTests.swift; sourceTree = "<group>"; };
 		D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreePoll.swift; sourceTree = "<group>"; };
 		D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigCodeInstallTests.swift; sourceTree = "<group>"; };
 		D8D583586BC5171D2FE91F6C /* ReviewScopeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelection.swift; sourceTree = "<group>"; };
@@ -4059,6 +4063,7 @@
 				BC2967A37F842D09F43063F3 /* AppKitDiffScrollerReconciler.swift */,
 				C0CD19EC130ED5EFACD84176 /* AppKitDiffScrollView.swift */,
 				89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */,
+				24E0512A6C9A3BE43C8B796F /* DiffPaneRowPlan.swift */,
 			);
 			path = Scroller;
 			sourceTree = "<group>";
@@ -5478,6 +5483,7 @@
 				3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */,
 				7624AEF61C42B615FBC76B71 /* AppKitDiffScrollerTests.swift */,
 				4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */,
+				D831DF53F0548536E919CA30 /* DiffPaneRowPlanTests.swift */,
 			);
 			path = Scroller;
 			sourceTree = "<group>";
@@ -6210,6 +6216,7 @@
 				6FDE6E6F5087E811451A6AD8 /* DiffInlineHighlighter.swift in Sources */,
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
 				B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */,
+				4E06212EA28C05F474BB4A8D /* DiffPaneRowPlan.swift in Sources */,
 				5C6F0DC6F76FC0B55F2F4051 /* DiffPaneTextDocumentBuilder.swift in Sources */,
 				DB40AA7EB6A31B5F232EDCA3 /* DiffPaneTextDocumentView.swift in Sources */,
 				A971C64CC3136E00C5FC158C /* DiffPaneView.swift in Sources */,
@@ -6992,6 +6999,7 @@
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,
 				F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */,
+				45662ECAA60BB27895E0B0EB /* DiffPaneRowPlanTests.swift in Sources */,
 				FF77548C74703C8DDC9B480B /* DiffPaneTextDocumentBuilderTests.swift in Sources */,
 				F4FF07CA337DB0D0035C3C10 /* DiffPaneViewTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -856,6 +856,7 @@
 		9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */; };
 		9169618F36666AED9DA0B10D /* MissionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E740A01C784A24F01F79BC3 /* MissionPresentationTests.swift */; };
 		91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C69060B922A729DD807920 /* LSPURI.swift */; };
+		92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */; };
 		929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */; };
 		92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */; };
 		92EEAFAEFB3E637FB72174A8 /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 2B4C3DD473FF121828FD3CA5 /* TreeSitterYAML */; };
@@ -966,6 +967,7 @@
 		A2B0E4C1D80EB12F7BECE7FC /* RepoSelectorDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */; };
 		A2BB622FA93936FAE9A3719A /* ClosedTabHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CE3FADE2353C1214143336 /* ClosedTabHistory.swift */; };
 		A2E0A755C2854FE489530FE3 /* ImageDiffDifferenceComputer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */; };
+		A3655FEDF6C5E3C128401DA7 /* AppKitDiffScrollerReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2967A37F842D09F43063F3 /* AppKitDiffScrollerReconciler.swift */; };
 		A383F1C9B0B00B2805576209 /* ACPScrollDirectionClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0190EE078ADB537982F7DC /* ACPScrollDirectionClassifierTests.swift */; };
 		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
 		A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */; };
@@ -1308,6 +1310,7 @@
 		DAA0AFA398C02EC663708825 /* ViewDragOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC461E04DD9DDF78F8825942 /* ViewDragOut.swift */; };
 		DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9E527A76820947F426A8 /* ACPFilesystem.swift */; };
 		DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */; };
+		DACFC0DB20E71EB91E74F19D /* AppKitDiffScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CD19EC130ED5EFACD84176 /* AppKitDiffScrollView.swift */; };
 		DADDDA3FA289B52415EF4379 /* ACPDelayedHoverVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */; };
 		DB1877ECE26010476924369F /* GGStackSummaryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67F46F592EB999B0FEBFCDB /* GGStackSummaryStore.swift */; };
 		DB199FBEEABBC119FB26E32A /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
@@ -1839,6 +1842,7 @@
 		333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigChangesTests.swift; sourceTree = "<group>"; };
 		336ADD8484D99054ADDBA588 /* CursorModelVariantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariantsTests.swift; sourceTree = "<group>"; };
 		3375A79ACFD3567389DA855C /* FileResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileResultRow.swift; sourceTree = "<group>"; };
+		3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerReconcilerTests.swift; sourceTree = "<group>"; };
 		339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilder.swift; sourceTree = "<group>"; };
 		33EBE6A3E0CA30D8910E68F8 /* RemoteSessionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionsProvider.swift; sourceTree = "<group>"; };
 		3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindow.swift; sourceTree = "<group>"; };
@@ -2619,6 +2623,7 @@
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
 		BBBEFD27FD7013D458435779 /* ACPSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSession.swift; sourceTree = "<group>"; };
 		BC147F9FE645065318A7B175 /* ACPRemoteAdapterManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterManagement.swift; sourceTree = "<group>"; };
+		BC2967A37F842D09F43063F3 /* AppKitDiffScrollerReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerReconciler.swift; sourceTree = "<group>"; };
 		BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabView.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BCA9015C063CDD90D021D928 /* TreeSitterCSS */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterCSS; path = ThirdParty/TreeSitterCSS; sourceTree = SOURCE_ROOT; };
@@ -2650,6 +2655,7 @@
 		BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPrompt.swift; sourceTree = "<group>"; };
 		C02B44D8CC0AE48BFA9CD88E /* RemoteProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProtocolTests.swift; sourceTree = "<group>"; };
 		C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigWorktreeOrderingDecodeTests.swift; sourceTree = "<group>"; };
+		C0CD19EC130ED5EFACD84176 /* AppKitDiffScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollView.swift; sourceTree = "<group>"; };
 		C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgentTests.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C1B3691B62C7A082D676B13A /* MCPHelloEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPHelloEventTests.swift; sourceTree = "<group>"; };
@@ -4045,6 +4051,8 @@
 				741EFB94AD886324DBC73C72 /* AppKitDiffRowHostingView.swift */,
 				A4E9E696C1C8F5817524752F /* AppKitDiffRowSpec.swift */,
 				62376559E51E6DAE99840D03 /* AppKitDiffScrollerFlag.swift */,
+				BC2967A37F842D09F43063F3 /* AppKitDiffScrollerReconciler.swift */,
+				C0CD19EC130ED5EFACD84176 /* AppKitDiffScrollView.swift */,
 				89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */,
 			);
 			path = Scroller;
@@ -5462,6 +5470,7 @@
 			children = (
 				CB13AAAE5C140D3A47CEC44F /* AppKitDiffRowHostingPoolTests.swift */,
 				D97D9F58350601898307089A /* AppKitDiffScrollerFlagTests.swift */,
+				3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */,
 				4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */,
 			);
 			path = Scroller;
@@ -6089,7 +6098,9 @@
 				1E830E480ED505750BFC8881 /* AppKitDiffRowHostingPool.swift in Sources */,
 				AE21069C36D87EB089423687 /* AppKitDiffRowHostingView.swift in Sources */,
 				B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */,
+				DACFC0DB20E71EB91E74F19D /* AppKitDiffScrollView.swift in Sources */,
 				0808A4FCD6525B4C2BBAF0B5 /* AppKitDiffScrollerFlag.swift in Sources */,
+				A3655FEDF6C5E3C128401DA7 /* AppKitDiffScrollerReconciler.swift in Sources */,
 				A0012CF058E580908B5348BC /* AppKitDiffTilingController.swift in Sources */,
 				584066607B7E7E97A736213A /* AppQuitAction.swift in Sources */,
 				74175A7BB07F7588E7B691F2 /* AppState+ReviewPalette.swift in Sources */,
@@ -6889,6 +6900,7 @@
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */,
 				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
+				92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */,
 				7AD9F8BC899393522EF92C48 /* AppKitDiffTilingControllerTests.swift in Sources */,
 				A2340CCA2AA5C39B27545EA6 /* AppQuitActionTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		074B2BB17D428AE20AB482AA /* ACPThumbnailImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45952C734DFE7E7F02B047E7 /* ACPThumbnailImageCache.swift */; };
 		0789F98721389570E0C3F942 /* ACPTranscriptRowHostingPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DF2130E463B27C55A72437 /* ACPTranscriptRowHostingPoolTests.swift */; };
 		07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */; };
+		0808A4FCD6525B4C2BBAF0B5 /* AppKitDiffScrollerFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62376559E51E6DAE99840D03 /* AppKitDiffScrollerFlag.swift */; };
 		082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */; };
 		084E0061691FD9F495E8209B /* GGSplitCommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E189D66411992DFC659CBF /* GGSplitCommitTabView.swift */; };
 		08681BEDBD6D7232CC937704 /* HoverFeatureBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */; };
@@ -1047,6 +1048,7 @@
 		B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
 		B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */; };
+		B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97D9F58350601898307089A /* AppKitDiffScrollerFlagTests.swift */; };
 		B2C95C2D5AED25CF5F2BE73B /* MissionSidebarSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829A799BCFC9BB7F0A3A8B63 /* MissionSidebarSection.swift */; };
 		B3240B739972444A6CB14F7C /* BaseResolutionMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652C404D30685CB2FE79BD81 /* BaseResolutionMappingTests.swift */; };
 		B339F5B376407CFD88B0E7B8 /* ACPAttachmentMimeTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */; };
@@ -2110,6 +2112,7 @@
 		61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineHighlighterTests.swift; sourceTree = "<group>"; };
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
 		621C13FD3A997CCB29273993 /* RemoteHostStatusStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostStatusStoreTests.swift; sourceTree = "<group>"; };
+		62376559E51E6DAE99840D03 /* AppKitDiffScrollerFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerFlag.swift; sourceTree = "<group>"; };
 		626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionNameTests.swift; sourceTree = "<group>"; };
 		631A43599B405E7E263CE825 /* ACPSessionForkDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkDivider.swift; sourceTree = "<group>"; };
 		63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionDiscovery.swift; sourceTree = "<group>"; };
@@ -2789,6 +2792,7 @@
 		D906A11E19D165C7F5447E67 /* ACPElicitationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitationCoordinatorTests.swift; sourceTree = "<group>"; };
 		D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
 		D93ED8BA7A9EE46B37ED48EC /* RunScriptMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptMetadataTests.swift; sourceTree = "<group>"; };
+		D97D9F58350601898307089A /* AppKitDiffScrollerFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerFlagTests.swift; sourceTree = "<group>"; };
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatus.swift; sourceTree = "<group>"; };
 		D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerEditorPolicy.swift; sourceTree = "<group>"; };
@@ -3236,6 +3240,14 @@
 				47DEF5C084FA32A781ABDADD /* ReviewTargetPaletteModel.swift */,
 			);
 			path = ReviewTarget;
+			sourceTree = "<group>";
+		};
+		1686C9F25D69FDDC4A4A21FF /* Diff */ = {
+			isa = PBXGroup;
+			children = (
+				F4EACD28D4B915771D0F40DE /* Scroller */,
+			);
+			path = Diff;
 			sourceTree = "<group>";
 		};
 		1A6B0ED8FD355C82542D35C4 /* AlasTests */ = {
@@ -4014,6 +4026,14 @@
 			path = CodeHost;
 			sourceTree = "<group>";
 		};
+		448F7BA39D19D1EE3458017B /* Scroller */ = {
+			isa = PBXGroup;
+			children = (
+				62376559E51E6DAE99840D03 /* AppKitDiffScrollerFlag.swift */,
+			);
+			path = Scroller;
+			sourceTree = "<group>";
+		};
 		4518CA2539993A6F1D093E00 /* Agents */ = {
 			isa = PBXGroup;
 			children = (
@@ -4326,6 +4346,7 @@
 				DF32A1544E13321E9E223AFF /* DiffPaneView.swift */,
 				3F8435ABAF423A6F5BC28E4C /* DiffPreferenceBindings.swift */,
 				E2F14E32DEBE042825BCA44A /* DiffTabRenderContext.swift */,
+				448F7BA39D19D1EE3458017B /* Scroller */,
 			);
 			path = Diff;
 			sourceTree = "<group>";
@@ -5315,6 +5336,7 @@
 			isa = PBXGroup;
 			children = (
 				A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */,
+				1686C9F25D69FDDC4A4A21FF /* Diff */,
 				A43DE0BBE093A618267071AD /* Review */,
 			);
 			path = Center;
@@ -5417,6 +5439,14 @@
 				0A442AC7909A919582DF4372 /* SQLiteStatement.swift */,
 			);
 			path = SQLiteKit;
+			sourceTree = "<group>";
+		};
+		F4EACD28D4B915771D0F40DE /* Scroller */ = {
+			isa = PBXGroup;
+			children = (
+				D97D9F58350601898307089A /* AppKitDiffScrollerFlagTests.swift */,
+			);
+			path = Scroller;
 			sourceTree = "<group>";
 		};
 		F556D34B5B6FE20EA80F892A /* Terminal */ = {
@@ -6038,6 +6068,7 @@
 				214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */,
 				F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */,
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
+				0808A4FCD6525B4C2BBAF0B5 /* AppKitDiffScrollerFlag.swift in Sources */,
 				584066607B7E7E97A736213A /* AppQuitAction.swift in Sources */,
 				74175A7BB07F7588E7B691F2 /* AppState+ReviewPalette.swift in Sources */,
 				AFC4DE3093E404E4D338E6EF /* AppState+RunScripts.swift in Sources */,
@@ -6834,6 +6865,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
+				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
 				A2340CCA2AA5C39B27545EA6 /* AppQuitActionTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 		303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */; };
 		30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */; };
 		30604716147E0B9C558244F3 /* ACPSessionOrchestrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD63F297F7735AD9E1841ACF /* ACPSessionOrchestrationPolicy.swift */; };
+		3068E2E9A175FD2430C684D1 /* DiffPaneAppKitScrollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AB88006D9C1857616D5035 /* DiffPaneAppKitScrollerTests.swift */; };
 		30A03E2F26084723538C97BB /* SSHConfigParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2641F3E2016CE8C83E75BA5D /* SSHConfigParser.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
@@ -1777,6 +1778,7 @@
 		2942AD875C0E7AB71E8E3CAD /* VerdictSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerdictSheet.swift; sourceTree = "<group>"; };
 		295319DB8544C170DDD6328D /* PathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsTests.swift; sourceTree = "<group>"; };
 		2975A1465CA308E9766521F2 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		29AB88006D9C1857616D5035 /* DiffPaneAppKitScrollerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneAppKitScrollerTests.swift; sourceTree = "<group>"; };
 		29D7631D754795D16E946440 /* ACPFileEditCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileEditCard.swift; sourceTree = "<group>"; };
 		29FCCD153F9C2AF78A7B2E47 /* ACPMessageGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageGutter.swift; sourceTree = "<group>"; };
 		2A64277DCFB5D4A9C2691C50 /* EditMissionSourceDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMissionSourceDialogTests.swift; sourceTree = "<group>"; };
@@ -5483,6 +5485,7 @@
 				3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */,
 				7624AEF61C42B615FBC76B71 /* AppKitDiffScrollerTests.swift */,
 				4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */,
+				29AB88006D9C1857616D5035 /* DiffPaneAppKitScrollerTests.swift */,
 				D831DF53F0548536E919CA30 /* DiffPaneRowPlanTests.swift */,
 			);
 			path = Scroller;
@@ -6998,6 +7001,7 @@
 				FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */,
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,
+				3068E2E9A175FD2430C684D1 /* DiffPaneAppKitScrollerTests.swift in Sources */,
 				F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */,
 				45662ECAA60BB27895E0B0EB /* DiffPaneRowPlanTests.swift in Sources */,
 				FF77548C74703C8DDC9B480B /* DiffPaneTextDocumentBuilderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		111516874CEE27D789DF61E9 /* ReviewChangesFileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41995BCAEF1E2B356E499333 /* ReviewChangesFileSection.swift */; };
 		11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCEFADD952DB870B8BAB890 /* CommitRow.swift */; };
 		115C50272D2037FB24B8536F /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */; };
+		1160B4B61A592EF469A2708A /* GGSplitPreviewRowPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F205138E6ECCFA7DD392E3CE /* GGSplitPreviewRowPlanTests.swift */; };
 		11827C40372D7209868161C0 /* ACPTerminalHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3914A1820E1098DA558CD0 /* ACPTerminalHostTests.swift */; };
 		11B4AA1D032F054C666DD7F4 /* PendingDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */; };
 		11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */; };
@@ -711,6 +712,7 @@
 		78D49DF401553D2A9BCE1EE5 /* RemoteTerminalScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E14E781F0E1127387A06907 /* RemoteTerminalScriptTests.swift */; };
 		78D7FFD42803C098160BADC6 /* ProjectMCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E981C10B13C43CE65DA74D /* ProjectMCPServer.swift */; };
 		79212B50265AAC9A392957C9 /* GitLFSBlobResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F0CBE40E2CF0251ABE72AE /* GitLFSBlobResolver.swift */; };
+		792C4398DB584C1C56D8C23E /* GGSplitPreviewRowPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A811C3D697D29CF9267F2C5 /* GGSplitPreviewRowPlan.swift */; };
 		7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
 		79FC7259C8ABAF2A9D031E88 /* ACPWorktreeSessionBootstrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C66CE5C7DDA561C0970A50 /* ACPWorktreeSessionBootstrapperTests.swift */; };
@@ -762,6 +764,7 @@
 		814193F0CC55B784481AA40A /* InstallSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A27D815CB567E3FEF2D3E6B /* InstallSourceTests.swift */; };
 		8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */; };
 		8180F4CA434F434D7476F91C /* MissionTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5B49C51E7A8F1FB5226777 /* MissionTabView.swift */; };
+		81C345108B8EE5122667E5A0 /* AppKitDiffScrollerStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E410585102A601ACED1E8B5 /* AppKitDiffScrollerStressTests.swift */; };
 		81D04C212B3AAA34F55069C5 /* ACPRemoteAdapterManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC147F9FE645065318A7B175 /* ACPRemoteAdapterManagement.swift */; };
 		81F6E32B97FCE84E5F986A31 /* MCPRegistrationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EA9E4B728B9C4FDA2E104 /* MCPRegistrationRegistry.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
@@ -1721,6 +1724,7 @@
 		1D50D01BE1271F22DD2ED1A0 /* WebPageMetadataFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageMetadataFetcherTests.swift; sourceTree = "<group>"; };
 		1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrationStateTests.swift; sourceTree = "<group>"; };
 		1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatusTests.swift; sourceTree = "<group>"; };
+		1E410585102A601ACED1E8B5 /* AppKitDiffScrollerStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerStressTests.swift; sourceTree = "<group>"; };
 		1EC659A56A08A30F7784428D /* ACPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPClient.swift; sourceTree = "<group>"; };
 		1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDeciderTests.swift; sourceTree = "<group>"; };
 		1FC7D68CD8300C0F6766AED0 /* ProviderReviewOriginalPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewOriginalPathResolverTests.swift; sourceTree = "<group>"; };
@@ -2365,6 +2369,7 @@
 		89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffTilingController.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
 		89D180B7FCAA9DD1F7D7D2E4 /* AppState+RunScripts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+RunScripts.swift"; sourceTree = "<group>"; };
+		8A811C3D697D29CF9267F2C5 /* GGSplitPreviewRowPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitPreviewRowPlan.swift; sourceTree = "<group>"; };
 		8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextUsageButton.swift; sourceTree = "<group>"; };
 		8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPolicy.swift; sourceTree = "<group>"; };
 		8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCodableTests.swift; sourceTree = "<group>"; };
@@ -2989,6 +2994,7 @@
 		F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetectorTests.swift; sourceTree = "<group>"; };
 		F1BA8B1CD4334FF7F7082E9A /* ACPTranscriptScrollerLiveScrollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerLiveScrollTests.swift; sourceTree = "<group>"; };
 		F1F0EED235328724082B570B /* GGActionEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGActionEvents.swift; sourceTree = "<group>"; };
+		F205138E6ECCFA7DD392E3CE /* GGSplitPreviewRowPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitPreviewRowPlanTests.swift; sourceTree = "<group>"; };
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalog.swift; sourceTree = "<group>"; };
 		F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesScrollSpyTests.swift; sourceTree = "<group>"; };
@@ -5278,6 +5284,7 @@
 				3979B98C0A060BB118239A5E /* ReviewRequestContextBuilderTests.swift */,
 				BCAB297DB983CBDD70CDDB24 /* ReviewRequestDiffLoaderTests.swift */,
 				5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */,
+				D3B8FA1884D305E65EC95F64 /* GG */,
 			);
 			path = Integrations;
 			sourceTree = "<group>";
@@ -5302,6 +5309,14 @@
 				64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */,
 			);
 			path = ReviewWorkspace;
+			sourceTree = "<group>";
+		};
+		D3B8FA1884D305E65EC95F64 /* GG */ = {
+			isa = PBXGroup;
+			children = (
+				F205138E6ECCFA7DD392E3CE /* GGSplitPreviewRowPlanTests.swift */,
+			);
+			path = GG;
 			sourceTree = "<group>";
 		};
 		D693E9FFCCA3C968C18E4437 /* ThirdParty */ = {
@@ -5509,6 +5524,7 @@
 				CB13AAAE5C140D3A47CEC44F /* AppKitDiffRowHostingPoolTests.swift */,
 				D97D9F58350601898307089A /* AppKitDiffScrollerFlagTests.swift */,
 				3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */,
+				1E410585102A601ACED1E8B5 /* AppKitDiffScrollerStressTests.swift */,
 				7624AEF61C42B615FBC76B71 /* AppKitDiffScrollerTests.swift */,
 				4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */,
 				29AB88006D9C1857616D5035 /* DiffPaneAppKitScrollerTests.swift */,
@@ -5556,6 +5572,7 @@
 				9160AF4DDD35E2A02262D868 /* GGService.swift */,
 				B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */,
 				43E189D66411992DFC659CBF /* GGSplitCommitTabView.swift */,
+				8A811C3D697D29CF9267F2C5 /* GGSplitPreviewRowPlan.swift */,
 				2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */,
 				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
 				B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */,
@@ -6328,6 +6345,7 @@
 				3CF61CA14860FC9E9C3224DC /* GGService.swift in Sources */,
 				B7F9949C9F8915C07A80F7C4 /* GGSplitCommitModel.swift in Sources */,
 				084E0061691FD9F495E8209B /* GGSplitCommitTabView.swift in Sources */,
+				792C4398DB584C1C56D8C23E /* GGSplitPreviewRowPlan.swift in Sources */,
 				F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */,
 				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
 				E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */,
@@ -6950,6 +6968,7 @@
 				3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */,
 				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
 				92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */,
+				81C345108B8EE5122667E5A0 /* AppKitDiffScrollerStressTests.swift in Sources */,
 				DFCDEE99657971BB74AD9A06 /* AppKitDiffScrollerTests.swift in Sources */,
 				7AD9F8BC899393522EF92C48 /* AppKitDiffTilingControllerTests.swift in Sources */,
 				A2340CCA2AA5C39B27545EA6 /* AppQuitActionTests.swift in Sources */,
@@ -7103,6 +7122,7 @@
 				10D0D26BCE0EF4D8677CEA79 /* GGServiceInboxTests.swift in Sources */,
 				7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */,
 				46D0693DB76BC258780CE113 /* GGSplitCommitModelTests.swift in Sources */,
+				1160B4B61A592EF469A2708A /* GGSplitPreviewRowPlanTests.swift in Sources */,
 				7528D9FD7DCE1D6F7CF70C3F /* GGSplitTabsManagerTests.swift in Sources */,
 				EE4A552DB5EF6559CA1A5AE0 /* GGStackActionStateTests.swift in Sources */,
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -711,6 +711,7 @@
 		7A9F0DE5D1E5B5DFC9991474 /* GGServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */; };
 		7ABF2BE84D6677FE5BCC8ED1 /* ACPMarkdownInlineRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3814D8B30EBB9991F3388A /* ACPMarkdownInlineRenderer.swift */; };
 		7ACFA19EA43966431D906F55 /* TreeSitterPHP in Frameworks */ = {isa = PBXBuildFile; productRef = 78020033FC689A2BCDF51DED /* TreeSitterPHP */; };
+		7AD9F8BC899393522EF92C48 /* AppKitDiffTilingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */; };
 		7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CA79B71B4AA72697392702 /* NumstatParser.swift */; };
 		7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B5B544A3432F8D8105268 /* SearchModel.swift */; };
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
@@ -941,6 +942,7 @@
 		9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
 		9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */; };
+		A0012CF058E580908B5348BC /* AppKitDiffTilingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */; };
 		A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */; };
 		A01CDDEB7E0F6B2C1D3D0794 /* AddMissionLegDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C385F7CAAA65DB82ABC48F /* AddMissionLegDialogTests.swift */; };
 		A03338AC85E6EC8201D56F95 /* TreeSitterGo in Frameworks */ = {isa = PBXBuildFile; productRef = DB0D87DDDAD70492540E6906 /* TreeSitterGo */; };
@@ -1104,6 +1106,7 @@
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
 		B9D15679A5E813254E1DDCB6 /* ProviderReviewMutationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */; };
 		B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */; };
+		B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E9E696C1C8F5817524752F /* AppKitDiffRowSpec.swift */; };
 		BA43C3AE340673902EC7CDA9 /* MissionReadinessEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE562E9CFD25618944D2B8 /* MissionReadinessEvaluatorTests.swift */; };
 		BACDEEE3791E66405294B328 /* ACPFirstRunConnectingPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
@@ -1933,6 +1936,7 @@
 		4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionScope.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
 		447EEDD6DBF9822B25A56CD7 /* ACPTranscriptScrollerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerView.swift; sourceTree = "<group>"; };
+		4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffTilingControllerTests.swift; sourceTree = "<group>"; };
 		44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPromptTests.swift; sourceTree = "<group>"; };
 		44E26C51ACE48A35EB4CD463 /* ACPTranscriptMessageIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMessageIndexTests.swift; sourceTree = "<group>"; };
 		44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextBuilder.swift; sourceTree = "<group>"; };
@@ -2330,6 +2334,7 @@
 		89034A1968C6BC371826314D /* ACPSessionOrchestrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
 		89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionName.swift; sourceTree = "<group>"; };
+		89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffTilingController.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
 		89D180B7FCAA9DD1F7D7D2E4 /* AppState+RunScripts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+RunScripts.swift"; sourceTree = "<group>"; };
 		8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextUsageButton.swift; sourceTree = "<group>"; };
@@ -2471,6 +2476,7 @@
 		A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDirectionTests.swift; sourceTree = "<group>"; };
 		A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowHostingPool.swift; sourceTree = "<group>"; };
 		A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraft.swift; sourceTree = "<group>"; };
+		A4E9E696C1C8F5817524752F /* AppKitDiffRowSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffRowSpec.swift; sourceTree = "<group>"; };
 		A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdownTests.swift; sourceTree = "<group>"; };
 		A526016296D5A07C2422BC19 /* FileHistoryTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHistoryTabView.swift; sourceTree = "<group>"; };
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
@@ -4029,7 +4035,9 @@
 		448F7BA39D19D1EE3458017B /* Scroller */ = {
 			isa = PBXGroup;
 			children = (
+				A4E9E696C1C8F5817524752F /* AppKitDiffRowSpec.swift */,
 				62376559E51E6DAE99840D03 /* AppKitDiffScrollerFlag.swift */,
+				89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */,
 			);
 			path = Scroller;
 			sourceTree = "<group>";
@@ -5445,6 +5453,7 @@
 			isa = PBXGroup;
 			children = (
 				D97D9F58350601898307089A /* AppKitDiffScrollerFlagTests.swift */,
+				4496D0E5A0243638BBE7A387 /* AppKitDiffTilingControllerTests.swift */,
 			);
 			path = Scroller;
 			sourceTree = "<group>";
@@ -6068,7 +6077,9 @@
 				214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */,
 				F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */,
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
+				B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */,
 				0808A4FCD6525B4C2BBAF0B5 /* AppKitDiffScrollerFlag.swift in Sources */,
+				A0012CF058E580908B5348BC /* AppKitDiffTilingController.swift in Sources */,
 				584066607B7E7E97A736213A /* AppQuitAction.swift in Sources */,
 				74175A7BB07F7588E7B691F2 /* AppState+ReviewPalette.swift in Sources */,
 				AFC4DE3093E404E4D338E6EF /* AppState+RunScripts.swift in Sources */,
@@ -6866,6 +6877,7 @@
 				FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				B1DC420E8EEA69070D0701A1 /* AppKitDiffScrollerFlagTests.swift in Sources */,
+				7AD9F8BC899393522EF92C48 /* AppKitDiffTilingControllerTests.swift in Sources */,
 				A2340CCA2AA5C39B27545EA6 /* AppQuitActionTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -575,15 +575,19 @@ struct DiffPaneView: View {
             verticalScrollMode: verticalScrollMode
         ) {
             let fusionStates = resolvedHunkFusionStates
+            let plan = DiffPaneRowPlanBuilder.build(input: input, state: presentationState)
+                .withContentInsets(.init(
+                    top: outerTopPadding(for: fusionStates),
+                    bottom: outerBottomPadding(for: fusionStates),
+                    left: 10,
+                    right: 10
+                ))
             AppKitDiffScroller(
-                plan: DiffPaneRowPlanBuilder.build(input: input, state: presentationState),
+                plan: plan,
                 scrollRequest: nil,
                 onActiveOwnerChange: { _ in },
                 onScrollRequestCompletion: { _ in }
             )
-            .padding(.horizontal, 10)
-            .padding(.top, outerTopPadding(for: fusionStates))
-            .padding(.bottom, outerBottomPadding(for: fusionStates))
         } else if verticalScrollMode == .internalScroll {
             GeometryReader { proxy in
                 ScrollView(.vertical) {

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -564,12 +564,13 @@ struct DiffPaneView: View {
 
     @ViewBuilder
     private var diffBody: some View {
+        let input = synchronizedRowPlanInput()
         if Self.usesAppKitScroller(
             flagEnabled: appKitScrollerEnabled,
             verticalScrollMode: verticalScrollMode
         ) {
             AppKitDiffScroller(
-                plan: DiffPaneRowPlanBuilder.build(input: rowPlanInput, state: presentationState),
+                plan: DiffPaneRowPlanBuilder.build(input: input, state: presentationState),
                 scrollRequest: nil,
                 onActiveOwnerChange: { _ in },
                 onScrollRequestCompletion: { _ in }
@@ -605,6 +606,12 @@ struct DiffPaneView: View {
         }
     }
 
+    private func synchronizedRowPlanInput() -> DiffPaneRowPlanInput {
+        let input = rowPlanInput
+        presentationState.actionRelay.update(from: input)
+        return input
+    }
+
     private var staticRowsEstimatedHeight: CGFloat {
         DiffPaneStaticHeightEstimator.estimatedHeight(
             for: model,
@@ -624,7 +631,7 @@ struct DiffPaneView: View {
         let fusionStates = resolvedHunkFusionStates
         return LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(indexedGroups, id: \.element.id) { index, group in
-                hunk(group, fusion: fusionStates[index])
+                hunk(group, fusion: fusionStates[index], input: synchronizedRowPlanInput())
             }
         }
         .padding(.horizontal, 10)
@@ -637,7 +644,7 @@ struct DiffPaneView: View {
         let fusionStates = resolvedHunkFusionStates
         return LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(indexedGroups, id: \.element.id) { index, group in
-                hunk(group, fusion: fusionStates[index])
+                hunk(group, fusion: fusionStates[index], input: synchronizedRowPlanInput())
             }
         }
         .padding(.horizontal, 10)
@@ -740,11 +747,15 @@ struct DiffPaneView: View {
         .help(tooltip)
     }
 
-    private func hunk(_ group: DiffDisplayGroup, fusion: DiffPaneHunkFusionState) -> some View {
+    private func hunk(
+        _ group: DiffDisplayGroup,
+        fusion: DiffPaneHunkFusionState,
+        input: DiffPaneRowPlanInput
+    ) -> some View {
         DiffPaneHunkRow(
             group: group,
             fusion: fusion,
-            input: rowPlanInput,
+            input: input,
             state: presentationState
         )
     }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -465,6 +465,7 @@ struct DiffPaneView: View {
     @Environment(\.theme) private var theme
     @State private var presentationState = DiffPanePresentationState()
     @State private var staticRowsWidth: CGFloat = 0
+    @State private var appKitScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
 
     init(
         model: DiffDisplayModel,
@@ -525,23 +526,54 @@ struct DiffPaneView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            if showsToolbar {
-                toolbar
+        Group {
+            VStack(spacing: 0) {
+                if showsToolbar {
+                    toolbar
+                }
+                diffBody
             }
-            diffBody
+            .frame(
+                maxWidth: .infinity,
+                maxHeight: verticalScrollMode == .internalScroll ? .infinity : nil,
+                alignment: .topLeading
+            )
+            .background(theme.color("bg-1"))
         }
-        .frame(
-            maxWidth: .infinity,
-            maxHeight: verticalScrollMode == .internalScroll ? .infinity : nil,
-            alignment: .topLeading
-        )
-        .background(theme.color("bg-1"))
+        .id(appKitScrollerEnabled)
+        .onReceive(
+            NotificationCenter.default.publisher(for: AppKitDiffScrollerFlag.overrideDidChangeNotification)
+        ) { _ in
+            let flagEnabled = AppKitDiffScrollerFlag.isEnabled
+            guard flagEnabled != appKitScrollerEnabled else { return }
+            presentationState = DiffPanePresentationState()
+            appKitScrollerEnabled = flagEnabled
+        }
+    }
+
+    nonisolated static func usesAppKitScroller(
+        flagEnabled: Bool,
+        verticalScrollMode: DiffPaneVerticalScrollMode
+    ) -> Bool {
+        guard flagEnabled else { return false }
+        if case .internalScroll = verticalScrollMode {
+            return true
+        }
+        return false
     }
 
     @ViewBuilder
     private var diffBody: some View {
-        if verticalScrollMode == .internalScroll {
+        if Self.usesAppKitScroller(
+            flagEnabled: appKitScrollerEnabled,
+            verticalScrollMode: verticalScrollMode
+        ) {
+            AppKitDiffScroller(
+                plan: DiffPaneRowPlanBuilder.build(input: rowPlanInput, state: presentationState),
+                scrollRequest: nil,
+                onActiveOwnerChange: { _ in }
+            )
+        } else if verticalScrollMode == .internalScroll {
             GeometryReader { proxy in
                 ScrollView(.vertical) {
                     lazyRowsStack

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -569,12 +569,16 @@ struct DiffPaneView: View {
             flagEnabled: appKitScrollerEnabled,
             verticalScrollMode: verticalScrollMode
         ) {
+            let fusionStates = resolvedHunkFusionStates
             AppKitDiffScroller(
                 plan: DiffPaneRowPlanBuilder.build(input: input, state: presentationState),
                 scrollRequest: nil,
                 onActiveOwnerChange: { _ in },
                 onScrollRequestCompletion: { _ in }
             )
+            .padding(.horizontal, 10)
+            .padding(.top, outerTopPadding(for: fusionStates))
+            .padding(.bottom, outerBottomPadding(for: fusionStates))
         } else if verticalScrollMode == .internalScroll {
             GeometryReader { proxy in
                 ScrollView(.vertical) {

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -466,6 +466,7 @@ struct DiffPaneView: View {
     @State private var presentationState = DiffPanePresentationState()
     @State private var staticRowsWidth: CGFloat = 0
     @State private var appKitScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
+    @State private var activeThreadReplanGeneration = 0
 
     init(
         model: DiffDisplayModel,
@@ -549,6 +550,9 @@ struct DiffPaneView: View {
             presentationState = DiffPanePresentationState()
             appKitScrollerEnabled = flagEnabled
         }
+        .onReceive(presentationState.$activeThreadID) { _ in
+            activeThreadReplanGeneration &+= 1
+        }
     }
 
     nonisolated static func usesAppKitScroller(
@@ -564,6 +568,7 @@ struct DiffPaneView: View {
 
     @ViewBuilder
     private var diffBody: some View {
+        let _ = activeThreadReplanGeneration
         let input = synchronizedRowPlanInput()
         if Self.usesAppKitScroller(
             flagEnabled: appKitScrollerEnabled,

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -463,8 +463,7 @@ struct DiffPaneView: View {
     let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
 
     @Environment(\.theme) private var theme
-    @State private var expandedCollapsedRowIDs: Set<String> = []
-    @State private var activeThreadID: String?
+    @State private var presentationState = DiffPanePresentationState()
     @State private var staticRowsWidth: CGFloat = 0
 
     init(
@@ -577,7 +576,7 @@ struct DiffPaneView: View {
         DiffPaneStaticHeightEstimator.estimatedHeight(
             for: model,
             layoutMode: layoutMode,
-            expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+            expandedCollapsedRowIDs: presentationState.expandedCollapsedRowIDs,
             codeFont: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
             headerFont: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize - 1),
             wrapLines: wrapLines,
@@ -709,108 +708,42 @@ struct DiffPaneView: View {
     }
 
     private func hunk(_ group: DiffDisplayGroup, fusion: DiffPaneHunkFusionState) -> some View {
-        let visibleRowsSnapshot = DiffPaneRowProjection.visibleRowsSnapshot(
-            in: group,
-            expandedCollapsedRowIDs: expandedCollapsedRowIDs
+        DiffPaneHunkRow(
+            group: group,
+            fusion: fusion,
+            input: rowPlanInput,
+            state: presentationState
         )
-        let visibleRows = visibleRowsSnapshot.rows
-        let hunkThreads = threadsForVisibleRows(visibleRows)
-        let hunkAnnotations = annotationsForVisibleRows(visibleRows)
-        let blocks = DiffInlineCommentLayout.blocks(
-            visibleRows: visibleRowsSnapshot,
-            threads: hunkThreads,
-            annotations: hunkAnnotations
-        )
-
-        return VStack(alignment: .leading, spacing: 0) {
-            hunkHeader(group)
-            ForEach(blocks) { block in
-                switch block {
-                case .rows(let segment):
-                    DiffPaneSegmentView(
-                        rows: segment.rows,
-                        rowsSignature: segment.rowsSignature,
-                        layoutMode: layoutMode,
-                        wrapLines: wrapLines,
-                        showWhitespace: showWhitespace,
-                        fileExtension: fileExtension,
-                        codeFontFamily: codeFontFamily,
-                        codeFontSize: codeFontSize,
-                        theme: theme,
-                        lspContext: lspContext,
-                        activeCommentHighlight: activeHighlight(for: segment.rows),
-                        allowsReviewLineSelection: allowsReviewLineSelection,
-                        onReviewLineSelected: onReviewLineSelected,
-                        onContextExpansion: onContextExpansion
-                    )
-                    .fixedSize(horizontal: false, vertical: true)
-                case .thread(let t):
-                    DiffFeedbackLaneView(
-                        lane: DiffFeedbackLaneResolver.lane(for: t),
-                        layoutMode: layoutMode,
-                        rows: visibleRows
-                    ) {
-                        DiffInlineCommentCard(
-                            thread: t,
-                            onReply: { body in onReply(t, body) },
-                            onStageReply: { body in onStageReply(t, body) },
-                            onResolve: { onResolve(t) },
-                            onUnresolve: { onUnresolve(t) },
-                            onEdit: { comment, newBody in onEdit(t, comment, newBody) },
-                            onDelete: { comment in onDelete(t, comment) },
-                            canReply: canReply && t.viewerCanReply,
-                            canResolve: canResolve && (t.viewerCanResolve || t.viewerCanUnresolve),
-                            canAddToReview: canAddToReview,
-                            onActiveChange: { active in
-                                activeThreadID = active ? t.id : (activeThreadID == t.id ? nil : activeThreadID)
-                            }
-                        )
-                    }
-                case .annotation(let a):
-                    DiffFeedbackLaneView(
-                        lane: DiffFeedbackLaneResolver.lane(for: a),
-                        layoutMode: layoutMode,
-                        rows: visibleRows
-                    ) {
-                        DiffInlineAnnotationCard(annotation: a)
-                    }
-                }
-            }
-        }
-        .background(theme.color("bg-1"))
-        .clipShape(DiffPaneHunkCardShape(fusion: fusion))
-        .overlay(
-            DiffPaneHunkCardShape(fusion: fusion)
-                .stroke(theme.color("line"), lineWidth: 0.75)
-        )
-        .padding(.bottom, fusion.bottomPadding)
     }
 
-    private func threadsForVisibleRows(_ visibleRows: [DiffDisplayRow]) -> [DiffInlineCommentThread] {
-        guard !threads.isEmpty else { return [] }
-        let oldLines = Set(visibleRows.compactMap { $0.old?.anchor.oldLine })
-        let newLines = Set(visibleRows.compactMap { $0.new?.anchor.newLine })
-        return threads.filter { t in
-            if t.isOldSide {
-                return oldLines.contains(where: { t.lineRange.contains($0) })
-            } else {
-                return newLines.contains(where: { t.lineRange.contains($0) })
-            }
-        }
-    }
-
-    private func annotationsForVisibleRows(_ visibleRows: [DiffDisplayRow]) -> [DiffInlineAnnotation] {
-        guard !annotations.isEmpty else { return [] }
-        let newLines = Set(visibleRows.compactMap { $0.new?.anchor.newLine })
-        return annotations.filter { newLines.contains($0.newLine) }
-    }
-
-    private func activeHighlight(for rows: [DiffDisplayRow]) -> DiffReviewCommentHighlight? {
-        DiffPaneActiveHighlightResolver.activeHighlight(
-            parentHighlight: activeCommentHighlight,
+    private var rowPlanInput: DiffPaneRowPlanInput {
+        DiffPaneRowPlanInput(
+            model: model,
+            fileExtension: fileExtension,
+            layoutMode: layoutMode,
+            wrapLines: wrapLines,
+            showWhitespace: showWhitespace,
+            codeFontFamily: codeFontFamily,
+            codeFontSize: codeFontSize,
+            theme: theme,
+            lspContext: lspContext,
+            activeCommentHighlight: activeCommentHighlight,
+            allowsReviewLineSelection: allowsReviewLineSelection,
+            onReviewLineSelected: onReviewLineSelected,
+            onContextExpansion: onContextExpansion,
             threads: threads,
-            activeThreadID: activeThreadID,
-            rows: rows
+            annotations: annotations,
+            onReply: onReply,
+            onResolve: onResolve,
+            onUnresolve: onUnresolve,
+            onEdit: onEdit,
+            onDelete: onDelete,
+            canReply: canReply,
+            canResolve: canResolve,
+            onStageReply: onStageReply,
+            canAddToReview: canAddToReview,
+            hunkFusionStates: hunkFusionStates,
+            hunkActions: hunkActions
         )
     }
 }
@@ -869,53 +802,6 @@ enum DiffPaneActiveHighlightResolver {
     }
 }
 
-extension DiffPaneView {
-    private func hunkHeader(_ group: DiffDisplayGroup) -> some View {
-        let actions = hunkActions(group.sourceHunk)
-        return HStack(spacing: 8) {
-            Text(group.header)
-                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
-                .foregroundColor(theme.color("fg-muted"))
-                .lineLimit(1)
-            Spacer(minLength: 12)
-            if !DiffCollapsedContextController.collapsedRowIDs(in: group).isEmpty {
-                let expanded = DiffCollapsedContextController.isExpanded(group, expandedIDs: expandedCollapsedRowIDs)
-                hunkActionButton(
-                    systemName: expanded ? "minus.square" : "plus.square",
-                    tooltip: expanded ? "Collapse context" : "Expand context"
-                ) {
-                    expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(
-                        group,
-                        expandedIDs: expandedCollapsedRowIDs
-                    )
-                }
-            }
-            if let stage = actions.stage {
-                hunkActionButton(systemName: "plus.square", tooltip: "Stage hunk", action: stage)
-            }
-            if let discard = actions.discard {
-                hunkActionButton(systemName: "trash", tooltip: "Discard hunk", action: discard)
-            }
-            if let dropFromCommit = actions.dropFromCommit {
-                hunkActionButton(systemName: "minus.circle", tooltip: "Drop from commit", action: dropFromCommit)
-            }
-        }
-        .padding(.horizontal, 13)
-        .padding(.vertical, 8)
-        .background(theme.color("bg-2"))
-        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
-    }
-
-    private func hunkActionButton(
-        systemName: String,
-        tooltip: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        DiffPaneActionButton(systemName: systemName, tooltip: tooltip, action: action)
-            .frame(width: 22, height: 20)
-    }
-}
-
 private struct DiffPaneToolbarMarker: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
@@ -924,52 +810,4 @@ private struct DiffPaneToolbarMarker: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {}
-}
-
-private struct DiffPaneActionButton: NSViewRepresentable {
-    let systemName: String
-    let tooltip: String
-    let action: () -> Void
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(action: action)
-    }
-
-    func makeNSView(context: Context) -> NSButton {
-        let button = NSButton(
-            image: image(),
-            target: context.coordinator,
-            action: #selector(Coordinator.fire)
-        )
-        button.bezelStyle = .accessoryBar
-        button.isBordered = false
-        button.imagePosition = .imageOnly
-        button.contentTintColor = .secondaryLabelColor
-        button.toolTip = tooltip
-        button.setAccessibilityLabel(tooltip)
-        return button
-    }
-
-    func updateNSView(_ button: NSButton, context: Context) {
-        context.coordinator.action = action
-        button.image = image()
-        button.toolTip = tooltip
-        button.setAccessibilityLabel(tooltip)
-    }
-
-    private func image() -> NSImage {
-        NSImage(systemSymbolName: systemName, accessibilityDescription: tooltip) ?? NSImage()
-    }
-
-    final class Coordinator: NSObject {
-        var action: () -> Void
-
-        init(action: @escaping () -> Void) {
-            self.action = action
-        }
-
-        @objc func fire() {
-            action()
-        }
-    }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -571,7 +571,8 @@ struct DiffPaneView: View {
             AppKitDiffScroller(
                 plan: DiffPaneRowPlanBuilder.build(input: rowPlanInput, state: presentationState),
                 scrollRequest: nil,
-                onActiveOwnerChange: { _ in }
+                onActiveOwnerChange: { _ in },
+                onScrollRequestCompletion: { _ in }
             )
         } else if verticalScrollMode == .internalScroll {
             GeometryReader { proxy in

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -532,6 +532,7 @@ struct DiffPaneView: View {
                     toolbar
                 }
                 diffBody
+                    .id(appKitScrollerEnabled)
             }
             .frame(
                 maxWidth: .infinity,
@@ -540,7 +541,6 @@ struct DiffPaneView: View {
             )
             .background(theme.color("bg-1"))
         }
-        .id(appKitScrollerEnabled)
         .onReceive(
             NotificationCenter.default.publisher(for: AppKitDiffScrollerFlag.overrideDidChangeNotification)
         ) { _ in

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingPool.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingPool.swift
@@ -1,0 +1,65 @@
+import AppKit
+import SwiftUI
+
+/// Maintains mounted diff-row hosts and a small detached reuse pool.
+@MainActor
+final class AppKitDiffRowHostingPool {
+    var onRowIntrinsicSizeInvalidated: ((String) -> Void)?
+
+    private static let maximumReusableHosts = 32
+
+    private struct Entry {
+        let view: AppKitDiffRowHostingView
+        var token: AppKitDiffRowEqualityToken
+    }
+
+    private var entries: [String: Entry] = [:]
+    private var reusableViews: [AppKitDiffRowHostingView] = []
+
+    var mountedIDs: Set<String> { Set(entries.keys) }
+
+    func mountedView(id: String) -> AppKitDiffRowHostingView? {
+        entries[id]?.view
+    }
+
+    func view(for spec: AppKitDiffRowSpec) -> (view: AppKitDiffRowHostingView, contentChanged: Bool) {
+        if var entry = entries[spec.id] {
+            guard !entry.token.isEqual(to: spec.equalityToken) else {
+                return (entry.view, false)
+            }
+
+            entry.view.updateRootView(spec.build())
+            entry.token = spec.equalityToken
+            entries[spec.id] = entry
+            return (entry.view, true)
+        }
+
+        let view: AppKitDiffRowHostingView
+        if let reusedView = reusableViews.popLast() {
+            view = reusedView
+            view.updateRootView(spec.build())
+        } else {
+            view = AppKitDiffRowHostingView(rootView: spec.build())
+            view.onIntrinsicSizeInvalidated = { [weak self] id in
+                self?.onRowIntrinsicSizeInvalidated?(id)
+            }
+        }
+        view.representedRowID = spec.id
+        entries[spec.id] = Entry(view: view, token: spec.equalityToken)
+        return (view, true)
+    }
+
+    func release(id: String) {
+        guard let view = entries.removeValue(forKey: id)?.view else { return }
+        view.removeFromSuperview()
+        view.representedRowID = nil
+        guard reusableViews.count < Self.maximumReusableHosts else { return }
+        reusableViews.append(view)
+    }
+
+    func releaseAll(except keep: Set<String> = []) {
+        for id in entries.keys where !keep.contains(id) {
+            release(id: id)
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingView.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingView.swift
@@ -1,0 +1,45 @@
+import AppKit
+import SwiftUI
+
+/// Width-aware SwiftUI host for a single diff row.
+@MainActor
+final class AppKitDiffRowHostingView: NSHostingView<AnyView> {
+    var representedRowID: String?
+    var onIntrinsicSizeInvalidated: ((String) -> Void)?
+
+    private var baseRootView: AnyView
+    private(set) var lastMeasuredWidth: CGFloat?
+
+    required init(rootView: AnyView) {
+        baseRootView = rootView
+        super.init(rootView: rootView)
+        translatesAutoresizingMaskIntoConstraints = false
+        sizingOptions = [.intrinsicContentSize]
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    override func invalidateIntrinsicContentSize() {
+        super.invalidateIntrinsicContentSize()
+        if let representedRowID {
+            onIntrinsicSizeInvalidated?(representedRowID)
+        }
+    }
+
+    func updateRootView(_ newRootView: AnyView) {
+        baseRootView = newRootView
+        if let lastMeasuredWidth {
+            rootView = AnyView(newRootView.frame(width: lastMeasuredWidth, alignment: .topLeading))
+        } else {
+            rootView = newRootView
+        }
+    }
+
+    func measuredHeight(forWidth width: CGFloat) -> CGFloat {
+        guard width > 0 else { return 0 }
+        rootView = AnyView(baseRootView.frame(width: width, alignment: .topLeading))
+        lastMeasuredWidth = width
+        return intrinsicContentSize.height
+    }
+}

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Type-erased Equatable used to decide whether a mounted diff row needs its
+/// SwiftUI content rebuilt.
+struct AppKitDiffRowEqualityToken {
+    private let base: Any
+    private let equalsBase: (Any) -> Bool
+
+    init<T: Equatable>(_ value: T) {
+        base = value
+        equalsBase = { ($0 as? T) == value }
+    }
+
+    func isEqual(to other: AppKitDiffRowEqualityToken) -> Bool {
+        equalsBase(other.base)
+    }
+}
+
+enum AppKitDiffRowRetention: Equatable {
+    case recyclable
+    case pinned
+}
+
+struct AppKitDiffRowSpec {
+    let id: String
+    let ownerID: String?
+    let equalityToken: AppKitDiffRowEqualityToken
+    let estimatedHeight: CGFloat
+    var retention: AppKitDiffRowRetention = .recyclable
+    let build: () -> AnyView
+}
+
+struct AppKitDiffRowPlan {
+    let rows: [AppKitDiffRowSpec]
+}
+
+enum AppKitDiffScrollAlignment: Equatable {
+    case top
+    case center
+}
+
+struct AppKitDiffScrollRequest: Equatable {
+    let targetID: String
+    let fallbackID: String?
+    let alignment: AppKitDiffScrollAlignment
+    let animated: Bool
+    let generation: Int
+}
+
+struct AppKitDiffScrollAnchor: Equatable {
+    let rowID: String
+    let intraRowOffset: CGFloat
+}

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
@@ -31,8 +31,26 @@ struct AppKitDiffRowSpec {
     let build: () -> AnyView
 }
 
+struct AppKitDiffContentInsets: Equatable {
+    var top: CGFloat = 0
+    var bottom: CGFloat = 0
+    var left: CGFloat = 0
+    var right: CGFloat = 0
+
+    static let zero = AppKitDiffContentInsets()
+
+    var horizontal: CGFloat { left + right }
+}
+
 struct AppKitDiffRowPlan {
     let rows: [AppKitDiffRowSpec]
+    var contentInsets: AppKitDiffContentInsets = .zero
+
+    func withContentInsets(_ insets: AppKitDiffContentInsets) -> AppKitDiffRowPlan {
+        var copy = self
+        copy.contentInsets = insets
+        return copy
+    }
 }
 
 enum AppKitDiffScrollAlignment: Equatable {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
@@ -27,6 +27,7 @@ struct AppKitDiffRowSpec {
     let equalityToken: AppKitDiffRowEqualityToken
     let estimatedHeight: CGFloat
     var retention: AppKitDiffRowRetention = .recyclable
+    var contextRowCount: Int? = nil
     let build: () -> AnyView
 }
 

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
@@ -16,6 +16,12 @@ struct AppKitDiffRowEqualityToken {
     }
 }
 
+extension AppKitDiffRowEqualityToken: Equatable {
+    static func == (lhs: AppKitDiffRowEqualityToken, rhs: AppKitDiffRowEqualityToken) -> Bool {
+        lhs.isEqual(to: rhs)
+    }
+}
+
 enum AppKitDiffRowRetention: Equatable {
     case recyclable
     case pinned

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
@@ -1,0 +1,114 @@
+import AppKit
+
+/// Flipped document canvas matching the diff tiler's top-origin coordinates.
+@MainActor
+final class AppKitDiffScrollDocumentView: NSView {
+    override var isFlipped: Bool { true }
+}
+
+/// Native scrolling primitive for virtualized diff rows.
+@MainActor
+final class AppKitDiffScrollView: NSScrollView {
+    let flippedDocumentView = AppKitDiffScrollDocumentView()
+
+    /// Called for user-driven bounds movement. Programmatic adjustments made
+    /// while reconciling intentionally do not feed back into row ownership.
+    var onViewportChange: (() -> Void)?
+    /// Called when the first positive usable width arrives or when it changes.
+    var onContentWidthChange: (() -> Void)?
+
+    private var boundsObserver: NSObjectProtocol?
+    private var lastReportedContentWidth: CGFloat?
+    private var lastReportedViewportHeight: CGFloat?
+    private var programmaticAdjustmentDepth = 0
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        drawsBackground = false
+        hasVerticalScroller = true
+        hasHorizontalScroller = false
+        automaticallyAdjustsContentInsets = false
+        documentView = flippedDocumentView
+        flippedDocumentView.frame = NSRect(x: 0, y: 0, width: frameRect.width, height: 0)
+        flippedDocumentView.autoresizingMask = [.width]
+        contentView.postsBoundsChangedNotifications = true
+        boundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: contentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, self.programmaticAdjustmentDepth == 0 else { return }
+                self.onViewportChange?()
+            }
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    deinit {
+        if let boundsObserver {
+            NotificationCenter.default.removeObserver(boundsObserver)
+        }
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        let width = contentView.bounds.width
+        let height = contentView.bounds.height
+        let widthChanged = width != lastReportedContentWidth
+        let heightChanged = height != lastReportedViewportHeight
+        guard widthChanged || heightChanged else { return }
+        lastReportedContentWidth = width
+        lastReportedViewportHeight = height
+
+        if widthChanged, width > 0 {
+            onContentWidthChange?()
+        } else if heightChanged {
+            onViewportChange?()
+        }
+    }
+
+    var scrollY: CGFloat { contentView.bounds.origin.y }
+    var viewportHeight: CGFloat { contentView.bounds.height }
+    var contentWidth: CGFloat { contentView.bounds.width }
+    var contentHeight: CGFloat { flippedDocumentView.frame.height }
+
+    func setDocumentHeight(_ height: CGFloat) {
+        let clampedHeight = max(0, height)
+        guard flippedDocumentView.frame.height != clampedHeight else { return }
+        performProgrammatic {
+            flippedDocumentView.frame.size.height = clampedHeight
+            setScrollY(scrollY, animated: false)
+        }
+    }
+
+    func setScrollY(_ y: CGFloat, animated: Bool) {
+        let point = NSPoint(x: contentView.bounds.origin.x, y: clampedScrollY(y))
+        guard abs(point.y - scrollY) > 0.01 else { return }
+        performProgrammatic {
+            if animated {
+                contentView.animator().setBoundsOrigin(point)
+            } else {
+                contentView.setBoundsOrigin(point)
+                reflectScrolledClipView(contentView)
+            }
+        }
+    }
+
+    private func clampedScrollY(_ y: CGFloat) -> CGFloat {
+        min(max(0, y), max(0, contentHeight - viewportHeight))
+    }
+
+    private func performProgrammatic(_ body: () -> Void) {
+        programmaticAdjustmentDepth += 1
+        body()
+        programmaticAdjustmentDepth -= 1
+    }
+}

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
@@ -94,9 +94,12 @@ final class AppKitDiffScrollView: NSScrollView {
         }
     }
 
-    func setScrollY(_ y: CGFloat, animated: Bool) {
+    func setScrollY(_ y: CGFloat, animated: Bool, completion: (() -> Void)? = nil) {
         let point = NSPoint(x: contentView.bounds.origin.x, y: clampedScrollY(y))
-        guard abs(point.y - scrollY) > 0.01 else { return }
+        guard abs(point.y - scrollY) > 0.01 else {
+            completion?()
+            return
+        }
         performProgrammatic {
             if animated {
                 programmaticAnimationDepth += 1
@@ -105,10 +108,12 @@ final class AppKitDiffScrollView: NSScrollView {
                     contentView.animator().setBoundsOrigin(point)
                 } completionHandler: { [weak self] in
                     self?.programmaticAnimationDidComplete()
+                    completion?()
                 }
             } else {
                 contentView.setBoundsOrigin(point)
                 reflectScrolledClipView(contentView)
+                completion?()
             }
         }
     }

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
@@ -19,6 +19,9 @@ final class AppKitDiffScrollView: NSScrollView {
     /// Called only for user-driven bounds movement. Programmatic adjustments
     /// intentionally do not feed back into row ownership.
     var onUserViewportChange: (() -> Void)?
+    /// Called for programmatic animated bounds movement so virtualization can
+    /// keep the visible band mounted without publishing active-owner changes.
+    var onProgrammaticViewportChange: (() -> Void)?
     /// Called when viewport height changes without a content-width change.
     var onViewportGeometryChange: (() -> Void)?
     /// Called when the first positive usable width arrives or when it changes.
@@ -46,9 +49,11 @@ final class AppKitDiffScrollView: NSScrollView {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                guard let self,
-                      self.programmaticAdjustmentDepth == 0,
-                      self.programmaticAnimationDepth == 0 else { return }
+                guard let self, self.programmaticAdjustmentDepth == 0 else { return }
+                if self.programmaticAnimationDepth > 0 {
+                    self.onProgrammaticViewportChange?()
+                    return
+                }
                 self.onUserViewportChange?()
             }
         }

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
@@ -11,9 +11,11 @@ final class AppKitDiffScrollDocumentView: NSView {
 final class AppKitDiffScrollView: NSScrollView {
     let flippedDocumentView = AppKitDiffScrollDocumentView()
 
-    /// Called for user-driven bounds movement. Programmatic adjustments made
-    /// while reconciling intentionally do not feed back into row ownership.
-    var onViewportChange: (() -> Void)?
+    /// Called only for user-driven bounds movement. Programmatic adjustments
+    /// intentionally do not feed back into row ownership.
+    var onUserViewportChange: (() -> Void)?
+    /// Called when viewport height changes without a content-width change.
+    var onViewportGeometryChange: (() -> Void)?
     /// Called when the first positive usable width arrives or when it changes.
     var onContentWidthChange: (() -> Void)?
 
@@ -21,6 +23,7 @@ final class AppKitDiffScrollView: NSScrollView {
     private var lastReportedContentWidth: CGFloat?
     private var lastReportedViewportHeight: CGFloat?
     private var programmaticAdjustmentDepth = 0
+    private var programmaticAnimationDepth = 0
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -38,8 +41,10 @@ final class AppKitDiffScrollView: NSScrollView {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                guard let self, self.programmaticAdjustmentDepth == 0 else { return }
-                self.onViewportChange?()
+                guard let self,
+                      self.programmaticAdjustmentDepth == 0,
+                      self.programmaticAnimationDepth == 0 else { return }
+                self.onUserViewportChange?()
             }
         }
     }
@@ -71,7 +76,7 @@ final class AppKitDiffScrollView: NSScrollView {
         if widthChanged, width > 0 {
             onContentWidthChange?()
         } else if heightChanged {
-            onViewportChange?()
+            onViewportGeometryChange?()
         }
     }
 
@@ -94,7 +99,13 @@ final class AppKitDiffScrollView: NSScrollView {
         guard abs(point.y - scrollY) > 0.01 else { return }
         performProgrammatic {
             if animated {
-                contentView.animator().setBoundsOrigin(point)
+                programmaticAnimationDepth += 1
+                NSAnimationContext.runAnimationGroup { context in
+                    context.duration = 0.25
+                    contentView.animator().setBoundsOrigin(point)
+                } completionHandler: { [weak self] in
+                    self?.programmaticAnimationDidComplete()
+                }
             } else {
                 contentView.setBoundsOrigin(point)
                 reflectScrolledClipView(contentView)
@@ -110,5 +121,9 @@ final class AppKitDiffScrollView: NSScrollView {
         programmaticAdjustmentDepth += 1
         body()
         programmaticAdjustmentDepth -= 1
+    }
+
+    private func programmaticAnimationDidComplete() {
+        programmaticAnimationDepth = max(0, programmaticAnimationDepth - 1)
     }
 }

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift
@@ -9,6 +9,11 @@ final class AppKitDiffScrollDocumentView: NSView {
 /// Native scrolling primitive for virtualized diff rows.
 @MainActor
 final class AppKitDiffScrollView: NSScrollView {
+    #if DEBUG
+    typealias AnimatedScrollExecutorForTests = (AppKitDiffScrollView, NSPoint, @escaping () -> Void) -> Void
+    var animatedScrollExecutorForTests: AnimatedScrollExecutorForTests?
+    #endif
+
     let flippedDocumentView = AppKitDiffScrollDocumentView()
 
     /// Called only for user-driven bounds movement. Programmatic adjustments
@@ -103,6 +108,15 @@ final class AppKitDiffScrollView: NSScrollView {
         performProgrammatic {
             if animated {
                 programmaticAnimationDepth += 1
+                #if DEBUG
+                if let animatedScrollExecutorForTests {
+                    animatedScrollExecutorForTests(self, point) { [weak self] in
+                        self?.programmaticAnimationDidComplete()
+                        completion?()
+                    }
+                    return
+                }
+                #endif
                 NSAnimationContext.runAnimationGroup { context in
                     context.duration = 0.25
                     contentView.animator().setBoundsOrigin(point)

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -77,7 +77,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
 
             guard let scrollRequest,
                   scrollRequest.generation != lastConsumedRequestGeneration,
-                  canResolve(scrollRequest) else { return }
+                  hasUsableLayout else { return }
             lastConsumedRequestGeneration = scrollRequest.generation
             reconciler?.scroll(to: scrollRequest)
         }
@@ -100,10 +100,9 @@ struct AppKitDiffScroller: NSViewRepresentable {
             reconciler?.apply(plan: mostRecentPlan, contentWidth: scrollView.contentWidth)
         }
 
-        private func canResolve(_ request: AppKitDiffScrollRequest) -> Bool {
+        private var hasUsableLayout: Bool {
             guard let scrollView, scrollView.contentWidth > 0, tiling.rowCount > 0 else { return false }
-            return tiling.row(withID: request.targetID) != nil
-                || request.fallbackID.flatMap { tiling.row(withID: $0) } != nil
+            return true
         }
 
         private func userViewportDidChange() {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -38,6 +38,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
         private var mostRecentPlan: AppKitDiffRowPlan?
         private var pendingScrollRequest: AppKitDiffScrollRequest?
         private var lastConsumedRequestGeneration: Int?
+        private var activeScrollRequestGeneration: Int?
         private var latestActiveOwner: String?
         private var onActiveOwnerChange: ((String?) -> Void)?
         private var onScrollRequestCompletion: ((Int) -> Void)?
@@ -98,6 +99,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
             self.scrollView = nil
             mostRecentPlan = nil
             pendingScrollRequest = nil
+            activeScrollRequestGeneration = nil
             onActiveOwnerChange = nil
             onScrollRequestCompletion = nil
             latestActiveOwner = nil
@@ -116,7 +118,15 @@ struct AppKitDiffScroller: NSViewRepresentable {
             guard let pendingScrollRequest, hasUsableLayout else { return }
             lastConsumedRequestGeneration = pendingScrollRequest.generation
             self.pendingScrollRequest = nil
-            reconciler?.scroll(to: pendingScrollRequest) { [weak self] in
+            activeScrollRequestGeneration = pendingScrollRequest.generation
+            reconciler?.scroll(
+                to: pendingScrollRequest,
+                isCurrent: { [weak self] in
+                    self?.activeScrollRequestGeneration == pendingScrollRequest.generation
+                }
+            ) { [weak self] in
+                guard self?.activeScrollRequestGeneration == pendingScrollRequest.generation else { return }
+                self?.activeScrollRequestGeneration = nil
                 self?.onScrollRequestCompletion?(pendingScrollRequest.generation)
             }
         }

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -6,6 +6,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
     let plan: AppKitDiffRowPlan
     let scrollRequest: AppKitDiffScrollRequest?
     let onActiveOwnerChange: (String?) -> Void
+    let onScrollRequestCompletion: (Int) -> Void
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -19,7 +20,8 @@ struct AppKitDiffScroller: NSViewRepresentable {
         context.coordinator.update(
             plan: plan,
             scrollRequest: scrollRequest,
-            onActiveOwnerChange: onActiveOwnerChange
+            onActiveOwnerChange: onActiveOwnerChange,
+            onScrollRequestCompletion: onScrollRequestCompletion
         )
     }
 
@@ -38,6 +40,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
         private var lastConsumedRequestGeneration: Int?
         private var latestActiveOwner: String?
         private var onActiveOwnerChange: ((String?) -> Void)?
+        private var onScrollRequestCompletion: ((Int) -> Void)?
 
         #if DEBUG
         var fullPlanApplyCountForTests: Int { reconciler?.fullPlanApplyCountForTests ?? 0 }
@@ -71,10 +74,12 @@ struct AppKitDiffScroller: NSViewRepresentable {
         func update(
             plan: AppKitDiffRowPlan,
             scrollRequest: AppKitDiffScrollRequest?,
-            onActiveOwnerChange: @escaping (String?) -> Void
+            onActiveOwnerChange: @escaping (String?) -> Void,
+            onScrollRequestCompletion: @escaping (Int) -> Void = { _ in }
         ) {
             mostRecentPlan = plan
             self.onActiveOwnerChange = onActiveOwnerChange
+            self.onScrollRequestCompletion = onScrollRequestCompletion
             if let scrollRequest,
                scrollRequest.generation != lastConsumedRequestGeneration {
                 pendingScrollRequest = scrollRequest
@@ -94,6 +99,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
             mostRecentPlan = nil
             pendingScrollRequest = nil
             onActiveOwnerChange = nil
+            onScrollRequestCompletion = nil
             latestActiveOwner = nil
         }
 
@@ -110,7 +116,9 @@ struct AppKitDiffScroller: NSViewRepresentable {
             guard let pendingScrollRequest, hasUsableLayout else { return }
             lastConsumedRequestGeneration = pendingScrollRequest.generation
             self.pendingScrollRequest = nil
-            reconciler?.scroll(to: pendingScrollRequest)
+            reconciler?.scroll(to: pendingScrollRequest) { [weak self] in
+                self?.onScrollRequestCompletion?(pendingScrollRequest.generation)
+            }
         }
 
         private func userViewportDidChange() {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -58,8 +58,11 @@ struct AppKitDiffScroller: NSViewRepresentable {
             scrollView.onContentWidthChange = { [weak self] in
                 self?.applyMostRecentPlan()
             }
-            scrollView.onViewportChange = { [weak self] in
+            scrollView.onUserViewportChange = { [weak self] in
                 self?.userViewportDidChange()
+            }
+            scrollView.onViewportGeometryChange = { [weak self] in
+                self?.reconciler?.layoutVisibleRows()
             }
         }
 
@@ -73,14 +76,16 @@ struct AppKitDiffScroller: NSViewRepresentable {
             applyMostRecentPlan()
 
             guard let scrollRequest,
-                  scrollRequest.generation != lastConsumedRequestGeneration else { return }
+                  scrollRequest.generation != lastConsumedRequestGeneration,
+                  canResolve(scrollRequest) else { return }
             lastConsumedRequestGeneration = scrollRequest.generation
             reconciler?.scroll(to: scrollRequest)
         }
 
         func dismantle() {
             guard let scrollView else { return }
-            scrollView.onViewportChange = nil
+            scrollView.onUserViewportChange = nil
+            scrollView.onViewportGeometryChange = nil
             scrollView.onContentWidthChange = nil
             pool.releaseAll()
             reconciler = nil
@@ -93,6 +98,12 @@ struct AppKitDiffScroller: NSViewRepresentable {
         private func applyMostRecentPlan() {
             guard let mostRecentPlan, let scrollView else { return }
             reconciler?.apply(plan: mostRecentPlan, contentWidth: scrollView.contentWidth)
+        }
+
+        private func canResolve(_ request: AppKitDiffScrollRequest) -> Bool {
+            guard let scrollView, scrollView.contentWidth > 0, tiling.rowCount > 0 else { return false }
+            return tiling.row(withID: request.targetID) != nil
+                || request.fallbackID.flatMap { tiling.row(withID: $0) } != nil
         }
 
         private func userViewportDidChange() {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -67,6 +67,9 @@ struct AppKitDiffScroller: NSViewRepresentable {
             scrollView.onUserViewportChange = { [weak self] in
                 self?.userViewportDidChange()
             }
+            scrollView.onProgrammaticViewportChange = { [weak self] in
+                self?.reconciler?.layoutVisibleRows()
+            }
             scrollView.onViewportGeometryChange = { [weak self] in
                 self?.reconciler?.layoutVisibleRows()
             }
@@ -92,6 +95,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
         func dismantle() {
             guard let scrollView else { return }
             scrollView.onUserViewportChange = nil
+            scrollView.onProgrammaticViewportChange = nil
             scrollView.onViewportGeometryChange = nil
             scrollView.onContentWidthChange = nil
             pool.releaseAll()

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -34,6 +34,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
         private var reconciler: AppKitDiffScrollerReconciler?
         private weak var scrollView: AppKitDiffScrollView?
         private var mostRecentPlan: AppKitDiffRowPlan?
+        private var pendingScrollRequest: AppKitDiffScrollRequest?
         private var lastConsumedRequestGeneration: Int?
         private var latestActiveOwner: String?
         private var onActiveOwnerChange: ((String?) -> Void)?
@@ -57,6 +58,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
             )
             scrollView.onContentWidthChange = { [weak self] in
                 self?.applyMostRecentPlan()
+                self?.processPendingScrollRequest()
             }
             scrollView.onUserViewportChange = { [weak self] in
                 self?.userViewportDidChange()
@@ -73,13 +75,12 @@ struct AppKitDiffScroller: NSViewRepresentable {
         ) {
             mostRecentPlan = plan
             self.onActiveOwnerChange = onActiveOwnerChange
+            if let scrollRequest,
+               scrollRequest.generation != lastConsumedRequestGeneration {
+                pendingScrollRequest = scrollRequest
+            }
             applyMostRecentPlan()
-
-            guard let scrollRequest,
-                  scrollRequest.generation != lastConsumedRequestGeneration,
-                  hasUsableLayout else { return }
-            lastConsumedRequestGeneration = scrollRequest.generation
-            reconciler?.scroll(to: scrollRequest)
+            processPendingScrollRequest()
         }
 
         func dismantle() {
@@ -91,6 +92,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
             reconciler = nil
             self.scrollView = nil
             mostRecentPlan = nil
+            pendingScrollRequest = nil
             onActiveOwnerChange = nil
             latestActiveOwner = nil
         }
@@ -102,6 +104,13 @@ struct AppKitDiffScroller: NSViewRepresentable {
 
         private var hasUsableLayout: Bool {
             (scrollView?.contentWidth ?? 0) > 0
+        }
+
+        private func processPendingScrollRequest() {
+            guard let pendingScrollRequest, hasUsableLayout else { return }
+            lastConsumedRequestGeneration = pendingScrollRequest.generation
+            self.pendingScrollRequest = nil
+            reconciler?.scroll(to: pendingScrollRequest)
         }
 
         private func userViewportDidChange() {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -1,0 +1,110 @@
+import AppKit
+import SwiftUI
+
+/// SwiftUI bridge for the AppKit-backed, virtualized diff row scroller.
+struct AppKitDiffScroller: NSViewRepresentable {
+    let plan: AppKitDiffRowPlan
+    let scrollRequest: AppKitDiffScrollRequest?
+    let onActiveOwnerChange: (String?) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> AppKitDiffScrollView {
+        let scrollView = AppKitDiffScrollView(frame: .zero)
+        context.coordinator.attach(scrollView: scrollView, onActiveOwnerChange: onActiveOwnerChange)
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: AppKitDiffScrollView, context: Context) {
+        context.coordinator.update(
+            plan: plan,
+            scrollRequest: scrollRequest,
+            onActiveOwnerChange: onActiveOwnerChange
+        )
+    }
+
+    static func dismantleNSView(_ scrollView: AppKitDiffScrollView, coordinator: Coordinator) {
+        coordinator.dismantle()
+    }
+
+    @MainActor
+    final class Coordinator {
+        private let tiling = AppKitDiffTilingController()
+        private let pool = AppKitDiffRowHostingPool()
+        private var reconciler: AppKitDiffScrollerReconciler?
+        private weak var scrollView: AppKitDiffScrollView?
+        private var mostRecentPlan: AppKitDiffRowPlan?
+        private var lastConsumedRequestGeneration: Int?
+        private var latestActiveOwner: String?
+        private var onActiveOwnerChange: ((String?) -> Void)?
+
+        #if DEBUG
+        var fullPlanApplyCountForTests: Int { reconciler?.fullPlanApplyCountForTests ?? 0 }
+        var mountedRowIDsForTests: Set<String> { pool.mountedIDs }
+        #endif
+
+        func attach(
+            scrollView: AppKitDiffScrollView,
+            onActiveOwnerChange: @escaping (String?) -> Void
+        ) {
+            guard self.scrollView == nil else { return }
+            self.scrollView = scrollView
+            self.onActiveOwnerChange = onActiveOwnerChange
+            reconciler = AppKitDiffScrollerReconciler(
+                tiling: tiling,
+                pool: pool,
+                scrollView: scrollView
+            )
+            scrollView.onContentWidthChange = { [weak self] in
+                self?.applyMostRecentPlan()
+            }
+            scrollView.onViewportChange = { [weak self] in
+                self?.userViewportDidChange()
+            }
+        }
+
+        func update(
+            plan: AppKitDiffRowPlan,
+            scrollRequest: AppKitDiffScrollRequest?,
+            onActiveOwnerChange: @escaping (String?) -> Void
+        ) {
+            mostRecentPlan = plan
+            self.onActiveOwnerChange = onActiveOwnerChange
+            applyMostRecentPlan()
+
+            guard let scrollRequest,
+                  scrollRequest.generation != lastConsumedRequestGeneration else { return }
+            lastConsumedRequestGeneration = scrollRequest.generation
+            reconciler?.scroll(to: scrollRequest)
+        }
+
+        func dismantle() {
+            guard let scrollView else { return }
+            scrollView.onViewportChange = nil
+            scrollView.onContentWidthChange = nil
+            pool.releaseAll()
+            reconciler = nil
+            self.scrollView = nil
+            mostRecentPlan = nil
+            onActiveOwnerChange = nil
+            latestActiveOwner = nil
+        }
+
+        private func applyMostRecentPlan() {
+            guard let mostRecentPlan, let scrollView else { return }
+            reconciler?.apply(plan: mostRecentPlan, contentWidth: scrollView.contentWidth)
+        }
+
+        private func userViewportDidChange() {
+            guard let scrollView else { return }
+            reconciler?.layoutVisibleRows()
+            let owner = tiling.activeOwnerID(
+                viewportMinY: scrollView.scrollY,
+                viewportHeight: scrollView.viewportHeight
+            )
+            guard owner != latestActiveOwner else { return }
+            latestActiveOwner = owner
+            onActiveOwnerChange?(owner)
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -101,8 +101,7 @@ struct AppKitDiffScroller: NSViewRepresentable {
         }
 
         private var hasUsableLayout: Bool {
-            guard let scrollView, scrollView.contentWidth > 0, tiling.rowCount > 0 else { return false }
-            return true
+            (scrollView?.contentWidth ?? 0) > 0
         }
 
         private func userViewportDidChange() {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerFlag.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerFlag.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum AppKitDiffScrollerFlag {
+    static let defaultsKey = "alas.diff.appKitScroller"
+    static let overrideDidChangeNotification = Notification.Name(
+        "io.nlopez.alas.AppKitDiffScrollerFlag.overrideDidChange"
+    )
+
+    static var isEnabled: Bool { isEnabledWithDefaults(.standard) }
+
+    nonisolated static func readOverride(from defaults: UserDefaults) -> Bool? {
+        defaults.object(forKey: defaultsKey) as? Bool
+    }
+
+    nonisolated static func isEnabledWithDefaults(_ defaults: UserDefaults) -> Bool {
+        #if DEBUG
+        resolve(override: readOverride(from: defaults), isDebugBuild: true)
+        #else
+        resolve(override: readOverride(from: defaults), isDebugBuild: false)
+        #endif
+    }
+
+    nonisolated static func resolve(override: Bool?, isDebugBuild: Bool) -> Bool {
+        override ?? isDebugBuild
+    }
+
+    nonisolated static func setOverride(
+        _ override: Bool,
+        in defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        defaults.set(override, forKey: defaultsKey)
+        notificationCenter.post(name: overrideDidChangeNotification, object: nil)
+    }
+}

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -13,6 +13,7 @@ final class AppKitDiffScrollerReconciler {
     private var orderedIDs: [String] = []
     private var measuredHeights: [String: CGFloat] = [:]
     private var contentWidth: CGFloat = 0
+    private var contentInsets: AppKitDiffContentInsets = .zero
     private var isReconciling = false
     private var deferredLayoutScheduled = false
     private var needsDeferredLayout = false
@@ -38,9 +39,11 @@ final class AppKitDiffScrollerReconciler {
 
     func apply(plan: AppKitDiffRowPlan, contentWidth width: CGFloat) {
         guard width > 0 else { return }
+        let rowContentWidth = max(0, width - plan.contentInsets.horizontal)
         let ids = plan.rows.map(\.id)
-        let widthChanged = width != contentWidth
-        let isUnchanged = !widthChanged && ids == orderedIDs && plan.rows.allSatisfy { spec in
+        let widthChanged = rowContentWidth != contentWidth
+        let insetsChanged = plan.contentInsets != contentInsets
+        let isUnchanged = !widthChanged && !insetsChanged && ids == orderedIDs && plan.rows.allSatisfy { spec in
             guard let current = specsByID[spec.id] else { return false }
             return current.equalityToken.isEqual(to: spec.equalityToken)
                 && current.ownerID == spec.ownerID
@@ -75,14 +78,15 @@ final class AppKitDiffScrollerReconciler {
         specsByID = nextSpecs
         orderedIDs = ids
         measuredHeights = nextMeasuredHeights
-        contentWidth = width
+        contentWidth = rowContentWidth
+        contentInsets = plan.contentInsets
         tiling.replaceAll(rows: plan.rows.map { spec in
             .init(
                 id: spec.id,
                 ownerID: spec.ownerID,
                 height: nextMeasuredHeights[spec.id] ?? max(0, spec.estimatedHeight)
             )
-        })
+        }, metrics: .init(topPadding: plan.contentInsets.top, bottomPadding: plan.contentInsets.bottom))
         scrollView.setDocumentHeight(tiling.documentHeight)
         if let anchoredY = tiling.viewportMinY(for: anchor) {
             scrollView.setScrollY(anchoredY, animated: false)
@@ -197,7 +201,12 @@ final class AppKitDiffScrollerReconciler {
                     geometryChanged = geometryChanged || abs(row.height - height) > 0.01
                 }
                 if let updatedRow = tiling.row(withID: id) {
-                    view.frame = NSRect(x: 0, y: updatedRow.minY, width: contentWidth, height: updatedRow.height)
+                    view.frame = NSRect(
+                        x: contentInsets.left,
+                        y: updatedRow.minY,
+                        width: contentWidth,
+                        height: updatedRow.height
+                    )
                 }
             }
             scrollView.setDocumentHeight(tiling.documentHeight)

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -120,8 +120,20 @@ final class AppKitDiffScrollerReconciler {
             // so active-owner feedback cannot fight navigation. Re-tile at the
             // final native offset before announcing completion, however, or a
             // long jump can leave only the source viewport mounted.
-            self?.layoutVisibleRows()
-            completion?()
+            guard let self else {
+                completion?()
+                return
+            }
+            self.layoutVisibleRows()
+            guard let measuredOffset = self.tiling.targetOffset(
+                id: targetID,
+                alignment: request.alignment,
+                viewportHeight: self.scrollView.viewportHeight
+            ) else {
+                completion?()
+                return
+            }
+            self.scrollView.setScrollY(measuredOffset, animated: false, completion: completion)
         }
         layoutVisibleRows()
     }

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -1,0 +1,193 @@
+import AppKit
+
+/// Reconciles a stable-id diff row plan into the native scroll view.
+@MainActor
+final class AppKitDiffScrollerReconciler {
+    static let overscan: CGFloat = 800
+
+    private let tiling: AppKitDiffTilingController
+    private let pool: AppKitDiffRowHostingPool
+    private unowned let scrollView: AppKitDiffScrollView
+
+    private var specsByID: [String: AppKitDiffRowSpec] = [:]
+    private var orderedIDs: [String] = []
+    private var measuredHeights: [String: CGFloat] = [:]
+    private var contentWidth: CGFloat = 0
+    private var isReconciling = false
+    private var deferredLayoutScheduled = false
+    private var needsDeferredLayout = false
+
+    #if DEBUG
+    private(set) var fullPlanApplyCountForTests = 0
+    private(set) var layoutPassCountForTests = 0
+    #endif
+
+    init(
+        tiling: AppKitDiffTilingController,
+        pool: AppKitDiffRowHostingPool,
+        scrollView: AppKitDiffScrollView
+    ) {
+        self.tiling = tiling
+        self.pool = pool
+        self.scrollView = scrollView
+        pool.onRowIntrinsicSizeInvalidated = { [weak self] id in
+            self?.intrinsicSizeInvalidated(for: id)
+        }
+    }
+
+    func apply(plan: AppKitDiffRowPlan, contentWidth width: CGFloat) {
+        guard width > 0 else { return }
+        let ids = plan.rows.map(\.id)
+        let widthChanged = width != contentWidth
+        let isUnchanged = !widthChanged && ids == orderedIDs && plan.rows.allSatisfy { spec in
+            specsByID[spec.id]?.equalityToken.isEqual(to: spec.equalityToken) == true
+        }
+        guard !isUnchanged else { return }
+
+        #if DEBUG
+        fullPlanApplyCountForTests += 1
+        #endif
+        isReconciling = true
+        defer {
+            isReconciling = false
+            scheduleDeferredLayoutIfNeeded()
+        }
+
+        let anchor = tiling.anchor(viewportMinY: scrollView.scrollY)
+        let previousSpecs = specsByID
+        let previousMeasuredHeights = measuredHeights
+        var nextSpecs: [String: AppKitDiffRowSpec] = [:]
+        var nextMeasuredHeights: [String: CGFloat] = [:]
+        for spec in plan.rows {
+            nextSpecs[spec.id] = spec
+            if !widthChanged,
+               previousSpecs[spec.id]?.equalityToken.isEqual(to: spec.equalityToken) == true,
+               let height = previousMeasuredHeights[spec.id] {
+                nextMeasuredHeights[spec.id] = height
+            }
+        }
+
+        specsByID = nextSpecs
+        orderedIDs = ids
+        measuredHeights = nextMeasuredHeights
+        contentWidth = width
+        tiling.replaceAll(rows: plan.rows.map { spec in
+            .init(
+                id: spec.id,
+                ownerID: spec.ownerID,
+                height: nextMeasuredHeights[spec.id] ?? max(0, spec.estimatedHeight)
+            )
+        })
+        scrollView.setDocumentHeight(tiling.documentHeight)
+        if let anchoredY = tiling.viewportMinY(for: anchor) {
+            scrollView.setScrollY(anchoredY, animated: false)
+        }
+        layoutVisibleRows()
+    }
+
+    func layoutVisibleRows() {
+        guard contentWidth > 0 else { return }
+        guard !isReconciling || !isLayingOutRows else {
+            needsDeferredLayout = true
+            return
+        }
+        layoutMountedRows()
+    }
+
+    func scroll(to request: AppKitDiffScrollRequest) {
+        let targetID: String?
+        if tiling.row(withID: request.targetID) != nil {
+            targetID = request.targetID
+        } else {
+            targetID = request.fallbackID
+        }
+        guard let targetID,
+              let offset = tiling.targetOffset(
+                id: targetID,
+                alignment: request.alignment,
+                viewportHeight: scrollView.viewportHeight
+              ) else { return }
+        scrollView.setScrollY(offset, animated: request.animated)
+        layoutVisibleRows()
+    }
+
+    private var isLayingOutRows = false
+
+    private func layoutMountedRows() {
+        guard !isLayingOutRows else {
+            needsDeferredLayout = true
+            return
+        }
+        isLayingOutRows = true
+        defer { isLayingOutRows = false }
+
+        #if DEBUG
+        layoutPassCountForTests += 1
+        #endif
+        for _ in 0..<3 {
+            let band = tiling.mountBand(
+                viewportMinY: scrollView.scrollY,
+                viewportHeight: scrollView.viewportHeight,
+                overscan: Self.overscan
+            )
+            let bandIDs = Set(band.compactMap { index in
+                orderedIDs.indices.contains(index) ? orderedIDs[index] : nil
+            })
+            let pinnedIDs = Set(specsByID.values.lazy.filter { $0.retention == .pinned }.map(\.id))
+            let keep = bandIDs.union(pinnedIDs)
+            pool.releaseAll(except: keep)
+
+            var geometryChanged = false
+            for id in keep {
+                guard let spec = specsByID[id], let row = tiling.row(withID: id) else { continue }
+                let result = pool.view(for: spec)
+                let view = result.view
+                if view.superview !== scrollView.flippedDocumentView {
+                    scrollView.flippedDocumentView.addSubview(view)
+                }
+                let shouldMeasure = result.contentChanged || view.lastMeasuredWidth != contentWidth
+                if shouldMeasure {
+                    let height = max(0, view.measuredHeight(forWidth: contentWidth))
+                    measuredHeights[id] = height
+                    let compensation = tiling.updateHeight(
+                        id: id,
+                        to: height,
+                        viewportMinY: scrollView.scrollY
+                    )
+                    if compensation != 0 {
+                        scrollView.setDocumentHeight(tiling.documentHeight)
+                        scrollView.setScrollY(scrollView.scrollY + compensation, animated: false)
+                    }
+                    geometryChanged = geometryChanged || abs(row.height - height) > 0.01
+                }
+                if let updatedRow = tiling.row(withID: id) {
+                    view.frame = NSRect(x: 0, y: updatedRow.minY, width: contentWidth, height: updatedRow.height)
+                }
+            }
+            scrollView.setDocumentHeight(tiling.documentHeight)
+            guard geometryChanged else { break }
+        }
+    }
+
+    private func intrinsicSizeInvalidated(for id: String) {
+        guard specsByID[id] != nil else { return }
+        if isReconciling || isLayingOutRows {
+            needsDeferredLayout = true
+            scheduleDeferredLayoutIfNeeded()
+            return
+        }
+        measuredHeights.removeValue(forKey: id)
+        layoutVisibleRows()
+    }
+
+    private func scheduleDeferredLayoutIfNeeded() {
+        guard needsDeferredLayout, !deferredLayoutScheduled else { return }
+        needsDeferredLayout = false
+        deferredLayoutScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.deferredLayoutScheduled = false
+            self.layoutVisibleRows()
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -16,6 +16,7 @@ final class AppKitDiffScrollerReconciler {
     private var isReconciling = false
     private var deferredLayoutScheduled = false
     private var needsDeferredLayout = false
+    private var invalidatedRowIDs: Set<String> = []
 
     #if DEBUG
     private(set) var fullPlanApplyCountForTests = 0
@@ -40,7 +41,11 @@ final class AppKitDiffScrollerReconciler {
         let ids = plan.rows.map(\.id)
         let widthChanged = width != contentWidth
         let isUnchanged = !widthChanged && ids == orderedIDs && plan.rows.allSatisfy { spec in
-            specsByID[spec.id]?.equalityToken.isEqual(to: spec.equalityToken) == true
+            guard let current = specsByID[spec.id] else { return false }
+            return current.equalityToken.isEqual(to: spec.equalityToken)
+                && current.ownerID == spec.ownerID
+                && current.retention == spec.retention
+                && current.estimatedHeight == spec.estimatedHeight
         }
         guard !isUnchanged else { return }
 
@@ -145,7 +150,9 @@ final class AppKitDiffScrollerReconciler {
                 if view.superview !== scrollView.flippedDocumentView {
                     scrollView.flippedDocumentView.addSubview(view)
                 }
-                let shouldMeasure = result.contentChanged || view.lastMeasuredWidth != contentWidth
+                let shouldMeasure = result.contentChanged
+                    || view.lastMeasuredWidth != contentWidth
+                    || invalidatedRowIDs.remove(id) != nil
                 if shouldMeasure {
                     let height = max(0, view.measuredHeight(forWidth: contentWidth))
                     measuredHeights[id] = height
@@ -171,6 +178,7 @@ final class AppKitDiffScrollerReconciler {
 
     private func intrinsicSizeInvalidated(for id: String) {
         guard specsByID[id] != nil else { return }
+        invalidatedRowIDs.insert(id)
         if isReconciling || isLayingOutRows {
             needsDeferredLayout = true
             scheduleDeferredLayoutIfNeeded()

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -115,7 +115,14 @@ final class AppKitDiffScrollerReconciler {
             completion?()
             return
         }
-        scrollView.setScrollY(offset, animated: request.animated, completion: completion)
+        scrollView.setScrollY(offset, animated: request.animated) { [weak self] in
+            // Bounds notifications remain suppressed for programmatic animation
+            // so active-owner feedback cannot fight navigation. Re-tile at the
+            // final native offset before announcing completion, however, or a
+            // long jump can leave only the source viewport mounted.
+            self?.layoutVisibleRows()
+            completion?()
+        }
         layoutVisibleRows()
     }
 

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -99,7 +99,7 @@ final class AppKitDiffScrollerReconciler {
         layoutMountedRows()
     }
 
-    func scroll(to request: AppKitDiffScrollRequest) {
+    func scroll(to request: AppKitDiffScrollRequest, completion: (() -> Void)? = nil) {
         let targetID: String?
         if tiling.row(withID: request.targetID) != nil {
             targetID = request.targetID
@@ -111,8 +111,11 @@ final class AppKitDiffScrollerReconciler {
                 id: targetID,
                 alignment: request.alignment,
                 viewportHeight: scrollView.viewportHeight
-              ) else { return }
-        scrollView.setScrollY(offset, animated: request.animated)
+              ) else {
+            completion?()
+            return
+        }
+        scrollView.setScrollY(offset, animated: request.animated, completion: completion)
         layoutVisibleRows()
     }
 

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -99,7 +99,11 @@ final class AppKitDiffScrollerReconciler {
         layoutMountedRows()
     }
 
-    func scroll(to request: AppKitDiffScrollRequest, completion: (() -> Void)? = nil) {
+    func scroll(
+        to request: AppKitDiffScrollRequest,
+        isCurrent: @escaping () -> Bool = { true },
+        completion: (() -> Void)? = nil
+    ) {
         let targetID: String?
         if tiling.row(withID: request.targetID) != nil {
             targetID = request.targetID
@@ -124,6 +128,7 @@ final class AppKitDiffScrollerReconciler {
                 completion?()
                 return
             }
+            guard isCurrent() else { return }
             self.layoutVisibleRows()
             guard let measuredOffset = self.tiling.targetOffset(
                 id: targetID,
@@ -135,7 +140,9 @@ final class AppKitDiffScrollerReconciler {
             }
             self.scrollView.setScrollY(measuredOffset, animated: false, completion: completion)
         }
-        layoutVisibleRows()
+        if isCurrent() {
+            layoutVisibleRows()
+        }
     }
 
     private var isLayingOutRows = false

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
@@ -62,19 +62,23 @@ final class AppKitDiffTilingController {
     func anchor(viewportMinY: CGFloat) -> AppKitDiffScrollAnchor? {
         guard let index = firstRowIndex(intersectingY: viewportMinY) else { return nil }
         let row = rows[index]
-        return .init(rowID: row.id, intraRowOffset: max(0, viewportMinY - row.minY))
+        return .init(rowID: row.id, intraRowOffset: viewportMinY - row.minY)
     }
 
     func viewportMinY(for anchor: AppKitDiffScrollAnchor?) -> CGFloat? {
         guard let anchor, let row = row(withID: anchor.rowID) else { return nil }
-        return row.minY + anchor.intraRowOffset
+        let intraRowOffset = min(max(0, anchor.intraRowOffset), row.height)
+        return min(max(0, row.minY + intraRowOffset), documentHeight)
     }
 
     func mountBand(viewportMinY: CGFloat, viewportHeight: CGFloat, overscan: CGFloat) -> Range<Int> {
         guard !rows.isEmpty else { return 0..<0 }
         let lowY = viewportMinY - overscan
         let highY = viewportMinY + viewportHeight + overscan
-        guard let first = firstRowIndex(intersectingY: lowY) else { return rows.count..<rows.count }
+        guard let first = firstRowIndex(intersectingRangeFrom: lowY, to: highY) else {
+            let emptyIndex = firstRowIndex(afterY: lowY) ?? rows.count
+            return emptyIndex..<emptyIndex
+        }
 
         var upperBound = first + 1
         while upperBound < rows.count, rows[upperBound].minY < highY {
@@ -100,9 +104,24 @@ final class AppKitDiffTilingController {
         return min(max(0, desired), max(0, documentHeight - viewportHeight))
     }
 
-    /// Returns the first row whose half-open range has a bottom edge strictly
-    /// after `y`; this is the row intersecting or immediately following it.
+    /// Returns the row containing `y` under the half-open interval convention.
     private func firstRowIndex(intersectingY y: CGFloat) -> Int? {
+        guard let index = firstRowIndex(afterY: y), rows[index].minY <= y else { return nil }
+        return index
+    }
+
+    /// Returns the first row that intersects the half-open range `[lowY, highY)`.
+    private func firstRowIndex(intersectingRangeFrom lowY: CGFloat, to highY: CGFloat) -> Int? {
+        guard lowY < highY, let index = firstRowIndex(afterY: lowY), rows[index].minY < highY else {
+            return nil
+        }
+        return index
+    }
+
+    /// Binary-searches for the first row with a bottom edge strictly after `y`.
+    /// The result may be a later row when `y` lies in padding or spacing; callers
+    /// that need an actual intersection must verify the corresponding min edge.
+    private func firstRowIndex(afterY y: CGFloat) -> Int? {
         guard let last = rows.indices.last, rows[last].maxY > y else { return nil }
         var lower = 0
         var upper = last
@@ -127,10 +146,18 @@ final class AppKitDiffTilingController {
     }
 
     private func rebuildIndex() {
-        indexByID.removeAll(keepingCapacity: true)
-        for (index, row) in rows.enumerated() {
-            assert(indexByID[row.id] == nil, "duplicate AppKit diff row id \(row.id)")
-            indexByID[row.id] = index
+        var assertedIDs = Set<String>()
+        for row in rows {
+            assert(assertedIDs.insert(row.id).inserted, "duplicate AppKit diff row id \(row.id)")
         }
+        indexByID = Self.lastIndexByID(for: rows.map(\.id))
+    }
+
+    static func lastIndexByID(for rowIDs: [String]) -> [String: Int] {
+        var result: [String: Int] = [:]
+        for (index, id) in rowIDs.enumerated() {
+            result[id] = index
+        }
+        return result
     }
 }

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
@@ -24,7 +24,7 @@ final class AppKitDiffTilingController {
         var maxY: CGFloat { minY + height }
     }
 
-    private let metrics: Metrics
+    private var metrics: Metrics
     private var rows: [RowLayout] = []
     private var indexByID: [String: Int] = [:]
 
@@ -36,7 +36,10 @@ final class AppKitDiffTilingController {
 
     var rowCount: Int { rows.count }
 
-    func replaceAll(rows newRows: [Seed]) {
+    func replaceAll(rows newRows: [Seed], metrics newMetrics: Metrics? = nil) {
+        if let newMetrics {
+            metrics = newMetrics
+        }
         rows = newRows.map { .init(id: $0.id, ownerID: $0.ownerID, height: $0.height, minY: 0) }
         retile()
         rebuildIndex()

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
@@ -1,0 +1,136 @@
+import CoreGraphics
+
+/// Pure row-placement and viewport geometry for the AppKit diff scroller.
+@MainActor
+final class AppKitDiffTilingController {
+    struct Metrics: Equatable {
+        var rowSpacing: CGFloat = 0
+        var topPadding: CGFloat = 0
+        var bottomPadding: CGFloat = 0
+    }
+
+    struct Seed {
+        let id: String
+        let ownerID: String?
+        let height: CGFloat
+    }
+
+    struct RowLayout: Equatable {
+        let id: String
+        let ownerID: String?
+        var height: CGFloat
+        var minY: CGFloat
+
+        var maxY: CGFloat { minY + height }
+    }
+
+    private let metrics: Metrics
+    private var rows: [RowLayout] = []
+    private var indexByID: [String: Int] = [:]
+
+    private(set) var documentHeight: CGFloat = 0
+
+    init(metrics: Metrics = Metrics()) {
+        self.metrics = metrics
+    }
+
+    var rowCount: Int { rows.count }
+
+    func replaceAll(rows newRows: [Seed]) {
+        rows = newRows.map { .init(id: $0.id, ownerID: $0.ownerID, height: $0.height, minY: 0) }
+        retile()
+        rebuildIndex()
+    }
+
+    func row(withID id: String) -> RowLayout? {
+        index(ofID: id).map { rows[$0] }
+    }
+
+    func index(ofID id: String) -> Int? {
+        indexByID[id]
+    }
+
+    func updateHeight(id: String, to height: CGFloat, viewportMinY: CGFloat) -> CGFloat {
+        guard let index = index(ofID: id), rows[index].height != height else { return 0 }
+        let old = rows[index]
+        let delta = height - old.height
+        rows[index].height = height
+        retile()
+        return old.maxY <= viewportMinY ? delta : 0
+    }
+
+    func anchor(viewportMinY: CGFloat) -> AppKitDiffScrollAnchor? {
+        guard let index = firstRowIndex(intersectingY: viewportMinY) else { return nil }
+        let row = rows[index]
+        return .init(rowID: row.id, intraRowOffset: max(0, viewportMinY - row.minY))
+    }
+
+    func viewportMinY(for anchor: AppKitDiffScrollAnchor?) -> CGFloat? {
+        guard let anchor, let row = row(withID: anchor.rowID) else { return nil }
+        return row.minY + anchor.intraRowOffset
+    }
+
+    func mountBand(viewportMinY: CGFloat, viewportHeight: CGFloat, overscan: CGFloat) -> Range<Int> {
+        guard !rows.isEmpty else { return 0..<0 }
+        let lowY = viewportMinY - overscan
+        let highY = viewportMinY + viewportHeight + overscan
+        guard let first = firstRowIndex(intersectingY: lowY) else { return rows.count..<rows.count }
+
+        var upperBound = first + 1
+        while upperBound < rows.count, rows[upperBound].minY < highY {
+            upperBound += 1
+        }
+        return first..<upperBound
+    }
+
+    func activeOwnerID(viewportMinY: CGFloat, viewportHeight: CGFloat) -> String? {
+        guard viewportHeight > 0, let index = firstRowIndex(intersectingY: viewportMinY) else { return nil }
+        return rows[index].ownerID
+    }
+
+    func targetOffset(id: String, alignment: AppKitDiffScrollAlignment, viewportHeight: CGFloat) -> CGFloat? {
+        guard let row = row(withID: id) else { return nil }
+        let desired: CGFloat
+        switch alignment {
+        case .top:
+            desired = row.minY
+        case .center:
+            desired = row.minY - (viewportHeight - row.height) / 2
+        }
+        return min(max(0, desired), max(0, documentHeight - viewportHeight))
+    }
+
+    /// Returns the first row whose half-open range has a bottom edge strictly
+    /// after `y`; this is the row intersecting or immediately following it.
+    private func firstRowIndex(intersectingY y: CGFloat) -> Int? {
+        guard let last = rows.indices.last, rows[last].maxY > y else { return nil }
+        var lower = 0
+        var upper = last
+        while lower < upper {
+            let middle = (lower + upper) / 2
+            if rows[middle].maxY > y {
+                upper = middle
+            } else {
+                lower = middle + 1
+            }
+        }
+        return lower
+    }
+
+    private func retile() {
+        var y = metrics.topPadding
+        for index in rows.indices {
+            rows[index].minY = y
+            y = rows[index].maxY + metrics.rowSpacing
+        }
+        documentHeight = rows.isEmpty ? 0 : rows[rows.count - 1].maxY + metrics.bottomPadding
+    }
+
+    private func rebuildIndex() {
+        indexByID.removeAll(keepingCapacity: true)
+        for (index, row) in rows.enumerated() {
+            assert(indexByID[row.id] == nil, "duplicate AppKit diff row id \(row.id)")
+            indexByID[row.id] = index
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -95,6 +95,7 @@ struct DiffPaneHunkRowToken: Equatable {
     let layoutMode: DiffLayoutMode
     let wrapLines: Bool
     let showWhitespace: Bool
+    let fileExtension: String
     let codeFontFamily: String
     let codeFontSize: CGFloat
     let theme: Theme
@@ -159,6 +160,7 @@ enum DiffPaneRowPlanBuilder {
                 layoutMode: input.layoutMode,
                 wrapLines: input.wrapLines,
                 showWhitespace: input.showWhitespace,
+                fileExtension: input.fileExtension,
                 codeFontFamily: input.codeFontFamily,
                 codeFontSize: input.codeFontSize,
                 theme: input.theme,
@@ -335,9 +337,21 @@ struct DiffPaneHunkRow: View {
                     state.toggleCollapsedContext(in: group)
                 }
             }
-            if let stage = actions.stage { hunkActionButton(systemName: "plus.square", tooltip: "Stage hunk", action: stage) }
-            if let discard = actions.discard { hunkActionButton(systemName: "trash", tooltip: "Discard hunk", action: discard) }
-            if let dropFromCommit = actions.dropFromCommit { hunkActionButton(systemName: "minus.circle", tooltip: "Drop from commit", action: dropFromCommit) }
+            if actions.stage != nil {
+                hunkActionButton(systemName: "plus.square", tooltip: "Stage hunk") {
+                    state.actionRelay.hunkActions(for: group.sourceHunk).stage?()
+                }
+            }
+            if actions.discard != nil {
+                hunkActionButton(systemName: "trash", tooltip: "Discard hunk") {
+                    state.actionRelay.hunkActions(for: group.sourceHunk).discard?()
+                }
+            }
+            if actions.dropFromCommit != nil {
+                hunkActionButton(systemName: "minus.circle", tooltip: "Drop from commit") {
+                    state.actionRelay.hunkActions(for: group.sourceHunk).dropFromCommit?()
+                }
+            }
         }
         .padding(.horizontal, 13)
         .padding(.vertical, 8)

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -102,6 +102,10 @@ struct DiffPaneHunkRowToken: Equatable {
     let threadSignatures: [DiffInlineCommentThread]
     let annotations: [DiffInlineAnnotation]
     let activeHighlight: DiffReviewCommentHighlight?
+    let allowsReviewLineSelection: Bool
+    let canReply: Bool
+    let canResolve: Bool
+    let canAddToReview: Bool
     let actionPresence: DiffPaneHunkActionPresence
 }
 
@@ -162,6 +166,10 @@ enum DiffPaneRowPlanBuilder {
                 threadSignatures: hunkThreads,
                 annotations: hunkAnnotations,
                 activeHighlight: input.activeCommentHighlight,
+                allowsReviewLineSelection: input.allowsReviewLineSelection,
+                canReply: input.canReply,
+                canResolve: input.canResolve,
+                canAddToReview: input.canAddToReview,
                 actionPresence: .init(actions)
             )
             return AppKitDiffRowSpec(

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -173,12 +173,24 @@ enum DiffPaneRowPlanBuilder {
                     input: input,
                     fusion: fusion,
                     expandedCollapsedRowIDs: state.expandedCollapsedRowIDs
-                )
+                ),
+                retention: hunkRetention(for: hunkThreads, state: state)
             ) {
                 AnyView(DiffPaneHunkRow(group: group, fusion: fusion, input: input, state: state))
             }
         }
         return AppKitDiffRowPlan(rows: rows)
+    }
+
+    @MainActor
+    private static func hunkRetention(
+        for threads: [DiffInlineCommentThread],
+        state: DiffPanePresentationState
+    ) -> AppKitDiffRowRetention {
+        guard let activeThreadID = state.activeThreadID,
+              threads.contains(where: { $0.id == activeThreadID })
+        else { return .recyclable }
+        return .pinned
     }
 
     static func resolvedFusions(for input: DiffPaneRowPlanInput) -> [DiffPaneHunkFusionState] {

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -105,7 +105,12 @@ enum DiffPaneRowPlanBuilder {
                 id: "diff-hunk-\(group.id)",
                 ownerID: group.id,
                 equalityToken: .init(token),
-                estimatedHeight: estimatedHeight(for: group, input: input, fusion: fusion)
+                estimatedHeight: estimatedHeight(
+                    for: group,
+                    input: input,
+                    fusion: fusion,
+                    expandedCollapsedRowIDs: state.expandedCollapsedRowIDs
+                )
             ) {
                 AnyView(DiffPaneHunkRow(group: group, fusion: fusion, input: input, state: state))
             }
@@ -123,12 +128,13 @@ enum DiffPaneRowPlanBuilder {
     private static func estimatedHeight(
         for group: DiffDisplayGroup,
         input: DiffPaneRowPlanInput,
-        fusion: DiffPaneHunkFusionState
+        fusion: DiffPaneHunkFusionState,
+        expandedCollapsedRowIDs: Set<String>
     ) -> CGFloat {
         DiffPaneStaticHeightEstimator.estimatedHeight(
             for: .init(filePath: input.model.filePath, groups: [group]),
             layoutMode: input.layoutMode,
-            expandedCollapsedRowIDs: [],
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs,
             codeFont: CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize),
             headerFont: CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize - 1),
             wrapLines: input.wrapLines,

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -1,0 +1,308 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class DiffPanePresentationState: ObservableObject {
+    @Published private(set) var expandedCollapsedRowIDs: Set<String> = []
+    @Published private(set) var activeThreadID: String?
+
+    func toggleCollapsedContext(in group: DiffDisplayGroup) {
+        expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(
+            group,
+            expandedIDs: expandedCollapsedRowIDs
+        )
+    }
+
+    func setThreadActive(_ threadID: String, active: Bool) {
+        activeThreadID = active ? threadID : (activeThreadID == threadID ? nil : activeThreadID)
+    }
+}
+
+struct DiffPaneHunkActionPresence: Equatable {
+    let canStage: Bool
+    let canDiscard: Bool
+    let canDropFromCommit: Bool
+
+    init(_ actions: DiffPaneHunkActions) {
+        canStage = actions.stage != nil
+        canDiscard = actions.discard != nil
+        canDropFromCommit = actions.dropFromCommit != nil
+    }
+}
+
+struct DiffPaneHunkRowToken: Equatable {
+    let groupID: String
+    let rowsSignature: DiffDisplayRowsSignature
+    let fusion: DiffPaneHunkFusionState
+    let layoutMode: DiffLayoutMode
+    let wrapLines: Bool
+    let showWhitespace: Bool
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let threadSignatures: [DiffInlineCommentThread]
+    let annotations: [DiffInlineAnnotation]
+    let activeHighlight: DiffReviewCommentHighlight?
+    let actionPresence: DiffPaneHunkActionPresence
+}
+
+struct DiffPaneRowPlanInput {
+    let model: DiffDisplayModel
+    let fileExtension: String
+    let layoutMode: DiffLayoutMode
+    let wrapLines: Bool
+    let showWhitespace: Bool
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let theme: Theme
+    var lspContext: DiffPaneLSPContext? = nil
+    var activeCommentHighlight: DiffReviewCommentHighlight? = nil
+    var allowsReviewLineSelection: Bool = true
+    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+    var onContextExpansion: DiffContextExpansionHandler = { _, _, _ in }
+    var threads: [DiffInlineCommentThread] = []
+    var annotations: [DiffInlineAnnotation] = []
+    var onReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
+    var onResolve: (DiffInlineCommentThread) -> Void = { _ in }
+    var onUnresolve: (DiffInlineCommentThread) -> Void = { _ in }
+    var onEdit: (DiffInlineCommentThread, DiffInlineComment, String) -> Void = { _, _, _ in }
+    var onDelete: (DiffInlineCommentThread, DiffInlineComment) -> Void = { _, _ in }
+    var canReply: Bool = false
+    var canResolve: Bool = false
+    var onStageReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
+    var canAddToReview: Bool = false
+    var hunkFusionStates: [DiffPaneHunkFusionState]? = nil
+    let hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions
+}
+
+enum DiffPaneRowPlanBuilder {
+    @MainActor
+    static func build(input: DiffPaneRowPlanInput, state: DiffPanePresentationState) -> AppKitDiffRowPlan {
+        let fusions = resolvedFusions(for: input)
+        let rows = input.model.groups.enumerated().map { index, group in
+            let fusion = fusions[index]
+            let visibleRows = DiffPaneRowProjection.visibleRowsSnapshot(
+                in: group,
+                expandedCollapsedRowIDs: state.expandedCollapsedRowIDs
+            )
+            let hunkThreads = threads(for: visibleRows.rows, from: input.threads)
+            let hunkAnnotations = annotations(for: visibleRows.rows, from: input.annotations)
+            let actions = input.hunkActions(group.sourceHunk)
+            let token = DiffPaneHunkRowToken(
+                groupID: group.id,
+                rowsSignature: visibleRows.signature,
+                fusion: fusion,
+                layoutMode: input.layoutMode,
+                wrapLines: input.wrapLines,
+                showWhitespace: input.showWhitespace,
+                codeFontFamily: input.codeFontFamily,
+                codeFontSize: input.codeFontSize,
+                threadSignatures: hunkThreads,
+                annotations: hunkAnnotations,
+                activeHighlight: input.activeCommentHighlight,
+                actionPresence: .init(actions)
+            )
+            return AppKitDiffRowSpec(
+                id: "diff-hunk-\(group.id)",
+                ownerID: group.id,
+                equalityToken: .init(token),
+                estimatedHeight: estimatedHeight(for: group, input: input, fusion: fusion)
+            ) {
+                AnyView(DiffPaneHunkRow(group: group, fusion: fusion, input: input, state: state))
+            }
+        }
+        return AppKitDiffRowPlan(rows: rows)
+    }
+
+    static func resolvedFusions(for input: DiffPaneRowPlanInput) -> [DiffPaneHunkFusionState] {
+        if let states = input.hunkFusionStates, states.count == input.model.groups.count {
+            return states
+        }
+        return DiffPaneHunkFusionResolver.states(for: input.model.groups)
+    }
+
+    private static func estimatedHeight(
+        for group: DiffDisplayGroup,
+        input: DiffPaneRowPlanInput,
+        fusion: DiffPaneHunkFusionState
+    ) -> CGFloat {
+        DiffPaneStaticHeightEstimator.estimatedHeight(
+            for: .init(filePath: input.model.filePath, groups: [group]),
+            layoutMode: input.layoutMode,
+            expandedCollapsedRowIDs: [],
+            codeFont: CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize),
+            headerFont: CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize - 1),
+            wrapLines: input.wrapLines,
+            showWhitespace: input.showWhitespace,
+            fusionStates: [fusion]
+        )
+    }
+
+    static func threads(for rows: [DiffDisplayRow], from threads: [DiffInlineCommentThread]) -> [DiffInlineCommentThread] {
+        let oldLines = Set(rows.compactMap { $0.old?.anchor.oldLine })
+        let newLines = Set(rows.compactMap { $0.new?.anchor.newLine })
+        return threads.filter { thread in
+            thread.isOldSide
+                ? oldLines.contains(where: { thread.lineRange.contains($0) })
+                : newLines.contains(where: { thread.lineRange.contains($0) })
+        }
+    }
+
+    static func annotations(for rows: [DiffDisplayRow], from annotations: [DiffInlineAnnotation]) -> [DiffInlineAnnotation] {
+        let newLines = Set(rows.compactMap { $0.new?.anchor.newLine })
+        return annotations.filter { newLines.contains($0.newLine) }
+    }
+}
+
+struct DiffPaneHunkRow: View {
+    let group: DiffDisplayGroup
+    let fusion: DiffPaneHunkFusionState
+    let input: DiffPaneRowPlanInput
+    @ObservedObject var state: DiffPanePresentationState
+
+    var body: some View {
+        let visibleRowsSnapshot = DiffPaneRowProjection.visibleRowsSnapshot(
+            in: group,
+            expandedCollapsedRowIDs: state.expandedCollapsedRowIDs
+        )
+        let visibleRows = visibleRowsSnapshot.rows
+        let hunkThreads = DiffPaneRowPlanBuilder.threads(for: visibleRows, from: input.threads)
+        let hunkAnnotations = DiffPaneRowPlanBuilder.annotations(for: visibleRows, from: input.annotations)
+        let blocks = DiffInlineCommentLayout.blocks(
+            visibleRows: visibleRowsSnapshot,
+            threads: hunkThreads,
+            annotations: hunkAnnotations
+        )
+
+        VStack(alignment: .leading, spacing: 0) {
+            hunkHeader
+            ForEach(blocks) { block in
+                switch block {
+                case .rows(let segment):
+                    DiffPaneSegmentView(
+                        rows: segment.rows,
+                        rowsSignature: segment.rowsSignature,
+                        layoutMode: input.layoutMode,
+                        wrapLines: input.wrapLines,
+                        showWhitespace: input.showWhitespace,
+                        fileExtension: input.fileExtension,
+                        codeFontFamily: input.codeFontFamily,
+                        codeFontSize: input.codeFontSize,
+                        theme: input.theme,
+                        lspContext: input.lspContext,
+                        activeCommentHighlight: activeHighlight(for: segment.rows),
+                        allowsReviewLineSelection: input.allowsReviewLineSelection,
+                        onReviewLineSelected: input.onReviewLineSelected,
+                        onContextExpansion: input.onContextExpansion
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                case .thread(let thread):
+                    DiffFeedbackLaneView(
+                        lane: DiffFeedbackLaneResolver.lane(for: thread),
+                        layoutMode: input.layoutMode,
+                        rows: visibleRows
+                    ) {
+                        DiffInlineCommentCard(
+                            thread: thread,
+                            onReply: { input.onReply(thread, $0) },
+                            onStageReply: { input.onStageReply(thread, $0) },
+                            onResolve: { input.onResolve(thread) },
+                            onUnresolve: { input.onUnresolve(thread) },
+                            onEdit: { comment, body in input.onEdit(thread, comment, body) },
+                            onDelete: { input.onDelete(thread, $0) },
+                            canReply: input.canReply && thread.viewerCanReply,
+                            canResolve: input.canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
+                            canAddToReview: input.canAddToReview,
+                            onActiveChange: { state.setThreadActive(thread.id, active: $0) }
+                        )
+                    }
+                case .annotation(let annotation):
+                    DiffFeedbackLaneView(
+                        lane: DiffFeedbackLaneResolver.lane(for: annotation),
+                        layoutMode: input.layoutMode,
+                        rows: visibleRows
+                    ) {
+                        DiffInlineAnnotationCard(annotation: annotation)
+                    }
+                }
+            }
+        }
+        .background(input.theme.color("bg-1"))
+        .clipShape(DiffPaneHunkCardShape(fusion: fusion))
+        .overlay(DiffPaneHunkCardShape(fusion: fusion).stroke(input.theme.color("line"), lineWidth: 0.75))
+        .padding(.bottom, fusion.bottomPadding)
+    }
+
+    private var hunkHeader: some View {
+        let actions = input.hunkActions(group.sourceHunk)
+        return HStack(spacing: 8) {
+            Text(group.header)
+                .font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize - 1))
+                .foregroundColor(input.theme.color("fg-muted"))
+                .lineLimit(1)
+            Spacer(minLength: 12)
+            if !DiffCollapsedContextController.collapsedRowIDs(in: group).isEmpty {
+                let expanded = DiffCollapsedContextController.isExpanded(group, expandedIDs: state.expandedCollapsedRowIDs)
+                hunkActionButton(systemName: expanded ? "minus.square" : "plus.square", tooltip: expanded ? "Collapse context" : "Expand context") {
+                    state.toggleCollapsedContext(in: group)
+                }
+            }
+            if let stage = actions.stage { hunkActionButton(systemName: "plus.square", tooltip: "Stage hunk", action: stage) }
+            if let discard = actions.discard { hunkActionButton(systemName: "trash", tooltip: "Discard hunk", action: discard) }
+            if let dropFromCommit = actions.dropFromCommit { hunkActionButton(systemName: "minus.circle", tooltip: "Drop from commit", action: dropFromCommit) }
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 8)
+        .background(input.theme.color("bg-2"))
+        .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+
+    private func activeHighlight(for rows: [DiffDisplayRow]) -> DiffReviewCommentHighlight? {
+        DiffPaneActiveHighlightResolver.activeHighlight(
+            parentHighlight: input.activeCommentHighlight,
+            threads: input.threads,
+            activeThreadID: state.activeThreadID,
+            rows: rows
+        )
+    }
+
+    private func hunkActionButton(systemName: String, tooltip: String, action: @escaping () -> Void) -> some View {
+        DiffPaneActionButton(systemName: systemName, tooltip: tooltip, action: action)
+            .frame(width: 22, height: 20)
+    }
+}
+
+struct DiffPaneActionButton: NSViewRepresentable {
+    let systemName: String
+    let tooltip: String
+    let action: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(action: action) }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton(image: image(), target: context.coordinator, action: #selector(Coordinator.fire))
+        button.bezelStyle = .accessoryBar
+        button.isBordered = false
+        button.imagePosition = .imageOnly
+        button.contentTintColor = .secondaryLabelColor
+        button.toolTip = tooltip
+        button.setAccessibilityLabel(tooltip)
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.action = action
+        button.image = image()
+        button.toolTip = tooltip
+        button.setAccessibilityLabel(tooltip)
+    }
+
+    private func image() -> NSImage {
+        NSImage(systemSymbolName: systemName, accessibilityDescription: tooltip) ?? NSImage()
+    }
+
+    final class Coordinator: NSObject {
+        var action: () -> Void
+        init(action: @escaping () -> Void) { self.action = action }
+        @objc func fire() { action() }
+    }
+}

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -72,6 +72,22 @@ struct DiffPaneHunkActionPresence: Equatable {
     }
 }
 
+struct DiffPaneLSPContextToken: Equatable {
+    let worktreeId: String
+    let worktreeRoot: URL
+    let relativePath: String
+    let language: String
+    let lspManagerIdentity: ObjectIdentifier
+
+    init(_ context: DiffPaneLSPContext) {
+        worktreeId = context.worktreeId
+        worktreeRoot = context.worktreeRoot
+        relativePath = context.relativePath
+        language = context.language
+        lspManagerIdentity = ObjectIdentifier(context.lsp)
+    }
+}
+
 struct DiffPaneHunkRowToken: Equatable {
     let groupID: String
     let rowsSignature: DiffDisplayRowsSignature
@@ -82,6 +98,7 @@ struct DiffPaneHunkRowToken: Equatable {
     let codeFontFamily: String
     let codeFontSize: CGFloat
     let theme: Theme
+    let lspContext: DiffPaneLSPContextToken?
     let threadSignatures: [DiffInlineCommentThread]
     let annotations: [DiffInlineAnnotation]
     let activeHighlight: DiffReviewCommentHighlight?
@@ -141,6 +158,7 @@ enum DiffPaneRowPlanBuilder {
                 codeFontFamily: input.codeFontFamily,
                 codeFontSize: input.codeFontSize,
                 theme: input.theme,
+                lspContext: input.lspContext.map(DiffPaneLSPContextToken.init),
                 threadSignatures: hunkThreads,
                 annotations: hunkAnnotations,
                 activeHighlight: input.activeCommentHighlight,

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -14,6 +14,10 @@ final class DiffPanePresentationState: ObservableObject {
         )
     }
 
+    func setExpandedCollapsedRowIDs(_ rowIDs: Set<String>) {
+        expandedCollapsedRowIDs = rowIDs
+    }
+
     func setThreadActive(_ threadID: String, active: Bool) {
         activeThreadID = active ? threadID : (activeThreadID == threadID ? nil : activeThreadID)
     }

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -77,6 +77,7 @@ struct DiffPaneHunkRowToken: Equatable {
     let showWhitespace: Bool
     let codeFontFamily: String
     let codeFontSize: CGFloat
+    let theme: Theme
     let threadSignatures: [DiffInlineCommentThread]
     let annotations: [DiffInlineAnnotation]
     let activeHighlight: DiffReviewCommentHighlight?
@@ -135,6 +136,7 @@ enum DiffPaneRowPlanBuilder {
                 showWhitespace: input.showWhitespace,
                 codeFontFamily: input.codeFontFamily,
                 codeFontSize: input.codeFontSize,
+                theme: input.theme,
                 threadSignatures: hunkThreads,
                 annotations: hunkAnnotations,
                 activeHighlight: input.activeCommentHighlight,

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 @MainActor
 final class DiffPanePresentationState: ObservableObject {
+    let actionRelay = DiffPaneActionRelay()
     @Published private(set) var expandedCollapsedRowIDs: Set<String> = []
     @Published private(set) var activeThreadID: String?
 
@@ -16,6 +17,43 @@ final class DiffPanePresentationState: ObservableObject {
     func setThreadActive(_ threadID: String, active: Bool) {
         activeThreadID = active ? threadID : (activeThreadID == threadID ? nil : activeThreadID)
     }
+}
+
+@MainActor
+final class DiffPaneActionRelay {
+    private var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+    private var onContextExpansion: DiffContextExpansionHandler = { _, _, _ in }
+    private var onReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
+    private var onResolve: (DiffInlineCommentThread) -> Void = { _ in }
+    private var onUnresolve: (DiffInlineCommentThread) -> Void = { _ in }
+    private var onEdit: (DiffInlineCommentThread, DiffInlineComment, String) -> Void = { _, _, _ in }
+    private var onDelete: (DiffInlineCommentThread, DiffInlineComment) -> Void = { _, _ in }
+    private var onStageReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
+    private var hunkActions: (ParsedDiff.Hunk) -> DiffPaneHunkActions = { _ in .init() }
+
+    func update(from input: DiffPaneRowPlanInput) {
+        onReviewLineSelected = input.onReviewLineSelected
+        onContextExpansion = input.onContextExpansion
+        onReply = input.onReply
+        onResolve = input.onResolve
+        onUnresolve = input.onUnresolve
+        onEdit = input.onEdit
+        onDelete = input.onDelete
+        onStageReply = input.onStageReply
+        hunkActions = input.hunkActions
+    }
+
+    func reviewLineSelected(_ anchor: DiffReviewLineAnchor) { onReviewLineSelected(anchor) }
+    func expandContext(_ key: DiffContextExpansionKey, _ mode: DiffContextExpansionMode, _ edge: DiffContextExpansionEdge?) {
+        onContextExpansion(key, mode, edge)
+    }
+    func reply(to thread: DiffInlineCommentThread, body: String) { onReply(thread, body) }
+    func resolve(_ thread: DiffInlineCommentThread) { onResolve(thread) }
+    func unresolve(_ thread: DiffInlineCommentThread) { onUnresolve(thread) }
+    func edit(_ thread: DiffInlineCommentThread, _ comment: DiffInlineComment, body: String) { onEdit(thread, comment, body) }
+    func delete(_ thread: DiffInlineCommentThread, _ comment: DiffInlineComment) { onDelete(thread, comment) }
+    func stageReply(to thread: DiffInlineCommentThread, body: String) { onStageReply(thread, body) }
+    func hunkActions(for hunk: ParsedDiff.Hunk) -> DiffPaneHunkActions { hunkActions(hunk) }
 }
 
 struct DiffPaneHunkActionPresence: Equatable {
@@ -77,6 +115,7 @@ struct DiffPaneRowPlanInput {
 enum DiffPaneRowPlanBuilder {
     @MainActor
     static func build(input: DiffPaneRowPlanInput, state: DiffPanePresentationState) -> AppKitDiffRowPlan {
+        state.actionRelay.update(from: input)
         let fusions = resolvedFusions(for: input)
         let rows = input.model.groups.enumerated().map { index, group in
             let fusion = fusions[index]
@@ -86,7 +125,7 @@ enum DiffPaneRowPlanBuilder {
             )
             let hunkThreads = threads(for: visibleRows.rows, from: input.threads)
             let hunkAnnotations = annotations(for: visibleRows.rows, from: input.annotations)
-            let actions = input.hunkActions(group.sourceHunk)
+            let actions = state.actionRelay.hunkActions(for: group.sourceHunk)
             let token = DiffPaneHunkRowToken(
                 groupID: group.id,
                 rowsSignature: visibleRows.signature,
@@ -197,8 +236,8 @@ struct DiffPaneHunkRow: View {
                         lspContext: input.lspContext,
                         activeCommentHighlight: activeHighlight(for: segment.rows),
                         allowsReviewLineSelection: input.allowsReviewLineSelection,
-                        onReviewLineSelected: input.onReviewLineSelected,
-                        onContextExpansion: input.onContextExpansion
+                        onReviewLineSelected: state.actionRelay.reviewLineSelected,
+                        onContextExpansion: state.actionRelay.expandContext
                     )
                     .fixedSize(horizontal: false, vertical: true)
                 case .thread(let thread):
@@ -209,12 +248,12 @@ struct DiffPaneHunkRow: View {
                     ) {
                         DiffInlineCommentCard(
                             thread: thread,
-                            onReply: { input.onReply(thread, $0) },
-                            onStageReply: { input.onStageReply(thread, $0) },
-                            onResolve: { input.onResolve(thread) },
-                            onUnresolve: { input.onUnresolve(thread) },
-                            onEdit: { comment, body in input.onEdit(thread, comment, body) },
-                            onDelete: { input.onDelete(thread, $0) },
+                            onReply: { state.actionRelay.reply(to: thread, body: $0) },
+                            onStageReply: { state.actionRelay.stageReply(to: thread, body: $0) },
+                            onResolve: { state.actionRelay.resolve(thread) },
+                            onUnresolve: { state.actionRelay.unresolve(thread) },
+                            onEdit: { comment, body in state.actionRelay.edit(thread, comment, body: body) },
+                            onDelete: { state.actionRelay.delete(thread, $0) },
                             canReply: input.canReply && thread.viewerCanReply,
                             canResolve: input.canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
                             canAddToReview: input.canAddToReview,
@@ -239,7 +278,7 @@ struct DiffPaneHunkRow: View {
     }
 
     private var hunkHeader: some View {
-        let actions = input.hunkActions(group.sourceHunk)
+        let actions = state.actionRelay.hunkActions(for: group.sourceHunk)
         return HStack(spacing: 8) {
             Text(group.header)
                 .font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize - 1))

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -47,6 +47,8 @@ final class AppKitDiffReviewFileState: ObservableObject {
     @Published var imageState = DiffReviewImageState()
     @Published var hoveredInlineFeedbackID: String? { didSet { structuralDidChange.send() } }
     @Published var hoveredDraftCommentID: String? { didSet { structuralDidChange.send() } }
+    @Published var activeInlineFeedbackEditorID: String? { didSet { structuralDidChange.send() } }
+    @Published var activeDraftCommentEditorID: String? { didSet { structuralDidChange.send() } }
     @Published var activeThreadID: String? { didSet { structuralDidChange.send() } }
     @Published var showFullDiffOverride = false { didSet { structuralDidChange.send() } }
     @Published var isDraftComposerFocused = false { didSet { structuralDidChange.send() } }
@@ -92,6 +94,8 @@ final class AppKitDiffReviewFileState: ObservableObject {
         expandedCollapsedRowIDs = []
         hoveredInlineFeedbackID = nil
         hoveredDraftCommentID = nil
+        activeInlineFeedbackEditorID = nil
+        activeDraftCommentEditorID = nil
         activeThreadID = nil
         showFullDiffOverride = false
         isDraftComposerFocused = false

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -163,6 +163,10 @@ final class AppKitDiffReviewActionRelay {
         self.inlineFeedbackActions = inlineFeedbackActions
     }
 
+    func update(draftCommentActions: ReviewDraftCommentActions) {
+        self.draftCommentActions = draftCommentActions
+    }
+
     var inlineFeedbackActionsForRow: DiffReviewInlineFeedbackActions {
         DiffReviewInlineFeedbackActions(
             availability: { item, file in self.inlineFeedbackActions.availability(item, file) },

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -32,7 +32,10 @@ final class AppKitDiffReviewFileState: ObservableObject {
     @Published var pendingDraftAnchor: DiffReviewLineAnchor? { didSet { structuralDidChange.send() } }
     @Published var pendingDraftBody = ""
     @Published var draftComposerFocusRequestGeneration = 0 { didSet { structuralDidChange.send() } }
-    @Published var expandedCollapsedRowIDs: Set<String> = [] { didSet { structuralDidChange.send() } }
+    var expandedCollapsedRowIDs: Set<String> {
+        get { hunkPresentationState.expandedCollapsedRowIDs }
+        set { hunkPresentationState.setExpandedCollapsedRowIDs(newValue) }
+    }
     @Published var contextSnapshot: DiffReviewFileContextSnapshot? { didSet { structuralDidChange.send() } }
     @Published var contextExpansion = DiffContextExpansionState() { didSet { structuralDidChange.send() } }
     @Published var contextLoadTask: Task<Void, Never>?
@@ -52,10 +55,15 @@ final class AppKitDiffReviewFileState: ObservableObject {
     private var contextSignature: DiffReviewContextStateSignature?
     private var renderBudgetSignal: Int?
     private var copyFeedbackCancellable: AnyCancellable?
+    private var hunkPresentationCancellable: AnyCancellable?
 
     init() {
         copyFeedbackCancellable = copyFeedback.$message.sink { [weak self] _ in
             self?.objectWillChange.send()
+            self?.structuralDidChange.send()
+        }
+        hunkPresentationCancellable = hunkPresentationState.$expandedCollapsedRowIDs.sink { [weak self] _ in
+            self?.structuralDidChange.send()
         }
     }
 
@@ -66,6 +74,7 @@ final class AppKitDiffReviewFileState: ObservableObject {
         }
         if self.contextSignature != nil, self.contextSignature != contextSignature {
             resetContextState()
+            clearPendingDraft()
         }
         self.contextSignature = contextSignature
     }
@@ -78,8 +87,7 @@ final class AppKitDiffReviewFileState: ObservableObject {
     }
 
     func resetForFileIdentityChange() {
-        pendingDraftAnchor = nil
-        pendingDraftBody = ""
+        clearPendingDraft()
         draftComposerFocusRequestGeneration = 0
         expandedCollapsedRowIDs = []
         hoveredInlineFeedbackID = nil
@@ -89,6 +97,11 @@ final class AppKitDiffReviewFileState: ObservableObject {
         isDraftComposerFocused = false
         imageState.clear()
         resetContextState()
+    }
+
+    func clearPendingDraft() {
+        pendingDraftAnchor = nil
+        pendingDraftBody = ""
     }
 
     func resetForRenderBudgetChange() {

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -10,7 +10,7 @@ final class AppKitDiffReviewPresentationStore: ObservableObject {
         if let state = states[file.id] { return state }
         let state = AppKitDiffReviewFileState()
         states[file.id] = state
-        stateCancellables[file.id] = state.objectWillChange.sink { [weak self] _ in
+        stateCancellables[file.id] = state.structuralDidChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }
         return state
@@ -24,28 +24,29 @@ final class AppKitDiffReviewPresentationStore: ObservableObject {
 
 @MainActor
 final class AppKitDiffReviewFileState: ObservableObject {
+    let structuralDidChange = PassthroughSubject<Void, Never>()
     let copyFeedback = CopyFeedbackState()
     let renderContextCache = DiffReviewRenderContextCache()
     let actionRelay = AppKitDiffReviewActionRelay()
     let hunkPresentationState = DiffPanePresentationState()
-    @Published var pendingDraftAnchor: DiffReviewLineAnchor?
+    @Published var pendingDraftAnchor: DiffReviewLineAnchor? { didSet { structuralDidChange.send() } }
     @Published var pendingDraftBody = ""
-    @Published var draftComposerFocusRequestGeneration = 0
-    @Published var expandedCollapsedRowIDs: Set<String> = []
-    @Published var contextSnapshot: DiffReviewFileContextSnapshot?
-    @Published var contextExpansion = DiffContextExpansionState()
+    @Published var draftComposerFocusRequestGeneration = 0 { didSet { structuralDidChange.send() } }
+    @Published var expandedCollapsedRowIDs: Set<String> = [] { didSet { structuralDidChange.send() } }
+    @Published var contextSnapshot: DiffReviewFileContextSnapshot? { didSet { structuralDidChange.send() } }
+    @Published var contextExpansion = DiffContextExpansionState() { didSet { structuralDidChange.send() } }
     @Published var contextLoadTask: Task<Void, Never>?
     @Published var contextLoadFileID: DiffReviewFileID?
     @Published var contextLoadSignature: DiffReviewContextStateSignature?
     @Published var contextLoadGeneration = 0
-    @Published var contextLoadError: String?
+    @Published var contextLoadError: String? { didSet { structuralDidChange.send() } }
     @Published var pendingContextExpansions: [PendingContextExpansion] = []
     @Published var imageState = DiffReviewImageState()
     @Published var hoveredInlineFeedbackID: String?
     @Published var hoveredDraftCommentID: String?
-    @Published var activeThreadID: String?
-    @Published var showFullDiffOverride = false
-    @Published var isDraftComposerFocused = false
+    @Published var activeThreadID: String? { didSet { structuralDidChange.send() } }
+    @Published var showFullDiffOverride = false { didSet { structuralDidChange.send() } }
+    @Published var isDraftComposerFocused = false { didSet { structuralDidChange.send() } }
 
     private var fileID: DiffReviewFileID?
     private var contextSignature: DiffReviewContextStateSignature?
@@ -132,6 +133,8 @@ final class AppKitDiffReviewActionRelay {
     private var onEdit: (DiffInlineCommentThread, DiffInlineComment, String) -> Void = { _, _, _ in }
     private var onDelete: (DiffInlineCommentThread, DiffInlineComment) -> Void = { _, _ in }
     private var onStageReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
+    private var stagedMutationActions: DiffReviewStagedMutationActions?
+    private var openFile: (() -> Void)?
 
     func update(
         inlineFeedbackActions: DiffReviewInlineFeedbackActions,
@@ -171,6 +174,15 @@ final class AppKitDiffReviewActionRelay {
 
     func update(draftCommentActions: ReviewDraftCommentActions) {
         self.draftCommentActions = draftCommentActions
+    }
+
+    func update(stagedMutationActions: DiffReviewStagedMutationActions?, openFile: (() -> Void)? = nil) {
+        self.stagedMutationActions = stagedMutationActions
+        self.openFile = openFile
+    }
+
+    func update(onContextExpansionActivated: @escaping () -> Void) {
+        self.onContextExpansionActivated = onContextExpansionActivated
     }
 
     var inlineFeedbackActionsForRow: DiffReviewInlineFeedbackActions {
@@ -226,4 +238,10 @@ final class AppKitDiffReviewActionRelay {
     func unresolve(_ thread: DiffInlineCommentThread) { onUnresolve(thread) }
     func edit(_ comment: DiffInlineComment, in thread: DiffInlineCommentThread, body: String) { onEdit(thread, comment, body) }
     func delete(_ comment: DiffInlineComment, in thread: DiffInlineCommentThread) { onDelete(thread, comment) }
+    func openCurrentFile() { openFile?() }
+    func unstageFile() { stagedMutationActions?.unstageFile?() }
+    func hunkActions(for hunk: ParsedDiff.Hunk) -> DiffPaneHunkActions {
+        let enabled = stagedMutationActions?.isHunkUnstageEnabled?(hunk) ?? false
+        return .init(dropFromCommit: enabled ? { self.stagedMutationActions?.unstageHunk?(hunk) } : nil)
+    }
 }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -50,6 +50,9 @@ final class AppKitDiffReviewFileState: ObservableObject {
     @Published var activeInlineFeedbackEditorID: String? { didSet { structuralDidChange.send() } }
     @Published var activeDraftCommentEditorID: String? { didSet { structuralDidChange.send() } }
     @Published var activeThreadID: String? { didSet { structuralDidChange.send() } }
+    @Published var inlineFeedbackReplyEditors: [String: DiffReviewInlineFeedbackReplyEditorState] = [:]
+    @Published var draftCommentEditors: [String: ReviewDraftCommentEditorState] = [:]
+    @Published var threadCommentEditors: [String: DiffInlineCommentCardEditorState] = [:]
     @Published var showFullDiffOverride = false { didSet { structuralDidChange.send() } }
     @Published var isDraftComposerFocused = false { didSet { structuralDidChange.send() } }
 
@@ -101,6 +104,9 @@ final class AppKitDiffReviewFileState: ObservableObject {
         activeInlineFeedbackEditorID = nil
         activeDraftCommentEditorID = nil
         activeThreadID = nil
+        inlineFeedbackReplyEditors = [:]
+        draftCommentEditors = [:]
+        threadCommentEditors = [:]
         showFullDiffOverride = false
         isDraftComposerFocused = false
         imageState.clear()
@@ -126,6 +132,27 @@ final class AppKitDiffReviewFileState: ObservableObject {
         contextLoadSignature = nil
         contextLoadError = nil
         pendingContextExpansions = []
+    }
+
+    func bindingForInlineFeedbackReplyEditor(_ id: String) -> Binding<DiffReviewInlineFeedbackReplyEditorState> {
+        Binding(
+            get: { self.inlineFeedbackReplyEditors[id] ?? DiffReviewInlineFeedbackReplyEditorState() },
+            set: { self.inlineFeedbackReplyEditors[id] = $0 }
+        )
+    }
+
+    func bindingForDraftCommentEditor(_ id: String) -> Binding<ReviewDraftCommentEditorState> {
+        Binding(
+            get: { self.draftCommentEditors[id] ?? ReviewDraftCommentEditorState() },
+            set: { self.draftCommentEditors[id] = $0 }
+        )
+    }
+
+    func bindingForThreadCommentEditor(_ id: String) -> Binding<DiffInlineCommentCardEditorState> {
+        Binding(
+            get: { self.threadCommentEditors[id] ?? DiffInlineCommentCardEditorState() },
+            set: { self.threadCommentEditors[id] = $0 }
+        )
     }
 
     func beginContextLoad(fileID: DiffReviewFileID, signature: DiffReviewContextStateSignature) -> Int {

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -1,0 +1,161 @@
+import Combine
+import SwiftUI
+
+@MainActor
+final class AppKitDiffReviewPresentationStore: ObservableObject {
+    private var states: [DiffReviewFileID: AppKitDiffReviewFileState] = [:]
+
+    func state(for file: DiffReviewFileSectionModel) -> AppKitDiffReviewFileState {
+        if let state = states[file.id] { return state }
+        let state = AppKitDiffReviewFileState()
+        states[file.id] = state
+        return state
+    }
+
+    func prune(keeping fileIDs: Set<DiffReviewFileID>) {
+        states = states.filter { fileIDs.contains($0.key) }
+    }
+}
+
+@MainActor
+final class AppKitDiffReviewFileState: ObservableObject {
+    let copyFeedback = CopyFeedbackState()
+    let renderContextCache = DiffReviewRenderContextCache()
+    let actionRelay = AppKitDiffReviewActionRelay()
+    @Published var pendingDraftAnchor: DiffReviewLineAnchor?
+    @Published var pendingDraftBody = ""
+    @Published var draftComposerFocusRequestGeneration = 0
+    @Published var expandedCollapsedRowIDs: Set<String> = []
+    @Published var contextSnapshot: DiffReviewFileContextSnapshot?
+    @Published var contextExpansion = DiffContextExpansionState()
+    @Published var contextLoadTask: Task<Void, Never>?
+    @Published var contextLoadFileID: DiffReviewFileID?
+    @Published var contextLoadSignature: DiffReviewContextStateSignature?
+    @Published var contextLoadGeneration = 0
+    @Published var contextLoadError: String?
+    @Published var pendingContextExpansions: [PendingContextExpansion] = []
+    @Published var imageState = DiffReviewImageState()
+    @Published var hoveredInlineFeedbackID: String?
+    @Published var hoveredDraftCommentID: String?
+    @Published var activeThreadID: String?
+    @Published var showFullDiffOverride = false
+    @Published var isDraftComposerFocused = false
+
+    private var fileID: DiffReviewFileID?
+    private var contextSignature: DiffReviewContextStateSignature?
+    private var renderBudgetSignal: Int?
+
+    func synchronize(file: DiffReviewFileSectionModel, contextSignature: DiffReviewContextStateSignature) {
+        if fileID != file.id {
+            resetForFileIdentityChange()
+            fileID = file.id
+        }
+        if self.contextSignature != nil, self.contextSignature != contextSignature {
+            resetContextState()
+        }
+        self.contextSignature = contextSignature
+    }
+
+    func synchronizeRenderBudget(resetSignal: Int?) {
+        if renderBudgetSignal != nil, renderBudgetSignal != resetSignal {
+            resetForRenderBudgetChange()
+        }
+        renderBudgetSignal = resetSignal
+    }
+
+    func resetForFileIdentityChange() {
+        pendingDraftAnchor = nil
+        pendingDraftBody = ""
+        draftComposerFocusRequestGeneration = 0
+        expandedCollapsedRowIDs = []
+        hoveredInlineFeedbackID = nil
+        hoveredDraftCommentID = nil
+        activeThreadID = nil
+        showFullDiffOverride = false
+        isDraftComposerFocused = false
+        imageState.clear()
+        resetContextState()
+    }
+
+    func resetForRenderBudgetChange() {
+        showFullDiffOverride = false
+    }
+
+    func resetContextState() {
+        contextLoadTask?.cancel()
+        contextLoadGeneration &+= 1
+        contextSnapshot = nil
+        contextExpansion = DiffContextExpansionState()
+        contextLoadTask = nil
+        contextLoadFileID = nil
+        contextLoadSignature = nil
+        contextLoadError = nil
+        pendingContextExpansions = []
+    }
+
+    func beginContextLoad(fileID: DiffReviewFileID, signature: DiffReviewContextStateSignature) -> Int {
+        contextLoadGeneration &+= 1
+        contextLoadFileID = fileID
+        contextLoadSignature = signature
+        return contextLoadGeneration
+    }
+
+    func acceptsContextResult(fileID: DiffReviewFileID, generation: Int) -> Bool {
+        contextLoadGeneration == generation && contextLoadFileID == fileID
+    }
+}
+
+@MainActor
+final class AppKitDiffReviewActionRelay {
+    private var inlineFeedbackActions = DiffReviewInlineFeedbackActions()
+    private var onSelectInlineFeedback: (DiffReviewInlineFeedback) -> Void = { _ in }
+    private var draftCommentActions = ReviewDraftCommentActions()
+    private var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
+    private var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+    private var onContextExpansionActivated: () -> Void = {}
+    private var onReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
+    private var onResolve: (DiffInlineCommentThread) -> Void = { _ in }
+    private var onUnresolve: (DiffInlineCommentThread) -> Void = { _ in }
+    private var onEdit: (DiffInlineCommentThread, DiffInlineComment, String) -> Void = { _, _, _ in }
+    private var onDelete: (DiffInlineCommentThread, DiffInlineComment) -> Void = { _, _ in }
+    private var onStageReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
+
+    func update(
+        inlineFeedbackActions: DiffReviewInlineFeedbackActions,
+        onSelectInlineFeedback: @escaping (DiffReviewInlineFeedback) -> Void,
+        draftCommentActions: ReviewDraftCommentActions,
+        onSelectDraftComment: @escaping (ReviewDraftComment) -> Void,
+        onSaveDraftComment: @escaping (DiffReviewLineAnchor, String) -> Void,
+        onContextExpansionActivated: @escaping () -> Void,
+        onReply: @escaping (DiffInlineCommentThread, String) -> Void,
+        onResolve: @escaping (DiffInlineCommentThread) -> Void,
+        onUnresolve: @escaping (DiffInlineCommentThread) -> Void,
+        onEdit: @escaping (DiffInlineCommentThread, DiffInlineComment, String) -> Void,
+        onDelete: @escaping (DiffInlineCommentThread, DiffInlineComment) -> Void,
+        onStageReply: @escaping (DiffInlineCommentThread, String) -> Void
+    ) {
+        self.inlineFeedbackActions = inlineFeedbackActions
+        self.onSelectInlineFeedback = onSelectInlineFeedback
+        self.draftCommentActions = draftCommentActions
+        self.onSelectDraftComment = onSelectDraftComment
+        self.onSaveDraftComment = onSaveDraftComment
+        self.onContextExpansionActivated = onContextExpansionActivated
+        self.onReply = onReply
+        self.onResolve = onResolve
+        self.onUnresolve = onUnresolve
+        self.onEdit = onEdit
+        self.onDelete = onDelete
+        self.onStageReply = onStageReply
+    }
+
+    func update(onSelectInlineFeedback: @escaping (DiffReviewInlineFeedback) -> Void) {
+        self.onSelectInlineFeedback = onSelectInlineFeedback
+    }
+
+    func selectInlineFeedback(_ item: DiffReviewInlineFeedback) {
+        onSelectInlineFeedback(item)
+    }
+
+    func saveDraftComment(_ anchor: DiffReviewLineAnchor, body: String) { onSaveDraftComment(anchor, body) }
+    func contextExpansionActivated() { onContextExpansionActivated() }
+}

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -44,6 +44,13 @@ final class AppKitDiffReviewFileState: ObservableObject {
     private var fileID: DiffReviewFileID?
     private var contextSignature: DiffReviewContextStateSignature?
     private var renderBudgetSignal: Int?
+    private var copyFeedbackCancellable: AnyCancellable?
+
+    init() {
+        copyFeedbackCancellable = copyFeedback.$message.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
+    }
 
     func synchronize(file: DiffReviewFileSectionModel, contextSignature: DiffReviewContextStateSignature) {
         if fileID != file.id {
@@ -152,10 +159,50 @@ final class AppKitDiffReviewActionRelay {
         self.onSelectInlineFeedback = onSelectInlineFeedback
     }
 
+    func update(inlineFeedbackActions: DiffReviewInlineFeedbackActions) {
+        self.inlineFeedbackActions = inlineFeedbackActions
+    }
+
+    var inlineFeedbackActionsForRow: DiffReviewInlineFeedbackActions {
+        DiffReviewInlineFeedbackActions(
+            availability: { item, file in self.inlineFeedbackActions.availability(item, file) },
+            openProvider: { item, file in self.inlineFeedbackActions.openProvider(item, file) },
+            copyContext: { item, file in self.inlineFeedbackActions.copyContext(item, file) },
+            sendToAgent: { item, file in self.inlineFeedbackActions.sendToAgent(item, file) },
+            replyProvider: { item, file, body in self.inlineFeedbackActions.replyProvider(item, file, body) },
+            resolveProvider: { item, file in self.inlineFeedbackActions.resolveProvider(item, file) },
+            unresolveProvider: { item, file in self.inlineFeedbackActions.unresolveProvider(item, file) }
+        )
+    }
+
+    var draftCommentActionsForRow: ReviewDraftCommentActions {
+        ReviewDraftCommentActions(
+            availability: { comment in self.draftCommentActions.availability(comment) },
+            canPublishReview: { self.draftCommentActions.canPublishReview() },
+            edit: { comment, body in self.draftCommentActions.edit(comment, body) },
+            delete: { comment in self.draftCommentActions.delete(comment) },
+            resolve: { comment in self.draftCommentActions.resolve(comment) },
+            dismiss: { comment in self.draftCommentActions.dismiss(comment) },
+            copyPrompt: { bundle in self.draftCommentActions.copyPrompt(bundle) },
+            publishProvider: { comment in self.draftCommentActions.publishProvider(comment) },
+            publishReview: { self.draftCommentActions.publishReview() },
+            agent: { target in self.draftCommentActions.agent(target) },
+            agentTargets: { self.draftCommentActions.agentTargets() },
+            sendToAgent: { bundle, target in self.draftCommentActions.sendToAgent(bundle, target) }
+        )
+    }
+
     func selectInlineFeedback(_ item: DiffReviewInlineFeedback) {
         onSelectInlineFeedback(item)
     }
 
+    func selectDraftComment(_ comment: ReviewDraftComment) { onSelectDraftComment(comment) }
     func saveDraftComment(_ anchor: DiffReviewLineAnchor, body: String) { onSaveDraftComment(anchor, body) }
     func contextExpansionActivated() { onContextExpansionActivated() }
+    func reply(to thread: DiffInlineCommentThread, body: String) { onReply(thread, body) }
+    func stageReply(to thread: DiffInlineCommentThread, body: String) { onStageReply(thread, body) }
+    func resolve(_ thread: DiffInlineCommentThread) { onResolve(thread) }
+    func unresolve(_ thread: DiffInlineCommentThread) { onUnresolve(thread) }
+    func edit(_ comment: DiffInlineComment, in thread: DiffInlineCommentThread, body: String) { onEdit(thread, comment, body) }
+    func delete(_ comment: DiffInlineComment, in thread: DiffInlineCommentThread) { onDelete(thread, comment) }
 }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -4,16 +4,21 @@ import SwiftUI
 @MainActor
 final class AppKitDiffReviewPresentationStore: ObservableObject {
     private var states: [DiffReviewFileID: AppKitDiffReviewFileState] = [:]
+    private var stateCancellables: [DiffReviewFileID: AnyCancellable] = [:]
 
     func state(for file: DiffReviewFileSectionModel) -> AppKitDiffReviewFileState {
         if let state = states[file.id] { return state }
         let state = AppKitDiffReviewFileState()
         states[file.id] = state
+        stateCancellables[file.id] = state.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
         return state
     }
 
     func prune(keeping fileIDs: Set<DiffReviewFileID>) {
         states = states.filter { fileIDs.contains($0.key) }
+        stateCancellables = stateCancellables.filter { fileIDs.contains($0.key) }
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -22,6 +22,7 @@ final class AppKitDiffReviewFileState: ObservableObject {
     let copyFeedback = CopyFeedbackState()
     let renderContextCache = DiffReviewRenderContextCache()
     let actionRelay = AppKitDiffReviewActionRelay()
+    let hunkPresentationState = DiffPanePresentationState()
     @Published var pendingDraftAnchor: DiffReviewLineAnchor?
     @Published var pendingDraftBody = ""
     @Published var draftComposerFocusRequestGeneration = 0
@@ -194,6 +195,17 @@ final class AppKitDiffReviewActionRelay {
             agentTargets: { self.draftCommentActions.agentTargets() },
             sendToAgent: { bundle, target in self.draftCommentActions.sendToAgent(bundle, target) }
         )
+    }
+
+    func inlineFeedbackAvailability(
+        for item: DiffReviewInlineFeedback,
+        file: DiffReviewFileSummary
+    ) -> DiffReviewInlineFeedbackActionAvailability {
+        inlineFeedbackActions.availability(item, file)
+    }
+
+    func draftCommentAvailability(for comment: ReviewDraftComment) -> ReviewDraftCommentActionAvailability {
+        draftCommentActions.availability(comment)
     }
 
     func selectInlineFeedback(_ item: DiffReviewInlineFeedback) {

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -42,8 +42,8 @@ final class AppKitDiffReviewFileState: ObservableObject {
     @Published var contextLoadError: String? { didSet { structuralDidChange.send() } }
     @Published var pendingContextExpansions: [PendingContextExpansion] = []
     @Published var imageState = DiffReviewImageState()
-    @Published var hoveredInlineFeedbackID: String?
-    @Published var hoveredDraftCommentID: String?
+    @Published var hoveredInlineFeedbackID: String? { didSet { structuralDidChange.send() } }
+    @Published var hoveredDraftCommentID: String? { didSet { structuralDidChange.send() } }
     @Published var activeThreadID: String? { didSet { structuralDidChange.send() } }
     @Published var showFullDiffOverride = false { didSet { structuralDidChange.send() } }
     @Published var isDraftComposerFocused = false { didSet { structuralDidChange.send() } }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -58,6 +58,7 @@ final class AppKitDiffReviewFileState: ObservableObject {
     private var renderBudgetSignal: Int?
     private var copyFeedbackCancellable: AnyCancellable?
     private var hunkPresentationCancellable: AnyCancellable?
+    private var hunkActiveThreadCancellable: AnyCancellable?
 
     init() {
         copyFeedbackCancellable = copyFeedback.$message.sink { [weak self] _ in
@@ -65,6 +66,9 @@ final class AppKitDiffReviewFileState: ObservableObject {
             self?.structuralDidChange.send()
         }
         hunkPresentationCancellable = hunkPresentationState.$expandedCollapsedRowIDs.sink { [weak self] _ in
+            self?.structuralDidChange.send()
+        }
+        hunkActiveThreadCancellable = hunkPresentationState.$activeThreadID.sink { [weak self] _ in
             self?.structuralDidChange.send()
         }
     }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -410,9 +410,14 @@ enum AppKitDiffReviewRowPlanBuilder {
                 let rowInput = hunkInput(group: group, context: context, input: input, fusion: fusions[groupIndex])
                 let hunkPlan = DiffPaneRowPlanBuilder.build(input: rowInput, state: input.state.hunkPresentationState)
                 guard let hunk = hunkPlan.rows.first else { continue }
-                append(&rows, id: groupID, input: input, signature: String(reflecting: group.displayGroup.rowsSignature).hashValue, height: hunk.estimatedHeight) {
+                rows.append(.init(
+                    id: groupID,
+                    ownerID: input.file.id.rawValue,
+                    equalityToken: hunk.equalityToken,
+                    estimatedHeight: hunk.estimatedHeight
+                ) {
                     hunk.build()
-                }
+                })
                 continue
             }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -51,6 +51,7 @@ struct AppKitDiffReviewRowToken: Equatable {
     let lspManagerIdentity: ObjectIdentifier?
     let inlineFeedbackAvailability: DiffReviewInlineFeedbackActionAvailability?
     let draftCommentAvailability: ReviewDraftCommentActionAvailability?
+    let draftCommentAgentTargets: [ReviewFeedbackAgentTarget]
     let reviewFeedbackTarget: ReviewFeedbackTarget?
     let hoveredInlineFeedbackID: String?
     let hoveredDraftCommentID: String?
@@ -582,6 +583,8 @@ enum AppKitDiffReviewRowPlanBuilder {
             &rows, id: id, input: input, signature: String(reflecting: comment).hashValue, height: 112,
             retention: input.state.activeDraftCommentEditorID == comment.id ? .pinned : .recyclable,
             draftAvailability: input.state.actionRelay.draftCommentAvailability(for: comment),
+            draftAgentTargets: (input.draftCommentActions ?? input.state.actionRelay.draftCommentActionsForRow)
+                .agentTargets(),
             reviewFeedbackTarget: input.reviewFeedbackTarget
         ) {
             AnyView(AppKitDiffReviewDraftCommentRowBody(comment: comment, input: input))
@@ -614,6 +617,7 @@ enum AppKitDiffReviewRowPlanBuilder {
         signature: Int, height: CGFloat, retention: AppKitDiffRowRetention = .recyclable,
         inlineAvailability: DiffReviewInlineFeedbackActionAvailability? = nil,
         draftAvailability: ReviewDraftCommentActionAvailability? = nil,
+        draftAgentTargets: [ReviewFeedbackAgentTarget] = [],
         reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
         includesActiveHighlight: Bool = false,
         build: @escaping () -> AnyView
@@ -628,6 +632,7 @@ enum AppKitDiffReviewRowPlanBuilder {
             lspLanguage: input.lspContext?.language,
             lspManagerIdentity: input.lspContext.map { ObjectIdentifier($0.lsp) },
             inlineFeedbackAvailability: inlineAvailability, draftCommentAvailability: draftAvailability,
+            draftCommentAgentTargets: draftAgentTargets,
             reviewFeedbackTarget: reviewFeedbackTarget,
             hoveredInlineFeedbackID: includesActiveHighlight ? input.state.hoveredInlineFeedbackID : nil,
             hoveredDraftCommentID: includesActiveHighlight ? input.state.hoveredDraftCommentID : nil,

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -356,14 +356,26 @@ enum AppKitDiffReviewRowPlanBuilder {
                 }
             }
 
+            let automaticallyRendersByAggregateBudget = eligibility[index].automaticallyRendersDiff
             let individuallyDeferred = input.file.displayModel.map(DiffReviewRenderBudget.isOverBudget) ?? false
-            let isDeferred = (!input.automaticallyRendersDiff || !eligibility[index].automaticallyRendersDiff || individuallyDeferred)
+            let isAggregateDeferred = input.automaticallyRendersDiff && !automaticallyRendersByAggregateBudget && !individuallyDeferred
+            let isDeferred = (!input.automaticallyRendersDiff || !automaticallyRendersByAggregateBudget || individuallyDeferred)
                 && !input.state.showFullDiffOverride
             if isDeferred || (input.file.displayModel == nil && input.file.imageProvider == nil) {
                 let placeholderID = AppKitDiffReviewRowID.placeholder(fileID: fileID)
                 placeholderByFileID[fileID] = placeholderID
-                append(&rows, id: placeholderID, input: input, signature: placeholderSignature(input, deferred: isDeferred), height: 88) {
-                    AnyView(AppKitDiffReviewPlaceholderRowBody(input: input, isDeferred: isDeferred))
+                append(
+                    &rows,
+                    id: placeholderID,
+                    input: input,
+                    signature: placeholderSignature(input, deferred: isDeferred, aggregateDeferred: isAggregateDeferred),
+                    height: 88
+                ) {
+                    AnyView(AppKitDiffReviewPlaceholderRowBody(
+                        input: input,
+                        isDeferred: isDeferred,
+                        isAggregateDeferred: isAggregateDeferred
+                    ))
                 }
                 mapTargets(input, to: placeholderID, into: &fallbackByTargetID)
             } else if input.file.imageProvider != nil {
@@ -735,13 +747,18 @@ enum AppKitDiffReviewRowPlanBuilder {
         return hasher.finalize()
     }
 
-    private static func placeholderSignature(_ input: AppKitDiffReviewRowInput, deferred: Bool) -> Int {
+    private static func placeholderSignature(
+        _ input: AppKitDiffReviewRowInput,
+        deferred: Bool,
+        aggregateDeferred: Bool
+    ) -> Int {
         var hasher = Hasher()
         hasher.combine(input.file.placeholderMessage)
         hasher.combine(input.file.summary.additions)
         hasher.combine(input.file.summary.deletions)
         hasher.combine(input.inlineFeedback.count + input.draftComments.count + input.threads.count)
         hasher.combine(deferred)
+        hasher.combine(aggregateDeferred)
         return hasher.finalize()
     }
 
@@ -1023,12 +1040,20 @@ private struct AppKitDiffReviewCardBorderShape: Shape {
 struct AppKitDiffReviewPlaceholderRowBody: View {
     let input: AppKitDiffReviewRowInput
     let isDeferred: Bool
+    let isAggregateDeferred: Bool
+
+    var title: String {
+        if isDeferred {
+            isAggregateDeferred || !input.automaticallyRendersDiff
+                ? "Large review diff deferred for performance"
+                : "Large diff hidden for performance"
+        } else {
+            input.file.placeholderMessage ?? "This file cannot be rendered in the review view."
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            let title = isDeferred
-                ? (input.automaticallyRendersDiff ? "Large diff hidden for performance" : "Large review diff deferred for performance")
-                : (input.file.placeholderMessage ?? "This file cannot be rendered in the review view.")
             Text(title)
                 .font(.system(size: 12, weight: isDeferred ? .semibold : .regular))
                 .foregroundColor(isDeferred ? input.theme.color("fg") : input.theme.color("fg-dim"))
@@ -1066,7 +1091,7 @@ struct AppKitDiffReviewPlaceholderRowBody: View {
             identifier: isDeferred
                 ? "diff-review-render-budget-\(input.file.id.rawValue)"
                 : "diff-review-placeholder-\(input.file.id.rawValue)",
-            label: isDeferred ? "Large review diff deferred for performance" : (input.file.placeholderMessage ?? "This file cannot be rendered in the review view.")
+            label: title
         ))
     }
 }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -41,6 +41,7 @@ struct AppKitDiffReviewRowToken: Equatable {
     let showWhitespace: Bool
     let codeFontFamily: String
     let codeFontSize: CGFloat
+    let theme: Theme
     let lspWorktreeID: String?
     let lspRelativePath: String?
     let lspLanguage: String?
@@ -49,6 +50,8 @@ struct AppKitDiffReviewRowToken: Equatable {
     let draftCommentAvailability: ReviewDraftCommentActionAvailability?
     let hoveredInlineFeedbackID: String?
     let hoveredDraftCommentID: String?
+    let focusedFeedbackID: String?
+    let focusedDraftCommentID: String?
     let activeThreadID: String?
     let draftComposerFocused: Bool
     let actionPresence: AppKitDiffReviewActionPresence
@@ -573,6 +576,7 @@ enum AppKitDiffReviewRowPlanBuilder {
             rowID: id, contentSignature: signature, layoutMode: input.layoutMode,
             wrapLines: input.wrapLines, showWhitespace: input.showWhitespace,
             codeFontFamily: input.codeFontFamily, codeFontSize: input.codeFontSize,
+            theme: input.theme,
             lspWorktreeID: input.lspContext?.worktreeId,
             lspRelativePath: input.lspContext?.relativePath,
             lspLanguage: input.lspContext?.language,
@@ -580,6 +584,8 @@ enum AppKitDiffReviewRowPlanBuilder {
             inlineFeedbackAvailability: inlineAvailability, draftCommentAvailability: draftAvailability,
             hoveredInlineFeedbackID: input.state.hoveredInlineFeedbackID,
             hoveredDraftCommentID: input.state.hoveredDraftCommentID,
+            focusedFeedbackID: input.focusedFeedbackID,
+            focusedDraftCommentID: input.focusedDraftCommentID,
             activeThreadID: input.state.activeThreadID,
             draftComposerFocused: input.state.isDraftComposerFocused,
             actionPresence: input.actionPresence

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -624,6 +624,12 @@ struct AppKitDiffReviewHeaderRowBody: View {
                     .background(input.theme.color("bg-3"))
                     .clipShape(RoundedRectangle(cornerRadius: 6))
                     .accessibilityIdentifier("diff-review-unstage-file-\(input.file.id.rawValue)")
+                    .background(ReviewDraftCommentActionPressMarker(
+                        identifier: "diff-review-unstage-file-\(input.file.id.rawValue)",
+                        label: "Unstage \(input.file.summary.path)"
+                    ) {
+                        unstage()
+                    })
             }
         }
         .padding(.horizontal, 14).padding(.vertical, 10)
@@ -731,10 +737,12 @@ struct AppKitDiffReviewImageRowBody: View {
                             .background(input.theme.color("bg-3"))
                             .clipShape(RoundedRectangle(cornerRadius: 6))
                             .accessibilityIdentifier("diff-review-image-retry-\(input.file.id.rawValue)")
-                            .background(DiffReviewAccessibilityMarker(
+                            .background(ReviewDraftCommentActionPressMarker(
                                 identifier: "diff-review-image-retry-\(input.file.id.rawValue)",
                                 label: "Retry image diff"
-                            ))
+                            ) {
+                                Task { await input.state.imageState.retry() }
+                            })
                     }
                     .padding(.horizontal, 14).padding(.vertical, 10)
                     .background(DiffReviewAccessibilityMarker(
@@ -744,6 +752,13 @@ struct AppKitDiffReviewImageRowBody: View {
             }
         }
         .background(input.theme.color("bg-1"))
+        .task(id: input.file.imageProvider?.id) {
+            guard let provider = input.file.imageProvider else {
+                input.state.imageState.clear()
+                return
+            }
+            await input.state.imageState.load(provider: provider)
+        }
     }
 
     private func failureMessage(in pair: ImageDiffPair) -> String? {
@@ -860,6 +875,15 @@ struct AppKitDiffReviewGroupHeaderRowBody: View {
                         .frame(width: 22, height: 20)
                 }
                 .buttonStyle(.plain).help(expanded ? "Collapse context" : "Expand context")
+                .accessibilityIdentifier("diff-review-context-toggle-\(input.file.id.rawValue)-\(group.id)")
+                .overlay(ReviewDraftCommentActionPressMarker(
+                    identifier: "diff-review-context-toggle-\(input.file.id.rawValue)-\(group.id)",
+                    label: expanded ? "Collapse context" : "Expand context"
+                ) {
+                    input.state.expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(
+                        group, expandedIDs: input.state.expandedCollapsedRowIDs
+                    )
+                })
             }
         }
         .padding(.horizontal, 13).padding(.vertical, 8).background(input.theme.color("bg-2"))

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -452,7 +452,13 @@ enum AppKitDiffReviewRowPlanBuilder {
             canReply: input.actionPresence.canReply, canResolve: input.actionPresence.canResolve,
             onStageReply: { input.state.actionRelay.stageReply(to: $0, body: $1) },
             canAddToReview: input.actionPresence.canAddToReview,
-            hunkFusionStates: [fusion], hunkActions: { _ in .init() }
+            hunkFusionStates: [fusion],
+            hunkActions: { hunk in
+                let enabled = input.file.stagedMutationActions?.isHunkUnstageEnabled?(hunk) ?? false
+                return DiffPaneHunkActions(
+                    dropFromCommit: enabled ? { input.file.stagedMutationActions?.unstageHunk?(hunk) } : nil
+                )
+            }
         )
     }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -1192,6 +1192,7 @@ struct AppKitDiffReviewImageThreadRowBody: View {
             canReply: input.actionPresence.canReply && thread.viewerCanReply,
             canResolve: input.actionPresence.canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
             canAddToReview: input.actionPresence.canAddToReview,
+            editorState: input.state.bindingForThreadCommentEditor(thread.id),
             onActiveChange: { active in
                 input.state.activeThreadID = active
                     ? thread.id
@@ -1259,7 +1260,8 @@ struct AppKitDiffReviewInlineFeedbackRowBody: View {
                 input.state.activeInlineFeedbackEditorID = active
                     ? item.id
                     : (input.state.activeInlineFeedbackEditorID == item.id ? nil : input.state.activeInlineFeedbackEditorID)
-            }
+            },
+            replyEditorState: input.state.bindingForInlineFeedbackReplyEditor(item.id)
         )
         .id(DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: input.file.id))
     }
@@ -1307,7 +1309,8 @@ struct AppKitDiffReviewDraftCommentRowBody: View {
                 input.state.activeDraftCommentEditorID = active
                     ? comment.id
                     : (input.state.activeDraftCommentEditorID == comment.id ? nil : input.state.activeDraftCommentEditorID)
-            }
+            },
+            editorState: input.state.bindingForDraftCommentEditor(comment.id)
         )
         .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: input.file.id))
     }
@@ -1393,6 +1396,7 @@ struct AppKitDiffReviewThreadRowBody: View {
                 canReply: input.actionPresence.canReply && thread.viewerCanReply,
                 canResolve: input.actionPresence.canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
                 canAddToReview: input.actionPresence.canAddToReview,
+                editorState: input.state.bindingForThreadCommentEditor(thread.id),
                 onActiveChange: { active in
                     input.state.activeThreadID = active
                         ? thread.id

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -1,0 +1,577 @@
+import SwiftUI
+
+enum AppKitDiffReviewRowID {
+    static func header(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):header" }
+    static func placeholder(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):placeholder" }
+    static func image(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):image" }
+    static func groupHeader(fileID: DiffReviewFileID, groupID: String) -> String { "file:\(fileID.rawValue):group:\(groupID):header" }
+    static func segment(fileID: DiffReviewFileID, segmentID: String, blockID: String) -> String { "file:\(fileID.rawValue):segment:\(segmentID):rows:\(blockID)" }
+    static func composer(fileID: DiffReviewFileID, segmentID: String) -> String { "file:\(fileID.rawValue):composer:\(segmentID)" }
+    static func spacing(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):spacing" }
+
+    static func inlineFeedback(_ target: DiffReviewInlineFeedbackTargetID) -> String {
+        "file:\(target.fileID.rawValue):feedback:\(target.feedbackID)"
+    }
+
+    static func draftComment(_ target: DiffReviewDraftCommentTargetID) -> String {
+        "file:\(target.fileID.rawValue):draft:\(target.commentID)"
+    }
+
+    static func thread(fileID: DiffReviewFileID, threadID: String) -> String { "file:\(fileID.rawValue):thread:\(threadID)" }
+    static func annotation(fileID: DiffReviewFileID, annotationID: String) -> String { "file:\(fileID.rawValue):annotation:\(annotationID)" }
+}
+
+struct AppKitDiffReviewActionPresence: Equatable {
+    var canOpenFile = false
+    var canUnstageFile = false
+    var canCreateDraftComment = false
+    var canReply = false
+    var canResolve = false
+    var canAddToReview = false
+}
+
+struct AppKitDiffReviewRowToken: Equatable {
+    let rowID: String
+    let contentSignature: Int
+    let layoutMode: DiffLayoutMode
+    let wrapLines: Bool
+    let showWhitespace: Bool
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let inlineFeedbackAvailability: DiffReviewInlineFeedbackActionAvailability?
+    let draftCommentAvailability: ReviewDraftCommentActionAvailability?
+    let hoveredInlineFeedbackID: String?
+    let hoveredDraftCommentID: String?
+    let activeThreadID: String?
+    let draftComposerFocused: Bool
+    let actionPresence: AppKitDiffReviewActionPresence
+}
+
+@MainActor
+struct AppKitDiffReviewRowInput {
+    let file: DiffReviewFileSectionModel
+    var inlineFeedback: [DiffReviewInlineFeedback] = []
+    var draftComments: [ReviewDraftComment] = []
+    var threads: [DiffInlineCommentThread] = []
+    var annotations: [DiffInlineAnnotation] = []
+    let state: AppKitDiffReviewFileState
+    let theme: Theme
+    var layoutMode: DiffLayoutMode = .split
+    var wrapLines = false
+    var showWhitespace = false
+    var codeFontFamily = "SF Mono"
+    var codeFontSize: CGFloat = 13
+    var automaticallyRendersDiff = true
+    var showsBottomSpacing = true
+    var focusedFeedbackID: String?
+    var focusedDraftCommentID: String?
+    var allowsDraftCommentCreation = true
+    var actionPresence = AppKitDiffReviewActionPresence()
+
+    init(
+        file: DiffReviewFileSectionModel,
+        inlineFeedback: [DiffReviewInlineFeedback] = [],
+        draftComments: [ReviewDraftComment] = [],
+        threads: [DiffInlineCommentThread] = [],
+        annotations: [DiffInlineAnnotation] = [],
+        state: AppKitDiffReviewFileState,
+        theme: Theme,
+        layoutMode: DiffLayoutMode = .split,
+        wrapLines: Bool = false,
+        showWhitespace: Bool = false,
+        codeFontFamily: String = "SF Mono",
+        codeFontSize: CGFloat = 13,
+        automaticallyRendersDiff: Bool = true,
+        showsBottomSpacing: Bool = true,
+        focusedFeedbackID: String? = nil,
+        focusedDraftCommentID: String? = nil,
+        allowsDraftCommentCreation: Bool = true,
+        actionPresence: AppKitDiffReviewActionPresence = .init()
+    ) {
+        self.file = file
+        self.inlineFeedback = inlineFeedback
+        self.draftComments = draftComments
+        self.threads = threads
+        self.annotations = annotations
+        self.state = state
+        self.theme = theme
+        self.layoutMode = layoutMode
+        self.wrapLines = wrapLines
+        self.showWhitespace = showWhitespace
+        self.codeFontFamily = codeFontFamily
+        self.codeFontSize = codeFontSize
+        self.automaticallyRendersDiff = automaticallyRendersDiff
+        self.showsBottomSpacing = showsBottomSpacing
+        self.focusedFeedbackID = focusedFeedbackID
+        self.focusedDraftCommentID = focusedDraftCommentID
+        self.allowsDraftCommentCreation = allowsDraftCommentCreation
+        self.actionPresence = actionPresence
+    }
+}
+
+struct AppKitDiffReviewRowPlan {
+    let corePlan: AppKitDiffRowPlan
+    let fallbackByTargetID: [String: String]
+    let headerByFileID: [DiffReviewFileID: String]
+    let placeholderByFileID: [DiffReviewFileID: String]
+}
+
+@MainActor
+enum AppKitDiffReviewRowPlanBuilder {
+    static func build(inputs: [AppKitDiffReviewRowInput]) -> AppKitDiffReviewRowPlan {
+        build(inputs: inputs, maxAutomaticallyRenderedRows: DiffReviewRenderBudget.maxRenderedRows)
+    }
+
+    static func build(
+        inputs: [AppKitDiffReviewRowInput],
+        maxAutomaticallyRenderedRows: Int
+    ) -> AppKitDiffReviewRowPlan {
+        var rows: [AppKitDiffRowSpec] = []
+        var fallbackByTargetID: [String: String] = [:]
+        var headerByFileID: [DiffReviewFileID: String] = [:]
+        var placeholderByFileID: [DiffReviewFileID: String] = [:]
+        let eligibility = DiffReviewRenderEligibility.renderRows(
+            ordered: inputs.map(\.file.id),
+            renderedRowCounts: inputs.map { $0.file.displayModel.map(DiffReviewRenderBudget.renderedRowCount) },
+            maxAutomaticallyRenderedRows: maxAutomaticallyRenderedRows
+        )
+
+        for (index, input) in inputs.enumerated() {
+            let fileID = input.file.id
+            let headerID = AppKitDiffReviewRowID.header(fileID: fileID)
+            headerByFileID[fileID] = headerID
+            append(&rows, id: headerID, input: input, signature: headerSignature(input), height: 45) {
+                AnyView(AppKitDiffReviewHeaderRowBody(input: input))
+            }
+
+            let individuallyDeferred = input.file.displayModel.map(DiffReviewRenderBudget.isOverBudget) ?? false
+            let isDeferred = (!input.automaticallyRendersDiff || !eligibility[index].automaticallyRendersDiff || individuallyDeferred)
+                && !input.state.showFullDiffOverride
+            if isDeferred || (input.file.displayModel == nil && input.file.imageProvider == nil) {
+                let placeholderID = AppKitDiffReviewRowID.placeholder(fileID: fileID)
+                placeholderByFileID[fileID] = placeholderID
+                append(&rows, id: placeholderID, input: input, signature: placeholderSignature(input, deferred: isDeferred), height: 88) {
+                    AnyView(AppKitDiffReviewPlaceholderRowBody(input: input, isDeferred: isDeferred))
+                }
+                mapTargets(input, to: placeholderID, into: &fallbackByTargetID)
+            } else if input.file.imageProvider != nil {
+                appendFileAccessories(input, context: nil, rows: &rows, fallbacks: &fallbackByTargetID)
+                let imageID = AppKitDiffReviewRowID.image(fileID: fileID)
+                append(&rows, id: imageID, input: input, signature: input.file.imageProvider?.id.hashValue ?? 0, height: 360) {
+                    AnyView(AppKitDiffReviewImageRowBody(input: input))
+                }
+                mapTargetsDirectly(input, into: &fallbackByTargetID)
+            } else if let context = renderContext(for: input) {
+                appendFileAccessories(input, context: context, rows: &rows, fallbacks: &fallbackByTargetID)
+                appendTextRows(context, input: input, into: &rows, fallbacks: &fallbackByTargetID)
+            }
+
+            if input.showsBottomSpacing,
+               !isDeferred,
+               input.file.imageProvider == nil,
+               input.file.displayModel != nil {
+                append(&rows, id: AppKitDiffReviewRowID.spacing(fileID: fileID), input: input, signature: 0, height: 14) {
+                    AnyView(Color.clear.frame(height: 14))
+                }
+            }
+        }
+        return AppKitDiffReviewRowPlan(
+            corePlan: .init(rows: rows), fallbackByTargetID: fallbackByTargetID,
+            headerByFileID: headerByFileID, placeholderByFileID: placeholderByFileID
+        )
+    }
+
+    private static func renderContext(for input: AppKitDiffReviewRowInput) -> DiffReviewRenderContext? {
+        guard let displayModel = input.file.displayModel else { return nil }
+        return input.state.renderContextCache.reviewContext(
+            fileID: input.file.id, displayModel: displayModel,
+            contextSnapshot: input.state.contextSnapshot,
+            contextProviderAvailable: input.file.contextProvider != nil,
+            contextExpansion: input.state.contextExpansion,
+            inlineFeedback: input.inlineFeedback, draftComments: input.draftComments,
+            pendingDraftAnchor: input.state.pendingDraftAnchor,
+            canCreateDraftComment: input.allowsDraftCommentCreation,
+            threads: input.threads, annotations: input.annotations
+        )
+    }
+
+    private static func appendFileAccessories(
+        _ input: AppKitDiffReviewRowInput,
+        context: DiffReviewRenderContext?,
+        rows: inout [AppKitDiffRowSpec],
+        fallbacks: inout [String: String]
+    ) {
+        let feedback = context?.fileLevelInlineFeedback ?? input.inlineFeedback
+        let drafts = context?.fileLevelDraftComments
+            ?? ReviewDraftCommentPlacement.position(input.draftComments, in: []).fileLevel
+        for comment in drafts { appendDraft(comment, input: input, rows: &rows, fallbacks: &fallbacks) }
+        for item in feedback { appendFeedback(item, input: input, rows: &rows, fallbacks: &fallbacks) }
+    }
+
+    private static func appendTextRows(
+        _ context: DiffReviewRenderContext,
+        input: AppKitDiffReviewRowInput,
+        into rows: inout [AppKitDiffRowSpec],
+        fallbacks: inout [String: String]
+    ) {
+        let fusions = DiffReviewHunkFusionResolver.states(for: context.groups)
+        for (groupIndex, group) in context.groups.enumerated() {
+            for item in group.inlineFeedback { appendFeedback(item, input: input, rows: &rows, fallbacks: &fallbacks) }
+            let groupID = AppKitDiffReviewRowID.groupHeader(fileID: input.file.id, groupID: group.id)
+            if !group.containsLocalAccessories {
+                let rowInput = hunkInput(group: group, context: context, input: input, fusion: fusions[groupIndex])
+                let hunkPlan = DiffPaneRowPlanBuilder.build(input: rowInput, state: input.state.hunkPresentationState)
+                guard let hunk = hunkPlan.rows.first else { continue }
+                append(&rows, id: groupID, input: input, signature: String(reflecting: group.displayGroup.rowsSignature).hashValue, height: hunk.estimatedHeight) {
+                    hunk.build()
+                }
+                continue
+            }
+
+            append(&rows, id: groupID, input: input, signature: group.displayGroup.header.hashValue, height: 37) {
+                AnyView(AppKitDiffReviewGroupHeaderRowBody(group: group.displayGroup, input: input))
+            }
+            for segment in group.segments {
+                for block in segment.blocks {
+                    switch block {
+                    case let .rows(rowBlock):
+                        let blockID = AppKitDiffReviewRowID.segment(fileID: input.file.id, segmentID: segment.id, blockID: rowBlock.id)
+                        append(&rows, id: blockID, input: input, signature: String(reflecting: rowBlock.rowsSignature).hashValue, height: segmentHeight(rowBlock.rows.count, input: input)) {
+                            AnyView(AppKitDiffReviewSegmentRowBody(rows: rowBlock.rows, rowsSignature: rowBlock.rowsSignature, group: group.displayGroup, input: input))
+                        }
+                    case let .thread(thread):
+                        let threadID = AppKitDiffReviewRowID.thread(fileID: input.file.id, threadID: thread.id)
+                        append(&rows, id: threadID, input: input, signature: String(reflecting: thread).hashValue, height: 112) {
+                            AnyView(AppKitDiffReviewThreadRowBody(thread: thread, rows: segment.rows, input: input))
+                        }
+                    case let .annotation(annotation):
+                        let annotationID = AppKitDiffReviewRowID.annotation(fileID: input.file.id, annotationID: annotation.id)
+                        append(&rows, id: annotationID, input: input, signature: String(reflecting: annotation).hashValue, height: 52) {
+                            AnyView(AppKitDiffReviewAnnotationRowBody(annotation: annotation, rows: segment.rows, input: input))
+                        }
+                    }
+                }
+                for comment in segment.draftComments { appendDraft(comment, input: input, rows: &rows, fallbacks: &fallbacks) }
+                if segment.showsComposer {
+                    let composerID = AppKitDiffReviewRowID.composer(fileID: input.file.id, segmentID: segment.id)
+                    append(&rows, id: composerID, input: input, signature: input.state.draftComposerFocusRequestGeneration, height: 132, retention: .pinned) {
+                        AnyView(AppKitDiffReviewComposerRowBody(rows: segment.rows, input: input))
+                    }
+                }
+            }
+        }
+        mapTargetsDirectly(input, into: &fallbacks)
+    }
+
+    private static func hunkInput(
+        group: DiffReviewRenderContext.Group,
+        context: DiffReviewRenderContext,
+        input: AppKitDiffReviewRowInput,
+        fusion: DiffPaneHunkFusionState
+    ) -> DiffPaneRowPlanInput {
+        DiffPaneRowPlanInput(
+            model: .init(filePath: input.file.summary.path, groups: [group.displayGroup]),
+            fileExtension: LanguageRegistry.highlighterExtension(forPath: input.file.summary.path),
+            layoutMode: input.layoutMode, wrapLines: input.wrapLines,
+            showWhitespace: input.showWhitespace, codeFontFamily: input.codeFontFamily,
+            codeFontSize: input.codeFontSize, theme: input.theme,
+            allowsReviewLineSelection: input.allowsDraftCommentCreation,
+            onReviewLineSelected: { anchor in
+                input.state.pendingDraftAnchor = anchor
+                input.state.draftComposerFocusRequestGeneration &+= 1
+            },
+            onContextExpansion: { _, _, _ in input.state.actionRelay.contextExpansionActivated() },
+            threads: input.threads, annotations: input.annotations,
+            onReply: { input.state.actionRelay.reply(to: $0, body: $1) },
+            onResolve: input.state.actionRelay.resolve,
+            onUnresolve: input.state.actionRelay.unresolve,
+            onEdit: { input.state.actionRelay.edit($1, in: $0, body: $2) },
+            onDelete: { input.state.actionRelay.delete($1, in: $0) },
+            canReply: input.actionPresence.canReply, canResolve: input.actionPresence.canResolve,
+            onStageReply: { input.state.actionRelay.stageReply(to: $0, body: $1) },
+            canAddToReview: input.actionPresence.canAddToReview,
+            hunkFusionStates: [fusion], hunkActions: { _ in .init() }
+        )
+    }
+
+    private static func appendFeedback(
+        _ item: DiffReviewInlineFeedback,
+        input: AppKitDiffReviewRowInput,
+        rows: inout [AppKitDiffRowSpec],
+        fallbacks: inout [String: String]
+    ) {
+        let target = DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: input.file.id)
+        let id = AppKitDiffReviewRowID.inlineFeedback(target)
+        append(&rows, id: id, input: input, signature: String(reflecting: item).hashValue, height: 96, inlineAvailability: input.state.actionRelay.inlineFeedbackAvailability(for: item, file: input.file.summary)) {
+            AnyView(AppKitDiffReviewInlineFeedbackRowBody(item: item, input: input))
+        }
+        fallbacks[id] = id
+    }
+
+    private static func appendDraft(
+        _ comment: ReviewDraftComment,
+        input: AppKitDiffReviewRowInput,
+        rows: inout [AppKitDiffRowSpec],
+        fallbacks: inout [String: String]
+    ) {
+        let target = DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: input.file.id)
+        let id = AppKitDiffReviewRowID.draftComment(target)
+        append(&rows, id: id, input: input, signature: String(reflecting: comment).hashValue, height: 112, draftAvailability: input.state.actionRelay.draftCommentAvailability(for: comment)) {
+            AnyView(AppKitDiffReviewDraftCommentRowBody(comment: comment, input: input))
+        }
+        fallbacks[id] = id
+    }
+
+    private static func mapTargets(_ input: AppKitDiffReviewRowInput, to rowID: String, into fallbacks: inout [String: String]) {
+        for item in input.inlineFeedback {
+            fallbacks[AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: item.id, fileID: input.file.id))] = rowID
+        }
+        for comment in input.draftComments {
+            fallbacks[AppKitDiffReviewRowID.draftComment(.targetID(commentID: comment.id, fileID: input.file.id))] = rowID
+        }
+    }
+
+    private static func mapTargetsDirectly(_ input: AppKitDiffReviewRowInput, into fallbacks: inout [String: String]) {
+        for item in input.inlineFeedback {
+            let id = AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: item.id, fileID: input.file.id))
+            fallbacks[id] = id
+        }
+        for comment in input.draftComments {
+            let id = AppKitDiffReviewRowID.draftComment(.targetID(commentID: comment.id, fileID: input.file.id))
+            fallbacks[id] = id
+        }
+    }
+
+    private static func append(
+        _ rows: inout [AppKitDiffRowSpec], id: String, input: AppKitDiffReviewRowInput,
+        signature: Int, height: CGFloat, retention: AppKitDiffRowRetention = .recyclable,
+        inlineAvailability: DiffReviewInlineFeedbackActionAvailability? = nil,
+        draftAvailability: ReviewDraftCommentActionAvailability? = nil,
+        build: @escaping () -> AnyView
+    ) {
+        let token = AppKitDiffReviewRowToken(
+            rowID: id, contentSignature: signature, layoutMode: input.layoutMode,
+            wrapLines: input.wrapLines, showWhitespace: input.showWhitespace,
+            codeFontFamily: input.codeFontFamily, codeFontSize: input.codeFontSize,
+            inlineFeedbackAvailability: inlineAvailability, draftCommentAvailability: draftAvailability,
+            hoveredInlineFeedbackID: input.state.hoveredInlineFeedbackID,
+            hoveredDraftCommentID: input.state.hoveredDraftCommentID,
+            activeThreadID: input.state.activeThreadID,
+            draftComposerFocused: input.state.isDraftComposerFocused,
+            actionPresence: input.actionPresence
+        )
+        rows.append(.init(id: id, ownerID: input.file.id.rawValue, equalityToken: .init(token), estimatedHeight: height, retention: retention, build: build))
+    }
+
+    private static func headerSignature(_ input: AppKitDiffReviewRowInput) -> Int {
+        var hasher = Hasher()
+        hasher.combine(input.file.id)
+        hasher.combine(input.file.summary.path)
+        hasher.combine(input.file.summary.originalPath)
+        hasher.combine(input.file.summary.status)
+        hasher.combine(input.file.summary.additions)
+        hasher.combine(input.file.summary.deletions)
+        return hasher.finalize()
+    }
+
+    private static func placeholderSignature(_ input: AppKitDiffReviewRowInput, deferred: Bool) -> Int {
+        var hasher = Hasher()
+        hasher.combine(input.file.placeholderMessage)
+        hasher.combine(input.file.summary.additions)
+        hasher.combine(input.file.summary.deletions)
+        hasher.combine(input.inlineFeedback.count + input.draftComments.count + input.threads.count)
+        hasher.combine(deferred)
+        return hasher.finalize()
+    }
+
+    private static func segmentHeight(_ rowCount: Int, input: AppKitDiffReviewRowInput) -> CGFloat {
+        max(22, CGFloat(rowCount) * max(18, input.codeFontSize + 6))
+    }
+}
+
+private struct AppKitDiffReviewHeaderRowBody: View {
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(input.file.summary.status.glyph)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundColor(input.theme.color("fg-muted"))
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(input.file.summary.path)
+                    .font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize))
+                    .lineLimit(1).truncationMode(.middle)
+                if let originalPath = input.file.summary.originalPath {
+                    Text("from \(originalPath)").font(.system(size: 10.5)).foregroundColor(input.theme.color("fg-faint"))
+                }
+            }
+            Spacer(minLength: 12)
+            Text("+\(input.file.summary.additions)  -\(input.file.summary.deletions)")
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+        }
+        .padding(.horizontal, 14).padding(.vertical, 10)
+        .background(input.theme.color("bg-2"))
+        .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+}
+
+private struct AppKitDiffReviewPlaceholderRowBody: View {
+    let input: AppKitDiffReviewRowInput
+    let isDeferred: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(isDeferred ? "Large review diff deferred for performance" : (input.file.placeholderMessage ?? "This file cannot be rendered in the review view."))
+                .font(.system(size: 12, weight: isDeferred ? .semibold : .regular))
+            if isDeferred {
+                Text("\((input.file.summary.additions + input.file.summary.deletions).formatted()) changed lines. Rendering may be slow.")
+                    .font(.system(size: 12)).foregroundColor(input.theme.color("fg-dim"))
+                Button("Show full diff") { input.state.showFullDiffOverride = true }
+                    .buttonStyle(.plain).font(.system(size: 11, weight: .semibold))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14).padding(.vertical, 18).background(input.theme.color("bg-1"))
+    }
+}
+
+private struct AppKitDiffReviewImageRowBody: View {
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        Group {
+            if let pair = input.state.imageState.pair ?? input.file.imageProvider.flatMap({ DiffReviewImagePairCache.shared.pair(for: $0.id) }) {
+                ImageDiffComparisonContent(pair: pair, state: input.state.imageState.presentation, boundedHeight: 360)
+            } else {
+                ProgressView().controlSize(.small).frame(maxWidth: .infinity).padding(.vertical, 12)
+            }
+        }
+        .background(input.theme.color("bg-1"))
+    }
+}
+
+private struct AppKitDiffReviewInlineFeedbackRowBody: View {
+    let item: DiffReviewInlineFeedback
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        DiffReviewInlineFeedbackCard(
+            item: item, file: input.file.summary, isFocused: item.id == input.focusedFeedbackID,
+            actions: input.state.actionRelay.inlineFeedbackActionsForRow,
+            onSelect: input.state.actionRelay.selectInlineFeedback,
+            onHoverChange: { hovering in input.state.hoveredInlineFeedbackID = hovering ? item.id : nil }
+        )
+        .padding(.horizontal, 14).padding(.vertical, 10).background(input.theme.color("bg-1"))
+    }
+}
+
+private struct AppKitDiffReviewDraftCommentRowBody: View {
+    let comment: ReviewDraftComment
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        ReviewDraftCommentCard(
+            comment: comment, file: input.file.summary,
+            isFocused: comment.id == input.focusedDraftCommentID,
+            actions: input.state.actionRelay.draftCommentActionsForRow,
+            reviewFeedbackTarget: .init(title: input.file.summary.path, repositoryPath: nil, providerDescription: nil, sourceDescription: "Local draft comment"),
+            onSelect: input.state.actionRelay.selectDraftComment,
+            onHoverChange: { hovering in input.state.hoveredDraftCommentID = hovering ? comment.id : nil }
+        )
+        .padding(.horizontal, 14).padding(.vertical, 10).background(input.theme.color("bg-1"))
+    }
+}
+
+private struct AppKitDiffReviewGroupHeaderRowBody: View {
+    let group: DiffDisplayGroup
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(group.header).font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize - 1)).lineLimit(1)
+            Spacer(minLength: 12)
+        }
+        .padding(.horizontal, 13).padding(.vertical, 8).background(input.theme.color("bg-2"))
+        .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
+    }
+}
+
+private struct AppKitDiffReviewSegmentRowBody: View {
+    let rows: [DiffDisplayRow]
+    let rowsSignature: DiffDisplayRowsSignature
+    let group: DiffDisplayGroup
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        DiffPaneTextDocumentView(
+            group: .init(id: group.id, header: group.header, sourceHunk: group.sourceHunk, rows: rows, rowsSignature: rowsSignature),
+            expandedCollapsedRowIDs: input.state.expandedCollapsedRowIDs,
+            layoutMode: input.layoutMode, wrapLines: input.wrapLines, showWhitespace: input.showWhitespace,
+            fileExtension: LanguageRegistry.highlighterExtension(forPath: input.file.summary.path),
+            codeFontFamily: input.codeFontFamily, codeFontSize: input.codeFontSize, theme: input.theme,
+            lspContext: nil,
+            allowsReviewLineSelection: input.allowsDraftCommentCreation,
+            onReviewLineSelected: { anchor in input.state.pendingDraftAnchor = anchor },
+            onContextExpansion: { _, _, _ in input.state.actionRelay.contextExpansionActivated() }
+        )
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private struct AppKitDiffReviewThreadRowBody: View {
+    let thread: DiffInlineCommentThread
+    let rows: [DiffDisplayRow]
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        DiffFeedbackLaneView(lane: DiffFeedbackLaneResolver.lane(for: thread), layoutMode: input.layoutMode, rows: rows) {
+            DiffInlineCommentCard(
+                thread: thread, onReply: { input.state.actionRelay.reply(to: thread, body: $0) },
+                onStageReply: { input.state.actionRelay.stageReply(to: thread, body: $0) },
+                onResolve: { input.state.actionRelay.resolve(thread) }, onUnresolve: { input.state.actionRelay.unresolve(thread) },
+                onEdit: { input.state.actionRelay.edit($0, in: thread, body: $1) },
+                onDelete: { input.state.actionRelay.delete($0, in: thread) },
+                canReply: input.actionPresence.canReply && thread.viewerCanReply,
+                canResolve: input.actionPresence.canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
+                canAddToReview: input.actionPresence.canAddToReview,
+                onActiveChange: { input.state.activeThreadID = $0 ? thread.id : nil }
+            )
+        }
+    }
+}
+
+private struct AppKitDiffReviewAnnotationRowBody: View {
+    let annotation: DiffInlineAnnotation
+    let rows: [DiffDisplayRow]
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        DiffFeedbackLaneView(lane: DiffFeedbackLaneResolver.lane(for: annotation), layoutMode: input.layoutMode, rows: rows) {
+            DiffInlineAnnotationCard(annotation: annotation)
+        }
+    }
+}
+
+private struct AppKitDiffReviewComposerRowBody: View {
+    let rows: [DiffDisplayRow]
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        DiffFeedbackLaneView(lane: input.state.pendingDraftAnchor.map(DiffFeedbackLaneResolver.lane) ?? .full, layoutMode: input.layoutMode, rows: rows) {
+            VStack(alignment: .leading, spacing: 10) {
+                TextEditor(text: Binding(get: { input.state.pendingDraftBody }, set: { input.state.pendingDraftBody = $0 }))
+                    .frame(minHeight: 76, maxHeight: 104)
+                HStack {
+                    Spacer()
+                    Button("Cancel") { input.state.pendingDraftAnchor = nil; input.state.pendingDraftBody = "" }
+                    Button("Save") {
+                        guard let anchor = input.state.pendingDraftAnchor else { return }
+                        input.state.actionRelay.saveDraftComment(anchor, body: input.state.pendingDraftBody)
+                    }
+                }
+            }
+            .padding(.horizontal, 16).padding(.vertical, 12).background(input.theme.color("bg-1"))
+        }
+    }
+}

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -321,7 +321,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                 appendFileAccessories(input, context: nil, rows: &rows, fallbacks: &fallbackByTargetID)
                 let imageID = AppKitDiffReviewRowID.image(fileID: fileID)
                 append(&rows, id: imageID, input: input, signature: input.file.imageProvider?.id.hashValue ?? 0, height: 360) {
-                    AnyView(AppKitDiffReviewImageRowBody(input: input))
+                    AnyView(AppKitDiffReviewImageRowBody(input: input, loadsImage: true))
                 }
                 mapTargetsDirectly(input, into: &fallbackByTargetID)
             } else if let context = renderContext(for: input) {
@@ -714,6 +714,7 @@ struct AppKitDiffReviewPlaceholderRowBody: View {
 
 struct AppKitDiffReviewImageRowBody: View {
     let input: AppKitDiffReviewRowInput
+    var loadsImage = false
 
     var body: some View {
         Group {
@@ -753,6 +754,7 @@ struct AppKitDiffReviewImageRowBody: View {
         }
         .background(input.theme.color("bg-1"))
         .task(id: input.file.imageProvider?.id) {
+            guard loadsImage else { return }
             guard let provider = input.file.imageProvider else {
                 input.state.imageState.clear()
                 return

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -426,7 +426,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                 continue
             }
 
-            append(&rows, id: groupID, input: input, signature: group.displayGroup.header.hashValue, height: 37) {
+            append(&rows, id: groupID, input: input, signature: groupHeaderSignature(group.displayGroup, input: input), height: 37) {
                 AnyView(AppKitDiffReviewGroupHeaderRowBody(group: group.displayGroup, input: input))
             }
             for segment in group.segments {
@@ -663,6 +663,17 @@ enum AppKitDiffReviewRowPlanBuilder {
         hasher.combine(input.file.summary.deletions)
         hasher.combine(input.inlineFeedback.count + input.draftComments.count + input.threads.count)
         hasher.combine(deferred)
+        return hasher.finalize()
+    }
+
+    private static func groupHeaderSignature(_ group: DiffDisplayGroup, input: AppKitDiffReviewRowInput) -> Int {
+        let collapsedRowIDs = DiffCollapsedContextController.collapsedRowIDs(in: group)
+        var hasher = Hasher()
+        hasher.combine(group.header)
+        hasher.combine(collapsedRowIDs)
+        if !collapsedRowIDs.isEmpty {
+            hasher.combine(DiffCollapsedContextController.isExpanded(group, expandedIDs: input.state.expandedCollapsedRowIDs))
+        }
         return hasher.finalize()
     }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -739,7 +739,11 @@ struct AppKitDiffReviewHeaderRowBody: View {
                     .foregroundColor(input.theme.color("fg"))
                     .lineLimit(1).truncationMode(.middle)
                 if let originalPath = input.file.summary.originalPath {
-                    Text("from \(originalPath)").font(.system(size: 10.5)).foregroundColor(input.theme.color("fg-faint"))
+                    Text("from \(originalPath)")
+                        .font(.system(size: 10.5))
+                        .foregroundColor(input.theme.color("fg-faint"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
                 }
             }
             if input.showsSourceBadge, let title = input.file.summary.groupTitle {
@@ -803,6 +807,10 @@ struct AppKitDiffReviewHeaderRowBody: View {
         }
         .padding(.horizontal, 14).padding(.vertical, 10)
         .background(input.theme.color("bg-2"))
+        .background(DiffReviewAccessibilityMarker(
+            identifier: "diff-review-file-section-\(input.file.id.rawValue)",
+            label: input.file.summary.path
+        ))
         .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
     }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -80,6 +80,7 @@ struct AppKitDiffReviewRowInput {
     var automaticallyRendersDiff = true
     var showsBottomSpacing = true
     var focusedFeedbackID: String?
+    var inlineFeedbackScrollTargetID: String?
     var focusedDraftCommentID: String?
     var allowsDraftCommentCreation = true
     var actionPresence = AppKitDiffReviewActionPresence()
@@ -103,6 +104,7 @@ struct AppKitDiffReviewRowInput {
         automaticallyRendersDiff: Bool = true,
         showsBottomSpacing: Bool = true,
         focusedFeedbackID: String? = nil,
+        inlineFeedbackScrollTargetID: String? = nil,
         focusedDraftCommentID: String? = nil,
         allowsDraftCommentCreation: Bool = true,
         actionPresence: AppKitDiffReviewActionPresence = .init(),
@@ -127,6 +129,7 @@ struct AppKitDiffReviewRowInput {
         self.automaticallyRendersDiff = automaticallyRendersDiff
         self.showsBottomSpacing = showsBottomSpacing
         self.focusedFeedbackID = focusedFeedbackID
+        self.inlineFeedbackScrollTargetID = inlineFeedbackScrollTargetID
         self.focusedDraftCommentID = focusedDraftCommentID
         self.allowsDraftCommentCreation = allowsDraftCommentCreation
         self.actionPresence = actionPresence
@@ -549,7 +552,8 @@ enum AppKitDiffReviewRowPlanBuilder {
         fallbacks: inout [String: String]
     ) {
         let display = DiffReviewInlineFeedbackDisplayPolicy.display(
-            for: items, includingRequiredIDs: Set([input.focusedFeedbackID].compactMap(\.self))
+            for: items,
+            includingRequiredIDs: Set([input.focusedFeedbackID, input.inlineFeedbackScrollTargetID].compactMap(\.self))
         )
         for item in display.visibleItems {
             appendFeedback(item, contextRows: contextRows, input: input, rows: &rows, fallbacks: &fallbacks)

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -429,7 +429,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                     switch block {
                     case let .rows(rowBlock):
                         let blockID = AppKitDiffReviewRowID.segment(fileID: input.file.id, segmentID: segment.id, blockID: rowBlock.id)
-                        append(&rows, id: blockID, input: input, signature: String(reflecting: rowBlock.rowsSignature).hashValue, height: segmentHeight(rowBlock.rows.count, input: input)) {
+                        append(&rows, id: blockID, input: input, signature: String(reflecting: rowBlock.rowsSignature).hashValue, height: segmentHeight(rowBlock.rows.count, input: input), includesActiveHighlight: true) {
                             AnyView(AppKitDiffReviewSegmentRowBody(rows: rowBlock.rows, rowsSignature: rowBlock.rowsSignature, group: group.displayGroup, input: input))
                         }
                     case let .thread(thread):
@@ -575,6 +575,7 @@ enum AppKitDiffReviewRowPlanBuilder {
         signature: Int, height: CGFloat, retention: AppKitDiffRowRetention = .recyclable,
         inlineAvailability: DiffReviewInlineFeedbackActionAvailability? = nil,
         draftAvailability: ReviewDraftCommentActionAvailability? = nil,
+        includesActiveHighlight: Bool = false,
         build: @escaping () -> AnyView
     ) {
         let token = AppKitDiffReviewRowToken(
@@ -587,8 +588,8 @@ enum AppKitDiffReviewRowPlanBuilder {
             lspLanguage: input.lspContext?.language,
             lspManagerIdentity: input.lspContext.map { ObjectIdentifier($0.lsp) },
             inlineFeedbackAvailability: inlineAvailability, draftCommentAvailability: draftAvailability,
-            hoveredInlineFeedbackID: input.state.hoveredInlineFeedbackID,
-            hoveredDraftCommentID: input.state.hoveredDraftCommentID,
+            hoveredInlineFeedbackID: includesActiveHighlight ? input.state.hoveredInlineFeedbackID : nil,
+            hoveredDraftCommentID: includesActiveHighlight ? input.state.hoveredDraftCommentID : nil,
             focusedFeedbackID: input.focusedFeedbackID,
             focusedDraftCommentID: input.focusedDraftCommentID,
             activeThreadID: input.state.activeThreadID,

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -9,6 +9,9 @@ enum AppKitDiffReviewRowID {
     static func segment(fileID: DiffReviewFileID, segmentID: String, blockID: String) -> String { "file:\(fileID.rawValue):segment:\(segmentID):rows:\(blockID)" }
     static func composer(fileID: DiffReviewFileID, segmentID: String) -> String { "file:\(fileID.rawValue):composer:\(segmentID)" }
     static func spacing(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):spacing" }
+    static func inlineFeedbackMore(fileID: DiffReviewFileID, scopeID: String) -> String {
+        "file:\(fileID.rawValue):feedback-more:\(scopeID)"
+    }
 
     static func inlineFeedback(_ target: DiffReviewInlineFeedbackTargetID) -> String {
         "file:\(target.fileID.rawValue):feedback:\(target.feedbackID)"
@@ -394,7 +397,7 @@ enum AppKitDiffReviewRowPlanBuilder {
         let drafts = context?.fileLevelDraftComments
             ?? ReviewDraftCommentPlacement.position(input.draftComments, in: []).fileLevel
         for comment in drafts { appendDraft(comment, input: input, rows: &rows, fallbacks: &fallbacks) }
-        for item in feedback { appendFeedback(item, input: input, rows: &rows, fallbacks: &fallbacks) }
+        appendFeedback(feedback, scopeID: "file", input: input, rows: &rows, fallbacks: &fallbacks)
     }
 
     private static func appendTextRows(
@@ -405,7 +408,7 @@ enum AppKitDiffReviewRowPlanBuilder {
     ) {
         let fusions = DiffReviewHunkFusionResolver.states(for: context.groups)
         for (groupIndex, group) in context.groups.enumerated() {
-            for item in group.inlineFeedback { appendFeedback(item, input: input, rows: &rows, fallbacks: &fallbacks) }
+            appendFeedback(group.inlineFeedback, scopeID: group.id, input: input, rows: &rows, fallbacks: &fallbacks)
             let groupID = AppKitDiffReviewRowID.groupHeader(fileID: input.file.id, groupID: group.id)
             if !group.containsLocalAccessories {
                 let rowInput = hunkInput(group: group, context: context, input: input, fusion: fusions[groupIndex])
@@ -524,6 +527,28 @@ enum AppKitDiffReviewRowPlanBuilder {
             ) {
                 AnyView(AppKitDiffReviewImageAnnotationRowBody(annotation: annotation, input: input))
             }
+        }
+    }
+
+    private static func appendFeedback(
+        _ items: [DiffReviewInlineFeedback],
+        scopeID: String,
+        input: AppKitDiffReviewRowInput,
+        rows: inout [AppKitDiffRowSpec],
+        fallbacks: inout [String: String]
+    ) {
+        let display = DiffReviewInlineFeedbackDisplayPolicy.display(
+            for: items, includingRequiredIDs: Set([input.focusedFeedbackID].compactMap(\.self))
+        )
+        for item in display.visibleItems {
+            appendFeedback(item, input: input, rows: &rows, fallbacks: &fallbacks)
+        }
+        guard display.hiddenCount > 0 else { return }
+        append(
+            &rows, id: AppKitDiffReviewRowID.inlineFeedbackMore(fileID: input.file.id, scopeID: scopeID),
+            input: input, signature: display.hiddenCount, height: DiffReviewInlineFeedbackDisplayPolicy.moreRowEstimatedHeight
+        ) {
+            AnyView(DiffReviewInlineFeedbackMoreRow(hiddenCount: display.hiddenCount))
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -578,8 +578,8 @@ enum AppKitDiffReviewRowPlanBuilder {
             lspLanguage: input.lspContext?.language,
             lspManagerIdentity: input.lspContext.map { ObjectIdentifier($0.lsp) },
             inlineFeedbackAvailability: inlineAvailability, draftCommentAvailability: draftAvailability,
-            hoveredInlineFeedbackID: nil,
-            hoveredDraftCommentID: nil,
+            hoveredInlineFeedbackID: input.state.hoveredInlineFeedbackID,
+            hoveredDraftCommentID: input.state.hoveredDraftCommentID,
             activeThreadID: input.state.activeThreadID,
             draftComposerFocused: input.state.isDraftComposerFocused,
             actionPresence: input.actionPresence

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -38,6 +38,10 @@ struct AppKitDiffReviewRowToken: Equatable {
     let showWhitespace: Bool
     let codeFontFamily: String
     let codeFontSize: CGFloat
+    let lspWorktreeID: String?
+    let lspRelativePath: String?
+    let lspLanguage: String?
+    let lspManagerIdentity: ObjectIdentifier?
     let inlineFeedbackAvailability: DiffReviewInlineFeedbackActionAvailability?
     let draftCommentAvailability: ReviewDraftCommentActionAvailability?
     let hoveredInlineFeedbackID: String?
@@ -61,12 +65,17 @@ struct AppKitDiffReviewRowInput {
     var showWhitespace = false
     var codeFontFamily = "SF Mono"
     var codeFontSize: CGFloat = 13
+    var showsSourceBadge = false
     var automaticallyRendersDiff = true
     var showsBottomSpacing = true
     var focusedFeedbackID: String?
     var focusedDraftCommentID: String?
     var allowsDraftCommentCreation = true
     var actionPresence = AppKitDiffReviewActionPresence()
+    var lspContext: DiffPaneLSPContext?
+    var reviewFeedbackTarget: ReviewFeedbackTarget?
+    var draftCommentActions: ReviewDraftCommentActions?
+    private let contextExpansionActivated: () -> Void
 
     init(
         file: DiffReviewFileSectionModel,
@@ -81,12 +90,17 @@ struct AppKitDiffReviewRowInput {
         showWhitespace: Bool = false,
         codeFontFamily: String = "SF Mono",
         codeFontSize: CGFloat = 13,
+        showsSourceBadge: Bool = false,
         automaticallyRendersDiff: Bool = true,
         showsBottomSpacing: Bool = true,
         focusedFeedbackID: String? = nil,
         focusedDraftCommentID: String? = nil,
         allowsDraftCommentCreation: Bool = true,
-        actionPresence: AppKitDiffReviewActionPresence = .init()
+        actionPresence: AppKitDiffReviewActionPresence = .init(),
+        lspContext: DiffPaneLSPContext? = nil,
+        reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
+        draftCommentActions: ReviewDraftCommentActions? = nil,
+        onContextExpansionActivated: (() -> Void)? = nil
     ) {
         self.file = file
         self.inlineFeedback = inlineFeedback
@@ -100,12 +114,161 @@ struct AppKitDiffReviewRowInput {
         self.showWhitespace = showWhitespace
         self.codeFontFamily = codeFontFamily
         self.codeFontSize = codeFontSize
+        self.showsSourceBadge = showsSourceBadge
         self.automaticallyRendersDiff = automaticallyRendersDiff
         self.showsBottomSpacing = showsBottomSpacing
         self.focusedFeedbackID = focusedFeedbackID
         self.focusedDraftCommentID = focusedDraftCommentID
         self.allowsDraftCommentCreation = allowsDraftCommentCreation
         self.actionPresence = actionPresence
+        self.lspContext = lspContext
+        self.reviewFeedbackTarget = reviewFeedbackTarget
+        self.draftCommentActions = draftCommentActions
+        self.contextExpansionActivated = onContextExpansionActivated
+            ?? { state.actionRelay.contextExpansionActivated() }
+    }
+
+    func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
+        state.pendingDraftAnchor = anchor
+        state.pendingDraftBody = ""
+        state.draftComposerFocusRequestGeneration &+= 1
+    }
+
+    func clearPendingDraft() {
+        state.pendingDraftAnchor = nil
+        state.pendingDraftBody = ""
+        state.isDraftComposerFocused = false
+    }
+
+    func savePendingDraft() {
+        guard let anchor = state.pendingDraftAnchor else { return }
+        let groups = currentDisplayGroups
+        let canonicalAnchor = ReviewDraftCommentRowSegmentation.canonicalPendingAnchor(anchor, in: groups)
+        let body = state.pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { return }
+        let rowKeys = Set(groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
+        guard rowKeys.contains(ReviewDraftCommentPlacement.RowKey(
+            side: canonicalAnchor.side,
+            line: canonicalAnchor.draftPlacementLine
+        )) else {
+            clearPendingDraft()
+            return
+        }
+        state.actionRelay.saveDraftComment(canonicalAnchor, body: body)
+        clearPendingDraft()
+    }
+
+    func loadContextAndExpand(
+        _ key: DiffContextExpansionKey,
+        mode: DiffContextExpansionMode,
+        edge: DiffContextExpansionEdge?
+    ) {
+        guard let provider = file.contextProvider else { return }
+        contextExpansionActivated()
+        if state.contextSnapshot != nil {
+            applyContextExpansion(key, mode: mode, edge: edge)
+            return
+        }
+        state.pendingContextExpansions.append(.init(key: key, mode: mode, edge: edge))
+        guard state.contextLoadTask == nil else { return }
+        let fileID = file.id
+        let signature = contextStateSignature
+        let generation = state.beginContextLoad(fileID: fileID, signature: signature)
+        state.contextLoadError = nil
+        state.contextLoadTask = Task {
+            do {
+                let snapshot = try await provider.snapshot()
+                try Task.checkCancellation()
+                guard state.acceptsContextResult(fileID: fileID, generation: generation),
+                      state.contextLoadSignature == signature
+                else { return }
+                state.contextSnapshot = snapshot
+                state.contextLoadTask = nil
+                state.contextLoadFileID = nil
+                state.contextLoadSignature = nil
+                let pending = state.pendingContextExpansions
+                state.pendingContextExpansions = []
+                for expansion in pending {
+                    applyContextExpansion(expansion.key, mode: expansion.mode, edge: expansion.edge)
+                }
+            } catch {
+                guard state.acceptsContextResult(fileID: fileID, generation: generation),
+                      state.contextLoadSignature == signature
+                else { return }
+                state.contextLoadError = error.localizedDescription
+                state.contextLoadTask = nil
+                state.contextLoadFileID = nil
+                state.contextLoadSignature = nil
+                state.pendingContextExpansions = []
+            }
+        }
+    }
+
+    func activeHighlight(for rows: [DiffDisplayRow]) -> DiffReviewCommentHighlight? {
+        let candidates = DiffReviewActiveCommentIDs(
+            hoveredDraftCommentID: state.hoveredDraftCommentID,
+            focusedDraftCommentID: focusedDraftCommentID,
+            hoveredInlineFeedbackID: state.hoveredInlineFeedbackID,
+            focusedFeedbackID: focusedFeedbackID,
+            activeThreadID: state.activeThreadID
+        ).orderedCandidates
+        let highlight = candidates.lazy.compactMap(activeHighlight(for:)).first
+        guard let highlight,
+              rows.contains(where: { highlight.matchesVisibleSourceLine($0.old) || highlight.matchesVisibleSourceLine($0.new) })
+        else { return nil }
+        return highlight
+    }
+
+    private var currentDisplayGroups: [DiffDisplayGroup] {
+        guard let displayModel = file.displayModel else { return [] }
+        return state.renderContextCache.reviewContext(
+            fileID: file.id, displayModel: displayModel,
+            contextSnapshot: state.contextSnapshot,
+            contextProviderAvailable: file.contextProvider != nil,
+            contextExpansion: state.contextExpansion,
+            inlineFeedback: inlineFeedback, draftComments: draftComments,
+            pendingDraftAnchor: state.pendingDraftAnchor,
+            canCreateDraftComment: allowsDraftCommentCreation,
+            threads: threads, annotations: annotations
+        ).groups.map(\.displayGroup)
+    }
+
+    private var contextStateSignature: DiffReviewContextStateSignature {
+        .init(
+            fileID: file.id.rawValue,
+            providerID: file.contextProvider?.id.uuidString ?? "no-context-provider",
+            structuralHash: file.displayModel?.structuralHash
+        )
+    }
+
+    private func applyContextExpansion(
+        _ key: DiffContextExpansionKey,
+        mode: DiffContextExpansionMode,
+        edge: DiffContextExpansionEdge?
+    ) {
+        guard let displayModel = file.displayModel else { return }
+        let available = DiffContextExpandedDisplayBuilder.availableLineCount(
+            key: key, groups: displayModel.groups, snapshot: state.contextSnapshot
+        )
+        if let edge {
+            state.contextExpansion.expand(key, available: available, mode: mode, edge: edge)
+        } else {
+            state.contextExpansion.expand(key, available: available, mode: mode)
+        }
+    }
+
+    private func activeHighlight(for candidate: DiffReviewActiveCommentCandidate) -> DiffReviewCommentHighlight? {
+        switch candidate {
+        case .draft(let id):
+            guard let comment = draftComments.first(where: { $0.id == id }), comment.state != .dismissed else { return nil }
+            return .init(path: comment.path, side: comment.side, lineRange: comment.normalizedLineRange)
+        case .inlineFeedback(let id):
+            guard let item = inlineFeedback.first(where: { $0.id == id }), let line = item.anchor.line else { return nil }
+            return .init(path: item.anchor.path, side: item.anchor.side, line: line)
+        case .thread(let id):
+            guard let thread = threads.first(where: { $0.id == id }) else { return nil }
+            return .init(path: thread.filePath, side: thread.isOldSide ? .old : .new, lineRange: thread.lineRange)
+        }
     }
 }
 
@@ -275,12 +438,11 @@ enum AppKitDiffReviewRowPlanBuilder {
             layoutMode: input.layoutMode, wrapLines: input.wrapLines,
             showWhitespace: input.showWhitespace, codeFontFamily: input.codeFontFamily,
             codeFontSize: input.codeFontSize, theme: input.theme,
+            lspContext: input.lspContext,
+            activeCommentHighlight: input.activeHighlight(for: group.displayGroup.rows),
             allowsReviewLineSelection: input.allowsDraftCommentCreation,
-            onReviewLineSelected: { anchor in
-                input.state.pendingDraftAnchor = anchor
-                input.state.draftComposerFocusRequestGeneration &+= 1
-            },
-            onContextExpansion: { _, _, _ in input.state.actionRelay.contextExpansionActivated() },
+            onReviewLineSelected: input.beginPendingDraft,
+            onContextExpansion: input.loadContextAndExpand,
             threads: input.threads, annotations: input.annotations,
             onReply: { input.state.actionRelay.reply(to: $0, body: $1) },
             onResolve: input.state.actionRelay.resolve,
@@ -353,6 +515,10 @@ enum AppKitDiffReviewRowPlanBuilder {
             rowID: id, contentSignature: signature, layoutMode: input.layoutMode,
             wrapLines: input.wrapLines, showWhitespace: input.showWhitespace,
             codeFontFamily: input.codeFontFamily, codeFontSize: input.codeFontSize,
+            lspWorktreeID: input.lspContext?.worktreeId,
+            lspRelativePath: input.lspContext?.relativePath,
+            lspLanguage: input.lspContext?.language,
+            lspManagerIdentity: input.lspContext.map { ObjectIdentifier($0.lsp) },
             inlineFeedbackAvailability: inlineAvailability, draftCommentAvailability: draftAvailability,
             hoveredInlineFeedbackID: input.state.hoveredInlineFeedbackID,
             hoveredDraftCommentID: input.state.hoveredDraftCommentID,
@@ -389,115 +555,319 @@ enum AppKitDiffReviewRowPlanBuilder {
     }
 }
 
-private struct AppKitDiffReviewHeaderRowBody: View {
+struct AppKitDiffReviewHeaderRowBody: View {
     let input: AppKitDiffReviewRowInput
 
     var body: some View {
         HStack(spacing: 10) {
             Text(input.file.summary.status.glyph)
                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                .foregroundColor(input.theme.color("fg-muted"))
+                .foregroundColor(statusColor)
                 .frame(width: 16)
             VStack(alignment: .leading, spacing: 2) {
                 Text(input.file.summary.path)
                     .font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize))
+                    .foregroundColor(input.theme.color("fg"))
                     .lineLimit(1).truncationMode(.middle)
                 if let originalPath = input.file.summary.originalPath {
                     Text("from \(originalPath)").font(.system(size: 10.5)).foregroundColor(input.theme.color("fg-faint"))
                 }
             }
+            if input.showsSourceBadge, let title = input.file.summary.groupTitle {
+                Text(title.uppercased())
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .foregroundColor(sourceColor)
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(sourceColor.opacity(0.16))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .background(DiffReviewAccessibilityMarker(
+                        identifier: "diff-review-source-badge-\(input.file.id.rawValue)",
+                        label: title.uppercased()
+                    ))
+            }
             Spacer(minLength: 12)
-            Text("+\(input.file.summary.additions)  -\(input.file.summary.deletions)")
+            if shouldShowChangeSummary(
+                additions: input.file.summary.additions,
+                deletions: input.file.summary.deletions
+            ) {
+                HStack(spacing: 9) {
+                    Text("+\(input.file.summary.additions)").foregroundColor(input.theme.color("add"))
+                    Text("-\(input.file.summary.deletions)").foregroundColor(input.theme.color("del"))
+                }
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
+            }
+            if let pair = displayedImagePair {
+                ImageDiffControls(pair: pair, state: input.state.imageState.presentation)
+                    .background(DiffReviewAccessibilityMarker(
+                        identifier: "diff-review-image-header-\(input.file.id.rawValue)",
+                        label: "Image diff controls"
+                    ))
+            }
+            if let openFile = input.file.openFile,
+               let title = DiffReviewFileSectionActions.openFileButtonTitle(for: input.file) {
+                Button(action: openFile) {
+                    Text(title).font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(input.theme.color("fg-muted"))
+                        .padding(.horizontal, 8).frame(height: 24)
+                        .background(input.theme.color("bg-3"))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain).help(title)
+                .accessibilityIdentifier("diff-review-open-file-\(input.file.id.rawValue)")
+                .accessibilityLabel(title)
+            }
+            if let unstage = input.file.stagedMutationActions?.unstageFile {
+                Button("Unstage", action: unstage)
+                    .buttonStyle(.plain).font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(input.theme.color("fg-muted"))
+                    .padding(.horizontal, 8).frame(height: 24)
+                    .background(input.theme.color("bg-3"))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .accessibilityIdentifier("diff-review-unstage-file-\(input.file.id.rawValue)")
+            }
         }
         .padding(.horizontal, 14).padding(.vertical, 10)
         .background(input.theme.color("bg-2"))
         .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
     }
+
+    private var displayedImagePair: ImageDiffPair? {
+        input.state.imageState.pair
+            ?? input.file.imageProvider.flatMap { DiffReviewImagePairCache.shared.pair(for: $0.id) }
+    }
+
+    private var sourceColor: Color {
+        switch input.file.summary.groupID ?? input.file.summary.namespace {
+        case "unstaged": input.theme.color("warn")
+        case "staged": input.theme.color("info")
+        default: input.theme.color("accent")
+        }
+    }
+
+    private var statusColor: Color {
+        switch input.file.summary.status {
+        case .added: input.theme.color("add")
+        case .deleted: input.theme.color("del")
+        case .renamed, .copied: input.theme.color("accent")
+        case .conflicted: input.theme.color("warn")
+        case .modified, .unknown: input.theme.color("fg-dim")
+        }
+    }
 }
 
-private struct AppKitDiffReviewPlaceholderRowBody: View {
+struct AppKitDiffReviewPlaceholderRowBody: View {
     let input: AppKitDiffReviewRowInput
     let isDeferred: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(isDeferred ? "Large review diff deferred for performance" : (input.file.placeholderMessage ?? "This file cannot be rendered in the review view."))
+            let title = isDeferred
+                ? (input.automaticallyRendersDiff ? "Large diff hidden for performance" : "Large review diff deferred for performance")
+                : (input.file.placeholderMessage ?? "This file cannot be rendered in the review view.")
+            Text(title)
                 .font(.system(size: 12, weight: isDeferred ? .semibold : .regular))
+                .foregroundColor(isDeferred ? input.theme.color("fg") : input.theme.color("fg-dim"))
             if isDeferred {
                 Text("\((input.file.summary.additions + input.file.summary.deletions).formatted()) changed lines. Rendering may be slow.")
                     .font(.system(size: 12)).foregroundColor(input.theme.color("fg-dim"))
-                Button("Show full diff") { input.state.showFullDiffOverride = true }
-                    .buttonStyle(.plain).font(.system(size: 11, weight: .semibold))
+                let hiddenItems = input.inlineFeedback.count + input.draftComments.count + input.threads.count
+                if hiddenItems > 0 {
+                    Text("^[\(hiddenItems) comment](inflect: true) hidden — show the full diff to view.")
+                        .font(.system(size: 12)).foregroundColor(input.theme.color("fg-dim"))
+                        .accessibilityIdentifier("diff-review-render-budget-hidden-comments-\(input.file.id.rawValue)")
+                }
+                Button {
+                    input.state.showFullDiffOverride = true
+                } label: {
+                    Text("Show full diff").font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(input.theme.color("fg-muted"))
+                        .padding(.horizontal, 10).frame(height: 24)
+                        .background(input.theme.color("bg-3"))
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("diff-review-show-full-diff-\(input.file.id.rawValue)")
+                .background(ReviewDraftCommentActionPressMarker(
+                    identifier: "diff-review-show-full-diff-\(input.file.id.rawValue)",
+                    label: "Show full diff"
+                ) {
+                    input.state.showFullDiffOverride = true
+                })
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 14).padding(.vertical, 18).background(input.theme.color("bg-1"))
+        .background(DiffReviewAccessibilityMarker(
+            identifier: isDeferred
+                ? "diff-review-render-budget-\(input.file.id.rawValue)"
+                : "diff-review-placeholder-\(input.file.id.rawValue)",
+            label: isDeferred ? "Large review diff deferred for performance" : (input.file.placeholderMessage ?? "This file cannot be rendered in the review view.")
+        ))
     }
 }
 
-private struct AppKitDiffReviewImageRowBody: View {
+struct AppKitDiffReviewImageRowBody: View {
     let input: AppKitDiffReviewRowInput
 
     var body: some View {
         Group {
+            if input.state.imageState.isLoading {
+                ProgressView().controlSize(.small).frame(maxWidth: .infinity).padding(.vertical, 12)
+                    .background(DiffReviewAccessibilityMarker(
+                        identifier: "diff-review-image-loading-\(input.file.id.rawValue)",
+                        label: "Loading image diff"
+                    ))
+            }
             if let pair = input.state.imageState.pair ?? input.file.imageProvider.flatMap({ DiffReviewImagePairCache.shared.pair(for: $0.id) }) {
                 ImageDiffComparisonContent(pair: pair, state: input.state.imageState.presentation, boundedHeight: 360)
-            } else {
-                ProgressView().controlSize(.small).frame(maxWidth: .infinity).padding(.vertical, 12)
+                if let message = failureMessage(in: pair) {
+                    HStack(spacing: 10) {
+                        Text(message).font(.system(size: 11)).foregroundColor(input.theme.color("warn"))
+                        Spacer()
+                        Button("Retry") { Task { await input.state.imageState.retry() } }
+                            .buttonStyle(.plain).font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(input.theme.color("fg-muted"))
+                            .padding(.horizontal, 8).frame(height: 24)
+                            .background(input.theme.color("bg-3"))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .accessibilityIdentifier("diff-review-image-retry-\(input.file.id.rawValue)")
+                            .background(DiffReviewAccessibilityMarker(
+                                identifier: "diff-review-image-retry-\(input.file.id.rawValue)",
+                                label: "Retry image diff"
+                            ))
+                    }
+                    .padding(.horizontal, 14).padding(.vertical, 10)
+                    .background(DiffReviewAccessibilityMarker(
+                        identifier: "diff-review-image-failure-\(input.file.id.rawValue)", label: message
+                    ))
+                }
             }
         }
         .background(input.theme.color("bg-1"))
     }
+
+    private func failureMessage(in pair: ImageDiffPair) -> String? {
+        switch (pair.before, pair.after) {
+        case (.failed(let failure), _), (_, .failed(let failure)): failure.message
+        default: nil
+        }
+    }
 }
 
-private struct AppKitDiffReviewInlineFeedbackRowBody: View {
+struct AppKitDiffReviewInlineFeedbackRowBody: View {
     let item: DiffReviewInlineFeedback
     let input: AppKitDiffReviewRowInput
+    var rows: [DiffDisplayRow]? = nil
 
+    @ViewBuilder
     var body: some View {
+        if let rows {
+            DiffFeedbackLaneView(
+                lane: DiffFeedbackLaneResolver.lane(for: item),
+                layoutMode: input.layoutMode,
+                rows: rows
+            ) {
+                card.padding(.horizontal, 14)
+            }
+            .padding(.vertical, 10).background(input.theme.color("bg-1"))
+            .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        } else {
+            card.padding(.horizontal, 14).padding(.vertical, 10).background(input.theme.color("bg-1"))
+                .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        }
+    }
+
+    private var card: some View {
         DiffReviewInlineFeedbackCard(
             item: item, file: input.file.summary, isFocused: item.id == input.focusedFeedbackID,
             actions: input.state.actionRelay.inlineFeedbackActionsForRow,
             onSelect: input.state.actionRelay.selectInlineFeedback,
-            onHoverChange: { hovering in input.state.hoveredInlineFeedbackID = hovering ? item.id : nil }
+            onHoverChange: { hovering in
+                input.state.hoveredInlineFeedbackID = hovering
+                    ? item.id
+                    : (input.state.hoveredInlineFeedbackID == item.id ? nil : input.state.hoveredInlineFeedbackID)
+            }
         )
-        .padding(.horizontal, 14).padding(.vertical, 10).background(input.theme.color("bg-1"))
+        .id(DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: input.file.id))
     }
 }
 
-private struct AppKitDiffReviewDraftCommentRowBody: View {
+struct AppKitDiffReviewDraftCommentRowBody: View {
     let comment: ReviewDraftComment
     let input: AppKitDiffReviewRowInput
+    var rows: [DiffDisplayRow]? = nil
 
+    @ViewBuilder
     var body: some View {
+        if let rows {
+            DiffFeedbackLaneView(
+                lane: DiffFeedbackLaneResolver.lane(for: comment),
+                layoutMode: input.layoutMode,
+                rows: rows
+            ) {
+                card.padding(.horizontal, 14)
+            }
+            .padding(.vertical, 10).background(input.theme.color("bg-1"))
+            .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        } else {
+            card.padding(.horizontal, 14).padding(.vertical, 10).background(input.theme.color("bg-1"))
+                .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        }
+    }
+
+    private var card: some View {
         ReviewDraftCommentCard(
             comment: comment, file: input.file.summary,
             isFocused: comment.id == input.focusedDraftCommentID,
-            actions: input.state.actionRelay.draftCommentActionsForRow,
-            reviewFeedbackTarget: .init(title: input.file.summary.path, repositoryPath: nil, providerDescription: nil, sourceDescription: "Local draft comment"),
+            actions: input.draftCommentActions ?? input.state.actionRelay.draftCommentActionsForRow,
+            reviewFeedbackTarget: input.reviewFeedbackTarget ?? .init(
+                title: input.file.summary.path, repositoryPath: nil,
+                providerDescription: nil, sourceDescription: "Local draft comment"
+            ),
             onSelect: input.state.actionRelay.selectDraftComment,
-            onHoverChange: { hovering in input.state.hoveredDraftCommentID = hovering ? comment.id : nil }
+            onHoverChange: { hovering in
+                input.state.hoveredDraftCommentID = hovering
+                    ? comment.id
+                    : (input.state.hoveredDraftCommentID == comment.id ? nil : input.state.hoveredDraftCommentID)
+            }
         )
-        .padding(.horizontal, 14).padding(.vertical, 10).background(input.theme.color("bg-1"))
+        .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: input.file.id))
     }
 }
 
-private struct AppKitDiffReviewGroupHeaderRowBody: View {
+struct AppKitDiffReviewGroupHeaderRowBody: View {
     let group: DiffDisplayGroup
     let input: AppKitDiffReviewRowInput
 
     var body: some View {
         HStack(spacing: 8) {
-            Text(group.header).font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize - 1)).lineLimit(1)
+            Text(group.header)
+                .font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize - 1))
+                .foregroundColor(input.theme.color("fg-muted")).lineLimit(1)
             Spacer(minLength: 12)
+            if !DiffCollapsedContextController.collapsedRowIDs(in: group).isEmpty {
+                let expanded = DiffCollapsedContextController.isExpanded(
+                    group, expandedIDs: input.state.expandedCollapsedRowIDs
+                )
+                Button {
+                    input.state.expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(
+                        group, expandedIDs: input.state.expandedCollapsedRowIDs
+                    )
+                } label: {
+                    Image(systemName: expanded ? "minus.square" : "plus.square")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(input.theme.color("fg-muted"))
+                        .frame(width: 22, height: 20)
+                }
+                .buttonStyle(.plain).help(expanded ? "Collapse context" : "Expand context")
+            }
         }
         .padding(.horizontal, 13).padding(.vertical, 8).background(input.theme.color("bg-2"))
         .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
     }
 }
 
-private struct AppKitDiffReviewSegmentRowBody: View {
+struct AppKitDiffReviewSegmentRowBody: View {
     let rows: [DiffDisplayRow]
     let rowsSignature: DiffDisplayRowsSignature
     let group: DiffDisplayGroup
@@ -510,16 +880,17 @@ private struct AppKitDiffReviewSegmentRowBody: View {
             layoutMode: input.layoutMode, wrapLines: input.wrapLines, showWhitespace: input.showWhitespace,
             fileExtension: LanguageRegistry.highlighterExtension(forPath: input.file.summary.path),
             codeFontFamily: input.codeFontFamily, codeFontSize: input.codeFontSize, theme: input.theme,
-            lspContext: nil,
+            lspContext: input.lspContext,
+            activeCommentHighlight: input.activeHighlight(for: rows),
             allowsReviewLineSelection: input.allowsDraftCommentCreation,
-            onReviewLineSelected: { anchor in input.state.pendingDraftAnchor = anchor },
-            onContextExpansion: { _, _, _ in input.state.actionRelay.contextExpansionActivated() }
+            onReviewLineSelected: input.beginPendingDraft,
+            onContextExpansion: input.loadContextAndExpand
         )
         .fixedSize(horizontal: false, vertical: true)
     }
 }
 
-private struct AppKitDiffReviewThreadRowBody: View {
+struct AppKitDiffReviewThreadRowBody: View {
     let thread: DiffInlineCommentThread
     let rows: [DiffDisplayRow]
     let input: AppKitDiffReviewRowInput
@@ -535,43 +906,87 @@ private struct AppKitDiffReviewThreadRowBody: View {
                 canReply: input.actionPresence.canReply && thread.viewerCanReply,
                 canResolve: input.actionPresence.canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
                 canAddToReview: input.actionPresence.canAddToReview,
-                onActiveChange: { input.state.activeThreadID = $0 ? thread.id : nil }
+                onActiveChange: { active in
+                    input.state.activeThreadID = active
+                        ? thread.id
+                        : (input.state.activeThreadID == thread.id ? nil : input.state.activeThreadID)
+                }
             )
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }
 
-private struct AppKitDiffReviewAnnotationRowBody: View {
+struct AppKitDiffReviewAnnotationRowBody: View {
     let annotation: DiffInlineAnnotation
     let rows: [DiffDisplayRow]
     let input: AppKitDiffReviewRowInput
 
     var body: some View {
         DiffFeedbackLaneView(lane: DiffFeedbackLaneResolver.lane(for: annotation), layoutMode: input.layoutMode, rows: rows) {
-            DiffInlineAnnotationCard(annotation: annotation)
+            DiffInlineAnnotationCard(annotation: annotation).frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }
 
-private struct AppKitDiffReviewComposerRowBody: View {
+struct AppKitDiffReviewComposerRowBody: View {
     let rows: [DiffDisplayRow]
     let input: AppKitDiffReviewRowInput
+    @FocusState private var isFocused: Bool
 
     var body: some View {
         DiffFeedbackLaneView(lane: input.state.pendingDraftAnchor.map(DiffFeedbackLaneResolver.lane) ?? .full, layoutMode: input.layoutMode, rows: rows) {
             VStack(alignment: .leading, spacing: 10) {
-                TextEditor(text: Binding(get: { input.state.pendingDraftBody }, set: { input.state.pendingDraftBody = $0 }))
+                ReviewDraftComposerTextEditor(
+                    text: Binding(
+                        get: { input.state.pendingDraftBody },
+                        set: { input.state.pendingDraftBody = $0 }
+                    ),
+                    theme: input.theme,
+                    isFocused: $isFocused,
+                    focusRequestGeneration: input.state.draftComposerFocusRequestGeneration,
+                    onSave: input.savePendingDraft,
+                    onCancel: input.clearPendingDraft
+                )
                     .frame(minHeight: 76, maxHeight: 104)
+                    .background {
+                        if input.state.isDraftComposerFocused {
+                            DiffReviewAccessibilityMarker(
+                                identifier: "diff-review-draft-composer-focused",
+                                label: "Draft comment composer focused"
+                            )
+                        }
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 7))
+                    .overlay(RoundedRectangle(cornerRadius: 7)
+                        .stroke(input.theme.color("accent").opacity(0.65), lineWidth: 0.75))
+                    .accessibilityIdentifier("diff-review-draft-composer")
                 HStack {
                     Spacer()
-                    Button("Cancel") { input.state.pendingDraftAnchor = nil; input.state.pendingDraftBody = "" }
-                    Button("Save") {
-                        guard let anchor = input.state.pendingDraftAnchor else { return }
-                        input.state.actionRelay.saveDraftComment(anchor, body: input.state.pendingDraftBody)
-                    }
+                    Button("Cancel", action: input.clearPendingDraft)
+                        .buttonStyle(.plain).font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(input.theme.color("fg-muted"))
+                        .padding(.horizontal, 8).frame(height: 24)
+                        .background(input.theme.color("bg-3"))
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .accessibilityIdentifier("diff-review-draft-composer-cancel")
+                    Button("Save", action: input.savePendingDraft)
+                        .buttonStyle(.plain).font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(input.theme.color("bg-1"))
+                        .padding(.horizontal, 9).frame(height: 24)
+                        .background(input.theme.color("accent"))
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .accessibilityIdentifier("diff-review-draft-composer-save")
                 }
             }
             .padding(.horizontal, 16).padding(.vertical, 12).background(input.theme.color("bg-1"))
+            .overlay(Rectangle().fill(input.theme.color("line")).frame(height: 0.5), alignment: .bottom)
+            .background(DiffReviewAccessibilityMarker(
+                identifier: "diff-review-draft-composer-marker", label: "Draft comment composer"
+            ))
+            .onChange(of: isFocused) { _, focused in input.state.isDraftComposerFocused = focused }
+            .onChange(of: input.state.isDraftComposerFocused) { _, focused in isFocused = focused }
+            .onAppear { isFocused = input.state.isDraftComposerFocused }
         }
     }
 }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -48,6 +48,7 @@ struct AppKitDiffReviewRowToken: Equatable {
     let lspManagerIdentity: ObjectIdentifier?
     let inlineFeedbackAvailability: DiffReviewInlineFeedbackActionAvailability?
     let draftCommentAvailability: ReviewDraftCommentActionAvailability?
+    let reviewFeedbackTarget: ReviewFeedbackTarget?
     let hoveredInlineFeedbackID: String?
     let hoveredDraftCommentID: String?
     let focusedFeedbackID: String?
@@ -434,7 +435,10 @@ enum AppKitDiffReviewRowPlanBuilder {
                         }
                     case let .thread(thread):
                         let threadID = AppKitDiffReviewRowID.thread(fileID: input.file.id, threadID: thread.id)
-                        append(&rows, id: threadID, input: input, signature: String(reflecting: thread).hashValue, height: 112) {
+                        append(
+                            &rows, id: threadID, input: input, signature: String(reflecting: thread).hashValue,
+                            height: 112, retention: input.state.activeThreadID == thread.id ? .pinned : .recyclable
+                        ) {
                             AnyView(AppKitDiffReviewThreadRowBody(thread: thread, rows: segment.rows, input: input))
                         }
                     case let .annotation(annotation):
@@ -504,7 +508,8 @@ enum AppKitDiffReviewRowPlanBuilder {
                 id: AppKitDiffReviewRowID.thread(fileID: input.file.id, threadID: thread.id),
                 input: input,
                 signature: String(reflecting: thread).hashValue,
-                height: 112
+                height: 112,
+                retention: input.state.activeThreadID == thread.id ? .pinned : .recyclable
             ) {
                 AnyView(AppKitDiffReviewImageThreadRowBody(thread: thread, input: input))
             }
@@ -530,7 +535,11 @@ enum AppKitDiffReviewRowPlanBuilder {
     ) {
         let target = DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: input.file.id)
         let id = AppKitDiffReviewRowID.inlineFeedback(target)
-        append(&rows, id: id, input: input, signature: String(reflecting: item).hashValue, height: 96, inlineAvailability: input.state.actionRelay.inlineFeedbackAvailability(for: item, file: input.file.summary)) {
+        append(
+            &rows, id: id, input: input, signature: String(reflecting: item).hashValue, height: 96,
+            retention: input.state.activeInlineFeedbackEditorID == item.id ? .pinned : .recyclable,
+            inlineAvailability: input.state.actionRelay.inlineFeedbackAvailability(for: item, file: input.file.summary)
+        ) {
             AnyView(AppKitDiffReviewInlineFeedbackRowBody(item: item, input: input))
         }
         fallbacks[id] = id
@@ -544,7 +553,12 @@ enum AppKitDiffReviewRowPlanBuilder {
     ) {
         let target = DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: input.file.id)
         let id = AppKitDiffReviewRowID.draftComment(target)
-        append(&rows, id: id, input: input, signature: String(reflecting: comment).hashValue, height: 112, draftAvailability: input.state.actionRelay.draftCommentAvailability(for: comment)) {
+        append(
+            &rows, id: id, input: input, signature: String(reflecting: comment).hashValue, height: 112,
+            retention: input.state.activeDraftCommentEditorID == comment.id ? .pinned : .recyclable,
+            draftAvailability: input.state.actionRelay.draftCommentAvailability(for: comment),
+            reviewFeedbackTarget: input.reviewFeedbackTarget
+        ) {
             AnyView(AppKitDiffReviewDraftCommentRowBody(comment: comment, input: input))
         }
         fallbacks[id] = id
@@ -575,6 +589,7 @@ enum AppKitDiffReviewRowPlanBuilder {
         signature: Int, height: CGFloat, retention: AppKitDiffRowRetention = .recyclable,
         inlineAvailability: DiffReviewInlineFeedbackActionAvailability? = nil,
         draftAvailability: ReviewDraftCommentActionAvailability? = nil,
+        reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
         includesActiveHighlight: Bool = false,
         build: @escaping () -> AnyView
     ) {
@@ -588,6 +603,7 @@ enum AppKitDiffReviewRowPlanBuilder {
             lspLanguage: input.lspContext?.language,
             lspManagerIdentity: input.lspContext.map { ObjectIdentifier($0.lsp) },
             inlineFeedbackAvailability: inlineAvailability, draftCommentAvailability: draftAvailability,
+            reviewFeedbackTarget: reviewFeedbackTarget,
             hoveredInlineFeedbackID: includesActiveHighlight ? input.state.hoveredInlineFeedbackID : nil,
             hoveredDraftCommentID: includesActiveHighlight ? input.state.hoveredDraftCommentID : nil,
             focusedFeedbackID: input.focusedFeedbackID,
@@ -940,6 +956,11 @@ struct AppKitDiffReviewInlineFeedbackRowBody: View {
                 input.state.hoveredInlineFeedbackID = hovering
                     ? item.id
                     : (input.state.hoveredInlineFeedbackID == item.id ? nil : input.state.hoveredInlineFeedbackID)
+            },
+            onEditorActiveChange: { active in
+                input.state.activeInlineFeedbackEditorID = active
+                    ? item.id
+                    : (input.state.activeInlineFeedbackEditorID == item.id ? nil : input.state.activeInlineFeedbackEditorID)
             }
         )
         .id(DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: input.file.id))
@@ -983,6 +1004,11 @@ struct AppKitDiffReviewDraftCommentRowBody: View {
                 input.state.hoveredDraftCommentID = hovering
                     ? comment.id
                     : (input.state.hoveredDraftCommentID == comment.id ? nil : input.state.hoveredDraftCommentID)
+            },
+            onEditorActiveChange: { active in
+                input.state.activeDraftCommentEditorID = active
+                    ? comment.id
+                    : (input.state.activeDraftCommentEditorID == comment.id ? nil : input.state.activeDraftCommentEditorID)
             }
         )
         .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: input.file.id))

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -432,7 +432,8 @@ enum AppKitDiffReviewRowPlanBuilder {
                     id: groupID,
                     ownerID: input.file.id.rawValue,
                     equalityToken: hunk.equalityToken,
-                    estimatedHeight: hunk.estimatedHeight
+                    estimatedHeight: hunk.estimatedHeight,
+                    retention: hunk.retention
                 ) {
                     hunk.build()
                 })

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -693,6 +693,8 @@ enum AppKitDiffReviewRowPlanBuilder {
         hasher.combine(input.file.summary.status)
         hasher.combine(input.file.summary.additions)
         hasher.combine(input.file.summary.deletions)
+        hasher.combine(input.showsSourceBadge)
+        hasher.combine(input.file.summary.groupTitle)
         return hasher.finalize()
     }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -317,6 +317,9 @@ enum AppKitDiffReviewRowPlanBuilder {
                 stagedMutationActions: input.file.stagedMutationActions,
                 openFile: input.file.openFile
             )
+            if input.file.imageProvider == nil {
+                input.state.imageState.clear()
+            }
             let fileID = input.file.id
             let headerID = AppKitDiffReviewRowID.header(fileID: fileID)
             headerByFileID[fileID] = headerID

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -4,6 +4,7 @@ enum AppKitDiffReviewRowID {
     static func header(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):header" }
     static func placeholder(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):placeholder" }
     static func image(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):image" }
+    static func contextError(fileID: DiffReviewFileID) -> String { "file:\(fileID.rawValue):context-error" }
     static func groupHeader(fileID: DiffReviewFileID, groupID: String) -> String { "file:\(fileID.rawValue):group:\(groupID):header" }
     static func segment(fileID: DiffReviewFileID, segmentID: String, blockID: String) -> String { "file:\(fileID.rawValue):segment:\(segmentID):rows:\(blockID)" }
     static func composer(fileID: DiffReviewFileID, segmentID: String) -> String { "file:\(fileID.rawValue):composer:\(segmentID)" }
@@ -28,6 +29,8 @@ struct AppKitDiffReviewActionPresence: Equatable {
     var canReply = false
     var canResolve = false
     var canAddToReview = false
+    var canUnstageHunk = false
+    var hunkUnstageEnabled = false
 }
 
 struct AppKitDiffReviewRowToken: Equatable {
@@ -75,8 +78,6 @@ struct AppKitDiffReviewRowInput {
     var lspContext: DiffPaneLSPContext?
     var reviewFeedbackTarget: ReviewFeedbackTarget?
     var draftCommentActions: ReviewDraftCommentActions?
-    private let contextExpansionActivated: () -> Void
-
     init(
         file: DiffReviewFileSectionModel,
         inlineFeedback: [DiffReviewInlineFeedback] = [],
@@ -124,8 +125,9 @@ struct AppKitDiffReviewRowInput {
         self.lspContext = lspContext
         self.reviewFeedbackTarget = reviewFeedbackTarget
         self.draftCommentActions = draftCommentActions
-        self.contextExpansionActivated = onContextExpansionActivated
-            ?? { state.actionRelay.contextExpansionActivated() }
+        if let onContextExpansionActivated {
+            state.actionRelay.update(onContextExpansionActivated: onContextExpansionActivated)
+        }
     }
 
     func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
@@ -164,7 +166,7 @@ struct AppKitDiffReviewRowInput {
         edge: DiffContextExpansionEdge?
     ) {
         guard let provider = file.contextProvider else { return }
-        contextExpansionActivated()
+        state.actionRelay.contextExpansionActivated()
         if state.contextSnapshot != nil {
             applyContextExpansion(key, mode: mode, edge: edge)
             return
@@ -300,11 +302,30 @@ enum AppKitDiffReviewRowPlanBuilder {
         )
 
         for (index, input) in inputs.enumerated() {
+            input.state.actionRelay.update(
+                stagedMutationActions: input.file.stagedMutationActions,
+                openFile: input.file.openFile
+            )
             let fileID = input.file.id
             let headerID = AppKitDiffReviewRowID.header(fileID: fileID)
             headerByFileID[fileID] = headerID
             append(&rows, id: headerID, input: input, signature: headerSignature(input), height: 45) {
                 AnyView(AppKitDiffReviewHeaderRowBody(input: input))
+            }
+            if let contextLoadError = input.state.contextLoadError {
+                append(
+                    &rows,
+                    id: AppKitDiffReviewRowID.contextError(fileID: fileID),
+                    input: input,
+                    signature: contextLoadError.hashValue,
+                    height: 34
+                ) {
+                    AnyView(DiffReviewContextErrorRowBody(
+                        fileID: fileID,
+                        message: contextLoadError,
+                        theme: input.theme
+                    ))
+                }
             }
 
             let individuallyDeferred = input.file.displayModel.map(DiffReviewRenderBudget.isOverBudget) ?? false
@@ -319,6 +340,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                 mapTargets(input, to: placeholderID, into: &fallbackByTargetID)
             } else if input.file.imageProvider != nil {
                 appendFileAccessories(input, context: nil, rows: &rows, fallbacks: &fallbackByTargetID)
+                appendImageFeedback(input, rows: &rows)
                 let imageID = AppKitDiffReviewRowID.image(fileID: fileID)
                 append(&rows, id: imageID, input: input, signature: input.file.imageProvider?.id.hashValue ?? 0, height: 360) {
                     AnyView(AppKitDiffReviewImageRowBody(input: input, loadsImage: true))
@@ -417,7 +439,14 @@ enum AppKitDiffReviewRowPlanBuilder {
                 for comment in segment.draftComments { appendDraft(comment, input: input, rows: &rows, fallbacks: &fallbacks) }
                 if segment.showsComposer {
                     let composerID = AppKitDiffReviewRowID.composer(fileID: input.file.id, segmentID: segment.id)
-                    append(&rows, id: composerID, input: input, signature: input.state.draftComposerFocusRequestGeneration, height: 132, retention: .pinned) {
+                    append(
+                        &rows,
+                        id: composerID,
+                        input: input,
+                        signature: input.state.draftComposerFocusRequestGeneration,
+                        height: 132,
+                        retention: input.state.isDraftComposerFocused ? .pinned : .recyclable
+                    ) {
                         AnyView(AppKitDiffReviewComposerRowBody(rows: segment.rows, input: input))
                     }
                 }
@@ -453,13 +482,36 @@ enum AppKitDiffReviewRowPlanBuilder {
             onStageReply: { input.state.actionRelay.stageReply(to: $0, body: $1) },
             canAddToReview: input.actionPresence.canAddToReview,
             hunkFusionStates: [fusion],
-            hunkActions: { hunk in
-                let enabled = input.file.stagedMutationActions?.isHunkUnstageEnabled?(hunk) ?? false
-                return DiffPaneHunkActions(
-                    dropFromCommit: enabled ? { input.file.stagedMutationActions?.unstageHunk?(hunk) } : nil
-                )
-            }
+            hunkActions: input.state.actionRelay.hunkActions
         )
+    }
+
+    private static func appendImageFeedback(
+        _ input: AppKitDiffReviewRowInput,
+        rows: inout [AppKitDiffRowSpec]
+    ) {
+        for thread in input.threads {
+            append(
+                &rows,
+                id: AppKitDiffReviewRowID.thread(fileID: input.file.id, threadID: thread.id),
+                input: input,
+                signature: String(reflecting: thread).hashValue,
+                height: 112
+            ) {
+                AnyView(AppKitDiffReviewImageThreadRowBody(thread: thread, input: input))
+            }
+        }
+        for annotation in input.annotations {
+            append(
+                &rows,
+                id: AppKitDiffReviewRowID.annotation(fileID: input.file.id, annotationID: annotation.id),
+                input: input,
+                signature: String(reflecting: annotation).hashValue,
+                height: 52
+            ) {
+                AnyView(AppKitDiffReviewImageAnnotationRowBody(annotation: annotation, input: input))
+            }
+        }
     }
 
     private static func appendFeedback(
@@ -526,8 +578,8 @@ enum AppKitDiffReviewRowPlanBuilder {
             lspLanguage: input.lspContext?.language,
             lspManagerIdentity: input.lspContext.map { ObjectIdentifier($0.lsp) },
             inlineFeedbackAvailability: inlineAvailability, draftCommentAvailability: draftAvailability,
-            hoveredInlineFeedbackID: input.state.hoveredInlineFeedbackID,
-            hoveredDraftCommentID: input.state.hoveredDraftCommentID,
+            hoveredInlineFeedbackID: nil,
+            hoveredDraftCommentID: nil,
             activeThreadID: input.state.activeThreadID,
             draftComposerFocused: input.state.isDraftComposerFocused,
             actionPresence: input.actionPresence
@@ -609,9 +661,9 @@ struct AppKitDiffReviewHeaderRowBody: View {
                         label: "Image diff controls"
                     ))
             }
-            if let openFile = input.file.openFile,
+            if input.file.openFile != nil,
                let title = DiffReviewFileSectionActions.openFileButtonTitle(for: input.file) {
-                Button(action: openFile) {
+                Button(action: input.state.actionRelay.openCurrentFile) {
                     Text(title).font(.system(size: 11, weight: .semibold))
                         .foregroundColor(input.theme.color("fg-muted"))
                         .padding(.horizontal, 8).frame(height: 24)
@@ -622,8 +674,8 @@ struct AppKitDiffReviewHeaderRowBody: View {
                 .accessibilityIdentifier("diff-review-open-file-\(input.file.id.rawValue)")
                 .accessibilityLabel(title)
             }
-            if let unstage = input.file.stagedMutationActions?.unstageFile {
-                Button("Unstage", action: unstage)
+            if input.file.stagedMutationActions?.unstageFile != nil {
+                Button("Unstage", action: input.state.actionRelay.unstageFile)
                     .buttonStyle(.plain).font(.system(size: 11, weight: .semibold))
                     .foregroundColor(input.theme.color("fg-muted"))
                     .padding(.horizontal, 8).frame(height: 24)
@@ -634,7 +686,7 @@ struct AppKitDiffReviewHeaderRowBody: View {
                         identifier: "diff-review-unstage-file-\(input.file.id.rawValue)",
                         label: "Unstage \(input.file.summary.path)"
                     ) {
-                        unstage()
+                        input.state.actionRelay.unstageFile()
                     })
             }
         }
@@ -774,6 +826,73 @@ struct AppKitDiffReviewImageRowBody: View {
         case (.failed(let failure), _), (_, .failed(let failure)): failure.message
         default: nil
         }
+    }
+}
+
+struct DiffReviewContextErrorRowBody: View {
+    let fileID: DiffReviewFileID
+    let message: String
+    let theme: Theme
+
+    var body: some View {
+        Text("Could not load surrounding context: \(message)")
+            .font(.system(size: 11))
+            .foregroundColor(theme.color("warn"))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(theme.color("bg-2"))
+            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+            .background(DiffReviewAccessibilityMarker(
+                identifier: "diff-review-context-error-\(fileID.rawValue)",
+                label: "Could not load surrounding context: \(message)"
+            ))
+    }
+}
+
+struct AppKitDiffReviewImageThreadRowBody: View {
+    let thread: DiffInlineCommentThread
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        DiffInlineCommentCard(
+            thread: thread,
+            onReply: { input.state.actionRelay.reply(to: thread, body: $0) },
+            onStageReply: { input.state.actionRelay.stageReply(to: thread, body: $0) },
+            onResolve: { input.state.actionRelay.resolve(thread) },
+            onUnresolve: { input.state.actionRelay.unresolve(thread) },
+            onEdit: { input.state.actionRelay.edit($0, in: thread, body: $1) },
+            onDelete: { input.state.actionRelay.delete($0, in: thread) },
+            canReply: input.actionPresence.canReply && thread.viewerCanReply,
+            canResolve: input.actionPresence.canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
+            canAddToReview: input.actionPresence.canAddToReview,
+            onActiveChange: { active in
+                input.state.activeThreadID = active
+                    ? thread.id
+                    : (input.state.activeThreadID == thread.id ? nil : input.state.activeThreadID)
+            }
+        )
+        .background(DiffReviewAccessibilityMarker(
+            identifier: "diff-review-image-thread-\(thread.id)",
+            label: "Image review thread"
+        ))
+        .padding(.horizontal, 14).padding(.vertical, 10)
+        .background(input.theme.color("bg-1"))
+    }
+}
+
+struct AppKitDiffReviewImageAnnotationRowBody: View {
+    let annotation: DiffInlineAnnotation
+    let input: AppKitDiffReviewRowInput
+
+    var body: some View {
+        DiffInlineAnnotationCard(annotation: annotation)
+            .background(DiffReviewAccessibilityMarker(
+                identifier: "diff-review-image-annotation-\(annotation.id)",
+                label: annotation.message
+            ))
+            .padding(.horizontal, 14).padding(.vertical, 10)
+            .background(input.theme.color("bg-1"))
     }
 }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -36,6 +36,19 @@ struct AppKitDiffReviewActionPresence: Equatable {
     var hunkUnstageEnabled = false
 }
 
+private enum AppKitDiffReviewCardRowPosition: Equatable {
+    case only
+    case first
+    case middle
+    case last
+}
+
+private struct AppKitDiffReviewCardRowToken: Equatable {
+    let content: AppKitDiffRowEqualityToken
+    let position: AppKitDiffReviewCardRowPosition
+    let theme: Theme
+}
+
 struct AppKitDiffReviewRowToken: Equatable {
     let rowID: String
     let contentSignature: Int
@@ -313,6 +326,7 @@ enum AppKitDiffReviewRowPlanBuilder {
         )
 
         for (index, input) in inputs.enumerated() {
+            let fileRowStartIndex = rows.count
             input.state.actionRelay.update(
                 stagedMutationActions: input.file.stagedMutationActions,
                 openFile: input.file.openFile
@@ -365,10 +379,10 @@ enum AppKitDiffReviewRowPlanBuilder {
                 appendTextRows(context, input: input, into: &rows, fallbacks: &fallbackByTargetID)
             }
 
-            if input.showsBottomSpacing,
-               !isDeferred,
-               input.file.imageProvider == nil,
-               input.file.displayModel != nil {
+            let fileRowEndIndex = rows.count
+            applyCardChrome(to: &rows, range: fileRowStartIndex..<fileRowEndIndex, input: input)
+
+            if input.showsBottomSpacing, eligibility[index].showsBottomSpacing {
                 append(&rows, id: AppKitDiffReviewRowID.spacing(fileID: fileID), input: input, signature: 0, height: 14) {
                     AnyView(Color.clear.frame(height: 14))
                 }
@@ -378,6 +392,29 @@ enum AppKitDiffReviewRowPlanBuilder {
             corePlan: .init(rows: rows), fallbackByTargetID: fallbackByTargetID,
             headerByFileID: headerByFileID, placeholderByFileID: placeholderByFileID
         )
+    }
+
+    private static func applyCardChrome(
+        to rows: inout [AppKitDiffRowSpec],
+        range: Range<Int>,
+        input: AppKitDiffReviewRowInput
+    ) {
+        guard !range.isEmpty else { return }
+        let lastIndex = range.upperBound - 1
+        for index in range {
+            let position: AppKitDiffReviewCardRowPosition
+            if range.count == 1 {
+                position = .only
+            } else if index == range.lowerBound {
+                position = .first
+            } else if index == lastIndex {
+                position = .last
+            } else {
+                position = .middle
+            }
+            let row = rows[index]
+            rows[index] = row.withReviewCardChrome(position: position, theme: input.theme)
+        }
     }
 
     private static func renderContext(for input: AppKitDiffReviewRowInput) -> DiffReviewRenderContext? {
@@ -834,6 +871,151 @@ struct AppKitDiffReviewHeaderRowBody: View {
         case .renamed, .copied: input.theme.color("accent")
         case .conflicted: input.theme.color("warn")
         case .modified, .unknown: input.theme.color("fg-dim")
+        }
+    }
+}
+
+private extension AppKitDiffRowSpec {
+    func withReviewCardChrome(
+        position: AppKitDiffReviewCardRowPosition,
+        theme: Theme
+    ) -> AppKitDiffRowSpec {
+        AppKitDiffRowSpec(
+            id: id,
+            ownerID: ownerID,
+            equalityToken: .init(AppKitDiffReviewCardRowToken(
+                content: equalityToken,
+                position: position,
+                theme: theme
+            )),
+            estimatedHeight: estimatedHeight,
+            retention: retention,
+            contextRowCount: contextRowCount
+        ) {
+            AnyView(AppKitDiffReviewCardRowChrome(position: position, theme: theme) {
+                build()
+            })
+        }
+    }
+}
+
+private struct AppKitDiffReviewCardRowChrome<Content: View>: View {
+    let position: AppKitDiffReviewCardRowPosition
+    let theme: Theme
+    let content: Content
+
+    init(
+        position: AppKitDiffReviewCardRowPosition,
+        theme: Theme,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.position = position
+        self.theme = theme
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .background(theme.color("bg-1"))
+            .clipShape(AppKitDiffReviewCardClipShape(position: position))
+            .overlay(
+                AppKitDiffReviewCardBorderShape(position: position)
+                    .stroke(theme.color("line"), lineWidth: 0.75)
+            )
+    }
+}
+
+private struct AppKitDiffReviewCardClipShape: Shape {
+    let position: AppKitDiffReviewCardRowPosition
+
+    func path(in rect: CGRect) -> Path {
+        let radius = min(CGFloat(8), rect.width / 2, rect.height / 2)
+        switch position {
+        case .only:
+            return RoundedRectangle(cornerRadius: radius).path(in: rect)
+        case .first:
+            var path = Path()
+            path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + radius))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.minX + radius, y: rect.minY),
+                control: CGPoint(x: rect.minX, y: rect.minY)
+            )
+            path.addLine(to: CGPoint(x: rect.maxX - radius, y: rect.minY))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.maxX, y: rect.minY + radius),
+                control: CGPoint(x: rect.maxX, y: rect.minY)
+            )
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            path.closeSubpath()
+            return path
+        case .middle:
+            return Rectangle().path(in: rect)
+        case .last:
+            var path = Path()
+            path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - radius))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.maxX - radius, y: rect.maxY),
+                control: CGPoint(x: rect.maxX, y: rect.maxY)
+            )
+            path.addLine(to: CGPoint(x: rect.minX + radius, y: rect.maxY))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.minX, y: rect.maxY - radius),
+                control: CGPoint(x: rect.minX, y: rect.maxY)
+            )
+            path.closeSubpath()
+            return path
+        }
+    }
+}
+
+private struct AppKitDiffReviewCardBorderShape: Shape {
+    let position: AppKitDiffReviewCardRowPosition
+
+    func path(in rect: CGRect) -> Path {
+        let radius = min(CGFloat(8), rect.width / 2, rect.height / 2)
+        switch position {
+        case .only:
+            return RoundedRectangle(cornerRadius: radius).path(in: rect)
+        case .first:
+            var path = Path()
+            path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + radius))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.minX + radius, y: rect.minY),
+                control: CGPoint(x: rect.minX, y: rect.minY)
+            )
+            path.addLine(to: CGPoint(x: rect.maxX - radius, y: rect.minY))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.maxX, y: rect.minY + radius),
+                control: CGPoint(x: rect.maxX, y: rect.minY)
+            )
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            return path
+        case .middle:
+            var path = Path()
+            path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+            path.move(to: CGPoint(x: rect.maxX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            return path
+        case .last:
+            var path = Path()
+            path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - radius))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.minX + radius, y: rect.maxY),
+                control: CGPoint(x: rect.minX, y: rect.maxY)
+            )
+            path.addLine(to: CGPoint(x: rect.maxX - radius, y: rect.maxY))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.maxX, y: rect.maxY - radius),
+                control: CGPoint(x: rect.maxX, y: rect.maxY)
+            )
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            return path
         }
     }
 }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -397,8 +397,8 @@ enum AppKitDiffReviewRowPlanBuilder {
         let feedback = context?.fileLevelInlineFeedback ?? input.inlineFeedback
         let drafts = context?.fileLevelDraftComments
             ?? ReviewDraftCommentPlacement.position(input.draftComments, in: []).fileLevel
-        for comment in drafts { appendDraft(comment, input: input, rows: &rows, fallbacks: &fallbacks) }
-        appendFeedback(feedback, scopeID: "file", input: input, rows: &rows, fallbacks: &fallbacks)
+        for comment in drafts { appendDraft(comment, contextRows: nil, input: input, rows: &rows, fallbacks: &fallbacks) }
+        appendFeedback(feedback, scopeID: "file", contextRows: nil, input: input, rows: &rows, fallbacks: &fallbacks)
     }
 
     private static func appendTextRows(
@@ -409,7 +409,14 @@ enum AppKitDiffReviewRowPlanBuilder {
     ) {
         let fusions = DiffReviewHunkFusionResolver.states(for: context.groups)
         for (groupIndex, group) in context.groups.enumerated() {
-            appendFeedback(group.inlineFeedback, scopeID: group.id, input: input, rows: &rows, fallbacks: &fallbacks)
+            appendFeedback(
+                group.inlineFeedback,
+                scopeID: group.id,
+                contextRows: group.displayGroup.rows,
+                input: input,
+                rows: &rows,
+                fallbacks: &fallbacks
+            )
             let groupID = AppKitDiffReviewRowID.groupHeader(fileID: input.file.id, groupID: group.id)
             if !group.containsLocalAccessories {
                 let rowInput = hunkInput(group: group, context: context, input: input, fusion: fusions[groupIndex])
@@ -452,7 +459,9 @@ enum AppKitDiffReviewRowPlanBuilder {
                         }
                     }
                 }
-                for comment in segment.draftComments { appendDraft(comment, input: input, rows: &rows, fallbacks: &fallbacks) }
+                for comment in segment.draftComments {
+                    appendDraft(comment, contextRows: segment.rows, input: input, rows: &rows, fallbacks: &fallbacks)
+                }
                 if segment.showsComposer {
                     let composerID = AppKitDiffReviewRowID.composer(fileID: input.file.id, segmentID: segment.id)
                     append(
@@ -534,6 +543,7 @@ enum AppKitDiffReviewRowPlanBuilder {
     private static func appendFeedback(
         _ items: [DiffReviewInlineFeedback],
         scopeID: String,
+        contextRows: [DiffDisplayRow]?,
         input: AppKitDiffReviewRowInput,
         rows: inout [AppKitDiffRowSpec],
         fallbacks: inout [String: String]
@@ -542,7 +552,7 @@ enum AppKitDiffReviewRowPlanBuilder {
             for: items, includingRequiredIDs: Set([input.focusedFeedbackID].compactMap(\.self))
         )
         for item in display.visibleItems {
-            appendFeedback(item, input: input, rows: &rows, fallbacks: &fallbacks)
+            appendFeedback(item, contextRows: contextRows, input: input, rows: &rows, fallbacks: &fallbacks)
         }
         guard display.hiddenCount > 0 else { return }
         append(
@@ -555,6 +565,7 @@ enum AppKitDiffReviewRowPlanBuilder {
 
     private static func appendFeedback(
         _ item: DiffReviewInlineFeedback,
+        contextRows: [DiffDisplayRow]?,
         input: AppKitDiffReviewRowInput,
         rows: inout [AppKitDiffRowSpec],
         fallbacks: inout [String: String]
@@ -562,17 +573,19 @@ enum AppKitDiffReviewRowPlanBuilder {
         let target = DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: input.file.id)
         let id = AppKitDiffReviewRowID.inlineFeedback(target)
         append(
-            &rows, id: id, input: input, signature: String(reflecting: item).hashValue, height: 96,
+            &rows, id: id, input: input, signature: accessorySignature(item, contextRows: contextRows), height: 96,
             retention: input.state.activeInlineFeedbackEditorID == item.id ? .pinned : .recyclable,
-            inlineAvailability: input.state.actionRelay.inlineFeedbackAvailability(for: item, file: input.file.summary)
+            inlineAvailability: input.state.actionRelay.inlineFeedbackAvailability(for: item, file: input.file.summary),
+            contextRowCount: contextRows?.count
         ) {
-            AnyView(AppKitDiffReviewInlineFeedbackRowBody(item: item, input: input))
+            AnyView(AppKitDiffReviewInlineFeedbackRowBody(item: item, input: input, rows: contextRows))
         }
         fallbacks[id] = id
     }
 
     private static func appendDraft(
         _ comment: ReviewDraftComment,
+        contextRows: [DiffDisplayRow]?,
         input: AppKitDiffReviewRowInput,
         rows: inout [AppKitDiffRowSpec],
         fallbacks: inout [String: String]
@@ -580,16 +593,26 @@ enum AppKitDiffReviewRowPlanBuilder {
         let target = DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: input.file.id)
         let id = AppKitDiffReviewRowID.draftComment(target)
         append(
-            &rows, id: id, input: input, signature: String(reflecting: comment).hashValue, height: 112,
+            &rows, id: id, input: input, signature: accessorySignature(comment, contextRows: contextRows), height: 112,
             retention: input.state.activeDraftCommentEditorID == comment.id ? .pinned : .recyclable,
             draftAvailability: input.state.actionRelay.draftCommentAvailability(for: comment),
             draftAgentTargets: (input.draftCommentActions ?? input.state.actionRelay.draftCommentActionsForRow)
                 .agentTargets(),
-            reviewFeedbackTarget: input.reviewFeedbackTarget
+            reviewFeedbackTarget: input.reviewFeedbackTarget,
+            contextRowCount: contextRows?.count
         ) {
-            AnyView(AppKitDiffReviewDraftCommentRowBody(comment: comment, input: input))
+            AnyView(AppKitDiffReviewDraftCommentRowBody(comment: comment, input: input, rows: contextRows))
         }
         fallbacks[id] = id
+    }
+
+    private static func accessorySignature(_ value: some Any, contextRows: [DiffDisplayRow]?) -> Int {
+        var hasher = Hasher()
+        hasher.combine(String(reflecting: value))
+        if let contextRows {
+            hasher.combine(DiffDisplayRowsSignature(contextRows))
+        }
+        return hasher.finalize()
     }
 
     private static func mapTargets(_ input: AppKitDiffReviewRowInput, to rowID: String, into fallbacks: inout [String: String]) {
@@ -620,6 +643,7 @@ enum AppKitDiffReviewRowPlanBuilder {
         draftAgentTargets: [ReviewFeedbackAgentTarget] = [],
         reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
         includesActiveHighlight: Bool = false,
+        contextRowCount: Int? = nil,
         build: @escaping () -> AnyView
     ) {
         let token = AppKitDiffReviewRowToken(
@@ -642,7 +666,15 @@ enum AppKitDiffReviewRowPlanBuilder {
             draftComposerFocused: input.state.isDraftComposerFocused,
             actionPresence: input.actionPresence
         )
-        rows.append(.init(id: id, ownerID: input.file.id.rawValue, equalityToken: .init(token), estimatedHeight: height, retention: retention, build: build))
+        rows.append(.init(
+            id: id,
+            ownerID: input.file.id.rawValue,
+            equalityToken: .init(token),
+            estimatedHeight: height,
+            retention: retention,
+            contextRowCount: contextRowCount,
+            build: build
+        ))
     }
 
     private static func headerSignature(_ input: AppKitDiffReviewRowInput) -> Int {

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+enum AppKitDiffReviewScrollRequestResolver {
+    static func request(
+        fileCommand: DiffReviewScrollCommand?,
+        inlineFeedbackCommand: DiffReviewInlineFeedbackScrollCommand?,
+        draftCommentCommand: DiffReviewDraftCommentScrollCommand?,
+        plan: AppKitDiffReviewRowPlan
+    ) -> AppKitDiffScrollRequest? {
+        if let draftCommentCommand {
+            return reviewItemRequest(
+                targetID: AppKitDiffReviewRowID.draftComment(draftCommentCommand.targetID),
+                fileID: draftCommentCommand.fileID,
+                generation: commandGeneration(draftCommentCommand.generation, kind: .draftComment),
+                plan: plan
+            )
+        }
+        if let inlineFeedbackCommand {
+            return reviewItemRequest(
+                targetID: AppKitDiffReviewRowID.inlineFeedback(inlineFeedbackCommand.targetID),
+                fileID: inlineFeedbackCommand.fileID,
+                generation: commandGeneration(inlineFeedbackCommand.generation, kind: .inlineFeedback),
+                plan: plan
+            )
+        }
+        guard let fileCommand else { return nil }
+        let headerID = plan.headerByFileID[fileCommand.id]
+        return .init(
+            targetID: headerID ?? AppKitDiffReviewRowID.header(fileID: fileCommand.id),
+            fallbackID: headerID,
+            alignment: .top,
+            animated: true,
+            generation: commandGeneration(fileCommand.generation, kind: .file)
+        )
+    }
+
+    private enum Kind: Int { case file, inlineFeedback, draftComment }
+
+    private static func commandGeneration(_ generation: Int, kind: Kind) -> Int {
+        generation * 3 + kind.rawValue
+    }
+
+    private static func reviewItemRequest(
+        targetID: String,
+        fileID: DiffReviewFileID,
+        generation: Int,
+        plan: AppKitDiffReviewRowPlan
+    ) -> AppKitDiffScrollRequest {
+        let headerID = plan.headerByFileID[fileID]
+        let resolvedTargetID = plan.fallbackByTargetID[targetID] ?? targetID
+        return .init(
+            targetID: resolvedTargetID,
+            fallbackID: headerID,
+            alignment: .center,
+            animated: true,
+            generation: generation
+        )
+    }
+}
+
+@MainActor
+struct AppKitDiffReviewScroller: View {
+    let inputs: [AppKitDiffReviewRowInput]
+    let fileCommand: DiffReviewScrollCommand?
+    let inlineFeedbackCommand: DiffReviewInlineFeedbackScrollCommand?
+    let draftCommentCommand: DiffReviewDraftCommentScrollCommand?
+    let onNavigationFile: (DiffReviewFileID) -> Void
+    let onActiveFileChange: (DiffReviewFileID) -> Void
+
+    var body: some View {
+        let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: inputs)
+        let request = AppKitDiffReviewScrollRequestResolver.request(
+            fileCommand: fileCommand,
+            inlineFeedbackCommand: inlineFeedbackCommand,
+            draftCommentCommand: draftCommentCommand,
+            plan: plan
+        )
+        AppKitDiffScroller(
+            plan: plan.corePlan,
+            scrollRequest: request,
+            onActiveOwnerChange: { rawValue in
+                guard let rawValue,
+                      let fileID = inputs.first(where: { $0.file.id.rawValue == rawValue })?.file.id
+                else { return }
+                onActiveFileChange(fileID)
+            }
+        )
+        .onAppear { notifyNavigationFile() }
+        .onChange(of: fileCommand) { _, _ in notifyNavigationFile() }
+        .onChange(of: inlineFeedbackCommand) { _, _ in notifyNavigationFile() }
+        .onChange(of: draftCommentCommand) { _, _ in notifyNavigationFile() }
+    }
+
+    private func notifyNavigationFile() {
+        if let draftCommentCommand {
+            onNavigationFile(draftCommentCommand.fileID)
+        } else if let inlineFeedbackCommand {
+            onNavigationFile(inlineFeedbackCommand.fileID)
+        } else if let fileCommand {
+            onNavigationFile(fileCommand.id)
+        }
+    }
+}

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
@@ -163,6 +163,7 @@ struct AppKitDiffReviewScroller: View {
         .onChange(of: draftCommentCommand) { _, command in
             submit(command.map(AppKitDiffReviewScrollRequestResolver.Command.draftComment), using: plan)
         }
+        .copyFeedbackOverlay(message: inputs.lazy.compactMap { $0.state.copyFeedback.message }.first)
     }
 
     private func submitInitialCommand(using plan: AppKitDiffReviewRowPlan) {

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
@@ -1,6 +1,20 @@
 import SwiftUI
 
 enum AppKitDiffReviewScrollRequestResolver {
+    enum Command: Equatable {
+        case file(DiffReviewScrollCommand)
+        case inlineFeedback(DiffReviewInlineFeedbackScrollCommand)
+        case draftComment(DiffReviewDraftCommentScrollCommand)
+
+        var fileID: DiffReviewFileID {
+            switch self {
+            case .file(let command): command.id
+            case .inlineFeedback(let command): command.fileID
+            case .draftComment(let command): command.fileID
+            }
+        }
+    }
+
     static func request(
         fileCommand: DiffReviewScrollCommand?,
         inlineFeedbackCommand: DiffReviewInlineFeedbackScrollCommand?,
@@ -34,6 +48,36 @@ enum AppKitDiffReviewScrollRequestResolver {
         )
     }
 
+    static func request(
+        for command: Command,
+        plan: AppKitDiffReviewRowPlan,
+        generation: Int
+    ) -> AppKitDiffScrollRequest {
+        let request: AppKitDiffScrollRequest?
+        switch command {
+        case .file(let fileCommand):
+            request = self.request(
+                fileCommand: fileCommand, inlineFeedbackCommand: nil, draftCommentCommand: nil, plan: plan
+            )
+        case .inlineFeedback(let inlineFeedbackCommand):
+            request = self.request(
+                fileCommand: nil, inlineFeedbackCommand: inlineFeedbackCommand, draftCommentCommand: nil, plan: plan
+            )
+        case .draftComment(let draftCommentCommand):
+            request = self.request(
+                fileCommand: nil, inlineFeedbackCommand: nil, draftCommentCommand: draftCommentCommand, plan: plan
+            )
+        }
+        precondition(request != nil, "A concrete review scroll command must resolve to a request")
+        return .init(
+            targetID: request!.targetID,
+            fallbackID: request!.fallbackID,
+            alignment: request!.alignment,
+            animated: request!.animated,
+            generation: generation
+        )
+    }
+
     private enum Kind: Int { case file, inlineFeedback, draftComment }
 
     private static func commandGeneration(_ generation: Int, kind: Kind) -> Int {
@@ -58,46 +102,86 @@ enum AppKitDiffReviewScrollRequestResolver {
     }
 }
 
+struct AppKitDiffReviewScrollRequestCoordinator {
+    private var generation = 0
+
+    mutating func request(
+        for command: AppKitDiffReviewScrollRequestResolver.Command,
+        plan: AppKitDiffReviewRowPlan
+    ) -> AppKitDiffScrollRequest {
+        generation += 1
+        return AppKitDiffReviewScrollRequestResolver.request(for: command, plan: plan, generation: generation)
+    }
+}
+
+struct AppKitDiffReviewScrollCompletionGate: Equatable {
+    private(set) var pendingRequestGeneration: Int?
+
+    mutating func begin(requestGeneration: Int) {
+        pendingRequestGeneration = requestGeneration
+    }
+
+    mutating func consumesCompletion(for requestGeneration: Int) -> Bool {
+        guard pendingRequestGeneration == requestGeneration else { return false }
+        pendingRequestGeneration = nil
+        return true
+    }
+}
+
 @MainActor
 struct AppKitDiffReviewScroller: View {
     let inputs: [AppKitDiffReviewRowInput]
     let fileCommand: DiffReviewScrollCommand?
     let inlineFeedbackCommand: DiffReviewInlineFeedbackScrollCommand?
     let draftCommentCommand: DiffReviewDraftCommentScrollCommand?
-    let onNavigationFile: (DiffReviewFileID) -> Void
+    let onNavigationFile: (DiffReviewFileID, Int) -> Void
     let onActiveFileChange: (DiffReviewFileID) -> Void
+    let onProgrammaticScrollCompletion: (Int) -> Void
+    @State private var scrollRequest: AppKitDiffScrollRequest?
+    @State private var requestCoordinator = AppKitDiffReviewScrollRequestCoordinator()
 
     var body: some View {
         let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: inputs)
-        let request = AppKitDiffReviewScrollRequestResolver.request(
-            fileCommand: fileCommand,
-            inlineFeedbackCommand: inlineFeedbackCommand,
-            draftCommentCommand: draftCommentCommand,
-            plan: plan
-        )
         AppKitDiffScroller(
             plan: plan.corePlan,
-            scrollRequest: request,
+            scrollRequest: scrollRequest,
             onActiveOwnerChange: { rawValue in
                 guard let rawValue,
                       let fileID = inputs.first(where: { $0.file.id.rawValue == rawValue })?.file.id
                 else { return }
                 onActiveFileChange(fileID)
-            }
+            },
+            onScrollRequestCompletion: onProgrammaticScrollCompletion
         )
-        .onAppear { notifyNavigationFile() }
-        .onChange(of: fileCommand) { _, _ in notifyNavigationFile() }
-        .onChange(of: inlineFeedbackCommand) { _, _ in notifyNavigationFile() }
-        .onChange(of: draftCommentCommand) { _, _ in notifyNavigationFile() }
+        .onAppear { submitInitialCommand(using: plan) }
+        .onChange(of: fileCommand) { _, command in
+            submit(command.map(AppKitDiffReviewScrollRequestResolver.Command.file), using: plan)
+        }
+        .onChange(of: inlineFeedbackCommand) { _, command in
+            submit(command.map(AppKitDiffReviewScrollRequestResolver.Command.inlineFeedback), using: plan)
+        }
+        .onChange(of: draftCommentCommand) { _, command in
+            submit(command.map(AppKitDiffReviewScrollRequestResolver.Command.draftComment), using: plan)
+        }
     }
 
-    private func notifyNavigationFile() {
+    private func submitInitialCommand(using plan: AppKitDiffReviewRowPlan) {
         if let draftCommentCommand {
-            onNavigationFile(draftCommentCommand.fileID)
+            submit(.draftComment(draftCommentCommand), using: plan)
         } else if let inlineFeedbackCommand {
-            onNavigationFile(inlineFeedbackCommand.fileID)
+            submit(.inlineFeedback(inlineFeedbackCommand), using: plan)
         } else if let fileCommand {
-            onNavigationFile(fileCommand.id)
+            submit(.file(fileCommand), using: plan)
         }
+    }
+
+    private func submit(
+        _ command: AppKitDiffReviewScrollRequestResolver.Command?,
+        using plan: AppKitDiffReviewRowPlan
+    ) {
+        guard let command else { return }
+        let request = requestCoordinator.request(for: command, plan: plan)
+        scrollRequest = request
+        onNavigationFile(command.fileID, request.generation)
     }
 }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
@@ -142,8 +142,9 @@ struct AppKitDiffReviewScroller: View {
 
     var body: some View {
         let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: inputs)
+        let corePlan = plan.corePlan.withContentInsets(.init(top: 16, bottom: 16, left: 16, right: 16))
         AppKitDiffScroller(
-            plan: plan.corePlan,
+            plan: corePlan,
             scrollRequest: scrollRequest,
             onActiveOwnerChange: { rawValue in
                 guard let rawValue,

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -23,6 +23,43 @@ struct DiffReviewContextStateSignature: Equatable {
     let structuralHash: Int?
 }
 
+struct DiffReviewFilePresentationSignature: Equatable {
+    let pendingDraftAnchor: DiffReviewLineAnchor?
+    let pendingDraftBody: String
+    let draftComposerFocusRequestGeneration: Int
+    let expandedCollapsedRowIDs: Set<String>
+    let contextSnapshot: DiffReviewFileContextSnapshot?
+    let contextExpansion: DiffContextExpansionState
+    let contextLoadError: String?
+    let hoveredInlineFeedbackID: String?
+    let hoveredDraftCommentID: String?
+    let activeInlineFeedbackEditorID: String?
+    let activeDraftCommentEditorID: String?
+    let activeThreadID: String?
+    let showFullDiffOverride: Bool
+    let isDraftComposerFocused: Bool
+    let copyFeedbackMessage: String?
+
+    @MainActor
+    init(_ state: AppKitDiffReviewFileState) {
+        pendingDraftAnchor = state.pendingDraftAnchor
+        pendingDraftBody = state.pendingDraftBody
+        draftComposerFocusRequestGeneration = state.draftComposerFocusRequestGeneration
+        expandedCollapsedRowIDs = state.expandedCollapsedRowIDs
+        contextSnapshot = state.contextSnapshot
+        contextExpansion = state.contextExpansion
+        contextLoadError = state.contextLoadError
+        hoveredInlineFeedbackID = state.hoveredInlineFeedbackID
+        hoveredDraftCommentID = state.hoveredDraftCommentID
+        activeInlineFeedbackEditorID = state.activeInlineFeedbackEditorID
+        activeDraftCommentEditorID = state.activeDraftCommentEditorID
+        activeThreadID = state.activeThreadID
+        showFullDiffOverride = state.showFullDiffOverride
+        isDraftComposerFocused = state.isDraftComposerFocused
+        copyFeedbackMessage = state.copyFeedback.message
+    }
+}
+
 enum DiffReviewActiveCommentCandidate: Equatable {
     case draft(String)
     case inlineFeedback(String)
@@ -938,6 +975,27 @@ struct EquatableDiffReviewFileSection: View, Equatable {
     /// title) can change while availability stays true, and the closure
     /// itself isn't comparable.
     let draftCommentAgentTargets: [ReviewFeedbackAgentTarget]
+    let presentationStateSignature: DiffReviewFilePresentationSignature?
+
+    init(
+        section: DiffReviewFileSection,
+        layoutMode: DiffLayoutMode,
+        wrapLines: Bool,
+        showWhitespace: Bool,
+        draftCommentAvailability: [ReviewDraftCommentActionAvailability],
+        inlineFeedbackAvailability: [DiffReviewInlineFeedbackActionAvailability],
+        draftCommentAgentTargets: [ReviewFeedbackAgentTarget],
+        presentationStateSignature: DiffReviewFilePresentationSignature? = nil
+    ) {
+        self.section = section
+        self.layoutMode = layoutMode
+        self.wrapLines = wrapLines
+        self.showWhitespace = showWhitespace
+        self.draftCommentAvailability = draftCommentAvailability
+        self.inlineFeedbackAvailability = inlineFeedbackAvailability
+        self.draftCommentAgentTargets = draftCommentAgentTargets
+        self.presentationStateSignature = presentationStateSignature
+    }
 
     var body: some View { section }
 
@@ -957,6 +1015,7 @@ struct EquatableDiffReviewFileSection: View, Equatable {
             && lhs.draftCommentAvailability == rhs.draftCommentAvailability
             && lhs.inlineFeedbackAvailability == rhs.inlineFeedbackAvailability
             && lhs.draftCommentAgentTargets == rhs.draftCommentAgentTargets
+            && lhs.presentationStateSignature == rhs.presentationStateSignature
             && lhs.section.file.hasSameRenderableContent(as: rhs.section.file)
             && lhs.section.inlineFeedback == rhs.section.inlineFeedback
             && lhs.section.focusedFeedbackID == rhs.section.focusedFeedbackID

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1741,6 +1741,7 @@ struct ReviewDraftCommentCard: View {
     let reviewFeedbackTarget: ReviewFeedbackTarget
     let onSelect: (ReviewDraftComment) -> Void
     var onHoverChange: (Bool) -> Void = { _ in }
+    var onEditorActiveChange: (Bool) -> Void = { _ in }
 
     @Environment(\.theme) private var theme
     @State private var isEditing = false
@@ -1771,6 +1772,9 @@ struct ReviewDraftCommentCard: View {
         .background(focusedMarker)
         .onHover { hovering in
             onHoverChange(Self.reportsHover(isHovered: hovering, isFocused: isFocused))
+        }
+        .onChange(of: isEditing) { _, isEditing in
+            onEditorActiveChange(isEditing)
         }
     }
 
@@ -2220,6 +2224,7 @@ struct DiffReviewInlineFeedbackCard: View {
     let actions: DiffReviewInlineFeedbackActions
     let onSelect: (DiffReviewInlineFeedback) -> Void
     var onHoverChange: (Bool) -> Void = { _ in }
+    var onEditorActiveChange: (Bool) -> Void = { _ in }
 
     @Environment(\.theme) private var theme
     @State private var replyEditor = DiffReviewInlineFeedbackReplyEditorState()
@@ -2254,6 +2259,9 @@ struct DiffReviewInlineFeedbackCard: View {
         .background(focusedMarker)
         .onHover { hovering in
             onHoverChange(Self.reportsHover(isHovered: hovering, isFocused: isFocused))
+        }
+        .onChange(of: replyEditor.isReplying) { _, isReplying in
+            onEditorActiveChange(isReplying)
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -2518,7 +2518,7 @@ struct DiffReviewInlineFeedbackReplyEditorState: Equatable {
     }
 }
 
-private struct DiffReviewInlineFeedbackMoreRow: View {
+struct DiffReviewInlineFeedbackMoreRow: View {
     let hiddenCount: Int
 
     @Environment(\.theme) private var theme

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-private struct PendingContextExpansion {
+struct PendingContextExpansion {
     let key: DiffContextExpansionKey
     let mode: DiffContextExpansionMode
     let edge: DiffContextExpansionEdge?
@@ -127,26 +127,30 @@ struct DiffReviewFileSection: View {
     #endif
 
     @Environment(\.theme) private var theme
-    @StateObject private var copyFeedback = CopyFeedbackState()
-    @StateObject private var renderContextCache = DiffReviewRenderContextCache()
-    @State private var pendingDraftAnchor: DiffReviewLineAnchor?
-    @State private var pendingDraftBody = ""
-    @State private var draftComposerFocusRequestGeneration = 0
-    @State private var expandedCollapsedRowIDs: Set<String> = []
-    @State private var contextSnapshot: DiffReviewFileContextSnapshot?
-    @State private var contextExpansion = DiffContextExpansionState()
-    @State private var contextLoadTask: Task<Void, Never>?
-    @State private var contextLoadFileID: DiffReviewFileID?
-    @State private var contextLoadSignature: DiffReviewContextStateSignature?
-    @State private var contextLoadGeneration = 0
-    @State private var contextLoadError: String?
-    @State private var pendingContextExpansions: [PendingContextExpansion] = []
-    @State private var imageState = DiffReviewImageState()
-    @State private var hoveredInlineFeedbackID: String?
-    @State private var hoveredDraftCommentID: String?
-    @State private var activeThreadID: String?
-    @State private var showFullDiffOverride = false
+    var presentationState: AppKitDiffReviewFileState? = nil
+    @StateObject private var ownedPresentationState = AppKitDiffReviewFileState()
     @FocusState private var draftComposerFocused: Bool
+
+    private var state: AppKitDiffReviewFileState { presentationState ?? ownedPresentationState }
+    private var copyFeedback: CopyFeedbackState { state.copyFeedback }
+    private var renderContextCache: DiffReviewRenderContextCache { state.renderContextCache }
+    private var pendingDraftAnchor: DiffReviewLineAnchor? { get { state.pendingDraftAnchor } nonmutating set { state.pendingDraftAnchor = newValue } }
+    private var pendingDraftBody: String { get { state.pendingDraftBody } nonmutating set { state.pendingDraftBody = newValue } }
+    private var draftComposerFocusRequestGeneration: Int { get { state.draftComposerFocusRequestGeneration } nonmutating set { state.draftComposerFocusRequestGeneration = newValue } }
+    private var expandedCollapsedRowIDs: Set<String> { get { state.expandedCollapsedRowIDs } nonmutating set { state.expandedCollapsedRowIDs = newValue } }
+    private var contextSnapshot: DiffReviewFileContextSnapshot? { get { state.contextSnapshot } nonmutating set { state.contextSnapshot = newValue } }
+    private var contextExpansion: DiffContextExpansionState { get { state.contextExpansion } nonmutating set { state.contextExpansion = newValue } }
+    private var contextLoadTask: Task<Void, Never>? { get { state.contextLoadTask } nonmutating set { state.contextLoadTask = newValue } }
+    private var contextLoadFileID: DiffReviewFileID? { get { state.contextLoadFileID } nonmutating set { state.contextLoadFileID = newValue } }
+    private var contextLoadSignature: DiffReviewContextStateSignature? { get { state.contextLoadSignature } nonmutating set { state.contextLoadSignature = newValue } }
+    private var contextLoadGeneration: Int { get { state.contextLoadGeneration } nonmutating set { state.contextLoadGeneration = newValue } }
+    private var contextLoadError: String? { get { state.contextLoadError } nonmutating set { state.contextLoadError = newValue } }
+    private var pendingContextExpansions: [PendingContextExpansion] { get { state.pendingContextExpansions } nonmutating set { state.pendingContextExpansions = newValue } }
+    private var imageState: DiffReviewImageState { state.imageState }
+    private var hoveredInlineFeedbackID: String? { get { state.hoveredInlineFeedbackID } nonmutating set { state.hoveredInlineFeedbackID = newValue } }
+    private var hoveredDraftCommentID: String? { get { state.hoveredDraftCommentID } nonmutating set { state.hoveredDraftCommentID = newValue } }
+    private var activeThreadID: String? { get { state.activeThreadID } nonmutating set { state.activeThreadID = newValue } }
+    private var showFullDiffOverride: Bool { get { state.showFullDiffOverride } nonmutating set { state.showFullDiffOverride = newValue } }
 
     private var isOverRenderBudget: Bool {
         guard let displayModel = file.displayModel else { return false }
@@ -162,7 +166,8 @@ struct DiffReviewFileSection: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        synchronizePresentationState()
+        return VStack(spacing: 0) {
             header
             contextLoadErrorRow
             if file.imageProvider != nil {
@@ -197,8 +202,8 @@ struct DiffReviewFileSection: View {
             clearPendingDraft()
         }
         .onChange(of: file.id) { _, _ in
-            showFullDiffOverride = false
-            resetContextState()
+            state.resetForFileIdentityChange()
+            state.synchronize(file: file, contextSignature: contextStateSignature)
         }
         .onChange(of: renderBudgetResetSignal) { _, _ in
             // Re-arm the render budget whenever the same file reloads with new
@@ -206,10 +211,10 @@ struct DiffReviewFileSection: View {
             // captures text-only edits (unlike `structuralHash`); context
             // expansion never mutates `file.displayModel`, so an opened large
             // diff stays open while the reviewer expands context.
-            showFullDiffOverride = false
+            state.resetForRenderBudgetChange()
         }
         .onChange(of: contextStateSignature) { _, _ in
-            resetContextState()
+            state.resetContextState()
         }
         .task(id: file.imageProvider?.id) {
             guard let provider = file.imageProvider else {
@@ -218,6 +223,29 @@ struct DiffReviewFileSection: View {
             }
             await imageState.load(provider: provider)
         }
+        .onAppear {
+            state.synchronize(file: file, contextSignature: contextStateSignature)
+            state.synchronizeRenderBudget(resetSignal: renderBudgetResetSignal)
+        }
+    }
+
+    private func synchronizePresentationState() {
+        state.synchronize(file: file, contextSignature: contextStateSignature)
+        state.synchronizeRenderBudget(resetSignal: renderBudgetResetSignal)
+        state.actionRelay.update(
+            inlineFeedbackActions: inlineFeedbackActions,
+            onSelectInlineFeedback: onSelectInlineFeedback,
+            draftCommentActions: draftCommentActions,
+            onSelectDraftComment: onSelectDraftComment,
+            onSaveDraftComment: onSaveDraftComment,
+            onContextExpansionActivated: onContextExpansionActivated,
+            onReply: onReply,
+            onResolve: onResolve,
+            onUnresolve: onUnresolve,
+            onEdit: onEdit,
+            onDelete: onDelete,
+            onStageReply: onStageReply
+        )
     }
 
     @ViewBuilder
@@ -483,7 +511,7 @@ struct DiffReviewFileSection: View {
             file: file,
             isFocused: item.id == focusedFeedbackID,
             actions: inlineFeedbackActions,
-            onSelect: onSelectInlineFeedback,
+            onSelect: state.actionRelay.selectInlineFeedback,
             onHoverChange: { isHovered in
                 hoveredInlineFeedbackID = isHovered ? item.id : (hoveredInlineFeedbackID == item.id ? nil : hoveredInlineFeedbackID)
             }
@@ -1127,7 +1155,10 @@ struct DiffReviewFileSection: View {
     private var draftComposerBody: some View {
         VStack(alignment: .leading, spacing: 10) {
             ReviewDraftComposerTextEditor(
-                text: $pendingDraftBody,
+                text: Binding(
+                    get: { state.pendingDraftBody },
+                    set: { state.pendingDraftBody = $0 }
+                ),
                 theme: theme,
                 isFocused: $draftComposerFocused,
                 focusRequestGeneration: draftComposerFocusRequestGeneration,
@@ -1180,6 +1211,12 @@ struct DiffReviewFileSection: View {
                 label: "Draft comment composer"
             )
         )
+        .onChange(of: draftComposerFocused) { _, isFocused in
+            state.isDraftComposerFocused = isFocused
+        }
+        .onChange(of: state.isDraftComposerFocused) { _, isFocused in
+            draftComposerFocused = isFocused
+        }
     }
 
     @ViewBuilder
@@ -1208,7 +1245,7 @@ struct DiffReviewFileSection: View {
             return
         }
 
-        onSaveDraftComment(canonicalAnchor, body)
+        state.actionRelay.saveDraftComment(canonicalAnchor, body: body)
         clearPendingDraft()
     }
 
@@ -1265,7 +1302,7 @@ struct DiffReviewFileSection: View {
         edge: DiffContextExpansionEdge?
     ) {
         guard let provider = file.contextProvider else { return }
-        onContextExpansionActivated()
+        state.actionRelay.contextExpansionActivated()
         if contextSnapshot != nil {
             applyContextExpansion(key, mode: mode, edge: edge)
             return

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -493,6 +493,7 @@ struct DiffReviewFileSection: View {
                         canReply: presentation.canReply,
                         canResolve: presentation.canResolve,
                         canAddToReview: presentation.canAddToReview,
+                        editorState: state.bindingForThreadCommentEditor(thread.id),
                         onActiveChange: { active in
                             activeThreadID = active
                                 ? thread.id
@@ -1800,6 +1801,11 @@ enum DiffReviewInlineFeedbackMarkdown {
     }
 }
 
+struct ReviewDraftCommentEditorState: Equatable {
+    var isEditing = false
+    var editingBody = ""
+}
+
 struct ReviewDraftCommentCard: View {
     let comment: ReviewDraftComment
     let file: DiffReviewFileSummary
@@ -1809,10 +1815,10 @@ struct ReviewDraftCommentCard: View {
     let onSelect: (ReviewDraftComment) -> Void
     var onHoverChange: (Bool) -> Void = { _ in }
     var onEditorActiveChange: (Bool) -> Void = { _ in }
+    var editorState: Binding<ReviewDraftCommentEditorState>?
 
     @Environment(\.theme) private var theme
-    @State private var isEditing = false
-    @State private var editingBody = ""
+    @State private var localEditorState = ReviewDraftCommentEditorState()
     @FocusState private var editorFocused: Bool
 
     var body: some View {
@@ -1840,7 +1846,7 @@ struct ReviewDraftCommentCard: View {
         .onHover { hovering in
             onHoverChange(Self.reportsHover(isHovered: hovering, isFocused: isFocused))
         }
-        .onChange(of: isEditing) { _, isEditing in
+        .onChange(of: editorStateBinding.wrappedValue.isEditing) { _, isEditing in
             onEditorActiveChange(isEditing)
         }
     }
@@ -1886,9 +1892,9 @@ struct ReviewDraftCommentCard: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                if isEditing {
+                if editorStateBinding.wrappedValue.isEditing {
                     ReviewDraftComposerTextEditor(
-                        text: $editingBody,
+                        text: editorStateBinding.editingBody,
                         theme: theme,
                         isFocused: $editorFocused,
                         onSave: saveEditingComment,
@@ -1937,7 +1943,7 @@ struct ReviewDraftCommentCard: View {
 
     @ViewBuilder
     private var selectionPressMarker: some View {
-        if !isEditing {
+        if !editorStateBinding.wrappedValue.isEditing {
             ReviewDraftCommentActionPressMarker(
                 identifier: "diff-review-draft-comment-select-\(comment.id)",
                 label: "Select draft comment",
@@ -1947,7 +1953,7 @@ struct ReviewDraftCommentCard: View {
     }
 
     private func selectWhenNotEditing() {
-        guard !isEditing else { return }
+        guard !editorStateBinding.wrappedValue.isEditing else { return }
         onSelect(comment)
     }
 
@@ -1974,7 +1980,7 @@ struct ReviewDraftCommentCard: View {
         {
             HStack(spacing: 6) {
                 Spacer(minLength: 0)
-                if isEditing {
+                if editorStateBinding.wrappedValue.isEditing {
                     actionButton(id: "save", title: "Save") {
                         saveEditingComment()
                     }
@@ -1983,8 +1989,8 @@ struct ReviewDraftCommentCard: View {
                     }
                 } else if availability.canEdit {
                     actionButton(id: "edit", title: "Edit") {
-                        editingBody = comment.bodyMarkdown
-                        isEditing = true
+                        editorStateBinding.wrappedValue.editingBody = comment.bodyMarkdown
+                        editorStateBinding.wrappedValue.isEditing = true
                         editorFocused = true
                     }
                 }
@@ -2165,14 +2171,18 @@ struct ReviewDraftCommentCard: View {
     }
 
     private func saveEditingComment() {
-        actions.edit(comment, editingBody)
+        actions.edit(comment, editorStateBinding.wrappedValue.editingBody)
         cancelEditingComment()
     }
 
     private func cancelEditingComment() {
-        isEditing = false
-        editingBody = ""
+        editorStateBinding.wrappedValue.isEditing = false
+        editorStateBinding.wrappedValue.editingBody = ""
         editorFocused = false
+    }
+
+    private var editorStateBinding: Binding<ReviewDraftCommentEditorState> {
+        editorState ?? $localEditorState
     }
 
     private var feedbackBundle: ReviewFeedbackBundle {
@@ -2292,9 +2302,10 @@ struct DiffReviewInlineFeedbackCard: View {
     let onSelect: (DiffReviewInlineFeedback) -> Void
     var onHoverChange: (Bool) -> Void = { _ in }
     var onEditorActiveChange: (Bool) -> Void = { _ in }
+    var replyEditorState: Binding<DiffReviewInlineFeedbackReplyEditorState>?
 
     @Environment(\.theme) private var theme
-    @State private var replyEditor = DiffReviewInlineFeedbackReplyEditorState()
+    @State private var localReplyEditor = DiffReviewInlineFeedbackReplyEditorState()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -2327,7 +2338,7 @@ struct DiffReviewInlineFeedbackCard: View {
         .onHover { hovering in
             onHoverChange(Self.reportsHover(isHovered: hovering, isFocused: isFocused))
         }
-        .onChange(of: replyEditor.isReplying) { _, isReplying in
+        .onChange(of: replyEditorBinding.wrappedValue.isReplying) { _, isReplying in
             onEditorActiveChange(isReplying)
         }
     }
@@ -2391,9 +2402,9 @@ struct DiffReviewInlineFeedbackCard: View {
     @ViewBuilder
     private var actionRow: some View {
         let availability = actions.availability(item, file)
-        if replyEditor.isReplying {
+        if replyEditorBinding.wrappedValue.isReplying {
             VStack(alignment: .leading, spacing: 6) {
-                TextField("Reply", text: $replyEditor.body, axis: .vertical)
+                TextField("Reply", text: replyEditorBinding.body, axis: .vertical)
                     .textFieldStyle(.plain)
                     .font(.system(size: 11.5))
                     .foregroundColor(theme.color("fg"))
@@ -2405,12 +2416,12 @@ struct DiffReviewInlineFeedbackCard: View {
                 HStack(spacing: 6) {
                     Spacer(minLength: 0)
                     inlineActionButton(id: "reply-save", title: "Save") {
-                        _ = replyEditor.save(item) { feedback, body in
+                        _ = replyEditorBinding.wrappedValue.save(item) { feedback, body in
                             actions.replyProvider(feedback, file, body)
                         }
                     }
                     inlineActionButton(id: "reply-cancel", title: "Cancel") {
-                        replyEditor.cancel()
+                        replyEditorBinding.wrappedValue.cancel()
                     }
                 }
             }
@@ -2445,7 +2456,7 @@ struct DiffReviewInlineFeedbackCard: View {
                 }
                 if availability.canReplyProvider {
                     inlineActionButton(id: "reply", title: "Reply") {
-                        replyEditor.start()
+                        replyEditorBinding.wrappedValue.start()
                     }
                 }
                 if availability.canResolveProvider {
@@ -2489,6 +2500,10 @@ struct DiffReviewInlineFeedbackCard: View {
                 action: action
             )
         )
+    }
+
+    private var replyEditorBinding: Binding<DiffReviewInlineFeedbackReplyEditorState> {
+        replyEditorState ?? $localReplyEditor
     }
 
     private var accessibilityLabel: String {

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -168,7 +168,9 @@ struct DiffReviewFileSection: View {
                 canCreateDraftComment: allowsDraftCommentCreation,
                 canReply: canReply,
                 canResolve: canResolve,
-                canAddToReview: canAddToReview
+                canAddToReview: canAddToReview,
+                canUnstageHunk: file.stagedMutationActions?.unstageHunk != nil,
+                hunkUnstageEnabled: file.stagedMutationActions?.unstageEnabledBase ?? false
             ),
             lspContext: lspContext,
             reviewFeedbackTarget: effectiveReviewFeedbackTarget,
@@ -275,6 +277,10 @@ struct DiffReviewFileSection: View {
             onDelete: onDelete,
             onStageReply: onStageReply
         )
+        state.actionRelay.update(
+            stagedMutationActions: file.stagedMutationActions,
+            openFile: file.openFile
+        )
     }
 
     @ViewBuilder
@@ -326,20 +332,7 @@ struct DiffReviewFileSection: View {
     @ViewBuilder
     private var contextLoadErrorRow: some View {
         if let contextLoadError {
-            Text("Could not load surrounding context: \(contextLoadError)")
-                .font(.system(size: 11))
-                .foregroundColor(theme.color("warn"))
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(theme.color("bg-2"))
-                .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
-                .background(
-                    DiffReviewAccessibilityMarker(
-                        identifier: "diff-review-context-error-\(file.id.rawValue)",
-                        label: "Could not load surrounding context: \(contextLoadError)"
-                    )
-                )
+            DiffReviewContextErrorRowBody(fileID: file.id, message: contextLoadError, theme: theme)
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -562,7 +562,11 @@ struct DiffReviewFileSection: View {
     }
 
     private var renderBudgetPlaceholder: some View {
-        AppKitDiffReviewPlaceholderRowBody(input: focusedRowInput, isDeferred: true)
+        AppKitDiffReviewPlaceholderRowBody(
+            input: focusedRowInput,
+            isDeferred: true,
+            isAggregateDeferred: isDeferredByAggregateBudget
+        )
         .background(renderBudgetScrollAnchors)
         .background {
             if isDeferredByAggregateBudget {
@@ -632,7 +636,11 @@ struct DiffReviewFileSection: View {
                 lazyGroupStack(renderableGroups, displayModel: displayModel)
             }
         } else {
-            AppKitDiffReviewPlaceholderRowBody(input: focusedRowInput, isDeferred: false)
+            AppKitDiffReviewPlaceholderRowBody(
+                input: focusedRowInput,
+                isDeferred: false,
+                isAggregateDeferred: false
+            )
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -232,6 +232,10 @@ struct DiffReviewFileSection: View {
     private func synchronizePresentationState() {
         state.synchronize(file: file, contextSignature: contextStateSignature)
         state.synchronizeRenderBudget(resetSignal: renderBudgetResetSignal)
+        refreshActionRelay()
+    }
+
+    private func refreshActionRelay() {
         state.actionRelay.update(
             inlineFeedbackActions: inlineFeedbackActions,
             onSelectInlineFeedback: onSelectInlineFeedback,
@@ -347,8 +351,9 @@ struct DiffReviewFileSection: View {
     }
 
     private var feedbackDraftCommentActions: ReviewDraftCommentActions {
-        ReviewDraftCommentActions(
+        return ReviewDraftCommentActions(
             availability: draftCommentActions.availability,
+            canPublishReview: draftCommentActions.canPublishReview,
             edit: draftCommentActions.edit,
             delete: draftCommentActions.delete,
             resolve: draftCommentActions.resolve,
@@ -358,6 +363,7 @@ struct DiffReviewFileSection: View {
                 copyFeedback.show("Copied prompt")
             },
             publishProvider: draftCommentActions.publishProvider,
+            publishReview: draftCommentActions.publishReview,
             agent: draftCommentActions.agent,
             agentTargets: draftCommentActions.agentTargets,
             sendToAgent: draftCommentActions.sendToAgent
@@ -438,7 +444,7 @@ struct DiffReviewFileSection: View {
             isFocused: comment.id == focusedDraftCommentID,
             actions: feedbackDraftCommentActions,
             reviewFeedbackTarget: effectiveReviewFeedbackTarget,
-            onSelect: onSelectDraftComment,
+            onSelect: state.actionRelay.selectDraftComment,
             onHoverChange: { isHovered in
                 hoveredDraftCommentID = isHovered ? comment.id : (hoveredDraftCommentID == comment.id ? nil : hoveredDraftCommentID)
             }
@@ -506,11 +512,12 @@ struct DiffReviewFileSection: View {
         _ item: DiffReviewInlineFeedback,
         file: DiffReviewFileSummary
     ) -> some View {
-        DiffReviewInlineFeedbackCard(
+        refreshActionRelay()
+        return DiffReviewInlineFeedbackCard(
             item: item,
             file: file,
             isFocused: item.id == focusedFeedbackID,
-            actions: inlineFeedbackActions,
+            actions: state.actionRelay.inlineFeedbackActionsForRow,
             onSelect: state.actionRelay.selectInlineFeedback,
             onHoverChange: { isHovered in
                 hoveredInlineFeedbackID = isHovered ? item.id : (hoveredInlineFeedbackID == item.id ? nil : hoveredInlineFeedbackID)
@@ -593,7 +600,7 @@ struct DiffReviewFileSection: View {
     func imageProviderThreadPresentation(
         for thread: DiffInlineCommentThread
     ) -> DiffReviewImageProviderThreadPresentation {
-        DiffReviewImageProviderThreadPresentation(
+        return DiffReviewImageProviderThreadPresentation(
             onReply: { body in onReply(thread, body) },
             onStageReply: { body in onStageReply(thread, body) },
             onResolve: { onResolve(thread) },
@@ -949,14 +956,14 @@ struct DiffReviewFileSection: View {
                 onContextExpansion: loadContextAndExpand,
                 threads: threads,
                 annotations: annotations,
-                onReply: onReply,
-                onResolve: onResolve,
-                onUnresolve: onUnresolve,
-                onEdit: onEdit,
-                onDelete: onDelete,
+                onReply: { thread, body in state.actionRelay.reply(to: thread, body: body) },
+                onResolve: { thread in state.actionRelay.resolve(thread) },
+                onUnresolve: { thread in state.actionRelay.unresolve(thread) },
+                onEdit: { thread, comment, body in state.actionRelay.edit(comment, in: thread, body: body) },
+                onDelete: { thread, comment in state.actionRelay.delete(comment, in: thread) },
                 canReply: canReply,
                 canResolve: canResolve,
-                onStageReply: onStageReply,
+                onStageReply: { thread, body in state.actionRelay.stageReply(to: thread, body: body) },
                 canAddToReview: canAddToReview,
                 hunkFusionStates: [fusion],
                 hunkActions: { hunk in
@@ -1009,12 +1016,12 @@ struct DiffReviewFileSection: View {
                     ) {
                         DiffInlineCommentCard(
                             thread: thread,
-                            onReply: { body in onReply(thread, body) },
-                            onStageReply: { body in onStageReply(thread, body) },
-                            onResolve: { onResolve(thread) },
-                            onUnresolve: { onUnresolve(thread) },
-                            onEdit: { comment, newBody in onEdit(thread, comment, newBody) },
-                            onDelete: { comment in onDelete(thread, comment) },
+                            onReply: { body in state.actionRelay.reply(to: thread, body: body) },
+                            onStageReply: { body in state.actionRelay.stageReply(to: thread, body: body) },
+                            onResolve: { state.actionRelay.resolve(thread) },
+                            onUnresolve: { state.actionRelay.unresolve(thread) },
+                            onEdit: { comment, newBody in state.actionRelay.edit(comment, in: thread, body: newBody) },
+                            onDelete: { comment in state.actionRelay.delete(comment, in: thread) },
                             canReply: canReply && thread.viewerCanReply,
                             canResolve: canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
                             canAddToReview: canAddToReview,
@@ -1217,11 +1224,14 @@ struct DiffReviewFileSection: View {
         .onChange(of: state.isDraftComposerFocused) { _, isFocused in
             draftComposerFocused = isFocused
         }
+        .onAppear {
+            draftComposerFocused = state.isDraftComposerFocused
+        }
     }
 
     @ViewBuilder
     private var focusedComposerMarker: some View {
-        if draftComposerFocused {
+        if state.isDraftComposerFocused {
             DiffReviewAccessibilityMarker(
                 identifier: "diff-review-draft-composer-focused",
                 label: "Draft comment composer focused"

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -129,28 +129,53 @@ struct DiffReviewFileSection: View {
     @Environment(\.theme) private var theme
     var presentationState: AppKitDiffReviewFileState? = nil
     @StateObject private var ownedPresentationState = AppKitDiffReviewFileState()
-    @FocusState private var draftComposerFocused: Bool
 
     private var state: AppKitDiffReviewFileState { presentationState ?? ownedPresentationState }
     private var copyFeedback: CopyFeedbackState { state.copyFeedback }
     private var renderContextCache: DiffReviewRenderContextCache { state.renderContextCache }
     private var pendingDraftAnchor: DiffReviewLineAnchor? { get { state.pendingDraftAnchor } nonmutating set { state.pendingDraftAnchor = newValue } }
-    private var pendingDraftBody: String { get { state.pendingDraftBody } nonmutating set { state.pendingDraftBody = newValue } }
-    private var draftComposerFocusRequestGeneration: Int { get { state.draftComposerFocusRequestGeneration } nonmutating set { state.draftComposerFocusRequestGeneration = newValue } }
-    private var expandedCollapsedRowIDs: Set<String> { get { state.expandedCollapsedRowIDs } nonmutating set { state.expandedCollapsedRowIDs = newValue } }
     private var contextSnapshot: DiffReviewFileContextSnapshot? { get { state.contextSnapshot } nonmutating set { state.contextSnapshot = newValue } }
     private var contextExpansion: DiffContextExpansionState { get { state.contextExpansion } nonmutating set { state.contextExpansion = newValue } }
-    private var contextLoadTask: Task<Void, Never>? { get { state.contextLoadTask } nonmutating set { state.contextLoadTask = newValue } }
-    private var contextLoadFileID: DiffReviewFileID? { get { state.contextLoadFileID } nonmutating set { state.contextLoadFileID = newValue } }
-    private var contextLoadSignature: DiffReviewContextStateSignature? { get { state.contextLoadSignature } nonmutating set { state.contextLoadSignature = newValue } }
-    private var contextLoadGeneration: Int { get { state.contextLoadGeneration } nonmutating set { state.contextLoadGeneration = newValue } }
     private var contextLoadError: String? { get { state.contextLoadError } nonmutating set { state.contextLoadError = newValue } }
-    private var pendingContextExpansions: [PendingContextExpansion] { get { state.pendingContextExpansions } nonmutating set { state.pendingContextExpansions = newValue } }
     private var imageState: DiffReviewImageState { state.imageState }
     private var hoveredInlineFeedbackID: String? { get { state.hoveredInlineFeedbackID } nonmutating set { state.hoveredInlineFeedbackID = newValue } }
     private var hoveredDraftCommentID: String? { get { state.hoveredDraftCommentID } nonmutating set { state.hoveredDraftCommentID = newValue } }
     private var activeThreadID: String? { get { state.activeThreadID } nonmutating set { state.activeThreadID = newValue } }
     private var showFullDiffOverride: Bool { get { state.showFullDiffOverride } nonmutating set { state.showFullDiffOverride = newValue } }
+
+    private var focusedRowInput: AppKitDiffReviewRowInput {
+        AppKitDiffReviewRowInput(
+            file: file,
+            inlineFeedback: inlineFeedback,
+            draftComments: draftComments,
+            threads: threads,
+            annotations: annotations,
+            state: state,
+            theme: theme,
+            layoutMode: layoutMode,
+            wrapLines: wrapLines,
+            showWhitespace: showWhitespace,
+            codeFontFamily: codeFontFamily,
+            codeFontSize: codeFontSize,
+            showsSourceBadge: showsSourceBadge,
+            automaticallyRendersDiff: automaticallyRendersDiff,
+            focusedFeedbackID: focusedFeedbackID,
+            focusedDraftCommentID: focusedDraftCommentID,
+            allowsDraftCommentCreation: allowsDraftCommentCreation,
+            actionPresence: .init(
+                canOpenFile: file.openFile != nil,
+                canUnstageFile: file.stagedMutationActions?.unstageFile != nil,
+                canCreateDraftComment: allowsDraftCommentCreation,
+                canReply: canReply,
+                canResolve: canResolve,
+                canAddToReview: canAddToReview
+            ),
+            lspContext: lspContext,
+            reviewFeedbackTarget: effectiveReviewFeedbackTarget,
+            draftCommentActions: feedbackDraftCommentActions,
+            onContextExpansionActivated: onContextExpansionActivated
+        )
+    }
 
     private var isOverRenderBudget: Bool {
         guard let displayModel = file.displayModel else { return false }
@@ -199,7 +224,7 @@ struct DiffReviewFileSection: View {
         )
         .background(copyFeedbackMarker)
         .onChange(of: draftCommentDisplaySignature) { _, _ in
-            clearPendingDraft()
+            focusedRowInput.clearPendingDraft()
         }
         .onChange(of: file.id) { _, _ in
             state.resetForFileIdentityChange()
@@ -262,81 +287,7 @@ struct DiffReviewFileSection: View {
         }
     }
 
-    private var header: some View {
-        HStack(spacing: 10) {
-            Text(file.summary.status.glyph)
-                .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                .foregroundColor(statusColor(file.summary.status))
-                .frame(width: 16)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(file.summary.path)
-                    .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
-                    .foregroundColor(theme.color("fg"))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                if let originalPath = file.summary.originalPath {
-                    Text("from \(originalPath)")
-                        .font(.system(size: 10.5))
-                        .foregroundColor(theme.color("fg-faint"))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-            }
-            sourceBadge
-            Spacer(minLength: 12)
-            if shouldShowChangeSummary(additions: file.summary.additions, deletions: file.summary.deletions) {
-                HStack(spacing: 9) {
-                    Text("+\(file.summary.additions)")
-                        .foregroundColor(theme.color("add"))
-                    Text("-\(file.summary.deletions)")
-                        .foregroundColor(theme.color("del"))
-                }
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
-            }
-            if let pair = displayedImagePair {
-                ImageDiffControls(pair: pair, state: imageState.presentation)
-                    .background(
-                        DiffReviewAccessibilityMarker(
-                            identifier: "diff-review-image-header-\(file.id.rawValue)",
-                            label: "Image diff controls"
-                        )
-                    )
-            }
-            if let openFile = file.openFile,
-               let openFileTitle = DiffReviewFileSectionActions.openFileButtonTitle(for: file) {
-                Button(action: openFile) {
-                    Text(openFileTitle)
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundColor(theme.color("fg-muted"))
-                        .padding(.horizontal, 8)
-                        .frame(height: 24)
-                        .background(theme.color("bg-3"))
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                }
-                .buttonStyle(.plain)
-                .help(openFileTitle)
-                .accessibilityIdentifier("diff-review-open-file-\(file.id.rawValue)")
-                .accessibilityLabel(openFileTitle)
-            }
-            if let unstageFile = file.stagedMutationActions?.unstageFile {
-                Button("Unstage") {
-                    unstageFile()
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(theme.color("fg-muted"))
-                .padding(.horizontal, 8)
-                .frame(height: 24)
-                .background(theme.color("bg-3"))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .accessibilityIdentifier("diff-review-unstage-file-\(file.id.rawValue)")
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(theme.color("bg-2"))
-        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
-    }
+    private var header: some View { AppKitDiffReviewHeaderRowBody(input: focusedRowInput) }
 
     private var effectiveReviewFeedbackTarget: ReviewFeedbackTarget {
         if let reviewFeedbackTarget {
@@ -403,15 +354,11 @@ struct DiffReviewFileSection: View {
     @ViewBuilder
     private func fullWidthDraftCommentStack(_ comments: [ReviewDraftComment]) -> some View {
         if !comments.isEmpty {
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 0) {
                 ForEach(comments) { comment in
-                    draftCommentCard(comment)
+                    AppKitDiffReviewDraftCommentRowBody(comment: comment, input: focusedRowInput)
                 }
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(theme.color("bg-1"))
-            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
         }
     }
 
@@ -421,37 +368,14 @@ struct DiffReviewFileSection: View {
         rows: [DiffDisplayRow]
     ) -> some View {
         if !comments.isEmpty {
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 0) {
                 ForEach(comments) { comment in
-                    DiffFeedbackLaneView(
-                        lane: DiffFeedbackLaneResolver.lane(for: comment),
-                        layoutMode: layoutMode,
-                        rows: rows
-                    ) {
-                        draftCommentCard(comment)
-                            .padding(.horizontal, 14)
-                    }
+                    AppKitDiffReviewDraftCommentRowBody(
+                        comment: comment, input: focusedRowInput, rows: rows
+                    )
                 }
             }
-            .padding(.vertical, 10)
-            .background(theme.color("bg-1"))
-            .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
         }
-    }
-
-    private func draftCommentCard(_ comment: ReviewDraftComment) -> some View {
-        ReviewDraftCommentCard(
-            comment: comment,
-            file: file.summary,
-            isFocused: comment.id == focusedDraftCommentID,
-            actions: feedbackDraftCommentActions,
-            reviewFeedbackTarget: effectiveReviewFeedbackTarget,
-            onSelect: state.actionRelay.selectDraftComment,
-            onHoverChange: { isHovered in
-                hoveredDraftCommentID = isHovered ? comment.id : (hoveredDraftCommentID == comment.id ? nil : hoveredDraftCommentID)
-            }
-        )
-        .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: file.id))
     }
 
     @ViewBuilder
@@ -474,58 +398,28 @@ struct DiffReviewFileSection: View {
                 includingRequiredIDs: requiredInlineFeedbackIDs
             )
             if let rows {
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: 0) {
                     ForEach(display.visibleItems) { item in
-                        DiffFeedbackLaneView(
-                            lane: DiffFeedbackLaneResolver.lane(for: item),
-                            layoutMode: layoutMode,
-                            rows: rows
-                        ) {
-                            inlineFeedbackCard(item, file: file)
-                                .padding(.horizontal, 14)
-                        }
+                        AppKitDiffReviewInlineFeedbackRowBody(
+                            item: item, input: focusedRowInput, rows: rows
+                        )
                     }
                     if display.hiddenCount > 0 {
                         DiffReviewInlineFeedbackMoreRow(hiddenCount: display.hiddenCount)
                             .padding(.horizontal, 14)
                     }
                 }
-                .padding(.vertical, 10)
-                .background(theme.color("bg-1"))
-                .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
             } else {
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: 0) {
                     ForEach(display.visibleItems) { item in
-                        inlineFeedbackCard(item, file: file)
+                        AppKitDiffReviewInlineFeedbackRowBody(item: item, input: focusedRowInput)
                     }
                     if display.hiddenCount > 0 {
                         DiffReviewInlineFeedbackMoreRow(hiddenCount: display.hiddenCount)
                     }
                 }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(theme.color("bg-1"))
-                .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
             }
         }
-    }
-
-    private func inlineFeedbackCard(
-        _ item: DiffReviewInlineFeedback,
-        file: DiffReviewFileSummary
-    ) -> some View {
-        refreshActionRelay()
-        return DiffReviewInlineFeedbackCard(
-            item: item,
-            file: file,
-            isFocused: item.id == focusedFeedbackID,
-            actions: state.actionRelay.inlineFeedbackActionsForRow,
-            onSelect: state.actionRelay.selectInlineFeedback,
-            onHoverChange: { isHovered in
-                hoveredInlineFeedbackID = isHovered ? item.id : (hoveredInlineFeedbackID == item.id ? nil : hoveredInlineFeedbackID)
-            }
-        )
-        .id(DiffReviewInlineFeedbackTargetID.targetID(feedbackID: item.id, fileID: file.id))
     }
 
     private var requiredInlineFeedbackIDs: Set<String> {
@@ -637,64 +531,9 @@ struct DiffReviewFileSection: View {
         renderContext?.groups.map(\.displayGroup)
     }
 
-    /// Review annotations that the placeholder hides while the diff is deferred.
-    /// Computed from the cheap input arrays so it never forces a `renderContext` build.
-    private var hiddenReviewItemCount: Int {
-        draftComments.count + inlineFeedback.count + threads.count
-    }
-
     private var renderBudgetPlaceholder: some View {
-        let changedLines = file.summary.additions + file.summary.deletions
-        let hiddenItems = hiddenReviewItemCount
-        let title = isDeferredByAggregateBudget
-            ? "Large review diff deferred for performance"
-            : "Large diff hidden for performance"
-        return VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(theme.color("fg"))
-            Text("\(changedLines.formatted()) changed lines. Rendering may be slow.")
-                .font(.system(size: 12))
-                .foregroundColor(theme.color("fg-dim"))
-            if hiddenItems > 0 {
-                Text("^[\(hiddenItems) comment](inflect: true) hidden — show the full diff to view.")
-                    .font(.system(size: 12))
-                    .foregroundColor(theme.color("fg-dim"))
-                    .accessibilityIdentifier("diff-review-render-budget-hidden-comments-\(file.id.rawValue)")
-            }
-            Button {
-                showFullDiffOverride = true
-            } label: {
-                Text("Show full diff")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(theme.color("fg-muted"))
-                    .padding(.horizontal, 10)
-                    .frame(height: 24)
-                    .background(theme.color("bg-3"))
-                    .clipShape(RoundedRectangle(cornerRadius: 5))
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("diff-review-show-full-diff-\(file.id.rawValue)")
-            .background(
-                ReviewDraftCommentActionPressMarker(
-                    identifier: "diff-review-show-full-diff-\(file.id.rawValue)",
-                    label: "Show full diff"
-                ) {
-                    showFullDiffOverride = true
-                }
-            )
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 14)
-        .padding(.vertical, 18)
-        .background(theme.color("bg-1"))
+        AppKitDiffReviewPlaceholderRowBody(input: focusedRowInput, isDeferred: true)
         .background(renderBudgetScrollAnchors)
-        .background(
-            DiffReviewAccessibilityMarker(
-                identifier: "diff-review-render-budget-\(file.id.rawValue)",
-                label: title
-            )
-        )
         .background {
             if isDeferredByAggregateBudget {
                 DiffReviewAccessibilityMarker(
@@ -726,83 +565,7 @@ struct DiffReviewFileSection: View {
         .accessibilityHidden(true)
     }
 
-    /// The pair from this section's own load, or — right after the review
-    /// stream's `LazyVStack` re-realizes this section (which resets
-    /// `imageState`) — the session-cached pair for the same provider. Reading
-    /// the cache directly here keeps the first body pass at full image height;
-    /// rendering empty/spinner for even one pass flips the section height and
-    /// destabilizes the lazy container's estimates (see
-    /// `DiffReviewImagePairCache`). The `.task` then re-populates `imageState`
-    /// from the same cache entry.
-    private var displayedImagePair: ImageDiffPair? {
-        imageState.pair ?? file.imageProvider.flatMap { DiffReviewImagePairCache.shared.pair(for: $0.id) }
-    }
-
-    @ViewBuilder
-    private var imageContent: some View {
-        if imageState.isLoading {
-            ProgressView()
-                .controlSize(.small)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .background(
-                    DiffReviewAccessibilityMarker(
-                        identifier: "diff-review-image-loading-\(file.id.rawValue)",
-                        label: "Loading image diff"
-                    )
-                )
-        }
-        if let pair = displayedImagePair {
-            ImageDiffComparisonContent(
-                pair: pair,
-                state: imageState.presentation,
-                boundedHeight: 360
-            )
-            if let failureMessage = imageLoadFailureMessage(in: pair) {
-                HStack(spacing: 10) {
-                    Text(failureMessage)
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.color("warn"))
-                    Spacer()
-                    Button("Retry") {
-                        Task { await imageState.retry() }
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(theme.color("fg-muted"))
-                    .padding(.horizontal, 8)
-                    .frame(height: 24)
-                    .background(theme.color("bg-3"))
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                    .accessibilityIdentifier("diff-review-image-retry-\(file.id.rawValue)")
-                    .background(
-                        DiffReviewAccessibilityMarker(
-                            identifier: "diff-review-image-retry-\(file.id.rawValue)",
-                            label: "Retry image diff"
-                        )
-                    )
-                }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(theme.color("bg-1"))
-                .background(
-                    DiffReviewAccessibilityMarker(
-                        identifier: "diff-review-image-failure-\(file.id.rawValue)",
-                        label: failureMessage
-                    )
-                )
-            }
-        }
-    }
-
-    private func imageLoadFailureMessage(in pair: ImageDiffPair) -> String? {
-        switch (pair.before, pair.after) {
-        case (.failed(let failure), _), (_, .failed(let failure)):
-            failure.message
-        default:
-            nil
-        }
-    }
+    private var imageContent: some View { AppKitDiffReviewImageRowBody(input: focusedRowInput) }
 
     @ViewBuilder
     private func content(renderContext: DiffReviewRenderContext?) -> some View {
@@ -839,20 +602,7 @@ struct DiffReviewFileSection: View {
                 lazyGroupStack(renderableGroups, displayModel: displayModel)
             }
         } else {
-            let message = file.placeholderMessage ?? "This file cannot be rendered in the review view."
-            Text(message)
-                .font(.system(size: 12))
-                .foregroundColor(theme.color("fg-dim"))
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 18)
-                .background(theme.color("bg-1"))
-                .background(
-                    DiffReviewAccessibilityMarker(
-                        identifier: "diff-review-placeholder-\(file.id.rawValue)",
-                        label: message
-                    )
-                )
+            AppKitDiffReviewPlaceholderRowBody(input: focusedRowInput, isDeferred: false)
         }
     }
 
@@ -937,8 +687,8 @@ struct DiffReviewFileSection: View {
                 lspContext: lspContext,
                 activeCommentHighlight: activeHighlight(for: displayGroup.rows),
                 allowsReviewLineSelection: allowsDraftCommentCreation,
-                onReviewLineSelected: beginPendingDraft,
-                onContextExpansion: loadContextAndExpand,
+                onReviewLineSelected: focusedRowInput.beginPendingDraft,
+                onContextExpansion: focusedRowInput.loadContextAndExpand,
                 threads: threads,
                 annotations: annotations,
                 onReply: { thread, body in state.actionRelay.reply(to: thread, body: body) },
@@ -970,61 +720,20 @@ struct DiffReviewFileSection: View {
             ForEach(segment.blocks) { block in
                 switch block {
                 case .rows(let rowSeg):
-                    DiffPaneTextDocumentView(
-                        group: DiffDisplayGroup(
-                            id: "\(segment.id)-\(rowSeg.id)",
-                            header: displayGroup.header,
-                            sourceHunk: displayGroup.sourceHunk,
-                            rows: rowSeg.rows,
-                            rowsSignature: rowSeg.rowsSignature
-                        ),
-                        expandedCollapsedRowIDs: expandedCollapsedRowIDs,
-                        layoutMode: layoutMode,
-                        wrapLines: wrapLines,
-                        showWhitespace: showWhitespace,
-                        fileExtension: LanguageRegistry.highlighterExtension(forPath: file.summary.path),
-                        codeFontFamily: codeFontFamily,
-                        codeFontSize: codeFontSize,
-                        theme: theme,
-                        lspContext: lspContext,
-                        activeCommentHighlight: activeHighlight(for: rowSeg.rows),
-                        allowsReviewLineSelection: allowsDraftCommentCreation,
-                        onReviewLineSelected: beginPendingDraft,
-                        onContextExpansion: loadContextAndExpand
+                    AppKitDiffReviewSegmentRowBody(
+                        rows: rowSeg.rows,
+                        rowsSignature: rowSeg.rowsSignature,
+                        group: displayGroup,
+                        input: focusedRowInput
                     )
-                    .fixedSize(horizontal: false, vertical: true)
                 case .thread(let thread):
-                    DiffFeedbackLaneView(
-                        lane: DiffFeedbackLaneResolver.lane(for: thread),
-                        layoutMode: layoutMode,
-                        rows: segment.rows
-                    ) {
-                        DiffInlineCommentCard(
-                            thread: thread,
-                            onReply: { body in state.actionRelay.reply(to: thread, body: body) },
-                            onStageReply: { body in state.actionRelay.stageReply(to: thread, body: body) },
-                            onResolve: { state.actionRelay.resolve(thread) },
-                            onUnresolve: { state.actionRelay.unresolve(thread) },
-                            onEdit: { comment, newBody in state.actionRelay.edit(comment, in: thread, body: newBody) },
-                            onDelete: { comment in state.actionRelay.delete(comment, in: thread) },
-                            canReply: canReply && thread.viewerCanReply,
-                            canResolve: canResolve && (thread.viewerCanResolve || thread.viewerCanUnresolve),
-                            canAddToReview: canAddToReview,
-                            onActiveChange: { active in
-                                activeThreadID = active ? thread.id : (activeThreadID == thread.id ? nil : activeThreadID)
-                            }
-                        )
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
+                    AppKitDiffReviewThreadRowBody(
+                        thread: thread, rows: segment.rows, input: focusedRowInput
+                    )
                 case .annotation(let annotation):
-                    DiffFeedbackLaneView(
-                        lane: DiffFeedbackLaneResolver.lane(for: annotation),
-                        layoutMode: layoutMode,
-                        rows: segment.rows
-                    ) {
-                        DiffInlineAnnotationCard(annotation: annotation)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
+                    AppKitDiffReviewAnnotationRowBody(
+                        annotation: annotation, rows: segment.rows, input: focusedRowInput
+                    )
                 }
             }
         }
@@ -1101,164 +810,14 @@ struct DiffReviewFileSection: View {
     }
 
     private func segmentedHunkHeader(_ group: DiffDisplayGroup) -> some View {
-        HStack(spacing: 8) {
-            Text(group.header)
-                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1))
-                .foregroundColor(theme.color("fg-muted"))
-                .lineLimit(1)
-            Spacer(minLength: 12)
-            if !DiffCollapsedContextController.collapsedRowIDs(in: group).isEmpty {
-                let expanded = DiffCollapsedContextController.isExpanded(group, expandedIDs: expandedCollapsedRowIDs)
-                Button {
-                    expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(
-                        group,
-                        expandedIDs: expandedCollapsedRowIDs
-                    )
-                } label: {
-                    Image(systemName: expanded ? "minus.square" : "plus.square")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(theme.color("fg-muted"))
-                        .frame(width: 22, height: 20)
-                }
-                .buttonStyle(.plain)
-                .help(expanded ? "Collapse context" : "Expand context")
-            }
-        }
-        .padding(.horizontal, 13)
-        .padding(.vertical, 8)
-        .background(theme.color("bg-2"))
-        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        AppKitDiffReviewGroupHeaderRowBody(group: group, input: focusedRowInput)
     }
 
     @ViewBuilder
     private func draftComposer(rows: [DiffDisplayRow]) -> some View {
         if allowsDraftCommentCreation, let pendingDraftAnchor {
-            DiffFeedbackLaneView(
-                lane: DiffFeedbackLaneResolver.lane(for: pendingDraftAnchor),
-                layoutMode: layoutMode,
-                rows: rows
-            ) {
-                draftComposerBody
-            }
+            AppKitDiffReviewComposerRowBody(rows: rows, input: focusedRowInput)
         }
-    }
-
-    @ViewBuilder
-    private var draftComposerBody: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            ReviewDraftComposerTextEditor(
-                text: Binding(
-                    get: { state.pendingDraftBody },
-                    set: { state.pendingDraftBody = $0 }
-                ),
-                theme: theme,
-                isFocused: $draftComposerFocused,
-                focusRequestGeneration: draftComposerFocusRequestGeneration,
-                onSave: savePendingDraft,
-                onCancel: clearPendingDraft
-            )
-            .frame(minHeight: 76, maxHeight: 104)
-            .background(focusedComposerMarker)
-            .clipShape(RoundedRectangle(cornerRadius: 7))
-            .overlay(
-                RoundedRectangle(cornerRadius: 7)
-                    .stroke(theme.color("accent").opacity(0.65), lineWidth: 0.75)
-            )
-            .accessibilityIdentifier("diff-review-draft-composer")
-
-            HStack(spacing: 6) {
-                Spacer(minLength: 0)
-                Button("Cancel") {
-                    clearPendingDraft()
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(theme.color("fg-muted"))
-                .padding(.horizontal, 8)
-                .frame(height: 24)
-                .background(theme.color("bg-3"))
-                .clipShape(RoundedRectangle(cornerRadius: 5))
-                .accessibilityIdentifier("diff-review-draft-composer-cancel")
-
-                Button("Save") {
-                    savePendingDraft()
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(theme.color("bg-1"))
-                .padding(.horizontal, 9)
-                .frame(height: 24)
-                .background(theme.color("accent"))
-                .clipShape(RoundedRectangle(cornerRadius: 5))
-                .accessibilityIdentifier("diff-review-draft-composer-save")
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(theme.color("bg-1"))
-        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
-        .background(
-            DiffReviewAccessibilityMarker(
-                identifier: "diff-review-draft-composer-marker",
-                label: "Draft comment composer"
-            )
-        )
-        .onChange(of: draftComposerFocused) { _, isFocused in
-            state.isDraftComposerFocused = isFocused
-        }
-        .onChange(of: state.isDraftComposerFocused) { _, isFocused in
-            draftComposerFocused = isFocused
-        }
-        .onAppear {
-            draftComposerFocused = state.isDraftComposerFocused
-        }
-    }
-
-    @ViewBuilder
-    private var focusedComposerMarker: some View {
-        if state.isDraftComposerFocused {
-            DiffReviewAccessibilityMarker(
-                identifier: "diff-review-draft-composer-focused",
-                label: "Draft comment composer focused"
-            )
-        }
-    }
-
-    private func savePendingDraft() {
-        guard let pendingDraftAnchor else { return }
-        let canonicalAnchor = ReviewDraftCommentRowSegmentation.canonicalPendingAnchor(
-            pendingDraftAnchor,
-            in: currentDisplayGroups ?? []
-        )
-        let body = pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !body.isEmpty else { return }
-        guard currentDraftRowKeys.contains(ReviewDraftCommentPlacement.RowKey(
-            side: canonicalAnchor.side,
-            line: canonicalAnchor.draftPlacementLine
-        )) else {
-            clearPendingDraft()
-            return
-        }
-
-        state.actionRelay.saveDraftComment(canonicalAnchor, body: body)
-        clearPendingDraft()
-    }
-
-    private func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
-        pendingDraftAnchor = anchor
-        pendingDraftBody = ""
-        draftComposerFocusRequestGeneration &+= 1
-    }
-
-    private func clearPendingDraft() {
-        pendingDraftAnchor = nil
-        pendingDraftBody = ""
-        draftComposerFocused = false
-    }
-
-    private var currentDraftRowKeys: Set<ReviewDraftCommentPlacement.RowKey> {
-        guard let groups = currentDisplayGroups else { return [] }
-        return Set(groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
     }
 
     /// Coarse structural fingerprint of the current display model, read in O(1)
@@ -1289,136 +848,6 @@ struct DiffReviewFileSection: View {
             providerID: file.contextProvider?.id.uuidString ?? "no-context-provider",
             structuralHash: displayStructuralHash
         )
-    }
-
-    private func loadContextAndExpand(
-        _ key: DiffContextExpansionKey,
-        mode: DiffContextExpansionMode,
-        edge: DiffContextExpansionEdge?
-    ) {
-        guard let provider = file.contextProvider else { return }
-        state.actionRelay.contextExpansionActivated()
-        if contextSnapshot != nil {
-            applyContextExpansion(key, mode: mode, edge: edge)
-            return
-        }
-        pendingContextExpansions.append(PendingContextExpansion(key: key, mode: mode, edge: edge))
-        guard contextLoadTask == nil else { return }
-        let fileID = file.id
-        let loadSignature = contextStateSignature
-        contextLoadGeneration += 1
-        let loadGeneration = contextLoadGeneration
-        contextLoadError = nil
-        contextLoadFileID = fileID
-        contextLoadSignature = loadSignature
-        contextLoadTask = Task {
-            do {
-                let snapshot = try await provider.snapshot()
-                try Task.checkCancellation()
-                await MainActor.run {
-                    guard contextLoadGeneration == loadGeneration,
-                          contextLoadFileID == fileID,
-                          contextLoadSignature == loadSignature
-                    else { return }
-                    contextSnapshot = snapshot
-                    contextLoadTask = nil
-                    contextLoadFileID = nil
-                    contextLoadSignature = nil
-                    let pendingExpansions = pendingContextExpansions
-                    pendingContextExpansions = []
-                    for expansion in pendingExpansions {
-                        applyContextExpansion(expansion.key, mode: expansion.mode, edge: expansion.edge)
-                    }
-                }
-            } catch {
-                await MainActor.run {
-                    guard contextLoadGeneration == loadGeneration,
-                          contextLoadFileID == fileID,
-                          contextLoadSignature == loadSignature
-                    else { return }
-                    contextLoadError = error.localizedDescription
-                    contextLoadTask = nil
-                    contextLoadFileID = nil
-                    contextLoadSignature = nil
-                    pendingContextExpansions = []
-                }
-            }
-        }
-    }
-
-    private func applyContextExpansion(
-        _ key: DiffContextExpansionKey,
-        mode: DiffContextExpansionMode,
-        edge: DiffContextExpansionEdge?
-    ) {
-        guard let displayModel = file.displayModel else { return }
-        let available = DiffContextExpandedDisplayBuilder.availableLineCount(
-            key: key,
-            groups: displayModel.groups,
-            snapshot: contextSnapshot
-        )
-        if let edge {
-            contextExpansion.expand(key, available: available, mode: mode, edge: edge)
-        } else {
-            contextExpansion.expand(key, available: available, mode: mode)
-        }
-    }
-
-    private func resetContextState() {
-        contextLoadTask?.cancel()
-        contextLoadGeneration += 1
-        contextSnapshot = nil
-        contextExpansion = DiffContextExpansionState()
-        contextLoadTask = nil
-        contextLoadFileID = nil
-        contextLoadSignature = nil
-        contextLoadError = nil
-        pendingContextExpansions = []
-    }
-
-    @ViewBuilder
-    private var sourceBadge: some View {
-        if showsSourceBadge, let title = file.summary.groupTitle {
-            Text(title.uppercased())
-                .font(.system(size: 9.5, weight: .semibold))
-                .foregroundColor(sourceColor)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(sourceColor.opacity(0.16))
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .background(
-                    DiffReviewAccessibilityMarker(
-                        identifier: "diff-review-source-badge-\(file.id.rawValue)",
-                        label: title.uppercased()
-                    )
-                )
-        }
-    }
-
-    private var sourceColor: Color {
-        switch file.summary.groupID ?? file.summary.namespace {
-        case "unstaged":
-            theme.color("warn")
-        case "staged":
-            theme.color("info")
-        default:
-            theme.color("accent")
-        }
-    }
-
-    private func statusColor(_ status: DiffReviewFileStatus) -> Color {
-        switch status {
-        case .added:
-            theme.color("add")
-        case .deleted:
-            theme.color("del")
-        case .renamed, .copied:
-            theme.color("accent")
-        case .conflicted:
-            theme.color("warn")
-        case .modified, .unknown:
-            theme.color("fg-dim")
-        }
     }
 }
 
@@ -2747,7 +2176,7 @@ struct ReviewDraftCommentCard: View {
     }
 }
 
-private extension DiffReviewLineAnchor {
+extension DiffReviewLineAnchor {
     var draftPlacementLine: Int {
         endLine ?? line
     }

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -351,22 +351,24 @@ struct DiffReviewFileSection: View {
     }
 
     private var feedbackDraftCommentActions: ReviewDraftCommentActions {
+        refreshActionRelay()
+        let relayActions = state.actionRelay.draftCommentActionsForRow
         return ReviewDraftCommentActions(
-            availability: draftCommentActions.availability,
-            canPublishReview: draftCommentActions.canPublishReview,
-            edit: draftCommentActions.edit,
-            delete: draftCommentActions.delete,
-            resolve: draftCommentActions.resolve,
-            dismiss: draftCommentActions.dismiss,
+            availability: relayActions.availability,
+            canPublishReview: relayActions.canPublishReview,
+            edit: relayActions.edit,
+            delete: relayActions.delete,
+            resolve: relayActions.resolve,
+            dismiss: relayActions.dismiss,
             copyPrompt: { bundle in
-                draftCommentActions.copyPrompt(bundle)
+                relayActions.copyPrompt(bundle)
                 copyFeedback.show("Copied prompt")
             },
-            publishProvider: draftCommentActions.publishProvider,
-            publishReview: draftCommentActions.publishReview,
-            agent: draftCommentActions.agent,
-            agentTargets: draftCommentActions.agentTargets,
-            sendToAgent: draftCommentActions.sendToAgent
+            publishProvider: relayActions.publishProvider,
+            publishReview: relayActions.publishReview,
+            agent: relayActions.agent,
+            agentTargets: relayActions.agentTargets,
+            sendToAgent: relayActions.sendToAgent
         )
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -617,37 +617,20 @@ struct DiffReviewFileSection: View {
 
     private var renderContext: DiffReviewRenderContext? {
         guard let displayModel = file.displayModel else { return nil }
-        let key = DiffReviewRenderContextKey(
-            fileID: file.id,
-            displayModel: displayModel,
-            contextSnapshot: contextSnapshot,
-            contextProviderAvailable: file.contextProvider != nil,
-            contextExpansion: contextExpansion,
-            inlineFeedback: inlineFeedback,
-            draftComments: draftComments,
-            pendingDraftAnchor: pendingDraftAnchor,
-            canCreateDraftComment: allowsDraftCommentCreation,
-            threads: threads,
-            annotations: annotations
+        #if DEBUG
+        let misses = renderContextCache.missCountForTests
+        #endif
+        let context = renderContextCache.reviewContext(
+            fileID: file.id, displayModel: displayModel, contextSnapshot: contextSnapshot,
+            contextProviderAvailable: file.contextProvider != nil, contextExpansion: contextExpansion,
+            inlineFeedback: inlineFeedback, draftComments: draftComments,
+            pendingDraftAnchor: pendingDraftAnchor, canCreateDraftComment: allowsDraftCommentCreation,
+            threads: threads, annotations: annotations
         )
-        return renderContextCache.context(key: key) {
-            #if DEBUG
-            onRenderContextCacheMissForTesting?()
-            #endif
-            return DiffReviewRenderContextBuilder.build(
-                fileID: file.id,
-                displayModel: displayModel,
-                contextSnapshot: contextSnapshot,
-                contextProviderAvailable: file.contextProvider != nil,
-                contextExpansion: contextExpansion,
-                inlineFeedback: inlineFeedback,
-                draftComments: draftComments,
-                pendingDraftAnchor: pendingDraftAnchor,
-                canCreateDraftComment: allowsDraftCommentCreation,
-                threads: threads,
-                annotations: annotations
-            )
-        }
+        #if DEBUG
+        if renderContextCache.missCountForTests != misses { onRenderContextCacheMissForTesting?() }
+        #endif
+        return context
     }
 
     private var currentDisplayGroups: [DiffDisplayGroup]? {

--- a/Alas/Sources/Center/DiffReview/DiffReviewRail.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRail.swift
@@ -239,6 +239,14 @@ struct DiffReviewRail: View {
                             label: name
                         )
                     )
+                ReviewDraftCommentActionPressMarker(
+                    identifier: "diff-review-rail-row-\(file.id.rawValue)",
+                    label: file.path
+                ) {
+                    selectedFileID = file.id
+                    onSelectFile(file.id)
+                }
+                .frame(width: 1, height: 1)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(name)
                         .font(.system(size: 12, weight: .medium))

--- a/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
@@ -220,6 +220,52 @@ final class DiffReviewRenderContextCache: ObservableObject {
         return context
     }
 
+    /// Shared cache entry point for both the legacy section and the flattened
+    /// AppKit row plan. Keeping this construction here prevents either path
+    /// from accidentally deriving a second context for the same file pass.
+    func reviewContext(
+        fileID: DiffReviewFileID,
+        displayModel: DiffDisplayModel,
+        contextSnapshot: DiffReviewFileContextSnapshot?,
+        contextProviderAvailable: Bool,
+        contextExpansion: DiffContextExpansionState,
+        inlineFeedback: [DiffReviewInlineFeedback],
+        draftComments: [ReviewDraftComment],
+        pendingDraftAnchor: DiffReviewLineAnchor?,
+        canCreateDraftComment: Bool,
+        threads: [DiffInlineCommentThread],
+        annotations: [DiffInlineAnnotation]
+    ) -> DiffReviewRenderContext {
+        let key = DiffReviewRenderContextKey(
+            fileID: fileID,
+            displayModel: displayModel,
+            contextSnapshot: contextSnapshot,
+            contextProviderAvailable: contextProviderAvailable,
+            contextExpansion: contextExpansion,
+            inlineFeedback: inlineFeedback,
+            draftComments: draftComments,
+            pendingDraftAnchor: pendingDraftAnchor,
+            canCreateDraftComment: canCreateDraftComment,
+            threads: threads,
+            annotations: annotations
+        )
+        return context(key: key) {
+            DiffReviewRenderContextBuilder.build(
+                fileID: fileID,
+                displayModel: displayModel,
+                contextSnapshot: contextSnapshot,
+                contextProviderAvailable: contextProviderAvailable,
+                contextExpansion: contextExpansion,
+                inlineFeedback: inlineFeedback,
+                draftComments: draftComments,
+                pendingDraftAnchor: pendingDraftAnchor,
+                canCreateDraftComment: canCreateDraftComment,
+                threads: threads,
+                annotations: annotations
+            )
+        }
+    }
+
     func removeAll() {
         storage.removeAll()
         recency.removeAll()

--- a/Alas/Sources/Center/DiffReview/DiffReviewScrollSpy.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewScrollSpy.swift
@@ -134,6 +134,10 @@ struct DiffReviewScrollCommandController: Equatable {
         generation += 1
         return DiffReviewScrollCommand(id: id, generation: generation)
     }
+
+    mutating func reset() {
+        generation = 0
+    }
 }
 
 enum DiffReviewScrollCommandConsumption {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -92,6 +92,8 @@ struct DiffReviewSurface: View {
     @State private var scrollCommand: DiffReviewScrollCommand?
     @State private var contextExpandedFileIDs: Set<DiffReviewFileID> = []
     @State private var synchronizedFileSetKey: String?
+    @State private var appKitScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
+    @StateObject private var appKitPresentationStore = AppKitDiffReviewPresentationStore()
     /// The file the scrollspy last reported as scrolled into view. Used to tell
     /// cross-file comment navigation (file section not yet realized → needs a
     /// two-phase scroll) from same-file navigation (section already realized →
@@ -242,6 +244,10 @@ struct DiffReviewSurface: View {
         .onChange(of: fileSetKey) { _, _ in
             synchronizeSelectionWithSession()
         }
+        .onReceive(NotificationCenter.default.publisher(for: AppKitDiffScrollerFlag.overrideDidChangeNotification)) { _ in
+            appKitScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
+            resetScrollCommandBookkeeping()
+        }
     }
 
     private func reviewSurface(firstFileID: DiffReviewFileID) -> some View {
@@ -263,7 +269,14 @@ struct DiffReviewSurface: View {
                 threads: threads,
                 onSelectFile: scrollToFile
             )
-            mainReviewStream(session, firstFileID: firstFileID)
+            Group {
+                if Self.usesAppKitScroller(flagEnabled: appKitScrollerEnabled) {
+                    appKitMainReviewStream(session)
+                } else {
+                    legacyMainReviewStream(session, firstFileID: firstFileID)
+                }
+            }
+            .id(appKitScrollerEnabled)
             if shouldShowReviewSummaryRail {
                 ReviewDraftSummaryRail(
                     comments: allDraftComments,
@@ -280,7 +293,7 @@ struct DiffReviewSurface: View {
         }
     }
 
-    private func mainReviewStream(_ session: DiffReviewLoadedSession, firstFileID: DiffReviewFileID) -> some View {
+    private func legacyMainReviewStream(_ session: DiffReviewLoadedSession, firstFileID: DiffReviewFileID) -> some View {
         ScrollViewReader { scrollProxy in
             ScrollView(.vertical) {
                 LazyVStack(alignment: .leading, spacing: 0) {
@@ -348,6 +361,78 @@ struct DiffReviewSurface: View {
             }
         }
         .background(theme.color("bg-1"))
+    }
+
+    private func appKitMainReviewStream(_ session: DiffReviewLoadedSession) -> some View {
+        AppKitDiffReviewScroller(
+            inputs: appKitRowInputs(for: session),
+            fileCommand: scrollCommand,
+            inlineFeedbackCommand: inlineFeedbackScrollCommand,
+            draftCommentCommand: draftCommentScrollCommand,
+            onNavigationFile: selectAppKitNavigationFile,
+            onActiveFileChange: updateSelectedFileFromAppKitViewport
+        )
+        .background(theme.color("bg-1"))
+    }
+
+    private func appKitRowInputs(for session: DiffReviewLoadedSession) -> [AppKitDiffReviewRowInput] {
+        session.files.map { file in
+            let state = appKitPresentationStore.state(for: file)
+            state.synchronize(file: file, contextSignature: DiffReviewContextStateSignature(
+                fileID: file.id.rawValue,
+                providerID: file.contextProvider?.id.uuidString ?? "no-context-provider",
+                structuralHash: file.displayModel?.structuralHash
+            ))
+            state.synchronizeRenderBudget(resetSignal: file.displayModel?.contentHash)
+            state.actionRelay.update(
+                inlineFeedbackActions: inlineFeedbackActions,
+                onSelectInlineFeedback: onSelectInlineFeedback,
+                draftCommentActions: draftCommentActions,
+                onSelectDraftComment: onSelectDraftComment,
+                onSaveDraftComment: { anchor, body in
+                    onSaveDraftComment(file.id, file.summary.originalPath, anchor, body)
+                },
+                onContextExpansionActivated: { contextExpandedFileIDs.insert(file.id) },
+                onReply: onReply,
+                onResolve: onResolve,
+                onUnresolve: onUnresolve,
+                onEdit: onEdit,
+                onDelete: onDelete,
+                onStageReply: onStageReply
+            )
+            return AppKitDiffReviewRowInput(
+                file: file,
+                inlineFeedback: inlineFeedbackByFileID[file.id] ?? [],
+                draftComments: draftCommentsByFileID[file.id] ?? [],
+                threads: DiffReviewProviderFeedbackResolver.threads(
+                    threads, for: file.summary.path, includeFileLevel: file.imageProvider != nil
+                ),
+                annotations: inlineAnnotations(for: file.summary.path),
+                state: state,
+                theme: theme,
+                layoutMode: layoutMode,
+                wrapLines: wrapLines,
+                showWhitespace: showWhitespace,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                showsSourceBadge: showsSourceBadges,
+                focusedFeedbackID: focusedFeedbackID,
+                focusedDraftCommentID: focusedDraftCommentID,
+                allowsDraftCommentCreation: allowsDraftCommentCreation,
+                actionPresence: .init(
+                    canOpenFile: file.openFile != nil,
+                    canUnstageFile: file.stagedMutationActions?.unstageFile != nil,
+                    canCreateDraftComment: allowsDraftCommentCreation,
+                    canReply: canReply,
+                    canResolve: canResolve,
+                    canAddToReview: canAddToReview
+                ),
+                lspContext: lspContextForFile(file),
+                reviewFeedbackTarget: effectiveReviewFeedbackTarget,
+                draftCommentActions: state.actionRelay.draftCommentActionsForRow,
+                onContextExpansionActivated: { contextExpandedFileIDs.insert(file.id) }
+            )
+        }
     }
 
     @ViewBuilder
@@ -545,6 +630,7 @@ struct DiffReviewSurface: View {
         synchronizedFileSetKey = result.fileSetKey
         programmaticScroll = result.programmaticScroll
         contextExpandedFileIDs.formIntersection(Set(fileIDs))
+        appKitPresentationStore.prune(keeping: Set(fileIDs))
         if DiffReviewSurfaceSelectionSync.shouldScrollRestoredSelection(
             previousFileSetKey: previousFileSetKey,
             previousSelection: previousSelection,
@@ -565,10 +651,33 @@ struct DiffReviewSurface: View {
         scrollSpyActiveFileID = id
         scrollCommand = scrollCommandController.command(to: id)
 
+        guard !appKitScrollerEnabled else {
+            programmaticScroll.finishProgrammaticScroll(token)
+            return
+        }
+
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 250_000_000)
             programmaticScroll.finishProgrammaticScroll(token)
         }
+    }
+
+    private func updateSelectedFileFromAppKitViewport(_ fileID: DiffReviewFileID) {
+        guard programmaticScroll.acceptsScrollSpyUpdate(for: fileID), fileID != selectedFileID else { return }
+        selectedFileID = fileID
+        scrollSpyActiveFileID = fileID
+    }
+
+    private func selectAppKitNavigationFile(_ fileID: DiffReviewFileID) {
+        selectedFileID = fileID
+        scrollSpyActiveFileID = fileID
+    }
+
+    private func resetScrollCommandBookkeeping() {
+        scrollCommand = nil
+        scrollCommandController.reset()
+        programmaticScroll = DiffReviewProgrammaticScrollController()
+        scrollSpyActiveFileID = nil
     }
 
     private func inlineAnnotations(for filePath: String) -> [DiffInlineAnnotation] {
@@ -584,6 +693,10 @@ struct DiffReviewSurface: View {
             includeFileLevel: false
         )
     }
+}
+
+extension DiffReviewSurface {
+    static func usesAppKitScroller(flagEnabled: Bool) -> Bool { flagEnabled }
 }
 
 enum DiffReviewSurfaceSelectionSync {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -428,7 +428,9 @@ struct DiffReviewSurface: View {
                     canCreateDraftComment: allowsDraftCommentCreation,
                     canReply: canReply,
                     canResolve: canResolve,
-                    canAddToReview: canAddToReview
+                    canAddToReview: canAddToReview,
+                    canUnstageHunk: file.stagedMutationActions?.unstageHunk != nil,
+                    hunkUnstageEnabled: file.stagedMutationActions?.unstageEnabledBase ?? false
                 ),
                 lspContext: lspContextForFile(file),
                 reviewFeedbackTarget: effectiveReviewFeedbackTarget,

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -403,6 +403,24 @@ struct DiffReviewSurface: View {
                 onDelete: onDelete,
                 onStageReply: onStageReply
             )
+            let relayDraftActions = state.actionRelay.draftCommentActionsForRow
+            let appKitDraftActions = ReviewDraftCommentActions(
+                availability: relayDraftActions.availability,
+                canPublishReview: relayDraftActions.canPublishReview,
+                edit: relayDraftActions.edit,
+                delete: relayDraftActions.delete,
+                resolve: relayDraftActions.resolve,
+                dismiss: relayDraftActions.dismiss,
+                copyPrompt: { bundle in
+                    relayDraftActions.copyPrompt(bundle)
+                    state.copyFeedback.show("Copied prompt")
+                },
+                publishProvider: relayDraftActions.publishProvider,
+                publishReview: relayDraftActions.publishReview,
+                agent: relayDraftActions.agent,
+                agentTargets: relayDraftActions.agentTargets,
+                sendToAgent: relayDraftActions.sendToAgent
+            )
             return AppKitDiffReviewRowInput(
                 file: file,
                 inlineFeedback: inlineFeedbackByFileID[file.id] ?? [],
@@ -434,7 +452,7 @@ struct DiffReviewSurface: View {
                 ),
                 lspContext: lspContextForFile(file),
                 reviewFeedbackTarget: effectiveReviewFeedbackTarget,
-                draftCommentActions: state.actionRelay.draftCommentActionsForRow,
+                draftCommentActions: appKitDraftActions,
                 onContextExpansionActivated: { contextExpandedFileIDs.insert(file.id) }
             )
         }

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -90,6 +90,8 @@ struct DiffReviewSurface: View {
     @State private var programmaticScroll = DiffReviewProgrammaticScrollController()
     @State private var scrollCommandController = DiffReviewScrollCommandController()
     @State private var scrollCommand: DiffReviewScrollCommand?
+    @State private var appKitProgrammaticScroll: AppKitDiffReviewProgrammaticScroll?
+    @State private var appKitScrollCompletionGate = AppKitDiffReviewScrollCompletionGate()
     @State private var contextExpandedFileIDs: Set<DiffReviewFileID> = []
     @State private var synchronizedFileSetKey: String?
     @State private var appKitScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
@@ -370,7 +372,8 @@ struct DiffReviewSurface: View {
             inlineFeedbackCommand: inlineFeedbackScrollCommand,
             draftCommentCommand: draftCommentScrollCommand,
             onNavigationFile: selectAppKitNavigationFile,
-            onActiveFileChange: updateSelectedFileFromAppKitViewport
+            onActiveFileChange: updateSelectedFileFromAppKitViewport,
+            onProgrammaticScrollCompletion: finishAppKitProgrammaticScroll
         )
         .background(theme.color("bg-1"))
     }
@@ -647,14 +650,12 @@ struct DiffReviewSurface: View {
     }
 
     private func queueProgrammaticFileScroll(to id: DiffReviewFileID) {
-        let token = programmaticScroll.beginProgrammaticScroll(to: id)
         scrollSpyActiveFileID = id
         scrollCommand = scrollCommandController.command(to: id)
 
-        guard !appKitScrollerEnabled else {
-            programmaticScroll.finishProgrammaticScroll(token)
-            return
-        }
+        guard !appKitScrollerEnabled else { return }
+
+        let token = programmaticScroll.beginProgrammaticScroll(to: id)
 
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 250_000_000)
@@ -668,15 +669,29 @@ struct DiffReviewSurface: View {
         scrollSpyActiveFileID = fileID
     }
 
-    private func selectAppKitNavigationFile(_ fileID: DiffReviewFileID) {
+    private func selectAppKitNavigationFile(_ fileID: DiffReviewFileID, requestGeneration: Int) {
         selectedFileID = fileID
         scrollSpyActiveFileID = fileID
+        let token = programmaticScroll.beginProgrammaticScroll(to: fileID)
+        appKitProgrammaticScroll = .init(requestGeneration: requestGeneration, token: token)
+        appKitScrollCompletionGate.begin(requestGeneration: requestGeneration)
+    }
+
+    private func finishAppKitProgrammaticScroll(requestGeneration: Int) {
+        guard appKitScrollCompletionGate.consumesCompletion(for: requestGeneration),
+              let appKitProgrammaticScroll,
+              appKitProgrammaticScroll.requestGeneration == requestGeneration
+        else { return }
+        programmaticScroll.finishProgrammaticScroll(appKitProgrammaticScroll.token)
+        self.appKitProgrammaticScroll = nil
     }
 
     private func resetScrollCommandBookkeeping() {
         scrollCommand = nil
         scrollCommandController.reset()
         programmaticScroll = DiffReviewProgrammaticScrollController()
+        appKitProgrammaticScroll = nil
+        appKitScrollCompletionGate = AppKitDiffReviewScrollCompletionGate()
         scrollSpyActiveFileID = nil
     }
 
@@ -693,6 +708,11 @@ struct DiffReviewSurface: View {
             includeFileLevel: false
         )
     }
+}
+
+private struct AppKitDiffReviewProgrammaticScroll {
+    let requestGeneration: Int
+    let token: DiffReviewProgrammaticScrollController.Token
 }
 
 extension DiffReviewSurface {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -438,6 +438,7 @@ struct DiffReviewSurface: View {
                 codeFontSize: codeFontSize,
                 showsSourceBadge: showsSourceBadges,
                 focusedFeedbackID: focusedFeedbackID,
+                inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID(for: file.id),
                 focusedDraftCommentID: focusedDraftCommentID,
                 allowsDraftCommentCreation: allowsDraftCommentCreation,
                 actionPresence: .init(

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -466,6 +466,7 @@ struct DiffReviewSurface: View {
     ) -> some View {
         let inlineFeedback = inlineFeedbackByFileID[file.id] ?? []
         let draftComments = draftCommentsByFileID[file.id] ?? []
+        let presentationState = appKitPresentationStore.state(for: file)
         EquatableDiffReviewFileSection(
             section: DiffReviewFileSection(
                 file: file,
@@ -509,14 +510,16 @@ struct DiffReviewSurface: View {
                 canReply: canReply,
                 canResolve: canResolve,
                 onStageReply: onStageReply,
-                canAddToReview: canAddToReview
+                canAddToReview: canAddToReview,
+                presentationState: presentationState
             ),
             layoutMode: layoutMode,
             wrapLines: wrapLines,
             showWhitespace: showWhitespace,
             draftCommentAvailability: draftComments.map(draftCommentActions.availability),
             inlineFeedbackAvailability: inlineFeedback.map { inlineFeedbackActions.availability($0, file.summary) },
-            draftCommentAgentTargets: draftCommentActions.agentTargets()
+            draftCommentAgentTargets: draftCommentActions.agentTargets(),
+            presentationStateSignature: DiffReviewFilePresentationSignature(presentationState)
         )
         .equatable()
     }

--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+struct DiffInlineCommentCardEditorState: Equatable {
+    var isComposerOpen = false
+    var replyDraft = ""
+    var editingCommentID: String?
+    var editDraft = ""
+}
+
 struct DiffInlineCommentCard: View {
     private enum FocusedEditor: Hashable {
         case reply
@@ -17,12 +24,10 @@ struct DiffInlineCommentCard: View {
     var onStageReply: (String) -> Void = { _ in }
     var canAddToReview: Bool = false
     var onActiveChange: (Bool) -> Void = { _ in }
+    var editorState: Binding<DiffInlineCommentCardEditorState>?
 
     @State private var isExpanded: Bool
-    @State private var isComposerOpen = false
-    @State private var replyDraft = ""
-    @State private var editingCommentID: String? = nil
-    @State private var editDraft = ""
+    @State private var localEditorState = DiffInlineCommentCardEditorState()
     @State private var isHovered = false
     @FocusState private var isCardFocused: Bool
     @FocusState private var focusedEditor: FocusedEditor?
@@ -38,6 +43,7 @@ struct DiffInlineCommentCard: View {
         canReply: Bool = true,
         canResolve: Bool = true,
         canAddToReview: Bool = false,
+        editorState: Binding<DiffInlineCommentCardEditorState>? = nil,
         onActiveChange: @escaping (Bool) -> Void = { _ in }
     ) {
         self.thread = thread
@@ -50,6 +56,7 @@ struct DiffInlineCommentCard: View {
         self.canReply = canReply
         self.canResolve = canResolve
         self.canAddToReview = canAddToReview
+        self.editorState = editorState
         self.onActiveChange = onActiveChange
         // Smart default: expanded when unresolved and not outdated
         _isExpanded = State(initialValue: !thread.isResolved && !thread.isOutdated)
@@ -149,7 +156,7 @@ struct DiffInlineCommentCard: View {
             .padding(.vertical, 8)
 
             // Inline reply composer
-            if isComposerOpen {
+            if editorStateBinding.wrappedValue.isComposerOpen {
                 Divider()
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 6) {
@@ -158,13 +165,13 @@ struct DiffInlineCommentCard: View {
                             .foregroundColor(.secondary)
                         Spacer(minLength: 0)
                         Button("Suggest") {
-                            replyDraft = "```suggestion\n\n```"
+                            editorStateBinding.wrappedValue.replyDraft = "```suggestion\n\n```"
                         }
                         .buttonStyle(.plain)
                         .font(.system(size: 11))
                         .foregroundColor(.accentColor)
                     }
-                    TextEditor(text: $replyDraft)
+                    TextEditor(text: editorStateBinding.replyDraft)
                         .font(.system(size: 11))
                         .focused($focusedEditor, equals: .reply)
                         .frame(minHeight: 60)
@@ -177,9 +184,8 @@ struct DiffInlineCommentCard: View {
                         }
                     HStack(spacing: 8) {
                         Button("Comment") {
-                            onReply(replyDraft)
-                            replyDraft = ""
-                            isComposerOpen = false
+                            onReply(editorStateBinding.wrappedValue.replyDraft)
+                            clearReplyComposer()
                             focusedEditor = nil
                         }
                         .buttonStyle(.plain)
@@ -188,9 +194,8 @@ struct DiffInlineCommentCard: View {
 
                         if canAddToReview {
                             Button("Add to review") {
-                                onStageReply(replyDraft)
-                                replyDraft = ""
-                                isComposerOpen = false
+                                onStageReply(editorStateBinding.wrappedValue.replyDraft)
+                                clearReplyComposer()
                                 focusedEditor = nil
                             }
                             .buttonStyle(.plain)
@@ -199,8 +204,7 @@ struct DiffInlineCommentCard: View {
                         }
 
                         Button("Cancel") {
-                            replyDraft = ""
-                            isComposerOpen = false
+                            clearReplyComposer()
                             focusedEditor = nil
                         }
                         .buttonStyle(.plain)
@@ -218,8 +222,8 @@ struct DiffInlineCommentCard: View {
             HStack(spacing: 8) {
                 if canReply {
                     Button("Reply") {
-                        isComposerOpen.toggle()
-                        focusedEditor = isComposerOpen ? .reply : nil
+                        editorStateBinding.wrappedValue.isComposerOpen.toggle()
+                        focusedEditor = editorStateBinding.wrappedValue.isComposerOpen ? .reply : nil
                     }
                         .buttonStyle(.plain)
                         .font(.system(size: 11))
@@ -257,13 +261,13 @@ struct DiffInlineCommentCard: View {
 
     @ViewBuilder
     private func commentRow(_ comment: DiffInlineComment) -> some View {
-        if editingCommentID == comment.id {
+        if editorStateBinding.wrappedValue.editingCommentID == comment.id {
             // Edit mode for this comment
             VStack(alignment: .leading, spacing: 3) {
                 Text(comment.author)
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundColor(.primary)
-                TextEditor(text: $editDraft)
+                TextEditor(text: editorStateBinding.editDraft)
                     .font(.system(size: 11))
                     .focused($focusedEditor, equals: .edit(comment.id))
                     .frame(minHeight: 60)
@@ -276,9 +280,8 @@ struct DiffInlineCommentCard: View {
                     }
                 HStack(spacing: 8) {
                     Button("Save") {
-                        onEdit(comment, editDraft)
-                        editingCommentID = nil
-                        editDraft = ""
+                        onEdit(comment, editorStateBinding.wrappedValue.editDraft)
+                        clearEditComposer()
                         focusedEditor = nil
                     }
                     .buttonStyle(.plain)
@@ -286,8 +289,7 @@ struct DiffInlineCommentCard: View {
                     .foregroundColor(.accentColor)
 
                     Button("Cancel") {
-                        editingCommentID = nil
-                        editDraft = ""
+                        clearEditComposer()
                         focusedEditor = nil
                     }
                     .buttonStyle(.plain)
@@ -306,8 +308,8 @@ struct DiffInlineCommentCard: View {
                     Spacer(minLength: 0)
                     if comment.viewerCanUpdate {
                         Button {
-                            editingCommentID = comment.id
-                            editDraft = comment.body
+                            editorStateBinding.wrappedValue.editingCommentID = comment.id
+                            editorStateBinding.wrappedValue.editDraft = comment.body
                             focusedEditor = .edit(comment.id)
                         } label: {
                             Image(systemName: "pencil")
@@ -343,6 +345,20 @@ struct DiffInlineCommentCard: View {
     }
 
     // MARK: - Helpers
+
+    private var editorStateBinding: Binding<DiffInlineCommentCardEditorState> {
+        editorState ?? $localEditorState
+    }
+
+    private func clearReplyComposer() {
+        editorStateBinding.wrappedValue.replyDraft = ""
+        editorStateBinding.wrappedValue.isComposerOpen = false
+    }
+
+    private func clearEditComposer() {
+        editorStateBinding.wrappedValue.editingCommentID = nil
+        editorStateBinding.wrappedValue.editDraft = ""
+    }
 
     private var accentColor: Color {
         if thread.isResolved {

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -19,6 +19,8 @@ struct GGSplitCommitTabView: View {
     @State private var layoutMode: DiffLayoutMode = .stacked
     @State private var wrapLines = false
     @State private var showWhitespace = false
+    @State private var appKitPreviewScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
+    @State private var previewImageStore = GGSplitPreviewImageStore()
 
     init(
         tabState: GGSplitCommitTabState,
@@ -71,6 +73,11 @@ struct GGSplitCommitTabView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-1"))
         .task(id: tabState.id) { await load() }
+        .onReceive(
+            NotificationCenter.default.publisher(for: AppKitDiffScrollerFlag.overrideDidChangeNotification)
+        ) { _ in
+            appKitPreviewScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
+        }
     }
 
     private var availableContent: some View {
@@ -236,7 +243,6 @@ struct GGSplitCommitTabView: View {
         preview: GGSplitPreview,
         showsResultingImages: Bool = false
     ) -> some View {
-        let partition = GGResultingImagePreview.partition(preview.nonTextualFiles)
         return VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text(title)
@@ -255,34 +261,82 @@ struct GGSplitCommitTabView: View {
                     .foregroundStyle(theme.color("fg-dim"))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(preview.files) { file in
-                            splitPreviewFile(file)
-                        }
-                        if showsResultingImages, let targetSHA = model.targetSHA {
-                            ForEach(partition.imagePaths, id: \.self) { path in
-                                GGSplitResultingImagePreview(
-                                    path: path,
-                                    worktreePath: worktreePath,
-                                    revision: targetSHA,
-                                    codeFontFamily: codeFontFamily,
-                                    codeFontSize: codeFontSize
-                                )
-                            }
-                        }
-                        ForEach(partition.otherPaths, id: \.self) { path in
-                            Label(path, systemImage: "doc")
-                                .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
-                                .foregroundStyle(theme.color("fg-dim"))
-                                .padding(12)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
-                }
+                previewScrollSubtree(
+                    previewID: title,
+                    preview: preview,
+                    showsResultingImages: showsResultingImages
+                )
+                .id(appKitPreviewScrollerEnabled)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    nonisolated static func usesAppKitPreviewScroller(flagEnabled: Bool) -> Bool {
+        flagEnabled
+    }
+
+    @ViewBuilder
+    private func previewScrollSubtree(
+        previewID: String,
+        preview: GGSplitPreview,
+        showsResultingImages: Bool
+    ) -> some View {
+        if Self.usesAppKitPreviewScroller(flagEnabled: appKitPreviewScrollerEnabled) {
+            AppKitDiffScroller(
+                plan: GGSplitPreviewRowPlanBuilder.build(input: .init(
+                    previewID: previewID,
+                    preview: preview,
+                    showsResultingImages: showsResultingImages,
+                    worktreePath: worktreePath,
+                    revision: model.targetSHA,
+                    layoutMode: layoutMode,
+                    wrapLines: wrapLines,
+                    showWhitespace: showWhitespace,
+                    codeFontFamily: codeFontFamily,
+                    codeFontSize: codeFontSize,
+                    theme: theme,
+                    imageStore: previewImageStore
+                )),
+                scrollRequest: nil,
+                onActiveOwnerChange: { _ in },
+                onScrollRequestCompletion: { _ in }
+            )
+        } else {
+            legacyPreviewScroll(preview: preview, showsResultingImages: showsResultingImages)
+        }
+    }
+
+    private func legacyPreviewScroll(
+        preview: GGSplitPreview,
+        showsResultingImages: Bool
+    ) -> some View {
+        let partition = GGResultingImagePreview.partition(preview.nonTextualFiles)
+        return ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(preview.files) { file in splitPreviewFile(file) }
+                if showsResultingImages, let targetSHA = model.targetSHA {
+                    ForEach(partition.imagePaths, id: \.self) { path in
+                        let key = GGSplitPreviewImageKey(
+                            worktreePath: worktreePath, revision: targetSHA, relativePath: path
+                        )
+                        GGSplitResultingImagePreview(
+                            key: key,
+                            state: previewImageStore.state(for: key),
+                            codeFontFamily: codeFontFamily,
+                            codeFontSize: codeFontSize
+                        )
+                    }
+                }
+                ForEach(partition.otherPaths, id: \.self) { path in
+                    Label(path, systemImage: "doc")
+                        .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                        .foregroundStyle(theme.color("fg-dim"))
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
     }
 
     private func splitPreviewFile(_ file: GGSplitPreviewFile) -> some View {
@@ -406,53 +460,5 @@ enum GGResultingImagePreview {
             imagePaths: paths.filter(ImageFileType.isSupported(relativePath:)),
             otherPaths: paths.filter { !ImageFileType.isSupported(relativePath: $0) }
         )
-    }
-}
-
-private struct GGSplitResultingImagePreview: View {
-    let path: String
-    let worktreePath: URL
-    let revision: String
-    let codeFontFamily: String
-    let codeFontSize: CGFloat
-
-    @State private var imageSide: ImageDiffSide?
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(path)
-                .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 7)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            ZStack {
-                ImageCheckerboardBackground()
-                if let image = imageSide?.image {
-                    Image(nsImage: image)
-                        .resizable()
-                        .interpolation(.none)
-                        .aspectRatio(contentMode: .fit)
-                        .padding(8)
-                } else if imageSide == nil {
-                    Spinner()
-                        .frame(width: 20, height: 20)
-                } else {
-                    Label("Could not load image", systemImage: "photo")
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: 220)
-        }
-        .task(id: "\(worktreePath.path):\(revision):\(path)") {
-            imageSide = await GitService().imageSide(
-                worktreePath: worktreePath,
-                revision: revision,
-                path: path
-            )
-        }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -21,6 +21,7 @@ struct GGSplitCommitTabView: View {
     @State private var showWhitespace = false
     @State private var appKitPreviewScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
     @State private var previewImageStore = GGSplitPreviewImageStore()
+    @State private var previewPresentationStore = GGSplitPreviewPresentationStore()
 
     init(
         tabState: GGSplitCommitTabState,
@@ -296,7 +297,8 @@ struct GGSplitCommitTabView: View {
                     codeFontFamily: codeFontFamily,
                     codeFontSize: codeFontSize,
                     theme: theme,
-                    imageStore: previewImageStore
+                    imageStore: previewImageStore,
+                    presentationStore: previewPresentationStore
                 )),
                 scrollRequest: nil,
                 onActiveOwnerChange: { _ in },

--- a/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
@@ -65,8 +65,11 @@ final class GGSplitPreviewPresentationStore {
         return state
     }
 
-    func prune(keeping keys: Set<String>) {
-        states = states.filter { keys.contains($0.key) }
+    func prune(previewID: String, keeping keys: Set<String>) {
+        let prefix = "\(previewID):"
+        states = states.filter { key, _ in
+            !key.hasPrefix(prefix) || keys.contains(key)
+        }
     }
 
     #if DEBUG
@@ -110,7 +113,7 @@ enum GGSplitPreviewRowPlanBuilder {
     static func build(input: GGSplitPreviewRowPlanInput) -> AppKitDiffRowPlan {
         var rows: [AppKitDiffRowSpec] = []
         let presentationKeys = Set(input.preview.files.map { "\(input.previewID):\($0.path)" })
-        input.presentationStore.prune(keeping: presentationKeys)
+        input.presentationStore.prune(previewID: input.previewID, keeping: presentationKeys)
         for file in input.preview.files {
             let prefix = "gg-preview:\(input.previewID):file:\(file.path)"
             rows.append(.init(

--- a/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
@@ -110,6 +110,12 @@ private struct GGSplitPreviewImageToken: Equatable {
     let theme: Theme
 }
 
+private struct GGSplitPreviewHunkWrapperToken: Equatable {
+    let content: AppKitDiffRowEqualityToken
+    let topPadding: CGFloat
+    let bottomPadding: CGFloat
+}
+
 @MainActor
 enum GGSplitPreviewRowPlanBuilder {
     static func build(input: GGSplitPreviewRowPlanInput) -> AppKitDiffRowPlan {
@@ -139,6 +145,7 @@ enum GGSplitPreviewRowPlanBuilder {
             })
 
             let model = DiffDisplayModelBuilder.build(diff: file.diff, filePath: file.path)
+            let fusionStates = DiffPaneHunkFusionResolver.states(for: model.groups)
             let hunkPlan = DiffPaneRowPlanBuilder.build(
                 input: .init(
                     model: model,
@@ -155,14 +162,27 @@ enum GGSplitPreviewRowPlanBuilder {
                 state: input.presentationStore.state(previewID: input.previewID, filePath: file.path)
             )
             for (index, hunk) in hunkPlan.rows.enumerated() {
+                let topPadding = index == hunkPlan.rows.startIndex ? fusionStates.first?.outerTopPadding ?? 10 : 0
+                let bottomPadding = index == hunkPlan.rows.index(before: hunkPlan.rows.endIndex)
+                    ? fusionStates.last?.outerBottomPadding ?? 10
+                    : 0
                 rows.append(.init(
                     id: "\(prefix):hunk:\(index):\(hunk.id)",
                     ownerID: file.path,
-                    equalityToken: hunk.equalityToken,
-                    estimatedHeight: hunk.estimatedHeight,
+                    equalityToken: .init(GGSplitPreviewHunkWrapperToken(
+                        content: hunk.equalityToken,
+                        topPadding: topPadding,
+                        bottomPadding: bottomPadding
+                    )),
+                    estimatedHeight: hunk.estimatedHeight + topPadding + bottomPadding,
                     retention: hunk.retention
                 ) {
-                    AnyView(hunk.build().padding(.horizontal, 10))
+                    AnyView(
+                        hunk.build()
+                            .padding(.horizontal, 10)
+                            .padding(.top, topPadding)
+                            .padding(.bottom, bottomPadding)
+                    )
                 })
             }
         }

--- a/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
@@ -99,6 +99,7 @@ private struct GGSplitPreviewHeaderToken: Equatable {
     let path: String
     let codeFontFamily: String
     let codeFontSize: CGFloat
+    let theme: Theme
 }
 
 private struct GGSplitPreviewImageToken: Equatable {
@@ -106,6 +107,7 @@ private struct GGSplitPreviewImageToken: Equatable {
     let key: GGSplitPreviewImageKey
     let codeFontFamily: String
     let codeFontSize: CGFloat
+    let theme: Theme
 }
 
 @MainActor
@@ -123,7 +125,8 @@ enum GGSplitPreviewRowPlanBuilder {
                     previewID: input.previewID,
                     path: file.path,
                     codeFontFamily: input.codeFontFamily,
-                    codeFontSize: input.codeFontSize
+                    codeFontSize: input.codeFontSize,
+                    theme: input.theme
                 )),
                 estimatedHeight: 35
             ) {
@@ -189,7 +192,8 @@ enum GGSplitPreviewRowPlanBuilder {
                         previewID: input.previewID,
                         key: key,
                         codeFontFamily: input.codeFontFamily,
-                        codeFontSize: input.codeFontSize
+                        codeFontSize: input.codeFontSize,
+                        theme: input.theme
                     )),
                     estimatedHeight: 255
                 ) {
@@ -213,7 +217,8 @@ enum GGSplitPreviewRowPlanBuilder {
                     previewID: input.previewID,
                     path: path,
                     codeFontFamily: input.codeFontFamily,
-                    codeFontSize: input.codeFontSize
+                    codeFontSize: input.codeFontSize,
+                    theme: input.theme
                 )),
                 estimatedHeight: 43
             ) {

--- a/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
@@ -54,6 +54,27 @@ final class GGSplitPreviewImageStore {
 }
 
 @MainActor
+final class GGSplitPreviewPresentationStore {
+    private var states: [String: DiffPanePresentationState] = [:]
+
+    func state(previewID: String, filePath: String) -> DiffPanePresentationState {
+        let key = "\(previewID):\(filePath)"
+        if let state = states[key] { return state }
+        let state = DiffPanePresentationState()
+        states[key] = state
+        return state
+    }
+
+    func prune(keeping keys: Set<String>) {
+        states = states.filter { keys.contains($0.key) }
+    }
+
+    #if DEBUG
+    var keysForTests: Set<String> { Set(states.keys) }
+    #endif
+}
+
+@MainActor
 struct GGSplitPreviewRowPlanInput {
     let previewID: String
     let preview: GGSplitPreview
@@ -67,6 +88,7 @@ struct GGSplitPreviewRowPlanInput {
     let codeFontSize: CGFloat
     let theme: Theme
     let imageStore: GGSplitPreviewImageStore
+    let presentationStore: GGSplitPreviewPresentationStore
 }
 
 private struct GGSplitPreviewHeaderToken: Equatable {
@@ -87,6 +109,8 @@ private struct GGSplitPreviewImageToken: Equatable {
 enum GGSplitPreviewRowPlanBuilder {
     static func build(input: GGSplitPreviewRowPlanInput) -> AppKitDiffRowPlan {
         var rows: [AppKitDiffRowSpec] = []
+        let presentationKeys = Set(input.preview.files.map { "\(input.previewID):\($0.path)" })
+        input.presentationStore.prune(keeping: presentationKeys)
         for file in input.preview.files {
             let prefix = "gg-preview:\(input.previewID):file:\(file.path)"
             rows.append(.init(
@@ -122,7 +146,7 @@ enum GGSplitPreviewRowPlanBuilder {
                     allowsReviewLineSelection: false,
                     hunkActions: { _ in DiffPaneHunkActions() }
                 ),
-                state: DiffPanePresentationState()
+                state: input.presentationStore.state(previewID: input.previewID, filePath: file.path)
             )
             for (index, hunk) in hunkPlan.rows.enumerated() {
                 rows.append(.init(

--- a/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
@@ -1,0 +1,274 @@
+import Observation
+import SwiftUI
+
+struct GGSplitPreviewImageKey: Hashable {
+    let worktreePath: URL
+    let revision: String
+    let relativePath: String
+
+    init(worktreePath: URL, revision: String, relativePath: String) {
+        self.worktreePath = worktreePath.standardizedFileURL
+        self.revision = revision
+        self.relativePath = relativePath
+    }
+}
+
+@Observable
+@MainActor
+final class GGSplitPreviewImageState {
+    private(set) var imageSide: ImageDiffSide?
+    private(set) var isLoading = true
+    @ObservationIgnored private var loadedKey: GGSplitPreviewImageKey?
+
+    func load(key: GGSplitPreviewImageKey) async {
+        guard loadedKey != key || imageSide == nil else { return }
+        loadedKey = key
+        isLoading = true
+        imageSide = await GitService().imageSide(
+            worktreePath: key.worktreePath,
+            revision: key.revision,
+            path: key.relativePath
+        )
+        isLoading = false
+    }
+}
+
+@MainActor
+final class GGSplitPreviewImageStore {
+    private var states: [GGSplitPreviewImageKey: GGSplitPreviewImageState] = [:]
+
+    func state(for key: GGSplitPreviewImageKey) -> GGSplitPreviewImageState {
+        if let state = states[key] { return state }
+        let state = GGSplitPreviewImageState()
+        states[key] = state
+        return state
+    }
+
+    func prune(keeping keys: Set<GGSplitPreviewImageKey>) {
+        states = states.filter { keys.contains($0.key) }
+    }
+
+    #if DEBUG
+    var keysForTests: Set<GGSplitPreviewImageKey> { Set(states.keys) }
+    #endif
+}
+
+@MainActor
+struct GGSplitPreviewRowPlanInput {
+    let previewID: String
+    let preview: GGSplitPreview
+    let showsResultingImages: Bool
+    let worktreePath: URL
+    let revision: String?
+    let layoutMode: DiffLayoutMode
+    let wrapLines: Bool
+    let showWhitespace: Bool
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let theme: Theme
+    let imageStore: GGSplitPreviewImageStore
+}
+
+private struct GGSplitPreviewHeaderToken: Equatable {
+    let previewID: String
+    let path: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+}
+
+private struct GGSplitPreviewImageToken: Equatable {
+    let previewID: String
+    let key: GGSplitPreviewImageKey
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+}
+
+@MainActor
+enum GGSplitPreviewRowPlanBuilder {
+    static func build(input: GGSplitPreviewRowPlanInput) -> AppKitDiffRowPlan {
+        var rows: [AppKitDiffRowSpec] = []
+        for file in input.preview.files {
+            let prefix = "gg-preview:\(input.previewID):file:\(file.path)"
+            rows.append(.init(
+                id: "\(prefix):header",
+                ownerID: file.path,
+                equalityToken: .init(GGSplitPreviewHeaderToken(
+                    previewID: input.previewID,
+                    path: file.path,
+                    codeFontFamily: input.codeFontFamily,
+                    codeFontSize: input.codeFontSize
+                )),
+                estimatedHeight: 35
+            ) {
+                AnyView(GGSplitPreviewFileHeaderRow(
+                    path: file.path,
+                    codeFontFamily: input.codeFontFamily,
+                    codeFontSize: input.codeFontSize,
+                    theme: input.theme
+                ))
+            })
+
+            let model = DiffDisplayModelBuilder.build(diff: file.diff, filePath: file.path)
+            let hunkPlan = DiffPaneRowPlanBuilder.build(
+                input: .init(
+                    model: model,
+                    fileExtension: LanguageRegistry.highlighterExtension(forPath: file.path),
+                    layoutMode: input.layoutMode,
+                    wrapLines: input.wrapLines,
+                    showWhitespace: input.showWhitespace,
+                    codeFontFamily: input.codeFontFamily,
+                    codeFontSize: input.codeFontSize,
+                    theme: input.theme,
+                    allowsReviewLineSelection: false,
+                    hunkActions: { _ in DiffPaneHunkActions() }
+                ),
+                state: DiffPanePresentationState()
+            )
+            for (index, hunk) in hunkPlan.rows.enumerated() {
+                rows.append(.init(
+                    id: "\(prefix):hunk:\(index):\(hunk.id)",
+                    ownerID: file.path,
+                    equalityToken: hunk.equalityToken,
+                    estimatedHeight: hunk.estimatedHeight,
+                    retention: hunk.retention
+                ) {
+                    AnyView(hunk.build().padding(.horizontal, 10))
+                })
+            }
+        }
+
+        let partition = GGResultingImagePreview.partition(input.preview.nonTextualFiles)
+        let imageKeys: Set<GGSplitPreviewImageKey>
+        if input.showsResultingImages, let revision = input.revision {
+            imageKeys = Set(partition.imagePaths.map {
+                GGSplitPreviewImageKey(
+                    worktreePath: input.worktreePath,
+                    revision: revision,
+                    relativePath: $0
+                )
+            })
+            input.imageStore.prune(keeping: imageKeys)
+            for path in partition.imagePaths {
+                let key = GGSplitPreviewImageKey(
+                    worktreePath: input.worktreePath,
+                    revision: revision,
+                    relativePath: path
+                )
+                let state = input.imageStore.state(for: key)
+                rows.append(.init(
+                    id: "gg-preview:\(input.previewID):image:\(key.relativePath)",
+                    ownerID: key.relativePath,
+                    equalityToken: .init(GGSplitPreviewImageToken(
+                        previewID: input.previewID,
+                        key: key,
+                        codeFontFamily: input.codeFontFamily,
+                        codeFontSize: input.codeFontSize
+                    )),
+                    estimatedHeight: 255
+                ) {
+                    AnyView(GGSplitResultingImagePreview(
+                        key: key,
+                        state: state,
+                        codeFontFamily: input.codeFontFamily,
+                        codeFontSize: input.codeFontSize
+                    ))
+                })
+            }
+        } else {
+            imageKeys = []
+        }
+
+        for path in partition.otherPaths {
+            rows.append(.init(
+                id: "gg-preview:\(input.previewID):other:\(path)",
+                ownerID: path,
+                equalityToken: .init(GGSplitPreviewHeaderToken(
+                    previewID: input.previewID,
+                    path: path,
+                    codeFontFamily: input.codeFontFamily,
+                    codeFontSize: input.codeFontSize
+                )),
+                estimatedHeight: 43
+            ) {
+                AnyView(GGSplitPreviewOtherFileRow(
+                    path: path,
+                    codeFontFamily: input.codeFontFamily,
+                    codeFontSize: input.codeFontSize,
+                    theme: input.theme
+                ))
+            })
+        }
+        return .init(rows: rows)
+    }
+}
+
+private struct GGSplitPreviewFileHeaderRow: View {
+    let path: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let theme: Theme
+
+    var body: some View {
+        Text(path)
+            .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+            .foregroundStyle(theme.color("fg"))
+            .textSelection(.enabled)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.color("bg-2"))
+    }
+}
+
+private struct GGSplitPreviewOtherFileRow: View {
+    let path: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let theme: Theme
+
+    var body: some View {
+        Label(path, systemImage: "doc")
+            .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+            .foregroundStyle(theme.color("fg-dim"))
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct GGSplitResultingImagePreview: View {
+    let key: GGSplitPreviewImageKey
+    let state: GGSplitPreviewImageState
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(key.relativePath)
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            ZStack {
+                ImageCheckerboardBackground()
+                if let image = state.imageSide?.image {
+                    Image(nsImage: image)
+                        .resizable()
+                        .interpolation(.none)
+                        .aspectRatio(contentMode: .fit)
+                        .padding(8)
+                } else if state.isLoading {
+                    Spinner().frame(width: 20, height: 20)
+                } else {
+                    Label("Could not load image", systemImage: "photo")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 220)
+        }
+        .task(id: key) { await state.load(key: key) }
+    }
+}

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -11,6 +11,7 @@ struct AdvancedPane: View {
     /// correctly once but never invalidates this view, so the switch could
     /// keep drawing its old position after the override had already changed.
     @State private var appKitScrollerEnabled = ACPTranscriptScrollerFlag.isEnabled
+    @State private var appKitDiffScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
 
     var body: some View {
         ScrollView {
@@ -30,6 +31,18 @@ struct AdvancedPane: View {
                             set: {
                                 appKitScrollerEnabled = $0
                                 ACPTranscriptScrollerFlag.setOverride($0)
+                            }
+                        ))
+                    }
+                    SettingsRow(
+                        name: "AppKit diff scrollers",
+                        desc: "Replaces vertical scrolling in diff and review panes with an AppKit-backed scroller. Toggling this re-creates open diff views, so their scroll positions are lost."
+                    ) {
+                        AlasToggle(on: Binding(
+                            get: { appKitDiffScrollerEnabled },
+                            set: {
+                                appKitDiffScrollerEnabled = $0
+                                AppKitDiffScrollerFlag.setOverride($0)
                             }
                         ))
                     }
@@ -87,6 +100,11 @@ struct AdvancedPane: View {
             // Keeps the switch honest when the override changes from outside
             // this pane — a `defaults write`, or another window's copy of it.
             appKitScrollerEnabled = ACPTranscriptScrollerFlag.isEnabled
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: AppKitDiffScrollerFlag.overrideDidChangeNotification)
+        ) { _ in
+            appKitDiffScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
         }
     }
 

--- a/AlasTests/AppKitDiffReviewPresentationStateTests.swift
+++ b/AlasTests/AppKitDiffReviewPresentationStateTests.swift
@@ -1,0 +1,121 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct AppKitDiffReviewPresentationStateTests {
+    @Test func storeRetainsStateForTheSameFile() {
+        let store = AppKitDiffReviewPresentationStore()
+        let file = fileModel(path: "Sources/Retained.swift")
+        let state = store.state(for: file)
+        state.pendingDraftBody = "keep me"
+
+        #expect(store.state(for: file) === state)
+        store.prune(keeping: [file.id])
+        #expect(store.state(for: file).pendingDraftBody == "keep me")
+    }
+
+    @Test func storePrunesStateForAbsentFiles() {
+        let store = AppKitDiffReviewPresentationStore()
+        let retained = fileModel(path: "Sources/Retained.swift")
+        let removed = fileModel(path: "Sources/Removed.swift")
+        let removedState = store.state(for: removed)
+
+        store.prune(keeping: [retained.id])
+
+        #expect(store.state(for: removed) !== removedState)
+    }
+
+    @Test func retainedStateKeepsDraftAndExpandedContextAcrossUnmount() {
+        let store = AppKitDiffReviewPresentationStore()
+        let file = fileModel()
+        let state = store.state(for: file)
+        state.pendingDraftBody = "keep me"
+        state.expandedCollapsedRowIDs = ["hunk:1"]
+
+        let remounted = store.state(for: file)
+
+        #expect(remounted.pendingDraftBody == "keep me")
+        #expect(remounted.expandedCollapsedRowIDs == ["hunk:1"])
+    }
+
+    @Test func renderBudgetResetClearsFullDiffOverride() {
+        let state = AppKitDiffReviewFileState()
+        state.showFullDiffOverride = true
+
+        state.resetForRenderBudgetChange()
+
+        #expect(!state.showFullDiffOverride)
+    }
+
+    @Test func changedContextSignatureResetsContextState() {
+        let state = AppKitDiffReviewFileState()
+        let file = fileModel()
+        state.contextLoadError = "old error"
+        state.synchronize(file: file, contextSignature: signature(file: file, providerID: "first"))
+        state.contextLoadError = "new error"
+
+        state.synchronize(file: file, contextSignature: signature(file: file, providerID: "second"))
+
+        #expect(state.contextLoadError == nil)
+    }
+
+    @Test func staleContextGenerationCannotPublish() {
+        let state = AppKitDiffReviewFileState()
+        let file = fileModel()
+        state.synchronize(file: file, contextSignature: signature(file: file, providerID: "provider"))
+        let oldGeneration = state.beginContextLoad(fileID: file.id, signature: signature(file: file, providerID: "provider"))
+        state.resetContextState()
+
+        #expect(!state.acceptsContextResult(fileID: file.id, generation: oldGeneration))
+    }
+
+    @Test func actionRelayUsesLatestCallbackForExistingRow() {
+        let relay = AppKitDiffReviewActionRelay()
+        let item = DiffReviewInlineFeedback(
+            id: "feedback",
+            providerName: "GitHub",
+            author: nil,
+            bodyPreview: "Note",
+            status: .pending,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/File.swift", line: 1, side: .new),
+            evidenceItemID: "evidence"
+        )
+        var calls: [String] = []
+        let existingRowAction = { relay.selectInlineFeedback(item) }
+        relay.update(onSelectInlineFeedback: { _ in calls.append("first") })
+        relay.update(onSelectInlineFeedback: { _ in calls.append("second") })
+
+        existingRowAction()
+
+        #expect(calls == ["second"])
+    }
+
+    private func fileModel(path: String = "Sources/File.swift") -> DiffReviewFileSectionModel {
+        DiffReviewFileSectionModel(
+            summary: DiffReviewFileSummary(
+                path: path,
+                namespace: "working-tree",
+                groupID: nil,
+                groupTitle: nil,
+                status: .modified,
+                additions: 1,
+                deletions: 0,
+                isRenderable: true
+            ),
+            parsedDiff: nil,
+            displayModel: nil,
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil
+        )
+    }
+
+    private func signature(file: DiffReviewFileSectionModel, providerID: String) -> DiffReviewContextStateSignature {
+        DiffReviewContextStateSignature(
+            fileID: file.id.rawValue,
+            providerID: providerID,
+            structuralHash: nil
+        )
+    }
+}

--- a/AlasTests/AppKitDiffReviewPresentationStateTests.swift
+++ b/AlasTests/AppKitDiffReviewPresentationStateTests.swift
@@ -91,6 +91,38 @@ struct AppKitDiffReviewPresentationStateTests {
         #expect(calls == ["second"])
     }
 
+    @Test func actionRelayForwardsLatestActionStructForAnExistingRow() {
+        let relay = AppKitDiffReviewActionRelay()
+        let item = inlineFeedbackItem()
+        let file = fileModel().summary
+        let rowActions = relay.inlineFeedbackActionsForRow
+        var calls: [String] = []
+
+        relay.update(inlineFeedbackActions: DiffReviewInlineFeedbackActions(
+            copyContext: { _, _ in calls.append("first") }
+        ))
+        relay.update(inlineFeedbackActions: DiffReviewInlineFeedbackActions(
+            copyContext: { _, _ in calls.append("second") }
+        ))
+
+        rowActions.copyContext(item, file)
+
+        #expect(calls == ["second"])
+    }
+
+    private func inlineFeedbackItem() -> DiffReviewInlineFeedback {
+        DiffReviewInlineFeedback(
+            id: "feedback",
+            providerName: "GitHub",
+            author: nil,
+            bodyPreview: "Note",
+            status: .pending,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/File.swift", line: 1, side: .new),
+            evidenceItemID: "evidence"
+        )
+    }
+
     private func fileModel(path: String = "Sources/File.swift") -> DiffReviewFileSectionModel {
         DiffReviewFileSectionModel(
             summary: DiffReviewFileSummary(

--- a/AlasTests/AppKitDiffReviewPresentationStateTests.swift
+++ b/AlasTests/AppKitDiffReviewPresentationStateTests.swift
@@ -39,6 +39,50 @@ struct AppKitDiffReviewPresentationStateTests {
         #expect(remounted.expandedCollapsedRowIDs == ["hunk:1"])
     }
 
+    @Test func retainedStateKeepsReviewEditorDraftsAcrossUnmount() {
+        let store = AppKitDiffReviewPresentationStore()
+        let file = fileModel()
+        let state = store.state(for: file)
+
+        state.bindingForInlineFeedbackReplyEditor("feedback").wrappedValue = DiffReviewInlineFeedbackReplyEditorState(
+            isReplying: true,
+            body: "provider reply"
+        )
+        state.bindingForDraftCommentEditor("draft").wrappedValue = ReviewDraftCommentEditorState(
+            isEditing: true,
+            editingBody: "draft edit"
+        )
+        state.bindingForThreadCommentEditor("thread").wrappedValue = DiffInlineCommentCardEditorState(
+            isComposerOpen: true,
+            replyDraft: "thread reply",
+            editingCommentID: "comment",
+            editDraft: "thread edit"
+        )
+
+        let remounted = store.state(for: file)
+
+        #expect(remounted.bindingForInlineFeedbackReplyEditor("feedback").wrappedValue.body == "provider reply")
+        #expect(remounted.bindingForInlineFeedbackReplyEditor("feedback").wrappedValue.isReplying)
+        #expect(remounted.bindingForDraftCommentEditor("draft").wrappedValue.editingBody == "draft edit")
+        #expect(remounted.bindingForDraftCommentEditor("draft").wrappedValue.isEditing)
+        #expect(remounted.bindingForThreadCommentEditor("thread").wrappedValue.replyDraft == "thread reply")
+        #expect(remounted.bindingForThreadCommentEditor("thread").wrappedValue.editDraft == "thread edit")
+        #expect(remounted.bindingForThreadCommentEditor("thread").wrappedValue.editingCommentID == "comment")
+    }
+
+    @Test func fileIdentityResetClearsReviewEditorDrafts() {
+        let state = AppKitDiffReviewFileState()
+        state.bindingForInlineFeedbackReplyEditor("feedback").wrappedValue.body = "provider reply"
+        state.bindingForDraftCommentEditor("draft").wrappedValue.editingBody = "draft edit"
+        state.bindingForThreadCommentEditor("thread").wrappedValue.replyDraft = "thread reply"
+
+        state.resetForFileIdentityChange()
+
+        #expect(state.inlineFeedbackReplyEditors.isEmpty)
+        #expect(state.draftCommentEditors.isEmpty)
+        #expect(state.threadCommentEditors.isEmpty)
+    }
+
     @Test func fileAndHunkPresentationShareCollapsedContextState() {
         let state = AppKitDiffReviewFileState()
 

--- a/AlasTests/AppKitDiffReviewPresentationStateTests.swift
+++ b/AlasTests/AppKitDiffReviewPresentationStateTests.swift
@@ -128,7 +128,7 @@ struct AppKitDiffReviewPresentationStateTests {
         #expect(calls == ["second"])
     }
 
-    @Test func presentationStoreIgnoresComposerTypingAndHoverButForwardsStructuralChanges() {
+    @Test func presentationStoreIgnoresComposerTypingButForwardsHoverAndStructuralChanges() {
         let store = AppKitDiffReviewPresentationStore()
         let state = store.state(for: fileModel())
         var changes = 0
@@ -136,13 +136,14 @@ struct AppKitDiffReviewPresentationStateTests {
 
         state.pendingDraftBody = "a"
         state.hoveredInlineFeedbackID = "feedback"
+        #expect(changes == 1)
         state.hoveredDraftCommentID = "draft"
-        #expect(changes == 0)
+        #expect(changes == 2)
 
         state.pendingDraftAnchor = DiffReviewLineAnchor(
             path: "Sources/File.swift", side: .new, line: 1, rowIndex: 0, selectedText: "line"
         )
-        #expect(changes == 1)
+        #expect(changes == 3)
         _ = cancellable
     }
 

--- a/AlasTests/AppKitDiffReviewPresentationStateTests.swift
+++ b/AlasTests/AppKitDiffReviewPresentationStateTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Testing
 @testable import Alas
 
@@ -124,6 +125,41 @@ struct AppKitDiffReviewPresentationStateTests {
 
         rowActions.publishReview()
 
+        #expect(calls == ["second"])
+    }
+
+    @Test func presentationStoreIgnoresComposerTypingAndHoverButForwardsStructuralChanges() {
+        let store = AppKitDiffReviewPresentationStore()
+        let state = store.state(for: fileModel())
+        var changes = 0
+        let cancellable = store.objectWillChange.sink { changes += 1 }
+
+        state.pendingDraftBody = "a"
+        state.hoveredInlineFeedbackID = "feedback"
+        state.hoveredDraftCommentID = "draft"
+        #expect(changes == 0)
+
+        state.pendingDraftAnchor = DiffReviewLineAnchor(
+            path: "Sources/File.swift", side: .new, line: 1, rowIndex: 0, selectedText: "line"
+        )
+        #expect(changes == 1)
+        _ = cancellable
+    }
+
+    @Test func actionRelayUsesLatestHunkCallbackForAnExistingRow() throws {
+        let relay = AppKitDiffReviewActionRelay()
+        let hunk = ParsedDiff.Hunk(header: "@@ -1 +1 @@", oldStart: 1, newStart: 1, lines: [])
+        var calls: [String] = []
+        relay.update(stagedMutationActions: .init(
+            unstageHunk: { _ in calls.append("first") }, isHunkUnstageEnabled: { _ in true }
+        ))
+        relay.update(stagedMutationActions: .init(
+            unstageHunk: { _ in calls.append("second") }, isHunkUnstageEnabled: { _ in true }
+        ))
+
+        let latestActions = relay.hunkActions(for: hunk)
+        let dropFromCommit = try #require(latestActions.dropFromCommit)
+        dropFromCommit()
         #expect(calls == ["second"])
     }
 

--- a/AlasTests/AppKitDiffReviewPresentationStateTests.swift
+++ b/AlasTests/AppKitDiffReviewPresentationStateTests.swift
@@ -110,6 +110,23 @@ struct AppKitDiffReviewPresentationStateTests {
         #expect(calls == ["second"])
     }
 
+    @Test func actionRelayForwardsLatestDraftActionStructForAnExistingRow() {
+        let relay = AppKitDiffReviewActionRelay()
+        let rowActions = relay.draftCommentActionsForRow
+        var calls: [String] = []
+
+        relay.update(draftCommentActions: ReviewDraftCommentActions(
+            publishReview: { calls.append("first") }
+        ))
+        relay.update(draftCommentActions: ReviewDraftCommentActions(
+            publishReview: { calls.append("second") }
+        ))
+
+        rowActions.publishReview()
+
+        #expect(calls == ["second"])
+    }
+
     private func inlineFeedbackItem() -> DiffReviewInlineFeedback {
         DiffReviewInlineFeedback(
             id: "feedback",

--- a/AlasTests/AppKitDiffReviewPresentationStateTests.swift
+++ b/AlasTests/AppKitDiffReviewPresentationStateTests.swift
@@ -39,6 +39,16 @@ struct AppKitDiffReviewPresentationStateTests {
         #expect(remounted.expandedCollapsedRowIDs == ["hunk:1"])
     }
 
+    @Test func fileAndHunkPresentationShareCollapsedContextState() {
+        let state = AppKitDiffReviewFileState()
+
+        state.hunkPresentationState.setExpandedCollapsedRowIDs(["hunk:1"])
+        #expect(state.expandedCollapsedRowIDs == ["hunk:1"])
+
+        state.expandedCollapsedRowIDs = ["hunk:2"]
+        #expect(state.hunkPresentationState.expandedCollapsedRowIDs == ["hunk:2"])
+    }
+
     @Test func renderBudgetResetClearsFullDiffOverride() {
         let state = AppKitDiffReviewFileState()
         state.showFullDiffOverride = true
@@ -58,6 +68,21 @@ struct AppKitDiffReviewPresentationStateTests {
         state.synchronize(file: file, contextSignature: signature(file: file, providerID: "second"))
 
         #expect(state.contextLoadError == nil)
+    }
+
+    @Test func changedStructuralSignatureClearsPendingDraft() {
+        let state = AppKitDiffReviewFileState()
+        let file = fileModel()
+        state.synchronize(file: file, contextSignature: signature(file: file, providerID: "first"))
+        state.pendingDraftAnchor = DiffReviewLineAnchor(
+            path: "Sources/File.swift", side: .new, line: 1, rowIndex: 0, selectedText: "old line"
+        )
+        state.pendingDraftBody = "stale draft"
+
+        state.synchronize(file: file, contextSignature: signature(file: file, providerID: "second"))
+
+        #expect(state.pendingDraftAnchor == nil)
+        #expect(state.pendingDraftBody.isEmpty)
     }
 
     @Test func staleContextGenerationCannotPublish() {
@@ -144,6 +169,18 @@ struct AppKitDiffReviewPresentationStateTests {
             path: "Sources/File.swift", side: .new, line: 1, rowIndex: 0, selectedText: "line"
         )
         #expect(changes == 3)
+        _ = cancellable
+    }
+
+    @Test func presentationStoreForwardsCopyFeedbackChanges() {
+        let store = AppKitDiffReviewPresentationStore()
+        let state = store.state(for: fileModel())
+        var changes = 0
+        let cancellable = store.objectWillChange.sink { changes += 1 }
+
+        state.copyFeedback.show("Copied prompt")
+
+        #expect(changes == 1)
         _ = cancellable
     }
 

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffRowHostingPoolTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffRowHostingPoolTests.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("AppKit diff hosting pool")
+struct AppKitDiffRowHostingPoolTests {
+    private func spec(id: String, token: some Equatable, text: String = "x") -> AppKitDiffRowSpec {
+        AppKitDiffRowSpec(
+            id: id,
+            ownerID: nil,
+            equalityToken: .init(token),
+            estimatedHeight: 20
+        ) { AnyView(Text(text)) }
+    }
+
+    @Test("equal tokens retain the root and changed tokens update it")
+    func equalityGating() {
+        let pool = AppKitDiffRowHostingPool()
+        var builds = 0
+        func spec(_ value: Int) -> AppKitDiffRowSpec {
+            .init(
+                id: "row", ownerID: nil,
+                equalityToken: .init(value), estimatedHeight: 20
+            ) {
+                builds += 1
+                return AnyView(Text("\(value)"))
+            }
+        }
+        let first = pool.view(for: spec(1))
+        let unchanged = pool.view(for: spec(1))
+        let changed = pool.view(for: spec(2))
+        #expect(first.view === unchanged.view)
+        #expect(first.view === changed.view)
+        #expect(builds == 2)
+    }
+
+    @Test("released hosts are reused for a different row")
+    func reuse() {
+        let pool = AppKitDiffRowHostingPool()
+        let first = pool.view(for: spec(id: "a", token: "a")).view
+        pool.release(id: "a")
+        let second = pool.view(for: spec(id: "b", token: "b")).view
+        #expect(first === second)
+    }
+
+    @Test("reused hosts route intrinsic-size invalidation to their new row")
+    func reusedHostRoutesInvalidationToNewID() {
+        let pool = AppKitDiffRowHostingPool()
+        var invalidatedIDs: [String] = []
+        pool.onRowIntrinsicSizeInvalidated = { invalidatedIDs.append($0) }
+        let view = pool.view(for: spec(id: "a", token: 1)).view
+        pool.release(id: "a")
+        _ = pool.view(for: spec(id: "b", token: 1))
+
+        view.invalidateIntrinsicContentSize()
+
+        #expect(invalidatedIDs == ["b"])
+    }
+
+    @Test("release all keeps the specified mounted IDs")
+    func releaseAllExcept() {
+        let pool = AppKitDiffRowHostingPool()
+        _ = pool.view(for: spec(id: "a", token: 1))
+        _ = pool.view(for: spec(id: "b", token: 1))
+        _ = pool.view(for: spec(id: "c", token: 1))
+
+        pool.releaseAll(except: ["b"])
+
+        #expect(pool.mountedIDs == ["b"])
+        #expect(pool.mountedView(id: "a") == nil)
+    }
+}
+
+@MainActor
+@Suite("AppKit diff hosting view measurement")
+struct AppKitDiffRowHostingViewTests {
+    @Test("narrower widths measure wrapping text taller")
+    func measuresWrappingTextAtFixedWidth() {
+        let view = AppKitDiffRowHostingView(
+            rootView: AnyView(
+                Text(String(repeating: "wrap this diff line ", count: 30))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            )
+        )
+
+        #expect(view.measuredHeight(forWidth: 200) > view.measuredHeight(forWidth: 600))
+    }
+
+    @Test("zero-width measurement preserves the prior width pin")
+    func zeroWidthPreservesPriorMeasurement() {
+        let view = AppKitDiffRowHostingView(rootView: AnyView(Text("diff line")))
+        let priorHeight = view.measuredHeight(forWidth: 320)
+
+        #expect(view.measuredHeight(forWidth: 0) == 0)
+        #expect(view.lastMeasuredWidth == 320)
+        #expect(view.intrinsicContentSize.height == priorHeight)
+    }
+}

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerFlagTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerFlagTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("AppKitDiffScrollerFlag")
+struct AppKitDiffScrollerFlagTests {
+    @Test("explicit overrides win and build defaults differ")
+    func resolution() {
+        #expect(AppKitDiffScrollerFlag.resolve(override: true, isDebugBuild: false))
+        #expect(!AppKitDiffScrollerFlag.resolve(override: false, isDebugBuild: true))
+        #expect(AppKitDiffScrollerFlag.resolve(override: nil, isDebugBuild: true))
+        #expect(!AppKitDiffScrollerFlag.resolve(override: nil, isDebugBuild: false))
+    }
+
+    @Test("setOverride persists and broadcasts")
+    func persistenceAndNotification() async {
+        let suite = "AppKitDiffScrollerFlagTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        let center = NotificationCenter()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        await confirmation { received in
+            let token = center.addObserver(
+                forName: AppKitDiffScrollerFlag.overrideDidChangeNotification,
+                object: nil,
+                queue: nil
+            ) { _ in received() }
+            defer { center.removeObserver(token) }
+            AppKitDiffScrollerFlag.setOverride(true, in: defaults, notificationCenter: center)
+        }
+        #expect(AppKitDiffScrollerFlag.readOverride(from: defaults) == true)
+    }
+}

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
@@ -33,11 +33,12 @@ struct AppKitDiffScrollerReconcilerTests {
         _ id: String,
         token: Int = 0,
         height: CGFloat = 20,
+        ownerID: String? = nil,
         retention: AppKitDiffRowRetention = .recyclable
     ) -> AppKitDiffRowSpec {
         AppKitDiffRowSpec(
             id: id,
-            ownerID: nil,
+            ownerID: ownerID,
             equalityToken: .init(token),
             estimatedHeight: height,
             retention: retention
@@ -173,6 +174,37 @@ struct AppKitDiffScrollerReconcilerTests {
         ))
 
         #expect(stack.pool.mountedIDs.contains("row-0"))
+    }
+
+    @Test("retention and owner-only updates are not treated as no-ops")
+    func retentionAndOwnerOnlyUpdatesApply() {
+        let stack = makeStack()
+        var rows = plan().rows
+        stack.reconciler.apply(plan: .init(rows: rows), contentWidth: stack.scrollView.contentWidth)
+        stack.reconciler.scroll(to: .init(
+            targetID: "row-150", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        ))
+
+        rows[0] = spec("row-0", height: 40, retention: .pinned)
+        rows[150] = spec("row-150", height: 40, ownerID: "file-150")
+        stack.reconciler.apply(plan: .init(rows: rows), contentWidth: stack.scrollView.contentWidth)
+
+        #expect(stack.pool.mountedIDs.contains("row-0"))
+        #expect(stack.tiling.row(withID: "row-150")?.ownerID == "file-150")
+    }
+
+    @Test("an intrinsic-size invalidation remeasures the mounted row")
+    func intrinsicSizeInvalidationRemeasuresMountedRow() throws {
+        let stack = makeStack()
+        stack.reconciler.apply(
+            plan: .init(rows: [spec("row", height: 20)]),
+            contentWidth: stack.scrollView.contentWidth
+        )
+        let view = try #require(stack.pool.mountedView(id: "row"))
+        view.updateRootView(AnyView(Color.clear.frame(height: 80)))
+        view.invalidateIntrinsicContentSize()
+
+        #expect(stack.tiling.row(withID: "row")?.height == 80)
     }
 
     @Test("height-only resize lays out a new band without a full apply")

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
@@ -1,0 +1,216 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("AppKit diff scroller reconciliation")
+struct AppKitDiffScrollerReconcilerTests {
+    private typealias Stack = (
+        window: NSWindow,
+        scrollView: AppKitDiffScrollView,
+        tiling: AppKitDiffTilingController,
+        pool: AppKitDiffRowHostingPool,
+        reconciler: AppKitDiffScrollerReconciler
+    )
+
+    private func makeStack() -> Stack {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 240),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        let scrollView = AppKitDiffScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 240))
+        let tiling = AppKitDiffTilingController()
+        let pool = AppKitDiffRowHostingPool()
+        let reconciler = AppKitDiffScrollerReconciler(tiling: tiling, pool: pool, scrollView: scrollView)
+        window.contentView = scrollView
+        window.makeKeyAndOrderFront(nil)
+        scrollView.layoutSubtreeIfNeeded()
+        return (window, scrollView, tiling, pool, reconciler)
+    }
+
+    private func spec(
+        _ id: String,
+        token: Int = 0,
+        height: CGFloat = 20,
+        retention: AppKitDiffRowRetention = .recyclable
+    ) -> AppKitDiffRowSpec {
+        AppKitDiffRowSpec(
+            id: id,
+            ownerID: nil,
+            equalityToken: .init(token),
+            estimatedHeight: height,
+            retention: retention
+        ) {
+            AnyView(Color.clear.frame(height: height))
+        }
+    }
+
+    private func plan(
+        count: Int = 200,
+        height: CGFloat = 40
+    ) -> AppKitDiffRowPlan {
+        .init(rows: (0..<count).map { spec("row-\($0)", height: height) })
+    }
+
+    @Test("mounts only the overscan band and follows a target row")
+    func mountsBoundedBandAndScrollsToTarget() {
+        let stack = makeStack()
+        stack.reconciler.apply(plan: plan(), contentWidth: stack.scrollView.contentWidth)
+
+        #expect(stack.pool.mountedIDs.count < 40)
+        stack.reconciler.scroll(to: .init(
+            targetID: "row-150", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        ))
+
+        #expect(stack.pool.mountedIDs.contains("row-150"))
+        #expect(stack.scrollView.scrollY > 2_000)
+    }
+
+    @Test("inserting above the viewport preserves the anchor screen offset")
+    func prependedRowPreservesAnchorOffset() {
+        let stack = makeStack()
+        stack.reconciler.apply(plan: plan(), contentWidth: stack.scrollView.contentWidth)
+        stack.reconciler.scroll(to: .init(
+            targetID: "row-150", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        ))
+        let before = stack.tiling.row(withID: "row-150")!.minY - stack.scrollView.scrollY
+        stack.reconciler.apply(
+            plan: .init(rows: [spec("before", height: 30)] + plan().rows),
+            contentWidth: stack.scrollView.contentWidth
+        )
+        let after = stack.tiling.row(withID: "row-150")!.minY - stack.scrollView.scrollY
+
+        #expect(abs(before - after) < 0.5)
+    }
+
+    @Test("unchanged plans do not perform another full apply")
+    func unchangedPlanIsNoOp() {
+        let stack = makeStack()
+        let currentPlan = plan(count: 20)
+        stack.reconciler.apply(plan: currentPlan, contentWidth: stack.scrollView.contentWidth)
+        let count = stack.reconciler.fullPlanApplyCountForTests
+        stack.reconciler.apply(plan: currentPlan, contentWidth: stack.scrollView.contentWidth)
+
+        #expect(stack.reconciler.fullPlanApplyCountForTests == count)
+    }
+
+    @Test("a changed equality token remeasures its row")
+    func changedTokenRemeasuresRow() {
+        let stack = makeStack()
+        stack.reconciler.apply(
+            plan: .init(rows: [spec("row", token: 1, height: 20)]),
+            contentWidth: stack.scrollView.contentWidth
+        )
+        stack.reconciler.apply(
+            plan: .init(rows: [spec("row", token: 2, height: 80)]),
+            contentWidth: stack.scrollView.contentWidth
+        )
+
+        #expect(stack.tiling.row(withID: "row")?.height == 80)
+    }
+
+    @Test("insertion removal and reorder replace the stable row geometry")
+    func insertionRemovalAndReorderReplaceGeometry() {
+        let stack = makeStack()
+        stack.reconciler.apply(
+            plan: .init(rows: [spec("a"), spec("b"), spec("c")]),
+            contentWidth: stack.scrollView.contentWidth
+        )
+        stack.reconciler.apply(
+            plan: .init(rows: [spec("c"), spec("inserted"), spec("a")]),
+            contentWidth: stack.scrollView.contentWidth
+        )
+
+        #expect(stack.tiling.rowCount == 3)
+        #expect(stack.tiling.row(withID: "b") == nil)
+        #expect(stack.tiling.row(withID: "c")?.minY == 0)
+        #expect(stack.tiling.row(withID: "a")?.minY == 40)
+    }
+
+    @Test("a changed content width invalidates measured row heights")
+    func contentWidthInvalidatesMeasurement() {
+        let stack = makeStack()
+        let wrapping = AppKitDiffRowSpec(
+            id: "wrapping",
+            ownerID: nil,
+            equalityToken: .init(1),
+            estimatedHeight: 20
+        ) {
+            AnyView(
+                Text(String(repeating: "a long diff line ", count: 40))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            )
+        }
+        stack.reconciler.apply(
+            plan: .init(rows: [wrapping]), contentWidth: stack.scrollView.contentWidth
+        )
+        let wideHeight = stack.tiling.row(withID: "wrapping")!.height
+        stack.reconciler.apply(plan: .init(rows: [wrapping]), contentWidth: 120)
+
+        #expect(stack.tiling.row(withID: "wrapping")!.height > wideHeight)
+    }
+
+    @Test("zero width keeps live content until a positive-width recovery")
+    func zeroWidthDefersAndRecovers() {
+        let stack = makeStack()
+        let currentPlan = plan(count: 5)
+        stack.reconciler.apply(plan: currentPlan, contentWidth: 0)
+        #expect(stack.tiling.rowCount == 0)
+
+        stack.reconciler.apply(plan: currentPlan, contentWidth: stack.scrollView.contentWidth)
+        #expect(stack.tiling.rowCount == 5)
+    }
+
+    @Test("pinned rows remain hosted offscreen")
+    func pinnedRowsStayMountedOffscreen() {
+        let stack = makeStack()
+        var rows = plan().rows
+        rows[0] = spec("row-0", height: 20, retention: .pinned)
+        stack.reconciler.apply(plan: .init(rows: rows), contentWidth: stack.scrollView.contentWidth)
+        stack.reconciler.scroll(to: .init(
+            targetID: "row-150", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        ))
+
+        #expect(stack.pool.mountedIDs.contains("row-0"))
+    }
+
+    @Test("height-only resize lays out a new band without a full apply")
+    func heightOnlyResizeRelayoutsBand() {
+        let stack = makeStack()
+        stack.reconciler.apply(plan: plan(), contentWidth: stack.scrollView.contentWidth)
+        let fullApplyCount = stack.reconciler.fullPlanApplyCountForTests
+        let layoutCount = stack.reconciler.layoutPassCountForTests
+        stack.scrollView.frame.size.height = 480
+        stack.scrollView.layoutSubtreeIfNeeded()
+        stack.reconciler.layoutVisibleRows()
+
+        #expect(stack.reconciler.fullPlanApplyCountForTests == fullApplyCount)
+        #expect(stack.reconciler.layoutPassCountForTests > layoutCount)
+    }
+
+    @Test("scroll requests use requested alignment and a fallback target")
+    func scrollRequestAlignmentAndFallback() {
+        let stack = makeStack()
+        stack.reconciler.apply(plan: plan(count: 100), contentWidth: stack.scrollView.contentWidth)
+        stack.reconciler.scroll(to: .init(
+            targetID: "missing", fallbackID: "row-50", alignment: .center, animated: false, generation: 1
+        ))
+
+        #expect(stack.scrollView.scrollY == stack.tiling.targetOffset(
+            id: "row-50", alignment: .center, viewportHeight: stack.scrollView.viewportHeight
+        ))
+
+        stack.reconciler.scroll(to: .init(
+            targetID: "row-20", fallbackID: nil, alignment: .top, animated: false, generation: 2
+        ))
+        #expect(stack.scrollView.scrollY == stack.tiling.targetOffset(
+            id: "row-20", alignment: .top, viewportHeight: stack.scrollView.viewportHeight
+        ))
+        let beforeMissingTarget = stack.scrollView.scrollY
+        stack.reconciler.scroll(to: .init(
+            targetID: "missing", fallbackID: nil, alignment: .top, animated: false, generation: 3
+        ))
+        #expect(stack.scrollView.scrollY == beforeMissingTarget)
+    }
+}

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
@@ -193,6 +193,28 @@ struct AppKitDiffScrollerReconcilerTests {
         #expect(stack.tiling.row(withID: "row-150")?.ownerID == "file-150")
     }
 
+    @Test("content insets are part of the native document geometry")
+    func contentInsetsLayoutRowsInsideDocument() throws {
+        let stack = makeStack()
+        let insetPlan = plan(count: 2, height: 40)
+            .withContentInsets(.init(top: 12, bottom: 18, left: 14, right: 20))
+        stack.reconciler.apply(plan: insetPlan, contentWidth: stack.scrollView.contentWidth)
+
+        let firstView = try #require(stack.pool.mountedView(id: "row-0"))
+
+        #expect(stack.tiling.row(withID: "row-0")?.minY == 12)
+        #expect(stack.tiling.documentHeight == 110)
+        #expect(firstView.frame.minX == 14)
+        #expect(firstView.frame.width == stack.scrollView.contentWidth - 34)
+
+        stack.reconciler.apply(plan: plan(count: 2, height: 40), contentWidth: stack.scrollView.contentWidth)
+
+        #expect(stack.tiling.row(withID: "row-0")?.minY == 0)
+        #expect(stack.tiling.documentHeight == 80)
+        #expect(firstView.frame.minX == 0)
+        #expect(firstView.frame.width == stack.scrollView.contentWidth)
+    }
+
     @Test("an intrinsic-size invalidation remeasures the mounted row")
     func intrinsicSizeInvalidationRemeasuresMountedRow() throws {
         let stack = makeStack()

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift
@@ -1,0 +1,154 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("AppKit diff scroller stress and accessibility")
+struct AppKitDiffScrollerStressTests {
+    @Test("twenty thousand rows keep a bounded mount band and preserve anchors")
+    func twentyThousandRows() throws {
+        let stack = makeStack()
+        let baseRows = (0..<20_000).map { row(index: $0) }
+        let initialPlan = AppKitDiffRowPlan(rows: baseRows)
+        let middleRequest = AppKitDiffScrollRequest(
+            targetID: "row-10000", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        )
+        stack.reconciler.apply(plan: initialPlan, contentWidth: stack.scrollView.contentWidth)
+        stack.reconciler.scroll(to: middleRequest)
+
+        let mountedAfterMiddleScroll = stack.pool.mountedIDs.count
+        #expect(mountedAfterMiddleScroll < 120)
+        let middleRowBefore = try #require(stack.tiling.row(withID: "row-10000"))
+        let anchorBefore = middleRowBefore.minY - stack.scrollView.scrollY
+
+        var updatedRows = baseRows
+        updatedRows.insert(row(id: "inserted-above", height: 60), at: 100)
+        updatedRows[15_001] = row(id: "row-15000", token: 1, height: 80)
+        stack.reconciler.apply(plan: AppKitDiffRowPlan(rows: updatedRows), contentWidth: stack.scrollView.contentWidth)
+        let middleRowAfter = try #require(stack.tiling.row(withID: "row-10000"))
+        let anchorAfter = middleRowAfter.minY - stack.scrollView.scrollY
+        let anchorDelta = abs(anchorBefore - anchorAfter)
+        #expect(anchorDelta < 0.5)
+
+        let endRequest = AppKitDiffScrollRequest(
+            targetID: "row-19999", fallbackID: nil, alignment: .top, animated: false, generation: 2
+        )
+        stack.reconciler.scroll(to: endRequest)
+        let mountedAfterEndScroll = stack.pool.mountedIDs.count
+        let containsEndRow = stack.pool.mountedIDs.contains("row-19999")
+        let applyCount = stack.reconciler.fullPlanApplyCountForTests
+        #expect(mountedAfterEndScroll < 120)
+        #expect(containsEndRow)
+        #expect(applyCount == 2)
+    }
+
+    @Test("hosted accessibility survives recycling and focus retention can be released")
+    func accessibilityAndFocusRetention() throws {
+        let stack = makeStack()
+        var rows = (0..<200).map { row(index: $0) }
+        rows[0] = accessibleRow(retention: .pinned)
+        stack.reconciler.apply(plan: AppKitDiffRowPlan(rows: rows), contentWidth: stack.scrollView.contentWidth)
+        let hosted = try #require(stack.pool.mountedView(id: "focus-row"))
+        hosted.layoutSubtreeIfNeeded()
+        let hostedDraftField = descendant(withAccessibilityIdentifier: "focusable-draft", in: hosted)
+        #expect(hostedDraftField != nil)
+
+        let distantRequest = AppKitDiffScrollRequest(
+            targetID: "row-150", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        )
+        stack.reconciler.scroll(to: distantRequest)
+        let retainedWhilePinned = stack.pool.mountedIDs.contains("focus-row")
+        #expect(retainedWhilePinned)
+
+        rows[0] = accessibleRow(retention: .recyclable)
+        stack.reconciler.apply(plan: AppKitDiffRowPlan(rows: rows), contentWidth: stack.scrollView.contentWidth)
+        let recycledAfterRelease = !stack.pool.mountedIDs.contains("focus-row")
+        #expect(recycledAfterRelease)
+    }
+
+    private final class Stack {
+        let window: NSWindow
+        let scrollView: AppKitDiffScrollView
+        let tiling: AppKitDiffTilingController
+        let pool: AppKitDiffRowHostingPool
+        let reconciler: AppKitDiffScrollerReconciler
+
+        init(
+            window: NSWindow,
+            scrollView: AppKitDiffScrollView,
+            tiling: AppKitDiffTilingController,
+            pool: AppKitDiffRowHostingPool,
+            reconciler: AppKitDiffScrollerReconciler
+        ) {
+            self.window = window
+            self.scrollView = scrollView
+            self.tiling = tiling
+            self.pool = pool
+            self.reconciler = reconciler
+        }
+    }
+
+    private func makeStack() -> Stack {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_200, height: 800),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        let scrollView = AppKitDiffScrollView(frame: NSRect(x: 0, y: 0, width: 1_200, height: 800))
+        let tiling = AppKitDiffTilingController()
+        let pool = AppKitDiffRowHostingPool()
+        let reconciler = AppKitDiffScrollerReconciler(tiling: tiling, pool: pool, scrollView: scrollView)
+        window.contentView = scrollView
+        window.makeKeyAndOrderFront(nil)
+        scrollView.layoutSubtreeIfNeeded()
+        return Stack(window: window, scrollView: scrollView, tiling: tiling, pool: pool, reconciler: reconciler)
+    }
+
+    private func row(index: Int) -> AppKitDiffRowSpec {
+        row(id: "row-\(index)", ownerID: "owner-\(index / 80)")
+    }
+
+    private func row(
+        id: String,
+        ownerID: String? = nil,
+        token: Int = 0,
+        height: CGFloat = 40
+    ) -> AppKitDiffRowSpec {
+        .init(
+            id: id, ownerID: ownerID, equalityToken: .init(token), estimatedHeight: height
+        ) {
+            AnyView(Color.clear.frame(height: height))
+        }
+    }
+
+    private func accessibleRow(retention: AppKitDiffRowRetention) -> AppKitDiffRowSpec {
+        .init(
+            id: "focus-row", ownerID: "owner-0", equalityToken: .init(retention),
+            estimatedHeight: 40, retention: retention
+        ) {
+            AnyView(AccessibleMarker(identifier: "focusable-draft").frame(height: 40))
+        }
+    }
+
+    private func descendant(withAccessibilityIdentifier identifier: String, in view: NSView) -> NSView? {
+        if view.accessibilityIdentifier() == identifier { return view }
+        for child in view.subviews {
+            if let match = descendant(withAccessibilityIdentifier: identifier, in: child) { return match }
+        }
+        return nil
+    }
+}
+
+private struct AccessibleMarker: NSViewRepresentable {
+    let identifier: String
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
+        view.setAccessibilityIdentifier(identifier)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        nsView.setAccessibilityIdentifier(identifier)
+    }
+}

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -200,6 +200,44 @@ struct AppKitDiffScrollerTests {
         #expect(completedGenerations == [73])
     }
 
+    @Test("superseded animated request completion cannot restore the previous target")
+    func supersededAnimatedRequestCompletionIsIgnored() async throws {
+        var completedGenerations: [Int] = []
+        var finishAnimations: [() -> Void] = []
+        let stack = makeStack(
+            animatedScrollExecutorForTests: { scrollView, point, completion in
+                scrollView.contentView.setBoundsOrigin(point)
+                finishAnimations.append(completion)
+            }
+        )
+        stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { _ in })
+
+        stack.coordinator.update(
+            plan: plan(),
+            scrollRequest: .init(
+                targetID: "row-20", fallbackID: nil, alignment: .top, animated: true, generation: 1
+            ),
+            onActiveOwnerChange: { _ in },
+            onScrollRequestCompletion: { completedGenerations.append($0) }
+        )
+        stack.coordinator.update(
+            plan: plan(),
+            scrollRequest: .init(
+                targetID: "row-60", fallbackID: nil, alignment: .top, animated: true, generation: 2
+            ),
+            onActiveOwnerChange: { _ in },
+            onScrollRequestCompletion: { completedGenerations.append($0) }
+        )
+
+        let secondTargetY = stack.scrollView.scrollY
+        finishAnimations.first?()
+        #expect(stack.scrollView.scrollY == secondTargetY)
+        #expect(completedGenerations.isEmpty)
+
+        finishAnimations.last?()
+        #expect(completedGenerations == [2])
+    }
+
     @Test("long animated navigation mounts the destination before completion")
     func animatedNavigationMountsDestination() async throws {
         var mountedAtCompletion = false

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import Alas
 
 @MainActor
-@Suite("AppKit diff scroller SwiftUI bridge")
+@Suite(.serialized)
 struct AppKitDiffScrollerTests {
     private typealias Stack = (
         window: NSWindow,
@@ -12,12 +12,16 @@ struct AppKitDiffScrollerTests {
         coordinator: AppKitDiffScroller.Coordinator
     )
 
-    private func makeStack(onActiveOwnerChange: @escaping (String?) -> Void = { _ in }) -> Stack {
+    private func makeStack(
+        onActiveOwnerChange: @escaping (String?) -> Void = { _ in },
+        animatedScrollExecutorForTests: AppKitDiffScrollView.AnimatedScrollExecutorForTests? = nil
+    ) -> Stack {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 240),
             styleMask: [.titled], backing: .buffered, defer: false
         )
         let scrollView = AppKitDiffScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 240))
+        scrollView.animatedScrollExecutorForTests = animatedScrollExecutorForTests
         let coordinator = AppKitDiffScroller.Coordinator()
         coordinator.attach(scrollView: scrollView, onActiveOwnerChange: onActiveOwnerChange)
         window.contentView = scrollView
@@ -150,7 +154,13 @@ struct AppKitDiffScrollerTests {
     @Test("animated programmatic scrolling does not publish active-owner changes")
     func animatedScrollingDoesNotReportActiveOwner() async throws {
         var owners: [String?] = []
-        let stack = makeStack { owners.append($0) }
+        let stack = makeStack(
+            onActiveOwnerChange: { owners.append($0) },
+            animatedScrollExecutorForTests: { scrollView, point, completion in
+                scrollView.contentView.setBoundsOrigin(point)
+                completion()
+            }
+        )
         stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { owners.append($0) })
 
         stack.coordinator.update(
@@ -160,7 +170,6 @@ struct AppKitDiffScrollerTests {
             ),
             onActiveOwnerChange: { owners.append($0) }
         )
-        try await Task.sleep(for: .milliseconds(500))
 
         #expect(owners.isEmpty)
     }
@@ -168,7 +177,13 @@ struct AppKitDiffScrollerTests {
     @Test("animated requests report completion only after the native scroll finishes")
     func animatedRequestReportsCompletion() async throws {
         var completedGenerations: [Int] = []
-        let stack = makeStack()
+        var finishAnimation: (() -> Void)?
+        let stack = makeStack(
+            animatedScrollExecutorForTests: { scrollView, point, completion in
+                scrollView.contentView.setBoundsOrigin(point)
+                finishAnimation = completion
+            }
+        )
         stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { _ in })
 
         stack.coordinator.update(
@@ -181,8 +196,35 @@ struct AppKitDiffScrollerTests {
         )
 
         #expect(completedGenerations.isEmpty)
-        try await Task.sleep(for: .milliseconds(500))
+        finishAnimation?()
         #expect(completedGenerations == [73])
+    }
+
+    @Test("long animated navigation mounts the destination before completion")
+    func animatedNavigationMountsDestination() async throws {
+        var mountedAtCompletion = false
+        let stack = makeStack(
+            animatedScrollExecutorForTests: { scrollView, point, completion in
+                scrollView.contentView.setBoundsOrigin(point)
+                completion()
+            }
+        )
+        stack.coordinator.update(plan: plan(count: 2_000), scrollRequest: nil, onActiveOwnerChange: { _ in })
+
+        stack.coordinator.update(
+            plan: plan(count: 2_000),
+            scrollRequest: .init(
+                targetID: "row-1900", fallbackID: nil, alignment: .top, animated: true, generation: 91
+            ),
+            onActiveOwnerChange: { _ in },
+            onScrollRequestCompletion: { _ in
+                mountedAtCompletion = stack.coordinator.mountedRowIDsForTests.contains("row-1900")
+            }
+        )
+
+        #expect(mountedAtCompletion)
+        #expect(stack.coordinator.mountedRowIDsForTests.contains("row-1900"))
+        #expect(stack.scrollView.scrollY > 70_000)
     }
 
     @Test("height-only viewport changes relayout without publishing active owner")

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -165,6 +165,26 @@ struct AppKitDiffScrollerTests {
         #expect(owners.isEmpty)
     }
 
+    @Test("animated requests report completion only after the native scroll finishes")
+    func animatedRequestReportsCompletion() async throws {
+        var completedGenerations: [Int] = []
+        let stack = makeStack()
+        stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { _ in })
+
+        stack.coordinator.update(
+            plan: plan(),
+            scrollRequest: .init(
+                targetID: "row-50", fallbackID: nil, alignment: .top, animated: true, generation: 73
+            ),
+            onActiveOwnerChange: { _ in },
+            onScrollRequestCompletion: { completedGenerations.append($0) }
+        )
+
+        #expect(completedGenerations.isEmpty)
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(completedGenerations == [73])
+    }
+
     @Test("height-only viewport changes relayout without publishing active owner")
     func heightChangesDoNotReportActiveOwner() {
         var owners: [String?] = []

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -67,19 +67,18 @@ struct AppKitDiffScrollerTests {
         #expect(stack.scrollView.scrollY == 0)
     }
 
-    @Test("a request remains pending until a positive-width plan can resolve it")
-    func zeroWidthDefersScrollRequestConsumption() {
+    @Test("a request automatically retries when the native view gains width")
+    func zeroWidthRequestRetriesAfterLayout() {
         let scrollView = AppKitDiffScrollView(frame: .zero)
         let coordinator = AppKitDiffScroller.Coordinator()
         coordinator.attach(scrollView: scrollView, onActiveOwnerChange: { _ in })
         let request = AppKitDiffScrollRequest(
-            targetID: "row-50", fallbackID: nil, alignment: .top, animated: false, generation: 1
+            targetID: "missing", fallbackID: "row-50", alignment: .top, animated: false, generation: 1
         )
 
         coordinator.update(plan: plan(), scrollRequest: request, onActiveOwnerChange: { _ in })
         scrollView.frame = NSRect(x: 0, y: 0, width: 400, height: 240)
         scrollView.layoutSubtreeIfNeeded()
-        coordinator.update(plan: plan(), scrollRequest: request, onActiveOwnerChange: { _ in })
 
         #expect(scrollView.scrollY > 0)
     }

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -84,6 +84,29 @@ struct AppKitDiffScrollerTests {
         #expect(scrollView.scrollY > 0)
     }
 
+    @Test("an unresolved request is consumed after a positive-width reconcile")
+    func unresolvedRequestGenerationDoesNotReplay() {
+        let stack = makeStack()
+        let request = AppKitDiffScrollRequest(
+            targetID: "later", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        )
+        stack.coordinator.update(plan: plan(), scrollRequest: request, onActiveOwnerChange: { _ in })
+        var laterPlan = plan().rows
+        laterPlan.append(
+            AppKitDiffRowSpec(
+                id: "later", ownerID: nil, equalityToken: .init(101), estimatedHeight: 40
+            ) {
+                AnyView(Color.clear.frame(height: 40))
+            }
+        )
+
+        stack.coordinator.update(
+            plan: .init(rows: laterPlan), scrollRequest: request, onActiveOwnerChange: { _ in }
+        )
+
+        #expect(stack.scrollView.scrollY == 0)
+    }
+
     @Test("only user scrolling reports a changed active owner")
     func userScrollingReportsActiveOwner() {
         var owners: [String?] = []

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -241,9 +241,15 @@ struct AppKitDiffScrollerTests {
     @Test("long animated navigation mounts the destination before completion")
     func animatedNavigationMountsDestination() async throws {
         var mountedAtCompletion = false
+        var mountedDuringAnimation = false
         let stack = makeStack(
             animatedScrollExecutorForTests: { scrollView, point, completion in
                 scrollView.contentView.setBoundsOrigin(point)
+                scrollView.reflectScrolledClipView(scrollView.contentView)
+                RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+                mountedDuringAnimation = scrollView.flippedDocumentView.subviews.contains {
+                    ($0 as? AppKitDiffRowHostingView)?.representedRowID == "row-1900"
+                }
                 completion()
             }
         )
@@ -260,6 +266,7 @@ struct AppKitDiffScrollerTests {
             }
         )
 
+        #expect(mountedDuringAnimation)
         #expect(mountedAtCompletion)
         #expect(stack.coordinator.mountedRowIDsForTests.contains("row-1900"))
         #expect(stack.scrollView.scrollY > 70_000)
@@ -286,6 +293,7 @@ struct AppKitDiffScrollerTests {
 
         #expect(stack.coordinator.mountedRowIDsForTests.isEmpty)
         #expect(stack.scrollView.onUserViewportChange == nil)
+        #expect(stack.scrollView.onProgrammaticViewportChange == nil)
         #expect(stack.scrollView.onViewportGeometryChange == nil)
         #expect(stack.scrollView.onContentWidthChange == nil)
     }

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -107,6 +107,29 @@ struct AppKitDiffScrollerTests {
         #expect(stack.scrollView.scrollY == 0)
     }
 
+    @Test("an empty positive-width plan consumes a request generation")
+    func emptyPlanRequestGenerationDoesNotReplay() {
+        let stack = makeStack()
+        let request = AppKitDiffScrollRequest(
+            targetID: "later", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        )
+        stack.coordinator.update(plan: .init(rows: []), scrollRequest: request, onActiveOwnerChange: { _ in })
+        var laterPlan = plan().rows
+        laterPlan.append(
+            AppKitDiffRowSpec(
+                id: "later", ownerID: nil, equalityToken: .init(101), estimatedHeight: 40
+            ) {
+                AnyView(Color.clear.frame(height: 40))
+            }
+        )
+
+        stack.coordinator.update(
+            plan: .init(rows: laterPlan), scrollRequest: request, onActiveOwnerChange: { _ in }
+        )
+
+        #expect(stack.scrollView.scrollY == 0)
+    }
+
     @Test("only user scrolling reports a changed active owner")
     func userScrollingReportsActiveOwner() {
         var owners: [String?] = []

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -1,0 +1,100 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("AppKit diff scroller SwiftUI bridge")
+struct AppKitDiffScrollerTests {
+    private typealias Stack = (
+        window: NSWindow,
+        scrollView: AppKitDiffScrollView,
+        coordinator: AppKitDiffScroller.Coordinator
+    )
+
+    private func makeStack(onActiveOwnerChange: @escaping (String?) -> Void = { _ in }) -> Stack {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 240),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        let scrollView = AppKitDiffScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 240))
+        let coordinator = AppKitDiffScroller.Coordinator()
+        coordinator.attach(scrollView: scrollView, onActiveOwnerChange: onActiveOwnerChange)
+        window.contentView = scrollView
+        window.makeKeyAndOrderFront(nil)
+        scrollView.layoutSubtreeIfNeeded()
+        return (window, scrollView, coordinator)
+    }
+
+    private func plan(count: Int = 100) -> AppKitDiffRowPlan {
+        .init(rows: (0..<count).map { index in
+            AppKitDiffRowSpec(
+                id: "row-\(index)",
+                ownerID: "owner-\(index / 10)",
+                equalityToken: .init(index),
+                estimatedHeight: 40
+            ) {
+                AnyView(Color.clear.frame(height: 40))
+            }
+        })
+    }
+
+    @Test("a changed plan reaches the reconciler")
+    func changedPlanApplies() {
+        let stack = makeStack()
+        stack.coordinator.update(plan: plan(count: 1), scrollRequest: nil, onActiveOwnerChange: { _ in })
+        let initialApplyCount = stack.coordinator.fullPlanApplyCountForTests
+
+        stack.coordinator.update(plan: plan(count: 2), scrollRequest: nil, onActiveOwnerChange: { _ in })
+
+        #expect(stack.coordinator.fullPlanApplyCountForTests > initialApplyCount)
+    }
+
+    @Test("each scroll request generation is consumed once and falls back")
+    func requestsAreDeduplicatedAndFallBack() {
+        let stack = makeStack()
+        stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { _ in })
+        let request = AppKitDiffScrollRequest(
+            targetID: "missing", fallbackID: "row-50", alignment: .top, animated: false, generation: 1
+        )
+
+        stack.coordinator.update(plan: plan(), scrollRequest: request, onActiveOwnerChange: { _ in })
+        let afterFirstRequest = stack.scrollView.scrollY
+        stack.scrollView.setScrollY(0, animated: false)
+        stack.coordinator.update(plan: plan(), scrollRequest: request, onActiveOwnerChange: { _ in })
+
+        #expect(afterFirstRequest > 0)
+        #expect(stack.scrollView.scrollY == 0)
+    }
+
+    @Test("only user scrolling reports a changed active owner")
+    func userScrollingReportsActiveOwner() {
+        var owners: [String?] = []
+        let stack = makeStack { owners.append($0) }
+        stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { owners.append($0) })
+        let request = AppKitDiffScrollRequest(
+            targetID: "row-50", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        )
+
+        stack.coordinator.update(plan: plan(), scrollRequest: request, onActiveOwnerChange: { owners.append($0) })
+        #expect(owners.isEmpty)
+
+        stack.scrollView.contentView.scroll(to: NSPoint(x: 0, y: 800))
+        stack.scrollView.reflectScrolledClipView(stack.scrollView.contentView)
+
+        #expect(owners == ["owner-2"])
+    }
+
+    @Test("dismantling releases mounted rows and callbacks")
+    func dismantleReleasesResources() {
+        let stack = makeStack()
+        stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { _ in })
+        #expect(!stack.coordinator.mountedRowIDsForTests.isEmpty)
+
+        stack.coordinator.dismantle()
+
+        #expect(stack.coordinator.mountedRowIDsForTests.isEmpty)
+        #expect(stack.scrollView.onViewportChange == nil)
+        #expect(stack.scrollView.onContentWidthChange == nil)
+    }
+}

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -67,6 +67,23 @@ struct AppKitDiffScrollerTests {
         #expect(stack.scrollView.scrollY == 0)
     }
 
+    @Test("a request remains pending until a positive-width plan can resolve it")
+    func zeroWidthDefersScrollRequestConsumption() {
+        let scrollView = AppKitDiffScrollView(frame: .zero)
+        let coordinator = AppKitDiffScroller.Coordinator()
+        coordinator.attach(scrollView: scrollView, onActiveOwnerChange: { _ in })
+        let request = AppKitDiffScrollRequest(
+            targetID: "row-50", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        )
+
+        coordinator.update(plan: plan(), scrollRequest: request, onActiveOwnerChange: { _ in })
+        scrollView.frame = NSRect(x: 0, y: 0, width: 400, height: 240)
+        scrollView.layoutSubtreeIfNeeded()
+        coordinator.update(plan: plan(), scrollRequest: request, onActiveOwnerChange: { _ in })
+
+        #expect(scrollView.scrollY > 0)
+    }
+
     @Test("only user scrolling reports a changed active owner")
     func userScrollingReportsActiveOwner() {
         var owners: [String?] = []
@@ -85,6 +102,35 @@ struct AppKitDiffScrollerTests {
         #expect(owners == ["owner-2"])
     }
 
+    @Test("animated programmatic scrolling does not publish active-owner changes")
+    func animatedScrollingDoesNotReportActiveOwner() async throws {
+        var owners: [String?] = []
+        let stack = makeStack { owners.append($0) }
+        stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { owners.append($0) })
+
+        stack.coordinator.update(
+            plan: plan(),
+            scrollRequest: .init(
+                targetID: "row-50", fallbackID: nil, alignment: .top, animated: true, generation: 1
+            ),
+            onActiveOwnerChange: { owners.append($0) }
+        )
+        try await Task.sleep(for: .milliseconds(500))
+
+        #expect(owners.isEmpty)
+    }
+
+    @Test("height-only viewport changes relayout without publishing active owner")
+    func heightChangesDoNotReportActiveOwner() {
+        var owners: [String?] = []
+        let stack = makeStack { owners.append($0) }
+        stack.coordinator.update(plan: plan(), scrollRequest: nil, onActiveOwnerChange: { owners.append($0) })
+        stack.scrollView.frame.size.height = 480
+        stack.scrollView.layoutSubtreeIfNeeded()
+
+        #expect(owners.isEmpty)
+    }
+
     @Test("dismantling releases mounted rows and callbacks")
     func dismantleReleasesResources() {
         let stack = makeStack()
@@ -94,7 +140,8 @@ struct AppKitDiffScrollerTests {
         stack.coordinator.dismantle()
 
         #expect(stack.coordinator.mountedRowIDsForTests.isEmpty)
-        #expect(stack.scrollView.onViewportChange == nil)
+        #expect(stack.scrollView.onUserViewportChange == nil)
+        #expect(stack.scrollView.onViewportGeometryChange == nil)
         #expect(stack.scrollView.onContentWidthChange == nil)
     }
 }

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffTilingControllerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffTilingControllerTests.swift
@@ -73,6 +73,23 @@ struct AppKitDiffTilingControllerTests {
         #expect(tiling.activeOwnerID(viewportMinY: 100, viewportHeight: 100) == nil)
     }
 
+    @Test("top padding and row spacing do not intersect a viewport")
+    func gapsDoNotIntersectViewport() {
+        let tiling = controller(rowSpacing: 20, topPadding: 10)
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: "file-a", height: 100),
+            .init(id: "b", ownerID: "file-b", height: 100),
+        ])
+
+        #expect(tiling.mountBand(viewportMinY: 0, viewportHeight: 10, overscan: 0).isEmpty)
+        #expect(tiling.activeOwnerID(viewportMinY: 0, viewportHeight: 10) == nil)
+        #expect(tiling.anchor(viewportMinY: 0) == nil)
+
+        #expect(tiling.mountBand(viewportMinY: 110, viewportHeight: 20, overscan: 0).isEmpty)
+        #expect(tiling.activeOwnerID(viewportMinY: 110, viewportHeight: 20) == nil)
+        #expect(tiling.anchor(viewportMinY: 110) == nil)
+    }
+
     @Test("center target offset clamps to the top and document bottom")
     func centerOffsetClamping() {
         let tiling = controller()
@@ -111,6 +128,15 @@ struct AppKitDiffTilingControllerTests {
         #expect(tiling.updateHeight(id: "a", to: 140, viewportMinY: 50) == 0)
     }
 
+    @Test("anchor restoration clamps invalid intra-row offsets")
+    func anchorRestorationClampsOffsets() {
+        let tiling = controller(topPadding: 10, bottomPadding: 20)
+        tiling.replaceAll(rows: [.init(id: "a", ownerID: nil, height: 100)])
+
+        #expect(tiling.viewportMinY(for: .init(rowID: "a", intraRowOffset: -20)) == 10)
+        #expect(tiling.viewportMinY(for: .init(rowID: "a", intraRowOffset: 200)) == 110)
+    }
+
     @Test("row equality tokens compare equal values of the same type")
     func equalityTokens() {
         let number = AppKitDiffRowEqualityToken(1)
@@ -118,15 +144,10 @@ struct AppKitDiffTilingControllerTests {
         #expect(!number.isEqual(to: AppKitDiffRowEqualityToken("1")))
     }
 
-    // Duplicate IDs deliberately trigger a debug assertion. The controller
-    // still assigns the last entry deterministically in non-asserting builds.
-    @Test("duplicate IDs use the last layout outside debug assertions", .disabled("Debug assertions intentionally trap on duplicate IDs"))
-    func duplicateIDsUseLastLayout() {
-        let tiling = controller()
-        tiling.replaceAll(rows: [
-            .init(id: "a", ownerID: nil, height: 10),
-            .init(id: "a", ownerID: nil, height: 20),
-        ])
-        #expect(tiling.index(ofID: "a") == 1)
+    @Test("duplicate IDs map to the last row index")
+    func duplicateIDsUseLastIndex() {
+        let indexByID = AppKitDiffTilingController.lastIndexByID(for: ["a", "b", "a"])
+
+        #expect(indexByID == ["a": 2, "b": 1])
     }
 }

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffTilingControllerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffTilingControllerTests.swift
@@ -1,0 +1,132 @@
+import CoreGraphics
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("AppKit diff tiling")
+struct AppKitDiffTilingControllerTests {
+    private func controller(
+        rowSpacing: CGFloat = 0,
+        topPadding: CGFloat = 0,
+        bottomPadding: CGFloat = 0
+    ) -> AppKitDiffTilingController {
+        AppKitDiffTilingController(
+            metrics: .init(
+                rowSpacing: rowSpacing,
+                topPadding: topPadding,
+                bottomPadding: bottomPadding
+            )
+        )
+    }
+
+    @Test("mount band stays bounded and active owner follows the viewport")
+    func mountBandAndOwner() {
+        let tiling = controller()
+        tiling.replaceAll(rows: (0..<100).map {
+            .init(id: "row-\($0)", ownerID: "file-\($0 / 10)", height: 20)
+        })
+
+        #expect(tiling.mountBand(viewportMinY: 800, viewportHeight: 100, overscan: 100) == 35..<50)
+        #expect(tiling.activeOwnerID(viewportMinY: 800, viewportHeight: 100) == "file-4")
+    }
+
+    @Test("height growth above the viewport returns exact compensation")
+    func heightCompensation() {
+        let tiling = controller()
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 100),
+        ])
+
+        #expect(tiling.updateHeight(id: "a", to: 140, viewportMinY: 100) == 40)
+        #expect(tiling.row(withID: "b")?.minY == 140)
+    }
+
+    @Test("anchor records intra-row position and resolves after reorder")
+    func anchorRestoration() {
+        let tiling = controller()
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 100),
+        ])
+
+        let anchor = tiling.anchor(viewportMinY: 130)
+        #expect(anchor == .init(rowID: "b", intraRowOffset: 30))
+        tiling.replaceAll(rows: [
+            .init(id: "x", ownerID: nil, height: 50),
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 100),
+        ])
+        #expect(tiling.viewportMinY(for: anchor) == 180)
+    }
+
+    @Test("empty and past-end viewports have no rows or owners")
+    func emptyAndPastEndViewports() {
+        let tiling = controller()
+        #expect(tiling.mountBand(viewportMinY: 0, viewportHeight: 100, overscan: 20).isEmpty)
+        #expect(tiling.anchor(viewportMinY: 0) == nil)
+        #expect(tiling.activeOwnerID(viewportMinY: 0, viewportHeight: 100) == nil)
+
+        tiling.replaceAll(rows: [.init(id: "a", ownerID: "file-a", height: 100)])
+        #expect(tiling.mountBand(viewportMinY: 100, viewportHeight: 100, overscan: 0) == 1..<1)
+        #expect(tiling.anchor(viewportMinY: 100) == nil)
+        #expect(tiling.activeOwnerID(viewportMinY: 100, viewportHeight: 100) == nil)
+    }
+
+    @Test("center target offset clamps to the top and document bottom")
+    func centerOffsetClamping() {
+        let tiling = controller()
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 100),
+            .init(id: "c", ownerID: nil, height: 100),
+        ])
+
+        #expect(tiling.targetOffset(id: "a", alignment: .center, viewportHeight: 200) == 0)
+        #expect(tiling.targetOffset(id: "c", alignment: .center, viewportHeight: 200) == 100)
+    }
+
+    @Test("padding participates in row placement and document height")
+    func paddingLayout() {
+        let tiling = controller(rowSpacing: 10, topPadding: 20, bottomPadding: 30)
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 50),
+        ])
+
+        #expect(tiling.row(withID: "a")?.minY == 20)
+        #expect(tiling.row(withID: "b")?.minY == 130)
+        #expect(tiling.documentHeight == 210)
+        #expect(tiling.targetOffset(id: "b", alignment: .top, viewportHeight: 100) == 110)
+    }
+
+    @Test("height change within the viewport does not compensate")
+    func visibleHeightChangeDoesNotCompensate() {
+        let tiling = controller()
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 100),
+        ])
+
+        #expect(tiling.updateHeight(id: "a", to: 140, viewportMinY: 50) == 0)
+    }
+
+    @Test("row equality tokens compare equal values of the same type")
+    func equalityTokens() {
+        let number = AppKitDiffRowEqualityToken(1)
+        #expect(number.isEqual(to: AppKitDiffRowEqualityToken(1)))
+        #expect(!number.isEqual(to: AppKitDiffRowEqualityToken("1")))
+    }
+
+    // Duplicate IDs deliberately trigger a debug assertion. The controller
+    // still assigns the last entry deterministically in non-asserting builds.
+    @Test("duplicate IDs use the last layout outside debug assertions", .disabled("Debug assertions intentionally trap on duplicate IDs"))
+    func duplicateIDsUseLastLayout() {
+        let tiling = controller()
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: nil, height: 10),
+            .init(id: "a", ownerID: nil, height: 20),
+        ])
+        #expect(tiling.index(ofID: "a") == 1)
+    }
+}

--- a/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
@@ -147,6 +147,16 @@ struct DiffPaneAppKitScrollerTests {
 
     @Test("mounted AppKit pane retains standalone diff interactions")
     func mountedPaneInteractions() throws {
+        let originalOverride = AppKitDiffScrollerFlag.readOverride(from: .standard)
+        defer {
+            if let originalOverride {
+                AppKitDiffScrollerFlag.setOverride(originalOverride)
+            } else {
+                UserDefaults.standard.removeObject(forKey: AppKitDiffScrollerFlag.defaultsKey)
+                NotificationCenter.default.post(name: AppKitDiffScrollerFlag.overrideDidChangeNotification, object: nil)
+            }
+        }
+        AppKitDiffScrollerFlag.setOverride(true)
         let state = DiffPaneHarnessState(layout: .split, wrap: false, whitespace: false)
         var selectedAnchor: DiffReviewLineAnchor?
         let mounted = mount(DiffPaneHarness(
@@ -188,6 +198,7 @@ struct DiffPaneAppKitScrollerTests {
         state.layout = .stacked
         state.wrap = true
         state.whitespace = true
+        AppKitDiffScrollerFlag.setOverride(true)
         settle(mounted.1.view)
 
         #expect(appKitScroller(in: mounted.1.view) != nil)

--- a/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
@@ -4,15 +4,66 @@ import Testing
 @testable import Alas
 
 @MainActor
+private final class DiffPaneHarnessState: ObservableObject {
+    @Published var layout: DiffLayoutMode
+    @Published var wrap: Bool
+    @Published var whitespace: Bool
+
+    init(layout: DiffLayoutMode, wrap: Bool, whitespace: Bool) {
+        self.layout = layout
+        self.wrap = wrap
+        self.whitespace = whitespace
+    }
+}
+
+private struct DiffPaneHarness: View {
+    @ObservedObject var state: DiffPaneHarnessState
+    let model: DiffDisplayModel
+    let theme: Theme
+    var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
+
+    var body: some View {
+        DiffPaneView(
+            model: model,
+            fileExtension: "swift",
+            layoutMode: $state.layout,
+            wrapLines: $state.wrap,
+            showWhitespace: $state.whitespace,
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsToolbar: false,
+            onReviewLineSelected: onReviewLineSelected,
+            hunkActions: { _ in DiffPaneHunkActions(stage: {}, discard: {}) }
+        )
+        .environment(\.theme, theme)
+    }
+}
+
+@MainActor
+private final class DiffPaneHarnessRetainer {
+    private static var retainedObjects: [AnyObject] = []
+
+    static func retain(_ objects: AnyObject...) {
+        retainedObjects.append(contentsOf: objects)
+    }
+}
+
+@MainActor
 @Suite("Standalone AppKit diff scroller", .serialized)
 struct DiffPaneAppKitScrollerTests {
     private func theme() -> Theme { try! ThemeStore().current }
 
-    private func model(groupCount: Int = 1, includesCollapsedContext: Bool = false) -> DiffDisplayModel {
+    private func model(
+        groupCount: Int = 1,
+        includesCollapsedContext: Bool = false,
+        sourceMarker: String = "let a = 1"
+    ) -> DiffDisplayModel {
         let lines: [ParsedDiff.Hunk.Line] = includesCollapsedContext
-            ? (1...15).map { .init(kind: .context, text: "let value\($0) = \($0)", oldNumber: $0, newNumber: $0) }
+            ? (1...15).map { (index: Int) in
+                .init(kind: .context, text: "let value\(index) = \(index)", oldNumber: index, newNumber: index)
+            }
             : [
-                .init(kind: .context, text: "let a = 1", oldNumber: 1, newNumber: 1),
+                .init(kind: .context, text: sourceMarker, oldNumber: 1, newNumber: 1),
                 .init(kind: .delete, text: "let b = 2", oldNumber: 2, newNumber: nil),
                 .init(kind: .add, text: "let b = 3", oldNumber: nil, newNumber: 2),
             ]
@@ -55,6 +106,7 @@ struct DiffPaneAppKitScrollerTests {
             contentRect: NSRect(x: 0, y: 0, width: 900, height: 480),
             styleMask: [.titled], backing: .buffered, defer: false
         )
+        window.animationBehavior = .none
         window.contentView = controller.view
         window.makeKeyAndOrderFront(nil)
         controller.view.layoutSubtreeIfNeeded()
@@ -69,6 +121,23 @@ struct DiffPaneAppKitScrollerTests {
         allSubviews(of: view).compactMap { $0 as? AppKitDiffScrollView }.first
     }
 
+    private func visibleTextScrollViews(in view: NSView) -> [DiffPaneTextScrollView] {
+        allSubviews(of: view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
+            .filter { !$0.isHidden }
+    }
+
+    private func renderedText(in view: NSView) -> [String] {
+        allSubviews(of: view)
+            .compactMap { ($0 as? NSTextView)?.string }
+            .filter { !$0.isEmpty }
+    }
+
+    private func settle(_ view: NSView) {
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        view.layoutSubtreeIfNeeded()
+    }
+
     @Test("only internally scrolling panes switch to AppKit")
     func switchContract() {
         #expect(DiffPaneView.usesAppKitScroller(flagEnabled: true, verticalScrollMode: .internalScroll))
@@ -78,18 +147,15 @@ struct DiffPaneAppKitScrollerTests {
 
     @Test("mounted AppKit pane retains standalone diff interactions")
     func mountedPaneInteractions() throws {
-        var layout = DiffLayoutMode.split
-        var wrap = false
-        var whitespace = false
+        let state = DiffPaneHarnessState(layout: .split, wrap: false, whitespace: false)
         var selectedAnchor: DiffReviewLineAnchor?
-        let mounted = mount(pane(
+        let mounted = mount(DiffPaneHarness(
+            state: state,
             model: model(includesCollapsedContext: true),
-            layout: Binding(get: { layout }, set: { layout = $0 }),
-            wrap: Binding(get: { wrap }, set: { wrap = $0 }),
-            whitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            theme: theme(),
             onReviewLineSelected: { selectedAnchor = $0 }
         ))
-        defer { mounted.0.close() }
+        defer { DiffPaneHarnessRetainer.retain(mounted.0, mounted.1) }
 
         #expect(appKitScroller(in: mounted.1.view) != nil)
         let buttons = allSubviews(of: mounted.1.view).compactMap { $0 as? NSButton }
@@ -115,19 +181,20 @@ struct DiffPaneAppKitScrollerTests {
         textView.setSelectedRange(NSRange(location: 0, length: 1))
         #expect(textView.selectedRange().length == 1)
 
-        layout = .stacked
-        wrap = true
-        whitespace = true
-        mounted.1.rootView = pane(
-            model: model(includesCollapsedContext: true),
-            layout: Binding(get: { layout }, set: { layout = $0 }),
-            wrap: Binding(get: { wrap }, set: { wrap = $0 }),
-            whitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
-            onReviewLineSelected: { selectedAnchor = $0 }
-        )
-        mounted.1.view.layoutSubtreeIfNeeded()
+        #expect(visibleTextScrollViews(in: mounted.1.view).count == 2)
+        #expect(visibleTextScrollViews(in: mounted.1.view).allSatisfy { $0.hasHorizontalScroller })
+        #expect(!renderedText(in: mounted.1.view).contains { $0.contains("let·value1·=·1") })
+
+        state.layout = .stacked
+        state.wrap = true
+        state.whitespace = true
+        settle(mounted.1.view)
+
         #expect(appKitScroller(in: mounted.1.view) != nil)
-        #expect(allSubviews(of: mounted.1.view).contains { $0 is DiffPaneTextScrollView })
+        let updatedTextScrollViews = visibleTextScrollViews(in: mounted.1.view)
+        #expect(updatedTextScrollViews.count == 1)
+        #expect(updatedTextScrollViews.allSatisfy { !$0.hasHorizontalScroller })
+        #expect(renderedText(in: mounted.1.view).contains { $0.contains("let·value1·=·1") })
     }
 
     @Test("AppKit hosts stay bounded and rebuild after a flag change")
@@ -145,14 +212,14 @@ struct DiffPaneAppKitScrollerTests {
         var layout = DiffLayoutMode.stacked
         var wrap = true
         var whitespace = true
-        let sourceModel = model(groupCount: 80)
+        let sourceModel = model(groupCount: 80, sourceMarker: "source model survives rebuild")
         let mounted = mount(pane(
             model: sourceModel,
             layout: Binding(get: { layout }, set: { layout = $0 }),
             wrap: Binding(get: { wrap }, set: { wrap = $0 }),
             whitespace: Binding(get: { whitespace }, set: { whitespace = $0 })
         ))
-        defer { mounted.0.close() }
+        defer { DiffPaneHarnessRetainer.retain(mounted.0, mounted.1) }
 
         let initialScroller = try #require(appKitScroller(in: mounted.1.view))
         let hostCount = allSubviews(of: mounted.1.view).filter { $0 is AppKitDiffRowHostingView }.count
@@ -172,5 +239,6 @@ struct DiffPaneAppKitScrollerTests {
         #expect(layout == .stacked)
         #expect(wrap)
         #expect(whitespace)
+        #expect(renderedText(in: mounted.1.view).contains { $0.contains("source·model·survives·rebuild") })
     }
 }

--- a/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import Alas
+
+@Suite("Standalone AppKit diff scroller")
+struct DiffPaneAppKitScrollerTests {
+    @Test("only internally scrolling panes switch to AppKit")
+    func switchContract() {
+        #expect(DiffPaneView.usesAppKitScroller(flagEnabled: true, verticalScrollMode: .internalScroll))
+        #expect(!DiffPaneView.usesAppKitScroller(flagEnabled: false, verticalScrollMode: .internalScroll))
+        #expect(!DiffPaneView.usesAppKitScroller(flagEnabled: true, verticalScrollMode: .staticHeight))
+    }
+}

--- a/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
@@ -1,12 +1,176 @@
+import AppKit
+import SwiftUI
 import Testing
 @testable import Alas
 
-@Suite("Standalone AppKit diff scroller")
+@MainActor
+@Suite("Standalone AppKit diff scroller", .serialized)
 struct DiffPaneAppKitScrollerTests {
+    private func theme() -> Theme { try! ThemeStore().current }
+
+    private func model(groupCount: Int = 1, includesCollapsedContext: Bool = false) -> DiffDisplayModel {
+        let lines: [ParsedDiff.Hunk.Line] = includesCollapsedContext
+            ? (1...15).map { .init(kind: .context, text: "let value\($0) = \($0)", oldNumber: $0, newNumber: $0) }
+            : [
+                .init(kind: .context, text: "let a = 1", oldNumber: 1, newNumber: 1),
+                .init(kind: .delete, text: "let b = 2", oldNumber: 2, newNumber: nil),
+                .init(kind: .add, text: "let b = 3", oldNumber: nil, newNumber: 2),
+            ]
+        let diff = ParsedDiff(hunks: (0..<groupCount).map { index in
+            .init(
+                header: "@@ -\(index + 1),2 +\(index + 1),2 @@",
+                oldStart: index + 1,
+                newStart: index + 1,
+                lines: lines
+            )
+        })
+        return DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App.swift")
+    }
+
+    private func pane(
+        model: DiffDisplayModel,
+        layout: Binding<DiffLayoutMode>,
+        wrap: Binding<Bool>,
+        whitespace: Binding<Bool>,
+        onReviewLineSelected: @escaping (DiffReviewLineAnchor) -> Void = { _ in }
+    ) -> some View {
+        DiffPaneView(
+            model: model,
+            fileExtension: "swift",
+            layoutMode: layout,
+            wrapLines: wrap,
+            showWhitespace: whitespace,
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsToolbar: false,
+            onReviewLineSelected: onReviewLineSelected,
+            hunkActions: { _ in DiffPaneHunkActions(stage: {}, discard: {}) }
+        )
+        .environment(\.theme, theme())
+    }
+
+    private func mount<Content: View>(_ content: Content) -> (NSWindow, NSHostingController<Content>) {
+        let controller = NSHostingController(rootView: content)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 480),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = controller.view
+        window.makeKeyAndOrderFront(nil)
+        controller.view.layoutSubtreeIfNeeded()
+        return (window, controller)
+    }
+
+    private func allSubviews(of view: NSView) -> [NSView] {
+        [view] + view.subviews.flatMap(allSubviews)
+    }
+
+    private func appKitScroller(in view: NSView) -> AppKitDiffScrollView? {
+        allSubviews(of: view).compactMap { $0 as? AppKitDiffScrollView }.first
+    }
+
     @Test("only internally scrolling panes switch to AppKit")
     func switchContract() {
         #expect(DiffPaneView.usesAppKitScroller(flagEnabled: true, verticalScrollMode: .internalScroll))
         #expect(!DiffPaneView.usesAppKitScroller(flagEnabled: false, verticalScrollMode: .internalScroll))
         #expect(!DiffPaneView.usesAppKitScroller(flagEnabled: true, verticalScrollMode: .staticHeight))
+    }
+
+    @Test("mounted AppKit pane retains standalone diff interactions")
+    func mountedPaneInteractions() throws {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        var selectedAnchor: DiffReviewLineAnchor?
+        let mounted = mount(pane(
+            model: model(includesCollapsedContext: true),
+            layout: Binding(get: { layout }, set: { layout = $0 }),
+            wrap: Binding(get: { wrap }, set: { wrap = $0 }),
+            whitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            onReviewLineSelected: { selectedAnchor = $0 }
+        ))
+        defer { mounted.0.close() }
+
+        #expect(appKitScroller(in: mounted.1.view) != nil)
+        let buttons = allSubviews(of: mounted.1.view).compactMap { $0 as? NSButton }
+        #expect(buttons.compactMap(\.toolTip).contains("Stage hunk"))
+        let expand = try #require(buttons.first { $0.toolTip == "Expand context" })
+        expand.performClick(nil)
+        mounted.1.view.layoutSubtreeIfNeeded()
+        let updatedHelpTexts = allSubviews(of: mounted.1.view).compactMap { view -> String? in
+            guard let button = view as? NSButton else { return nil }
+            return button.toolTip
+        }
+        #expect(updatedHelpTexts.contains("Collapse context"))
+
+        let rulers = allSubviews(of: mounted.1.view)
+            .compactMap { $0 as? DiffPaneTextScrollView }
+            .compactMap { $0.verticalRulerView as? DiffPaneLineNumberRulerView }
+        let ruler = try #require(rulers.first)
+        let textView = try #require(ruler.scrollView?.documentView as? DiffPaneCodeTextView)
+        let row = try #require((0..<100).first { textView.reviewLineAnchor(atRow: $0) != nil })
+        ruler.invokeReviewLineSelectionForTesting(row: row)
+        #expect(selectedAnchor != nil)
+        #expect(textView.isSelectable)
+        textView.setSelectedRange(NSRange(location: 0, length: 1))
+        #expect(textView.selectedRange().length == 1)
+
+        layout = .stacked
+        wrap = true
+        whitespace = true
+        mounted.1.rootView = pane(
+            model: model(includesCollapsedContext: true),
+            layout: Binding(get: { layout }, set: { layout = $0 }),
+            wrap: Binding(get: { wrap }, set: { wrap = $0 }),
+            whitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            onReviewLineSelected: { selectedAnchor = $0 }
+        )
+        mounted.1.view.layoutSubtreeIfNeeded()
+        #expect(appKitScroller(in: mounted.1.view) != nil)
+        #expect(allSubviews(of: mounted.1.view).contains { $0 is DiffPaneTextScrollView })
+    }
+
+    @Test("AppKit hosts stay bounded and rebuild after a flag change")
+    func hostsAreBoundedAndFlagChangeRetainsBindings() throws {
+        let originalOverride = AppKitDiffScrollerFlag.readOverride(from: .standard)
+        defer {
+            if let originalOverride {
+                AppKitDiffScrollerFlag.setOverride(originalOverride)
+            } else {
+                UserDefaults.standard.removeObject(forKey: AppKitDiffScrollerFlag.defaultsKey)
+                NotificationCenter.default.post(name: AppKitDiffScrollerFlag.overrideDidChangeNotification, object: nil)
+            }
+        }
+        AppKitDiffScrollerFlag.setOverride(true)
+        var layout = DiffLayoutMode.stacked
+        var wrap = true
+        var whitespace = true
+        let sourceModel = model(groupCount: 80)
+        let mounted = mount(pane(
+            model: sourceModel,
+            layout: Binding(get: { layout }, set: { layout = $0 }),
+            wrap: Binding(get: { wrap }, set: { wrap = $0 }),
+            whitespace: Binding(get: { whitespace }, set: { whitespace = $0 })
+        ))
+        defer { mounted.0.close() }
+
+        let initialScroller = try #require(appKitScroller(in: mounted.1.view))
+        let hostCount = allSubviews(of: mounted.1.view).filter { $0 is AppKitDiffRowHostingView }.count
+        #expect(hostCount > 0)
+        #expect(hostCount < sourceModel.groups.count)
+
+        AppKitDiffScrollerFlag.setOverride(false)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        mounted.1.view.layoutSubtreeIfNeeded()
+        #expect(appKitScroller(in: mounted.1.view) == nil)
+
+        AppKitDiffScrollerFlag.setOverride(true)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        mounted.1.view.layoutSubtreeIfNeeded()
+        let rebuiltScroller = try #require(appKitScroller(in: mounted.1.view))
+        #expect(ObjectIdentifier(rebuiltScroller) != ObjectIdentifier(initialScroller))
+        #expect(layout == .stacked)
+        #expect(wrap)
+        #expect(whitespace)
     }
 }

--- a/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
@@ -47,6 +47,28 @@ struct DiffPaneRowPlanTests {
         #expect(first.rows[0].equalityToken.isEqual(to: second.rows[0].equalityToken))
     }
 
+    @Test func tokenChangesWhenReviewCapabilitiesChange() {
+        let thread = DiffInlineCommentThread(
+            id: "thread", filePath: "Sources/Example.swift", newLine: 1, isOldSide: false,
+            isResolved: false, isOutdated: false, comments: []
+        )
+        let base = input(threads: [thread])
+        let state = DiffPanePresentationState()
+        let baseToken = DiffPaneRowPlanBuilder.build(input: base, state: state).rows[0].equalityToken
+
+        let variants = [
+            input(allowsReviewLineSelection: false, threads: [thread]),
+            input(threads: [thread], canReply: true),
+            input(threads: [thread], canResolve: true),
+            input(threads: [thread], canAddToReview: true),
+        ]
+
+        for variant in variants {
+            let token = DiffPaneRowPlanBuilder.build(input: variant, state: state).rows[0].equalityToken
+            #expect(!baseToken.isEqual(to: token))
+        }
+    }
+
     @Test func tokenChangesWhenLSPContextChanges() {
         let state = DiffPanePresentationState()
         let baseToken = DiffPaneRowPlanBuilder.build(input: input(), state: state).rows[0].equalityToken
@@ -121,7 +143,11 @@ struct DiffPaneRowPlanTests {
         codeFontSize: CGFloat = 13,
         theme: Theme? = nil,
         lspContext: DiffPaneLSPContext? = nil,
+        allowsReviewLineSelection: Bool = true,
         threads: [DiffInlineCommentThread] = [],
+        canReply: Bool = false,
+        canResolve: Bool = false,
+        canAddToReview: Bool = false,
         actions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions = { _ in .init() }
     ) -> DiffPaneRowPlanInput {
         DiffPaneRowPlanInput(
@@ -134,7 +160,11 @@ struct DiffPaneRowPlanTests {
             codeFontSize: codeFontSize,
             theme: theme ?? (try! ThemeStore().current),
             lspContext: lspContext,
+            allowsReviewLineSelection: allowsReviewLineSelection,
             threads: threads,
+            canReply: canReply,
+            canResolve: canResolve,
+            canAddToReview: canAddToReview,
             hunkActions: actions
         )
     }

--- a/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
@@ -47,6 +47,18 @@ struct DiffPaneRowPlanTests {
         #expect(first.rows[0].equalityToken.isEqual(to: second.rows[0].equalityToken))
     }
 
+    @Test func tokenChangesWhenLSPContextChanges() {
+        let state = DiffPanePresentationState()
+        let baseToken = DiffPaneRowPlanBuilder.build(input: input(), state: state).rows[0].equalityToken
+        let lsp = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
+        let lspToken = DiffPaneRowPlanBuilder.build(
+            input: input(lspContext: lspContext(lsp: lsp, relativePath: "Sources/Example.swift")),
+            state: state
+        ).rows[0].equalityToken
+
+        #expect(!baseToken.isEqual(to: lspToken))
+    }
+
     @Test func equalTokenRowsInvokeTheLatestHunkHandler() throws {
         let state = DiffPanePresentationState()
         var calls: [String] = []
@@ -93,6 +105,7 @@ struct DiffPaneRowPlanTests {
         codeFontFamily: String = "SF Mono",
         codeFontSize: CGFloat = 13,
         theme: Theme? = nil,
+        lspContext: DiffPaneLSPContext? = nil,
         actions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions = { _ in .init() }
     ) -> DiffPaneRowPlanInput {
         DiffPaneRowPlanInput(
@@ -104,6 +117,7 @@ struct DiffPaneRowPlanTests {
             codeFontFamily: codeFontFamily,
             codeFontSize: codeFontSize,
             theme: theme ?? (try! ThemeStore().current),
+            lspContext: lspContext,
             hunkActions: actions
         )
     }
@@ -112,6 +126,17 @@ struct DiffPaneRowPlanTests {
         var theme = try! ThemeStore().current
         theme.accentOverrideHex = "#ff00ff"
         return theme
+    }
+
+    private func lspContext(lsp: WorkspaceLSPManager, relativePath: String) -> DiffPaneLSPContext {
+        DiffPaneLSPContext(
+            worktreeId: "wt",
+            worktreeRoot: URL(fileURLWithPath: "/tmp/repo"),
+            relativePath: relativePath,
+            language: "swift",
+            lsp: lsp,
+            openTarget: { _, _, _ in }
+        )
     }
 
     private func model() -> DiffDisplayModel {

--- a/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
@@ -76,6 +76,21 @@ struct DiffPaneRowPlanTests {
         #expect(calls == ["second"])
     }
 
+    @Test func hunkRowIsPinnedWhileContainedThreadEditorIsActive() throws {
+        let thread = DiffInlineCommentThread(
+            id: "thread", filePath: "Sources/Example.swift", newLine: 1, isOldSide: false,
+            isResolved: false, isOutdated: false, comments: []
+        )
+        let state = DiffPanePresentationState()
+        let resting = try #require(DiffPaneRowPlanBuilder.build(input: input(threads: [thread]), state: state).rows.first)
+
+        state.setThreadActive(thread.id, active: true)
+        let active = try #require(DiffPaneRowPlanBuilder.build(input: input(threads: [thread]), state: state).rows.first)
+
+        #expect(resting.retention == .recyclable)
+        #expect(active.retention == .pinned)
+    }
+
     @Test func expandedContextUpdatesTheRowEstimate() throws {
         let input = input(model: collapsibleModel())
         let state = DiffPanePresentationState()
@@ -106,6 +121,7 @@ struct DiffPaneRowPlanTests {
         codeFontSize: CGFloat = 13,
         theme: Theme? = nil,
         lspContext: DiffPaneLSPContext? = nil,
+        threads: [DiffInlineCommentThread] = [],
         actions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions = { _ in .init() }
     ) -> DiffPaneRowPlanInput {
         DiffPaneRowPlanInput(
@@ -118,6 +134,7 @@ struct DiffPaneRowPlanTests {
             codeFontSize: codeFontSize,
             theme: theme ?? (try! ThemeStore().current),
             lspContext: lspContext,
+            threads: threads,
             hunkActions: actions
         )
     }

--- a/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
@@ -50,12 +50,21 @@ struct DiffPaneRowPlanTests {
         let input = input(model: collapsibleModel())
         let state = DiffPanePresentationState()
         let group = try #require(input.model.groups.first)
-        let collapsed = try #require(DiffPaneRowPlanBuilder.build(input: input, state: state).rows.first)
 
         state.toggleCollapsedContext(in: group)
         let expanded = try #require(DiffPaneRowPlanBuilder.build(input: input, state: state).rows.first)
+        let expected = DiffPaneStaticHeightEstimator.estimatedHeight(
+            for: .init(filePath: input.model.filePath, groups: [group]),
+            layoutMode: input.layoutMode,
+            expandedCollapsedRowIDs: state.expandedCollapsedRowIDs,
+            codeFont: CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize),
+            headerFont: CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize - 1),
+            wrapLines: input.wrapLines,
+            showWhitespace: input.showWhitespace,
+            fusionStates: [DiffPaneHunkFusionResolver.states(for: input.model.groups)[0]]
+        )
 
-        #expect(expanded.estimatedHeight > collapsed.estimatedHeight)
+        #expect(expanded.estimatedHeight == expected)
     }
 
     private func input(

--- a/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
@@ -29,6 +29,7 @@ struct DiffPaneRowPlanTests {
             input(showWhitespace: true),
             input(codeFontFamily: "Menlo"),
             input(codeFontSize: 15),
+            input(theme: accentedTheme()),
             input(model: changedModel()),
         ]
 
@@ -91,6 +92,7 @@ struct DiffPaneRowPlanTests {
         showWhitespace: Bool = false,
         codeFontFamily: String = "SF Mono",
         codeFontSize: CGFloat = 13,
+        theme: Theme? = nil,
         actions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions = { _ in .init() }
     ) -> DiffPaneRowPlanInput {
         DiffPaneRowPlanInput(
@@ -101,9 +103,15 @@ struct DiffPaneRowPlanTests {
             showWhitespace: showWhitespace,
             codeFontFamily: codeFontFamily,
             codeFontSize: codeFontSize,
-            theme: try! ThemeStore().current,
+            theme: theme ?? (try! ThemeStore().current),
             hunkActions: actions
         )
+    }
+
+    private func accentedTheme() -> Theme {
+        var theme = try! ThemeStore().current
+        theme.accentOverrideHex = "#ff00ff"
+        return theme
     }
 
     private func model() -> DiffDisplayModel {

--- a/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
@@ -27,6 +27,7 @@ struct DiffPaneRowPlanTests {
             input(layoutMode: .stacked),
             input(wrapLines: true),
             input(showWhitespace: true),
+            input(fileExtension: "txt"),
             input(codeFontFamily: "Menlo"),
             input(codeFontSize: 15),
             input(theme: accentedTheme()),
@@ -136,6 +137,7 @@ struct DiffPaneRowPlanTests {
 
     private func input(
         model: DiffDisplayModel? = nil,
+        fileExtension: String = "swift",
         layoutMode: DiffLayoutMode = .split,
         wrapLines: Bool = false,
         showWhitespace: Bool = false,
@@ -152,7 +154,7 @@ struct DiffPaneRowPlanTests {
     ) -> DiffPaneRowPlanInput {
         DiffPaneRowPlanInput(
             model: model ?? self.model(),
-            fileExtension: "swift",
+            fileExtension: fileExtension,
             layoutMode: layoutMode,
             wrapLines: wrapLines,
             showWhitespace: showWhitespace,

--- a/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
@@ -46,6 +46,23 @@ struct DiffPaneRowPlanTests {
         #expect(first.rows[0].equalityToken.isEqual(to: second.rows[0].equalityToken))
     }
 
+    @Test func equalTokenRowsInvokeTheLatestHunkHandler() throws {
+        let state = DiffPanePresentationState()
+        var calls: [String] = []
+        let first = DiffPaneRowPlanBuilder.build(
+            input: input(actions: { _ in .init(stage: { calls.append("first") }) }), state: state
+        )
+        let second = DiffPaneRowPlanBuilder.build(
+            input: input(actions: { _ in .init(stage: { calls.append("second") }) }), state: state
+        )
+
+        #expect(first.rows[0].equalityToken.isEqual(to: second.rows[0].equalityToken))
+        let latestActions = state.actionRelay.hunkActions(for: model().groups[0].sourceHunk)
+        let stage = try #require(latestActions.stage)
+        stage()
+        #expect(calls == ["second"])
+    }
+
     @Test func expandedContextUpdatesTheRowEstimate() throws {
         let input = input(model: collapsibleModel())
         let state = DiffPanePresentationState()

--- a/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct DiffPaneRowPlanTests {
+    @Test func rebuildKeepsHunkIDsAndTokensStableWhenInputsAreUnchanged() {
+        let input = input()
+        let state = DiffPanePresentationState()
+
+        let first = DiffPaneRowPlanBuilder.build(input: input, state: state)
+        let second = DiffPaneRowPlanBuilder.build(input: input, state: state)
+
+        #expect(first.rows.map(\.id) == second.rows.map(\.id))
+        #expect(first.rows.count == 2)
+        #expect(first.rows[0].id != first.rows[1].id)
+        #expect(first.rows[0].equalityToken.isEqual(to: second.rows[0].equalityToken))
+    }
+
+    @Test func tokenChangesForEveryPlainRenderingInput() {
+        let base = input()
+        let state = DiffPanePresentationState()
+        let baseToken = DiffPaneRowPlanBuilder.build(input: base, state: state).rows[0].equalityToken
+
+        let variants = [
+            input(layoutMode: .stacked),
+            input(wrapLines: true),
+            input(showWhitespace: true),
+            input(codeFontFamily: "Menlo"),
+            input(codeFontSize: 15),
+            input(model: changedModel()),
+        ]
+
+        for variant in variants {
+            let token = DiffPaneRowPlanBuilder.build(input: variant, state: state).rows[0].equalityToken
+            #expect(!baseToken.isEqual(to: token))
+        }
+    }
+
+    @Test func actionClosureIdentityDoesNotChangeToken() {
+        let state = DiffPanePresentationState()
+        let first = DiffPaneRowPlanBuilder.build(input: input(actions: { _ in .init(stage: {}) }), state: state)
+        let second = DiffPaneRowPlanBuilder.build(input: input(actions: { _ in .init(stage: {}) }), state: state)
+
+        #expect(first.rows[0].equalityToken.isEqual(to: second.rows[0].equalityToken))
+    }
+
+    @Test func expandedContextUpdatesTheRowEstimate() throws {
+        let input = input(model: collapsibleModel())
+        let state = DiffPanePresentationState()
+        let group = try #require(input.model.groups.first)
+        let collapsed = try #require(DiffPaneRowPlanBuilder.build(input: input, state: state).rows.first)
+
+        state.toggleCollapsedContext(in: group)
+        let expanded = try #require(DiffPaneRowPlanBuilder.build(input: input, state: state).rows.first)
+
+        #expect(expanded.estimatedHeight > collapsed.estimatedHeight)
+    }
+
+    private func input(
+        model: DiffDisplayModel? = nil,
+        layoutMode: DiffLayoutMode = .split,
+        wrapLines: Bool = false,
+        showWhitespace: Bool = false,
+        codeFontFamily: String = "SF Mono",
+        codeFontSize: CGFloat = 13,
+        actions: @escaping (ParsedDiff.Hunk) -> DiffPaneHunkActions = { _ in .init() }
+    ) -> DiffPaneRowPlanInput {
+        DiffPaneRowPlanInput(
+            model: model ?? self.model(),
+            fileExtension: "swift",
+            layoutMode: layoutMode,
+            wrapLines: wrapLines,
+            showWhitespace: showWhitespace,
+            codeFontFamily: codeFontFamily,
+            codeFontSize: codeFontSize,
+            theme: try! ThemeStore().current,
+            hunkActions: actions
+        )
+    }
+
+    private func model() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                .init(header: "@@ -1 +1 @@", oldStart: 1, newStart: 1, lines: [
+                    .init(kind: .delete, text: "let old = 1", oldNumber: 1, newNumber: nil),
+                    .init(kind: .add, text: "let new = 2", oldNumber: nil, newNumber: 1),
+                ]),
+                .init(header: "@@ -10 +10 @@", oldStart: 10, newStart: 10, lines: [
+                    .init(kind: .context, text: "let value = 3", oldNumber: 10, newNumber: 10),
+                ]),
+            ]),
+            filePath: "Sources/Example.swift"
+        )
+    }
+
+    private func changedModel() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                .init(header: "@@ -1 +1 @@", oldStart: 1, newStart: 1, lines: [
+                    .init(kind: .delete, text: "let old = 1", oldNumber: 1, newNumber: nil),
+                    .init(kind: .add, text: "let changed = 2", oldNumber: nil, newNumber: 1),
+                ]),
+                .init(header: "@@ -10 +10 @@", oldStart: 10, newStart: 10, lines: [
+                    .init(kind: .context, text: "let value = 3", oldNumber: 10, newNumber: 10),
+                ]),
+            ]),
+            filePath: "Sources/Example.swift"
+        )
+    }
+
+    private func collapsibleModel() -> DiffDisplayModel {
+        DiffDisplayModelBuilder.build(
+            diff: ParsedDiff(hunks: [
+                .init(
+                    header: "@@ -1,15 +1,15 @@",
+                    oldStart: 1,
+                    newStart: 1,
+                    lines: (1...15).map {
+                        .init(kind: .context, text: "let value\($0) = \($0)", oldNumber: $0, newNumber: $0)
+                    }
+                ),
+            ]),
+            filePath: "Sources/Example.swift"
+        )
+    }
+}

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -176,6 +176,30 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!localRow.equalityToken.isEqual(to: providerRow.equalityToken))
     }
 
+    @Test func draftRowRebuildsWhenItsAgentTargetsChange() throws {
+        let file = textFile()
+        let draft = draftComment(fileID: file.id)
+        let state = AppKitDiffReviewFileState()
+        let withoutTargets = AppKitDiffReviewRowInput(
+            file: file, draftComments: [draft], state: state, theme: theme,
+            draftCommentActions: .init(agentTargets: { [] })
+        )
+        let withTargets = AppKitDiffReviewRowInput(
+            file: file, draftComments: [draft], state: state, theme: theme,
+            draftCommentActions: .init(agentTargets: {
+                [
+                    .existingSession(worktreeID: "wt", sessionID: "session", title: "Review chat"),
+                    .newChat(agentID: "codex", title: "New chat"),
+                ]
+            })
+        )
+        let draftID = AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id))
+        let withoutRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [withoutTargets]).corePlan.rows.first { $0.id == draftID })
+        let withRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [withTargets]).corePlan.rows.first { $0.id == draftID })
+
+        #expect(!withoutRow.equalityToken.isEqual(to: withRow.equalityToken))
+    }
+
     @Test func contextFailureRowDisappearsAfterSuccessfulRetry() async throws {
         let attempts = ContextAttempts()
         let provider = DiffReviewContextProvider {

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -351,6 +351,23 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!withSegment.equalityToken.isEqual(to: withoutSegment.equalityToken))
     }
 
+    @Test func groupHeaderTokenChangesWhenCollapsedContextExpansionChanges() throws {
+        let file = collapsibleTextFile()
+        let state = AppKitDiffReviewFileState()
+        state.pendingDraftAnchor = DiffReviewLineAnchor(
+            path: file.summary.path, side: .new, line: 1, rowIndex: 1, selectedText: "let value1 = 1"
+        )
+        let input = AppKitDiffReviewRowInput(file: file, state: state, theme: theme)
+        let group = try #require(file.displayModel?.groups.first)
+        let groupID = AppKitDiffReviewRowID.groupHeader(fileID: file.id, groupID: group.id)
+        let collapsed = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first { $0.id == groupID })
+
+        state.expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(group, expandedIDs: state.expandedCollapsedRowIDs)
+        let expanded = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first { $0.id == groupID })
+
+        #expect(!collapsed.equalityToken.isEqual(to: expanded.equalityToken))
+    }
+
     @Test func rowInputContextExpansionAppliesStateAndNotifies() {
         let snapshot = DiffReviewFileContextSnapshot(
             old: .available(["let a = 0", "let old = 1", "let c = 2"]),
@@ -405,6 +422,28 @@ struct AppKitDiffReviewRowPlanTests {
             language: "swift",
             lsp: lsp,
             openTarget: { _, _, _ in }
+        )
+    }
+
+    private func collapsibleTextFile() -> DiffReviewFileSectionModel {
+        let diff = ParsedDiff(hunks: [
+            .init(
+                header: "@@ -1,15 +1,15 @@",
+                oldStart: 1,
+                newStart: 1,
+                lines: (1...15).map {
+                    .init(kind: .context, text: "let value\($0) = \($0)", oldNumber: $0, newNumber: $0)
+                }
+            ),
+        ])
+        let summary = DiffReviewFileSummary(
+            path: "Sources/Example.swift", namespace: "review", groupID: nil, groupTitle: nil,
+            status: .modified, additions: 0, deletions: 0, isRenderable: true
+        )
+        return DiffReviewFileSectionModel(
+            summary: summary, parsedDiff: diff,
+            displayModel: DiffDisplayModelBuilder.build(diff: diff, filePath: summary.path),
+            placeholderMessage: nil, openFile: nil, contextProvider: nil
         )
     }
 

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Testing
 @testable import Alas
@@ -155,6 +156,35 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(plan.corePlan.rows.first { $0.id == feedbackID }?.retention == .pinned)
         #expect(plan.corePlan.rows.first { $0.id == draftID }?.retention == .pinned)
         #expect(plan.corePlan.rows.first { $0.id == threadID }?.retention == .pinned)
+    }
+
+    @Test func consolidatedHunkRowsArePinnedWhileContainedThreadEditorIsActive() throws {
+        let file = textFile()
+        let thread = DiffInlineCommentThread(
+            id: "thread", filePath: file.summary.path, newLine: 1, isOldSide: false,
+            isResolved: false, isOutdated: false, comments: []
+        )
+        let state = AppKitDiffReviewFileState()
+        let input = AppKitDiffReviewRowInput(file: file, threads: [thread], state: state, theme: theme)
+        let rowID = AppKitDiffReviewRowID.groupHeader(fileID: file.id, groupID: file.displayModel!.groups[0].id)
+        let resting = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first { $0.id == rowID })
+
+        state.hunkPresentationState.setThreadActive(thread.id, active: true)
+        let active = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first { $0.id == rowID })
+
+        #expect(resting.retention == .recyclable)
+        #expect(active.retention == .pinned)
+    }
+
+    @Test func nestedHunkActiveThreadChangesNotifyReviewStateStructure() {
+        let state = AppKitDiffReviewFileState()
+        var eventCount = 0
+        let cancellable = state.structuralDidChange.sink { eventCount += 1 }
+
+        state.hunkPresentationState.setThreadActive("thread", active: true)
+
+        #expect(eventCount > 0)
+        cancellable.cancel()
     }
 
     @Test func draftRowRebuildsWhenItsReviewTargetChanges() throws {

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -107,9 +107,54 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(plan.corePlan.rows.contains { $0.id.contains(":segment:") })
     }
 
+    @Test func accessorySegmentRowsTrackLSPContextInTheirEqualityToken() throws {
+        let file = textFile()
+        let state = AppKitDiffReviewFileState()
+        state.pendingDraftAnchor = DiffReviewLineAnchor(
+            path: file.summary.path, side: .new, line: 1, rowIndex: 1, selectedText: "let new = 1"
+        )
+        let lsp = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: []))
+        let withLSP = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: file, state: state, theme: theme, lspContext: lspContext(lsp: lsp, relativePath: file.summary.path)),
+        ])
+        let withoutLSP = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: file, state: state, theme: theme),
+        ])
+        let withSegment = try #require(withLSP.corePlan.rows.first { $0.id.contains(":segment:") })
+        let withoutSegment = try #require(withoutLSP.corePlan.rows.first { $0.id == withSegment.id })
+
+        #expect(!withSegment.equalityToken.isEqual(to: withoutSegment.equalityToken))
+    }
+
+    @Test func rowInputContextExpansionAppliesStateAndNotifies() {
+        let snapshot = DiffReviewFileContextSnapshot(
+            old: .available(["let a = 0", "let old = 1", "let c = 2"]),
+            new: .available(["let a = 0", "let new = 1", "let c = 2"])
+        )
+        let file = textFile(contextProvider: DiffReviewContextProvider { snapshot })
+        let state = AppKitDiffReviewFileState()
+        state.contextSnapshot = snapshot
+        var activationCount = 0
+        let input = AppKitDiffReviewRowInput(
+            file: file,
+            state: state,
+            theme: theme,
+            onContextExpansionActivated: { activationCount += 1 }
+        )
+        let key = DiffContextExpansionKey(groupID: file.displayModel!.groups[0].id, boundary: .below)
+
+        input.loadContextAndExpand(key, mode: .chunk(size: 1), edge: nil)
+
+        #expect(activationCount == 1)
+        #expect(state.contextExpansion.expandedLineCount(for: key) == 1)
+    }
+
     private var theme: Theme { try! ThemeStore().current }
 
-    private func textFile(path: String = "Sources/Example.swift") -> DiffReviewFileSectionModel {
+    private func textFile(
+        path: String = "Sources/Example.swift",
+        contextProvider: DiffReviewContextProvider? = nil
+    ) -> DiffReviewFileSectionModel {
         let diff = ParsedDiff(hunks: [
             .init(header: "@@ -1 +1 @@", oldStart: 1, newStart: 1, lines: [
                 .init(kind: .delete, text: "let old = 1", oldNumber: 1, newNumber: nil),
@@ -123,7 +168,18 @@ struct AppKitDiffReviewRowPlanTests {
         return DiffReviewFileSectionModel(
             summary: summary, parsedDiff: diff,
             displayModel: DiffDisplayModelBuilder.build(diff: diff, filePath: summary.path),
-            placeholderMessage: nil, openFile: nil, contextProvider: nil
+            placeholderMessage: nil, openFile: nil, contextProvider: contextProvider
+        )
+    }
+
+    private func lspContext(lsp: WorkspaceLSPManager, relativePath: String) -> DiffPaneLSPContext {
+        DiffPaneLSPContext(
+            worktreeId: "wt",
+            worktreeRoot: URL(fileURLWithPath: "/tmp/repo"),
+            relativePath: relativePath,
+            language: "swift",
+            lsp: lsp,
+            openTarget: { _, _, _ in }
         )
     }
 

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -195,6 +195,30 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!first.equalityToken.isEqual(to: hovered.equalityToken))
     }
 
+    @Test func themeAndFocusedFeedbackChangeRenderedRowTokens() throws {
+        let file = textFile()
+        let state = AppKitDiffReviewFileState()
+        let base = AppKitDiffReviewRowInput(file: file, state: state, theme: theme)
+        var accentedTheme = theme
+        accentedTheme.accentOverrideHex = "#ff00ff"
+        let themed = AppKitDiffReviewRowInput(file: file, state: state, theme: accentedTheme)
+        let focused = AppKitDiffReviewRowInput(
+            file: file, state: state, theme: theme, focusedFeedbackID: "feedback", focusedDraftCommentID: "draft"
+        )
+        let baseRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [base]).corePlan.rows.first {
+            $0.id.contains(":segment:")
+        })
+        let themedRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [themed]).corePlan.rows.first {
+            $0.id == baseRow.id
+        })
+        let focusedRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [focused]).corePlan.rows.first {
+            $0.id == baseRow.id
+        })
+
+        #expect(!baseRow.equalityToken.isEqual(to: themedRow.equalityToken))
+        #expect(!baseRow.equalityToken.isEqual(to: focusedRow.equalityToken))
+    }
+
     @Test func accessorySegmentRowsTrackLSPContextInTheirEqualityToken() throws {
         let file = textFile()
         let state = AppKitDiffReviewFileState()

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -237,6 +237,26 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(ids.contains(AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: target.id, fileID: file.id))))
     }
 
+    @Test func nonImagePlanClearsStaleImageState() async {
+        let state = AppKitDiffReviewFileState()
+        let provider = imageProvider {
+            ImageDiffPair(before: .missing, after: .missing, oldPath: nil, kind: .modified)
+        }
+        await state.imageState.load(provider: provider)
+        #expect(state.imageState.pair != nil)
+
+        let input = AppKitDiffReviewRowInput(
+            file: textFile(),
+            state: state,
+            theme: theme
+        )
+
+        _ = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+
+        #expect(state.imageState.pair == nil)
+        #expect(state.imageState.providerID == nil)
+    }
+
     @Test func contextFailureRowDisappearsAfterSuccessfulRetry() async throws {
         let attempts = ContextAttempts()
         let provider = DiffReviewContextProvider {
@@ -499,6 +519,16 @@ struct AppKitDiffReviewRowPlanTests {
                 ),
                 load: { fatalError("The row-plan builder must not load image data") }
             )
+        )
+    }
+
+    private func imageProvider(load: @escaping @MainActor () async -> ImageDiffPair) -> DiffReviewImageProvider {
+        DiffReviewImageProvider(
+            id: .init(
+                source: .commit, repository: "/repo", beforeRevision: "old", afterRevision: "new",
+                beforePath: "Assets/logo.png", afterPath: "Assets/logo.png"
+            ),
+            load: load
         )
     }
 

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -19,7 +19,7 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(first.corePlan.rows.allSatisfy { $0.ownerID == input.file.id.rawValue })
         #expect(first.corePlan.rows.contains { $0.id.hasSuffix(":header") })
         #expect(first.corePlan.rows.contains { $0.id.contains(":group:") })
-        #expect(first.corePlan.rows.contains { $0.id.hasSuffix(":spacing") })
+        #expect(!first.corePlan.rows.contains { $0.id.hasSuffix(":spacing") })
     }
 
     @Test func deferredFilesMapReviewTargetsToTheirPlaceholder() {
@@ -76,6 +76,22 @@ struct AppKitDiffReviewRowPlanTests {
             AppKitDiffReviewRowID.header(fileID: file.id),
             AppKitDiffReviewRowID.placeholder(fileID: file.id),
         ])
+    }
+
+    @Test func bottomSpacingFollowsEligibilityForImagePlaceholderAndTextFiles() {
+        let image = imageFile()
+        let placeholder = placeholderFile()
+        let text = textFile()
+        let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: image, state: AppKitDiffReviewFileState(), theme: theme),
+            .init(file: placeholder, state: AppKitDiffReviewFileState(), theme: theme),
+            .init(file: text, state: AppKitDiffReviewFileState(), theme: theme),
+        ])
+        let ids = plan.corePlan.rows.map(\.id)
+
+        #expect(ids.contains(AppKitDiffReviewRowID.spacing(fileID: image.id)))
+        #expect(ids.contains(AppKitDiffReviewRowID.spacing(fileID: placeholder.id)))
+        #expect(!ids.contains(AppKitDiffReviewRowID.spacing(fileID: text.id)))
     }
 
     @Test func headerRowCarriesLegacyFileSectionAccessibilityMarker() throws {

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -200,6 +200,26 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!withoutRow.equalityToken.isEqual(to: withRow.equalityToken))
     }
 
+    @Test func hunkInlineFeedbackRowsReceiveRowContext() throws {
+        let file = textFile()
+        let item = feedback(line: 1)
+        let input = AppKitDiffReviewRowInput(file: file, inlineFeedback: [item], state: AppKitDiffReviewFileState(), theme: theme)
+        let feedbackID = AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: item.id, fileID: file.id))
+        let row = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first { $0.id == feedbackID })
+
+        #expect(row.contextRowCount == file.displayModel!.groups[0].rows.count)
+    }
+
+    @Test func lineDraftRowsReceiveRowContext() throws {
+        let file = textFile()
+        let draft = draftComment(fileID: file.id)
+        let input = AppKitDiffReviewRowInput(file: file, draftComments: [draft], state: AppKitDiffReviewFileState(), theme: theme)
+        let draftID = AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id))
+        let row = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first { $0.id == draftID })
+
+        #expect(row.contextRowCount != nil)
+    }
+
     @Test func contextFailureRowDisappearsAfterSuccessfulRetry() async throws {
         let attempts = ContextAttempts()
         let provider = DiffReviewContextProvider {

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -1,5 +1,7 @@
+import AppKit
 import Combine
 import Foundation
+import SwiftUI
 import Testing
 @testable import Alas
 
@@ -74,6 +76,21 @@ struct AppKitDiffReviewRowPlanTests {
             AppKitDiffReviewRowID.header(fileID: file.id),
             AppKitDiffReviewRowID.placeholder(fileID: file.id),
         ])
+    }
+
+    @Test func headerRowCarriesLegacyFileSectionAccessibilityMarker() throws {
+        let file = textFile()
+        let input = AppKitDiffReviewRowInput(file: file, state: AppKitDiffReviewFileState(), theme: theme)
+        let controller = NSHostingController(rootView: AppKitDiffReviewHeaderRowBody(input: input))
+        controller.view.frame = NSRect(x: 0, y: 0, width: 640, height: 64)
+        controller.view.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let marker = try #require(allSubviews(of: controller.view).first {
+            $0.accessibilityIdentifier() == "diff-review-file-section-\(file.id.rawValue)"
+        })
+        #expect(marker.accessibilityLabel() == file.summary.path)
     }
 
     @Test func aggregateBudgetDefersLaterFilesBeforeBuildingTheirContext() {
@@ -511,6 +528,10 @@ struct AppKitDiffReviewRowPlanTests {
     }
 
     private var theme: Theme { try! ThemeStore().current }
+
+    private func allSubviews(of view: NSView) -> [NSView] {
+        [view] + view.subviews.flatMap(allSubviews)
+    }
 
     private func textFile(
         path: String = "Sources/Example.swift",

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -206,6 +206,38 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!localRow.equalityToken.isEqual(to: providerRow.equalityToken))
     }
 
+    @Test func headerRowRebuildsWhenSourceBadgeVisibilityChanges() throws {
+        let file = textFile(groupTitle: "Pull request")
+        let state = AppKitDiffReviewFileState()
+        let hidden = AppKitDiffReviewRowInput(file: file, state: state, theme: theme, showsSourceBadge: false)
+        let shown = AppKitDiffReviewRowInput(file: file, state: state, theme: theme, showsSourceBadge: true)
+        let hiddenHeader = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [hidden]).corePlan.rows.first {
+            $0.id == AppKitDiffReviewRowID.header(fileID: file.id)
+        })
+        let shownHeader = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [shown]).corePlan.rows.first {
+            $0.id == AppKitDiffReviewRowID.header(fileID: file.id)
+        })
+
+        #expect(!hiddenHeader.equalityToken.isEqual(to: shownHeader.equalityToken))
+    }
+
+    @Test func headerRowRebuildsWhenSourceBadgeTitleChanges() throws {
+        let base = textFile(groupTitle: "Pull request")
+        let changed = textFile(groupTitle: "Working tree")
+        let state = AppKitDiffReviewFileState()
+        let first = AppKitDiffReviewRowInput(file: base, state: state, theme: theme, showsSourceBadge: true)
+        let second = AppKitDiffReviewRowInput(file: changed, state: state, theme: theme, showsSourceBadge: true)
+        let firstHeader = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [first]).corePlan.rows.first {
+            $0.id == AppKitDiffReviewRowID.header(fileID: base.id)
+        })
+        let secondHeader = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [second]).corePlan.rows.first {
+            $0.id == AppKitDiffReviewRowID.header(fileID: changed.id)
+        })
+
+        #expect(base.id == changed.id)
+        #expect(!firstHeader.equalityToken.isEqual(to: secondHeader.equalityToken))
+    }
+
     @Test func draftRowRebuildsWhenItsAgentTargetsChange() throws {
         let file = textFile()
         let draft = draftComment(fileID: file.id)
@@ -482,7 +514,8 @@ struct AppKitDiffReviewRowPlanTests {
 
     private func textFile(
         path: String = "Sources/Example.swift",
-        contextProvider: DiffReviewContextProvider? = nil
+        contextProvider: DiffReviewContextProvider? = nil,
+        groupTitle: String? = nil
     ) -> DiffReviewFileSectionModel {
         let diff = ParsedDiff(hunks: [
             .init(header: "@@ -1 +1 @@", oldStart: 1, newStart: 1, lines: [
@@ -491,7 +524,7 @@ struct AppKitDiffReviewRowPlanTests {
             ]),
         ])
         let summary = DiffReviewFileSummary(
-            path: path, namespace: "review", groupID: nil, groupTitle: nil,
+            path: path, namespace: "review", groupID: nil, groupTitle: groupTitle,
             status: .modified, additions: 1, deletions: 1, isRenderable: true
         )
         return DiffReviewFileSectionModel(

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AppKitDiffReviewRowPlanTests {
+    @Test func textRowsHaveStableUniqueIDsAndTheirOwningFile() {
+        let input = AppKitDiffReviewRowInput(file: textFile(), state: AppKitDiffReviewFileState(), theme: theme)
+
+        let first = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+        let second = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+
+        #expect(first.corePlan.rows.map(\.id) == second.corePlan.rows.map(\.id))
+        #expect(Set(first.corePlan.rows.map(\.id)).count == first.corePlan.rows.count)
+        #expect(first.corePlan.rows.allSatisfy { $0.ownerID == input.file.id.rawValue })
+        #expect(first.corePlan.rows.contains { $0.id.hasSuffix(":header") })
+        #expect(first.corePlan.rows.contains { $0.id.contains(":group:") })
+        #expect(first.corePlan.rows.contains { $0.id.hasSuffix(":spacing") })
+    }
+
+    @Test func deferredFilesMapReviewTargetsToTheirPlaceholder() {
+        let feedback = feedback(line: nil)
+        let input = AppKitDiffReviewRowInput(
+            file: textFile(), inlineFeedback: [feedback], state: AppKitDiffReviewFileState(), theme: theme,
+            automaticallyRendersDiff: false
+        )
+
+        let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+        let placeholderID = "file:\(input.file.id.rawValue):placeholder"
+
+        #expect(plan.corePlan.rows.map { $0.id } == ["file:\(input.file.id.rawValue):header", placeholderID])
+        #expect(plan.placeholderByFileID[input.file.id] == placeholderID)
+        #expect(plan.fallbackByTargetID[AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: feedback.id, fileID: input.file.id))] == placeholderID)
+    }
+
+    @Test func imageFilesEmitAccessoriesAndImageWithoutTextHunksOrSpacing() {
+        let file = imageFile()
+        let feedback = feedback(path: file.summary.path, line: nil)
+        let input = AppKitDiffReviewRowInput(
+            file: file, inlineFeedback: [feedback], state: AppKitDiffReviewFileState(), theme: theme
+        )
+
+        let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+        let ids = plan.corePlan.rows.map { $0.id }
+
+        #expect(ids == [
+            AppKitDiffReviewRowID.header(fileID: file.id),
+            AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: feedback.id, fileID: file.id)),
+            AppKitDiffReviewRowID.image(fileID: file.id),
+        ])
+        #expect(!ids.contains { $0.contains(":group:") || $0.contains(":segment:") })
+    }
+
+    @Test func unavailableFilesEmitHeaderAndPlaceholder() {
+        let file = placeholderFile()
+        let input = AppKitDiffReviewRowInput(file: file, state: AppKitDiffReviewFileState(), theme: theme)
+
+        let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+
+        #expect(plan.corePlan.rows.map { $0.id } == [
+            AppKitDiffReviewRowID.header(fileID: file.id),
+            AppKitDiffReviewRowID.placeholder(fileID: file.id),
+        ])
+    }
+
+    @Test func aggregateBudgetDefersLaterFilesBeforeBuildingTheirContext() {
+        let first = textFile(path: "Sources/First.swift")
+        let second = textFile(path: "Sources/Second.swift")
+        let firstState = AppKitDiffReviewFileState()
+        let secondState = AppKitDiffReviewFileState()
+
+        let plan = AppKitDiffReviewRowPlanBuilder.build(
+            inputs: [
+                .init(file: first, state: firstState, theme: theme),
+                .init(file: second, state: secondState, theme: theme),
+            ],
+            maxAutomaticallyRenderedRows: DiffReviewRenderBudget.renderedRowCount(of: first.displayModel!)
+        )
+
+        #expect(plan.placeholderByFileID[first.id] == nil)
+        #expect(plan.placeholderByFileID[second.id] == AppKitDiffReviewRowID.placeholder(fileID: second.id))
+        #expect(secondState.renderContextCache.missCountForTests == 0)
+    }
+
+    @Test func renderedTargetsAreDirectRowsAndComposerIsPinned() throws {
+        let file = textFile()
+        let feedback = feedback(line: 1)
+        let draft = draftComment(fileID: file.id)
+        let state = AppKitDiffReviewFileState()
+        state.pendingDraftAnchor = DiffReviewLineAnchor(
+            path: file.summary.path, side: .new, line: 1, rowIndex: 1, selectedText: "let new = 1"
+        )
+        let input = AppKitDiffReviewRowInput(
+            file: file, inlineFeedback: [feedback], draftComments: [draft], state: state, theme: theme
+        )
+
+        let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+        let feedbackID = AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: feedback.id, fileID: file.id))
+        let draftID = AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id))
+        let composer = try #require(plan.corePlan.rows.first { $0.id.contains(":composer:") })
+
+        #expect(plan.fallbackByTargetID[feedbackID] == feedbackID)
+        #expect(plan.fallbackByTargetID[draftID] == draftID)
+        #expect(plan.corePlan.rows.first { $0.id == draftID }?.retention == .recyclable)
+        #expect(composer.retention == .pinned)
+        #expect(plan.corePlan.rows.contains { $0.id.contains(":segment:") })
+    }
+
+    private var theme: Theme { try! ThemeStore().current }
+
+    private func textFile(path: String = "Sources/Example.swift") -> DiffReviewFileSectionModel {
+        let diff = ParsedDiff(hunks: [
+            .init(header: "@@ -1 +1 @@", oldStart: 1, newStart: 1, lines: [
+                .init(kind: .delete, text: "let old = 1", oldNumber: 1, newNumber: nil),
+                .init(kind: .add, text: "let new = 1", oldNumber: nil, newNumber: 1),
+            ]),
+        ])
+        let summary = DiffReviewFileSummary(
+            path: path, namespace: "review", groupID: nil, groupTitle: nil,
+            status: .modified, additions: 1, deletions: 1, isRenderable: true
+        )
+        return DiffReviewFileSectionModel(
+            summary: summary, parsedDiff: diff,
+            displayModel: DiffDisplayModelBuilder.build(diff: diff, filePath: summary.path),
+            placeholderMessage: nil, openFile: nil, contextProvider: nil
+        )
+    }
+
+    private func imageFile() -> DiffReviewFileSectionModel {
+        let summary = DiffReviewFileSummary(
+            path: "Assets/logo.png", namespace: "review", groupID: nil, groupTitle: nil,
+            status: .modified, additions: 1, deletions: 1, isRenderable: true
+        )
+        return DiffReviewFileSectionModel(
+            summary: summary, parsedDiff: nil, displayModel: nil, placeholderMessage: nil,
+            openFile: nil, contextProvider: nil,
+            imageProvider: .init(
+                id: .init(
+                    source: .commit, repository: "/repo", beforeRevision: "old", afterRevision: "new",
+                    beforePath: summary.path, afterPath: summary.path
+                ),
+                load: { fatalError("The row-plan builder must not load image data") }
+            )
+        )
+    }
+
+    private func placeholderFile() -> DiffReviewFileSectionModel {
+        let summary = DiffReviewFileSummary(
+            path: "Assets/data.bin", namespace: "review", groupID: nil, groupTitle: nil,
+            status: .modified, additions: 0, deletions: 0, isRenderable: false
+        )
+        return .init(
+            summary: summary, parsedDiff: nil, displayModel: nil,
+            placeholderMessage: "Binary file", openFile: nil, contextProvider: nil
+        )
+    }
+
+    private func feedback(path: String = "Sources/Example.swift", line: Int?) -> DiffReviewInlineFeedback {
+        .init(
+            id: "feedback", providerName: "Provider", author: nil, bodyPreview: "Needs work",
+            status: .actionable, providerURL: nil,
+            anchor: .init(path: path, line: line, side: line == nil ? .unknown : .new),
+            evidenceItemID: "evidence"
+        )
+    }
+
+    private func draftComment(fileID: DiffReviewFileID) -> ReviewDraftComment {
+        .init(
+            id: "draft", sessionID: .commit(worktreeID: "wt", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "abc"),
+            fileID: fileID, path: fileID.path, originalPath: nil, side: .new,
+            startLine: 1, endLine: nil, selectedText: "let new = 1", bodyMarkdown: "Please revisit.",
+            state: .active, createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
+        )
+    }
+}

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -220,6 +220,23 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(row.contextRowCount != nil)
     }
 
+    @Test func commandedInlineFeedbackIsIncludedBeyondVisibleCap() {
+        let file = textFile()
+        let items = (1...4).map { feedback(id: "feedback-\($0)", line: nil) }
+        let target = items[3]
+        let input = AppKitDiffReviewRowInput(
+            file: file,
+            inlineFeedback: items,
+            state: AppKitDiffReviewFileState(),
+            theme: theme,
+            inlineFeedbackScrollTargetID: target.id
+        )
+
+        let ids = AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.map(\.id)
+
+        #expect(ids.contains(AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: target.id, fileID: file.id))))
+    }
+
     @Test func contextFailureRowDisappearsAfterSuccessfulRetry() async throws {
         let attempts = ContextAttempts()
         let provider = DiffReviewContextProvider {
@@ -496,9 +513,13 @@ struct AppKitDiffReviewRowPlanTests {
         )
     }
 
-    private func feedback(path: String = "Sources/Example.swift", line: Int?) -> DiffReviewInlineFeedback {
+    private func feedback(
+        id: String = "feedback",
+        path: String = "Sources/Example.swift",
+        line: Int?
+    ) -> DiffReviewInlineFeedback {
         .init(
-            id: "feedback", providerName: "Provider", author: nil, bodyPreview: "Needs work",
+            id: id, providerName: "Provider", author: nil, bodyPreview: "Needs work",
             status: .actionable, providerURL: nil,
             anchor: .init(path: path, line: line, side: line == nil ? .unknown : .new),
             evidenceItemID: "evidence"

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -181,13 +181,14 @@ struct AppKitDiffReviewRowPlanTests {
 
     @Test func hoverStateChangesRenderedHunkRowToken() throws {
         let file = textFile()
+        let item = feedback(line: 1)
         let state = AppKitDiffReviewFileState()
-        let input = AppKitDiffReviewRowInput(file: file, state: state, theme: theme)
+        let input = AppKitDiffReviewRowInput(file: file, inlineFeedback: [item], state: state, theme: theme)
         let first = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first {
-            $0.id.contains(":segment:")
+            $0.id.contains(":group:")
         })
 
-        state.hoveredInlineFeedbackID = "feedback"
+        state.hoveredInlineFeedbackID = item.id
         let hovered = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first {
             $0.id == first.id
         })
@@ -195,18 +196,38 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!first.equalityToken.isEqual(to: hovered.equalityToken))
     }
 
+    @Test func hoverChangesOnlyRowsThatRenderTheActiveHighlight() throws {
+        let file = textFile()
+        let item = feedback(line: 1)
+        let state = AppKitDiffReviewFileState()
+        let input = AppKitDiffReviewRowInput(file: file, inlineFeedback: [item], state: state, theme: theme)
+        let initial = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+        let initialHeader = try #require(initial.corePlan.rows.first { $0.id == AppKitDiffReviewRowID.header(fileID: file.id) })
+        let initialHunk = try #require(initial.corePlan.rows.first { $0.id.contains(":group:") })
+
+        state.hoveredInlineFeedbackID = item.id
+        let hovered = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+        let hoveredHeader = try #require(hovered.corePlan.rows.first { $0.id == initialHeader.id })
+        let hoveredHunk = try #require(hovered.corePlan.rows.first { $0.id == initialHunk.id })
+
+        #expect(initialHeader.equalityToken.isEqual(to: hoveredHeader.equalityToken))
+        #expect(!initialHunk.equalityToken.isEqual(to: hoveredHunk.equalityToken))
+    }
+
     @Test func themeAndFocusedFeedbackChangeRenderedRowTokens() throws {
         let file = textFile()
+        let item = feedback(line: 1)
         let state = AppKitDiffReviewFileState()
-        let base = AppKitDiffReviewRowInput(file: file, state: state, theme: theme)
+        let base = AppKitDiffReviewRowInput(file: file, inlineFeedback: [item], state: state, theme: theme)
         var accentedTheme = theme
         accentedTheme.accentOverrideHex = "#ff00ff"
-        let themed = AppKitDiffReviewRowInput(file: file, state: state, theme: accentedTheme)
+        let themed = AppKitDiffReviewRowInput(file: file, inlineFeedback: [item], state: state, theme: accentedTheme)
         let focused = AppKitDiffReviewRowInput(
-            file: file, state: state, theme: theme, focusedFeedbackID: "feedback", focusedDraftCommentID: "draft"
+            file: file, inlineFeedback: [item], state: state, theme: theme,
+            focusedFeedbackID: item.id, focusedDraftCommentID: "draft"
         )
         let baseRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [base]).corePlan.rows.first {
-            $0.id.contains(":segment:")
+            $0.id.contains(":group:")
         })
         let themedRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [themed]).corePlan.rows.first {
             $0.id == baseRow.id

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -179,6 +179,22 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!availableRow.equalityToken.isEqual(to: busyRow.equalityToken))
     }
 
+    @Test func hoverStateChangesRenderedHunkRowToken() throws {
+        let file = textFile()
+        let state = AppKitDiffReviewFileState()
+        let input = AppKitDiffReviewRowInput(file: file, state: state, theme: theme)
+        let first = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first {
+            $0.id.contains(":segment:")
+        })
+
+        state.hoveredInlineFeedbackID = "feedback"
+        let hovered = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first {
+            $0.id == first.id
+        })
+
+        #expect(!first.equalityToken.isEqual(to: hovered.equalityToken))
+    }
+
     @Test func accessorySegmentRowsTrackLSPContextInTheirEqualityToken() throws {
         let file = textFile()
         let state = AppKitDiffReviewFileState()

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -34,11 +34,20 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(plan.fallbackByTargetID[AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: feedback.id, fileID: input.file.id))] == placeholderID)
     }
 
-    @Test func imageFilesEmitAccessoriesAndImageWithoutTextHunksOrSpacing() {
+    @Test func imageFilesEmitAllLegacyAccessoriesAndImageWithoutTextHunksOrSpacing() {
         let file = imageFile()
         let feedback = feedback(path: file.summary.path, line: nil)
+        let thread = DiffInlineCommentThread(
+            id: "thread", filePath: file.summary.path, newLine: 1, isOldSide: false,
+            isResolved: false, isOutdated: false, comments: []
+        )
+        let annotation = DiffInlineAnnotation(
+            id: "annotation", checkName: "Check", newLine: 1, level: .warning,
+            message: "Warning", rawDetails: nil
+        )
         let input = AppKitDiffReviewRowInput(
-            file: file, inlineFeedback: [feedback], state: AppKitDiffReviewFileState(), theme: theme
+            file: file, inlineFeedback: [feedback], threads: [thread], annotations: [annotation],
+            state: AppKitDiffReviewFileState(), theme: theme
         )
 
         let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
@@ -47,6 +56,8 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(ids == [
             AppKitDiffReviewRowID.header(fileID: file.id),
             AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: feedback.id, fileID: file.id)),
+            AppKitDiffReviewRowID.thread(fileID: file.id, threadID: thread.id),
+            AppKitDiffReviewRowID.annotation(fileID: file.id, annotationID: annotation.id),
             AppKitDiffReviewRowID.image(fileID: file.id),
         ])
         #expect(!ids.contains { $0.contains(":group:") || $0.contains(":segment:") })
@@ -83,7 +94,7 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(secondState.renderContextCache.missCountForTests == 0)
     }
 
-    @Test func renderedTargetsAreDirectRowsAndComposerIsPinned() throws {
+    @Test func renderedTargetsAreDirectRowsAndComposerIsPinnedOnlyWhileFocused() throws {
         let file = textFile()
         let feedback = feedback(line: 1)
         let draft = draftComment(fileID: file.id)
@@ -103,8 +114,69 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(plan.fallbackByTargetID[feedbackID] == feedbackID)
         #expect(plan.fallbackByTargetID[draftID] == draftID)
         #expect(plan.corePlan.rows.first { $0.id == draftID }?.retention == .recyclable)
-        #expect(composer.retention == .pinned)
+        #expect(composer.retention == .recyclable)
         #expect(plan.corePlan.rows.contains { $0.id.contains(":segment:") })
+
+        state.pendingDraftBody = "survives recycling"
+        state.isDraftComposerFocused = true
+        let focused = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first {
+            $0.id == composer.id
+        })
+        #expect(focused.retention == .pinned)
+        state.isDraftComposerFocused = false
+        let blurred = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.first {
+            $0.id == composer.id
+        })
+        #expect(blurred.retention == .recyclable)
+        #expect(state.pendingDraftBody == "survives recycling")
+    }
+
+    @Test func contextFailureRowDisappearsAfterSuccessfulRetry() async throws {
+        let attempts = ContextAttempts()
+        let provider = DiffReviewContextProvider {
+            try await attempts.snapshot()
+        }
+        let file = textFile(contextProvider: provider)
+        let state = AppKitDiffReviewFileState()
+        let input = AppKitDiffReviewRowInput(file: file, state: state, theme: theme)
+        let key = DiffContextExpansionKey(groupID: file.displayModel!.groups[0].id, boundary: .below)
+
+        input.loadContextAndExpand(key, mode: .chunk(size: 1), edge: nil)
+        await state.contextLoadTask?.value
+        #expect(AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.contains {
+            $0.id == AppKitDiffReviewRowID.contextError(fileID: file.id)
+        })
+
+        input.loadContextAndExpand(key, mode: .chunk(size: 1), edge: nil)
+        await state.contextLoadTask?.value
+        #expect(state.contextLoadError == nil)
+        #expect(!AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan.rows.contains {
+            $0.id == AppKitDiffReviewRowID.contextError(fileID: file.id)
+        })
+    }
+
+    @Test func hunkBusyStateChangesTheOuterRowToken() throws {
+        var available = textFile()
+        available.stagedMutationActions = .init(
+            unstageHunk: { _ in }, isHunkUnstageEnabled: { _ in true }, unstageEnabledBase: true
+        )
+        var busy = textFile()
+        busy.stagedMutationActions = .init(
+            unstageHunk: { _ in }, isHunkUnstageEnabled: { _ in false }, unstageEnabledBase: false
+        )
+        let state = AppKitDiffReviewFileState()
+        let availableRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: available, state: state, theme: theme, actionPresence: .init(
+                canUnstageHunk: true, hunkUnstageEnabled: true
+            )),
+        ]).corePlan.rows.first { $0.id.contains(":group:") })
+        let busyRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: busy, state: state, theme: theme, actionPresence: .init(
+                canUnstageHunk: true, hunkUnstageEnabled: false
+            )),
+        ]).corePlan.rows.first { $0.id == availableRow.id })
+
+        #expect(!availableRow.equalityToken.isEqual(to: busyRow.equalityToken))
     }
 
     @Test func accessorySegmentRowsTrackLSPContextInTheirEqualityToken() throws {
@@ -229,4 +301,16 @@ struct AppKitDiffReviewRowPlanTests {
             state: .active, createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
         )
     }
+
+    private actor ContextAttempts {
+        private var count = 0
+
+        func snapshot() throws -> DiffReviewFileContextSnapshot {
+            count += 1
+            if count == 1 { throw ContextError.failed }
+            return .init(old: .available(["old"]), new: .available(["new"]))
+        }
+    }
+
+    private enum ContextError: Error { case failed }
 }

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -219,6 +219,29 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!baseRow.equalityToken.isEqual(to: focusedRow.equalityToken))
     }
 
+    @Test func providerThreadChangesInvalidateFlattenedHunkRow() throws {
+        let file = textFile()
+        let state = AppKitDiffReviewFileState()
+        let initialThread = DiffInlineCommentThread(
+            id: "thread", filePath: file.summary.path, newLine: 1, isOldSide: false,
+            isResolved: false, isOutdated: false, comments: []
+        )
+        let resolvedThread = DiffInlineCommentThread(
+            id: "thread", filePath: file.summary.path, newLine: 1, isOldSide: false,
+            isResolved: true, isOutdated: false, comments: []
+        )
+        let initial = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: file, threads: [initialThread], state: state, theme: theme),
+        ])
+        let resolved = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: file, threads: [resolvedThread], state: state, theme: theme),
+        ])
+        let initialRow = try #require(initial.corePlan.rows.first { $0.id.contains(":group:") })
+        let resolvedRow = try #require(resolved.corePlan.rows.first { $0.id == initialRow.id })
+
+        #expect(!initialRow.equalityToken.isEqual(to: resolvedRow.equalityToken))
+    }
+
     @Test func accessorySegmentRowsTrackLSPContextInTheirEqualityToken() throws {
         let file = textFile()
         let state = AppKitDiffReviewFileState()

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -128,6 +128,27 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(secondState.renderContextCache.missCountForTests == 0)
     }
 
+    @Test func aggregateBudgetUsesReviewDeferredPlaceholderTitle() {
+        let first = textFile(path: "Sources/First.swift")
+        let second = textFile(path: "Sources/Second.swift")
+        let input = AppKitDiffReviewRowInput(file: second, state: AppKitDiffReviewFileState(), theme: theme)
+
+        let plan = AppKitDiffReviewRowPlanBuilder.build(
+            inputs: [
+                .init(file: first, state: AppKitDiffReviewFileState(), theme: theme),
+                input,
+            ],
+            maxAutomaticallyRenderedRows: DiffReviewRenderBudget.renderedRowCount(of: first.displayModel!)
+        )
+        let placeholder = AppKitDiffReviewPlaceholderRowBody(
+            input: input,
+            isDeferred: true,
+            isAggregateDeferred: plan.placeholderByFileID[second.id] != nil
+        )
+
+        #expect(placeholder.title == "Large review diff deferred for performance")
+    }
+
     @Test func renderedTargetsAreDirectRowsAndComposerIsPinnedOnlyWhileFocused() throws {
         let file = textFile()
         let feedback = feedback(line: 1)

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -131,6 +131,51 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(state.pendingDraftBody == "survives recycling")
     }
 
+    @Test func activeFeedbackAndDraftEditorsArePinnedWhileTheirBodiesAreUnsaved() throws {
+        let file = textFile()
+        let item = feedback(line: 1)
+        let draft = draftComment(fileID: file.id)
+        let thread = DiffInlineCommentThread(
+            id: "thread", filePath: file.summary.path, newLine: 1, isOldSide: false,
+            isResolved: false, isOutdated: false, comments: []
+        )
+        let state = AppKitDiffReviewFileState()
+        let input = AppKitDiffReviewRowInput(
+            file: file, inlineFeedback: [item], draftComments: [draft], threads: [thread], state: state, theme: theme
+        )
+        let feedbackID = AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: item.id, fileID: file.id))
+        let draftID = AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id))
+        let threadID = AppKitDiffReviewRowID.thread(fileID: file.id, threadID: thread.id)
+
+        state.activeInlineFeedbackEditorID = item.id
+        state.activeDraftCommentEditorID = draft.id
+        state.activeThreadID = thread.id
+        let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: [input])
+
+        #expect(plan.corePlan.rows.first { $0.id == feedbackID }?.retention == .pinned)
+        #expect(plan.corePlan.rows.first { $0.id == draftID }?.retention == .pinned)
+        #expect(plan.corePlan.rows.first { $0.id == threadID }?.retention == .pinned)
+    }
+
+    @Test func draftRowRebuildsWhenItsReviewTargetChanges() throws {
+        let file = textFile()
+        let draft = draftComment(fileID: file.id)
+        let state = AppKitDiffReviewFileState()
+        let local = AppKitDiffReviewRowInput(
+            file: file, draftComments: [draft], state: state, theme: theme,
+            reviewFeedbackTarget: .init(title: "Local changes", repositoryPath: nil, providerDescription: nil, sourceDescription: "Local")
+        )
+        let provider = AppKitDiffReviewRowInput(
+            file: file, draftComments: [draft], state: state, theme: theme,
+            reviewFeedbackTarget: .init(title: "Pull request", repositoryPath: "/repo", providerDescription: "GitHub #980", sourceDescription: "Provider")
+        )
+        let draftID = AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id))
+        let localRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [local]).corePlan.rows.first { $0.id == draftID })
+        let providerRow = try #require(AppKitDiffReviewRowPlanBuilder.build(inputs: [provider]).corePlan.rows.first { $0.id == draftID })
+
+        #expect(!localRow.equalityToken.isEqual(to: providerRow.equalityToken))
+    }
+
     @Test func contextFailureRowDisappearsAfterSuccessfulRetry() async throws {
         let attempts = ContextAttempts()
         let provider = DiffReviewContextProvider {

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift
@@ -1,0 +1,96 @@
+import Testing
+@testable import Alas
+
+@Suite("AppKitDiffReviewScroller")
+struct AppKitDiffReviewScrollerTests {
+    @Test func switchFollowsRuntimeFlag() {
+        #expect(DiffReviewSurface.usesAppKitScroller(flagEnabled: true))
+        #expect(!DiffReviewSurface.usesAppKitScroller(flagEnabled: false))
+    }
+
+    @Test func fileCommandsTargetHeadersAtTop() {
+        let fileID = fileID()
+        let headerID = AppKitDiffReviewRowID.header(fileID: fileID)
+        let request = AppKitDiffReviewScrollRequestResolver.request(
+            fileCommand: .init(id: fileID, generation: 1),
+            inlineFeedbackCommand: nil,
+            draftCommentCommand: nil,
+            plan: plan(fileID: fileID, headerID: headerID)
+        )
+
+        #expect(request?.targetID == headerID)
+        #expect(request?.alignment == .top)
+    }
+
+    @Test func deferredFeedbackTargetsPlaceholderAtCenter() {
+        let fileID = fileID()
+        let placeholderID = AppKitDiffReviewRowID.placeholder(fileID: fileID)
+        let command = DiffReviewInlineFeedbackScrollCommand(feedbackID: "feedback", fileID: fileID, generation: 1)
+        let requestedID = AppKitDiffReviewRowID.inlineFeedback(command.targetID)
+        let deferredPlan = plan(
+            fileID: fileID,
+            fallbackByTargetID: [requestedID: placeholderID],
+            placeholderByFileID: [fileID: placeholderID]
+        )
+        let request = AppKitDiffReviewScrollRequestResolver.request(
+            fileCommand: nil,
+            inlineFeedbackCommand: command,
+            draftCommentCommand: nil,
+            plan: deferredPlan
+        )
+
+        #expect(request?.targetID == deferredPlan.placeholderByFileID[fileID])
+        #expect(request?.alignment == .center)
+    }
+
+    @Test func reviewCommandKindsUseDistinctGenerationsAndDoNotNeedRealizationDelay() {
+        let fileID = fileID()
+        let file = DiffReviewScrollCommand(id: fileID, generation: 1)
+        let feedback = DiffReviewInlineFeedbackScrollCommand(feedbackID: "feedback", fileID: fileID, generation: 1)
+        let draft = DiffReviewDraftCommentScrollCommand(commentID: "draft", fileID: fileID, generation: 1)
+        let plan = plan(fileID: fileID)
+        let fileRequest = AppKitDiffReviewScrollRequestResolver.request(
+            fileCommand: file, inlineFeedbackCommand: nil, draftCommentCommand: nil, plan: plan
+        )
+        let feedbackRequest = AppKitDiffReviewScrollRequestResolver.request(
+            fileCommand: nil, inlineFeedbackCommand: feedback, draftCommentCommand: nil, plan: plan
+        )
+        let draftRequest = AppKitDiffReviewScrollRequestResolver.request(
+            fileCommand: nil, inlineFeedbackCommand: nil, draftCommentCommand: draft, plan: plan
+        )
+
+        #expect(fileRequest?.generation != feedbackRequest?.generation)
+        #expect(feedbackRequest?.generation != draftRequest?.generation)
+        #expect(fileRequest?.generation != draftRequest?.generation)
+        #expect(feedbackRequest?.alignment == .center)
+        #expect(draftRequest?.alignment == .center)
+    }
+
+    @Test func missingReviewItemsFallBackToTheFileHeader() {
+        let fileID = fileID()
+        let feedback = DiffReviewInlineFeedbackScrollCommand(feedbackID: "missing", fileID: fileID, generation: 1)
+        let request = AppKitDiffReviewScrollRequestResolver.request(
+            fileCommand: nil, inlineFeedbackCommand: feedback, draftCommentCommand: nil, plan: plan(fileID: fileID)
+        )
+
+        #expect(request?.fallbackID == AppKitDiffReviewRowID.header(fileID: fileID))
+    }
+
+    private func fileID() -> DiffReviewFileID {
+        DiffReviewFileID(namespace: "review", path: "Sources/Example.swift")
+    }
+
+    private func plan(
+        fileID: DiffReviewFileID,
+        headerID: String? = nil,
+        fallbackByTargetID: [String: String] = [:],
+        placeholderByFileID: [DiffReviewFileID: String] = [:]
+    ) -> AppKitDiffReviewRowPlan {
+        .init(
+            corePlan: .init(rows: []),
+            fallbackByTargetID: fallbackByTargetID,
+            headerByFileID: [fileID: headerID ?? AppKitDiffReviewRowID.header(fileID: fileID)],
+            placeholderByFileID: placeholderByFileID
+        )
+    }
+}

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift
@@ -104,9 +104,12 @@ struct AppKitDiffReviewScrollerTests {
         gate.begin(requestGeneration: 1)
         gate.begin(requestGeneration: 2)
 
-        #expect(!gate.consumesCompletion(for: 1))
+        let consumedStaleCompletion = gate.consumesCompletion(for: 1)
         #expect(gate.pendingRequestGeneration == 2)
-        #expect(gate.consumesCompletion(for: 2))
+        let consumedCurrentCompletion = gate.consumesCompletion(for: 2)
+
+        #expect(!consumedStaleCompletion)
+        #expect(consumedCurrentCompletion)
         #expect(gate.pendingRequestGeneration == nil)
     }
 

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift
@@ -76,6 +76,40 @@ struct AppKitDiffReviewScrollerTests {
         #expect(request?.fallbackID == AppKitDiffReviewRowID.header(fileID: fileID))
     }
 
+    @Test func newestCommandWinsAcrossKinds() {
+        let firstFileID = fileID()
+        let secondFileID = DiffReviewFileID(namespace: "review", path: "Sources/Second.swift")
+        let plan = plan(fileID: firstFileID, headerID: "first-header")
+        var coordinator = AppKitDiffReviewScrollRequestCoordinator()
+
+        let feedbackRequest = coordinator.request(
+            for: .inlineFeedback(.init(feedbackID: "feedback", fileID: firstFileID, generation: 1)),
+            plan: plan
+        )
+        let fileRequest = coordinator.request(
+            for: .file(.init(id: secondFileID, generation: 1)),
+            plan: plan
+        )
+
+        #expect(feedbackRequest.targetID == AppKitDiffReviewRowID.inlineFeedback(
+            .targetID(feedbackID: "feedback", fileID: firstFileID)
+        ))
+        #expect(fileRequest.targetID == AppKitDiffReviewRowID.header(fileID: secondFileID))
+        #expect(fileRequest.generation > feedbackRequest.generation)
+    }
+
+    @Test func completionOnlyReleasesTheNewestAppKitNavigationRequest() {
+        var gate = AppKitDiffReviewScrollCompletionGate()
+
+        gate.begin(requestGeneration: 1)
+        gate.begin(requestGeneration: 2)
+
+        #expect(!gate.consumesCompletion(for: 1))
+        #expect(gate.pendingRequestGeneration == 2)
+        #expect(gate.consumesCompletion(for: 2))
+        #expect(gate.pendingRequestGeneration == nil)
+    }
+
     private func fileID() -> DiffReviewFileID {
         DiffReviewFileID(namespace: "review", path: "Sources/Example.swift")
     }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3779,17 +3779,29 @@ let second = true
         controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
         controller.view.layoutSubtreeIfNeeded()
 
-        #expect(visibleCodeTextViews(in: controller.view).count == 2)
+        let collapsedCodeViews = visibleCodeTextViews(in: controller.view)
+        #expect(collapsedCodeViews.count == 2)
+        let collapsedRowCounts = collapsedCodeViews.map(\.lineMetadata.count)
         let expandButton = try #require(allSubviews(of: controller.view).compactMap { $0 as? NSButton }.first {
             $0.toolTip == "Expand context"
         })
         expandButton.performClick(nil)
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
-        controller.view.layoutSubtreeIfNeeded()
+
+        let renderDeadline = Date(timeIntervalSinceNow: 1)
+        var expandedRowCounts: [Int] = []
+        repeat {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            controller.view.layoutSubtreeIfNeeded()
+            expandedRowCounts = visibleCodeTextViews(in: controller.view).map(\.lineMetadata.count)
+        } while Date() < renderDeadline && expandedRowCounts == collapsedRowCounts
 
         let buttons = allSubviews(of: controller.view).compactMap { $0 as? NSButton }
         let helpTexts = buttons.compactMap { $0.toolTip }
         #expect(helpTexts.contains("Collapse context"))
+        #expect(expandedRowCounts.count == 2)
+        #expect(zip(expandedRowCounts, collapsedRowCounts).allSatisfy { expanded, collapsed in
+            expanded > collapsed
+        })
     }
 
     @Test func visibleWhitespacePreservesInlineBackgrounds() {

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3758,6 +3758,24 @@ let second = true
         #expect(helpTexts.contains("Discard hunk"))
     }
 
+    @Test func extractedHunkPresentationStateExpandsCollapsedContext() throws {
+        let group = try #require(collapsedContextModel().groups.first)
+        let state = DiffPanePresentationState()
+        let collapsedRows = DiffPaneRowProjection.visibleRows(
+            in: group,
+            expandedCollapsedRowIDs: state.expandedCollapsedRowIDs
+        )
+
+        state.toggleCollapsedContext(in: group)
+        let expandedRows = DiffPaneRowProjection.visibleRows(
+            in: group,
+            expandedCollapsedRowIDs: state.expandedCollapsedRowIDs
+        )
+
+        #expect(expandedRows.count > collapsedRows.count)
+        #expect(DiffCollapsedContextController.isExpanded(group, expandedIDs: state.expandedCollapsedRowIDs))
+    }
+
     @Test func visibleWhitespacePreservesInlineBackgrounds() {
         let rendered = DiffCodeText.attributedString(
             text: "\tlet b = 3",

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3758,22 +3758,38 @@ let second = true
         #expect(helpTexts.contains("Discard hunk"))
     }
 
-    @Test func extractedHunkPresentationStateExpandsCollapsedContext() throws {
-        let group = try #require(collapsedContextModel().groups.first)
-        let state = DiffPanePresentationState()
-        let collapsedRows = DiffPaneRowProjection.visibleRows(
-            in: group,
-            expandedCollapsedRowIDs: state.expandedCollapsedRowIDs
+    @Test func extractedHunkRowExpandsCollapsedContextInMountedLegacyPane() throws {
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffPaneView(
+            model: collapsedContextModel(),
+            fileExtension: "swift",
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            verticalScrollMode: .staticHeight,
+            hunkActions: { _ in DiffPaneHunkActions() },
         )
+        .environment(\.theme, theme())
 
-        state.toggleCollapsedContext(in: group)
-        let expandedRows = DiffPaneRowProjection.visibleRows(
-            in: group,
-            expandedCollapsedRowIDs: state.expandedCollapsedRowIDs
-        )
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
 
-        #expect(expandedRows.count > collapsedRows.count)
-        #expect(DiffCollapsedContextController.isExpanded(group, expandedIDs: state.expandedCollapsedRowIDs))
+        #expect(visibleCodeTextViews(in: controller.view).count == 2)
+        let expandButton = try #require(allSubviews(of: controller.view).compactMap { $0 as? NSButton }.first {
+            $0.toolTip == "Expand context"
+        })
+        expandButton.performClick(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let buttons = allSubviews(of: controller.view).compactMap { $0 as? NSButton }
+        let helpTexts = buttons.compactMap { $0.toolTip }
+        #expect(helpTexts.contains("Collapse context"))
     }
 
     @Test func visibleWhitespacePreservesInlineBackgrounds() {

--- a/AlasTests/DiffReviewFileSectionEqualityTests.swift
+++ b/AlasTests/DiffReviewFileSectionEqualityTests.swift
@@ -46,6 +46,17 @@ struct DiffReviewFileSectionEqualityTests {
         #expect(base != section(file: file, canAddToReview: true))
     }
 
+    @Test func sharedPresentationStateParticipatesInEquality() {
+        let file = fileModel(path: "a.swift")
+        let state = AppKitDiffReviewFileState()
+        let base = section(file: file, presentationStateSignature: DiffReviewFilePresentationSignature(state))
+
+        state.showFullDiffOverride = true
+        let updated = section(file: file, presentationStateSignature: DiffReviewFilePresentationSignature(state))
+
+        #expect(base != updated)
+    }
+
     @Test func collectionsParticipateInEquality() {
         let file = fileModel(path: "a.swift")
         let base = section(file: file)
@@ -256,7 +267,8 @@ private func section(
     canAddToReview: Bool = false,
     draftCommentAvailability: [ReviewDraftCommentActionAvailability] = [],
     inlineFeedbackAvailability: [DiffReviewInlineFeedbackActionAvailability] = [],
-    draftCommentAgentTargets: [ReviewFeedbackAgentTarget] = []
+    draftCommentAgentTargets: [ReviewFeedbackAgentTarget] = [],
+    presentationStateSignature: DiffReviewFilePresentationSignature? = nil
 ) -> EquatableDiffReviewFileSection {
     EquatableDiffReviewFileSection(
         section: DiffReviewFileSection(
@@ -287,7 +299,8 @@ private func section(
         showWhitespace: showWhitespace,
         draftCommentAvailability: draftCommentAvailability,
         inlineFeedbackAvailability: inlineFeedbackAvailability,
-        draftCommentAgentTargets: draftCommentAgentTargets
+        draftCommentAgentTargets: draftCommentAgentTargets,
+        presentationStateSignature: presentationStateSignature
     )
 }
 

--- a/AlasTests/DiffReviewScrollSpyTests.swift
+++ b/AlasTests/DiffReviewScrollSpyTests.swift
@@ -91,6 +91,15 @@ struct DiffReviewScrollSpyTests {
         #expect(controller.acceptsScrollSpyUpdate(for: first))
     }
 
+    @Test func resetScrollCommandGenerationStartsNewToggleSequence() {
+        let file = DiffReviewFileID(namespace: "unstaged", path: "first.swift")
+        var controller = DiffReviewScrollCommandController()
+        _ = controller.command(to: file)
+        controller.reset()
+
+        #expect(controller.command(to: file).generation == 1)
+    }
+
     @Test func activeSelectionSkipsRedundantScrollUpdates() {
         let first = DiffReviewFileID(namespace: "unstaged", path: "first.swift")
         let second = DiffReviewFileID(namespace: "unstaged", path: "second.swift")

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -124,6 +124,214 @@ struct DiffReviewSurfaceTests {
         }
     }
 
+    @Test func appKitReviewWindowHandlesRailSameFileFallbackAndSuppressedNavigationUpdates() async throws {
+        let files = [
+            summary(path: "Sources/First.swift"),
+            summary(path: "Sources/Second.swift"),
+            summary(path: "Sources/Third.swift"),
+            summary(path: "Sources/Fourth.swift"),
+            summary(path: "Sources/Fifth.swift"),
+        ]
+        let session = loadedSession(summaries: files)
+        let model = AppKitReviewSurfaceWindowModel(session: session)
+        let sameFileFeedback = DiffReviewInlineFeedback(
+            id: "same-file-feedback",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Stay on this file.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: files[2].path, line: nil, side: .unknown),
+            evidenceItemID: "same-file-feedback"
+        )
+        let farDraft = draftComment(
+            id: "far-draft",
+            fileID: files[4].id,
+            path: files[4].path,
+            startLine: 1
+        )
+        model.inlineFeedbackByFileID = [files[2].id: [sameFileFeedback]]
+        model.draftCommentsByFileID = [files[4].id: [farDraft]]
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 150
+            )
+            let window = attachWindow(controller, width: 1_000, height: 150)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+            let scroller = try #require(appKitReviewScroller(in: controller.view))
+
+            model.inlineFeedbackCommand = .init(feedbackID: "same-file-feedback", fileID: files[2].id, generation: 1)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.25))
+            await drainSwiftUI(controller.view)
+            #expect(model.selected == files[2].id)
+
+            model.inlineFeedbackCommand = .init(feedbackID: "same-file-feedback", fileID: files[2].id, generation: 2)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.20))
+            await drainSwiftUI(controller.view)
+            #expect(model.selected == files[2].id)
+
+            model.inlineFeedbackCommand = .init(feedbackID: "missing-feedback", fileID: files[2].id, generation: 3)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.20))
+            await drainSwiftUI(controller.view)
+            #expect(model.selected == files[2].id)
+
+            model.inlineFeedbackCommand = nil
+            model.draftCommentCommand = .init(commentID: "far-draft", fileID: files[4].id, generation: 1)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            scroller.contentView.scroll(to: NSPoint(x: 0, y: 0))
+            scroller.reflectScrolledClipView(scroller.contentView)
+            await drainSwiftUI(controller.view)
+            #expect(model.selected == files[4].id)
+        }
+    }
+
+    @Test func appKitReviewWindowExpandsContextAndCompensatesInsertionsAboveViewport() async throws {
+        let firstSummary = summary(path: "Sources/Context.swift")
+        let secondSummary = summary(path: "Sources/Below.swift")
+        let collapsedFirst = fileSection(
+            summary: firstSummary,
+            displayModel: collapsedContextDisplayModel(filePath: firstSummary.path, hiddenRowCount: 8)
+        )
+        let second = fileSection(
+            summary: secondSummary,
+            displayModel: largeSingleGroupDisplayModel(rowCount: 40, filePath: secondSummary.path)
+        )
+        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [collapsedFirst, second]))
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 220
+            )
+            let window = attachWindow(controller, width: 1_000, height: 220)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+            let scroller = try #require(appKitReviewScroller(in: controller.view))
+
+            #expect(pressAccessibilityElement(
+                withAccessibilityIdentifier: "diff-review-rail-row-\(secondSummary.id.rawValue)",
+                in: controller.view
+            ))
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.25))
+            await drainSwiftUI(controller.view)
+            let beforeInsertionY = scroller.scrollY
+
+            let expandedFirst = fileSection(
+                summary: firstSummary,
+                displayModel: expandedContextDisplayModel(filePath: firstSummary.path, hiddenRowCount: 16)
+            )
+            model.session = loadedSession(files: [expandedFirst, second])
+            await drainSwiftUI(controller.view)
+
+            #expect(model.selected == secondSummary.id)
+            #expect(scroller.scrollY >= beforeInsertionY)
+        }
+    }
+
+    @Test func appKitReviewWindowPinsFocusedComposerWhileScrolling() async throws {
+        let file = fileSection(
+            summary: summary(path: "Sources/Composer.swift"),
+            displayModel: largeSingleGroupDisplayModel(rowCount: 80, filePath: "Sources/Composer.swift")
+        )
+        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [file]))
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 260
+            )
+            let window = attachWindow(controller, width: 1_000, height: 260)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+
+            try selectReviewLine(selectionIndex: 0, in: controller.view)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.20))
+            await drainSwiftUI(controller.view)
+            let composer = try #require(draftComposerTextView(in: controller.view))
+            #expect(window.firstResponder === composer)
+
+            let scroller = try #require(appKitReviewScroller(in: controller.view))
+            scroller.setScrollY(900, animated: false)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.10))
+            await drainSwiftUI(controller.view)
+            #expect(draftComposerTextView(in: controller.view) != nil)
+            #expect(window.firstResponder === composer)
+        }
+    }
+
+    @Test func appKitReviewWindowRoutesImageRetryAndStagedMutationActions() async throws {
+        let imageLoader = AppKitImageRetryRecorder()
+        let actions = AppKitReviewActionRecorder()
+        let imageSummary = summary(path: "Assets/logo.png", status: .modified)
+        let stagedSummary = summary(
+            path: "Sources/Staged.swift",
+            namespace: "staged",
+            groupID: "staged",
+            groupTitle: "Staged"
+        )
+        let imageFile = fileSection(
+            summary: imageSummary,
+            displayModel: nil,
+            imageProvider: DiffReviewImageProvider(
+                id: DiffReviewImageProviderID(
+                    source: .commit,
+                    repository: "/repo",
+                    beforeRevision: "abc123^",
+                    afterRevision: "abc123",
+                    beforePath: imageSummary.path,
+                    afterPath: imageSummary.path
+                ),
+                load: { await imageLoader.load() }
+            )
+        )
+        let stagedFile = fileSection(
+            summary: stagedSummary,
+            displayModel: displayModel(),
+            stagedMutationActions: DiffReviewStagedMutationActions(
+                unstageFile: { actions.unstagedFiles += 1 },
+                unstageHunk: { _ in actions.unstagedHunks += 1 },
+                isHunkUnstageEnabled: { _ in true }
+            )
+        )
+        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [imageFile, stagedFile]))
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 900
+            )
+            let window = attachWindow(controller, width: 1_000, height: 900)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.20))
+            await drainSwiftUI(controller.view)
+
+            #expect(imageLoader.loadCount == 1)
+            #expect(pressAccessibilityElement(
+                withAccessibilityIdentifier: "diff-review-image-retry-\(imageSummary.id.rawValue)",
+                in: controller.view
+            ))
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.20))
+            await drainSwiftUI(controller.view)
+            #expect(imageLoader.loadCount == 2)
+
+            let scroller = try #require(appKitReviewScroller(in: controller.view))
+            scroller.setScrollY(420, animated: false)
+            await drainSwiftUI(controller.view)
+            #expect(pressAccessibilityElement(
+                withAccessibilityIdentifier: "diff-review-unstage-file-\(stagedSummary.id.rawValue)",
+                in: controller.view
+            ))
+            #expect(actions.unstagedFiles == 1)
+        }
+    }
+
     @Test func draftComposerRefocusesForEachNewFocusRequestGeneration() async throws {
         let model = ReviewDraftComposerFocusModel()
         let controller = NSHostingController(
@@ -4142,6 +4350,91 @@ struct DiffReviewSurfaceTests {
         return DiffDisplayModel(filePath: filePath, groups: [group])
     }
 
+    private func collapsedContextDisplayModel(filePath: String, hiddenRowCount: Int) -> DiffDisplayModel {
+        let hiddenRows = (1...hiddenRowCount).map { line in
+            DiffDisplayRow(
+                id: "hidden-row-\(line)",
+                kind: .context,
+                old: nil,
+                new: diffLine(
+                    id: "hidden-line-\(line)",
+                    side: .new,
+                    newLine: line,
+                    text: "let hidden\(line) = \(line)",
+                    rowIndex: line - 1
+                ),
+                collapsedLineCount: 0
+            )
+        }
+        let collapsed = DiffDisplayRow(
+            id: "collapsed-context",
+            kind: .collapsed,
+            old: nil,
+            new: nil,
+            collapsedLineCount: hiddenRowCount,
+            collapsedRows: hiddenRows
+        )
+        let changed = DiffDisplayRow(
+            id: "visible-change",
+            kind: .add,
+            old: nil,
+            new: diffLine(
+                id: "visible-line",
+                side: .new,
+                newLine: hiddenRowCount + 1,
+                text: "let visible = true",
+                kind: .add,
+                rowIndex: hiddenRowCount
+            ),
+            collapsedLineCount: 0
+        )
+        let group = DiffDisplayGroup(
+            id: "context-group",
+            header: "@@ -1,\(hiddenRowCount + 1) +1,\(hiddenRowCount + 1) @@",
+            sourceHunk: parsedDiff().hunks[0],
+            rows: [collapsed, changed]
+        )
+        return DiffDisplayModel(filePath: filePath, groups: [group])
+    }
+
+    private func expandedContextDisplayModel(filePath: String, hiddenRowCount: Int) -> DiffDisplayModel {
+        let collapsedModel = collapsedContextDisplayModel(filePath: filePath, hiddenRowCount: hiddenRowCount)
+        let group = collapsedModel.groups[0]
+        let expandedRows = group.rows.flatMap { row in
+            row.kind == .collapsed ? [row] + row.collapsedRows : [row]
+        }
+        return DiffDisplayModel(
+            filePath: filePath,
+            groups: [
+                DiffDisplayGroup(
+                    id: group.id,
+                    header: group.header,
+                    sourceHunk: group.sourceHunk,
+                    rows: expandedRows
+                ),
+            ]
+        )
+    }
+
+    private func fileSection(
+        summary: DiffReviewFileSummary,
+        displayModel: DiffDisplayModel?,
+        imageProvider: DiffReviewImageProvider? = nil,
+        stagedMutationActions: DiffReviewStagedMutationActions? = nil
+    ) -> DiffReviewFileSectionModel {
+        var file = DiffReviewFileSectionModel(
+            summary: summary,
+            parsedDiff: displayModel == nil ? nil : parsedDiff(),
+            displayModel: displayModel,
+            placeholderMessage: displayModel == nil && imageProvider == nil ? "No diff." : nil,
+            openFile: nil,
+            contextProvider: nil,
+            imageProvider: imageProvider
+        )
+        file.stagedMutationActions = stagedMutationActions
+        return file
+    }
+
     private func loadedSession(summaries: [DiffReviewFileSummary]) -> DiffReviewLoadedSession {
         DiffReviewLoadedSession(
             files: summaries.map { summary in
@@ -4155,6 +4448,13 @@ struct DiffReviewSurfaceTests {
                 )
             },
             summary: DiffReviewSessionModel(files: summaries, groupsEnabled: false)
+        )
+    }
+
+    private func loadedSession(files: [DiffReviewFileSectionModel]) -> DiffReviewLoadedSession {
+        DiffReviewLoadedSession(
+            files: files,
+            summary: DiffReviewSessionModel(files: files.map(\.summary), groupsEnabled: false)
         )
     }
 
@@ -4347,6 +4647,14 @@ struct DiffReviewSurfaceTests {
         return false
     }
 
+    private func pressButton(withToolTip toolTip: String, in view: NSView) -> Bool {
+        for button in allSubviews(of: view).compactMap({ $0 as? NSButton }) where button.toolTip == toolTip {
+            button.performClick(nil)
+            return true
+        }
+        return false
+    }
+
     private func selectReviewLine(selectionIndex: Int, in view: NSView) throws {
         let selectableRows = allSubviews(of: view)
             .compactMap { $0 as? DiffPaneLineNumberRulerView }
@@ -4530,4 +4838,25 @@ private final class ReviewBundleActionRecorder: @unchecked Sendable {
     var copied: ReviewFeedbackBundle?
     var sent: ReviewFeedbackBundle?
     var sentTarget: ReviewFeedbackAgentTarget?
+}
+
+@MainActor
+private final class AppKitImageRetryRecorder {
+    private(set) var loadCount = 0
+
+    func load() async -> ImageDiffPair {
+        loadCount += 1
+        return ImageDiffPair(
+            before: .failed(.init(message: "Could not decode before image")),
+            after: .missing,
+            oldPath: nil,
+            kind: .deleted
+        )
+    }
+}
+
+@MainActor
+private final class AppKitReviewActionRecorder {
+    var unstagedFiles = 0
+    var unstagedHunks = 0
 }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -9,6 +9,11 @@ import Testing
 struct DiffReviewSurfaceTests {
     private func theme() -> Theme { try! ThemeStore().current }
 
+    @Test func appKitScrollerSwitchMatchesRuntimeFlag() {
+        #expect(DiffReviewSurface.usesAppKitScroller(flagEnabled: true))
+        #expect(!DiffReviewSurface.usesAppKitScroller(flagEnabled: false))
+    }
+
     @Test func draftComposerRefocusesForEachNewFocusRequestGeneration() async throws {
         let model = ReviewDraftComposerFocusModel()
         let controller = NSHostingController(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -403,6 +403,39 @@ struct DiffReviewSurfaceTests {
         }
     }
 
+    @Test func appKitReviewWindowRoutesStagedHunkMutationAction() async throws {
+        let actions = AppKitReviewActionRecorder()
+        let stagedSummary = summary(
+            path: "Sources/StagedHunk.swift",
+            namespace: "staged",
+            groupID: "staged",
+            groupTitle: "Staged"
+        )
+        let stagedFile = fileSection(
+            summary: stagedSummary,
+            displayModel: displayModel(),
+            stagedMutationActions: DiffReviewStagedMutationActions(
+                unstageHunk: { _ in actions.unstagedHunks += 1 },
+                isHunkUnstageEnabled: { _ in true }
+            )
+        )
+        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [stagedFile]))
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 420
+            )
+            let window = attachWindow(controller, width: 1_000, height: 420)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+
+            #expect(pressButton(withToolTip: "Drop from commit", in: controller.view))
+            #expect(actions.unstagedHunks == 1)
+        }
+    }
+
     @Test func draftComposerRefocusesForEachNewFocusRequestGeneration() async throws {
         let model = ReviewDraftComposerFocusModel()
         let controller = NSHostingController(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -189,6 +189,51 @@ struct DiffReviewSurfaceTests {
         }
     }
 
+    @Test func appKitReviewWindowScrollsSameFileItemsAndMissingTargetsToFallback() async throws {
+        let summary = summary(path: "Sources/LargeSameFile.swift")
+        let file = fileSection(
+            summary: summary,
+            displayModel: largeDisplayModel(groupCount: 80, filePath: summary.path)
+        )
+        let feedback = DiffReviewInlineFeedback(
+            id: "deep-feedback",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Review the deep line.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: summary.path, line: 80, side: .new),
+            evidenceItemID: "deep-feedback"
+        )
+        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [file]))
+        model.inlineFeedbackByFileID = [file.id: [feedback]]
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 260
+            )
+            let window = attachWindow(controller, width: 1_000, height: 260)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+            let scroller = try #require(appKitReviewScroller(in: controller.view))
+
+            model.inlineFeedbackCommand = .init(feedbackID: "deep-feedback", fileID: file.id, generation: 1)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.30))
+            await drainSwiftUI(controller.view)
+            let deepTargetY = scroller.scrollY
+            #expect(deepTargetY > 0)
+            #expect(model.selected == file.id)
+
+            model.inlineFeedbackCommand = .init(feedbackID: "missing-feedback", fileID: file.id, generation: 2)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.30))
+            await drainSwiftUI(controller.view)
+            #expect(scroller.scrollY < deepTargetY)
+            #expect(model.selected == file.id)
+        }
+    }
+
     @Test func appKitReviewWindowExpandsContextAndCompensatesInsertionsAboveViewport() async throws {
         let firstSummary = summary(path: "Sources/Context.swift")
         let secondSummary = summary(path: "Sources/Below.swift")
@@ -230,6 +275,34 @@ struct DiffReviewSurfaceTests {
 
             #expect(model.selected == secondSummary.id)
             #expect(scroller.scrollY >= beforeInsertionY)
+        }
+    }
+
+    @Test func appKitReviewWindowExpandsContextThroughRenderedControl() async throws {
+        let summary = summary(path: "Sources/ContextControl.swift")
+        let file = fileSection(
+            summary: summary,
+            displayModel: collapsedContextDisplayModel(filePath: summary.path, hiddenRowCount: 8)
+        )
+        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [file]))
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 420
+            )
+            let window = attachWindow(controller, width: 1_000, height: 420)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+            let scroller = try #require(appKitReviewScroller(in: controller.view))
+            let collapsedHeight = scroller.documentView?.frame.height ?? 0
+
+            #expect(pressButton(withToolTip: "Expand context", in: controller.view))
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.20))
+            await drainSwiftUI(controller.view)
+
+            #expect((scroller.documentView?.frame.height ?? 0) > collapsedHeight)
         }
     }
 
@@ -543,6 +616,49 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "diff-review-image-loading-\(file.id.rawValue)", in: controller.view) == nil)
         #expect(subview(withAccessibilityIdentifier: "diff-review-image-failure-\(file.id.rawValue)", in: controller.view) != nil)
         #expect(subview(withAccessibilityIdentifier: "diff-review-image-retry-\(file.id.rawValue)", in: controller.view) != nil)
+    }
+
+    @Test func legacyFileSectionImageProviderLoadsOnce() async {
+        let imageLoader = AppKitImageRetryRecorder()
+        let file = DiffReviewFileSectionModel(
+            summary: summary(path: "Assets/legacy.png", status: .modified),
+            parsedDiff: nil,
+            displayModel: nil,
+            placeholderMessage: nil,
+            openFile: nil,
+            contextProvider: nil,
+            imageProvider: DiffReviewImageProvider(
+                id: DiffReviewImageProviderID(
+                    source: .commit,
+                    repository: "/repo",
+                    beforeRevision: "abc123^",
+                    afterRevision: "abc123",
+                    beforePath: "Assets/legacy.png",
+                    afterPath: "Assets/legacy.png"
+                ),
+                load: { await imageLoader.load() }
+            )
+        )
+        var layout = DiffLayoutMode.split
+        var wrap = false
+        var whitespace = false
+        let view = DiffReviewFileSection(
+            file: file,
+            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
+            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
+            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            showsSourceBadge: false,
+            allowsDraftCommentCreation: false
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 900, height: 520)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.20))
+        await drainSwiftUI(controller.view)
+
+        #expect(imageLoader.loadCount == 1)
     }
 
     @Test func imageFileSectionRendersProviderThreadsAndAnnotations() async {
@@ -4648,7 +4764,8 @@ struct DiffReviewSurfaceTests {
     }
 
     private func pressButton(withToolTip toolTip: String, in view: NSView) -> Bool {
-        for button in allSubviews(of: view).compactMap({ $0 as? NSButton }) where button.toolTip == toolTip {
+        for button in allSubviews(of: view).compactMap({ $0 as? NSButton })
+            where button.toolTip == toolTip || button.accessibilityLabel() == toolTip {
             button.performClick(nil)
             return true
         }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -189,51 +189,6 @@ struct DiffReviewSurfaceTests {
         }
     }
 
-    @Test func appKitReviewWindowScrollsSameFileItemsAndMissingTargetsToFallback() async throws {
-        let summary = summary(path: "Sources/LargeSameFile.swift")
-        let file = fileSection(
-            summary: summary,
-            displayModel: largeDisplayModel(groupCount: 80, filePath: summary.path)
-        )
-        let feedback = DiffReviewInlineFeedback(
-            id: "deep-feedback",
-            providerName: "GitHub",
-            author: "reviewer",
-            bodyPreview: "Review the deep line.",
-            status: .actionable,
-            providerURL: nil,
-            anchor: DiffReviewInlineFeedbackAnchor(path: summary.path, line: 80, side: .new),
-            evidenceItemID: "deep-feedback"
-        )
-        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [file]))
-        model.inlineFeedbackByFileID = [file.id: [feedback]]
-
-        try await withAppKitReviewScroller {
-            let controller = host(
-                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
-                width: 1_000,
-                height: 260
-            )
-            let window = attachWindow(controller, width: 1_000, height: 260)
-            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
-            await drainSwiftUI(controller.view)
-            let scroller = try #require(appKitReviewScroller(in: controller.view))
-
-            model.inlineFeedbackCommand = .init(feedbackID: "deep-feedback", fileID: file.id, generation: 1)
-            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.30))
-            await drainSwiftUI(controller.view)
-            let deepTargetY = scroller.scrollY
-            #expect(deepTargetY > 0)
-            #expect(model.selected == file.id)
-
-            model.inlineFeedbackCommand = .init(feedbackID: "missing-feedback", fileID: file.id, generation: 2)
-            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.30))
-            await drainSwiftUI(controller.view)
-            #expect(scroller.scrollY < deepTargetY)
-            #expect(model.selected == file.id)
-        }
-    }
-
     @Test func appKitReviewWindowExpandsContextAndCompensatesInsertionsAboveViewport() async throws {
         let firstSummary = summary(path: "Sources/Context.swift")
         let secondSummary = summary(path: "Sources/Below.swift")
@@ -271,6 +226,49 @@ struct DiffReviewSurfaceTests {
                 displayModel: expandedContextDisplayModel(filePath: firstSummary.path, hiddenRowCount: 16)
             )
             model.session = loadedSession(files: [expandedFirst, second])
+            await drainSwiftUI(controller.view)
+
+            #expect(model.selected == secondSummary.id)
+            #expect(scroller.scrollY >= beforeInsertionY)
+        }
+    }
+
+    @Test func appKitReviewWindowCompensatesCommentInsertionAboveViewport() async throws {
+        let firstSummary = summary(path: "Sources/CommentAbove.swift")
+        let secondSummary = summary(path: "Sources/CommentBelow.swift")
+        let first = fileSection(
+            summary: firstSummary,
+            displayModel: largeSingleGroupDisplayModel(rowCount: 30, filePath: firstSummary.path)
+        )
+        let second = fileSection(
+            summary: secondSummary,
+            displayModel: largeSingleGroupDisplayModel(rowCount: 30, filePath: secondSummary.path)
+        )
+        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [first, second]))
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 260
+            )
+            let window = attachWindow(controller, width: 1_000, height: 260)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+            let scroller = try #require(appKitReviewScroller(in: controller.view))
+
+            #expect(pressAccessibilityElement(
+                withAccessibilityIdentifier: "diff-review-rail-row-\(secondSummary.id.rawValue)",
+                in: controller.view
+            ))
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.30))
+            await drainSwiftUI(controller.view)
+            let beforeInsertionY = scroller.scrollY
+            #expect(model.selected == secondSummary.id)
+
+            model.draftCommentsByFileID = [
+                first.id: [draftComment(id: "above-draft", fileID: first.id, path: first.summary.path, startLine: 1)],
+            ]
             await drainSwiftUI(controller.view)
 
             #expect(model.selected == secondSummary.id)

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -7,11 +7,121 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct DiffReviewSurfaceTests {
+    init() {
+        AppKitDiffScrollerFlag.setOverride(false)
+    }
+
     private func theme() -> Theme { try! ThemeStore().current }
 
     @Test func appKitScrollerSwitchMatchesRuntimeFlag() {
         #expect(DiffReviewSurface.usesAppKitScroller(flagEnabled: true))
         #expect(!DiffReviewSurface.usesAppKitScroller(flagEnabled: false))
+    }
+
+    @Test func appKitReviewWindowConnectsViewportAndReviewNavigationCommands() async throws {
+        let files = [
+            summary(path: "Sources/First.swift"),
+            summary(path: "Sources/Second.swift"),
+            summary(path: "Sources/Third.swift"),
+            summary(path: "Sources/Fourth.swift"),
+            summary(path: "Sources/Fifth.swift"),
+        ]
+        let session = loadedSession(summaries: files)
+        let model = AppKitReviewSurfaceWindowModel(session: session)
+        let feedback = DiffReviewInlineFeedback(
+            id: "feedback",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Feedback",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: files[3].path, line: 1, side: .new),
+            evidenceItemID: "feedback"
+        )
+        let draft = draftComment(
+            id: "draft",
+            fileID: files[4].id,
+            path: files[4].path,
+            startLine: 1
+        )
+        model.inlineFeedbackByFileID = [files[3].id: [feedback]]
+        model.draftCommentsByFileID = [files[4].id: [draft]]
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 160
+            )
+            let window = attachWindow(controller, width: 1_000, height: 160)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+            let scroller = try #require(appKitReviewScroller(in: controller.view))
+
+            scroller.contentView.scroll(to: NSPoint(x: 0, y: 250))
+            scroller.reflectScrolledClipView(scroller.contentView)
+            await drainSwiftUI(controller.view)
+            #expect(model.selected == files[2].id)
+
+            model.inlineFeedbackCommand = .init(feedbackID: "feedback", fileID: files[3].id, generation: 1)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+            await drainSwiftUI(controller.view)
+            #expect(model.selected == files[3].id)
+
+            model.inlineFeedbackCommand = nil
+            model.draftCommentCommand = .init(commentID: "draft", fileID: files[4].id, generation: 1)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+            await drainSwiftUI(controller.view)
+            #expect(model.selected == files[4].id)
+        }
+    }
+
+    @Test func appKitReviewWindowRetainsSurfaceUpdatesAcrossPreferencesSessionReplacementAndToggle() async throws {
+        let initial = loadedSession(summaries: [
+            summary(path: "Sources/Initial.swift"),
+            summary(path: "Sources/InitialTwo.swift"),
+        ])
+        let replacement = loadedSession(summaries: [
+            summary(path: "Sources/Replacement.swift"),
+            summary(path: "Sources/ReplacementTwo.swift"),
+        ])
+        let model = AppKitReviewSurfaceWindowModel(session: initial)
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 260
+            )
+            let window = attachWindow(controller, width: 1_000, height: 260)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+            let originalScroller = try #require(appKitReviewScroller(in: controller.view))
+
+            model.layout = .split
+            model.wrap = true
+            model.whitespace = true
+            await drainSwiftUI(controller.view)
+            #expect(appKitReviewScroller(in: controller.view) === originalScroller)
+
+            model.session = replacement
+            await drainSwiftUI(controller.view)
+            #expect(model.selected == replacement.files[0].id)
+            #expect(subview(
+                withAccessibilityIdentifier: "diff-review-rail-row-\(replacement.files[0].id.rawValue)",
+                in: controller.view
+            ) != nil)
+
+            AppKitDiffScrollerFlag.setOverride(false)
+            await drainSwiftUI(controller.view)
+            #expect(appKitReviewScroller(in: controller.view) == nil)
+
+            AppKitDiffScrollerFlag.setOverride(true)
+            await drainSwiftUI(controller.view)
+            let rebuiltScroller = try #require(appKitReviewScroller(in: controller.view))
+            #expect(ObjectIdentifier(rebuiltScroller) != ObjectIdentifier(originalScroller))
+            #expect(rebuiltScroller.scrollY == 0)
+        }
     }
 
     @Test func draftComposerRefocusesForEachNewFocusRequestGeneration() async throws {
@@ -4163,6 +4273,43 @@ struct DiffReviewSurfaceTests {
         return controller
     }
 
+    private func attachWindow<Content: View>(
+        _ controller: NSHostingController<Content>,
+        width: CGFloat,
+        height: CGFloat
+    ) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: width, height: height),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        controller.view.frame = window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: width, height: height)
+        controller.view.layoutSubtreeIfNeeded()
+        return window
+    }
+
+    private func appKitReviewScroller(in view: NSView) -> AppKitDiffScrollView? {
+        allSubviews(of: view).compactMap { $0 as? AppKitDiffScrollView }.first
+    }
+
+    private func withAppKitReviewScroller(
+        _ body: () async throws -> Void
+    ) async rethrows {
+        let originalOverride = AppKitDiffScrollerFlag.readOverride(from: .standard)
+        defer {
+            if let originalOverride {
+                AppKitDiffScrollerFlag.setOverride(originalOverride)
+            } else {
+                UserDefaults.standard.removeObject(forKey: AppKitDiffScrollerFlag.defaultsKey)
+                NotificationCenter.default.post(name: AppKitDiffScrollerFlag.overrideDidChangeNotification, object: nil)
+            }
+        }
+        AppKitDiffScrollerFlag.setOverride(true)
+        try await body()
+    }
+
     private func drainSwiftUI(_ view: NSView) async {
         for _ in 0..<6 {
             view.layoutSubtreeIfNeeded()
@@ -4335,6 +4482,48 @@ private struct ReviewDraftComposerFocusSiblingView: NSViewRepresentable {
 
 private final class FocusSinkView: NSView {
     override var acceptsFirstResponder: Bool { true }
+}
+
+@Observable
+@MainActor
+private final class AppKitReviewSurfaceWindowModel {
+    var session: DiffReviewLoadedSession
+    var selected: DiffReviewFileID?
+    var railCollapsed = false
+    var layout = DiffLayoutMode.stacked
+    var wrap = false
+    var whitespace = false
+    var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
+    var draftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] = [:]
+    var inlineFeedbackCommand: DiffReviewInlineFeedbackScrollCommand?
+    var draftCommentCommand: DiffReviewDraftCommentScrollCommand?
+
+    init(session: DiffReviewLoadedSession) {
+        self.session = session
+        selected = session.files.first?.id
+    }
+}
+
+@MainActor
+private struct AppKitReviewSurfaceWindowHarness: View {
+    let model: AppKitReviewSurfaceWindowModel
+
+    var body: some View {
+        DiffReviewSurface(
+            session: model.session,
+            selectedFileID: Binding(get: { model.selected }, set: { model.selected = $0 }),
+            railCollapsed: Binding(get: { model.railCollapsed }, set: { model.railCollapsed = $0 }),
+            layoutMode: Binding(get: { model.layout }, set: { model.layout = $0 }),
+            wrapLines: Binding(get: { model.wrap }, set: { model.wrap = $0 }),
+            showWhitespace: Binding(get: { model.whitespace }, set: { model.whitespace = $0 }),
+            codeFontFamily: "",
+            codeFontSize: 13,
+            inlineFeedbackByFileID: model.inlineFeedbackByFileID,
+            inlineFeedbackScrollCommand: model.inlineFeedbackCommand,
+            draftCommentsByFileID: model.draftCommentsByFileID,
+            draftCommentScrollCommand: model.draftCommentCommand
+        )
+    }
 }
 
 private final class ReviewBundleActionRecorder: @unchecked Sendable {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -7,10 +7,6 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct DiffReviewSurfaceTests {
-    init() {
-        AppKitDiffScrollerFlag.setOverride(false)
-    }
-
     private func theme() -> Theme { try! ThemeStore().current }
 
     @Test func appKitScrollerSwitchMatchesRuntimeFlag() {
@@ -947,49 +943,33 @@ struct DiffReviewSurfaceTests {
             openFile: nil,
             contextProvider: nil
         )
-        var layout = DiffLayoutMode.stacked
-        var wrap = false
-        var whitespace = false
-        let view = DiffReviewFileSection(
+        let presentationState = AppKitDiffReviewFileState()
+        let input = AppKitDiffReviewRowInput(
             file: file,
-            layoutMode: Binding(get: { layout }, set: { layout = $0 }),
-            wrapLines: Binding(get: { wrap }, set: { wrap = $0 }),
-            showWhitespace: Binding(get: { whitespace }, set: { whitespace = $0 }),
-            codeFontFamily: "",
-            codeFontSize: 13,
-            showsSourceBadge: false
+            state: presentationState,
+            theme: theme()
         )
-        .environment(\.theme, theme())
 
-        let controller = NSHostingController(rootView: view)
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 900, height: 520),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
+        let firstAnchor = DiffReviewLineAnchor(
+            path: file.summary.path,
+            side: .new,
+            line: 1,
+            rowIndex: 0,
+            selectedText: "let old = 1"
         )
-        window.contentViewController = controller
-        controller.view.frame = window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 900, height: 520)
-        controller.view.layoutSubtreeIfNeeded()
-        defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+        input.beginPendingDraft(at: firstAnchor)
+        let firstGeneration = presentationState.draftComposerFocusRequestGeneration
 
-        await drainSwiftUI(controller.view)
-        try selectReviewLine(selectionIndex: 0, in: controller.view)
-        await drainSwiftUI(controller.view)
-
-        let firstComposer = try #require(draftComposerTextView(in: controller.view))
-        #expect(window.firstResponder === firstComposer)
-
-        let sink = FocusSinkView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
-        controller.view.addSubview(sink)
-        #expect(window.makeFirstResponder(sink))
-        #expect(window.firstResponder !== firstComposer)
-
-        try selectReviewLine(selectionIndex: 1, in: controller.view)
-        await drainSwiftUI(controller.view)
-
-        let relocatedComposer = try #require(draftComposerTextView(in: controller.view))
-        #expect(window.firstResponder === relocatedComposer)
+        let relocatedAnchor = DiffReviewLineAnchor(
+            path: file.summary.path,
+            side: .new,
+            line: 2,
+            rowIndex: 1,
+            selectedText: "let new = 2"
+        )
+        input.beginPendingDraft(at: relocatedAnchor)
+        #expect(presentationState.pendingDraftAnchor == relocatedAnchor)
+        #expect(presentationState.draftComposerFocusRequestGeneration > firstGeneration)
     }
 
     @Test func stackedFileSectionBoundsHunkMaterializationToScrollViewport() throws {

--- a/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
+++ b/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
@@ -70,11 +70,38 @@ struct GGSplitPreviewRowPlanTests {
         #expect(!GGSplitCommitTabView.usesAppKitPreviewScroller(flagEnabled: false))
     }
 
+    @Test("text hunk state survives a preview rebuild and is pruned with its file")
+    func textStateRetentionAndPruning() {
+        let imageStore = GGSplitPreviewImageStore()
+        let presentationStore = GGSplitPreviewPresentationStore()
+        let preview = GGSplitPreview(files: [previewFile(path: "Sources/Retained.swift")], nonTextualFiles: [])
+        _ = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "remainder", preview: preview, showsResultingImages: false,
+            imageStore: imageStore, presentationStore: presentationStore
+        ))
+        let state = presentationStore.state(previewID: "remainder", filePath: "Sources/Retained.swift")
+        state.expandedCollapsedRowIDs = ["collapsed"]
+
+        _ = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "remainder", preview: preview, showsResultingImages: false,
+            imageStore: imageStore, presentationStore: presentationStore
+        ))
+        #expect(presentationStore.state(previewID: "remainder", filePath: "Sources/Retained.swift") === state)
+        #expect(state.expandedCollapsedRowIDs == ["collapsed"])
+
+        _ = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "remainder", preview: .init(files: [], nonTextualFiles: []), showsResultingImages: false,
+            imageStore: imageStore, presentationStore: presentationStore
+        ))
+        #expect(presentationStore.keysForTests.isEmpty)
+    }
+
     private func input(
         previewID: String,
         preview: GGSplitPreview,
         showsResultingImages: Bool,
-        imageStore: GGSplitPreviewImageStore
+        imageStore: GGSplitPreviewImageStore,
+        presentationStore: GGSplitPreviewPresentationStore = GGSplitPreviewPresentationStore()
     ) -> GGSplitPreviewRowPlanInput {
         GGSplitPreviewRowPlanInput(
             previewID: previewID,
@@ -88,7 +115,8 @@ struct GGSplitPreviewRowPlanTests {
             codeFontFamily: "SF Mono",
             codeFontSize: 13,
             theme: try! ThemeStore().current,
-            imageStore: imageStore
+            imageStore: imageStore,
+            presentationStore: presentationStore
         )
     }
 

--- a/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
+++ b/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
@@ -90,10 +90,16 @@ struct GGSplitPreviewRowPlanTests {
         #expect(state.expandedCollapsedRowIDs == ["collapsed"])
 
         _ = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "first-commit", preview: .init(files: [previewFile(path: "Sources/First.swift")], nonTextualFiles: []),
+            showsResultingImages: false, imageStore: imageStore, presentationStore: presentationStore
+        ))
+        #expect(presentationStore.state(previewID: "remainder", filePath: "Sources/Retained.swift") === state)
+
+        _ = GGSplitPreviewRowPlanBuilder.build(input: input(
             previewID: "remainder", preview: .init(files: [], nonTextualFiles: []), showsResultingImages: false,
             imageStore: imageStore, presentationStore: presentationStore
         ))
-        #expect(presentationStore.keysForTests.isEmpty)
+        #expect(presentationStore.keysForTests == ["first-commit:Sources/First.swift"])
     }
 
     private func input(

--- a/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
+++ b/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
@@ -102,6 +102,36 @@ struct GGSplitPreviewRowPlanTests {
         #expect(presentationStore.keysForTests == ["first-commit:Sources/First.swift"])
     }
 
+    @Test("text hunks preserve standalone pane outer vertical padding")
+    func textHunksPreserveOuterVerticalPadding() throws {
+        let previewFile = previewFile(path: "Sources/Padded.swift")
+        let plan = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "remainder",
+            preview: .init(files: [previewFile], nonTextualFiles: []),
+            showsResultingImages: false,
+            imageStore: GGSplitPreviewImageStore()
+        ))
+        let hunk = try #require(plan.rows.first { $0.id.contains(":hunk:") })
+        let model = DiffDisplayModelBuilder.build(diff: previewFile.diff, filePath: previewFile.path)
+        let raw = try #require(DiffPaneRowPlanBuilder.build(
+            input: .init(
+                model: model,
+                fileExtension: LanguageRegistry.highlighterExtension(forPath: previewFile.path),
+                layoutMode: .stacked,
+                wrapLines: false,
+                showWhitespace: false,
+                codeFontFamily: "SF Mono",
+                codeFontSize: 13,
+                theme: try! ThemeStore().current,
+                allowsReviewLineSelection: false,
+                hunkActions: { _ in DiffPaneHunkActions() }
+            ),
+            state: DiffPanePresentationState()
+        ).rows.first)
+
+        #expect(hunk.estimatedHeight == raw.estimatedHeight + 20)
+    }
+
     private func input(
         previewID: String,
         preview: GGSplitPreview,

--- a/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
+++ b/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("GG split preview row plan")
+struct GGSplitPreviewRowPlanTests {
+    @Test("text files, images, and other files retain legacy order with pane-scoped IDs")
+    func rowOrderAndIdentity() {
+        let store = GGSplitPreviewImageStore()
+        let preview = GGSplitPreview(
+            files: [previewFile(path: "Sources/First.swift"), previewFile(path: "Sources/Second.swift")],
+            nonTextualFiles: ["Assets/result.png", "Assets/archive.bin"]
+        )
+
+        let plan = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "remainder",
+            preview: preview,
+            showsResultingImages: true,
+            imageStore: store
+        ))
+        let ids = plan.rows.map(\.id)
+
+        let firstHeader = try! #require(ids.firstIndex(of: "gg-preview:remainder:file:Sources/First.swift:header"))
+        let secondHeader = try! #require(ids.firstIndex(of: "gg-preview:remainder:file:Sources/Second.swift:header"))
+        let image = try! #require(ids.firstIndex(of: "gg-preview:remainder:image:Assets/result.png"))
+        let other = try! #require(ids.firstIndex(of: "gg-preview:remainder:other:Assets/archive.bin"))
+        #expect(firstHeader < secondHeader)
+        #expect(secondHeader < image)
+        #expect(image < other)
+        #expect(ids.filter { $0.contains("Sources/First.swift:hunk:") }.isEmpty == false)
+        #expect(ids.filter { $0.contains("Sources/Second.swift:hunk:") }.isEmpty == false)
+        #expect(Set(ids).count == ids.count)
+
+        let firstPane = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "first-commit",
+            preview: preview,
+            showsResultingImages: true,
+            imageStore: GGSplitPreviewImageStore()
+        ))
+        #expect(Set(ids).isDisjoint(with: Set(firstPane.rows.map(\.id))))
+    }
+
+    @Test("image state survives plan rebuilds and removed paths are pruned")
+    func imageStateRetentionAndPruning() throws {
+        let store = GGSplitPreviewImageStore()
+        let original = GGSplitPreview(files: [], nonTextualFiles: ["a.png", "b.png"])
+        _ = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "remainder", preview: original, showsResultingImages: true, imageStore: store
+        ))
+        let key = GGSplitPreviewImageKey(
+            worktreePath: URL(fileURLWithPath: "/repo"), revision: "abc", relativePath: "a.png"
+        )
+        let retained = store.state(for: key)
+
+        _ = GGSplitPreviewRowPlanBuilder.build(input: input(
+            previewID: "remainder",
+            preview: .init(files: [], nonTextualFiles: ["a.png"]),
+            showsResultingImages: true,
+            imageStore: store
+        ))
+
+        #expect(store.state(for: key) === retained)
+        #expect(store.keysForTests == [key])
+    }
+
+    @Test("feature flag selects only the native preview scroller")
+    func featureFlagSwitch() {
+        #expect(GGSplitCommitTabView.usesAppKitPreviewScroller(flagEnabled: true))
+        #expect(!GGSplitCommitTabView.usesAppKitPreviewScroller(flagEnabled: false))
+    }
+
+    private func input(
+        previewID: String,
+        preview: GGSplitPreview,
+        showsResultingImages: Bool,
+        imageStore: GGSplitPreviewImageStore
+    ) -> GGSplitPreviewRowPlanInput {
+        GGSplitPreviewRowPlanInput(
+            previewID: previewID,
+            preview: preview,
+            showsResultingImages: showsResultingImages,
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            revision: "abc",
+            layoutMode: .stacked,
+            wrapLines: false,
+            showWhitespace: false,
+            codeFontFamily: "SF Mono",
+            codeFontSize: 13,
+            theme: try! ThemeStore().current,
+            imageStore: imageStore
+        )
+    }
+
+    private func previewFile(path: String) -> GGSplitPreviewFile {
+        let diff = DiffParser.parse("""
+        @@ -1 +1 @@
+        -let old = 1
+        +let new = 1
+        """)
+        return .init(path: path, hunkIDs: [path], diff: diff)
+    }
+}

--- a/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
+++ b/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
@@ -80,7 +80,7 @@ struct GGSplitPreviewRowPlanTests {
             imageStore: imageStore, presentationStore: presentationStore
         ))
         let state = presentationStore.state(previewID: "remainder", filePath: "Sources/Retained.swift")
-        state.expandedCollapsedRowIDs = ["collapsed"]
+        state.setExpandedCollapsedRowIDs(["collapsed"])
 
         _ = GGSplitPreviewRowPlanBuilder.build(input: input(
             previewID: "remainder", preview: preview, showsResultingImages: false,

--- a/docs/superpowers/plans/2026-08-06-appkit-diff-review-scrollers.md
+++ b/docs/superpowers/plans/2026-08-06-appkit-diff-review-scrollers.md
@@ -1,0 +1,930 @@
+# AppKit Diff and Review Scrollers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace SwiftUI-owned vertical scrolling in Alas diff and review surfaces with one feature-flagged AppKit hosted-row virtualization engine while preserving the legacy path and all existing behavior.
+
+**Architecture:** A diff-specific `NSScrollView` owns geometry, viewport tracking, stable-ID reconciliation, offset compensation, and pooled `NSHostingView` rows. Shared non-scrolling row views feed three adapters: internally scrolling `DiffPaneView`, the multi-file `DiffReviewSurface`, and the GG split preview. Keyed presentation-state objects keep interactive state alive while rows recycle.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AppKit (`NSScrollView`, `NSHostingView`), Swift Testing, XcodeGen, SwiftFormat, macOS 15+
+
+## Global Constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Keep the existing AppKit diff text renderer and TextKit behavior unchanged.
+- Do not modify or generalize the ACP transcript scroller; port only proven algorithms into diff-specific types.
+- Preserve text/image rendering, comments, drafts, focus, selection, LSP behavior, context expansion, mutations, accessibility, and render budgets.
+- Use one `alas.diff.appKitScroller` override: enabled by default in debug builds and disabled by default in release builds.
+- Runtime flag changes rebuild scrolling subtrees and deliberately reset scroll position while preserving parent-owned selections and drafts.
+- Do not add analytics, persisted presentation state, wire/schema changes, or elapsed-time CI thresholds.
+- Run `rtk xcodegen` after adding source/test files and commit the generated project changes with the owning task.
+- Make each implementation task test-first and commit it before starting the next task.
+
+---
+
+## File Map
+
+Create these focused engine files under `Alas/Sources/Center/Diff/Scroller/`:
+
+- `AppKitDiffScrollerFlag.swift` — experiment resolution, persistence, and notification.
+- `AppKitDiffRowSpec.swift` — row IDs, equality tokens, plans, retention, scroll requests, and callback-independent metadata.
+- `AppKitDiffTilingController.swift` — ordered geometry, anchor calculation, mount bands, active-owner lookup, and target offsets.
+- `AppKitDiffRowHostingView.swift` — fixed-width SwiftUI measurement and intrinsic-size invalidation.
+- `AppKitDiffRowHostingPool.swift` — mounted entries and reusable host storage.
+- `AppKitDiffScrollView.swift` — flipped AppKit document and native scroll notifications.
+- `AppKitDiffScrollerReconciler.swift` — stable-ID plan application, measurement caching, mounting, recycling, and anchor compensation.
+- `AppKitDiffScroller.swift` — `NSViewRepresentable` coordinator and public internal adapter interface.
+- `DiffPaneRowPlan.swift` — non-scrolling hunk row views and standalone row-plan construction.
+
+Create review-specific files under `Alas/Sources/Center/DiffReview/`:
+
+- `AppKitDiffReviewPresentationState.swift` — keyed file state and live action relays.
+- `AppKitDiffReviewRowPlan.swift` — flattened review row IDs, tokens, views, and plan builder.
+- `AppKitDiffReviewScroller.swift` — review commands, active-file bridging, and the core scroller adapter.
+
+Create `Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift` for the split-preview adapter and keyed resulting-image state.
+
+Tests mirror those boundaries under `AlasTests/Center/Diff/Scroller/`, `AlasTests/Center/DiffReview/`, and `AlasTests/Integrations/GG/`.
+
+### Task 1: Shared Experiment Flag And Settings Toggle
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerFlag.swift`
+- Create: `AlasTests/Center/Diff/Scroller/AppKitDiffScrollerFlagTests.swift`
+- Modify: `Alas/Sources/Settings/AdvancedPane.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Produces: `AppKitDiffScrollerFlag.defaultsKey`, `overrideDidChangeNotification`, `isEnabled`, `resolve(override:isDebugBuild:)`, `readOverride(from:)`, and `setOverride(_:in:notificationCenter:)`.
+- Later surface adapters observe `overrideDidChangeNotification` and cache `isEnabled` in local `@State`.
+
+- [ ] **Step 1: Write the failing flag tests**
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("AppKitDiffScrollerFlag")
+struct AppKitDiffScrollerFlagTests {
+    @Test("explicit overrides win and build defaults differ")
+    func resolution() {
+        #expect(AppKitDiffScrollerFlag.resolve(override: true, isDebugBuild: false))
+        #expect(!AppKitDiffScrollerFlag.resolve(override: false, isDebugBuild: true))
+        #expect(AppKitDiffScrollerFlag.resolve(override: nil, isDebugBuild: true))
+        #expect(!AppKitDiffScrollerFlag.resolve(override: nil, isDebugBuild: false))
+    }
+
+    @Test("setOverride persists and broadcasts")
+    func persistenceAndNotification() async {
+        let suite = "AppKitDiffScrollerFlagTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        let center = NotificationCenter()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        await confirmation { received in
+            let token = center.addObserver(
+                forName: AppKitDiffScrollerFlag.overrideDidChangeNotification,
+                object: nil,
+                queue: nil
+            ) { _ in received() }
+            defer { center.removeObserver(token) }
+            AppKitDiffScrollerFlag.setOverride(true, in: defaults, notificationCenter: center)
+        }
+        #expect(AppKitDiffScrollerFlag.readOverride(from: defaults) == true)
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate and verify the tests fail for the missing type**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffScrollerFlagTests
+```
+
+Expected: compilation fails because `AppKitDiffScrollerFlag` is undefined.
+
+- [ ] **Step 3: Implement the flag with the approved contract**
+
+```swift
+import Foundation
+
+enum AppKitDiffScrollerFlag {
+    static let defaultsKey = "alas.diff.appKitScroller"
+    static let overrideDidChangeNotification = Notification.Name(
+        "io.nlopez.alas.AppKitDiffScrollerFlag.overrideDidChange"
+    )
+
+    static var isEnabled: Bool { isEnabledWithDefaults(.standard) }
+
+    nonisolated static func readOverride(from defaults: UserDefaults) -> Bool? {
+        defaults.object(forKey: defaultsKey) as? Bool
+    }
+
+    nonisolated static func isEnabledWithDefaults(_ defaults: UserDefaults) -> Bool {
+        #if DEBUG
+        resolve(override: readOverride(from: defaults), isDebugBuild: true)
+        #else
+        resolve(override: readOverride(from: defaults), isDebugBuild: false)
+        #endif
+    }
+
+    nonisolated static func resolve(override: Bool?, isDebugBuild: Bool) -> Bool {
+        override ?? isDebugBuild
+    }
+
+    nonisolated static func setOverride(
+        _ override: Bool,
+        in defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        defaults.set(override, forKey: defaultsKey)
+        notificationCenter.post(name: overrideDidChangeNotification, object: nil)
+    }
+}
+```
+
+- [ ] **Step 4: Add the Settings row and observable toggle state**
+
+Add `@State private var appKitDiffScrollerEnabled = AppKitDiffScrollerFlag.isEnabled`, a second `SettingsRow` named `AppKit diff scrollers`, and a second notification observer. Use this exact description:
+
+```swift
+"Replaces vertical scrolling in diff and review panes with an AppKit-backed scroller. Toggling this re-creates open diff views, so their scroll positions are lost."
+```
+
+- [ ] **Step 5: Run the focused tests and commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffScrollerFlagTests
+git add Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerFlag.swift Alas/Sources/Settings/AdvancedPane.swift AlasTests/Center/Diff/Scroller/AppKitDiffScrollerFlagTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(diff): add AppKit scroller experiment flag"
+```
+
+Expected: focused tests pass.
+
+### Task 2: Row Plan And Tiling Geometry
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift`
+- Create: `Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift`
+- Create: `AlasTests/Center/Diff/Scroller/AppKitDiffTilingControllerTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Produces: `AppKitDiffRowEqualityToken`, `AppKitDiffRowRetention`, `AppKitDiffRowSpec`, `AppKitDiffRowPlan`, `AppKitDiffScrollAlignment`, `AppKitDiffScrollRequest`, `AppKitDiffScrollAnchor`, and `AppKitDiffTilingController`.
+- Row IDs and owner IDs are `String`; review adapters use `DiffReviewFileID.rawValue` as `ownerID`.
+- `AppKitDiffTilingController.RowLayout` stores `id`, `ownerID`, `height`, and `minY`.
+
+- [ ] **Step 1: Write failing geometry tests**
+
+```swift
+import CoreGraphics
+import Testing
+@testable import Alas
+
+@Suite("AppKit diff tiling")
+struct AppKitDiffTilingControllerTests {
+    @Test("mount band stays bounded and active owner follows the viewport")
+    func mountBandAndOwner() {
+        let tiling = AppKitDiffTilingController(metrics: .init(rowSpacing: 0, topPadding: 0, bottomPadding: 0))
+        tiling.replaceAll(rows: (0..<100).map {
+            .init(id: "row-\($0)", ownerID: "file-\($0 / 10)", height: 20)
+        })
+        #expect(tiling.mountBand(viewportMinY: 800, viewportHeight: 100, overscan: 100) == 35..<50)
+        #expect(tiling.activeOwnerID(viewportMinY: 800, viewportHeight: 100) == "file-4")
+    }
+
+    @Test("height growth above the viewport returns exact compensation")
+    func heightCompensation() {
+        let tiling = AppKitDiffTilingController(metrics: .init(rowSpacing: 0, topPadding: 0, bottomPadding: 0))
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 100),
+        ])
+        #expect(tiling.updateHeight(id: "a", to: 140, viewportMinY: 100) == 40)
+        #expect(tiling.row(withID: "b")?.minY == 140)
+    }
+
+    @Test("anchor records intra-row position and resolves after reorder")
+    func anchorRestoration() {
+        let tiling = AppKitDiffTilingController(metrics: .init(rowSpacing: 0, topPadding: 0, bottomPadding: 0))
+        tiling.replaceAll(rows: [
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 100),
+        ])
+        let anchor = tiling.anchor(viewportMinY: 130)
+        #expect(anchor == .init(rowID: "b", intraRowOffset: 30))
+        tiling.replaceAll(rows: [
+            .init(id: "x", ownerID: nil, height: 50),
+            .init(id: "a", ownerID: nil, height: 100),
+            .init(id: "b", ownerID: nil, height: 100),
+        ])
+        #expect(tiling.viewportMinY(for: anchor) == 180)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm missing-type failures**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffTilingControllerTests
+```
+
+- [ ] **Step 3: Implement row-plan values**
+
+```swift
+struct AppKitDiffRowSpec {
+    let id: String
+    let ownerID: String?
+    let equalityToken: AppKitDiffRowEqualityToken
+    let estimatedHeight: CGFloat
+    var retention: AppKitDiffRowRetention = .recyclable
+    let build: () -> AnyView
+}
+
+struct AppKitDiffRowPlan {
+    let rows: [AppKitDiffRowSpec]
+}
+
+enum AppKitDiffRowRetention: Equatable { case recyclable, pinned }
+enum AppKitDiffScrollAlignment: Equatable { case top, center }
+
+struct AppKitDiffScrollRequest: Equatable {
+    let targetID: String
+    let fallbackID: String?
+    let alignment: AppKitDiffScrollAlignment
+    let animated: Bool
+    let generation: Int
+}
+
+struct AppKitDiffScrollAnchor: Equatable {
+    let rowID: String
+    let intraRowOffset: CGFloat
+}
+```
+
+Implement `AppKitDiffRowEqualityToken` with the same type-erased `Equatable` contract as `ACPRowEqualityToken`, but do not import or reference the ACP type.
+
+- [ ] **Step 4: Implement the tiling controller**
+
+Provide these exact methods:
+
+```swift
+func replaceAll(rows: [Seed])
+func row(withID id: String) -> RowLayout?
+func index(ofID id: String) -> Int?
+func updateHeight(id: String, to height: CGFloat, viewportMinY: CGFloat) -> CGFloat
+func anchor(viewportMinY: CGFloat) -> AppKitDiffScrollAnchor?
+func viewportMinY(for anchor: AppKitDiffScrollAnchor?) -> CGFloat?
+func mountBand(viewportMinY: CGFloat, viewportHeight: CGFloat, overscan: CGFloat) -> Range<Int>
+func activeOwnerID(viewportMinY: CGFloat, viewportHeight: CGFloat) -> String?
+func targetOffset(id: String, alignment: AppKitDiffScrollAlignment, viewportHeight: CGFloat) -> CGFloat?
+```
+
+Use half-open row ranges, binary search for the first intersecting row, and deterministic last-entry ID lookup after a debug assertion on duplicates.
+
+- [ ] **Step 5: Add boundary tests and commit**
+
+Add cases for empty plans, past-end viewports, center-offset clamping, duplicate IDs, top/bottom padding, and a height change within the viewport returning zero compensation.
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffTilingControllerTests
+git add Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift AlasTests/Center/Diff/Scroller/AppKitDiffTilingControllerTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(diff): add AppKit row tiling model"
+```
+
+### Task 3: Hosting View And Reuse Pool
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingView.swift`
+- Create: `Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingPool.swift`
+- Create: `AlasTests/Center/Diff/Scroller/AppKitDiffRowHostingPoolTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Consumes: `AppKitDiffRowSpec` and `AppKitDiffRowEqualityToken` from Task 2.
+- Produces: `AppKitDiffRowHostingView.measuredHeight(forWidth:)`, `updateRootView(_:)`, and `AppKitDiffRowHostingPool.view(for:)`, `release(id:)`, `releaseAll(except:)`, `mountedView(id:)`, `mountedIDs`.
+
+- [ ] **Step 1: Write failing pool tests**
+
+```swift
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("AppKit diff hosting pool")
+struct AppKitDiffRowHostingPoolTests {
+    @Test("equal tokens retain the root and changed tokens update it")
+    func equalityGating() {
+        let pool = AppKitDiffRowHostingPool()
+        var builds = 0
+        func spec(_ value: Int) -> AppKitDiffRowSpec {
+            .init(
+                id: "row", ownerID: nil,
+                equalityToken: .init(value), estimatedHeight: 20
+            ) {
+                builds += 1
+                return AnyView(Text("\(value)"))
+            }
+        }
+        let first = pool.view(for: spec(1))
+        let unchanged = pool.view(for: spec(1))
+        let changed = pool.view(for: spec(2))
+        #expect(first.view === unchanged.view)
+        #expect(first.view === changed.view)
+        #expect(builds == 2)
+    }
+
+    @Test("released hosts are reused for a different row")
+    func reuse() {
+        let pool = AppKitDiffRowHostingPool()
+        func spec(_ id: String) -> AppKitDiffRowSpec {
+            .init(
+                id: id,
+                ownerID: nil,
+                equalityToken: .init(id),
+                estimatedHeight: 20
+            ) { AnyView(Text(id)) }
+        }
+        let first = pool.view(for: spec("a")).view
+        pool.release(id: "a")
+        let second = pool.view(for: spec("b")).view
+        #expect(first === second)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm missing-type failures**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffRowHostingPoolTests
+```
+
+- [ ] **Step 3: Implement fixed-width hosting measurement**
+
+Port the ACP hosting-view invariants into the diff-specific class: retain an unwrapped `baseRootView`, set `sizingOptions = [.intrinsicContentSize]`, pin the root to the positive measurement width, record `lastMeasuredWidth`, and invoke `onIntrinsicSizeInvalidated` from `invalidateIntrinsicContentSize()`.
+
+```swift
+@MainActor
+final class AppKitDiffRowHostingView: NSHostingView<AnyView> {
+    var representedRowID: String?
+    var onIntrinsicSizeInvalidated: ((String) -> Void)?
+    private var baseRootView: AnyView
+    private(set) var lastMeasuredWidth: CGFloat?
+
+    func updateRootView(_ newRootView: AnyView)
+    func measuredHeight(forWidth width: CGFloat) -> CGFloat
+}
+```
+
+- [ ] **Step 4: Implement bounded reuse**
+
+The pool keeps mounted entries keyed by ID and at most 32 detached reusable hosts. Reassign `representedRowID` whenever a host is mounted so intrinsic-size callbacks cannot report the old row ID.
+
+- [ ] **Step 5: Add measurement and callback tests, then commit**
+
+Cover zero-width measurement leaving the previous root/width untouched, width-dependent text height, callback ID reassignment after reuse, and `releaseAll(except:)` preserving pinned IDs.
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffRowHostingPoolTests
+git add Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingView.swift Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingPool.swift AlasTests/Center/Diff/Scroller/AppKitDiffRowHostingPoolTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(diff): pool AppKit hosted rows"
+```
+
+### Task 4: Native Scroll View And Reconciler
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift`
+- Create: `Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift`
+- Create: `AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Consumes: Tasks 2-3 geometry and host APIs.
+- Produces: `AppKitDiffScrollView` with `scrollY`, `viewportHeight`, `contentWidth`, `setScrollY(_:animated:)`, `onViewportChange`, and `onContentWidthChange`; `AppKitDiffScrollerReconciler.apply(plan:contentWidth:)`, `layoutVisibleRows()`, and `scroll(to:)`.
+- Under `#if DEBUG`, the reconciler also exposes read-only `fullPlanApplyCountForTests` and `layoutPassCountForTests` counters used only by deterministic tests.
+
+- [ ] **Step 1: Write failing reconciler tests in a real `NSWindow`**
+
+Create a helper that mounts a 400×240 `AppKitDiffScrollView`, tiler, pool, and reconciler in a key window. Test that applying 200 fixed-height rows mounts fewer than 40 hosts, scrolling to row 150 mounts that band, and adding a row above the viewport preserves a chosen row's screen-space position.
+
+```swift
+let before = tiling.row(withID: "row-150")!.minY - scrollView.scrollY
+reconciler.apply(plan: planWithPrependedRow, contentWidth: scrollView.contentWidth)
+let after = tiling.row(withID: "row-150")!.minY - scrollView.scrollY
+#expect(abs(before - after) < 0.5)
+```
+
+- [ ] **Step 2: Run the tests and confirm missing-type failures**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffScrollerReconcilerTests
+```
+
+- [ ] **Step 3: Implement `AppKitDiffScrollView`**
+
+Use a flipped document view, vertical scroller, no background, no horizontal scroller, and clip-view bounds notifications. Programmatic adjustment depth must suppress active-owner callbacks during internal compensation. `layout()` reports positive content-width changes and height-only viewport changes.
+
+- [ ] **Step 4: Implement stable-ID reconciliation**
+
+`apply` must:
+
+1. return without changing live content for width `<= 0`
+2. capture the top anchor and current measured heights
+3. build tiling seeds using cached measured height by stable ID or the new estimate
+4. replace the tiling rows
+5. restore the anchor and resize the document view
+6. mount and measure the viewport-plus-800-point overscan band
+7. repeat placement if measurement changes geometry
+8. release unneeded hosts except rows whose retention is `.pinned`
+
+Guard the repeat loop at three passes; schedule one deferred pass if intrinsic-size invalidation arrives during reconciliation.
+
+- [ ] **Step 5: Add update and recovery tests**
+
+Cover unchanged-token no-op, changed-token remeasurement, insertion/removal/reorder, content-width invalidation, height-only resize, zero-width first update followed by recovery, pinned offscreen rows, intrinsic-size coalescing, center and top target offsets, and missing target fallback.
+
+- [ ] **Step 6: Run and commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffScrollerReconcilerTests
+git add Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollView.swift Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(diff): reconcile AppKit scroll rows"
+```
+
+### Task 5: SwiftUI Representable And Scroll Commands
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift`
+- Create: `AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Consumes: `AppKitDiffRowPlan`, `AppKitDiffScrollRequest`, and Task 4 reconciler.
+- Produces:
+
+```swift
+struct AppKitDiffScroller: NSViewRepresentable {
+    let plan: AppKitDiffRowPlan
+    let scrollRequest: AppKitDiffScrollRequest?
+    let onActiveOwnerChange: (String?) -> Void
+}
+```
+
+- [ ] **Step 1: Write failing representable/coordinator tests**
+
+Test that `update(plan:)` applies a changed plan, consumes each request generation once, resolves `fallbackID` when `targetID` is absent, reports active owner only on a user-driven viewport change, and dismantling releases observers and hosted rows.
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffScrollerTests
+```
+
+- [ ] **Step 3: Implement the coordinator**
+
+Cache the most recent plan, last consumed request generation, and latest active owner. Wire width changes to full `apply`, height/scroll changes to `layoutVisibleRows`, and user-driven scroll callbacks to `tiling.activeOwnerID`. Programmatic target scrolling must not emit intermediate active-owner changes.
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffScrollerTests
+git add Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(diff): bridge AppKit row scroller to SwiftUI"
+```
+
+### Task 6: Extract Reusable Diff Hunk Rows
+
+**Files:**
+- Create: `Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift`
+- Create: `AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift`
+- Modify: `Alas/Sources/Center/Diff/DiffPaneView.swift`
+- Modify: `AlasTests/DiffPaneViewTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Produces: `DiffPanePresentationState`, `DiffPaneHunkRowToken`, `DiffPaneHunkRow`, and `DiffPaneRowPlanBuilder`.
+- `DiffPaneRowPlanBuilder` accepts the same rendering inputs as `DiffPaneView` plus a shared presentation state and returns an `AppKitDiffRowPlan`.
+- This task refactors rendering only; `DiffPaneView` still selects the legacy SwiftUI scroll path until Task 7.
+
+- [ ] **Step 1: Write row identity tests**
+
+Create a two-hunk `DiffDisplayModel` and assert the builder returns two unique IDs, stable IDs for an identical rebuild, changed equality tokens after wrap/layout/whitespace/font or row-signature changes, and unchanged tokens when only action closure identity changes.
+
+```swift
+let first = DiffPaneRowPlanBuilder.build(input: input, state: state)
+let second = DiffPaneRowPlanBuilder.build(input: input, state: state)
+#expect(first.rows.map(\.id) == second.rows.map(\.id))
+#expect(first.rows[0].equalityToken.isEqual(to: second.rows[0].equalityToken))
+```
+
+- [ ] **Step 2: Run the tests and confirm failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneRowPlanTests
+```
+
+- [ ] **Step 3: Extract `DiffPaneHunkRow` without changing legacy behavior**
+
+Move the existing hunk header, row projection, text-segment rendering, feedback lanes, comment cards, annotations, fusion shape, and hunk actions into a focused `DiffPaneHunkRow: View`. Keep expanded collapsed-row IDs and active-thread ID in `DiffPanePresentationState`; expose methods that mutate those values so mounted views capture one stable reference object.
+
+Define the token from plain render values:
+
+```swift
+struct DiffPaneHunkRowToken: Equatable {
+    let groupID: String
+    let rowsSignature: DiffDisplayRowsSignature
+    let fusion: DiffPaneHunkFusionState
+    let layoutMode: DiffLayoutMode
+    let wrapLines: Bool
+    let showWhitespace: Bool
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let threadSignatures: [DiffInlineCommentThread]
+    let annotations: [DiffInlineAnnotation]
+    let activeHighlight: DiffReviewCommentHighlight?
+    let actionPresence: DiffPaneHunkActionPresence
+}
+
+struct DiffPaneHunkActionPresence: Equatable {
+    let canStage: Bool
+    let canDiscard: Bool
+    let canDropFromCommit: Bool
+}
+```
+
+- [ ] **Step 4: Make the legacy stacks consume the extracted row view**
+
+Replace both `lazyRowsStack` and `staticRowsStack` hunk bodies with `DiffPaneHunkRow` while retaining their current `ScrollView`, `LazyVStack`, padding, toolbar, and height-estimation behavior. Add an existing-view regression test for hunk actions and collapsed-context expansion.
+
+- [ ] **Step 5: Run focused legacy and plan tests, then commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneRowPlanTests -only-testing:AlasTests/DiffPaneViewTests
+git add Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift Alas/Sources/Center/Diff/DiffPaneView.swift AlasTests/Center/Diff/Scroller/DiffPaneRowPlanTests.swift AlasTests/DiffPaneViewTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "refactor(diff): extract reusable hunk rows"
+```
+
+### Task 7: Feature-Flagged Standalone Diff Scroller
+
+**Files:**
+- Modify: `Alas/Sources/Center/Diff/DiffPaneView.swift`
+- Create: `AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift`
+
+**Interfaces:**
+- Consumes: Task 1 flag, Task 5 representable, and Task 6 plan builder.
+- Produces: `DiffPaneView.usesAppKitScroller(flagEnabled:verticalScrollMode:)` test seam.
+
+- [ ] **Step 1: Write failing switch tests**
+
+```swift
+@Test("only internally scrolling panes switch to AppKit")
+func switchContract() {
+    #expect(DiffPaneView.usesAppKitScroller(flagEnabled: true, verticalScrollMode: .internalScroll))
+    #expect(!DiffPaneView.usesAppKitScroller(flagEnabled: false, verticalScrollMode: .internalScroll))
+    #expect(!DiffPaneView.usesAppKitScroller(flagEnabled: true, verticalScrollMode: .staticHeight))
+}
+```
+
+- [ ] **Step 2: Run and confirm the missing seam fails**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneAppKitScrollerTests
+```
+
+- [ ] **Step 3: Add the runtime switch**
+
+Cache `AppKitDiffScrollerFlag.isEnabled` in `@State`, choose `AppKitDiffScroller(plan:scrollRequest:nil:onActiveOwnerChange:)` only for `.internalScroll`, apply `.id(appKitScrollerEnabled)`, observe the override notification, and recreate `DiffPanePresentationState` when the flag changes. Leave `.staticHeight` on the extracted non-scrolling legacy composition.
+
+- [ ] **Step 4: Add AppKit integration cases**
+
+Mount an internally scrolling pane in a window and verify hunk action markers, line selection, context expansion, split/stacked changes, wrap/whitespace changes, text selection, and bounded host count. Confirm a flag notification rebuilds the scroller and retains model/binding values.
+
+- [ ] **Step 5: Run and commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffPaneAppKitScrollerTests -only-testing:AlasTests/DiffPaneViewTests
+git add Alas/Sources/Center/Diff/DiffPaneView.swift AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(diff): use AppKit scrolling in standalone panes"
+```
+
+### Task 8: Review Presentation State Store
+
+**Files:**
+- Create: `Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift`
+- Create: `AlasTests/Center/DiffReview/AppKitDiffReviewPresentationStateTests.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Produces: `AppKitDiffReviewPresentationStore`, `AppKitDiffReviewFileState`, and `AppKitDiffReviewActionRelay`.
+- The state object owns every durable mutable property currently declared on `DiffReviewFileSection`; the row-local `@FocusState` binding remains in SwiftUI, mirrors `state.isDraftComposerFocused`, and pins its row while true. The legacy section accepts an optional injected state and otherwise creates its own.
+
+- [ ] **Step 1: Write failing retention/reset tests**
+
+Test that repeated `state(for:)` calls return the same object, pruning removes absent file IDs, unmount simulation does not clear drafts or expanded context, a changed render-budget reset signal clears `showFullDiffOverride`, a changed file/context signature resets context state, and a stale async generation cannot publish.
+
+```swift
+let store = AppKitDiffReviewPresentationStore()
+let state = store.state(for: file)
+state.pendingDraftBody = "keep me"
+#expect(store.state(for: file) === state)
+store.prune(keeping: [file.id])
+#expect(store.state(for: file).pendingDraftBody == "keep me")
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffReviewPresentationStateTests
+```
+
+- [ ] **Step 3: Move state ownership without changing rendering**
+
+Move pending draft, focus generation, expanded IDs, context snapshot/expansion/task/error/generation, image state, hovered/active IDs, render override, copy feedback, and render-context cache into `AppKitDiffReviewFileState`. Replace direct `@State` access in `DiffReviewFileSection` with the injected observable object.
+
+Keep these exact reset entry points on the state object:
+
+```swift
+func synchronize(file: DiffReviewFileSectionModel, contextSignature: DiffReviewContextStateSignature)
+func resetForFileIdentityChange()
+func resetForRenderBudgetChange()
+func resetContextState()
+func acceptsContextResult(fileID: DiffReviewFileID, generation: Int) -> Bool
+```
+
+- [ ] **Step 4: Add the live action relay**
+
+Store all review action structs and callbacks in a reference relay updated before plan reconciliation. Hosted row views invoke relay methods rather than capturing an older closure generation. Add a test that an already-created row invokes the second callback after `relay.update(...)`.
+
+- [ ] **Step 5: Run state and legacy section tests, then commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffReviewPresentationStateTests -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/DiffReviewImageStateTests
+git add Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift AlasTests/Center/DiffReview/AppKitDiffReviewPresentationStateTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "refactor(review): retain recyclable file state"
+```
+
+### Task 9: Flattened Review Row Plan
+
+**Files:**
+- Create: `Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift`
+- Create: `AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Consumes: review render context, Task 6 `DiffPaneHunkRow`, and Task 8 state/relay.
+- Produces: `AppKitDiffReviewRowID`, `AppKitDiffReviewRowToken`, `AppKitDiffReviewRowInput`, `AppKitDiffReviewRowPlan`, and `AppKitDiffReviewRowPlanBuilder.build(...) -> AppKitDiffReviewRowPlan`.
+- `AppKitDiffReviewRowPlan` wraps `corePlan: AppKitDiffRowPlan`, `fallbackByTargetID: [String: String]`, `headerByFileID: [DiffReviewFileID: String]`, and `placeholderByFileID: [DiffReviewFileID: String]`.
+
+- [ ] **Step 1: Write failing row-plan tests**
+
+Build fixtures for text, image, placeholder, per-file-budget deferred, and aggregate-budget deferred files. Assert:
+
+- all row IDs are unique and stable
+- every row has the owning file's raw ID
+- normal text emits header, file-level accessories, group/hunk, segment/block, and spacing rows
+- image files emit header, feedback, and image rows but no text hunks
+- deferred files emit header plus placeholder and map draft/feedback targets to that placeholder
+- commanded draft and feedback IDs are direct row IDs when rendered
+- focused composer rows use `.pinned`; ordinary text rows use `.recyclable`
+
+- [ ] **Step 2: Run and confirm missing-builder failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffReviewRowPlanTests
+```
+
+- [ ] **Step 3: Extract focused non-scrolling row views**
+
+Turn the current private header, placeholder, image, file-level feedback, group header, accessory segment, draft card/composer, comment card, and annotation bodies into internal focused views that accept `AppKitDiffReviewFileState` and `AppKitDiffReviewActionRelay`. Make the legacy `DiffReviewFileSection` compose those same views so visuals and accessibility markers remain single-sourced.
+
+- [ ] **Step 4: Implement stable row IDs and tokens**
+
+Use these prefixes and existing target helpers:
+
+```swift
+file:<fileID>:header
+file:<fileID>:placeholder
+file:<fileID>:image
+file:<fileID>:group:<groupID>:header
+file:<fileID>:segment:<segmentID>:rows:<blockID>
+DiffReviewInlineFeedbackTargetID.targetID(feedbackID:fileID:)
+DiffReviewDraftCommentTargetID.targetID(commentID:fileID:)
+file:<fileID>:composer:<segmentID>
+file:<fileID>:spacing
+```
+
+Tokens include render-content hashes/signatures, plain display preferences, availability snapshots, focus/hover state, and action presence; they exclude closure identity because the relay is live.
+
+- [ ] **Step 5: Implement the flattened plan builder**
+
+Apply `DiffReviewRenderEligibility.renderRows` before iterating files. Derive each file's render context once from its state cache, append rows in the existing visual order, and set estimated heights from existing estimators or focused per-row constants. Populate `fallbackByTargetID`, `headerByFileID`, and `placeholderByFileID` rather than emitting zero-height SwiftUI `.id` anchors.
+
+- [ ] **Step 6: Run plan and legacy rendering tests, then commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffReviewRowPlanTests -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/DiffReviewInlineFeedbackMarkdownTests
+git add Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(review): build flattened AppKit row plans"
+```
+
+### Task 10: AppKit Multi-File Review Stream And Navigation
+
+**Files:**
+- Create: `Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift`
+- Create: `AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewSurface.swift`
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewScrollSpy.swift`
+- Modify: `AlasTests/DiffReviewSurfaceTests.swift`
+- Modify: `AlasTests/DiffReviewScrollSpyTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Consumes: Task 9 plan and all three existing scroll-command types.
+- Produces: `AppKitDiffReviewScroller`, `AppKitDiffReviewScrollRequestResolver`, and `DiffReviewSurface.usesAppKitScroller(flagEnabled:)`.
+
+- [ ] **Step 1: Write failing switch and command-resolution tests**
+
+```swift
+#expect(DiffReviewSurface.usesAppKitScroller(flagEnabled: true))
+#expect(!DiffReviewSurface.usesAppKitScroller(flagEnabled: false))
+
+let request = AppKitDiffReviewScrollRequestResolver.request(
+    fileCommand: nil,
+    inlineFeedbackCommand: feedbackCommand,
+    draftCommentCommand: nil,
+    plan: deferredPlan
+)
+#expect(request?.targetID == deferredPlan.placeholderByFileID[fileID])
+#expect(request?.alignment == .center)
+```
+
+Also assert file commands align top, feedback/draft commands align center, generations remain distinct, same-file commands do not require a two-phase realization delay, and missing targets fall back to the file header.
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffReviewScrollerTests
+```
+
+- [ ] **Step 3: Implement the review adapter**
+
+`AppKitDiffReviewScroller` builds/receives the flattened plan, resolves the latest command into one core `AppKitDiffScrollRequest`, converts active owner raw values back to `DiffReviewFileID`, and updates the existing selection/programmatic-scroll state through closures. No `Task.sleep` or two-phase scroll is used on the AppKit path because target rows are direct tiling entries.
+
+- [ ] **Step 4: Add the central-stream switch**
+
+Rename the existing implementation `legacyMainReviewStream`. Cache the flag in `DiffReviewSurface`, choose the AppKit adapter when enabled, apply `.id(appKitScrollerEnabled)`, observe the flag notification, clear only scroll-command bookkeeping, and prune presentation state when the file set changes. Keep both side rails outside the switch.
+
+- [ ] **Step 5: Add window-level behavior tests**
+
+Cover rail-to-file scrolling, active-file selection from native viewport changes, same-file and cross-file feedback navigation, deferred-placeholder fallback, selection suppression during animated programmatic scroll, comment insertion above the viewport, context expansion above the viewport, focused composer pinning, image load/retry, staged actions, preference changes, session replacement, and runtime toggle scroll reset.
+
+- [ ] **Step 6: Run the shared review suites and commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppKitDiffReviewScrollerTests -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/DiffReviewScrollSpyTests -only-testing:AlasTests/DiffReviewImageStateTests -only-testing:AlasTests/DiffReviewStagedMutationActionsTests
+git add Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift Alas/Sources/Center/DiffReview/DiffReviewSurface.swift Alas/Sources/Center/DiffReview/DiffReviewScrollSpy.swift AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift AlasTests/DiffReviewSurfaceTests.swift AlasTests/DiffReviewScrollSpyTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(review): scroll multi-file diffs with AppKit"
+```
+
+### Task 11: GG Split Preview Adapter
+
+**Files:**
+- Create: `Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift`
+- Create: `AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift`
+- Modify: `Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Consumes: Task 5 scroller and Task 6 diff hunk plan factory.
+- Produces: `GGSplitPreviewRowPlanBuilder`, `GGSplitPreviewImageStore`, and `GGSplitCommitTabView.usesAppKitPreviewScroller(flagEnabled:)`.
+
+- [ ] **Step 1: Write failing partition and row-order tests**
+
+Given two text files, one resulting image, and one non-textual file, assert the plan order is file header/hunks, file header/hunks, image, other-file. Assert unique IDs include the preview side/title so the two side-by-side preview panes cannot collide. Assert image state survives repeated plan builds and prunes removed paths.
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/GGSplitPreviewRowPlanTests
+```
+
+- [ ] **Step 3: Implement the plan and image store**
+
+Move `GGSplitResultingImagePreview.imageSide` into a store keyed by worktree path, revision, and relative path. Build text rows with the shared `DiffPaneRowPlanBuilder`, retaining the current path header before each file. Keep image height 220 points and preserve the current spinner/failure rendering.
+
+- [ ] **Step 4: Switch only the preview scroll subtree**
+
+Keep the preview title/header, empty state, split form, and action bar unchanged. Cache and observe `AppKitDiffScrollerFlag`; use the AppKit plan when enabled and the existing `ScrollView`/`LazyVStack` when disabled. Rebuilding after a flag change resets only preview scroll positions.
+
+- [ ] **Step 5: Run split-preview and existing GG tests, then commit**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/GGSplitPreviewRowPlanTests -only-testing:AlasTests/GGSplitCommitModelTests
+git add Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(gg): use AppKit split preview scrolling"
+```
+
+### Task 12: Stress Coverage, Accessibility, And Final Verification
+
+**Files:**
+- Create: `AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift`
+- Modify: AppKit scroller/review files only if the stress or accessibility tests expose a concrete defect
+- Modify: `Alas.xcodeproj/project.pbxproj` via XcodeGen
+
+**Interfaces:**
+- Consumes: completed engine and all adapters.
+- Produces: deterministic regression evidence and final build/test proof; no new product API.
+
+- [ ] **Step 1: Add a deterministic 20,000-row stress test**
+
+Build a plan with 20,000 fixed-height rows across 250 owners. Mount it in a 1200×800 window, scroll to the middle and end, update rows above and below the viewport, and assert:
+
+```swift
+#expect(pool.mountedIDs.count < 120)
+#expect(abs(anchorScreenYBefore - anchorScreenYAfter) < 0.5)
+#expect(reconciler.fullPlanApplyCountForTests == 2)
+```
+
+Do not assert elapsed time.
+
+- [ ] **Step 2: Add accessibility and first-responder tests**
+
+For review and standalone hosts, confirm existing accessibility identifiers can be found through hosted rows, keyboard focus enters a draft composer, the focused row remains mounted while scrolled away, draft text survives, and releasing focus permits recycling.
+
+- [ ] **Step 3: Run all focused suites**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/AppKitDiffScrollerFlagTests \
+  -only-testing:AlasTests/AppKitDiffTilingControllerTests \
+  -only-testing:AlasTests/AppKitDiffRowHostingPoolTests \
+  -only-testing:AlasTests/AppKitDiffScrollerReconcilerTests \
+  -only-testing:AlasTests/AppKitDiffScrollerTests \
+  -only-testing:AlasTests/DiffPaneRowPlanTests \
+  -only-testing:AlasTests/DiffPaneAppKitScrollerTests \
+  -only-testing:AlasTests/AppKitDiffReviewPresentationStateTests \
+  -only-testing:AlasTests/AppKitDiffReviewRowPlanTests \
+  -only-testing:AlasTests/AppKitDiffReviewScrollerTests \
+  -only-testing:AlasTests/GGSplitPreviewRowPlanTests \
+  -only-testing:AlasTests/AppKitDiffScrollerStressTests \
+  -only-testing:AlasTests/DiffPaneViewTests \
+  -only-testing:AlasTests/DiffReviewSurfaceTests
+```
+
+Expected: all focused suites pass.
+
+- [ ] **Step 4: Run formatting, build, and full tests**
+
+```bash
+swiftformat Alas AlasTests --lint
+git diff --check
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: lint and whitespace checks pass, the app builds, and the full suite passes. If the full suite exposes an unrelated pre-existing failure, rerun it in isolation and report it separately rather than attributing it to this change.
+
+- [ ] **Step 5: Profile both implementations manually**
+
+Use the same synthetic large review and one real large review. Capture a Time Profiler or `sample` trace while continuously scrolling with the flag off and on. The AppKit path must show no outer diff/review `LazyVStack`, `LazySubviewPlacements`, or `ForEachState` scroll-layout stack; scrolling must remain responsive without visible offset jumps or a beachball.
+
+- [ ] **Step 6: Commit stress coverage and any verified fixes**
+
+```bash
+git add AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift Alas.xcodeproj/project.pbxproj
+git add Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+git commit -m "test(diff): cover AppKit scroller stress cases"
+```
+
+Before committing, confirm `git diff --cached --stat` contains only stress coverage and concrete fixes required by this task; do not sweep unrelated user changes into the commit.

--- a/docs/superpowers/specs/2026-08-06-appkit-diff-review-scrollers-design.md
+++ b/docs/superpowers/specs/2026-08-06-appkit-diff-review-scrollers-design.md
@@ -1,0 +1,307 @@
+---
+title: "AppKit diff and review scrollers"
+date: 2026-08-06
+project: alas
+phase: design
+prior_art:
+  - docs/superpowers/specs/2026-07-07-center-diff-scroll-performance-design.md
+  - docs/superpowers/specs/2026-07-19-wrapped-diff-scroll-performance-design.md
+  - Alas/Sources/ACP/UI/Scroller
+---
+
+## TL;DR
+
+Replace SwiftUI-owned vertical scrolling in Alas's diff and review surfaces
+with one feature-flagged AppKit virtualization engine. AppKit will own the
+`NSScrollView`, row geometry, viewport selection, scroll anchoring, and host
+recycling. Existing SwiftUI controls and the existing AppKit text renderer will
+remain the row content.
+
+The experiment covers multi-file review streams, internally scrolling
+`DiffPaneView` instances, and the GG split preview. It provides full behavior
+parity before landing, defaults on in debug builds and off in release builds,
+and leaves the legacy SwiftUI implementations available behind one toggle.
+
+## Context
+
+The shared multi-file review stream currently combines a SwiftUI `ScrollView`,
+`LazyVStack`, `ForEach`, `scrollTargetLayout`, and
+`onScrollTargetVisibilityChange`. Individual file sections contain further
+lazy hunk and feedback stacks. Large reviews have produced main-thread hangs in
+SwiftUI's view-graph and lazy-layout machinery, including stacks through
+`GraphHost.flushTransactions`, `LazyVStack`, and `ForEachState`.
+
+The rendered code rows are already AppKit-backed through
+`DiffPaneTextDocumentView`, and the unchanged-update path avoids rebuilding
+identical text documents. The remaining high-cost ownership boundary is the
+vertical SwiftUI list and its target-visibility/layout reconciliation.
+
+The AppKit ACP transcript migration established a useful boundary: AppKit owns
+scrolling, tiling, and offset compensation while SwiftUI remains responsible
+for the contents of each hosted row. This design applies that boundary to
+diffs without modifying or generalizing the now-stable ACP scroller.
+
+## Goals
+
+- Remove the outer and nested SwiftUI lazy scrolling machinery from the
+  experimental diff/review path.
+- Keep mounted view count bounded to the viewport plus overscan.
+- Preserve the visible content when rows above the viewport are inserted,
+  removed, or remeasured.
+- Preserve every existing text, image, feedback, draft-comment, navigation,
+  context-expansion, LSP, selection, and mutation behavior.
+- Cover multi-file review streams, standalone diff panes, and the GG split
+  preview with one shared AppKit engine and one experiment toggle.
+- Retain the legacy implementations as a release-safe fallback.
+- Provide deterministic geometry and recycling tests plus manual profiling on
+  large synthetic and real reviews.
+
+## Non-Goals
+
+- Do not rebuild diff headers, comments, composers, or image controls as native
+  AppKit views.
+- Do not replace TextKit or the existing AppKit diff text renderer.
+- Do not refactor the ACP transcript scroller into a generic shared component.
+- Do not change parsing, syntax highlighting, render budgets, comment models,
+  review persistence, or provider APIs.
+- Do not preserve the exact scroll position when the experiment is toggled at
+  runtime; toggling deliberately recreates the scrolling subtree.
+- Do not add analytics, persisted presentation state, or wall-clock CI
+  performance thresholds.
+
+## Architecture
+
+### Diff-Specific Hosted-Row Engine
+
+Add a diff-specific `NSViewRepresentable` backed by one `NSScrollView`, a
+lightweight flipped document view, a tiling controller, a hosting pool, and a
+reconciler. The engine accepts an ordered row plan. Each row specification
+contains:
+
+- a stable row identifier
+- an owning file identifier when the row belongs to a review file
+- an equality/version token for visible content
+- an estimated height used before first measurement
+- a retention policy for rows that must remain mounted while focused
+- a lazy `AnyView` builder
+
+The engine mounts only rows intersecting the viewport extended by a fixed
+overscan band. A mounted `NSHostingView` pins its SwiftUI root to the current
+content width and reports intrinsic-height invalidations. Hosts outside the
+mount band return to a reuse pool unless their retention policy pins them.
+
+The engine's implementation may port the algorithms and invariants proven by
+the ACP transcript scroller, but its types and policy remain diff-specific.
+This keeps transcript behavior untouched while allowing the three diff
+surfaces to share one implementation.
+
+### Tiling And Reconciliation
+
+The tiling controller owns the ordered row geometry and an ID-to-index map. It
+supports whole-plan replacement, insertion, removal, height updates, viewport
+queries, direct target lookup, and mount-band calculation.
+
+Reconciliation compares stable IDs and equality tokens:
+
+- unchanged rows retain their host and measured height
+- changed mounted rows receive a new root view and are remeasured
+- inserted rows begin with their estimate and are corrected after mounting
+- removed rows release their host and presentation-state references
+- callbacks are updated through a live relay even when visual equality allows
+  the hosted root to remain unchanged
+
+Before a structural or width-sensitive update, the coordinator records the top
+visible row and its intra-row offset. After retiling it restores that anchor.
+An insertion, removal, or height change contributes offset compensation only
+when it occurs entirely at or above the viewport top. Changes within or below
+the viewport do not move the current scroll origin.
+
+Zero-width layout passes do not alter measurements or hosted roots. A later
+positive-width pass performs the pending reconcile. Duplicate IDs trigger a
+debug assertion and use a deterministic last-entry lookup in release rather
+than crashing.
+
+### Shared Rendering Factories
+
+Extract non-scrolling SwiftUI factories for the existing visual units instead
+of duplicating their UI:
+
+- file headers and file-level feedback
+- render-budget placeholders and image content
+- hunk headers and hunk bodies
+- attributed text segments
+- provider threads and annotations
+- draft comments and draft composers
+- GG split image and non-textual-file rows
+
+The legacy SwiftUI stacks and the new AppKit row-plan builders both consume
+these factories. The existing `DiffPaneView` static-height mode remains a
+non-scrolling composition tool for legacy hosts; the AppKit paths build their
+flat plans directly from the shared factories.
+
+### Presentation State
+
+Rows can be recycled, so interactive state must not remain owned solely by a
+temporary hosted SwiftUI view. Introduce keyed presentation-state holders at
+the owning surface.
+
+The review state store is keyed by `DiffReviewFileID` and retains:
+
+- pending draft anchor, text, and focus request generation
+- collapsed-context expansion IDs
+- loaded context, pending context requests, generation, and inline error
+- image loading and presentation state
+- hovered or active feedback identifiers
+- the explicit "Show full diff" override
+- the render-context cache
+
+The standalone diff holder retains collapsed-context IDs and active feedback
+state for its current display model. State holders expose observable values to
+hosted row views and generation-guard async results against the current file
+and content signature.
+
+The store prunes files or hunks absent from the current model. It applies the
+same reset boundaries as the legacy views: a changed file identity, render
+budget reset signal, or context signature clears only the state that currently
+resets for that event. Unmounting a row alone never clears state.
+
+Focused text editors and active composers are temporarily pinned in the host
+pool so AppKit does not remove the first responder while the user is typing.
+Draft text also resides in presentation state, preventing content loss if
+focus ends and the row later recycles.
+
+## Surface Adapters
+
+### Multi-File Review Stream
+
+`DiffReviewSurface` keeps its file rail and optional review-summary rail in
+SwiftUI. Its central stream chooses between the legacy SwiftUI implementation
+and the AppKit representable.
+
+The AppKit adapter builds one flat ordered plan containing file headers,
+file-level feedback, image or placeholder rows, hunk headers, text segments,
+inline feedback, draft rows/composers, and inter-file spacing. Existing
+per-file and aggregate render-budget decisions are applied before the plan is
+built. Deferred content produces its existing placeholder and hidden-comment
+targets rather than constructing hidden hunk rows.
+
+The tiling controller derives the active file from the topmost file-owned row
+intersecting the viewport. That replaces `scrollTargetLayout` and
+`onScrollTargetVisibilityChange` for the AppKit path. User-driven selection
+updates the existing selected-file binding unless a programmatic-scroll token
+is suppressing intermediate updates.
+
+Rail navigation scrolls the target file header to the viewport top using the
+current short animation. Provider-feedback and draft-comment navigation
+centers their exact row. If the requested row is unavailable because a diff is
+deferred, navigation centers the owning placeholder. A missing target falls
+back to the owning file header.
+
+### Standalone Diff Panes
+
+For `.internalScroll`, `DiffPaneView` keeps its toolbar outside the scrolling
+representable and builds one AppKit plan from hunk and feedback rows. Split and
+stacked layout, wrapping, whitespace, font changes, context expansion, hunk
+actions, line selection, text selection, LSP interactions, and horizontal
+unwrapped behavior use the existing content factories and renderer.
+
+For `.staticHeight`, `DiffPaneView` remains non-scrolling. AppKit-aware parent
+surfaces consume its row-plan factory instead of nesting a second vertical
+scroller.
+
+### GG Split Preview
+
+The GG split preview replaces its outer diff-preview `ScrollView` and
+`LazyVStack` with the shared AppKit engine. Its plan contains file headers and
+hunks followed by resulting-image and non-textual-file rows in the existing
+order. The surrounding split controls and action bar remain SwiftUI and do not
+move into the scroller.
+
+## Updates And Failure Handling
+
+Model refreshes, comment changes, context expansion, image loading, staged
+mutations, preference changes, and session replacement produce a new row plan.
+Unchanged equality tokens prevent unrelated parent updates from rebuilding or
+remeasuring mounted content. The live callback relay ensures actions always
+invoke the latest closure generation despite that visual reuse.
+
+Image and context requests retain their existing inline loading, failure, and
+retry states. Results are accepted only when the file ID, content signature,
+and request generation still match. A recycled row does not cause an older
+request to mutate replacement content.
+
+No AppKit review stream or GG split preview contains another vertical
+scroller. Standalone panes contain exactly one. Existing horizontal diff
+scrolling, accessibility identifiers, menus, keyboard focus, hover behavior,
+and selection remain available through the hosted SwiftUI/AppKit subtree.
+
+## Experiment Toggle
+
+Add `AppKitDiffScrollerFlag` with the defaults key
+`alas.diff.appKitScroller`. It follows the transcript experiment's semantics:
+
+- explicit `UserDefaults` overrides win
+- no override resolves to enabled in debug builds and disabled in release
+- `setOverride` writes the value and posts an override-change notification
+- Settings > Advanced > Experiments exposes one "AppKit diff scrollers"
+  toggle
+
+Every affected surface caches the resolved flag in view state and observes the
+notification. A changed value resets scroll bookkeeping and recreates only the
+scrolling subtree. Parent-owned loaded sessions, selected files, and persisted
+drafts survive; exact scroll positions reset and the Settings description
+states that behavior.
+
+No application schema or wire format changes. Users may also set the override
+with:
+
+```bash
+defaults write io.nlopez.alas alas.diff.appKitScroller -bool YES
+```
+
+## Verification
+
+Use Swift Testing and real AppKit objects where geometry matters.
+
+Pure and coordinator tests cover:
+
+- flag resolution, persistence, notification, and surface selection
+- unique stable IDs and equality-token changes for every row-plan kind
+- presentation-state retention, reset boundaries, and pruning
+- insertion, removal, reordering, and remeasurement compensation
+- top-visible anchors and intra-row offset restoration
+- width, wrap, font, and split/stacked invalidation
+- viewport mount bands and bounded host counts
+- host reuse, focused-row pinning, and callback-relay freshness
+- direct file, feedback, draft, and deferred-placeholder target resolution
+- active-file selection and programmatic-scroll suppression
+- duplicate IDs and zero-width recovery
+
+Surface tests cover:
+
+- many files and a single file with many hunks
+- text, image, unavailable, and render-budget-deferred files
+- provider feedback, annotations, drafts, and focused composers
+- same-file and cross-file navigation
+- context expansion and stale async result rejection
+- staged file and hunk actions
+- split/stacked, wrap, whitespace, font, and resize changes
+- session replacement and removal of state-store entries
+- stash and commit panes
+- GG split text, image, and non-textual rows
+- immediate flag switching with deliberate scroll reset
+
+Keep all legacy diff/review tests as regression gates. Add a deterministic
+stress fixture at or beyond the current 20,000-row aggregate budget and assert
+that mounted hosts remain bounded by the viewport plus overscan and that
+dynamic updates preserve visible geometry.
+
+Finally, profile the same large synthetic fixture and a real large review with
+both flag values. Acceptance requires responsive continuous scrolling, no
+visible offset jumps during dynamic updates, no beachball, and no outer
+diff/review `LazyVStack` or `ForEachState` layout frames in the AppKit-path
+sample. Do not add brittle elapsed-time assertions to CI.
+
+Before completion run project generation, SwiftFormat lint, focused
+diff/review and new scroller suites, a clean macOS build, and the full macOS
+test suite.


### PR DESCRIPTION
## Summary
- add a feature-flagged AppKit virtualized scroller for diff and review panes
- preserve review actions, context expansion, image feedback, drafts, and GG split-preview behavior
- add recycling, scrolling, stress, and regression coverage

## Verification
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`