### PR TITLE
fix(cursor): stop false permission notifications

### DIFF
--- a/Alas/Sources/Harness/CursorInstaller.swift
+++ b/Alas/Sources/Harness/CursorInstaller.swift
@@ -68,20 +68,12 @@ struct CursorInstaller: AgentInstaller, Sendable {
         events: [.attached], agent: .cursor, forwardStdinAsBody: false)
     private static let detached = AlasHookCommand.compositeCommand(
         events: [.detached], agent: .cursor, forwardStdinAsBody: false)
-    private static let permissionRequestAndContinue = AlasHookCommand.compositeCommand(
-        events: [.permissionRequest],
-        agent: .cursor,
-        forwardStdinAsBody: false,
-        stdoutResponse: #"{"continue":true}"#
-    )
 
     private func hooksByEvent() -> [String: [[String: Any]]] {
         [
             "sessionStart": [flatEntry(command: Self.attached)],
             "sessionEnd": [flatEntry(command: Self.detached)],
             "beforeSubmitPrompt": [flatEntry(command: Self.busy)],
-            "beforeShellExecution": [flatEntry(command: Self.permissionRequestAndContinue)],
-            "beforeMCPExecution": [flatEntry(command: Self.permissionRequestAndContinue)],
             "afterAgentResponse": [flatEntry(command: Self.awaitingInputAndNotify)],
             "stop": [flatEntry(command: Self.idleAndNotify)],
         ]

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -127,10 +127,18 @@ final class HarnessService {
             }
 
         case .permissionRequest:
-            // Cancel pending cursor-idle debounce; permission requests are a real state change.
+            // Older Cursor installs reported every shell and MCP execution as
+            // a permission request. Cursor has no hook for actual approval
+            // prompts, so keep stale installs accurate until their hooks are
+            // updated.
             if event.agent == .cursor {
                 cursorIdleDebouncers.removeValue(forKey: event.sessionId)?.cancel()
                 pendingCursorIdleEvents.removeValue(forKey: event.sessionId)
+                activityBySession[event.sessionId] = HarnessActivityState(
+                    agent: event.agent, state: .busy, pid: event.pid,
+                    lastBody: nil, updatedAt: Date()
+                )
+                return
             }
             activityBySession[event.sessionId] = HarnessActivityState(
                 agent: event.agent, state: .permissionRequest, pid: event.pid,

--- a/AlasTests/CursorInstallerTests.swift
+++ b/AlasTests/CursorInstallerTests.swift
@@ -27,17 +27,10 @@ struct CursorInstallerTests {
         let installedHooks = installed["hooks"] as! [String: Any]
         #expect(installedHooks["sessionStart"] != nil)
         #expect(installedHooks["sessionEnd"] != nil)
-        #expect(installedHooks["beforeShellExecution"] != nil)
-        #expect(installedHooks["beforeMCPExecution"] != nil)
-
-        for event in ["beforeShellExecution", "beforeMCPExecution"] {
-            let entries = installedHooks[event] as! [[String: Any]]
-            #expect(entries.count == 1)
-            let command = entries[0]["command"] as! String
-            #expect(command.contains(#"printf '%s\n' '{"continue":true}'"#))
-            #expect(command.contains(#""event":"permission_request""#))
-            #expect(command.hasSuffix(AlasHookCommand.ownershipSentinel))
-        }
+        // Cursor's execution hooks fire for every shell command and MCP call;
+        // they do not indicate that the agent is blocked on user approval.
+        #expect(installedHooks["beforeShellExecution"] == nil)
+        #expect(installedHooks["beforeMCPExecution"] == nil)
 
         try installer.uninstall()
         #expect(installer.installState() == .notInstalled)
@@ -95,10 +88,40 @@ struct CursorInstallerTests {
 
         var json = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
         var hooks = json["hooks"] as! [String: Any]
-        hooks.removeValue(forKey: "beforeShellExecution")
+        hooks.removeValue(forKey: "beforeSubmitPrompt")
         json["hooks"] = hooks
         try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: url)
 
         #expect(installer.installState() == .outdated)
+    }
+
+    @Test func reinstall_removesLegacyExecutionHooks() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = CursorInstaller(settingsURL: url)
+        try await installer.install()
+
+        let legacyCommand = AlasHookCommand.compositeCommand(
+            events: [.permissionRequest],
+            agent: .cursor,
+            forwardStdinAsBody: false,
+            stdoutResponse: #"{"continue":true}"#
+        )
+        var json = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        var hooks = json["hooks"] as! [String: Any]
+        let legacyEntry: [String: Any] = ["command": legacyCommand, "timeout": 10]
+        hooks["beforeShellExecution"] = [legacyEntry]
+        hooks["beforeMCPExecution"] = [legacyEntry]
+        json["hooks"] = hooks
+        try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: url)
+
+        #expect(installer.installState() == .outdated)
+
+        try await installer.install()
+        let reinstalled = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        let reinstalledHooks = reinstalled["hooks"] as! [String: Any]
+        #expect(reinstalledHooks["beforeShellExecution"] == nil)
+        #expect(reinstalledHooks["beforeMCPExecution"] == nil)
+        #expect(installer.installState() == .installed)
     }
 }

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -144,7 +144,7 @@ struct HarnessServiceTests {
             stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
         )
         service.handleSocketEvent(
-            makeEvent(event: .permissionRequest, agent: .cursor, sessionId: "s2", body: "Allow command?"),
+            makeEvent(event: .permissionRequest, agent: .codex, sessionId: "s2", body: "Allow command?"),
             stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
         )
 
