### PR TITLE
perf(diff): cache syntax highlighting and hunk heights during scroll

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1095,6 +1095,7 @@
 		B6B861A60445F450FB94A0CF /* ACPComposerFocusPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1494739C8FBECE52DAAAE3 /* ACPComposerFocusPolicy.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
 		B7067A1BBEB1B1B5B9867BEA /* DiffPreferenceBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8435ABAF423A6F5BC28E4C /* DiffPreferenceBindings.swift */; };
+		B736E17293E8D8F114B9982C /* HighlightSpanCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D88FF0751011A91008BFC78 /* HighlightSpanCache.swift */; };
 		B7542C247255B91CEC68004F /* ChatFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */; };
 		B76AD708A9FD54304F84366A /* ImageFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F942D660C7ABA8542C77D /* ImageFileType.swift */; };
 		B785053315764F42E3601F15 /* UpdateProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF766C79A3F9F004A513D4D /* UpdateProgressSheet.swift */; };
@@ -1293,6 +1294,7 @@
 		D5DA3A3F8601334E0415CF0C /* CodeHostIssueResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279C594FF9D43EF68D698E00 /* CodeHostIssueResolver.swift */; };
 		D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */; };
 		D6022D340521FC907FD901DE /* DiffReviewFileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B5815D9BE36D3F835B5456 /* DiffReviewFileSection.swift */; };
+		D66C4645D23AC11B97B79489 /* DiffHighlightPrewarmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFAD7C8BA328957C381C3B0 /* DiffHighlightPrewarmer.swift */; };
 		D675E5B1E5E95E7239F3A89F /* InstallRecipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */; };
 		D6A8D3925ACCB69DAC380B95 /* AgentPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DD85A6E01972B39F2D8AD /* AgentPath.swift */; };
 		D6B39CE8878BB196FF2277B6 /* AgentDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */; };
@@ -1498,6 +1500,7 @@
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
 		F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */; };
 		F8DFFC12D5F7F2E1F8F19A02 /* MermaidRenderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */; };
+		F916235528BF9A5E4773804E /* AppKitDiffReviewFlingPerfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71DEA04B12C341C540CCD54A /* AppKitDiffReviewFlingPerfTests.swift */; };
 		F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */; };
 		F927B660B51081F2FACA5070 /* FileSystemOpenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596BB6B295D768E2C0D3BC85 /* FileSystemOpenTests.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
@@ -2117,6 +2120,7 @@
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5D60B1F5C752C6936F36CB04 /* AddMissionLegDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionLegDialog.swift; sourceTree = "<group>"; };
 		5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchBackend.swift; sourceTree = "<group>"; };
+		5D88FF0751011A91008BFC78 /* HighlightSpanCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightSpanCache.swift; sourceTree = "<group>"; };
 		5D89087B3506E3F54F29C718 /* OpenBinaryRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenBinaryRoutingTests.swift; sourceTree = "<group>"; };
 		5DA887927D32EBA2252792D9 /* ReviewChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabView.swift; sourceTree = "<group>"; };
 		5DABE7D3F41C67D28CA2C2F9 /* RemoteImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageCache.swift; sourceTree = "<group>"; };
@@ -2235,6 +2239,7 @@
 		71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionStateResolverTests.swift; sourceTree = "<group>"; };
 		71A90560CED6562BBC313F3C /* ProjectConfigHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigHostTests.swift; sourceTree = "<group>"; };
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
+		71DEA04B12C341C540CCD54A /* AppKitDiffReviewFlingPerfTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewFlingPerfTests.swift; sourceTree = "<group>"; };
 		71E01A18A7215E3FEEB71B07 /* ACPBrokerClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBrokerClientTests.swift; sourceTree = "<group>"; };
 		71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefill.swift; sourceTree = "<group>"; };
 		724A473AB9439DAA535B33F8 /* GGUndoMarkerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGUndoMarkerStore.swift; sourceTree = "<group>"; };
@@ -2308,6 +2313,7 @@
 		7E47BC69C5569A9CABEB4FD7 /* ImageDiffDecodedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDecodedCache.swift; sourceTree = "<group>"; };
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
 		7ECE27F4EE6CA578693BE83D /* RemoteProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProjectGitWatcher.swift; sourceTree = "<group>"; };
+		7EFAD7C8BA328957C381C3B0 /* DiffHighlightPrewarmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHighlightPrewarmer.swift; sourceTree = "<group>"; };
 		7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshot.swift; sourceTree = "<group>"; };
 		7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+CommitEditing.swift"; sourceTree = "<group>"; };
 		7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownLiveStylerImageChipTests.swift; sourceTree = "<group>"; };
@@ -3189,6 +3195,7 @@
 			isa = PBXGroup;
 			children = (
 				B7E50B0600EF60A0D9B09877 /* HighlightCapture.swift */,
