### PR TITLE
feat(follow): Improve followed revision controls

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1417,6 +1417,7 @@
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
 		E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A03B92542169A6595D432 /* HoverHighlightFeature.swift */; };
 		E867128A3FF1EFD04C2D65E4 /* session-new-request.json in Resources */ = {isa = PBXBuildFile; fileRef = 22677ECD3E098EBE6389D776 /* session-new-request.json */; };
+		E89040915D30C5E67C67B4C8 /* RevisionFollowControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C05EF64FD7701A941C81837 /* RevisionFollowControl.swift */; };
 		E8932BD40AA76C26A52D9BAC /* MergeResultPaneRenderPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE47FEB79311AC99E61C3AF6 /* MergeResultPaneRenderPlanTests.swift */; };
 		E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77927262BEAF31E39CE6698 /* RecommendedLanguageCatalogTests.swift */; };
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
@@ -2110,6 +2111,7 @@
 		5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabView.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
 		5BE3B261CC2B780A40B2EF4E /* ACPAdapterTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterTargetTests.swift; sourceTree = "<group>"; };
+		5C05EF64FD7701A941C81837 /* RevisionFollowControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevisionFollowControl.swift; sourceTree = "<group>"; };
 		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
 		5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffDisplayPreferences.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
@@ -5452,6 +5454,7 @@
 				71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */,
 				BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */,
 				E3E17C2FF7553AEA01B535B1 /* FollowRevisionPrefill.swift */,
+				5C05EF64FD7701A941C81837 /* RevisionFollowControl.swift */,
 				3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */,
 				16D35671971686B20DEA33CB /* TrackedRevision.swift */,
 			);
@@ -6639,6 +6642,7 @@
 				0A98E7EDC11BF68EAEEFED29 /* ReviewTargetPaletteEnvironment.swift in Sources */,
 				03C9B7EA452F3C62B39F7802 /* ReviewTargetPaletteModel.swift in Sources */,
 				4DF50D8995FBF711085A40AF /* ReviewThreadMutations.swift in Sources */,
