### PR TITLE
feat(follow): follow gg stack entries by GG-ID

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1554,6 +1554,7 @@
 		FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */; };
 		FF77548C74703C8DDC9B480B /* DiffPaneTextDocumentBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8501B285B416ECC49BCC22C3 /* DiffPaneTextDocumentBuilderTests.swift */; };
 		FF7DDFC667CE2E3964B51FA5 /* LSPInstallProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */; };
+		FF98581F6F377457DD574CBF /* TrackedRevisionStallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B5B9112025B94DF41A1AA2 /* TrackedRevisionStallTests.swift */; };
 		FFC747D542D806E6CF6FCD03 /* CompletionPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348D2E5F6030BB9F2BDEFA26 /* CompletionPopup.swift */; };
 /* End PBXBuildFile section */
 
@@ -1697,6 +1698,7 @@
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionChecker.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
+		15B5B9112025B94DF41A1AA2 /* TrackedRevisionStallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevisionStallTests.swift; sourceTree = "<group>"; };
 		15CE3FADE2353C1214143336 /* ClosedTabHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedTabHistory.swift; sourceTree = "<group>"; };
 		1688AB1B49758FAB5BF0AF2F /* light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = light.json; sourceTree = "<group>"; };
 		169FC38D03727F34855EB521 /* AlasFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasFieldTests.swift; sourceTree = "<group>"; };
@@ -3658,6 +3660,7 @@
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
 				D3552BE48184E15F0BE6084C /* TrackedRevisionCodingTests.swift */,
 				153CE5618748C7830799DBCE /* TrackedRevisionResolverTests.swift */,
+				15B5B9112025B94DF41A1AA2 /* TrackedRevisionStallTests.swift */,
 				D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */,
@@ -7466,6 +7469,7 @@
 				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
 				F24D9A50F61692958ABCB4F1 /* TrackedRevisionCodingTests.swift in Sources */,
 				9D7DBBABD4F28F7890E0844E /* TrackedRevisionResolverTests.swift in Sources */,
+				FF98581F6F377457DD574CBF /* TrackedRevisionStallTests.swift in Sources */,
 				6889CC15F0DA498DB58B9757 /* TrackedRevisionTargetTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		2A0E3B915DF645A8545D9B0B /* SpacesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B868809675C4110044C92E /* SpacesManager.swift */; };
 		2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */; };
 		2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */; };
+		2A2388EC5DA3A5B6E26D533C /* RevisionFollowCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D9414B19B769D162BA9ED9 /* RevisionFollowCapabilityTests.swift */; };
 		2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9E3F080F847EF069137844 /* ShortcutBinding.swift */; };
 		2AC164837BF88D1BD0F20E97 /* TreeSitterCPP in Frameworks */ = {isa = PBXBuildFile; productRef = 5F82D581FFC7034146EAE020 /* TreeSitterCPP */; };
 		2B4CBD06D1568EBC1BD327E0 /* SemanticVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */; };
@@ -2957,6 +2958,7 @@
 		E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPStatusPolicyTests.swift; sourceTree = "<group>"; };
 		E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActionButton.swift; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		E6D9414B19B769D162BA9ED9 /* RevisionFollowCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevisionFollowCapabilityTests.swift; sourceTree = "<group>"; };
 		E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolbar.swift; sourceTree = "<group>"; };
 		E7421C826E1F25534D594E03 /* ACPTranscriptRowWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowWindowTests.swift; sourceTree = "<group>"; };
 		E7C070765F0474DF1C4ACEF0 /* session-new-response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-new-response.json"; sourceTree = "<group>"; };
@@ -3601,6 +3603,7 @@
 				4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */,
 				A2506BDBA9F67B6516CE2BEF /* ReviewTargetPaletteModelTests.swift */,
 				B87101C6F8F27B57AEDC187D /* ReviewThreadWriteTests.swift */,
+				E6D9414B19B769D162BA9ED9 /* RevisionFollowCapabilityTests.swift */,
 				F6512F4CA47764514D593C1B /* RevisionSnapshotCacheTests.swift */,
 				94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */,
 				BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */,
@@ -7410,6 +7413,7 @@
 				14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */,
 				D4DE0AC014387E216A904D2E /* ReviewTargetPaletteModelTests.swift in Sources */,
 				1ACB56B9AA0EC3C1C2AF5E18 /* ReviewThreadWriteTests.swift in Sources */,
+				2A2388EC5DA3A5B6E26D533C /* RevisionFollowCapabilityTests.swift in Sources */,
 				652C66E1DA5C28C6FD1B5132 /* RevisionSnapshotCacheTests.swift in Sources */,
 				D4E6BD88D38563AF45E79C83 /* RightPaneGGLandTests.swift in Sources */,
 				4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
 		0A98E7EDC11BF68EAEEFED29 /* ReviewTargetPaletteEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D0F48B60A75972D3A8DBED /* ReviewTargetPaletteEnvironment.swift */; };
+		0AF3143BA962E031E6A21657 /* GGFollowEntrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F28FA9BC3F5FC98D0A64747 /* GGFollowEntrySheet.swift */; };
 		0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */; };
 		0B1FBD6B4CFC785D90E0E17D /* MissionReadinessEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450A13855438B606F539AEB5 /* MissionReadinessEvaluator.swift */; };
 		0B6ADBF320E6130E5888CAA7 /* RemoteSessionGatewayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */; };
@@ -888,6 +889,7 @@
 		9547580C9DFECD838C120B90 /* DiffReviewRenderEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389D0EB957CCC8447DB9C4FE /* DiffReviewRenderEligibility.swift */; };
 		95582A36D7EC3E02D8431E39 /* DragOutSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4610C65B69BD08EF8DF12311 /* DragOutSession.swift */; };
 		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
+		95A6A1F40F1987B349139058 /* AppStateFollowStackEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2DCADE875AAD3ED679901C /* AppStateFollowStackEntryTests.swift */; };
 		95DAB9F9E361DFD0395CC4C2 /* GGStackSummaryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4FE9500B277A3921C8AB2 /* GGStackSummaryStoreTests.swift */; };
 		95E01DC5A933FCC077399762 /* ACPTranscriptRowHostingPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */; };
 		960593EAB0380436038D1400 /* ACPSessionToolCallTruncationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */; };
@@ -1743,6 +1745,7 @@
 		1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatusTests.swift; sourceTree = "<group>"; };
 		1E410585102A601ACED1E8B5 /* AppKitDiffScrollerStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerStressTests.swift; sourceTree = "<group>"; };
 		1EC659A56A08A30F7784428D /* ACPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPClient.swift; sourceTree = "<group>"; };
+		1F28FA9BC3F5FC98D0A64747 /* GGFollowEntrySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGFollowEntrySheet.swift; sourceTree = "<group>"; };
 		1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDeciderTests.swift; sourceTree = "<group>"; };
 		1FC7D68CD8300C0F6766AED0 /* ProviderReviewOriginalPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewOriginalPathResolverTests.swift; sourceTree = "<group>"; };
 		1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouterTests.swift; sourceTree = "<group>"; };
@@ -2024,6 +2027,7 @@
 		4B89757CB3A518B333C56DC8 /* MissionSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionSidebarTests.swift; sourceTree = "<group>"; };
 		4BECCB29ED6324C55C541D54 /* DiffReviewRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRail.swift; sourceTree = "<group>"; };
 		4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionTests.swift; sourceTree = "<group>"; };
+		4C2DCADE875AAD3ED679901C /* AppStateFollowStackEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateFollowStackEntryTests.swift; sourceTree = "<group>"; };
 		4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTargetTests.swift; sourceTree = "<group>"; };
 		4C3F4EE1590F6355AF2AD9DA /* WorktreeSortMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSortMenuTests.swift; sourceTree = "<group>"; };
 		4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxHelpersTests.swift; sourceTree = "<group>"; };
@@ -3375,6 +3379,7 @@
 				3A8A5932B664C88F20BF00CA /* AppStateCreateWorktreeLaunchSurfaceTests.swift */,
 				E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */,
 				11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */,
+				4C2DCADE875AAD3ED679901C /* AppStateFollowStackEntryTests.swift */,
 				46554893BA6205CD856B99B5 /* AppStateKeepSessionsAliveTests.swift */,
 				6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */,
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
@@ -5603,6 +5608,7 @@
 				CA7C5CADC042EF509370EB87 /* GGCommitMenuModel.swift */,
 				56A2D492EE89A160CD404985 /* GGConfigReader.swift */,
 				E91EB168941D6B9502D30082 /* GGFollowEntryModel.swift */,
+				1F28FA9BC3F5FC98D0A64747 /* GGFollowEntrySheet.swift */,
 				9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */,
 				8C511B229168DDEA87173A41 /* GGInboxStore.swift */,
 				B32762D888121D56722E03F5 /* GGInboxTabView.swift */,
@@ -6384,6 +6390,7 @@
 				FBFAB8DAB738CC7A21076D22 /* GGCommitMenuModel.swift in Sources */,
 				31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */,
 				76D0B85664E226960BF98FE3 /* GGFollowEntryModel.swift in Sources */,
+				0AF3143BA962E031E6A21657 /* GGFollowEntrySheet.swift in Sources */,
 				188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */,
 				E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */,
 				56286C44BC30C1716CD44363 /* GGInboxTabView.swift in Sources */,
@@ -7032,6 +7039,7 @@
 				D8741FB38F9FB2C180FE37E3 /* AppStateCreateWorktreeLaunchSurfaceTests.swift in Sources */,
 				A75289A4560BCA2DACA0760B /* AppStateCreateWorktreeSymlinkTests.swift in Sources */,
 				BDBAA6601CA3FD8A5562E637 /* AppStateFocusMainWorktreeTests.swift in Sources */,
+				95A6A1F40F1987B349139058 /* AppStateFollowStackEntryTests.swift in Sources */,
 				B87B51AC9B374F318CCF1F08 /* AppStateKeepSessionsAliveTests.swift in Sources */,
 				ABB5595A9A39C8AF203B5873 /* AppStateOverlayFocusTests.swift in Sources */,
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -849,6 +849,7 @@
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8E8ABE6BBA778EEA4170423C /* MergeScrollCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */; };
 		8E988C41547B229AF19CBE31 /* ACPSessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A590E6B7A73546D38D4F95 /* ACPSessionPersistence.swift */; };
+		8EA82A5D99C02C5986486159 /* GGStackCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAF0296378A7605107A7D96 /* GGStackCache.swift */; };
 		8ED9196CA54498198826E799 /* GGWorktreeMenuModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792D7045679FE1E12AAFA04 /* GGWorktreeMenuModelTests.swift */; };
 		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
@@ -1539,6 +1540,7 @@
 		FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
 		FD9F0F14E4EA5ACF408211A7 /* ACPTranscriptTilingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A981A28B0FED8C3D95B107 /* ACPTranscriptTilingController.swift */; };
+		FDAAE84A48C2AD650444141B /* GGStackCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B6B0597FA2E0DF89580A60 /* GGStackCacheTests.swift */; };
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
 		FDE59101CBC2CA8CD6FFF91B /* ACPMCPExternalStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01291607F0A46E4A50104BB /* ACPMCPExternalStatus.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
@@ -1944,6 +1946,7 @@
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
 		3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageList.swift; sourceTree = "<group>"; };
 		3F8435ABAF423A6F5BC28E4C /* DiffPreferenceBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPreferenceBindings.swift; sourceTree = "<group>"; };
+		3FAF0296378A7605107A7D96 /* GGStackCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackCache.swift; sourceTree = "<group>"; };
 		40497B428C9395535DF6C146 /* DialogChromeLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChromeLayoutTests.swift; sourceTree = "<group>"; };
 		4068B3E83F9A82C2E3F8A6A1 /* OpenSessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSessions.swift; sourceTree = "<group>"; };
 		4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolver.swift; sourceTree = "<group>"; };
@@ -2350,6 +2353,7 @@
 		8351793355009D8A73AA91A2 /* SSHCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCommand.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
 		83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewRequestDraftTests.swift; sourceTree = "<group>"; };
+		83B6B0597FA2E0DF89580A60 /* GGStackCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackCacheTests.swift; sourceTree = "<group>"; };
 		843E7D6E8972C01B3DC924F2 /* RemoteHostCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostCapabilitiesTests.swift; sourceTree = "<group>"; };
 		8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStoreBaseBranchTests.swift; sourceTree = "<group>"; };
 		84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextView.swift; sourceTree = "<group>"; };
@@ -5288,6 +5292,7 @@
 				2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */,
 				C8257A2ECCB938BA608A972A /* GGSplitCommitModelTests.swift */,
 				7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */,
+				83B6B0597FA2E0DF89580A60 /* GGStackCacheTests.swift */,
 				59FC4FF152C92166C561D645 /* GGStackChipModelTests.swift */,
 				6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */,
 				A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */,
@@ -5601,6 +5606,7 @@
 				43E189D66411992DFC659CBF /* GGSplitCommitTabView.swift */,
 				8A811C3D697D29CF9267F2C5 /* GGSplitPreviewRowPlan.swift */,
 				2A9D7898F772DC2F10532A1F /* GGStackActionState.swift */,
+				3FAF0296378A7605107A7D96 /* GGStackCache.swift */,
 				E81D0FF9B67ADCA35679FF76 /* GGStackChip.swift */,
 				B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */,
 				D7860DF249939BC7FC1EBD76 /* GGStackDrawer.swift */,
@@ -6380,6 +6386,7 @@
 				084E0061691FD9F495E8209B /* GGSplitCommitTabView.swift in Sources */,
 				792C4398DB584C1C56D8C23E /* GGSplitPreviewRowPlan.swift in Sources */,
 				F59B834AB41CDD4BBCA84A7B /* GGStackActionState.swift in Sources */,
+				8EA82A5D99C02C5986486159 /* GGStackCache.swift in Sources */,
 				985B3CFBBCB9AF3059192796 /* GGStackChip.swift in Sources */,
 				E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */,
 				3AFEB19356A2BC5E7B6E1E4A /* GGStackDrawer.swift in Sources */,
@@ -7159,6 +7166,7 @@
 				1160B4B61A592EF469A2708A /* GGSplitPreviewRowPlanTests.swift in Sources */,
 				7528D9FD7DCE1D6F7CF70C3F /* GGSplitTabsManagerTests.swift in Sources */,
 				EE4A552DB5EF6559CA1A5AE0 /* GGStackActionStateTests.swift in Sources */,
+				FDAAE84A48C2AD650444141B /* GGStackCacheTests.swift in Sources */,
 				B8E2F8710E6B8A3CD1A23E49 /* GGStackChipModelTests.swift in Sources */,
 				0F118A7F54315A836A169B89 /* GGStackCreateModeTests.swift in Sources */,
 				2111C060CDF39B78FEFECB7A /* GGStackGateTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1473,6 +1473,7 @@
 		F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */; };
 		F22A776D791ABA7A584B4C18 /* ACPTranscriptMessageIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E26C51ACE48A35EB4CD463 /* ACPTranscriptMessageIndexTests.swift */; };
 		F2385B8730E9D1F47C7FA423 /* ReviewChangesRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C9EEDB5A71C5FAE2D0E42B /* ReviewChangesRail.swift */; };
