### PR TITLE
fix(launcher): honor default launch surface for ⌥⌘T

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -261,8 +261,8 @@ struct AlasApp: App {
                 NotificationCenter.default.post(name: .alasNewTerminalTab, object: nil)
             }
             .keyboardShortcut(state.shortcut(for: .newTerminalTab))
-            Button("Launch Agent Terminal…") {
-                NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: AppConfig.LauncherMode.terminal)
+            Button("Launch Agent…") {
+                NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: nil)
             }
             .keyboardShortcut(state.shortcut(for: .launchAgentTerminal))
             .disabled(state.projects.isEmpty)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -293,7 +293,7 @@ struct CenterPaneView: View {
                 } else if tabs.isEmpty {
                     EmptyTabView(
                         onNewTerminal: openTerminal,
-                        onNewAgentTerminal: { state.openAgentLauncherOverlay(mode: .terminal) },
+                        onNewAgentTerminal: { state.openAgentLauncherOverlay(mode: nil) },
                         onNewAgentChat: { state.openAgentLauncherOverlay(mode: .acp) },
                         newTerminalShortcut: state.binding(for: .newTerminalTab)?.displayString,
                         newAgentTerminalShortcut: state.binding(for: .launchAgentTerminal)?.displayString,

--- a/Alas/Sources/Center/EmptyTabView.swift
+++ b/Alas/Sources/Center/EmptyTabView.swift
@@ -42,8 +42,8 @@ struct EmptyTabView: View {
                 )
                 EmptyTabActionRow(
                     icon: "sparkle",
-                    title: "New Agent Terminal",
-                    subtitle: "Pick an enabled agent to run in a terminal",
+                    title: "New Agent",
+                    subtitle: "Pick an agent to launch on the default surface",
                     shortcut: newAgentTerminalShortcut,
                     action: onNewAgentTerminal
                 )

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -55,7 +55,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .newWorktree:              return "New Worktree"
         case .focusMainWorktree:        return "Focus Main Worktree"
         case .newTerminalTab:           return "New Terminal Tab"
-        case .launchAgentTerminal:      return "Launch Agent Terminal"
+        case .launchAgentTerminal:      return "Launch Agent"
         case .launchAgentChat:          return "Launch Agent Chat"
         case .openReviewPalette:        return "Review Worktree"
         case .runScript:                return "Run Script"
@@ -84,7 +84,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         switch self {
         case .searchFiles:        return "Open the file search"
         case .switchRepository:   return "Open the repository picker"
-        case .launchAgentTerminal: return "Open the agent launcher in Terminal mode"
+        case .launchAgentTerminal: return "Open the agent launcher on the default surface"
         case .launchAgentChat:     return "Open the agent launcher in Chat mode"
         case .openReviewPalette:   return "Open the review target palette"
         case .runScript:           return "Open the run script palette"


### PR DESCRIPTION
The ⌥⌘T menu command was hardcoded to post `.terminal` as the launcher mode, ignoring the user's **Settings → Chat → Default launch surface** preference. Post `nil` instead so `openAgentLauncherOverlay` falls back to `config.agents.defaultLauncherMode`, honoring the setting.

Renamed the menu item to "Launch Agent…" to reflect that the surface is now driven by the configured default. The ⌥⌘⇧T "Launch Agent Chat…" button still hardcodes `.acp`.