### PR TITLE
fix(run): zsh script exit status

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2711,7 +2711,7 @@ final class AppState {
             .map { "\($0.key)=\(shellQuote($0.value))" }
         let commandLine = (envPrefix + [shellQuote(command)] + args.map(shellQuote)).joined(separator: " ")
         guard exitOnCompletion else { return commandLine }
-        return "\(commandLine)\nstatus=$?\nexit \"$status\""
+        return "\(commandLine)\nexit_code=$?\nexit \"$exit_code\""
     }
 
     nonisolated private static func isValidShellAssignmentName(_ key: String) -> Bool {

--- a/AlasTests/RunScriptLaunchTests.swift
+++ b/AlasTests/RunScriptLaunchTests.swift
@@ -49,7 +49,33 @@ struct RunScriptLaunchTests {
             worktreeRoot: URL(fileURLWithPath: "/wt"),
             branch: "main", projectName: "alas", repoRoot: "/repo"
         )
-        #expect(suffix.hasSuffix("status=$?\nexit \"$status\""))
+        #expect(suffix.hasSuffix("exit_code=$?\nexit \"$exit_code\""))
+    }
+
+    @Test func closeOnExitPreservesScriptStatusInZsh() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let scriptURL = dir.appendingPathComponent("exit-42.sh")
+        try "#!/bin/sh\nexit 42\n".write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        let run = RunScript(
+            scope: .repo, fileName: scriptURL.lastPathComponent, fileURL: scriptURL,
+            displayName: "Exit 42", onExit: .close, cwd: nil, isExecutable: true
+        )
+        let suffix = try AppState.runScriptStartupScript(
+            script: run, worktreeRoot: dir,
+            branch: "main", projectName: "alas", repoRoot: dir.path
+        )
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-fc", suffix]
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 42)
     }
 
     @Test func cwdJoinsWorktreeRoot() throws {


### PR DESCRIPTION
Fixes Alas run scripts configured to close on completion under zsh.

Alas generated `status=$?`, but zsh reserves `status` as a read-only parameter. The wrapper now uses `exit_code`, and a regression test runs the generated command in zsh to verify the script exit code is preserved.

Validation: targeted run-script test added; local full Xcode test execution is pending CI because concurrent local build phases held the build database lock.