@@ -153,10 +153,26 @@ struct HarnessServiceTests {
 
         let summary = service.summary(forSessionIds: ["s1", "s2"])
         #expect(summary?.state == .awaiting)
-        #expect(summary?.agent == .cursor)
+        #expect(summary?.agent == .codex)
         #expect(summary?.primarySessionId == "s2")
         #expect(summary?.runningSessionCount == 1)
         #expect(summary?.awaitingSessionCount == 1)
+    }
+
+    @Test func cursorPermissionRequestIsTreatedAsBusyWithoutNotification() {
+        let (service, collector) = makeService()
+        service.handleSocketEvent(
+            makeEvent(event: .awaitingInput, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .permissionRequest, agent: .cursor),
+            stateLookup: { _ in (projectId: "p1", worktreeId: "w1") },
+            shouldNotifyOnAwaiting: { true }
+        )
+
+        #expect(service.activityBySession["session-1"]?.state == .busy)
+        #expect(collector.requests.isEmpty)
     }
 
     @Test func permissionRequestPostsPermissionNotificationWithFallbackBody() {
@@ -381,7 +397,7 @@ struct HarnessServiceTests {
         #expect(service.activityBySession["session-1"]?.state == .awaitingInput)
     }
 
-    @Test func cursorIdleDebounce_isCancelledByPermissionRequest() async throws {
+    @Test func cursorIdleDebounce_isCancelledByLegacyPermissionRequest() async throws {
         let (service, _) = makeService(cursorIdleDebounceInterval: 0.05)
         service.handleSocketEvent(
             makeEvent(event: .busy, agent: .cursor),
@@ -396,10 +412,10 @@ struct HarnessServiceTests {
             stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
         )
 
-        await waitForActivity(service) { $0?.state == .permissionRequest }
+        await waitForActivity(service) { $0?.state == .busy }
         try await Task.sleep(nanoseconds: 150_000_000)
         await waitForMainQueue()
-        #expect(service.activityBySession["session-1"]?.state == .permissionRequest)
+        #expect(service.activityBySession["session-1"]?.state == .busy)
     }
 
     @Test func claudeIdle_isNotDebounced() {


### PR DESCRIPTION
## Summary
- stop classifying every Cursor shell and MCP execution as a permission request
- treat events from legacy installed hooks as running activity without sending notifications
- update the Cursor hook configuration and regression coverage

## Test plan
- [x] `xcodegen`
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/CursorInstallerTests -only-testing:AlasTests/HarnessServiceTests`
- [ ] Full test suite has one pre-existing/reproducible failure in `DiffReviewSurfaceTests/surfacePassesFeedbackToMatchingFileOnly()`