+		F24D9A50F61692958ABCB4F1 /* TrackedRevisionCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3552BE48184E15F0BE6084C /* TrackedRevisionCodingTests.swift */; };
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
 		F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */; };
 		F2F75C44CD5042F209299FB9 /* InstallSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */; };
@@ -2814,6 +2815,7 @@
 		D2BD2F573498740A7DECCA3C /* ChangesPreparationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationModelTests.swift; sourceTree = "<group>"; };
 		D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteFileServerTests.swift; sourceTree = "<group>"; };
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
+		D3552BE48184E15F0BE6084C /* TrackedRevisionCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevisionCodingTests.swift; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
 		D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentStoreTests.swift; sourceTree = "<group>"; };
 		D39349809C87AB2DA9CACF56 /* MissionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionController.swift; sourceTree = "<group>"; };
@@ -3648,6 +3650,7 @@
 				C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
+				D3552BE48184E15F0BE6084C /* TrackedRevisionCodingTests.swift */,
 				D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */,
@@ -7450,6 +7453,7 @@
 				422B560D70571FF42F0E78E6 /* ThreePaneSizingTests.swift in Sources */,
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
+				F24D9A50F61692958ABCB4F1 /* TrackedRevisionCodingTests.swift in Sources */,
 				6889CC15F0DA498DB58B9757 /* TrackedRevisionTargetTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */; };
 		1E5EA96E9798649521CE1427 /* ACPAdapterInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */; };
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
+		1E822C74947023E654F3F50E /* TrackedRevisionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D1CCD3078AD3C2A24E5E23 /* TrackedRevisionTarget.swift */; };
 		1E830E480ED505750BFC8881 /* AppKitDiffRowHostingPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02207D1F1F421F2E19CD90D0 /* AppKitDiffRowHostingPool.swift */; };
 		1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */; };
 		1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */; };
@@ -626,6 +627,7 @@
 		67D9FD383A299A29780C3DE2 /* BinaryFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8182DA33443DD22A370892B7 /* BinaryFileType.swift */; };
 		6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4A215AF2876091E31F6F8A /* LineEnding.swift */; };
 		686BB3FB9735836CFCAAE0D1 /* MCPRegistrationDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE42251A40DA18A6DB0E7491 /* MCPRegistrationDecisionTests.swift */; };
+		6889CC15F0DA498DB58B9757 /* TrackedRevisionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */; };
 		68D58F9361C2C31EE200479A /* ACPBrokerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A27D9BBDE49BF3A41FAFB7 /* ACPBrokerClient.swift */; };
 		69C592752249412BC8A6EF3C /* GGInboxHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB6D67179D2557D3A255AA3 /* GGInboxHostTests.swift */; };
 		6A080E2F35BD0D925D5F7BD5 /* GGStackIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCDB66D0948AF52EBA880CD /* GGStackIcon.swift */; };
@@ -1893,6 +1895,7 @@
 		37987D5884297401F95478D3 /* AgentPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathTests.swift; sourceTree = "<group>"; };
 		379D90AD620EAF6E84A04902 /* ImageDiffSideBySideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSideBySideView.swift; sourceTree = "<group>"; };
 		37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorEnvironment.swift; sourceTree = "<group>"; };
+		37D1CCD3078AD3C2A24E5E23 /* TrackedRevisionTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevisionTarget.swift; sourceTree = "<group>"; };
 		37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusResolver.swift; sourceTree = "<group>"; };
 		380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailureTests.swift; sourceTree = "<group>"; };
 		38228AE1419253ADBC80E226 /* DragOutPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutPayload.swift; sourceTree = "<group>"; };
@@ -2794,6 +2797,7 @@
 		D020BC9CC6586ECAB8A38042 /* ACPReconnectPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPReconnectPolicy.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
+		D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevisionTargetTests.swift; sourceTree = "<group>"; };
 		D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateTests.swift; sourceTree = "<group>"; };
 		D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentityTests.swift; sourceTree = "<group>"; };
 		D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayout.swift; sourceTree = "<group>"; };
@@ -3644,6 +3648,7 @@
 				C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
+				D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */,
 				2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */,
@@ -5471,6 +5476,7 @@
 				5C05EF64FD7701A941C81837 /* RevisionFollowControl.swift */,
 				3B2FEDAAF927CDC9E4D19551 /* StagedDiffLoader.swift */,
 				16D35671971686B20DEA33CB /* TrackedRevision.swift */,
+				37D1CCD3078AD3C2A24E5E23 /* TrackedRevisionTarget.swift */,
 			);
 			path = Commit;
 			sourceTree = "<group>";
@@ -6751,6 +6757,7 @@
 				45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */,
 				AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */,
 				7BB5B3A83C8D0CB185D2365E /* TrackedRevision.swift in Sources */,
+				1E822C74947023E654F3F50E /* TrackedRevisionTarget.swift in Sources */,
 				6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */,
 				5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */,
 				443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */,
@@ -7443,6 +7450,7 @@
 				422B560D70571FF42F0E78E6 /* ThreePaneSizingTests.swift in Sources */,
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
+				6889CC15F0DA498DB58B9757 /* TrackedRevisionTargetTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
 				0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -948,6 +948,7 @@
 		9D439D5F19ACEB5A39B7CB68 /* CodexACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3985F2F58DB6E3BBF3520EFD /* CodexACPInstaller.swift */; };
 		9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21F30DB5A812E396262A926 /* ACPMessageWire.swift */; };
 		9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */; };
+		9D7DBBABD4F28F7890E0844E /* TrackedRevisionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153CE5618748C7830799DBCE /* TrackedRevisionResolverTests.swift */; };
 		9D99FFFDFB3A256C4960D388 /* ReleaseCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */; };
 		9DDA9F2462746F06A652973A /* DiffContextExpansionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9CB2A64E9E16A2DE3A6272 /* DiffContextExpansionTests.swift */; };
 		9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */; };
@@ -1692,6 +1693,7 @@
 		14D1ECA099BBDCB5BB2EEC67 /* DiffReviewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewModels.swift; sourceTree = "<group>"; };
 		1513AFD842F4CF16F8DEEA31 /* ChangesPreparationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationCard.swift; sourceTree = "<group>"; };
 		152EB5D0C23CAEB13283C634 /* GGRestackSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGRestackSheet.swift; sourceTree = "<group>"; };
+		153CE5618748C7830799DBCE /* TrackedRevisionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevisionResolverTests.swift; sourceTree = "<group>"; };
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionChecker.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
@@ -3655,6 +3657,7 @@
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
 				D3552BE48184E15F0BE6084C /* TrackedRevisionCodingTests.swift */,
+				153CE5618748C7830799DBCE /* TrackedRevisionResolverTests.swift */,
 				D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */,
@@ -7462,6 +7465,7 @@
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
 				F24D9A50F61692958ABCB4F1 /* TrackedRevisionCodingTests.swift in Sources */,
+				9D7DBBABD4F28F7890E0844E /* TrackedRevisionResolverTests.swift in Sources */,
 				6889CC15F0DA498DB58B9757 /* TrackedRevisionTargetTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		5ABD7DF29A68C38C8AA9EF37 /* MermaidRenderServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A107DA120039DD59C4F5CDD7 /* MermaidRenderServiceTests.swift */; };
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
 		5B2E19E0AE25DC4FA27332A3 /* AppKitDiffReviewRowPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF2F144BCF7B1A9460131EC /* AppKitDiffReviewRowPlan.swift */; };
+		5B3B25B2142A63E07E38C387 /* GGFollowEntryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B8A99E1627EE35CADD3681 /* GGFollowEntryModelTests.swift */; };
 		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
 		5BB2FF7F9DFFFEF75CA508A2 /* RemoteLSPLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89D9FFAC80BDE46A651A0F /* RemoteLSPLauncherTests.swift */; };
 		5C15CCD6E7D896DEFA533C82 /* BuiltInAlasMCP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7BEEA16E15CB254BD84F5F /* BuiltInAlasMCP.swift */; };
@@ -706,6 +707,7 @@
 		75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */; };
 		7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3855FBA3E4444960418639E9 /* FileIndexTests.swift */; };
 		763947308C99E2D3CB565889 /* AgentKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C792D59DBFFF6C28F2D426 /* AgentKind.swift */; };
+		76D0B85664E226960BF98FE3 /* GGFollowEntryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91EB168941D6B9502D30082 /* GGFollowEntryModel.swift */; };
 		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
 		77CDD88F7C517095DE580B50 /* ReviewEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11F5C6667A6ECB74E066AE /* ReviewEvidence.swift */; };
 		77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649D5CB480CE056B1C4457D6 /* GGInboxTabsTests.swift */; };
@@ -2171,6 +2173,7 @@
 		63376280CA1D01F9D564A6F6 /* ACPSessionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionDiscovery.swift; sourceTree = "<group>"; };
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
 		639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryTests.swift; sourceTree = "<group>"; };
+		63B8A99E1627EE35CADD3681 /* GGFollowEntryModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGFollowEntryModelTests.swift; sourceTree = "<group>"; };
 		649D5CB480CE056B1C4457D6 /* GGInboxTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxTabsTests.swift; sourceTree = "<group>"; };
 		64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabView.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
@@ -2963,6 +2966,7 @@
 		E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewInlineFeedbackActions.swift; sourceTree = "<group>"; };
 		E8BAFC83D9BC1577CB14ADD5 /* RemoteExecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteExecTests.swift; sourceTree = "<group>"; };
 		E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailViewTests.swift; sourceTree = "<group>"; };
+		E91EB168941D6B9502D30082 /* GGFollowEntryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGFollowEntryModel.swift; sourceTree = "<group>"; };
 		E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionTests.swift; sourceTree = "<group>"; };
 		E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeSymlinkTests.swift; sourceTree = "<group>"; };
 		E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPickerTests.swift; sourceTree = "<group>"; };
@@ -5286,6 +5290,7 @@
 				4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */,
 				98EE59978053FA18629BC280 /* GGCommitMenuModelTests.swift */,
 				B579717E28A31AA7575FE3E4 /* GGConfigReaderTests.swift */,
+				63B8A99E1627EE35CADD3681 /* GGFollowEntryModelTests.swift */,
 				4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */,
 				52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */,
 				98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */,
@@ -5597,6 +5602,7 @@
 				F1F0EED235328724082B570B /* GGActionEvents.swift */,
 				CA7C5CADC042EF509370EB87 /* GGCommitMenuModel.swift */,
 				56A2D492EE89A160CD404985 /* GGConfigReader.swift */,
+				E91EB168941D6B9502D30082 /* GGFollowEntryModel.swift */,
 				9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */,
 				8C511B229168DDEA87173A41 /* GGInboxStore.swift */,
 				B32762D888121D56722E03F5 /* GGInboxTabView.swift */,
@@ -6377,6 +6383,7 @@
 				1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */,
 				FBFAB8DAB738CC7A21076D22 /* GGCommitMenuModel.swift in Sources */,
 				31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */,
+				76D0B85664E226960BF98FE3 /* GGFollowEntryModel.swift in Sources */,
 				188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */,
 				E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */,
 				56286C44BC30C1716CD44363 /* GGInboxTabView.swift in Sources */,
@@ -7156,6 +7163,7 @@
 				A955D8E9871CA023ED98A095 /* GGCommitMenuModelTests.swift in Sources */,
 				BB3475BFADD030152EF48707 /* GGConfigCodableTests.swift in Sources */,
 				D179A669627D70CC3C8DC4A5 /* GGConfigReaderTests.swift in Sources */,
