### PR TITLE
fix(commit): Expand commit description scroller

### DIFF
--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -33,6 +33,7 @@ struct CommitHeaderView: View {
                     ScrollView(.vertical) {
                         expandedBlock
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .frame(maxHeight: Self.maxExpandedHeight)
             }

--- a/AlasTests/CommitHeaderViewTests.swift
+++ b/AlasTests/CommitHeaderViewTests.swift
@@ -108,6 +108,15 @@ struct CommitHeaderViewTests {
         #expect(longController.view.descendantScrollViews().count == 1)
     }
 
+    @Test func overflowingDetailsScrollerFillsHeaderWidth() {
+        let body = Array(repeating: "A long commit message line", count: 100)
+            .joined(separator: "\n")
+        let controller = hostExpandedHeader(body: body)
+        let scrollView = try! #require(controller.view.descendantScrollViews().first)
+
+        #expect(scrollView.frame.width >= controller.view.bounds.width - 32)
+    }
+
     @Test func headerRowHasButtonAccessibilityTrait() {
         let details = makeDetails(body: "Body")
         var expanded = false


### PR DESCRIPTION
## Summary

- Make the overflowing commit-description scroller fill the available header width.
- Add a regression test for the scroll view width.

## Why

Long commit descriptions used their intrinsic horizontal size, leaving the vertical scroller noticeably narrower than the commit header.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