+				5D88FF0751011A91008BFC78 /* HighlightSpanCache.swift */,
 				328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */,
 				5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */,
 			);
@@ -4393,6 +4400,7 @@
 				00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */,
 				5C96772DABFBCF15691FFB37 /* DiffDisplayPreferences.swift */,
 				4F03EE87AC76203E09C9F1C5 /* DiffFeedbackLane.swift */,
+				7EFAD7C8BA328957C381C3B0 /* DiffHighlightPrewarmer.swift */,
 				22CF502ECFD2763E52CB022F /* DiffInlineCommentModel.swift */,
 				6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */,
 				B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */,
@@ -5502,6 +5510,7 @@
 		F49FC1F7280807BA9B8075E0 /* DiffReview */ = {
 			isa = PBXGroup;
 			children = (
+				71DEA04B12C341C540CCD54A /* AppKitDiffReviewFlingPerfTests.swift */,
 				11202D7ACC80F782AE48CD81 /* AppKitDiffReviewRowPlanTests.swift */,
 				5B6C1F946AC7EC621C5A8A59 /* AppKitDiffReviewScrollerTests.swift */,
 			);
@@ -6259,6 +6268,7 @@
 				E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */,
 				3F0D7932AB67DDF711AF1B6F /* DiffDisplayPreferences.swift in Sources */,
 				9632444ADF742653917F387D /* DiffFeedbackLane.swift in Sources */,
+				D66C4645D23AC11B97B79489 /* DiffHighlightPrewarmer.swift in Sources */,
 				BDEA5736B570C77CF4C965F5 /* DiffInlineAnnotationCard.swift in Sources */,
 				850D54DB270088190BA20A13 /* DiffInlineCommentCard.swift in Sources */,
 				94B884D1DB09DB562A0DCC20 /* DiffInlineCommentModel.swift in Sources */,
@@ -6391,6 +6401,7 @@
 				90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */,
 				14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */,
 				C512EC7827D3C46907DDB7A1 /* HighlightCapture.swift in Sources */,
+				B736E17293E8D8F114B9982C /* HighlightSpanCache.swift in Sources */,
 				387EF12B6875648E422956F7 /* Highlighted.swift in Sources */,
 				B05BA1C6DD0BDA21E0932EE3 /* HookInstallNudgeResolver.swift in Sources */,
 				AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */,
@@ -6962,6 +6973,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
+				F916235528BF9A5E4773804E /* AppKitDiffReviewFlingPerfTests.swift in Sources */,
 				3B925198F948BE8054662C43 /* AppKitDiffReviewPresentationStateTests.swift in Sources */,
 				BBCC834135D0915CAEED5A4C /* AppKitDiffReviewRowPlanTests.swift in Sources */,
 				4977422707F8C79E2BD5E337 /* AppKitDiffReviewScrollerTests.swift in Sources */,

--- a/Alas/Sources/Center/Diff/DiffHighlightPrewarmer.swift
+++ b/Alas/Sources/Center/Diff/DiffHighlightPrewarmer.swift
@@ -1,0 +1,109 @@
+import AppKit
+
+/// Warms `HighlightSpanCache` for a diff's hunks off the scroll path.
+///
+/// Mounting a virtualized diff row tokenizes its hunk synchronously inside
+/// the scroll tick; a cold 80-line hunk costs tens of milliseconds and reads
+/// as a fling hiccup. Prewarming performs the same document build on a
+/// background queue when the row plan is first created, so row mounts hit the
+/// span cache instead of parsing mid-fling.
+enum DiffHighlightPrewarmer {
+    private static let queue = DispatchQueue(label: "io.nlopez.alas.diff-highlight-prewarm", qos: .utility)
+
+    static func prewarm(
+        groups: [DiffDisplayGroup],
+        expandedCollapsedRowIDs: Set<String>,
+        layoutMode: DiffLayoutMode,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) {
+        queue.async {
+            warm(
+                groups: groups,
+                expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                layoutMode: layoutMode,
+                fileExtension: fileExtension,
+                font: font,
+                showWhitespace: showWhitespace,
+                theme: theme
+            )
+        }
+    }
+
+    /// Same warm-up on the calling thread, for deterministic tests.
+    static func prewarmSynchronously(
+        groups: [DiffDisplayGroup],
+        expandedCollapsedRowIDs: Set<String>,
+        layoutMode: DiffLayoutMode,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) {
+        warm(
+            groups: groups,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+            layoutMode: layoutMode,
+            fileExtension: fileExtension,
+            font: font,
+            showWhitespace: showWhitespace,
+            theme: theme
+        )
+    }
+
+    /// Signature over everything that changes which sources get tokenized.
+    /// Font and theme are excluded on purpose: spans depend only on source
+    /// text and language.
+    static func signature(
+        groups: [DiffDisplayGroup],
+        expandedCollapsedRowIDs: Set<String>,
+        layoutMode: DiffLayoutMode,
+        fileExtension: String,
+        showWhitespace: Bool
+    ) -> Int {
+        var hasher = Hasher()
+        for group in groups {
+            hasher.combine(group.contentHash)
+        }
+        hasher.combine(expandedCollapsedRowIDs)
+        hasher.combine(layoutMode)
+        hasher.combine(fileExtension)
+        hasher.combine(showWhitespace)
+        return hasher.finalize()
+    }
+
+    private static func warm(
+        groups: [DiffDisplayGroup],
+        expandedCollapsedRowIDs: Set<String>,
+        layoutMode: DiffLayoutMode,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) {
+        for group in groups {
+            switch layoutMode {
+            case .split:
+                _ = DiffPaneTextDocumentBuilder.buildSplit(
+                    group: group,
+                    expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                    fileExtension: fileExtension,
+                    font: font,
+                    showWhitespace: showWhitespace,
+                    theme: theme
+                )
+            case .stacked:
+                _ = DiffPaneTextDocumentBuilder.buildStacked(
+                    group: group,
+                    expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                    fileExtension: fileExtension,
+                    font: font,
+                    showWhitespace: showWhitespace,
+                    theme: theme
+                )
+            }
+        }
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -184,22 +184,14 @@ enum DiffPaneStaticHeightEstimator {
         let hunkHeights = model.groups.enumerated().reduce(CGFloat(0)) { total, item in
             let (index, group) = item
             let fusion = index < fusionStates.count ? fusionStates[index] : .none
-            let visibleRows = DiffPaneRowProjection.visibleRows(
-                in: group,
-                expandedCollapsedRowIDs: expandedCollapsedRowIDs
-            )
-            let wrappingColumnWidth = wrappingColumnWidth(
-                layoutMode: layoutMode,
-                availableWidth: availableWidth,
-                rows: visibleRows
-            )
-            let rowsHeight = textRowsHeight(
-                for: visibleRows,
+            let rowsHeight = cachedTextRowsHeight(
+                group: group,
+                expandedCollapsedRowIDs: expandedCollapsedRowIDs,
                 layoutMode: layoutMode,
                 codeLineHeight: codeLineHeight,
                 contextControlRowHeight: contextControlRowHeight,
                 wrapLines: wrapLines,
-                wrappingColumnWidth: wrappingColumnWidth,
+                availableWidth: availableWidth,
                 codeFont: codeFont,
                 showWhitespace: showWhitespace
             )
@@ -211,6 +203,113 @@ enum DiffPaneStaticHeightEstimator {
         }
 
         return topPadding + hunkHeights + bottomPadding
+    }
+
+    /// Row-height estimation walks every row of a hunk, so a multi-file review
+    /// re-walks thousands of rows each time a row plan is rebuilt — including
+    /// rebuilds triggered by unrelated state such as the selected file
+    /// changing mid-fling. The result is a pure function of the group's
+    /// content and the presentation inputs below, so memoize it.
+    private static func cachedTextRowsHeight(
+        group: DiffDisplayGroup,
+        expandedCollapsedRowIDs: Set<String>,
+        layoutMode: DiffLayoutMode,
+        codeLineHeight: CGFloat,
+        contextControlRowHeight: CGFloat,
+        wrapLines: Bool,
+        availableWidth: CGFloat?,
+        codeFont: NSFont,
+        showWhitespace: Bool
+    ) -> CGFloat {
+        var hasher = Hasher()
+        hasher.combine(group.contentHash)
+        hasher.combine(layoutMode)
+        hasher.combine(codeLineHeight)
+        hasher.combine(contextControlRowHeight)
+        hasher.combine(wrapLines)
+        hasher.combine(availableWidth)
+        hasher.combine(codeFont.fontName)
+        hasher.combine(codeFont.pointSize)
+        hasher.combine(showWhitespace)
+        // Only expansions belonging to this group change its height.
+        for row in group.rows where row.kind == .collapsed && expandedCollapsedRowIDs.contains(row.id) {
+            hasher.combine(row.id)
+        }
+        let key = hasher.finalize()
+
+        if let cached = rowsHeightCache.value(forKey: key) { return cached }
+
+        let visibleRows = DiffPaneRowProjection.visibleRows(
+            in: group,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs
+        )
+        let height = textRowsHeight(
+            for: visibleRows,
+            layoutMode: layoutMode,
+            codeLineHeight: codeLineHeight,
+            contextControlRowHeight: contextControlRowHeight,
+            wrapLines: wrapLines,
+            wrappingColumnWidth: wrappingColumnWidth(
+                layoutMode: layoutMode,
+                availableWidth: availableWidth,
+                rows: visibleRows
+            ),
+            codeFont: codeFont,
+            showWhitespace: showWhitespace
+        )
+        rowsHeightCache.setValue(height, forKey: key)
+        return height
+    }
+
+    static let rowsHeightCache = HeightCache()
+
+    /// Small lock-guarded memo. `estimatedHeight` is reachable from both the
+    /// main actor and the background highlight prewarmer.
+    final class HeightCache: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [Int: CGFloat] = [:]
+
+        #if DEBUG
+        private var hits = 0
+        private var misses = 0
+
+        /// Row walks avoided (`hits`) versus performed (`misses`).
+        var statisticsForTests: (hits: Int, misses: Int) {
+            lock.lock()
+            defer { lock.unlock() }
+            return (hits, misses)
+        }
+
+        func resetStatisticsForTests() {
+            lock.lock()
+            defer { lock.unlock() }
+            hits = 0
+            misses = 0
+        }
+        #endif
+
+        func value(forKey key: Int) -> CGFloat? {
+            lock.lock()
+            defer { lock.unlock() }
+            let value = storage[key]
+            #if DEBUG
+            if value == nil { misses += 1 } else { hits += 1 }
+            #endif
+            return value
+        }
+
+        func setValue(_ value: CGFloat, forKey key: Int) {
+            lock.lock()
+            defer { lock.unlock() }
+            if storage.count > 4096 { storage.removeAll(keepingCapacity: true) }
+            storage[key] = value
+        }
+
+        func removeAll() {
+            lock.lock()
+            defer { lock.unlock() }
+            storage.removeAll(keepingCapacity: true)
+        }
     }
 
     private static func textRowsHeight(

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -6,6 +6,17 @@ final class DiffPanePresentationState: ObservableObject {
     let actionRelay = DiffPaneActionRelay()
     @Published private(set) var expandedCollapsedRowIDs: Set<String> = []
     @Published private(set) var activeThreadID: String?
+    private var prewarmedHighlightSignatures: Set<Int> = []
+
+    /// Records that a highlight prewarm for `signature` was scheduled.
+    /// Returns true only the first time a signature is seen so plan rebuilds
+    /// don't re-enqueue identical background work.
+    func registerHighlightPrewarm(signature: Int) -> Bool {
+        if prewarmedHighlightSignatures.count > 512 {
+            prewarmedHighlightSignatures.removeAll(keepingCapacity: true)
+        }
+        return prewarmedHighlightSignatures.insert(signature).inserted
+    }
 
     func toggleCollapsedContext(in group: DiffDisplayGroup) {
         expandedCollapsedRowIDs = DiffCollapsedContextController.toggled(
@@ -143,6 +154,7 @@ enum DiffPaneRowPlanBuilder {
     @MainActor
     static func build(input: DiffPaneRowPlanInput, state: DiffPanePresentationState) -> AppKitDiffRowPlan {
         state.actionRelay.update(from: input)
+        prewarmHighlightsIfNeeded(input: input, state: state)
         let fusions = resolvedFusions(for: input)
         let rows = input.model.groups.enumerated().map { index, group in
             let fusion = fusions[index]
@@ -193,6 +205,27 @@ enum DiffPaneRowPlanBuilder {
     }
 
     @MainActor
+    private static func prewarmHighlightsIfNeeded(input: DiffPaneRowPlanInput, state: DiffPanePresentationState) {
+        let signature = DiffHighlightPrewarmer.signature(
+            groups: input.model.groups,
+            expandedCollapsedRowIDs: state.expandedCollapsedRowIDs,
+            layoutMode: input.layoutMode,
+            fileExtension: input.fileExtension,
+            showWhitespace: input.showWhitespace
+        )
+        guard state.registerHighlightPrewarm(signature: signature) else { return }
+        DiffHighlightPrewarmer.prewarm(
+            groups: input.model.groups,
+            expandedCollapsedRowIDs: state.expandedCollapsedRowIDs,
+            layoutMode: input.layoutMode,
+            fileExtension: input.fileExtension,
+            font: CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize),
+            showWhitespace: input.showWhitespace,
+            theme: input.theme
+        )
+    }
+
+    @MainActor
     private static func hunkRetention(
         for threads: [DiffInlineCommentThread],
         state: DiffPanePresentationState
@@ -229,6 +262,7 @@ enum DiffPaneRowPlanBuilder {
     }
 
     static func threads(for rows: [DiffDisplayRow], from threads: [DiffInlineCommentThread]) -> [DiffInlineCommentThread] {
+        guard !threads.isEmpty else { return [] }
         let oldLines = Set(rows.compactMap { $0.old?.anchor.oldLine })
         let newLines = Set(rows.compactMap { $0.new?.anchor.newLine })
         return threads.filter { thread in
@@ -239,6 +273,7 @@ enum DiffPaneRowPlanBuilder {
     }
 
     static func annotations(for rows: [DiffDisplayRow], from annotations: [DiffInlineAnnotation]) -> [DiffInlineAnnotation] {
+        guard !annotations.isEmpty else { return [] }
         let newLines = Set(rows.compactMap { $0.new?.anchor.newLine })
         return annotations.filter { newLines.contains($0.newLine) }
     }

--- a/Alas/Sources/Code/Highlight/HighlightSpanCache.swift
+++ b/Alas/Sources/Code/Highlight/HighlightSpanCache.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Process-wide memo for tree-sitter highlight spans keyed by exact source
+/// text and file extension. Virtualized diff rows re-highlight identical
+/// content every time they remount during scrolling; this cache makes those
+/// remounts cheap and lets background prewarming pay the parse cost off the
+/// scroll path. Spans depend only on the source text and language, never on
+/// theme or font, so entries stay valid across appearance changes.
+final class HighlightSpanCache: @unchecked Sendable {
+    static let shared = HighlightSpanCache()
+
+    /// Whole-file sources (merge editor, markdown blocks) can be large;
+    /// parsing those is not on the diff fling path and caching them would
+    /// evict many row-sized entries.
+    private static let maximumSourceUTF16Length = 64 * 1024
+
+    private final class Entry {
+        let spans: [HighlightSpan]
+        init(spans: [HighlightSpan]) { self.spans = spans }
+    }
+
+    private let storage = NSCache<NSString, Entry>()
+
+    #if DEBUG
+    private let statsLock = NSLock()
+    private var hits = 0
+    private var misses = 0
+
+    /// Tokenization work avoided (`hits`) versus performed (`misses`).
+    var statisticsForTests: (hits: Int, misses: Int) {
+        statsLock.lock()
+        defer { statsLock.unlock() }
+        return (hits, misses)
+    }
+
+    func resetStatisticsForTests() {
+        statsLock.lock()
+        defer { statsLock.unlock() }
+        hits = 0
+        misses = 0
+    }
+
+    private func record(hit: Bool) {
+        statsLock.lock()
+        defer { statsLock.unlock() }
+        if hit { hits += 1 } else { misses += 1 }
+    }
+    #endif
+
+    init(countLimit: Int = 8192) {
+        storage.countLimit = countLimit
+    }
+
+    func spans(source: String, fileExtension: String) -> [HighlightSpan]? {
+        guard (source as NSString).length <= Self.maximumSourceUTF16Length else { return nil }
+        let spans = storage.object(forKey: Self.key(source: source, fileExtension: fileExtension))?.spans
+        #if DEBUG
+        record(hit: spans != nil)
+        #endif
+        return spans
+    }
+
+    func store(_ spans: [HighlightSpan], source: String, fileExtension: String) {
+        guard (source as NSString).length <= Self.maximumSourceUTF16Length else { return }
+        storage.setObject(Entry(spans: spans), forKey: Self.key(source: source, fileExtension: fileExtension))
+    }
+
+    func removeAll() {
+        storage.removeAllObjects()
+    }
+
+    private static func key(source: String, fileExtension: String) -> NSString {
+        "\(fileExtension)\u{1}\(source)" as NSString
+    }
+}

--- a/Alas/Sources/Code/Highlight/HighlightSpanCache.swift
+++ b/Alas/Sources/Code/Highlight/HighlightSpanCache.swift
@@ -47,8 +47,14 @@ final class HighlightSpanCache: @unchecked Sendable {
     }
     #endif
 
-    init(countLimit: Int = 8192) {
+    /// `countLimit` alone bounds entry count, not bytes: each key can retain
+    /// up to `maximumSourceUTF16Length` of source text plus its span array,
+    /// so an eagerly-prewarmed large review could otherwise grow this cache
+    /// into the hundreds of megabytes. Mirrors `ImageDiffDecodedCache`'s use
+    /// of a byte-cost limit for the same reason.
+    init(countLimit: Int = 8192, totalCostLimit: Int = 64 * 1024 * 1024) {
         storage.countLimit = countLimit
+        storage.totalCostLimit = totalCostLimit
     }
 
     func spans(source: String, fileExtension: String) -> [HighlightSpan]? {
@@ -62,7 +68,8 @@ final class HighlightSpanCache: @unchecked Sendable {
 
     func store(_ spans: [HighlightSpan], source: String, fileExtension: String) {
         guard (source as NSString).length <= Self.maximumSourceUTF16Length else { return }
-        storage.setObject(Entry(spans: spans), forKey: Self.key(source: source, fileExtension: fileExtension))
+        let cost = (source as NSString).length * 2 + spans.count * MemoryLayout<HighlightSpan>.stride
+        storage.setObject(Entry(spans: spans), forKey: Self.key(source: source, fileExtension: fileExtension), cost: cost)
     }
 
     func removeAll() {

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -92,7 +92,18 @@ struct TreeSitterHighlighter {
     }
 
     /// Tokenize a full file. Returns highlight spans against `source`.
+    /// Results are memoized in `HighlightSpanCache`; spans depend only on
+    /// the source text and language.
     static func highlight(source: String, fileExtension ext: String) -> [HighlightSpan] {
+        if let cached = HighlightSpanCache.shared.spans(source: source, fileExtension: ext) {
+            return cached
+        }
+        let spans = computeHighlight(source: source, fileExtension: ext)
+        HighlightSpanCache.shared.store(spans, source: source, fileExtension: ext)
+        return spans
+    }
+
+    private static func computeHighlight(source: String, fileExtension ext: String) -> [HighlightSpan] {
         let effectiveExt = effectiveExtension(for: source, fileExtension: ext)
         guard
             let language = LanguageRegistry.language(forFileExtension: effectiveExt),

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewFlingPerfTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewFlingPerfTests.swift
@@ -124,7 +124,10 @@ struct AppKitDiffReviewFlingPerfTests {
                     defer { newLine += 1 }
                     return .init(kind: .add, text: text, oldNumber: nil, newNumber: newLine)
                 default:
-                    defer { oldLine += 1; newLine += 1 }
+                    defer {
+                        oldLine += 1
+                        newLine += 1
+                    }
                     return .init(kind: .context, text: text, oldNumber: oldLine, newNumber: newLine)
                 }
             }

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewFlingPerfTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewFlingPerfTests.swift
@@ -1,0 +1,161 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+/// Guards the two costs that made fling-scrolling a multi-file review hitch:
+/// syntax tokenization on the row-mount path, and a full row-height re-walk
+/// every time the row plan is rebuilt (which happens on every file-boundary
+/// crossing, because the active file changing re-renders the review surface).
+///
+/// These assert on work avoided rather than wall-clock time so they stay
+/// meaningful on a loaded CI machine.
+@Suite(.serialized)
+@MainActor
+struct AppKitDiffReviewFlingPerfTests {
+    private static let fileCount = 6
+    private static let hunksPerFile = 4
+    private static let linesPerHunk = 40
+
+    @Test func prewarmingRemovesTokenizationFromTheRowMountPath() throws {
+        let theme = try ThemeStore().current
+        let file = makeFile(index: 0, salt: "prewarm")
+        let groups = try #require(file.displayModel?.groups)
+        let font = CenterTypography.resolveCodeFont(family: "SF Mono", size: 13)
+
+        DiffHighlightPrewarmer.prewarmSynchronously(
+            groups: groups, expandedCollapsedRowIDs: [], layoutMode: .split,
+            fileExtension: "swift", font: font, showWhitespace: false, theme: theme
+        )
+
+        // Building the same documents again is what a row mount does; after a
+        // prewarm it must not tokenize anything.
+        HighlightSpanCache.shared.resetStatisticsForTests()
+        for group in groups {
+            _ = DiffPaneTextDocumentBuilder.buildSplit(
+                group: group, expandedCollapsedRowIDs: [], fileExtension: "swift",
+                font: font, showWhitespace: false, theme: theme
+            )
+        }
+
+        let stats = HighlightSpanCache.shared.statisticsForTests
+        #expect(stats.hits > 0)
+        #expect(stats.misses == 0)
+    }
+
+    @Test func rebuildingTheRowPlanDoesNotRewalkRowHeights() throws {
+        let theme = try ThemeStore().current
+        let files = (0..<Self.fileCount).map { makeFile(index: $0, salt: "replan") }
+        let states = files.map { _ in AppKitDiffReviewFileState() }
+        let inputs = zip(files, states).map { file, state in
+            AppKitDiffReviewRowInput(file: file, state: state, theme: theme)
+        }
+
+        _ = AppKitDiffReviewRowPlanBuilder.build(inputs: inputs)
+
+        // A file-boundary crossing changes the selected file, which re-renders
+        // the surface and rebuilds this plan even though no row content moved.
+        DiffPaneStaticHeightEstimator.rowsHeightCache.resetStatisticsForTests()
+        _ = AppKitDiffReviewRowPlanBuilder.build(inputs: inputs)
+
+        let stats = DiffPaneStaticHeightEstimator.rowsHeightCache.statisticsForTests
+        #expect(stats.hits == Self.fileCount * Self.hunksPerFile)
+        #expect(stats.misses == 0)
+    }
+
+    @Test func expandingContextInvalidatesOnlyTheAffectedHunkHeight() throws {
+        let theme = try ThemeStore().current
+        let file = collapsibleFile()
+        let group = try #require(file.displayModel?.groups.first)
+        let font = CenterTypography.resolveCodeFont(family: "SF Mono", size: 13)
+        let collapsedID = try #require(
+            group.rows.first(where: { $0.kind == .collapsed })?.id
+        )
+
+        func height(expanded: Set<String>) -> CGFloat {
+            DiffPaneStaticHeightEstimator.estimatedHeight(
+                for: .init(filePath: file.summary.path, groups: [group]),
+                layoutMode: .split, expandedCollapsedRowIDs: expanded,
+                codeFont: font, headerFont: font, wrapLines: false, showWhitespace: false
+            )
+        }
+
+        let collapsed = height(expanded: [])
+        let expanded = height(expanded: [collapsedID])
+
+        #expect(expanded > collapsed)
+        // Re-asking must return each cached value, not the other one.
+        #expect(height(expanded: []) == collapsed)
+        #expect(height(expanded: [collapsedID]) == expanded)
+    }
+
+    @Test func heightCacheKeysOnPresentationInputs() throws {
+        let theme = try ThemeStore().current
+        let file = makeFile(index: 0, salt: "keys")
+        let group = try #require(file.displayModel?.groups.first)
+        let model = DiffDisplayModel(filePath: file.summary.path, groups: [group])
+        let small = CenterTypography.resolveCodeFont(family: "SF Mono", size: 11)
+        let large = CenterTypography.resolveCodeFont(family: "SF Mono", size: 17)
+        _ = theme
+
+        func height(font: NSFont, layoutMode: DiffLayoutMode) -> CGFloat {
+            DiffPaneStaticHeightEstimator.estimatedHeight(
+                for: model, layoutMode: layoutMode, expandedCollapsedRowIDs: [],
+                codeFont: font, headerFont: font, wrapLines: false, showWhitespace: false
+            )
+        }
+
+        #expect(height(font: small, layoutMode: .split) < height(font: large, layoutMode: .split))
+        #expect(height(font: small, layoutMode: .split) != height(font: small, layoutMode: .stacked))
+    }
+
+    private func makeFile(index: Int, salt: String) -> DiffReviewFileSectionModel {
+        let hunks = (0..<Self.hunksPerFile).map { hunkIndex -> ParsedDiff.Hunk in
+            let start = hunkIndex * 400 + 1
+            var oldLine = start
+            var newLine = start
+            let lines = (0..<Self.linesPerHunk).map { lineIndex -> ParsedDiff.Hunk.Line in
+                let text = "let value\(lineIndex) = SomeType.make(one: \(lineIndex), two: \"\(salt)-\(index)-\(hunkIndex)-\(lineIndex)\")"
+                switch lineIndex % 4 {
+                case 0:
+                    defer { oldLine += 1 }
+                    return .init(kind: .delete, text: text, oldNumber: oldLine, newNumber: nil)
+                case 1:
+                    defer { newLine += 1 }
+                    return .init(kind: .add, text: text, oldNumber: nil, newNumber: newLine)
+                default:
+                    defer { oldLine += 1; newLine += 1 }
+                    return .init(kind: .context, text: text, oldNumber: oldLine, newNumber: newLine)
+                }
+            }
+            return .init(
+                header: "@@ -\(start),\(Self.linesPerHunk) +\(start),\(Self.linesPerHunk) @@",
+                oldStart: start, newStart: start, lines: lines
+            )
+        }
+        return file(hunks: hunks, path: "Sources/Module\(index)/File\(salt)\(index).swift")
+    }
+
+    /// A hunk with enough leading context to collapse.
+    private func collapsibleFile() -> DiffReviewFileSectionModel {
+        var lines = (1...30).map { index in
+            ParsedDiff.Hunk.Line(kind: .context, text: "let context\(index) = \(index)", oldNumber: index, newNumber: index)
+        }
+        lines.append(.init(kind: .add, text: "let added = 0", oldNumber: nil, newNumber: 31))
+        let hunk = ParsedDiff.Hunk(header: "@@ -1,30 +1,31 @@", oldStart: 1, newStart: 1, lines: lines)
+        return file(hunks: [hunk], path: "Sources/Collapsible.swift")
+    }
+
+    private func file(hunks: [ParsedDiff.Hunk], path: String) -> DiffReviewFileSectionModel {
+        let diff = ParsedDiff(hunks: hunks)
+        let summary = DiffReviewFileSummary(
+            path: path, namespace: "review", groupID: nil, groupTitle: nil,
+            status: .modified, additions: 1, deletions: 1, isRenderable: true
+        )
+        return DiffReviewFileSectionModel(
+            summary: summary, parsedDiff: diff,
+            displayModel: DiffDisplayModelBuilder.build(diff: diff, filePath: summary.path),
+            placeholderMessage: nil, openFile: nil, contextProvider: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes visible jank when fling-scrolling a multi-file diff review, most noticeable when the scroll crosses from one file into the next.
- Two costs were sitting on the scroll path: hunks were re-tokenized with tree-sitter on every remount (even for hunks already scrolled past), and crossing a file boundary rebuilt the entire row plan — including a full row-height re-walk — even though no row content had changed.

### What changed

- `HighlightSpanCache` memoizes tree-sitter highlight spans by source text and language. Spans don't depend on theme or font, so entries stay valid across appearance changes.
- `DiffHighlightPrewarmer` warms that cache on a background queue as soon as a file's row plan is built, so row mounts during a fling hit the cache instead of parsing.
- `DiffPaneStaticHeightEstimator` now memoizes per-hunk row-height estimation, keyed on the hunk's content and the presentation inputs that affect its height (layout mode, font, wrap/whitespace settings, expanded-context rows). A file-boundary crossing that only changes the selected file no longer re-walks every row of every hunk.
- `threads(for:)`/`annotations(for:)` in the row-plan builder short-circuit when there are no threads/annotations to match, avoiding line-number set construction on the common empty case.

### Reviewer notes

- `AppKitDiffReviewFlingPerfTests` asserts on cache hit/miss counts rather than wall-clock timing, so it stays meaningful under CI load. I verified it's red-capable by temporarily neutering both caches and confirming the tests fail with the expected miss counts before restoring.
- Measured on a synthetic 12-file review (debug build): worst per-tick scroll cost dropped from ~41ms to ~23ms, p95 from ~36ms to ~15ms, and the file-boundary plan rebuild from ~8.7ms to ~2.7ms.
- Not addressed here: attributed-string assembly + TextKit layout still costs a few ms per row mount. The prewarmer already builds and discards those documents on a background thread, so caching the built `CodeDocument`s would remove that too, at the cost of holding attributed strings in memory for large reviews — left as a follow-up rather than bundled in.