### PR TITLE
fix(review): snap file-click scroll instead of always animating

### DIFF
--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
@@ -70,6 +70,10 @@ struct AppKitDiffScrollRequest: Equatable {
     let alignment: AppKitDiffScrollAlignment
     let animated: Bool
     let generation: Int
+    /// When true, a long jump snaps instantly instead of animating even
+    /// though `animated` is true — used for file-click navigation so a
+    /// multi-second slide doesn't get old on repeated clicks.
+    var snapsWhenFar: Bool = false
 }
 
 struct AppKitDiffScrollAnchor: Equatable {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -123,7 +123,13 @@ final class AppKitDiffScrollerReconciler {
             completion?()
             return
         }
-        scrollView.setScrollY(offset, animated: request.animated) { [weak self] in
+        // For requests that opt in (file-click navigation), snap for long
+        // jumps and only animate when the destination is already close
+        // enough (within one screen) that motion reads as a nudge rather
+        // than a multi-second slide.
+        let animated = request.animated
+            && (!request.snapsWhenFar || abs(offset - scrollView.scrollY) <= scrollView.viewportHeight)
+        scrollView.setScrollY(offset, animated: animated) { [weak self] in
             // Bounds notifications remain suppressed for programmatic animation
             // so active-owner feedback cannot fight navigation. Re-tile at the
             // final native offset before announcing completion, however, or a

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewScroller.swift
@@ -44,7 +44,8 @@ enum AppKitDiffReviewScrollRequestResolver {
             fallbackID: headerID,
             alignment: .top,
             animated: true,
-            generation: commandGeneration(fileCommand.generation, kind: .file)
+            generation: commandGeneration(fileCommand.generation, kind: .file),
+            snapsWhenFar: true
         )
     }
 
@@ -74,7 +75,8 @@ enum AppKitDiffReviewScrollRequestResolver {
             fallbackID: request!.fallbackID,
             alignment: request!.alignment,
             animated: request!.animated,
-            generation: generation
+            generation: generation,
+            snapsWhenFar: request!.snapsWhenFar
         )
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -330,9 +330,10 @@ struct DiffReviewSurface: View {
             }
             .onChange(of: scrollCommand) { _, command in
                 guard let command else { return }
-                withAnimation(.easeInOut(duration: 0.18)) {
-                    scrollProxy.scrollTo(command.id.rawValue, anchor: .top)
-                }
+                // Snap rather than animate: without a native scroll view we
+                // can't cheaply measure current offset for a distance-based
+                // heuristic, and this path is legacy fallback only.
+                scrollProxy.scrollTo(command.id.rawValue, anchor: .top)
                 scrollCommand = DiffReviewScrollCommandConsumption.consume(
                     current: scrollCommand,
                     consumed: command

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
@@ -267,4 +267,41 @@ struct AppKitDiffScrollerReconcilerTests {
         ))
         #expect(stack.scrollView.scrollY == beforeMissingTarget)
     }
+
+    @Test("snapsWhenFar requests skip animation for a jump beyond one viewport")
+    func snapsWhenFarSkipsAnimationForLongJump() {
+        var executorCalled = false
+        let stack = makeStack()
+        stack.scrollView.animatedScrollExecutorForTests = { scrollView, point, completion in
+            executorCalled = true
+            scrollView.contentView.setBoundsOrigin(point)
+            completion()
+        }
+        stack.reconciler.apply(plan: plan(), contentWidth: stack.scrollView.contentWidth)
+
+        stack.reconciler.scroll(to: .init(
+            targetID: "row-150", fallbackID: nil, alignment: .top, animated: true, generation: 1, snapsWhenFar: true
+        ))
+
+        #expect(!executorCalled)
+        #expect(stack.scrollView.scrollY > 2_000)
+    }
+
+    @Test("snapsWhenFar requests still animate a jump within one viewport")
+    func snapsWhenFarAnimatesNearbyJump() {
+        var executorCalled = false
+        let stack = makeStack()
+        stack.scrollView.animatedScrollExecutorForTests = { scrollView, point, completion in
+            executorCalled = true
+            scrollView.contentView.setBoundsOrigin(point)
+            completion()
+        }
+        stack.reconciler.apply(plan: plan(), contentWidth: stack.scrollView.contentWidth)
+
+        stack.reconciler.scroll(to: .init(
+            targetID: "row-1", fallbackID: nil, alignment: .top, animated: true, generation: 1, snapsWhenFar: true
+        ))
+
+        #expect(executorCalled)
+    }
 }

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewScrollerTests.swift
@@ -20,6 +20,7 @@ struct AppKitDiffReviewScrollerTests {
 
         #expect(request?.targetID == headerID)
         #expect(request?.alignment == .top)
+        #expect(request?.snapsWhenFar == true)
     }
 
     @Test func deferredFeedbackTargetsPlaceholderAtCenter() {
@@ -41,6 +42,7 @@ struct AppKitDiffReviewScrollerTests {
 
         #expect(request?.targetID == deferredPlan.placeholderByFileID[fileID])
         #expect(request?.alignment == .center)
+        #expect(request?.snapsWhenFar == false)
     }
 
     @Test func reviewCommandKindsUseDistinctGenerationsAndDoNotNeedRealizationDelay() {


### PR DESCRIPTION
## Summary

- Clicking a file in the review rail always animated the diff pane's scroll into view, which got old fast on repeated clicks.
- The AppKit scroller (default path since #980) now snaps instantly for jumps longer than one viewport, and only keeps the slide animation when the destination is already close by.
- The legacy SwiftUI fallback path (used when the AppKit scroller flag is off) drops the animation entirely, since it has no cheap way to measure the current scroll offset for a distance check.

### Reviewer notes

- The distance heuristic lives in `AppKitDiffScrollerReconciler.scroll(to:)`, comparing the target offset against the current `scrollY` versus `viewportHeight`.
- It's opt-in via a new `AppKitDiffScrollRequest.snapsWhenFar` flag, set only for file-click requests (`AppKitDiffReviewScrollRequestResolver`). Inline-comment and draft-comment jumps are unaffected and keep animating, since those are already short, local moves.
- Added reconciler tests for both branches of the heuristic (long jump snaps, short jump still animates) and resolver assertions that `snapsWhenFar` is set correctly per command kind.