+				E89040915D30C5E67C67B4C8 /* RevisionFollowControl.swift in Sources */,
 				018E8980EAA0FA97A08A6EF6 /* RevisionSnapshotCache.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -615,6 +615,7 @@ final class AppState {
     private let projectGitWatcherFactory: @MainActor (URL) -> ProjectGitWatcher
     private(set) var revisionChangeGenerations: [String: Int] = [:]
     private(set) var reviewSessionRetargetGenerations: [String: Int] = [:]
+    var followRevisionEditorRequest: FollowRevisionEditorRequest?
     private var followRevisionRequestGenerations: [String: Int] = [:]
 
     init(
@@ -3236,26 +3237,31 @@ final class AppState {
                 requestKey: requestKey,
                 requestGeneration: requestGeneration
             ) else { return }
-            presentFollowRevisionPrompt(worktreeID: worktreeID, tabID: tabID, prefill: resolvedPrefill, isEditing: prefill != nil)
+            followRevisionEditorRequest = FollowRevisionEditorRequest(
+                worktreeID: worktreeID,
+                tabID: tabID,
+                expression: resolvedPrefill ?? "",
+                isEditing: prefill != nil
+            )
         }
     }
 
-    private func presentFollowRevisionPrompt(worktreeID: String, tabID: TabID, prefill: String?, isEditing: Bool) {
-        let alert = NSAlert()
-        alert.messageText = isEditing ? "Edit Followed Revision" : "Follow Revision"
-        alert.informativeText = "Enter a single Git revision expression, such as HEAD~3."
-        alert.addButton(withTitle: "Follow")
-        alert.addButton(withTitle: "Cancel")
-        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
-        field.stringValue = prefill ?? ""
-        alert.accessoryView = field
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-        let expression = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !expression.isEmpty else {
-            Self.showWarningAlert(title: "Invalid Revision", message: "Revision expression must not be empty.")
-            return
-        }
-        followRevision(worktreeID: worktreeID, tabID: tabID, expression: expression)
+    func submitFollowRevisionEditor() {
+        guard var request = followRevisionEditorRequest,
+              let expression = request.submissionExpression
+        else { return }
+        request.isSubmitting = true
+        request.errorMessage = nil
+        followRevisionEditorRequest = request
+        followRevision(worktreeID: request.worktreeID, tabID: request.tabID, expression: expression)
+    }
+
+    func dismissFollowRevisionEditor() {
+        guard let request = followRevisionEditorRequest else { return }
+        _ = bumpFollowRevisionRequestGeneration(
+            followRevisionRequestKey(worktreeID: request.worktreeID, tabID: request.tabID)
+        )
+        followRevisionEditorRequest = nil
     }
 
     private func suggestedFollowRevisionPrefill(worktreeID: String, tabID: TabID) async -> String? {
@@ -3340,8 +3346,9 @@ final class AppState {
         } catch {
             guard isCurrentFollowRevisionRequest(worktreeID: worktreeID, requestKey: requestKey, requestGeneration: requestGeneration)
             else { return }
-            Self.showWarningAlert(
-                title: "Invalid Revision",
+            publishFollowRevisionError(
+                worktreeID: worktreeID,
+                requestKey: requestKey,
                 message: (error as NSError).localizedDescription
             )
             return
@@ -3354,13 +3361,22 @@ final class AppState {
         ) else {
             guard isCurrentFollowRevisionRequest(worktreeID: worktreeID, requestKey: requestKey, requestGeneration: requestGeneration)
             else { return }
-            Self.showWarningAlert(title: "Invalid Revision", message: "Revision expression must not be empty.")
+            publishFollowRevisionError(
+                worktreeID: worktreeID,
+                requestKey: requestKey,
+                message: "Revision expression must not be empty."
+            )
             return
         }
         guard isCurrentFollowRevisionRequest(worktreeID: worktreeID, requestKey: requestKey, requestGeneration: requestGeneration),
               let tab = followRevisionRequestTab(worktreeID: worktreeID, requestKey: requestKey)
         else {
             return
+        }
+        if followRevisionEditorRequest.map({
+            $0.worktreeID == worktreeID && followRevisionRequestKey(worktreeID: worktreeID, tabID: $0.tabID) == requestKey
+        }) == true {
+            followRevisionEditorRequest = nil
         }
 
         switch tab {
@@ -3373,6 +3389,19 @@ final class AppState {
         default:
             return
         }
+    }
+
+    private func publishFollowRevisionError(worktreeID: String, requestKey: String, message: String) {
+        guard var request = followRevisionEditorRequest,
+              request.worktreeID == worktreeID,
+              followRevisionRequestKey(worktreeID: worktreeID, tabID: request.tabID) == requestKey
+        else {
+            Self.showWarningAlert(title: "Invalid Revision", message: message)
+            return
+        }
+        request.isSubmitting = false
+        request.errorMessage = message
+        followRevisionEditorRequest = request
     }
 
     private func bumpFollowRevisionRequestGeneration(_ key: String) -> Int {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -617,6 +617,7 @@ final class AppState {
     private(set) var reviewSessionRetargetGenerations: [String: Int] = [:]
     var followRevisionEditorRequest: FollowRevisionEditorRequest?
     private var followRevisionRequestGenerations: [String: Int] = [:]
+    private var followRevisionEditorGeneration = 0
 
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
@@ -3225,6 +3226,7 @@ final class AppState {
     func promptFollowRevision(worktreeID: String, tabID: TabID, prefill: String? = nil) {
         let requestKey = followRevisionRequestKey(worktreeID: worktreeID, tabID: tabID)
         let requestGeneration = bumpFollowRevisionRequestGeneration(requestKey)
+        let editorGeneration = bumpFollowRevisionEditorGeneration()
         Task { @MainActor in
             let resolvedPrefill: String?
             if let prefill {
@@ -3236,7 +3238,8 @@ final class AppState {
                 worktreeID: worktreeID,
                 requestKey: requestKey,
                 requestGeneration: requestGeneration
-            ) else { return }
+            ), followRevisionEditorGeneration == editorGeneration
+            else { return }
             followRevisionEditorRequest = FollowRevisionEditorRequest(
                 worktreeID: worktreeID,
                 tabID: tabID,
@@ -3248,6 +3251,7 @@ final class AppState {
 
     func submitFollowRevisionEditor() {
         guard var request = followRevisionEditorRequest,
+              !request.isSubmitting,
               let expression = request.submissionExpression
         else { return }
         request.isSubmitting = true
@@ -3261,6 +3265,7 @@ final class AppState {
         _ = bumpFollowRevisionRequestGeneration(
             followRevisionRequestKey(worktreeID: request.worktreeID, tabID: request.tabID)
         )
+        _ = bumpFollowRevisionEditorGeneration()
         followRevisionEditorRequest = nil
     }
 
@@ -3408,6 +3413,11 @@ final class AppState {
         let next = followRevisionRequestGenerations[key, default: 0] + 1
         followRevisionRequestGenerations[key] = next
         return next
+    }
+
+    private func bumpFollowRevisionEditorGeneration() -> Int {
+        followRevisionEditorGeneration += 1
+        return followRevisionEditorGeneration
     }
 
     private func isCurrentFollowRevisionRequest(

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -189,6 +189,7 @@ struct CenterPaneView: View {
                     }
                 },
                 onFollowRevision: { id in
+                    state.activateWorktreeCenterTab(worktreeId: worktree.id, tabId: id)
                     state.promptFollowRevision(worktreeID: worktree.id, tabID: id)
                 },
                 onEditRevision: { id in
@@ -206,6 +207,7 @@ struct CenterPaneView: View {
                             return nil
                         }
                     }()
+                    state.activateWorktreeCenterTab(worktreeId: worktree.id, tabId: id)
                     state.promptFollowRevision(worktreeID: worktree.id, tabID: id, prefill: prefill)
                 },
                 onStopFollowingRevision: { id in

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -5,13 +5,12 @@ struct CommitHeaderView: View {
 
     let details: CommitDetails
     @Binding var expanded: Bool
-    var revisionExpression: String?
-    var pendingCheckout: TrackedRevisionCandidate?
+    var trackedRevision: TrackedRevision? = nil
+    var worktreeID = ""
+    var tabID: TabID = ""
+    var appState: AppState? = nil
     var isRefreshingRevision = false
     var revisionError: String?
-    var onFollowRevision: (() -> Void)?
-    var onEditRevision: (() -> Void)?
-    var onStopFollowingRevision: (() -> Void)?
     var onAcceptPendingCheckout: (() -> Void)?
     var onRetryRevision: (() -> Void)?
 
@@ -22,9 +21,8 @@ struct CommitHeaderView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             compactRow
-            if showsRevisionRow {
-                revisionRow
-                    .padding(.top, 8)
+            if appState != nil {
+                revisionRow.padding(.top, 8)
             }
             if expanded {
                 ViewThatFits(in: .vertical) {
@@ -42,14 +40,6 @@ struct CommitHeaderView: View {
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
         .copyFeedbackOverlay(message: copyFeedback.message)
-    }
-
-    private var showsRevisionRow: Bool {
-        revisionExpression != nil ||
-            pendingCheckout != nil ||
-            isRefreshingRevision ||
-            revisionError != nil ||
-            onFollowRevision != nil
     }
 
     private var compactRow: some View {
@@ -100,79 +90,20 @@ struct CommitHeaderView: View {
     }
 
     private var revisionRow: some View {
-        HStack(spacing: 8) {
-            if let revisionExpression {
-                Text("\(revisionExpression) -> \(details.info.shortSha)")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(theme.color("fg-muted"))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .accessibilityIdentifier("commit-revision-following-label")
-            } else if onFollowRevision != nil {
-                Text("Fixed commit")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg-muted"))
-            }
-
-            if isRefreshingRevision {
-                Text("Refreshing")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg-muted"))
-                    .accessibilityIdentifier("commit-revision-updating")
-            }
-
-            if let pendingCheckout {
-                Text("Paused on checkout to \(pendingCheckout.branch)")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("warn"))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .accessibilityIdentifier("commit-revision-pending-checkout")
-                Button("Update") {
-                    onAcceptPendingCheckout?()
-                }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
-                .accessibilityIdentifier("commit-revision-accept-checkout")
-            }
-
-            if let revisionError, !revisionError.isEmpty {
-                Text(revisionError)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("del"))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .accessibilityIdentifier("commit-revision-error")
-                if let onRetryRevision {
-                    Button("Retry", action: onRetryRevision)
-                        .buttonStyle(.borderless)
-                        .controlSize(.small)
-                        .accessibilityIdentifier("commit-revision-error-retry")
-                }
-            }
-
-            Spacer(minLength: 8)
-
-            if revisionExpression == nil, let onFollowRevision {
-                Button("Follow Revision…", action: onFollowRevision)
-                    .buttonStyle(.borderless)
-                    .controlSize(.small)
-                    .accessibilityIdentifier("commit-revision-follow")
-            } else {
-                if let onEditRevision {
-                    Button("Edit…", action: onEditRevision)
-                        .buttonStyle(.borderless)
-                        .controlSize(.small)
-                        .accessibilityIdentifier("commit-revision-edit")
-                }
-                if let onStopFollowingRevision {
-                    Button("Stop", action: onStopFollowingRevision)
-                        .buttonStyle(.borderless)
-                        .controlSize(.small)
-                        .accessibilityIdentifier("commit-revision-stop")
-                }
-            }
-        }
+        RevisionFollowControl(
+            presentation: RevisionFollowPresentation(
+                fixedSHA: details.info.sha,
+                revision: trackedRevision,
+                refreshError: trackedRevision == nil ? nil : revisionError
+            ),
+            worktreeID: worktreeID,
+            tabID: tabID,
+            accessibilityPrefix: "commit-revision",
+            appState: appState,
+            isRefreshing: isRefreshingRevision,
+            onAcceptPendingCheckout: onAcceptPendingCheckout,
+            onRetry: onRetryRevision
+        )
     }
 
     private var expandedBlock: some View {

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -71,13 +71,12 @@ struct CommitTabView: View {
                 CommitHeaderView(
                     details: details,
                     expanded: $headerExpanded,
-                    revisionExpression: tabState.revision.tracked?.expression,
-                    pendingCheckout: tabState.revision.tracked?.pendingCheckout,
+                    trackedRevision: tabState.revision.tracked,
+                    worktreeID: worktreeId,
+                    tabID: tabState.id,
+                    appState: appState,
                     isRefreshingRevision: isRefreshingTrackedRevision,
                     revisionError: detailsError,
-                    onFollowRevision: { appState.promptFollowRevision(worktreeID: worktreeId, tabID: tabState.id) },
-                    onEditRevision: editFollowedRevision,
-                    onStopFollowingRevision: stopFollowingRevision,
                     onAcceptPendingCheckout: acceptPendingCheckout,
                     onRetryRevision: retryRevisionRefresh
                 )
@@ -397,20 +396,6 @@ struct CommitTabView: View {
             },
             onFailure: { reviewSessionLaunchError = $0.localizedDescription }
         )
-    }
-
-    @MainActor
-    private func editFollowedRevision() {
-        appState.promptFollowRevision(
-            worktreeID: worktreeId,
-            tabID: tabState.id,
-            prefill: tabState.revision.tracked?.expression
-        )
-    }
-
-    @MainActor
-    private func stopFollowingRevision() {
-        appState.stopFollowingRevision(worktreeID: worktreeId, tabID: tabState.id)
     }
 
     @MainActor

--- a/Alas/Sources/Center/Commit/RevisionFollowControl.swift
+++ b/Alas/Sources/Center/Commit/RevisionFollowControl.swift
@@ -171,7 +171,8 @@ struct RevisionFollowControl: View {
                 placeholder: "HEAD~3",
                 monospaced: true,
                 focusOnAppear: true,
-                onSubmit: { appState?.submitFollowRevisionEditor() }
+                onSubmit: { appState?.submitFollowRevisionEditor() },
+                isEnabled: editorRequest?.isSubmitting != true
             )
             if let error = editorRequest?.errorMessage, !error.isEmpty {
                 Text(error)

--- a/Alas/Sources/Center/Commit/RevisionFollowControl.swift
+++ b/Alas/Sources/Center/Commit/RevisionFollowControl.swift
@@ -1,0 +1,260 @@
+import SwiftUI
+
+struct RevisionFollowControl: View {
+    let presentation: RevisionFollowPresentation
+    let worktreeID: String
+    let tabID: TabID
+    let accessibilityPrefix: String
+    let appState: AppState?
+    var isRefreshing = false
+    var onAcceptPendingCheckout: (() -> Void)?
+    var onRetry: (() -> Void)?
+
+    @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulse = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            tether
+
+            if isRefreshing {
+                ProgressView()
+                    .controlSize(.mini)
+                    .accessibilityIdentifier("\(accessibilityPrefix)-updating")
+            }
+
+            switch presentation {
+            case .paused(_, _, _, let message):
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("warn"))
+                    .lineLimit(1)
+                    .accessibilityIdentifier("\(accessibilityPrefix)-pending-checkout")
+                if let onAcceptPendingCheckout {
+                    Button("Update", action: onAcceptPendingCheckout)
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .accessibilityIdentifier("\(accessibilityPrefix)-accept-checkout")
+                }
+            case .failed(_, _, let message):
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("del"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .accessibilityIdentifier("\(accessibilityPrefix)-error")
+                if let onRetry {
+                    Button("Retry", action: onRetry)
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .accessibilityIdentifier("\(accessibilityPrefix)-error-retry")
+                }
+            default:
+                EmptyView()
+            }
+
+            Spacer(minLength: 8)
+            action
+        }
+        .frame(maxWidth: .infinity)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(LinearGradient(
+                    colors: [railColor.opacity(0.25), railColor, railColor.opacity(0.25)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                ))
+                .frame(height: pulse ? 2 : 1)
+                .shadow(color: pulse ? railColor.opacity(0.8) : .clear, radius: 4)
+                .offset(y: -9)
+        }
+        .popover(isPresented: editorPresented, arrowEdge: .bottom) {
+            editor
+        }
+        .onChange(of: presentation.resolvedSHA) { oldSHA, newSHA in
+            guard let newSHA else { return }
+            guard RevisionFollowPresentation.shouldPulse(
+                previousSHA: oldSHA,
+                resolvedSHA: newSHA,
+                reduceMotion: reduceMotion
+            ) else { return }
+            pulse = true
+            withAnimation(.easeOut(duration: 0.7)) { pulse = false }
+        }
+    }
+
+    @ViewBuilder
+    private var tether: some View {
+        switch presentation {
+        case .fixed(let sha):
+            RevisionTetherView(expression: nil, resolvedSHA: sha)
+        case .following(let expression, let resolvedSHA),
+             .failed(let expression, let resolvedSHA, _):
+            RevisionTetherView(expression: expression, resolvedSHA: resolvedSHA)
+                .accessibilityIdentifier("\(accessibilityPrefix)-following-label")
+        case .paused(let expression, let resolvedSHA, let candidateSHA, _):
+            RevisionTetherView(expression: expression, resolvedSHA: resolvedSHA, candidateSHA: candidateSHA)
+                .accessibilityIdentifier("\(accessibilityPrefix)-following-label")
+        }
+    }
+
+    @ViewBuilder
+    private var action: some View {
+        switch presentation {
+        case .fixed:
+            Button {
+                appState?.promptFollowRevision(worktreeID: worktreeID, tabID: tabID)
+            } label: {
+                Label("Follow a revision", systemImage: "link.badge.plus")
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .disabled(appState == nil)
+            .accessibilityIdentifier("\(accessibilityPrefix)-follow")
+        default:
+            Menu("Following") {
+                Button("Edit revision…") {
+                    appState?.promptFollowRevision(
+                        worktreeID: worktreeID,
+                        tabID: tabID,
+                        prefill: presentation.expression
+                    )
+                }
+                .accessibilityIdentifier("\(accessibilityPrefix)-edit")
+                Button("Stop following", role: .destructive) {
+                    appState?.stopFollowingRevision(worktreeID: worktreeID, tabID: tabID)
+                }
+                .accessibilityIdentifier("\(accessibilityPrefix)-stop")
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .disabled(appState == nil)
+        }
+    }
+
+    private var editorPresented: Binding<Bool> {
+        Binding(
+            get: { editorRequest != nil },
+            set: { if !$0 { appState?.dismissFollowRevisionEditor() } }
+        )
+    }
+
+    private var editorRequest: FollowRevisionEditorRequest? {
+        guard let request = appState?.followRevisionEditorRequest,
+              request.matches(worktreeID: worktreeID, tabID: tabID)
+        else { return nil }
+        return request
+    }
+
+    private var expression: Binding<String> {
+        Binding(
+            get: { editorRequest?.expression ?? "" },
+            set: { value in
+                guard var request = editorRequest else { return }
+                request.expression = value
+                request.errorMessage = nil
+                appState?.followRevisionEditorRequest = request
+            }
+        )
+    }
+
+    private var editor: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(editorRequest?.isEditing == true ? "Edit followed revision" : "Follow a revision")
+                .font(.system(size: 13, weight: .semibold))
+            Text("Enter a Git revision, such as HEAD~3.")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-muted"))
+            AlasField(
+                text: expression,
+                placeholder: "HEAD~3",
+                monospaced: true,
+                focusOnAppear: true,
+                onSubmit: { appState?.submitFollowRevisionEditor() }
+            )
+            if let error = editorRequest?.errorMessage, !error.isEmpty {
+                Text(error)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("del"))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            HStack {
+                Spacer()
+                Button("Cancel") { appState?.dismissFollowRevisionEditor() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Follow") { appState?.submitFollowRevisionEditor() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(editorRequest?.submissionExpression == nil || editorRequest?.isSubmitting == true)
+            }
+        }
+        .padding(14)
+        .frame(width: 300)
+    }
+
+    private var railColor: Color {
+        switch presentation {
+        case .failed: theme.color("del")
+        case .paused: theme.color("warn")
+        case .following: theme.color("accent")
+        case .fixed: theme.color("line")
+        }
+    }
+}
+
+struct RevisionTetherView: View {
+    let expression: String?
+    let resolvedSHA: String
+    var candidateSHA: String?
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 4) {
+            chip(expression ?? resolvedSHA, color: expression == nil ? theme.color("fg-muted") : theme.color("accent"))
+            if expression == nil {
+                Text("┄")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("line"))
+            } else {
+                Rectangle()
+                    .fill(theme.color("accent").opacity(0.55))
+                    .frame(width: 18, height: 1)
+                chip(resolvedSHA, color: theme.color("add"))
+            }
+            if let candidateSHA {
+                Image(systemName: "link.slash")
+                    .font(.system(size: 9))
+                    .foregroundColor(theme.color("warn"))
+                chip(candidateSHA, color: theme.color("warn"))
+            }
+        }
+        .lineLimit(1)
+    }
+
+    private func chip(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12))
+            .clipShape(Capsule())
+    }
+}
+
+private extension RevisionFollowPresentation {
+    var expression: String? {
+        switch self {
+        case .following(let expression, _), .paused(let expression, _, _, _), .failed(let expression, _, _): expression
+        case .fixed: nil
+        }
+    }
+
+    var resolvedSHA: String? {
+        switch self {
+        case .fixed(let sha): sha
+        case .following(_, let sha), .paused(_, let sha, _, _), .failed(_, let sha, _): sha
+        }
+    }
+}

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -330,3 +330,70 @@ enum TrackedRevisionRetargeter {
         )
     }
 }
+
+enum RevisionFollowPresentation: Equatable {
+    case fixed(sha: String)
+    case following(expression: String, resolvedSHA: String)
+    case paused(expression: String, resolvedSHA: String, candidateSHA: String, message: String)
+    case failed(expression: String, resolvedSHA: String, message: String)
+
+    init(fixedSHA: String, revision: TrackedRevision?, refreshError: String?) {
+        guard let revision else {
+            self = .fixed(sha: Self.shortSHA(fixedSHA))
+            return
+        }
+        if let refreshError, !refreshError.isEmpty {
+            self = .failed(
+                expression: revision.expression,
+                resolvedSHA: Self.shortSHA(revision.resolvedSHA),
+                message: refreshError
+            )
+        } else if let pending = revision.pendingCheckout {
+            self = .paused(
+                expression: revision.expression,
+                resolvedSHA: Self.shortSHA(revision.resolvedSHA),
+                candidateSHA: Self.shortSHA(pending.sha),
+                message: pending.branch.isEmpty
+                    ? "Paused: detached HEAD moved"
+                    : "Paused: HEAD moved to \(pending.branch)"
+            )
+        } else {
+            self = .following(
+                expression: revision.expression,
+                resolvedSHA: Self.shortSHA(revision.resolvedSHA)
+            )
+        }
+    }
+
+    var pauseMessage: String? {
+        guard case .paused(_, _, _, let message) = self else { return nil }
+        return message
+    }
+
+    static func shouldPulse(previousSHA: String?, resolvedSHA: String, reduceMotion: Bool) -> Bool {
+        guard !reduceMotion, let previousSHA else { return false }
+        return previousSHA != resolvedSHA
+    }
+
+    private static func shortSHA(_ sha: String) -> String {
+        String(sha.prefix(10))
+    }
+}
+
+struct FollowRevisionEditorRequest: Equatable {
+    let worktreeID: String
+    let tabID: TabID
+    var expression: String
+    let isEditing: Bool
+    var isSubmitting = false
+    var errorMessage: String?
+
+    var submissionExpression: String? {
+        let trimmed = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    func matches(worktreeID: String, tabID: TabID) -> Bool {
+        self.worktreeID == worktreeID && self.tabID == tabID
+    }
+}

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -342,13 +342,7 @@ enum RevisionFollowPresentation: Equatable {
             self = .fixed(sha: Self.shortSHA(fixedSHA))
             return
         }
-        if let refreshError, !refreshError.isEmpty {
-            self = .failed(
-                expression: revision.expression,
-                resolvedSHA: Self.shortSHA(revision.resolvedSHA),
-                message: refreshError
-            )
-        } else if let pending = revision.pendingCheckout {
+        if let pending = revision.pendingCheckout {
             self = .paused(
                 expression: revision.expression,
                 resolvedSHA: Self.shortSHA(revision.resolvedSHA),
@@ -356,6 +350,12 @@ enum RevisionFollowPresentation: Equatable {
                 message: pending.branch.isEmpty
                     ? "Paused: detached HEAD moved"
                     : "Paused: HEAD moved to \(pending.branch)"
+            )
+        } else if let refreshError, !refreshError.isEmpty {
+            self = .failed(
+                expression: revision.expression,
+                resolvedSHA: Self.shortSHA(revision.resolvedSHA),
+                message: refreshError
             )
         } else {
             self = .following(

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -273,76 +273,25 @@ struct ReviewSessionTabView: View {
     }
 
     private var trackedRevisionRow: some View {
-        HStack(spacing: 8) {
-            if let revision = trackedRevision {
-                Text("\(revision.expression) -> \(String(revision.resolvedSHA.prefix(10)))")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(theme.color("fg-muted"))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .accessibilityIdentifier("review-session-revision-following-label")
-
-                if let pending = revision.pendingCheckout {
-                    Text("Paused on checkout to \(pending.branch)")
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.color("warn"))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .accessibilityIdentifier("review-session-revision-pending-checkout")
-                    Button("Update") {
-                        acceptPendingCheckout()
-                    }
-                    .buttonStyle(.borderless)
-                    .controlSize(.small)
-                    .accessibilityIdentifier("review-session-revision-accept-checkout")
-                }
-            } else {
-                Text("Fixed commit review")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg-muted"))
-            }
-
-            Spacer(minLength: 8)
-
-            if trackedRevision == nil {
-                Button("Follow Revision…") {
-                    promptFollowRevision(prefill: nil)
-                }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
-                .accessibilityIdentifier("review-session-revision-follow")
-            } else {
-                Button("Edit…") {
-                    promptFollowRevision(prefill: trackedRevision?.expression)
-                }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
-                .accessibilityIdentifier("review-session-revision-edit")
-
-                Button("Stop") {
-                    stopFollowingRevision()
-                }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
-                .accessibilityIdentifier("review-session-revision-stop")
-            }
-        }
-    }
-
-    @MainActor
-    private func promptFollowRevision(prefill: String?) {
-        guard let worktree, let appState else { return }
-        appState.promptFollowRevision(
-            worktreeID: worktree.id,
+        RevisionFollowControl(
+            presentation: RevisionFollowPresentation(
+                fixedSHA: fixedReviewSHA,
+                revision: trackedRevision,
+                refreshError: trackedRevision == nil ? nil : loadError
+            ),
+            worktreeID: worktree?.id ?? tabState.worktreeId,
             tabID: tabState.id,
-            prefill: prefill
+            accessibilityPrefix: "review-session-revision",
+            appState: appState,
+            isRefreshing: isLoading && trackedRevision != nil,
+            onAcceptPendingCheckout: acceptPendingCheckout,
+            onRetry: { loadGeneration += 1 }
         )
     }
 
-    @MainActor
-    private func stopFollowingRevision() {
-        guard let worktree, let appState else { return }
-        appState.stopFollowingRevision(worktreeID: worktree.id, tabID: tabState.id)
+    private var fixedReviewSHA: String {
+        if case .commit(let sha) = record?.target.payload { return sha }
+        return trackedRevision?.resolvedSHA ?? "commit"
     }
 
     @MainActor
@@ -368,7 +317,7 @@ struct ReviewSessionTabView: View {
 
     private func emptyReviewState() -> some View {
         VStack(spacing: 0) {
-            if let loadError, !loadError.isEmpty {
+            if trackedRevision == nil, let loadError, !loadError.isEmpty {
                 trackedRefreshErrorBanner(loadError)
             }
             stateView(title: "No files to review", detail: "This review session has no file diffs.", color: theme.color("fg-dim"), showsRetry: false)
@@ -403,7 +352,7 @@ struct ReviewSessionTabView: View {
             if let providerPublishError, !providerPublishError.isEmpty {
                 providerErrorBanner(providerPublishError)
             }
-            if let loadError, !loadError.isEmpty {
+            if trackedRevision == nil, let loadError, !loadError.isEmpty {
                 trackedRefreshErrorBanner(loadError)
             }
             DiffReviewSurface(

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -164,15 +164,24 @@ struct TabBarView: View {
             }
             let revisionCapability = revisionFollowCapability(tab)
             if revisionCapability.isSupported {
-                Button(revisionCapability.isFollowing ? "Edit Followed Revision…" : "Follow Revision…") {
+                Button {
                     if revisionCapability.isFollowing {
                         onEditRevision(tab.id)
                     } else {
                         onFollowRevision(tab.id)
                     }
+                } label: {
+                    Label(
+                        revisionCapability.isFollowing ? "Edit Followed Revision…" : "Follow Revision…",
+                        systemImage: revisionCapability.isFollowing ? "link" : "link.badge.plus"
+                    )
                 }
                 if revisionCapability.isFollowing {
-                    Button("Stop Following Revision") { onStopFollowingRevision(tab.id) }
+                    Button {
+                        onStopFollowingRevision(tab.id)
+                    } label: {
+                        Label("Stop Following Revision", systemImage: "link.slash")
+                    }
                 }
                 Divider()
             }

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetDialog.swift
@@ -384,15 +384,9 @@ struct ReviewTargetDialog: View {
         isSelected: Bool
     ) -> some View {
         HStack(spacing: 10) {
-            Image(systemName: "pin")
-                .font(.system(size: 11))
-                .foregroundColor(theme.color("fg-muted"))
             VStack(alignment: .leading, spacing: 1) {
-                Text(expression)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(theme.color("fg"))
-                    .lineLimit(1)
-                Text("\(String(resolvedSHA.prefix(10))) · \(branch)")
+                RevisionTetherView(expression: expression, resolvedSHA: String(resolvedSHA.prefix(10)))
+                Text(branch)
                     .font(.system(size: 10))
                     .foregroundColor(theme.color("fg-dim"))
             }

--- a/Alas/Sources/UI/AlasField.swift
+++ b/Alas/Sources/UI/AlasField.swift
@@ -9,6 +9,7 @@ struct AlasField: View {
     var onSubmit: (() -> Void)? = nil
     var leadingIcon: String? = nil
     var inputFilter: GitRefNameInputFilter? = nil
+    var isEnabled: Bool = true
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -19,7 +20,8 @@ struct AlasField: View {
                 monospaced: monospaced,
                 focusOnAppear: focusOnAppear,
                 onSubmit: onSubmit,
-                inputFilter: inputFilter
+                inputFilter: inputFilter,
+                isEnabled: isEnabled
             )
             .alasFieldChrome(theme: theme)
         } else {
@@ -27,6 +29,7 @@ struct AlasField: View {
                 .textFieldStyle(.plain)
                 .font(.system(size: 12, design: monospaced ? .monospaced : .default))
                 .foregroundColor(theme.color("fg"))
+                .disabled(!isEnabled)
 
             if let leadingIcon = leadingIcon {
                 HStack(spacing: 6) {
@@ -65,6 +68,7 @@ private struct AlasNSTextField: NSViewRepresentable {
     var focusOnAppear: Bool
     var onSubmit: (() -> Void)?
     var inputFilter: GitRefNameInputFilter?
+    var isEnabled: Bool
 
     func makeNSView(context: Context) -> AlasNSTextFieldView {
         let field = AlasNSTextFieldView()
@@ -81,11 +85,13 @@ private struct AlasNSTextField: NSViewRepresentable {
         field.target = context.coordinator
         field.action = #selector(Coordinator.action(_:))
         field.focusOnAppear = focusOnAppear
+        field.isEnabled = isEnabled
         return field
     }
 
     func updateNSView(_ nsView: AlasNSTextFieldView, context: Context) {
         context.coordinator.parent = self
+        nsView.isEnabled = isEnabled
         if nsView.stringValue != text {
             nsView.stringValue = text
         }

--- a/AlasTests/AlasFieldTests.swift
+++ b/AlasTests/AlasFieldTests.swift
@@ -31,4 +31,26 @@ struct AlasFieldTests {
         controller.view.layoutSubtreeIfNeeded()
         #expect(!controller.view.subviews.isEmpty)
     }
+
+    @Test func appKitFieldCanRenderDisabled() {
+        let view = AlasField(
+            text: .constant("test"),
+            focusOnAppear: true,
+            isEnabled: false
+        )
+        .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(Self.firstTextField(in: controller.view)?.isEnabled == false)
+    }
+
+    private static func firstTextField(in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField { return field }
+        for subview in view.subviews {
+            if let field = firstTextField(in: subview) { return field }
+        }
+        return nil
+    }
 }

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -525,3 +525,143 @@ private enum ResolverTestError: Error, Equatable {
     case missingHEAD
     case unexpectedRef(String)
 }
+
+struct RevisionFollowPresentationTests {
+    @Test func fixedRevisionShowsOpenTether() {
+        let presentation = RevisionFollowPresentation(
+            fixedSHA: "0123456789abcdef",
+            revision: nil,
+            refreshError: nil
+        )
+
+        #expect(presentation == .fixed(sha: "0123456789"))
+    }
+
+    @Test func followedRevisionLinksExpressionToResolvedCommit() throws {
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD~3",
+            baselineBranch: "feature",
+            resolvedSHA: "abcdef0123456789"
+        ))
+
+        let presentation = RevisionFollowPresentation(
+            fixedSHA: "ignored",
+            revision: revision,
+            refreshError: nil
+        )
+
+        #expect(presentation == .following(expression: "HEAD~3", resolvedSHA: "abcdef0123"))
+    }
+
+    @Test func checkoutPauseKeepsCurrentCommitAndShowsCandidate() throws {
+        var revision = try #require(TrackedRevision(
+            expression: "HEAD~3",
+            baselineBranch: "feature",
+            resolvedSHA: "current012345"
+        ))
+        revision = revision.withPendingCheckout(TrackedRevisionCandidate(
+            branch: "main",
+            sha: "candidate98765"
+        ))
+
+        let presentation = RevisionFollowPresentation(
+            fixedSHA: "ignored",
+            revision: revision,
+            refreshError: nil
+        )
+
+        #expect(presentation == .paused(
+            expression: "HEAD~3",
+            resolvedSHA: "current012",
+            candidateSHA: "candidate9",
+            message: "Paused: HEAD moved to main"
+        ))
+    }
+
+    @Test func detachedCheckoutPauseHasUsefulMessage() throws {
+        var revision = try #require(TrackedRevision(
+            expression: "HEAD",
+            baselineBranch: "",
+            resolvedSHA: "current012345"
+        ))
+        revision = revision.withPendingCheckout(TrackedRevisionCandidate(
+            branch: "",
+            sha: "candidate98765"
+        ))
+
+        let presentation = RevisionFollowPresentation(
+            fixedSHA: "ignored",
+            revision: revision,
+            refreshError: nil
+        )
+
+        #expect(presentation.pauseMessage == "Paused: detached HEAD moved")
+    }
+
+    @Test func refreshFailureKeepsLastResolvedCommit() throws {
+        let revision = try #require(TrackedRevision(
+            expression: "HEAD~3",
+            baselineBranch: "feature",
+            resolvedSHA: "current012345"
+        ))
+
+        let presentation = RevisionFollowPresentation(
+            fixedSHA: "ignored",
+            revision: revision,
+            refreshError: "unknown revision"
+        )
+
+        #expect(presentation == .failed(
+            expression: "HEAD~3",
+            resolvedSHA: "current012",
+            message: "unknown revision"
+        ))
+    }
+
+    @Test func updatePulseRequiresAChangedCommitAndMotion() {
+        #expect(RevisionFollowPresentation.shouldPulse(
+            previousSHA: "old",
+            resolvedSHA: "new",
+            reduceMotion: false
+        ))
+        #expect(!RevisionFollowPresentation.shouldPulse(
+            previousSHA: "same",
+            resolvedSHA: "same",
+            reduceMotion: false
+        ))
+        #expect(!RevisionFollowPresentation.shouldPulse(
+            previousSHA: "old",
+            resolvedSHA: "new",
+            reduceMotion: true
+        ))
+        #expect(!RevisionFollowPresentation.shouldPulse(
+            previousSHA: nil,
+            resolvedSHA: "new",
+            reduceMotion: false
+        ))
+    }
+
+    @Test func editorRequestTrimsSubmissionAndMatchesItsTab() {
+        let request = FollowRevisionEditorRequest(
+            worktreeID: "wt",
+            tabID: "tab",
+            expression: "  HEAD~3  ",
+            isEditing: false
+        )
+
+        #expect(request.submissionExpression == "HEAD~3")
+        #expect(request.matches(worktreeID: "wt", tabID: "tab"))
+        #expect(!request.matches(worktreeID: "other", tabID: "tab"))
+    }
+
+    @Test func editorRequestRejectsWhitespaceOnlySubmission() {
+        let request = FollowRevisionEditorRequest(
+            worktreeID: "wt",
+            tabID: "tab",
+            expression: " \n ",
+            isEditing: false
+        )
+
+        #expect(request.submissionExpression == nil)
+    }
+}

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -578,6 +578,31 @@ struct RevisionFollowPresentationTests {
         ))
     }
 
+    @Test func checkoutPauseWinsOverRefreshFailure() throws {
+        var revision = try #require(TrackedRevision(
+            expression: "HEAD~3",
+            baselineBranch: "feature",
+            resolvedSHA: "current012345"
+        ))
+        revision = revision.withPendingCheckout(TrackedRevisionCandidate(
+            branch: "main",
+            sha: "candidate98765"
+        ))
+
+        let presentation = RevisionFollowPresentation(
+            fixedSHA: "ignored",
+            revision: revision,
+            refreshError: "unknown revision"
+        )
+
+        #expect(presentation == .paused(
+            expression: "HEAD~3",
+            resolvedSHA: "current012",
+            candidateSHA: "candidate9",
+            message: "Paused: HEAD moved to main"
+        ))
+    }
+
     @Test func detachedCheckoutPauseHasUsefulMessage() throws {
         var revision = try #require(TrackedRevision(
             expression: "HEAD",
@@ -663,5 +688,22 @@ struct RevisionFollowPresentationTests {
         )
 
         #expect(request.submissionExpression == nil)
+    }
+
+    @MainActor
+    @Test func submittingEditorRequestIgnoresRepeatSubmit() {
+        let state = AppState()
+        var request = FollowRevisionEditorRequest(
+            worktreeID: "wt",
+            tabID: "tab",
+            expression: "HEAD",
+            isEditing: false
+        )
+        request.isSubmitting = true
+        state.followRevisionEditorRequest = request
+
+        state.submitFollowRevisionEditor()
+
+        #expect(state.followRevisionEditorRequest == request)
     }
 }


### PR DESCRIPTION
## Summary
- Replace the revision follow alert with an anchored inline editor.
- Add a shared tethered visual state for fixed, following, paused, and failed revisions.
- Use the new control in commit detail, review sessions, the review-target palette, and tab menus.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Targeted revision-follow and affected UI tests

The full local suite has unrelated intermittent failures in terminal cleanup, diff-review accessibility, and local remote-server setup; each passed when rerun in isolation.