### PR TITLE
fix(gg): stop localizing the PR/MR number in the inbox pane

### DIFF
--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -410,7 +410,12 @@ struct GGInboxTabView: View {
                     }
                     .buttonStyle(.plain)
                     .focusEffectDisabled()
-                    .help("Open \(kind.reviewRequestLabel) \(kind.reviewRequestNumberPrefix)\(entry.prNumber)")
+                    .help(
+                        Text(
+                            verbatim: "Open \(kind.reviewRequestLabel) "
+                                + "\(kind.reviewRequestNumberPrefix)\(entry.prNumber)"
+                        )
+                    )
                 } else {
                     reviewReferenceLabel(entry.prNumber, kind: kind)
                 }
@@ -472,7 +477,7 @@ struct GGInboxTabView: View {
     }
 
     private func reviewReferenceLabel(_ number: Int, kind: CodeHostKind) -> some View {
-        Text("\(kind.reviewRequestNumberPrefix)\(number)")
+        Text(verbatim: "\(kind.reviewRequestNumberPrefix)\(number)")
             .font(.system(size: 11, weight: .medium, design: .monospaced))
             .foregroundColor(theme.color("accent"))
     }


### PR DESCRIPTION
## Summary
- The gg inbox pane rendered the review request reference through `Text("...")`, which goes through `LocalizedStringKey` interpolation and formats `Int` with the locale's grouping separator — GitLab MR `!9522` showed up as `!9.522`.
- Switched the label (and the matching tooltip) to verbatim interpolation so the number renders as-is.

## Test plan
- [ ] Open the gg inbox pane on a stack with a 4+ digit MR/PR number and confirm it renders without a thousands separator (e.g. `!9522`, not `!9.522`).
- [ ] Hover the reference to confirm the tooltip shows the same unformatted number.