+				5B3B25B2142A63E07E38C387 /* GGFollowEntryModelTests.swift in Sources */,
 				362A966BA9FED1E92B8410CC /* GGInboxHelpersTests.swift in Sources */,
 				69C592752249412BC8A6EF3C /* GGInboxHostTests.swift in Sources */,
 				490CB816CBED69EC7C886497 /* GGInboxModelsTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3388,10 +3388,14 @@ final class AppState {
             return state.sha
         case .reviewSession(let state):
             let record = try? ReviewSessionStore().load(id: state.sessionID)
-            if case .commit(let sha) = record?.target.payload {
+            switch record?.target.payload {
+            case .commit(let sha):
                 return sha
+            case .trackedCommit(let revision):
+                return revision.resolvedSHA
+            default:
+                return nil
             }
-            return nil
         default:
             return nil
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3200,6 +3200,7 @@ final class AppState {
         for path in changedPaths {
             GGStackSummaryStore.shared.summaries[path] = nil
         }
+        Task { await GGStackCache.shared.invalidate() }
     }
 
     func revisionChangeGeneration(worktreeID: String) -> Int {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3201,12 +3201,26 @@ final class AppState {
         for path in changedPaths {
             GGStackSummaryStore.shared.summaries[path] = nil
         }
-        Task { await GGStackCache.shared.invalidate() }
+        invalidateGGStackCacheAndRebumpGeneration(projectId: projectId)
     }
 
     private func handleProjectRevisionChange(projectId: String) {
         bumpRevisionGenerationForProject(projectId: projectId)
-        Task { await GGStackCache.shared.invalidate() }
+        invalidateGGStackCacheAndRebumpGeneration(projectId: projectId)
+    }
+
+    /// Invalidation itself is a fast, in-memory actor call, but it's still
+    /// async relative to the synchronous generation bump these callers just
+    /// made — a follower's `.task(id:)` can restart on the new generation
+    /// and read the cache before this completes, resolving a GG-ID against
+    /// the pre-rewrite stack. Bumping the generation again once invalidation
+    /// has actually landed gives any follower that raced ahead a second,
+    /// guaranteed-fresh reload instead of sticking to a stale entry.
+    private func invalidateGGStackCacheAndRebumpGeneration(projectId: String) {
+        Task { @MainActor in
+            await GGStackCache.shared.invalidate()
+            self.bumpRevisionGenerationForProject(projectId: projectId)
+        }
     }
 
     func revisionChangeGeneration(worktreeID: String) -> Int {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3319,15 +3319,15 @@ final class AppState {
 
     /// Whether this worktree can follow stack entries at all: gg must be
     /// installed, enabled for the project, and the branch stack-shaped.
+    ///
+    /// Reads the cached, observable gg context already maintained by
+    /// `rightPaneStore` (the same source `CenterPaneView`'s split-commit
+    /// workflow gate reads) instead of recomputing it from disk on every
+    /// call — this is invoked from SwiftUI view bodies, so it must stay
+    /// cheap. Falls back to `false` if the worktree's right pane state
+    /// hasn't been activated / seeded yet.
     func ggFollowSupported(worktreeID: String) -> Bool {
-        guard let worktree = worktree(withId: worktreeID),
-              let project = projectsManager.projects.first(where: { $0.id == worktree.projectId })
-        else { return false }
-        return ggWorktreeContext(
-            project: project,
-            worktree: worktree,
-            branch: worktree.branch
-        ).isActive
+        rightPaneStore.activeState(worktreeId: worktreeID)?.ggContext.isActive ?? false
     }
 
     private func followedStackEntryGGID(worktreeID: String, tabID: TabID) -> String? {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -321,6 +321,7 @@ final class AppState {
     var isReviewPaletteOpen: Bool = false
     var isRunScriptPaletteOpen: Bool = false
     var pendingRunScriptCreation: RunScriptCreationPresentation?
+    var pendingFollowStackEntry: GGFollowEntryPresentation?
     var isKeyboardOverlayOpen: Bool {
         isSearchOpen || isRepoSelectorOpen || isAgentLauncherOpen || isReviewPaletteOpen || isRunScriptPaletteOpen
     }
@@ -3230,28 +3231,118 @@ final class AppState {
     }
 
     func promptFollowRevision(worktreeID: String, tabID: TabID, prefill: TrackedRevisionTarget? = nil) {
+        switch FollowRevisionPromptRoute.route(
+            prefill: prefill,
+            stackEntrySupported: ggFollowSupported(worktreeID: worktreeID)
+        ) {
+        case .stackEntryPicker(let isEditing):
+            promptFollowStackEntry(worktreeID: worktreeID, tabID: tabID, isEditing: isEditing)
+        case .expressionPrompt(let expressionPrefill, let isEditing):
+            let requestKey = followRevisionRequestKey(worktreeID: worktreeID, tabID: tabID)
+            let requestGeneration = bumpFollowRevisionRequestGeneration(requestKey)
+            let editorGeneration = bumpFollowRevisionEditorGeneration()
+            Task { @MainActor in
+                let resolvedPrefill: String?
+                if let expressionPrefill {
+                    resolvedPrefill = expressionPrefill
+                } else {
+                    resolvedPrefill = await suggestedFollowRevisionPrefill(worktreeID: worktreeID, tabID: tabID)
+                }
+                guard isCurrentFollowRevisionRequest(
+                    worktreeID: worktreeID,
+                    requestKey: requestKey,
+                    requestGeneration: requestGeneration
+                ), followRevisionEditorGeneration == editorGeneration
+                else { return }
+                followRevisionEditorRequest = FollowRevisionEditorRequest(
+                    worktreeID: worktreeID,
+                    tabID: tabID,
+                    expression: resolvedPrefill ?? "",
+                    isEditing: isEditing
+                )
+            }
+        }
+    }
+
+    func promptFollowStackEntry(worktreeID: String, tabID: TabID, isEditing: Bool = false) {
         let requestKey = followRevisionRequestKey(worktreeID: worktreeID, tabID: tabID)
         let requestGeneration = bumpFollowRevisionRequestGeneration(requestKey)
-        let editorGeneration = bumpFollowRevisionEditorGeneration()
+        pendingFollowStackEntry = GGFollowEntryPresentation(
+            worktreeID: worktreeID,
+            tabID: tabID,
+            isEditing: isEditing,
+            state: .loading
+        )
+        guard let worktree = worktree(withId: worktreeID) else { return }
+        let currentGGID = followedStackEntryGGID(worktreeID: worktreeID, tabID: tabID)
+        let displayedSHA = displayedCommitSHA(worktreeID: worktreeID, tabID: tabID)
         Task { @MainActor in
-            let resolvedPrefill: String?
-            if let prefill {
-                resolvedPrefill = prefill.expressionValue
-            } else {
-                resolvedPrefill = await suggestedFollowRevisionPrefill(worktreeID: worktreeID, tabID: tabID)
+            let state: GGFollowEntryLoadState
+            do {
+                let stack = try await GGStackCache.shared.stack(at: worktree.path) {
+                    try await GGService().currentStack(worktreePath: worktree.path.path)
+                }
+                if let stack {
+                    state = .loaded(GGFollowEntryModel.make(
+                        entries: stack.entries,
+                        currentGGID: currentGGID,
+                        displayedSHA: displayedSHA
+                    ))
+                } else {
+                    state = .offStack
+                }
+            } catch {
+                state = .failed((error as? GGServiceError)?.userMessage ?? (error as NSError).localizedDescription)
             }
             guard isCurrentFollowRevisionRequest(
                 worktreeID: worktreeID,
                 requestKey: requestKey,
                 requestGeneration: requestGeneration
-            ), followRevisionEditorGeneration == editorGeneration
-            else { return }
-            followRevisionEditorRequest = FollowRevisionEditorRequest(
-                worktreeID: worktreeID,
-                tabID: tabID,
-                expression: resolvedPrefill ?? "",
-                isEditing: prefill != nil
-            )
+            ), pendingFollowStackEntry?.id == "\(worktreeID):\(tabID)" else { return }
+            pendingFollowStackEntry?.state = state
+        }
+    }
+
+    func confirmFollowStackEntry(ggID: String) {
+        guard let presentation = pendingFollowStackEntry else { return }
+        pendingFollowStackEntry = nil
+        followRevision(
+            worktreeID: presentation.worktreeID,
+            tabID: presentation.tabID,
+            target: .stackEntry(ggID: ggID)
+        )
+    }
+
+    func cancelFollowStackEntry() {
+        pendingFollowStackEntry = nil
+    }
+
+    /// Whether this worktree can follow stack entries at all: gg must be
+    /// installed, enabled for the project, and the branch stack-shaped.
+    func ggFollowSupported(worktreeID: String) -> Bool {
+        guard let worktree = worktree(withId: worktreeID),
+              let project = projectsManager.projects.first(where: { $0.id == worktree.projectId })
+        else { return false }
+        return ggWorktreeContext(
+            project: project,
+            worktree: worktree,
+            branch: worktree.branch
+        ).isActive
+    }
+
+    private func followedStackEntryGGID(worktreeID: String, tabID: TabID) -> String? {
+        guard let tab = tabs.tabs(forWorktree: worktreeID).first(where: { $0.id == tabID }) else { return nil }
+        switch tab {
+        case .commit(let state):
+            return state.revision.tracked?.target.ggID
+        case .reviewSession(let state):
+            let record = try? ReviewSessionStore().load(id: state.sessionID)
+            if case .trackedCommit(let revision) = record?.target.payload {
+                return revision.target.ggID
+            }
+            return nil
+        default:
+            return nil
         }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3324,10 +3324,22 @@ final class AppState {
     /// `rightPaneStore` (the same source `CenterPaneView`'s split-commit
     /// workflow gate reads) instead of recomputing it from disk on every
     /// call — this is invoked from SwiftUI view bodies, so it must stay
-    /// cheap. Falls back to `false` if the worktree's right pane state
-    /// hasn't been activated / seeded yet.
+    /// cheap. Commit and review-session tabs don't activate a right-pane
+    /// state on their own, so that cache can be unseeded even for a worktree
+    /// with an active gg stack; fall back to deriving the context directly
+    /// in that case rather than reporting unsupported.
     func ggFollowSupported(worktreeID: String) -> Bool {
-        rightPaneStore.activeState(worktreeId: worktreeID)?.ggContext.isActive ?? false
+        if let context = rightPaneStore.activeState(worktreeId: worktreeID)?.ggContext {
+            return context.isActive
+        }
+        guard let worktree = worktree(withId: worktreeID),
+              let project = projectsManager.projects.first(where: { $0.id == worktree.projectId })
+        else { return false }
+        return ggWorktreeContext(
+            project: project,
+            worktree: worktree,
+            branch: worktree.branch
+        ).isActive
     }
 
     private func followedStackEntryGGID(worktreeID: String, tabID: TabID) -> String? {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3210,7 +3210,7 @@ final class AppState {
         reviewSessionRetargetGenerations[sessionID.rawValue, default: 0]
     }
 
-    func followRevision(worktreeID: String, tabID: TabID, expression: String) {
+    func followRevision(worktreeID: String, tabID: TabID, target: TrackedRevisionTarget) {
         let requestKey = followRevisionRequestKey(worktreeID: worktreeID, tabID: tabID)
         let requestGeneration = bumpFollowRevisionRequestGeneration(requestKey)
         Task { @MainActor in
@@ -3218,19 +3218,19 @@ final class AppState {
                 worktreeID: worktreeID,
                 requestKey: requestKey,
                 requestGeneration: requestGeneration,
-                expression: expression
+                target: target
             )
         }
     }
 
-    func promptFollowRevision(worktreeID: String, tabID: TabID, prefill: String? = nil) {
+    func promptFollowRevision(worktreeID: String, tabID: TabID, prefill: TrackedRevisionTarget? = nil) {
         let requestKey = followRevisionRequestKey(worktreeID: worktreeID, tabID: tabID)
         let requestGeneration = bumpFollowRevisionRequestGeneration(requestKey)
         let editorGeneration = bumpFollowRevisionEditorGeneration()
         Task { @MainActor in
             let resolvedPrefill: String?
             if let prefill {
-                resolvedPrefill = prefill
+                resolvedPrefill = prefill.expressionValue
             } else {
                 resolvedPrefill = await suggestedFollowRevisionPrefill(worktreeID: worktreeID, tabID: tabID)
             }
@@ -3257,7 +3257,7 @@ final class AppState {
         request.isSubmitting = true
         request.errorMessage = nil
         followRevisionEditorRequest = request
-        followRevision(worktreeID: request.worktreeID, tabID: request.tabID, expression: expression)
+        followRevision(worktreeID: request.worktreeID, tabID: request.tabID, target: .expression(expression))
     }
 
     func dismissFollowRevisionEditor() {
@@ -3342,12 +3342,12 @@ final class AppState {
         worktreeID: String,
         requestKey: String,
         requestGeneration: Int,
-        expression: String
+        target: TrackedRevisionTarget
     ) async {
         guard let worktree = worktree(withId: worktreeID) else { return }
         let candidate: TrackedRevisionCandidate
         do {
-            candidate = try await TrackedRevisionResolver.live.resolve(at: worktree.path, expression: expression)
+            candidate = try await TrackedRevisionResolver.live.resolve(at: worktree.path, target: target)
         } catch {
             guard isCurrentFollowRevisionRequest(worktreeID: worktreeID, requestKey: requestKey, requestGeneration: requestGeneration)
             else { return }
@@ -3359,7 +3359,7 @@ final class AppState {
             return
         }
         guard let revision = TrackedRevision(
-            expression: expression,
+            target: target,
             baselineBranch: candidate.branch,
             baselineHEAD: candidate.headSHA,
             resolvedSHA: candidate.sha
@@ -3369,7 +3369,7 @@ final class AppState {
             publishFollowRevisionError(
                 worktreeID: worktreeID,
                 requestKey: requestKey,
-                message: "Revision expression must not be empty."
+                message: "Revision target must not be empty."
             )
             return
         }
@@ -3462,7 +3462,7 @@ final class AppState {
               let result = TrackedRevisionRetargeter.follow(
                   record: record,
                   revision: revision,
-                  title: "Review \(revision.expression)",
+                  title: "Review \(revision.target.displayLabel)",
                   now: Date()
               )
         else { return }
@@ -3537,7 +3537,7 @@ final class AppState {
               let result = TrackedRevisionRetargeter.follow(
                   record: record,
                   revision: accepted,
-                  title: "Review \(accepted.expression)",
+                  title: "Review \(accepted.target.displayLabel)",
                   now: Date()
               )
         else { return }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3152,9 +3152,9 @@ final class AppState {
             watcher.onHeadChanged = { [weak self] updates in
                 self?.handleProjectHeadUpdates(projectId: project.id, branchByWorktreePath: updates)
             }
-            watcher.onRevisionChanged = { [weak self] in self?.bumpRevisionGenerationForProject(projectId: project.id) }
+            watcher.onRevisionChanged = { [weak self] in self?.handleProjectRevisionChange(projectId: project.id) }
             watcher.onTopologyChanged = { [weak self] in
-                self?.bumpRevisionGenerationForProject(projectId: project.id)
+                self?.handleProjectRevisionChange(projectId: project.id)
                 self?.handleProjectTopologyChange(projectId: project.id)
             }
             remoteProjectWatchers[project.id] = watcher
@@ -3164,9 +3164,9 @@ final class AppState {
         let watcher = projectGitWatcherFactory(URL(fileURLWithPath: project.path))
         let projectId = project.id
         watcher.onHeadChanged = { [weak self] map in self?.handleProjectHeadUpdates(projectId: projectId, branchByWorktreePath: map) }
-        watcher.onRevisionChanged = { [weak self] in self?.bumpRevisionGenerationForProject(projectId: projectId) }
+        watcher.onRevisionChanged = { [weak self] in self?.handleProjectRevisionChange(projectId: projectId) }
         watcher.onTopologyChanged = { [weak self] in
-            self?.bumpRevisionGenerationForProject(projectId: projectId)
+            self?.handleProjectRevisionChange(projectId: projectId)
             self?.handleProjectTopologyChange(projectId: projectId)
         }
         watcher.start()
@@ -3200,6 +3200,11 @@ final class AppState {
         for path in changedPaths {
             GGStackSummaryStore.shared.summaries[path] = nil
         }
+        Task { await GGStackCache.shared.invalidate() }
+    }
+
+    private func handleProjectRevisionChange(projectId: String) {
+        bumpRevisionGenerationForProject(projectId: projectId)
         Task { await GGStackCache.shared.invalidate() }
     }
 

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -777,6 +777,19 @@ private struct RootGGPresentationHandlers: ViewModifier {
                 )
                 .environment(\.theme, state.themeStore.current)
             }
+            .sheet(
+                item: Binding(
+                    get: { state.pendingFollowStackEntry },
+                    set: { if $0 == nil { state.cancelFollowStackEntry() } }
+                )
+            ) { presentation in
+                GGFollowEntrySheet(
+                    presentation: presentation,
+                    onFollow: { state.confirmFollowStackEntry(ggID: $0) },
+                    onCancel: { state.cancelFollowStackEntry() }
+                )
+                .environment(\.theme, state.themeStore.current)
+            }
     }
 }
 

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -193,14 +193,14 @@ struct CenterPaneView: View {
                     state.promptFollowRevision(worktreeID: worktree.id, tabID: id)
                 },
                 onEditRevision: { id in
-                    let prefill: String? = {
+                    let prefill: TrackedRevisionTarget? = {
                         switch tabs.first(where: { $0.id == id }) {
                         case .commit(let s):
-                            return s.revision.tracked?.expression
+                            return s.revision.tracked?.target
                         case .reviewSession(let s):
                             let record = try? ReviewSessionStore().load(id: s.sessionID)
                             if case .trackedCommit(let revision) = record?.target.payload {
-                                return revision.expression
+                                return revision.target
                             }
                             return nil
                         default:

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -166,11 +166,13 @@ struct CenterPaneView: View {
                     FileSystemOpen.reveal(url: url)
                 },
                 revisionFollowCapability: { tab in
+                    let supportsStackEntry = state.ggFollowSupported(worktreeID: worktree.id)
                     switch tab {
                     case .commit(let state):
                         return RevisionFollowCapability(
                             isSupported: true,
-                            isFollowing: state.revision.tracked != nil
+                            isFollowing: state.revision.tracked != nil,
+                            supportsStackEntry: supportsStackEntry
                         )
                     case .reviewSession(let state):
                         let record = try? ReviewSessionStore().load(id: state.sessionID)
@@ -183,7 +185,11 @@ struct CenterPaneView: View {
                         } else {
                             isFollowing = false
                         }
-                        return RevisionFollowCapability(isSupported: true, isFollowing: isFollowing)
+                        return RevisionFollowCapability(
+                            isSupported: true,
+                            isFollowing: isFollowing,
+                            supportsStackEntry: supportsStackEntry
+                        )
                     default:
                         return RevisionFollowCapability(isSupported: false, isFollowing: false)
                     }
@@ -191,6 +197,9 @@ struct CenterPaneView: View {
                 onFollowRevision: { id in
                     state.activateWorktreeCenterTab(worktreeId: worktree.id, tabId: id)
                     state.promptFollowRevision(worktreeID: worktree.id, tabID: id)
+                },
+                onFollowStackEntry: { id in
+                    state.promptFollowStackEntry(worktreeID: worktree.id, tabID: id)
                 },
                 onEditRevision: { id in
                     let prefill: TrackedRevisionTarget? = {

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -100,6 +100,7 @@ struct CommitHeaderView: View {
             tabID: tabID,
             accessibilityPrefix: "commit-revision",
             appState: appState,
+            followedTarget: trackedRevision?.target,
             isRefreshing: isRefreshingRevision,
             onAcceptPendingCheckout: onAcceptPendingCheckout,
             onRetry: onRetryRevision

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -285,14 +285,26 @@ struct CommitTabView: View {
         guard case .following(let tracked) = tabState.revision else {
             return (tabState.sha, nil, false)
         }
-        let candidate = try await revisionResolver.resolve(at: worktreePath, target: tracked.target)
+        let candidate: TrackedRevisionCandidate
+        do {
+            candidate = try await revisionResolver.resolve(at: worktreePath, target: tracked.target)
+        } catch {
+            guard case .stall(let stalled) = TrackedRevisionPolicy.evaluate(current: tracked, error: error) else {
+                throw error
+            }
+            appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {
+                $0.revision = .following(stalled)
+            }
+            let canReuseSnapshot = details?.info.sha == stalled.resolvedSHA && reviewSession != nil
+            return (stalled.resolvedSHA, nil, canReuseSnapshot)
+        }
         switch TrackedRevisionPolicy.evaluate(current: tracked, candidate: candidate) {
         case .unchanged(let revision):
             let canReuseSnapshot = details?.info.sha == revision.resolvedSHA && reviewSession != nil
             return (revision.resolvedSHA, revision, canReuseSnapshot)
         case .follow(let revision):
             return (revision.resolvedSHA, revision, false)
-        case .pause(let revision):
+        case .pause(let revision), .stall(let revision):
             appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {
                 $0.revision = .following(revision)
             }

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -36,7 +36,7 @@ struct CommitTabView: View {
 
     private var loadTaskID: String {
         if let tracked = tabState.revision.tracked {
-            return "\(tabState.id):\(tracked.expression):\(appState.revisionChangeGeneration(worktreeID: worktreeId))"
+            return "\(tabState.id):\(tracked.target.identityKey):\(appState.revisionChangeGeneration(worktreeID: worktreeId))"
         }
         return "\(tabState.id):\(sha)"
     }
@@ -285,7 +285,7 @@ struct CommitTabView: View {
         guard case .following(let tracked) = tabState.revision else {
             return (tabState.sha, nil, false)
         }
-        let candidate = try await revisionResolver.resolve(at: worktreePath, expression: tracked.expression)
+        let candidate = try await revisionResolver.resolve(at: worktreePath, target: tracked.target)
         switch TrackedRevisionPolicy.evaluate(current: tracked, candidate: candidate) {
         case .unchanged(let revision):
             let canReuseSnapshot = details?.info.sha == revision.resolvedSHA && reviewSession != nil

--- a/Alas/Sources/Center/Commit/RevisionFollowControl.swift
+++ b/Alas/Sources/Center/Commit/RevisionFollowControl.swift
@@ -118,7 +118,7 @@ struct RevisionFollowControl: View {
                     appState?.promptFollowRevision(
                         worktreeID: worktreeID,
                         tabID: tabID,
-                        prefill: presentation.expression
+                        prefill: presentation.expression.map { .expression($0) }
                     )
                 }
                 .accessibilityIdentifier("\(accessibilityPrefix)-edit")

--- a/Alas/Sources/Center/Commit/RevisionFollowControl.swift
+++ b/Alas/Sources/Center/Commit/RevisionFollowControl.swift
@@ -37,6 +37,19 @@ struct RevisionFollowControl: View {
                         .controlSize(.small)
                         .accessibilityIdentifier("\(accessibilityPrefix)-accept-checkout")
                 }
+            case .stalled(_, _, let message):
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("warn"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .accessibilityIdentifier("\(accessibilityPrefix)-unresolved")
+                if let onRetry {
+                    Button("Retry", action: onRetry)
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .accessibilityIdentifier("\(accessibilityPrefix)-unresolved-retry")
+                }
             case .failed(_, _, let message):
                 Text(message)
                     .font(.system(size: 11))
@@ -87,7 +100,8 @@ struct RevisionFollowControl: View {
         case .fixed(let sha):
             RevisionTetherView(expression: nil, resolvedSHA: sha)
         case .following(let expression, let resolvedSHA),
-             .failed(let expression, let resolvedSHA, _):
+             .failed(let expression, let resolvedSHA, _),
+             .stalled(let expression, let resolvedSHA, _):
             RevisionTetherView(expression: expression, resolvedSHA: resolvedSHA)
                 .accessibilityIdentifier("\(accessibilityPrefix)-following-label")
         case .paused(let expression, let resolvedSHA, let candidateSHA, _):
@@ -199,7 +213,7 @@ struct RevisionFollowControl: View {
     private var railColor: Color {
         switch presentation {
         case .failed: theme.color("del")
-        case .paused: theme.color("warn")
+        case .paused, .stalled: theme.color("warn")
         case .following: theme.color("accent")
         case .fixed: theme.color("line")
         }
@@ -250,7 +264,10 @@ struct RevisionTetherView: View {
 private extension RevisionFollowPresentation {
     var expression: String? {
         switch self {
-        case .following(let expression, _), .paused(let expression, _, _, _), .failed(let expression, _, _): expression
+        case .following(let expression, _),
+             .paused(let expression, _, _, _),
+             .stalled(let expression, _, _),
+             .failed(let expression, _, _): expression
         case .fixed: nil
         }
     }
@@ -258,7 +275,10 @@ private extension RevisionFollowPresentation {
     var resolvedSHA: String? {
         switch self {
         case .fixed(let sha): sha
-        case .following(_, let sha), .paused(_, let sha, _, _), .failed(_, let sha, _): sha
+        case .following(_, let sha),
+             .paused(_, let sha, _, _),
+             .stalled(_, let sha, _),
+             .failed(_, let sha, _): sha
         }
     }
 }

--- a/Alas/Sources/Center/Commit/RevisionFollowControl.swift
+++ b/Alas/Sources/Center/Commit/RevisionFollowControl.swift
@@ -114,17 +114,39 @@ struct RevisionFollowControl: View {
     private var action: some View {
         switch presentation {
         case .fixed:
-            Button {
-                appState?.promptFollowRevision(worktreeID: worktreeID, tabID: tabID)
-            } label: {
-                Label("Follow a revision", systemImage: "link.badge.plus")
-            }
-            .buttonStyle(.borderless)
-            .controlSize(.small)
-            .disabled(appState == nil)
-            .accessibilityIdentifier("\(accessibilityPrefix)-follow")
-            .popover(isPresented: editorPresented, arrowEdge: .bottom) {
-                editor
+            if appState?.ggFollowSupported(worktreeID: worktreeID) == true {
+                Menu {
+                    Button("Stack Entry…") {
+                        appState?.promptFollowStackEntry(worktreeID: worktreeID, tabID: tabID)
+                    }
+                    .accessibilityIdentifier("\(accessibilityPrefix)-follow-stack-entry")
+                    Button("Revision…") {
+                        appState?.promptFollowRevision(worktreeID: worktreeID, tabID: tabID)
+                    }
+                    .accessibilityIdentifier("\(accessibilityPrefix)-follow-expression")
+                } label: {
+                    Label("Follow…", systemImage: "link.badge.plus")
+                }
+                .menuStyle(.borderlessButton)
+                .controlSize(.small)
+                .fixedSize()
+                .accessibilityIdentifier("\(accessibilityPrefix)-follow-menu")
+                .popover(isPresented: editorPresented, arrowEdge: .bottom) {
+                    editor
+                }
+            } else {
+                Button {
+                    appState?.promptFollowRevision(worktreeID: worktreeID, tabID: tabID)
+                } label: {
+                    Label("Follow a revision", systemImage: "link.badge.plus")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .disabled(appState == nil)
+                .accessibilityIdentifier("\(accessibilityPrefix)-follow")
+                .popover(isPresented: editorPresented, arrowEdge: .bottom) {
+                    editor
+                }
             }
         default:
             Menu("Following") {

--- a/Alas/Sources/Center/Commit/RevisionFollowControl.swift
+++ b/Alas/Sources/Center/Commit/RevisionFollowControl.swift
@@ -6,6 +6,11 @@ struct RevisionFollowControl: View {
     let tabID: TabID
     let accessibilityPrefix: String
     let appState: AppState?
+    /// The followed revision's typed target, used to seed the "Edit
+    /// revision…" prompt. `presentation.expression` is only a display
+    /// label — for a stack entry it's the bare GG-ID, which would
+    /// misroute into the plain-expression editor if wrapped as `.expression`.
+    var followedTarget: TrackedRevisionTarget?
     var isRefreshing = false
     var onAcceptPendingCheckout: (() -> Void)?
     var onRetry: (() -> Void)?
@@ -154,7 +159,7 @@ struct RevisionFollowControl: View {
                     appState?.promptFollowRevision(
                         worktreeID: worktreeID,
                         tabID: tabID,
-                        prefill: presentation.expression.map { .expression($0) }
+                        prefill: followedTarget
                     )
                 }
                 .accessibilityIdentifier("\(accessibilityPrefix)-edit")
@@ -284,16 +289,6 @@ struct RevisionTetherView: View {
 }
 
 private extension RevisionFollowPresentation {
-    var expression: String? {
-        switch self {
-        case .following(let expression, _),
-             .paused(let expression, _, _, _),
-             .stalled(let expression, _, _),
-             .failed(let expression, _, _): expression
-        case .fixed: nil
-        }
-    }
-
     var resolvedSHA: String? {
         switch self {
         case .fixed(let sha): sha

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -203,9 +203,21 @@ enum TrackedRevisionTransition: Equatable {
     case unchanged(TrackedRevision)
     case follow(TrackedRevision)
     case pause(TrackedRevision)
+    /// The target could not be resolved but the tab keeps its last commit
+    /// instead of erroring or unfollowing.
+    case stall(TrackedRevision)
 }
 
 enum TrackedRevisionPolicy {
+    /// Maps a resolve failure to a transition. Only a stack entry that left
+    /// the stack stalls; every other error stays on the caller's error path.
+    static func evaluate(current: TrackedRevision, error: any Error) -> TrackedRevisionTransition? {
+        guard let resolverError = error as? TrackedRevisionResolverError,
+              case .stackEntryNotFound = resolverError
+        else { return nil }
+        return .stall(current.stalled(reason: .stackEntryMissing))
+    }
+
     static func evaluate(
         current: TrackedRevision,
         candidate: TrackedRevisionCandidate
@@ -446,6 +458,9 @@ enum RevisionFollowPresentation: Equatable {
     case fixed(sha: String)
     case following(expression: String, resolvedSHA: String)
     case paused(expression: String, resolvedSHA: String, candidateSHA: String, message: String)
+    /// The followed target could not be resolved (e.g. a stack entry left
+    /// the stack), but the tab keeps its last commit instead of erroring.
+    case stalled(expression: String, resolvedSHA: String, message: String)
     case failed(expression: String, resolvedSHA: String, message: String)
 
     init(fixedSHA: String, revision: TrackedRevision?, refreshError: String?) {
@@ -461,6 +476,12 @@ enum RevisionFollowPresentation: Equatable {
                 message: pending.branch.isEmpty
                     ? "Paused: detached HEAD moved"
                     : "Paused: HEAD moved to \(pending.branch)"
+            )
+        } else if let unresolvedMessage = revision.unresolvedMessage {
+            self = .stalled(
+                expression: revision.target.displayLabel,
+                resolvedSHA: Self.shortSHA(revision.resolvedSHA),
+                message: unresolvedMessage
             )
         } else if let refreshError, !refreshError.isEmpty {
             self = .failed(

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -29,59 +29,126 @@ struct TrackedRevisionCandidate: Codable, Equatable, Hashable, Sendable {
     }
 }
 
+enum TrackedRevisionUnresolvedReason: String, Codable, Equatable, Hashable, Sendable {
+    /// The GG-ID is not in the worktree's current stack: it landed, it was
+    /// dropped, or a different stack is checked out.
+    case stackEntryMissing
+}
+
 struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
-    let expression: String
+    let target: TrackedRevisionTarget
     var baselineBranch: String
     var baselineHEAD: String
     var resolvedSHA: String
     var pendingCheckout: TrackedRevisionCandidate?
+    var unresolvedReason: TrackedRevisionUnresolvedReason?
 
     private enum CodingKeys: String, CodingKey {
+        case target
         case expression
         case baselineBranch
         case baselineHEAD
         case resolvedSHA
         case pendingCheckout
+        case unresolvedReason
     }
 
-    init?(expression: String, baselineBranch: String, baselineHEAD: String? = nil, resolvedSHA: String) {
-        let expression = expression.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !expression.isEmpty else { return nil }
-
-        self.expression = expression
+    init?(
+        target: TrackedRevisionTarget,
+        baselineBranch: String,
+        baselineHEAD: String? = nil,
+        resolvedSHA: String
+    ) {
+        guard let normalized = target.normalized() else { return nil }
+        self.target = normalized
         self.baselineBranch = baselineBranch
         self.baselineHEAD = baselineHEAD ?? resolvedSHA
         self.resolvedSHA = resolvedSHA
         self.pendingCheckout = nil
+        self.unresolvedReason = nil
+    }
+
+    init?(
+        expression: String,
+        baselineBranch: String,
+        baselineHEAD: String? = nil,
+        resolvedSHA: String
+    ) {
+        self.init(
+            target: .expression(expression),
+            baselineBranch: baselineBranch,
+            baselineHEAD: baselineHEAD,
+            resolvedSHA: resolvedSHA
+        )
     }
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let expression = try container.decode(String.self, forKey: .expression)
+        let target: TrackedRevisionTarget
+        if let decoded = try container.decodeIfPresent(TrackedRevisionTarget.self, forKey: .target) {
+            target = decoded
+        } else {
+            // Records written before targets existed carry a bare expression.
+            target = .expression(try container.decode(String.self, forKey: .expression))
+        }
         let baselineBranch = try container.decode(String.self, forKey: .baselineBranch)
         let baselineHEAD = try container.decodeIfPresent(String.self, forKey: .baselineHEAD)
         let resolvedSHA = try container.decode(String.self, forKey: .resolvedSHA)
         guard var revision = Self(
-            expression: expression,
+            target: target,
             baselineBranch: baselineBranch,
             baselineHEAD: baselineHEAD,
             resolvedSHA: resolvedSHA
         ) else {
             throw DecodingError.dataCorruptedError(
-                forKey: .expression,
+                forKey: .target,
                 in: container,
-                debugDescription: "Tracked revision expression must not be empty."
+                debugDescription: "Tracked revision target must not be empty."
             )
         }
         revision.pendingCheckout = try container.decodeIfPresent(
             TrackedRevisionCandidate.self,
             forKey: .pendingCheckout
         )
+        revision.unresolvedReason = try container.decodeIfPresent(
+            TrackedRevisionUnresolvedReason.self,
+            forKey: .unresolvedReason
+        )
         self = revision
     }
 
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(target, forKey: .target)
+        // Legacy mirror: a build that predates targets reads this key. A
+        // stack entry degrades to a commit pinned at its last resolved SHA
+        // rather than failing to decode the whole record.
+        try container.encode(target.expressionValue ?? resolvedSHA, forKey: .expression)
+        try container.encode(baselineBranch, forKey: .baselineBranch)
+        try container.encode(baselineHEAD, forKey: .baselineHEAD)
+        try container.encode(resolvedSHA, forKey: .resolvedSHA)
+        try container.encodeIfPresent(pendingCheckout, forKey: .pendingCheckout)
+        try container.encodeIfPresent(unresolvedReason, forKey: .unresolvedReason)
+    }
+
     var dependsOnWorktreeHEAD: Bool {
-        Self.usesWorktreeHEADAlias(expression)
+        guard let expression = target.expressionValue else { return false }
+        return Self.usesWorktreeHEADAlias(expression)
+    }
+
+    var unresolvedMessage: String? {
+        switch unresolvedReason {
+        case .none:
+            return nil
+        case .stackEntryMissing:
+            return "Stack entry \(target.displayLabel) is not in the current stack."
+        }
+    }
+
+    func stalled(reason: TrackedRevisionUnresolvedReason) -> Self {
+        var revision = self
+        revision.unresolvedReason = reason
+        return revision
     }
 
     static func usesWorktreeHEADAlias(_ expression: String) -> Bool {
@@ -107,6 +174,7 @@ struct TrackedRevision: Codable, Equatable, Hashable, Sendable {
         revision.baselineHEAD = candidate.headSHA
         revision.resolvedSHA = candidate.sha
         revision.pendingCheckout = nil
+        revision.unresolvedReason = nil
         return revision
     }
 
@@ -219,10 +287,18 @@ struct TrackedRevisionResolver {
             try Task.checkCancellation()
         }
     }
+
+    func resolve(at worktreePath: URL, target: TrackedRevisionTarget) async throws -> TrackedRevisionCandidate {
+        guard let expression = target.expressionValue else {
+            throw TrackedRevisionResolverError.stackEntryNotFound(target.displayLabel)
+        }
+        return try await resolve(at: worktreePath, expression: expression)
+    }
 }
 
 enum TrackedRevisionResolverError: LocalizedError, Equatable {
     case unsupportedReflogExpression(String)
+    case stackEntryNotFound(String)
 
     var errorDescription: String? {
         switch self {
@@ -232,6 +308,8 @@ enum TrackedRevisionResolverError: LocalizedError, Equatable {
             } else {
                 "Time-relative reflog expressions like @{\(selector)} are not supported for followed revisions."
             }
+        case .stackEntryNotFound(let ggID):
+            "Stack entry \(ggID) is not in the current stack."
         }
     }
 }
@@ -344,7 +422,7 @@ enum RevisionFollowPresentation: Equatable {
         }
         if let pending = revision.pendingCheckout {
             self = .paused(
-                expression: revision.expression,
+                expression: revision.target.displayLabel,
                 resolvedSHA: Self.shortSHA(revision.resolvedSHA),
                 candidateSHA: Self.shortSHA(pending.sha),
                 message: pending.branch.isEmpty
@@ -353,13 +431,13 @@ enum RevisionFollowPresentation: Equatable {
             )
         } else if let refreshError, !refreshError.isEmpty {
             self = .failed(
-                expression: revision.expression,
+                expression: revision.target.displayLabel,
                 resolvedSHA: Self.shortSHA(revision.resolvedSHA),
                 message: refreshError
             )
         } else {
             self = .following(
-                expression: revision.expression,
+                expression: revision.target.displayLabel,
                 resolvedSHA: Self.shortSHA(revision.resolvedSHA)
             )
         }

--- a/Alas/Sources/Center/Commit/TrackedRevision.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevision.swift
@@ -235,10 +235,16 @@ enum TrackedRevisionPolicy {
 struct TrackedRevisionResolver {
     var resolve: (URL, String) async throws -> String
     var branch: (URL) async throws -> String
+    var stack: (URL) async throws -> GGStack? = { _ in nil }
 
     static let live = TrackedRevisionResolver(
         resolve: { try await GitService().resolveRevision(at: $0, ref: $1) },
-        branch: { try await GitService().currentBranch(worktreePath: $0) }
+        branch: { try await GitService().currentBranch(worktreePath: $0) },
+        stack: { worktreePath in
+            try await GGStackCache.shared.stack(at: worktreePath) {
+                try await GGService().currentStack(worktreePath: worktreePath.path)
+            }
+        }
     )
 
     func resolve(at worktreePath: URL, expression: String) async throws -> TrackedRevisionCandidate {
@@ -289,10 +295,37 @@ struct TrackedRevisionResolver {
     }
 
     func resolve(at worktreePath: URL, target: TrackedRevisionTarget) async throws -> TrackedRevisionCandidate {
-        guard let expression = target.expressionValue else {
-            throw TrackedRevisionResolverError.stackEntryNotFound(target.displayLabel)
+        switch target {
+        case .expression(let expression):
+            return try await resolve(at: worktreePath, expression: expression)
+        case .stackEntry(let ggID):
+            return try await resolveStackEntry(at: worktreePath, ggID: ggID)
         }
-        return try await resolve(at: worktreePath, expression: expression)
+    }
+
+    private func resolveStackEntry(at worktreePath: URL, ggID: String) async throws -> TrackedRevisionCandidate {
+        while true {
+            let startingBranch = try await branch(worktreePath)
+            let startingHEAD = try await resolve(worktreePath, "HEAD")
+            guard let entry = try await stack(worktreePath)?
+                .entries
+                .first(where: { $0.ggId == ggID })
+            else {
+                throw TrackedRevisionResolverError.stackEntryNotFound(ggID)
+            }
+            // gg reports abbreviated SHAs; the rest of Alas carries full ones.
+            let resolvedSHA = try await resolve(worktreePath, entry.sha)
+            let endingBranch = try await branch(worktreePath)
+            let endingHEAD = try await resolve(worktreePath, "HEAD")
+            if startingBranch == endingBranch, startingHEAD == endingHEAD {
+                return TrackedRevisionCandidate(
+                    branch: endingBranch,
+                    sha: resolvedSHA,
+                    headSHA: endingHEAD
+                )
+            }
+            try Task.checkCancellation()
+        }
     }
 }
 

--- a/Alas/Sources/Center/Commit/TrackedRevisionTarget.swift
+++ b/Alas/Sources/Center/Commit/TrackedRevisionTarget.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// What a followed tab is tracking. `.expression` is a git revision
+/// expression re-resolved on each refresh; `.stackEntry` is a gg `GG-ID`
+/// trailer, which survives the rebases and reorders that shift `HEAD~n`.
+enum TrackedRevisionTarget: Equatable, Hashable, Sendable {
+    case expression(String)
+    case stackEntry(ggID: String)
+
+    /// Stable key for persisted identity — review-session IDs, review-draft
+    /// IDs, and commit-tab IDs are derived from it. For `.expression` it must
+    /// stay byte-identical to the raw expression, which is what those IDs
+    /// were built from before targets existed. Git refs cannot contain `:`,
+    /// so the `gg:` namespace cannot collide with an expression.
+    var identityKey: String {
+        switch self {
+        case .expression(let expression): expression
+        case .stackEntry(let ggID): "gg:\(ggID)"
+        }
+    }
+
+    /// What the revision row shows to the left of `-> <sha>`.
+    var displayLabel: String {
+        switch self {
+        case .expression(let expression): expression
+        case .stackEntry(let ggID): ggID
+        }
+    }
+
+    var expressionValue: String? {
+        guard case .expression(let expression) = self else { return nil }
+        return expression
+    }
+
+    var ggID: String? {
+        guard case .stackEntry(let ggID) = self else { return nil }
+        return ggID
+    }
+
+    var isStackEntry: Bool { ggID != nil }
+
+    /// Trims surrounding whitespace and rejects an empty payload.
+    func normalized() -> TrackedRevisionTarget? {
+        switch self {
+        case .expression(let expression):
+            let trimmed = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : .expression(trimmed)
+        case .stackEntry(let ggID):
+            let trimmed = ggID.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : .stackEntry(ggID: trimmed)
+        }
+    }
+}
+
+extension TrackedRevisionTarget: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case value
+    }
+
+    private enum Kind: String, Codable {
+        case expression
+        case stackEntry = "stack-entry"
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        let value = try container.decode(String.self, forKey: .value)
+        switch kind {
+        case .expression: self = .expression(value)
+        case .stackEntry: self = .stackEntry(ggID: value)
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .expression(let expression):
+            try container.encode(Kind.expression, forKey: .kind)
+            try container.encode(expression, forKey: .value)
+        case .stackEntry(let ggID):
+            try container.encode(Kind.stackEntry, forKey: .kind)
+            try container.encode(ggID, forKey: .value)
+        }
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -43,8 +43,8 @@ struct ReviewDraftSessionID: Codable, Equatable, Hashable, Sendable, RawRepresen
         make(.commit, [worktreeID, repositoryPath.standardizedFileURL.path, sha])
     }
 
-    static func trackedCommit(worktreeID: String, repositoryPath: URL, expression: String) -> Self {
-        make(.trackedCommit, [worktreeID, repositoryPath.standardizedFileURL.path, expression])
+    static func trackedCommit(worktreeID: String, repositoryPath: URL, targetKey: String) -> Self {
+        make(.trackedCommit, [worktreeID, repositoryPath.standardizedFileURL.path, targetKey])
     }
 
     static func commitRange(worktreeID: String, repositoryPath: URL, base: String, head: String) -> Self {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionModels.swift
@@ -96,9 +96,9 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
         title: String
     ) -> Self {
         let path = standardizedPath(repositoryPath)
-        let revisionDescription = "\(revision.expression) -> \(revision.resolvedSHA)"
+        let revisionDescription = "\(revision.target.displayLabel) -> \(revision.resolvedSHA)"
         return ReviewSessionTarget(
-            id: makeID(.trackedCommit, [worktreeID, path, revision.expression]),
+            id: makeID(.trackedCommit, [worktreeID, path, revision.target.identityKey]),
             kind: .trackedCommit,
             worktreeID: worktreeID,
             repositoryPath: standardizedURL(repositoryPath),
@@ -110,7 +110,7 @@ struct ReviewSessionTarget: Codable, Equatable, Hashable, Identifiable, Sendable
             draftSessionID: .trackedCommit(
                 worktreeID: worktreeID,
                 repositoryPath: repositoryPath,
-                expression: revision.expression
+                targetKey: revision.target.identityKey
             ),
             payload: .trackedCommit(revision)
         )

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -650,10 +650,22 @@ struct ReviewSessionTabView: View {
         guard let worktree, case .trackedCommit(let revision) = storedRecord.target.payload else {
             return (storedRecord, false)
         }
-        let candidate = try await TrackedRevisionResolver.live.resolve(
-            at: worktree.path,
-            target: revision.target
-        )
+        let candidate: TrackedRevisionCandidate
+        do {
+            candidate = try await TrackedRevisionResolver.live.resolve(
+                at: worktree.path,
+                target: revision.target
+            )
+        } catch {
+            guard case .stall(let stalled) = TrackedRevisionPolicy.evaluate(current: revision, error: error) else {
+                throw error
+            }
+            let target = storedRecord.target.updatingTrackedRevision(stalled, title: storedRecord.target.title)
+            return (
+                storedRecord.retargetingCommit(to: target, resolvedSHAChanged: false, now: now()),
+                false
+            )
+        }
         switch TrackedRevisionPolicy.evaluate(current: revision, candidate: candidate) {
         case .unchanged(let updated):
             let target = storedRecord.target.updatingTrackedRevision(updated, title: storedRecord.target.title)
@@ -675,10 +687,6 @@ struct ReviewSessionTabView: View {
                 ),
                 false
             )
-        // A stall is only produced from a resolver error, which this
-        // candidate-only path does not handle. Keep the compatibility arm
-        // equivalent to pause so adding the transition does not alter review
-        // session behavior.
         case .pause(let updated), .stall(let updated):
             let target = storedRecord.target.updatingTrackedRevision(updated, title: storedRecord.target.title)
             return (

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -663,7 +663,7 @@ struct ReviewSessionTabView: View {
             let target = storedRecord.target.updatingTrackedRevision(stalled, title: storedRecord.target.title)
             return (
                 storedRecord.retargetingCommit(to: target, resolvedSHAChanged: false, now: now()),
-                false
+                true
             )
         }
         switch TrackedRevisionPolicy.evaluate(current: revision, candidate: candidate) {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -675,7 +675,11 @@ struct ReviewSessionTabView: View {
                 ),
                 false
             )
-        case .pause(let updated):
+        // A stall is only produced from a resolver error, which this
+        // candidate-only path does not handle. Keep the compatibility arm
+        // equivalent to pause so adding the transition does not alter review
+        // session behavior.
+        case .pause(let updated), .stall(let updated):
             let target = storedRecord.target.updatingTrackedRevision(updated, title: storedRecord.target.title)
             return (
                 storedRecord.retargetingCommit(

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -652,7 +652,7 @@ struct ReviewSessionTabView: View {
         }
         let candidate = try await TrackedRevisionResolver.live.resolve(
             at: worktree.path,
-            expression: revision.expression
+            target: revision.target
         )
         switch TrackedRevisionPolicy.evaluate(current: revision, candidate: candidate) {
         case .unchanged(let updated):
@@ -666,7 +666,7 @@ struct ReviewSessionTabView: View {
                 false
             )
         case .follow(let updated):
-            let target = storedRecord.target.updatingTrackedRevision(updated, title: "Review \(updated.expression)")
+            let target = storedRecord.target.updatingTrackedRevision(updated, title: "Review \(updated.target.displayLabel)")
             return (
                 storedRecord.retargetingCommit(
                     to: target,

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -283,6 +283,7 @@ struct ReviewSessionTabView: View {
             tabID: tabState.id,
             accessibilityPrefix: "review-session-revision",
             appState: appState,
+            followedTarget: trackedRevision?.target,
             isRefreshing: isLoading && trackedRevision != nil,
             onAcceptPendingCheckout: acceptPendingCheckout,
             onRetry: { loadGeneration += 1 }

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -440,7 +440,7 @@ struct CommitTabState: Codable, Equatable, Identifiable {
     }
 
     init(worktreeId: String, trackedRevision: TrackedRevision, title: String) {
-        self.id = Self.trackedID(worktreeId: worktreeId, expression: trackedRevision.expression)
+        self.id = Self.trackedID(worktreeId: worktreeId, targetKey: trackedRevision.target.identityKey)
         self.worktreeId = worktreeId
         self.viewID = id
         self.revision = .following(trackedRevision)
@@ -471,7 +471,7 @@ struct CommitTabState: Codable, Equatable, Identifiable {
     }
 
     mutating func follow(_ revision: TrackedRevision) {
-        id = Self.trackedID(worktreeId: worktreeId, expression: revision.expression)
+        id = Self.trackedID(worktreeId: worktreeId, targetKey: revision.target.identityKey)
         self.revision = .following(revision)
     }
 
@@ -484,12 +484,12 @@ struct CommitTabState: Codable, Equatable, Identifiable {
         "commit:\(worktreeId):\(sha)"
     }
 
-    private static func trackedID(worktreeId: String, expression: String) -> String {
-        "commit:\(worktreeId):tracked:\(trackedIDDigest(for: expression))"
+    private static func trackedID(worktreeId: String, targetKey: String) -> String {
+        "commit:\(worktreeId):tracked:\(trackedIDDigest(for: targetKey))"
     }
 
-    private static func trackedIDDigest(for expression: String) -> String {
-        SHA256.hash(data: Data(expression.utf8))
+    private static func trackedIDDigest(for targetKey: String) -> String {
+        SHA256.hash(data: Data(targetKey.utf8))
             .map { String(format: "%02x", $0) }
             .joined()
     }

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -22,6 +22,7 @@ struct TabBarView: View {
         RevisionFollowCapability(tab: tab)
     }
     var onFollowRevision: (TabID) -> Void = { _ in }
+    var onFollowStackEntry: (TabID) -> Void = { _ in }
     var onEditRevision: (TabID) -> Void = { _ in }
     var onStopFollowingRevision: (TabID) -> Void = { _ in }
     /// Whether system-open / reveal-in-Finder actions are available for this
@@ -164,6 +165,13 @@ struct TabBarView: View {
             }
             let revisionCapability = revisionFollowCapability(tab)
             if revisionCapability.isSupported {
+                if revisionCapability.supportsStackEntry {
+                    Button {
+                        onFollowStackEntry(tab.id)
+                    } label: {
+                        Label("Follow Stack Entry…", systemImage: "arrow.triangle.branch")
+                    }
+                }
                 Button {
                     if revisionCapability.isFollowing {
                         onEditRevision(tab.id)
@@ -220,10 +228,14 @@ struct TabBarView: View {
 struct RevisionFollowCapability: Equatable {
     let isSupported: Bool
     let isFollowing: Bool
+    let supportsStackEntry: Bool
 
-    init(isSupported: Bool, isFollowing: Bool) {
+    init(isSupported: Bool, isFollowing: Bool, supportsStackEntry: Bool = false) {
         self.isSupported = isSupported
         self.isFollowing = isFollowing
+        // Stack-entry following is a refinement of revision following, never
+        // an alternative to it.
+        self.supportsStackEntry = isSupported && supportsStackEntry
     }
 
     init(tab: Tab) {

--- a/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
+++ b/Alas/Sources/Dialogs/ReviewTarget/ReviewTargetPaletteModel.swift
@@ -557,7 +557,7 @@ final class ReviewTargetPaletteModel {
                 worktreeID: worktree.id,
                 repositoryPath: worktree.path,
                 revision: revision,
-                title: "Review \(revision.expression)"
+                title: "Review \(revision.target.displayLabel)"
             ),
             worktree
         )

--- a/Alas/Sources/Integrations/GG/GGFollowEntryModel.swift
+++ b/Alas/Sources/Integrations/GG/GGFollowEntryModel.swift
@@ -86,3 +86,43 @@ enum GGFollowEntryLoadState: Equatable, Sendable {
     case offStack
     case failed(String)
 }
+
+struct GGFollowEntryPresentation: Equatable, Identifiable, Sendable {
+    let worktreeID: String
+    let tabID: TabID
+    let isEditing: Bool
+    var state: GGFollowEntryLoadState
+
+    var id: String { "\(worktreeID):\(tabID)" }
+
+    var selectedGGID: String? {
+        guard case .loaded(let model) = state else { return nil }
+        return model.canFollow ? model.selected?.ggID : nil
+    }
+}
+
+/// Which prompt "Follow…" / "Edit…" opens, given what the tab currently
+/// follows. Pure so the branch is testable without standing up tabs.
+enum FollowRevisionPromptRoute: Equatable {
+    case expressionPrompt(prefill: String?, isEditing: Bool)
+    case stackEntryPicker(isEditing: Bool)
+
+    static func route(
+        prefill: TrackedRevisionTarget?,
+        stackEntrySupported: Bool
+    ) -> FollowRevisionPromptRoute {
+        switch prefill {
+        case .none:
+            return .expressionPrompt(prefill: nil, isEditing: false)
+        case .expression(let expression):
+            return .expressionPrompt(prefill: expression, isEditing: true)
+        case .stackEntry:
+            // gg can go inactive under a tab that is already following an
+            // entry; fall back to the expression prompt with the usual
+            // suggested prefill rather than a picker that cannot load.
+            return stackEntrySupported
+                ? .stackEntryPicker(isEditing: true)
+                : .expressionPrompt(prefill: nil, isEditing: true)
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGFollowEntryModel.swift
+++ b/Alas/Sources/Integrations/GG/GGFollowEntryModel.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// One row in the follow-a-stack-entry picker.
+struct GGFollowEntryCandidate: Equatable, Identifiable, Sendable {
+    let position: Int
+    let title: String
+    let sha: String
+    let ggID: String?
+    let prNumber: Int?
+    let prState: GGPRState?
+    let ciStatus: GGCIStatus?
+
+    var id: String { ggID ?? sha }
+
+    /// Only a commit carrying a `GG-ID` trailer has an identity stable enough
+    /// to follow. Commits without one are shown so the stack reads correctly,
+    /// but cannot be picked.
+    var isSelectable: Bool { ggID != nil }
+
+    init(entry: GGStackEntry) {
+        position = entry.position
+        title = entry.title
+        sha = entry.sha
+        ggID = entry.ggId
+        prNumber = entry.prNumber
+        prState = entry.prState
+        ciStatus = entry.ciStatus
+    }
+}
+
+struct GGFollowEntryModel: Equatable, Sendable {
+    var candidates: [GGFollowEntryCandidate]
+    var selectedID: String?
+
+    var selected: GGFollowEntryCandidate? {
+        guard let selectedID else { return nil }
+        return candidates.first { $0.id == selectedID }
+    }
+
+    var canFollow: Bool { selected?.isSelectable == true }
+
+    /// Tip first, matching how commits are listed everywhere else in Alas.
+    /// Preselection prefers the entry already followed, then the entry whose
+    /// commit the tab is displaying, then the tip.
+    static func make(
+        entries: [GGStackEntry],
+        currentGGID: String?,
+        displayedSHA: String?
+    ) -> GGFollowEntryModel {
+        let candidates = entries
+            .sorted { $0.position > $1.position }
+            .map(GGFollowEntryCandidate.init(entry:))
+        return GGFollowEntryModel(
+            candidates: candidates,
+            selectedID: preselection(
+                candidates: candidates,
+                currentGGID: currentGGID,
+                displayedSHA: displayedSHA
+            )
+        )
+    }
+
+    private static func preselection(
+        candidates: [GGFollowEntryCandidate],
+        currentGGID: String?,
+        displayedSHA: String?
+    ) -> String? {
+        if let currentGGID,
+           let match = candidates.first(where: { $0.ggID == currentGGID }) {
+            return match.id
+        }
+        if let displayedSHA, !displayedSHA.isEmpty,
+           let match = candidates.first(where: {
+               $0.isSelectable && ($0.sha.hasPrefix(displayedSHA) || displayedSHA.hasPrefix($0.sha))
+           }) {
+            return match.id
+        }
+        return candidates.first(where: \.isSelectable)?.id
+    }
+}
+
+enum GGFollowEntryLoadState: Equatable, Sendable {
+    case loading
+    case loaded(GGFollowEntryModel)
+    /// The branch is not a gg stack right now.
+    case offStack
+    case failed(String)
+}

--- a/Alas/Sources/Integrations/GG/GGFollowEntrySheet.swift
+++ b/Alas/Sources/Integrations/GG/GGFollowEntrySheet.swift
@@ -35,6 +35,14 @@ struct GGFollowEntrySheet: View {
         .padding(18)
         .frame(minWidth: 520)
         .onAppear { selectedID = presentation.selectedGGID ?? loadedModel?.selectedID }
+        .onChange(of: presentation.state) { _, _ in
+            // The sheet is presented while the stack is still loading
+            // (`presentation.state == .loading`), so `onAppear` fires before
+            // there is anything to preselect. Re-seed once the load resolves,
+            // without clobbering a selection the user already made.
+            guard selectedID == nil else { return }
+            selectedID = presentation.selectedGGID ?? loadedModel?.selectedID
+        }
     }
 
     @ViewBuilder

--- a/Alas/Sources/Integrations/GG/GGFollowEntrySheet.swift
+++ b/Alas/Sources/Integrations/GG/GGFollowEntrySheet.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+/// Picks a gg stack entry for a tab to follow. Shaped like `GGReorderSheet`:
+/// a bordered list of stack rows with an apply/cancel footer.
+struct GGFollowEntrySheet: View {
+    let presentation: GGFollowEntryPresentation
+    let onFollow: (String) -> Void
+    let onCancel: () -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var selectedID: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(presentation.isEditing ? "Edit Followed Stack Entry" : "Follow Stack Entry")
+                .font(.system(size: 16, weight: .semibold))
+            Text("The tab tracks this commit's GG-ID across rebases, reorders, and amends.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(theme.color("fg-dim"))
+
+            content
+
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Follow") {
+                    guard let selectedID, let ggID = ggID(for: selectedID) else { return }
+                    onFollow(ggID)
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canFollow)
+            }
+        }
+        .padding(18)
+        .frame(minWidth: 520)
+        .onAppear { selectedID = presentation.selectedGGID ?? loadedModel?.selectedID }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch presentation.state {
+        case .loading:
+            HStack(spacing: 8) {
+                Spinner().frame(width: 14, height: 14)
+                Text("Loading stack…")
+                    .font(.system(size: 12))
+                    .foregroundStyle(theme.color("fg-dim"))
+            }
+            .frame(minWidth: 480, minHeight: 260, alignment: .center)
+        case .offStack:
+            message("This worktree is not on a gg stack right now.")
+        case .failed(let error):
+            message(error, color: theme.color("warn"))
+        case .loaded(let model):
+            List(selection: $selectedID) {
+                ForEach(model.candidates) { candidate in
+                    row(candidate)
+                        .tag(candidate.id)
+                        .selectionDisabled(!candidate.isSelectable)
+                }
+            }
+            .listStyle(.bordered(alternatesRowBackgrounds: true))
+            .frame(minWidth: 480, minHeight: 260)
+        }
+    }
+
+    private func message(_ text: String, color: Color? = nil) -> some View {
+        Text(text)
+            .font(.system(size: 12))
+            .foregroundStyle(color ?? theme.color("fg-dim"))
+            .frame(minWidth: 480, minHeight: 260, alignment: .center)
+    }
+
+    private func row(_ candidate: GGFollowEntryCandidate) -> some View {
+        HStack(spacing: 10) {
+            Text("\(candidate.position)")
+                .font(.system(size: 10.5, design: .monospaced))
+                .foregroundStyle(theme.color("fg-faint"))
+                .frame(width: 18, alignment: .trailing)
+            Text(candidate.title)
+                .font(.system(size: 12.5))
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            if let number = candidate.prNumber {
+                Text("#\(number)")
+                    .font(.system(size: 10.5, design: .monospaced))
+                    .foregroundStyle(theme.color("fg-dim"))
+            }
+            if let ciStatus = candidate.ciStatus {
+                Text(ciStatus.rawValue)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(theme.color("fg-faint"))
+            }
+            Text(candidate.ggID ?? "no GG-ID")
+                .font(.system(size: 10.5, design: .monospaced))
+                .foregroundStyle(theme.color(candidate.isSelectable ? "fg-faint" : "warn"))
+                .lineLimit(1)
+        }
+        .frame(height: 30)
+        .opacity(candidate.isSelectable ? 1 : 0.55)
+    }
+
+    private var loadedModel: GGFollowEntryModel? {
+        guard case .loaded(let model) = presentation.state else { return nil }
+        return model
+    }
+
+    private var canFollow: Bool {
+        guard let selectedID else { return false }
+        return ggID(for: selectedID) != nil
+    }
+
+    private func ggID(for id: String) -> String? {
+        loadedModel?.candidates.first { $0.id == id }?.ggID
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGStackCache.swift
+++ b/Alas/Sources/Integrations/GG/GGStackCache.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Shares one `gg ls --json` per worktree across every followed tab until
+/// the stack can have changed. `gg ls` can hit the forge for PR and CI
+/// state, so a per-tab-per-refresh load is not affordable.
+///
+/// Invalidation is event-based, not time-based: `AppState` invalidates on
+/// the same HEAD-update signal that clears `GGStackSummaryStore`, which is
+/// what every gg mutation ultimately produces.
+actor GGStackCache {
+    static let shared = GGStackCache()
+
+    private var generation = 0
+    private var cached: [String: (generation: Int, task: Task<GGStack?, any Error>)] = [:]
+
+    init() {}
+
+    func stack(
+        at worktreePath: URL,
+        load: @escaping @Sendable () async throws -> GGStack?
+    ) async throws -> GGStack? {
+        let key = worktreePath.standardizedFileURL.path
+        if let entry = cached[key], entry.generation == generation {
+            return try await entry.task.value
+        }
+        let currentGeneration = generation
+        let task = Task { try await load() }
+        cached[key] = (currentGeneration, task)
+        do {
+            return try await task.value
+        } catch {
+            // A failed load must not stick: the next refresh retries.
+            if cached[key]?.generation == currentGeneration {
+                cached[key] = nil
+            }
+            throw error
+        }
+    }
+
+    func invalidate() {
+        generation &+= 1
+        cached.removeAll()
+    }
+}

--- a/AlasTests/AppStateFollowStackEntryTests.swift
+++ b/AlasTests/AppStateFollowStackEntryTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import Alas
 
+@MainActor
 struct AppStateFollowStackEntryTests {
     @Test func noPrefillRoutesToTheExpressionPrompt() {
         #expect(FollowRevisionPromptRoute.route(prefill: nil, stackEntrySupported: true)
@@ -43,5 +44,38 @@ struct AppStateFollowStackEntryTests {
 
         #expect(presentation.selectedGGID == "c-aaa1111")
         #expect(presentation.id == "wt:tab")
+    }
+
+    /// `ggFollowSupported` must read the cached, observable gg context that
+    /// `rightPaneStore` already maintains rather than recomputing it from
+    /// disk — it's called from SwiftUI view bodies on every re-evaluation.
+    @Test func ggFollowSupportedReadsTheCachedRightPaneContext() {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-follow-supported-\(UUID().uuidString)")
+        let worktree = Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "test-project",
+            name: "feature",
+            branch: "feature",
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = AppState()
+
+        // No right pane state has been activated for this worktree yet:
+        // fall back to false rather than recomputing the gate from disk.
+        #expect(!state.ggFollowSupported(worktreeID: worktree.id))
+
+        let rightPaneState = state.rightPaneStore.state(
+            for: worktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        rightPaneState.ggContext = .active(stackName: "stack")
+        #expect(state.ggFollowSupported(worktreeID: worktree.id))
+
+        rightPaneState.ggContext = .inactive(reason: .policyOff)
+        #expect(!state.ggFollowSupported(worktreeID: worktree.id))
     }
 }

--- a/AlasTests/AppStateFollowStackEntryTests.swift
+++ b/AlasTests/AppStateFollowStackEntryTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct AppStateFollowStackEntryTests {
+    @Test func noPrefillRoutesToTheExpressionPrompt() {
+        #expect(FollowRevisionPromptRoute.route(prefill: nil, stackEntrySupported: true)
+            == .expressionPrompt(prefill: nil, isEditing: false))
+    }
+
+    @Test func expressionPrefillRoutesToTheExpressionPrompt() {
+        #expect(FollowRevisionPromptRoute.route(prefill: .expression("HEAD~2"), stackEntrySupported: true)
+            == .expressionPrompt(prefill: "HEAD~2", isEditing: true))
+    }
+
+    @Test func stackEntryPrefillRoutesToThePicker() {
+        #expect(FollowRevisionPromptRoute.route(prefill: .stackEntry(ggID: "c-abc1234"), stackEntrySupported: true)
+            == .stackEntryPicker(isEditing: true))
+    }
+
+    @Test func stackEntryPrefillFallsBackWhenGGWentInactive() {
+        // gg mode was turned off while a tab was following an entry: editing
+        // must still offer something rather than opening a picker that
+        // cannot load.
+        #expect(FollowRevisionPromptRoute.route(prefill: .stackEntry(ggID: "c-abc1234"), stackEntrySupported: false)
+            == .expressionPrompt(prefill: nil, isEditing: true))
+    }
+
+    @Test func presentationExposesTheSelectedEntry() {
+        var presentation = GGFollowEntryPresentation(
+            worktreeID: "wt",
+            tabID: "tab",
+            isEditing: false,
+            state: .loading
+        )
+        #expect(presentation.selectedGGID == nil)
+
+        presentation.state = .loaded(GGFollowEntryModel.make(
+            entries: [GGStackEntry(position: 1, sha: "aaa1111", title: "base", ggId: "c-aaa1111")],
+            currentGGID: nil,
+            displayedSHA: nil
+        ))
+
+        #expect(presentation.selectedGGID == "c-aaa1111")
+        #expect(presentation.id == "wt:tab")
+    }
+}

--- a/AlasTests/CommitTabStateTests.swift
+++ b/AlasTests/CommitTabStateTests.swift
@@ -98,7 +98,7 @@ struct CommitTabStateTests {
             expression: "@feature", baselineBranch: "feature", resolvedSHA: "old"
         ))
 
-        #expect(headRelative.expression == "HEAD~3")
+        #expect(headRelative.target.identityKey == "HEAD~3")
         #expect(headRelative.dependsOnWorktreeHEAD)
         #expect(headAlias.dependsOnWorktreeHEAD)
         #expect(!namedRef.dependsOnWorktreeHEAD)
@@ -364,7 +364,7 @@ struct CommitTabStateTests {
 
         let revision = try JSONDecoder().decode(TrackedRevision.self, from: Data(json.utf8))
 
-        #expect(revision.expression == "HEAD~2")
+        #expect(revision.target.identityKey == "HEAD~2")
         #expect(revision.pendingCheckout == TrackedRevisionCandidate(branch: "main", sha: "new"))
         #expect(try JSONDecoder().decode(TrackedRevision.self, from: JSONEncoder().encode(revision)) == revision)
         #expect(throws: DecodingError.self) {

--- a/AlasTests/Integrations/GGFollowEntryModelTests.swift
+++ b/AlasTests/Integrations/GGFollowEntryModelTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGFollowEntryModelTests {
+    private let entries = [
+        GGStackEntry(position: 1, sha: "aaa1111", title: "base work", ggId: "c-aaa1111"),
+        GGStackEntry(position: 2, sha: "bbb2222", title: "middle", ggId: "c-bbb2222"),
+        GGStackEntry(position: 3, sha: "ccc3333", title: "tip", ggId: "c-ccc3333"),
+    ]
+
+    @Test func listsTipFirst() {
+        let model = GGFollowEntryModel.make(entries: entries, currentGGID: nil, displayedSHA: nil)
+
+        #expect(model.candidates.map(\.position) == [3, 2, 1])
+        #expect(model.candidates.first?.title == "tip")
+    }
+
+    @Test func preselectsTheCurrentlyFollowedEntry() {
+        let model = GGFollowEntryModel.make(
+            entries: entries,
+            currentGGID: "c-bbb2222",
+            displayedSHA: "ccc3333000000000000000000000000000000000"
+        )
+
+        #expect(model.selectedID == "c-bbb2222")
+        #expect(model.canFollow)
+    }
+
+    @Test func fallsBackToTheDisplayedCommit() {
+        // Alas holds a full SHA, gg reports an abbreviated one.
+        let model = GGFollowEntryModel.make(
+            entries: entries,
+            currentGGID: nil,
+            displayedSHA: "bbb2222000000000000000000000000000000000"
+        )
+
+        #expect(model.selectedID == "c-bbb2222")
+    }
+
+    @Test func fallsBackToTheTipWhenNothingMatches() {
+        let model = GGFollowEntryModel.make(
+            entries: entries,
+            currentGGID: "c-gone",
+            displayedSHA: "unrelated"
+        )
+
+        #expect(model.selectedID == "c-ccc3333")
+    }
+
+    @Test func entriesWithoutAGGIDAreListedButNotSelectable() {
+        let model = GGFollowEntryModel.make(
+            entries: [GGStackEntry(position: 1, sha: "aaa1111", title: "unstacked")],
+            currentGGID: nil,
+            displayedSHA: nil
+        )
+
+        #expect(model.candidates.count == 1)
+        #expect(!(model.candidates[0].isSelectable))
+        #expect(model.selectedID == nil)
+        #expect(!model.canFollow)
+    }
+
+    @Test func carriesForgeStateForTheRows() {
+        let model = GGFollowEntryModel.make(
+            entries: [
+                GGStackEntry(
+                    position: 1,
+                    sha: "aaa1111",
+                    title: "base work",
+                    ggId: "c-aaa1111",
+                    prNumber: 42,
+                    prState: .open,
+                    ciStatus: .success
+                ),
+            ],
+            currentGGID: nil,
+            displayedSHA: nil
+        )
+
+        #expect(model.candidates[0].prNumber == 42)
+        #expect(model.candidates[0].prState == .open)
+        #expect(model.candidates[0].ciStatus == .success)
+    }
+}

--- a/AlasTests/Integrations/GGStackCacheTests.swift
+++ b/AlasTests/Integrations/GGStackCacheTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import Alas
+
+private actor LoadCounter {
+    private(set) var count = 0
+    func increment() { count += 1 }
+}
+
+struct GGStackCacheTests {
+    private func stack(name: String) -> GGStack {
+        GGStack(
+            name: name,
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: [GGStackEntry(position: 1, sha: "abc1234", title: "first", ggId: "c-abc1234")]
+        )
+    }
+
+    @Test func secondCallReusesTheCachedStack() async throws {
+        let cache = GGStackCache()
+        let counter = LoadCounter()
+        let path = URL(fileURLWithPath: "/tmp/wt")
+
+        let first = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+        let second = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+
+        #expect(first?.name == "s")
+        #expect(second?.name == "s")
+        #expect(await counter.count == 1)
+    }
+
+    @Test func differentWorktreesLoadIndependently() async throws {
+        let cache = GGStackCache()
+        let counter = LoadCounter()
+
+        _ = try await cache.stack(at: URL(fileURLWithPath: "/tmp/a")) {
+            await counter.increment(); return self.stack(name: "a")
+        }
+        _ = try await cache.stack(at: URL(fileURLWithPath: "/tmp/b")) {
+            await counter.increment(); return self.stack(name: "b")
+        }
+
+        #expect(await counter.count == 2)
+    }
+
+    @Test func invalidateForcesAReload() async throws {
+        let cache = GGStackCache()
+        let counter = LoadCounter()
+        let path = URL(fileURLWithPath: "/tmp/wt")
+
+        _ = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+        await cache.invalidate()
+        _ = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+
+        #expect(await counter.count == 2)
+    }
+
+    @Test func failuresAreNotCached() async throws {
+        struct Boom: Error {}
+        let cache = GGStackCache()
+        let counter = LoadCounter()
+        let path = URL(fileURLWithPath: "/tmp/wt")
+
+        await #expect(throws: Boom.self) {
+            try await cache.stack(at: path) { await counter.increment(); throw Boom() }
+        }
+        _ = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+
+        #expect(await counter.count == 2)
+    }
+
+    @Test func concurrentCallersShareOneLoad() async throws {
+        let cache = GGStackCache()
+        let counter = LoadCounter()
+        let path = URL(fileURLWithPath: "/tmp/wt")
+
+        async let a = cache.stack(at: path) {
+            await counter.increment()
+            try await Task.sleep(nanoseconds: 20_000_000)
+            return self.stack(name: "s")
+        }
+        async let b = cache.stack(at: path) {
+            await counter.increment()
+            try await Task.sleep(nanoseconds: 20_000_000)
+            return self.stack(name: "s")
+        }
+
+        _ = try await [a, b]
+        #expect(await counter.count == 1)
+    }
+}

--- a/AlasTests/Integrations/GGStackCacheTests.swift
+++ b/AlasTests/Integrations/GGStackCacheTests.swift
@@ -25,8 +25,14 @@ struct GGStackCacheTests {
         let counter = LoadCounter()
         let path = URL(fileURLWithPath: "/tmp/wt")
 
-        let first = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
-        let second = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+        let first = try await cache.stack(at: path) {
+            await counter.increment()
+            return self.stack(name: "s")
+        }
+        let second = try await cache.stack(at: path) {
+            await counter.increment()
+            return self.stack(name: "s")
+        }
 
         #expect(first?.name == "s")
         #expect(second?.name == "s")
@@ -38,10 +44,12 @@ struct GGStackCacheTests {
         let counter = LoadCounter()
 
         _ = try await cache.stack(at: URL(fileURLWithPath: "/tmp/a")) {
-            await counter.increment(); return self.stack(name: "a")
+            await counter.increment()
+            return self.stack(name: "a")
         }
         _ = try await cache.stack(at: URL(fileURLWithPath: "/tmp/b")) {
-            await counter.increment(); return self.stack(name: "b")
+            await counter.increment()
+            return self.stack(name: "b")
         }
 
         #expect(await counter.count == 2)
@@ -52,9 +60,15 @@ struct GGStackCacheTests {
         let counter = LoadCounter()
         let path = URL(fileURLWithPath: "/tmp/wt")
 
-        _ = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+        _ = try await cache.stack(at: path) {
+            await counter.increment()
+            return self.stack(name: "s")
+        }
         await cache.invalidate()
-        _ = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+        _ = try await cache.stack(at: path) {
+            await counter.increment()
+            return self.stack(name: "s")
+        }
 
         #expect(await counter.count == 2)
     }
@@ -66,9 +80,15 @@ struct GGStackCacheTests {
         let path = URL(fileURLWithPath: "/tmp/wt")
 
         await #expect(throws: Boom.self) {
-            try await cache.stack(at: path) { await counter.increment(); throw Boom() }
+            try await cache.stack(at: path) {
+                await counter.increment()
+                throw Boom()
+            }
         }
-        _ = try await cache.stack(at: path) { await counter.increment(); return self.stack(name: "s") }
+        _ = try await cache.stack(at: path) {
+            await counter.increment()
+            return self.stack(name: "s")
+        }
 
         #expect(await counter.count == 2)
     }

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -168,6 +168,33 @@ struct ProjectsManagerHeadUpdatesTests {
         #expect(state.projectsManager.worktrees(projectId: project.id).first { $0.id == linked.id }?.branch == "feature")
     }
 
+    /// A follower's `.task(id:)` can restart on the synchronous generation
+    /// bump before the async `GGStackCache` invalidation lands, and read a
+    /// stale stack. The generation must bump again once invalidation
+    /// actually completes so that follower gets a guaranteed-fresh reload.
+    @Test func headUpdatesRebumpGenerationAfterCacheInvalidationCompletes() async throws {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let main = wt(path: "/repo", branch: "main")
+        seed(state.projectsManager, projectId: project.id, [main])
+
+        state.handleProjectHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [main.path: "main-updated"]
+        )
+        #expect(state.revisionChangeGeneration(worktreeID: main.id) == 1)
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(state.revisionChangeGeneration(worktreeID: main.id) == 2)
+    }
+
     @Test func revisionWatcherInvalidatesGGStackCache() async throws {
         let project = ProjectConfig(
             id: "p1",

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -167,4 +167,69 @@ struct ProjectsManagerHeadUpdatesTests {
         #expect(state.projectsManager.worktrees(projectId: project.id).first { $0.id == main.id }?.branch == "main-updated")
         #expect(state.projectsManager.worktrees(projectId: project.id).first { $0.id == linked.id }?.branch == "feature")
     }
+
+    @Test func revisionWatcherInvalidatesGGStackCache() async throws {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date()
+        )
+        let main = wt(path: "/repo", branch: "main")
+        let gitDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-app-state-watcher-\(UUID().uuidString)/.git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent()) }
+
+        let watcher = ProjectGitWatcher(
+            repoPath: URL(fileURLWithPath: project.path),
+            resolvedGitDir: gitDir,
+            resolvedWorktreeRoot: main.path,
+            headDebounceInterval: 0.05,
+            headDebounceMaxWait: 0.2,
+            topologyDebounceInterval: 0.05,
+            topologyDebounceMaxWait: 0.2,
+            startStreamOverride: { _, _ in }
+        )
+        let state = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [project])),
+            projectGitWatcherFactory: { _ in watcher }
+        )
+        seed(state.projectsManager, projectId: project.id, [main])
+
+        actor LoadCounter {
+            var count = 0
+            func increment() { count += 1 }
+        }
+        let loads = LoadCounter()
+        let cachePath = gitDir.appendingPathComponent("worktree")
+        let stack = GGStack(
+            name: "stack",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: []
+        )
+
+        await GGStackCache.shared.invalidate()
+        defer { Task { await GGStackCache.shared.invalidate() } }
+        _ = try await GGStackCache.shared.stack(at: cachePath) {
+            await loads.increment()
+            return stack
+        }
+
+        state.startProjectGitWatcher(for: project)
+        watcher.processEvents([gitDir.appendingPathComponent("refs/heads/main").path])
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        _ = try await GGStackCache.shared.stack(at: cachePath) {
+            await loads.increment()
+            return stack
+        }
+        #expect(await loads.count == 2)
+        state.stopProjectGitWatcher(projectId: project.id)
+    }
 }

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -166,7 +166,7 @@ return value + other
         let newID = ReviewDraftSessionID.trackedCommit(
             worktreeID: "wt",
             repositoryPath: URL(fileURLWithPath: "/repo"),
-            expression: "HEAD~3"
+            targetKey: "HEAD~3"
         )
         let existing = makeComment(
             id: "draft-1",
@@ -206,7 +206,7 @@ return value + other
         let newID = ReviewDraftSessionID.trackedCommit(
             worktreeID: "wt",
             repositoryPath: URL(fileURLWithPath: "/repo"),
-            expression: "HEAD~3"
+            targetKey: "HEAD~3"
         )
         let source = makeComment(
             id: "draft-1",

--- a/AlasTests/ReviewSessionModelsTests.swift
+++ b/AlasTests/ReviewSessionModelsTests.swift
@@ -126,7 +126,7 @@ struct ReviewSessionModelsTests {
         #expect(first.draftSessionID == .trackedCommit(
             worktreeID: "wt-1",
             repositoryPath: repositoryPath,
-            expression: "HEAD~3"
+            targetKey: "HEAD~3"
         ))
         #expect(second.revisionDescription == "HEAD~3 -> bbb")
         #expect(second.sourceDescription == "Commit HEAD~3 -> bbb")

--- a/AlasTests/RevisionFollowCapabilityTests.swift
+++ b/AlasTests/RevisionFollowCapabilityTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RevisionFollowCapabilityTests {
+    @Test func defaultsKeepStackEntryOff() {
+        let capability = RevisionFollowCapability(isSupported: true, isFollowing: false)
+        #expect(!capability.supportsStackEntry)
+    }
+
+    @Test func stackEntrySupportRequiresRevisionSupport() {
+        // A tab kind that cannot follow at all never offers stack entries,
+        // however gg is configured.
+        let capability = RevisionFollowCapability(
+            isSupported: false,
+            isFollowing: false,
+            supportsStackEntry: true
+        )
+        #expect(!capability.supportsStackEntry)
+    }
+
+    @Test func supportedTabInAGGWorktreeOffersStackEntries() {
+        let capability = RevisionFollowCapability(
+            isSupported: true,
+            isFollowing: true,
+            supportsStackEntry: true
+        )
+        #expect(capability.supportsStackEntry)
+    }
+}

--- a/AlasTests/TrackedRevisionCodingTests.swift
+++ b/AlasTests/TrackedRevisionCodingTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct TrackedRevisionCodingTests {
+    private func revision(target: TrackedRevisionTarget) throws -> TrackedRevision {
+        try #require(TrackedRevision(
+            target: target,
+            baselineBranch: "nacho/my-feature",
+            baselineHEAD: "head000",
+            resolvedSHA: "sha111"
+        ))
+    }
+
+    @Test func legacyRecordWithoutTargetDecodesAsExpression() throws {
+        let json = #"""
+        {"expression":"HEAD~2","baselineBranch":"feature","baselineHEAD":"h1","resolvedSHA":"s1"}
+        """#
+
+        let decoded = try JSONDecoder().decode(TrackedRevision.self, from: Data(json.utf8))
+
+        #expect(decoded.target == .expression("HEAD~2"))
+        #expect(decoded.resolvedSHA == "s1")
+        #expect(decoded.unresolvedReason == nil)
+    }
+
+    @Test func expressionRoundTripsAndKeepsLegacyMirror() throws {
+        let original = try revision(target: .expression("HEAD~2"))
+
+        let data = try JSONEncoder().encode(original)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["expression"] as? String == "HEAD~2")
+        #expect(try JSONDecoder().decode(TrackedRevision.self, from: data) == original)
+    }
+
+    @Test func stackEntryMirrorsResolvedSHAForDowngradedBuilds() throws {
+        let original = try revision(target: .stackEntry(ggID: "c-abc1234"))
+
+        let data = try JSONEncoder().encode(original)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        // A build that predates targets reads `expression` and degrades to a
+        // pinned commit rather than failing to decode.
+        #expect(json["expression"] as? String == "sha111")
+        #expect(try JSONDecoder().decode(TrackedRevision.self, from: data) == original)
+    }
+
+    @Test func stackEntryNeverDependsOnWorktreeHEAD() throws {
+        let expression = try revision(target: .expression("HEAD~2"))
+        // A GG-ID that happens to spell "HEAD" is still not HEAD-relative,
+        // so the checkout-pause path must never fire for it.
+        let entry = try revision(target: .stackEntry(ggID: "HEAD"))
+
+        #expect(expression.dependsOnWorktreeHEAD)
+        #expect(!entry.dependsOnWorktreeHEAD)
+    }
+
+    @Test func stallSetsMessageAndResolvingClearsIt() throws {
+        let stalled = try revision(target: .stackEntry(ggID: "c-abc1234"))
+            .stalled(reason: .stackEntryMissing)
+
+        #expect(stalled.unresolvedReason == .stackEntryMissing)
+        #expect(stalled.unresolvedMessage == "Stack entry c-abc1234 is not in the current stack.")
+
+        let resolved = stalled.resolving(
+            TrackedRevisionCandidate(branch: "nacho/my-feature", sha: "sha222", headSHA: "head222")
+        )
+
+        #expect(resolved.unresolvedReason == nil)
+        #expect(resolved.unresolvedMessage == nil)
+        #expect(resolved.resolvedSHA == "sha222")
+    }
+
+    @Test func stallSurvivesCodableRoundTrip() throws {
+        let stalled = try revision(target: .stackEntry(ggID: "c-abc1234"))
+            .stalled(reason: .stackEntryMissing)
+
+        let decoded = try JSONDecoder().decode(
+            TrackedRevision.self,
+            from: JSONEncoder().encode(stalled)
+        )
+
+        #expect(decoded == stalled)
+    }
+
+    @Test func emptyTargetIsRejected() {
+        #expect(TrackedRevision(
+            target: .stackEntry(ggID: "  "),
+            baselineBranch: "b",
+            resolvedSHA: "s"
+        ) == nil)
+    }
+}

--- a/AlasTests/TrackedRevisionResolverTests.swift
+++ b/AlasTests/TrackedRevisionResolverTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct TrackedRevisionResolverTests {
+    private let worktree = URL(fileURLWithPath: "/tmp/wt")
+
+    private func stack(entries: [GGStackEntry]) -> GGStack {
+        GGStack(
+            name: "my-feature",
+            base: "main",
+            totalCommits: entries.count,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: entries
+        )
+    }
+
+    private func resolver(
+        stack: GGStack?,
+        shas: [String: String] = [:],
+        branch: String = "nacho/my-feature"
+    ) -> TrackedRevisionResolver {
+        TrackedRevisionResolver(
+            resolve: { _, ref in
+                if ref == "HEAD" { return "head000" }
+                if let full = shas[ref] { return full }
+                return ref
+            },
+            branch: { _ in branch },
+            stack: { _ in stack }
+        )
+    }
+
+    @Test func expandsTheAbbreviatedShaGGReports() async throws {
+        let resolver = resolver(
+            stack: stack(entries: [
+                GGStackEntry(position: 1, sha: "abc1234", title: "first", ggId: "c-abc1234"),
+                GGStackEntry(position: 2, sha: "def5678", title: "second", ggId: "c-def5678"),
+            ]),
+            shas: ["def5678": "def5678000000000000000000000000000000000"]
+        )
+
+        let candidate = try await resolver.resolve(
+            at: worktree,
+            target: .stackEntry(ggID: "c-def5678")
+        )
+
+        #expect(candidate.sha == "def5678000000000000000000000000000000000")
+        #expect(candidate.branch == "nacho/my-feature")
+        #expect(candidate.headSHA == "head000")
+    }
+
+    @Test func missingEntryThrowsStackEntryNotFound() async {
+        let resolver = resolver(
+            stack: stack(entries: [
+                GGStackEntry(position: 1, sha: "abc1234", title: "first", ggId: "c-abc1234"),
+            ])
+        )
+
+        await #expect(throws: TrackedRevisionResolverError.stackEntryNotFound("c-gone")) {
+            try await resolver.resolve(at: worktree, target: .stackEntry(ggID: "c-gone"))
+        }
+    }
+
+    @Test func offStackBranchThrowsStackEntryNotFound() async {
+        let resolver = resolver(stack: nil)
+
+        await #expect(throws: TrackedRevisionResolverError.stackEntryNotFound("c-abc1234")) {
+            try await resolver.resolve(at: worktree, target: .stackEntry(ggID: "c-abc1234"))
+        }
+    }
+
+    @Test func entriesWithoutAGGIDAreNeverMatched() async {
+        let resolver = resolver(
+            stack: stack(entries: [GGStackEntry(position: 1, sha: "abc1234", title: "unstacked")])
+        )
+
+        await #expect(throws: TrackedRevisionResolverError.stackEntryNotFound("abc1234")) {
+            try await resolver.resolve(at: worktree, target: .stackEntry(ggID: "abc1234"))
+        }
+    }
+
+    @Test func expressionTargetsStillResolveThroughGit() async throws {
+        let resolver = resolver(stack: nil, shas: ["head000~2": "older00"])
+
+        let candidate = try await resolver.resolve(at: worktree, target: .expression("HEAD~2"))
+
+        #expect(candidate.sha == "older00")
+        #expect(candidate.headSHA == "head000")
+    }
+}

--- a/AlasTests/TrackedRevisionStallTests.swift
+++ b/AlasTests/TrackedRevisionStallTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct TrackedRevisionStallTests {
+    private func followed(_ target: TrackedRevisionTarget) throws -> TrackedRevision {
+        try #require(TrackedRevision(
+            target: target,
+            baselineBranch: "nacho/my-feature",
+            baselineHEAD: "head000",
+            resolvedSHA: "sha111"
+        ))
+    }
+
+    @Test func missingStackEntryBecomesAStall() throws {
+        let current = try followed(.stackEntry(ggID: "c-abc1234"))
+
+        let transition = TrackedRevisionPolicy.evaluate(
+            current: current,
+            error: TrackedRevisionResolverError.stackEntryNotFound("c-abc1234")
+        )
+
+        guard case .stall(let stalled) = transition else {
+            Issue.record("expected .stall, got \(String(describing: transition))")
+            return
+        }
+        #expect(stalled.unresolvedReason == .stackEntryMissing)
+        // The tab keeps rendering the commit it already had.
+        #expect(stalled.resolvedSHA == "sha111")
+    }
+
+    @Test func otherErrorsAreNotStalls() throws {
+        let current = try followed(.expression("HEAD~2"))
+
+        #expect(TrackedRevisionPolicy.evaluate(
+            current: current,
+            error: TrackedRevisionResolverError.unsupportedReflogExpression("push")
+        ) == nil)
+
+        struct Boom: Error {}
+        #expect(TrackedRevisionPolicy.evaluate(current: current, error: Boom()) == nil)
+    }
+
+    @Test func aSuccessfulResolveAfterAStallClearsIt() throws {
+        let stalled = try followed(.stackEntry(ggID: "c-abc1234"))
+            .stalled(reason: .stackEntryMissing)
+
+        let transition = TrackedRevisionPolicy.evaluate(
+            current: stalled,
+            candidate: TrackedRevisionCandidate(
+                branch: "nacho/my-feature",
+                sha: "sha222",
+                headSHA: "head222"
+            )
+        )
+
+        guard case .follow(let revision) = transition else {
+            Issue.record("expected .follow, got \(transition)")
+            return
+        }
+        #expect(revision.unresolvedReason == nil)
+        #expect(revision.resolvedSHA == "sha222")
+    }
+}

--- a/AlasTests/TrackedRevisionTargetTests.swift
+++ b/AlasTests/TrackedRevisionTargetTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct TrackedRevisionTargetTests {
+    @Test func expressionIdentityKeyIsTheExpressionItself() {
+        #expect(TrackedRevisionTarget.expression("HEAD~3").identityKey == "HEAD~3")
+        #expect(TrackedRevisionTarget.expression("HEAD~3").displayLabel == "HEAD~3")
+    }
+
+    @Test func stackEntryIdentityKeyIsNamespaced() {
+        let target = TrackedRevisionTarget.stackEntry(ggID: "c-abc1234")
+        #expect(target.identityKey == "gg:c-abc1234")
+        #expect(target.displayLabel == "c-abc1234")
+    }
+
+    @Test func accessorsDiscriminateCases() {
+        let expression = TrackedRevisionTarget.expression("main")
+        let entry = TrackedRevisionTarget.stackEntry(ggID: "c-abc1234")
+
+        #expect(expression.expressionValue == "main")
+        #expect(expression.ggID == nil)
+        #expect(!expression.isStackEntry)
+        #expect(entry.expressionValue == nil)
+        #expect(entry.ggID == "c-abc1234")
+        #expect(entry.isStackEntry)
+    }
+
+    @Test func normalizationTrimsAndRejectsEmpty() {
+        #expect(TrackedRevisionTarget.expression("  HEAD~1 ").normalized() == .expression("HEAD~1"))
+        #expect(TrackedRevisionTarget.stackEntry(ggID: " c-abc1234 ").normalized() == .stackEntry(ggID: "c-abc1234"))
+        #expect(TrackedRevisionTarget.expression("   ").normalized() == nil)
+        #expect(TrackedRevisionTarget.stackEntry(ggID: "").normalized() == nil)
+    }
+
+    @Test func codableRoundTripsBothCases() throws {
+        for target in [
+            TrackedRevisionTarget.expression("HEAD~3"),
+            TrackedRevisionTarget.stackEntry(ggID: "c-abc1234"),
+        ] {
+            let data = try JSONEncoder().encode(target)
+            #expect(try JSONDecoder().decode(TrackedRevisionTarget.self, from: data) == target)
+        }
+    }
+
+    @Test func encodedStackEntryUsesStableWireKind() throws {
+        let data = try JSONEncoder().encode(TrackedRevisionTarget.stackEntry(ggID: "c-abc1234"))
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: String]
+        )
+        #expect(json["kind"] == "stack-entry")
+        #expect(json["value"] == "c-abc1234")
+    }
+}


### PR DESCRIPTION
## Summary

- Lets a commit tab or review-session tab follow a gg stack entry by its stable GG-ID instead of a positional git expression (`HEAD~3`), so the tab keeps tracking the same logical commit across reorders, rebases, and amends — cases where `HEAD~n` silently breaks.
- When a followed stack entry temporarily leaves the current stack (wrong branch checked out, entry dropped), the tab stalls on its last known commit with a recoverable warning and Retry, instead of erroring or unfollowing.
- Adds a picker sheet (reachable from the tab context menu, the commit header, and the review-session tab menu) for choosing which stack entry to follow, gated on gg being active for the worktree.

## What changed

- `TrackedRevisionTarget`: new typed target (`.expression(String)` / `.stackEntry(ggID:)`) replacing the raw expression string `TrackedRevision` used to hold. `identityKey` stays byte-identical to today's `.expression` string so existing review-session IDs, draft IDs, and commit-tab IDs are unaffected.
- `GGStackCache`: caches `gg ls` output per worktree per HEAD-change generation, invalidated on any ref rewrite (including reorders/rebases that don't go through the normal HEAD-update path).
- `TrackedRevisionResolver` resolves `.stackEntry(ggID:)` against the cache, expanding gg's abbreviated SHA to Alas's full 40-char SHA, and throws a typed `stackEntryNotFound` error when the entry is absent from the stack.
- Commit and review-session tabs both stall (keep last resolved SHA, surface a warning banner with Retry) on that specific error, and clear the stall automatically once the entry reappears.
- `GGFollowEntryModel` / `GGFollowEntrySheet`: the picker's pure model (tip-first ordering, preselection of the currently-followed entry or displayed commit) and its SwiftUI sheet, modeled on the existing `GGReorderSheet`.
- All three follow surfaces (tab context menu, commit header, review-session tab) offer "Follow Stack Entry…" alongside "Follow Revision…" when gg is active for the worktree; hidden (not disabled) when it isn't.

## Reviewer notes

- This branch was rebased onto `main` after `#983`/`#990` landed, which replaced the old NSAlert-based follow-revision UI with the shared anchored-editor `RevisionFollowControl`. The stack-entry picker menu and the stall presentation (`RevisionFollowPresentation.stalled`) were re-integrated into that shared control during the rebase rather than the original per-file UI each task originally touched — `RevisionFollowControl`/`CommitHeaderView`/`ReviewSessionTabView` are worth a second look given that.
- `identityKey` byte-compatibility for `.expression` is the one change that could silently orphan existing users' review sessions and drafts if wrong — covered by `TrackedRevisionCodingTests` and unmodified assertions in `CommitTabStateTests`/`ReviewSessionStoreTests`.
- The picker only lists the current stack — following an entry in a stack you don't have checked out isn't supported (deliberate, documented scope boundary).