### PR TITLE
feat(gg): Improve GG split pane UX

### DIFF
--- a/Alas/Sources/Integrations/GG/GGSplitCommitModel.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitModel.swift
@@ -37,6 +37,11 @@ enum GGSplitCommitFileGroupKind: Equatable {
     }
 }
 
+enum GGSplitCommitDestination: Equatable {
+    case newCommit
+    case originalCommit
+}
+
 struct GGSplitCommitFileGroup: Equatable, Identifiable {
     // A path can appear as both a selectable group and a remainder-only group
     // (e.g. text edits plus a metadata/chmod change on the same file), so the
@@ -81,10 +86,10 @@ extension GGSplitCommitValidationError: LocalizedError {
         switch self {
         case .unavailable: "Update GG to use native Split Commit"
         case .notLoaded: "Load the split plan before applying it."
-        case .emptySelection: "Select at least one hunk for the first commit."
-        case .allHunksSelected: "Leave at least one hunk for the remainder commit."
-        case .emptyFirstMessage: "Enter a message for the first commit."
-        case .emptyRemainderMessage: "Enter a message for the remainder commit."
+        case .emptySelection: "Select at least one hunk for the new commit."
+        case .allHunksSelected: "Leave at least one hunk for the original commit."
+        case .emptyFirstMessage: "Enter a message for the new commit."
+        case .emptyRemainderMessage: "Enter a message for the original commit."
         }
     }
 }
@@ -230,11 +235,26 @@ final class GGSplitCommitModel {
     }
 
     func toggleHunk(_ id: String) {
-        guard description?.hunks.contains(where: { $0.id == id }) == true else { return }
-        if selectedHunkIDs.contains(id) {
-            selectedHunkIDs.remove(id)
-        } else {
-            selectedHunkIDs.insert(id)
+        guard let destination = destination(for: id) else { return }
+        assignHunk(id, to: destination == .newCommit ? .originalCommit : .newCommit)
+    }
+
+    func destination(for id: String) -> GGSplitCommitDestination? {
+        guard description?.hunks.contains(where: { $0.id == id }) == true else { return nil }
+        return selectedHunkIDs.contains(id) ? .newCommit : .originalCommit
+    }
+
+    func assignHunk(_ id: String, to destination: GGSplitCommitDestination) {
+        guard self.destination(for: id) != nil else { return }
+        switch destination {
+        case .newCommit: selectedHunkIDs.insert(id)
+        case .originalCommit: selectedHunkIDs.remove(id)
+        }
+    }
+
+    func assignHunks(in group: GGSplitCommitFileGroup, to destination: GGSplitCommitDestination) {
+        for hunk in group.hunks {
+            assignHunk(hunk.id, to: destination)
         }
     }
 

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -408,7 +408,7 @@ struct GGSplitCommitTabView: View {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(preview.files) { file in
                         splitPreviewFile(file)
-                            .id(file.path)
+                            .id(GGSplitPreviewRowID.legacyFile(path: file.path))
                     }
                     if showsResultingImages, let targetSHA = model.targetSHA {
                         ForEach(partition.imagePaths, id: \.self) { path in
@@ -421,7 +421,7 @@ struct GGSplitCommitTabView: View {
                                 codeFontFamily: codeFontFamily,
                                 codeFontSize: codeFontSize
                             )
-                            .id(path)
+                            .id(GGSplitPreviewRowID.legacyImage(path: path))
                         }
                     }
                     ForEach(partition.otherPaths, id: \.self) { path in
@@ -430,7 +430,7 @@ struct GGSplitCommitTabView: View {
                             .foregroundStyle(theme.color("fg-dim"))
                             .padding(12)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .id(path)
+                            .id(GGSplitPreviewRowID.legacyOther(path: path))
                     }
                 }
             }
@@ -530,7 +530,7 @@ struct GGSplitCommitTabView: View {
             previewID: destination.previewID,
             path: path
         )
-        legacyScrollPath = path
+        legacyScrollPath = GGSplitPreviewRowID.legacyFile(path: path)
         legacyScrollGeneration += 1
     }
 

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -22,6 +22,12 @@ struct GGSplitCommitTabView: View {
     @State private var appKitPreviewScrollerEnabled = AppKitDiffScrollerFlag.isEnabled
     @State private var previewImageStore = GGSplitPreviewImageStore()
     @State private var previewPresentationStore = GGSplitPreviewPresentationStore()
+    @State private var activeDestination = GGSplitCommitDestination.newCommit
+    @State private var collapsedFileGroupIDs: Set<String> = []
+    @State private var previewScrollCoordinator = GGSplitPreviewScrollRequestCoordinator()
+    @State private var previewScrollRequest: AppKitDiffScrollRequest?
+    @State private var legacyScrollPath: String?
+    @State private var legacyScrollGeneration = 0
 
     init(
         tabState: GGSplitCommitTabState,
@@ -92,10 +98,9 @@ struct GGSplitCommitTabView: View {
             } else if model.description == nil {
                 loadFailure
             } else {
-                HStack(spacing: 0) {
+                HSplitView {
                     selectionPane
-                        .frame(minWidth: 240, idealWidth: 300, maxWidth: 380)
-                    Divider()
+                        .frame(minWidth: 260, idealWidth: 320, maxWidth: 460)
                     editorAndPreviews
                         .frame(minWidth: 440, maxWidth: .infinity, maxHeight: .infinity)
                 }
@@ -131,8 +136,14 @@ struct GGSplitCommitTabView: View {
 
     private var selectionPane: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Hunks")
-                .font(.headline)
+            HStack {
+                Text("Changes")
+                    .font(.headline)
+                Spacer()
+                Text("\(model.selectedHunkIDs.count) new · \(originalHunkCount) original")
+                    .font(.caption)
+                    .foregroundStyle(theme.color("fg-dim"))
+            }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
             Divider()
@@ -148,105 +159,179 @@ struct GGSplitCommitTabView: View {
     }
 
     private func splitFileGroup(_ group: GGSplitCommitFileGroup) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 6) {
-                Image(systemName: group.kind == .selectable ? "doc.text" : "doc")
-                    .foregroundStyle(theme.color("fg-dim"))
-                Text(group.path)
-                    .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
-                    .lineLimit(2)
-                    .textSelection(.enabled)
-                Spacer(minLength: 4)
-                if group.kind == .remainderOnly {
-                    Text("Remainder only")
+                if group.kind == .selectable {
+                    Button {
+                        if collapsedFileGroupIDs.contains(group.id) {
+                            collapsedFileGroupIDs.remove(group.id)
+                        } else {
+                            collapsedFileGroupIDs.insert(group.id)
+                        }
+                    } label: {
+                        Label {
+                            Text(group.path)
+                                .lineLimit(2)
+                                .truncationMode(.middle)
+                        } icon: {
+                            Image(systemName: collapsedFileGroupIDs.contains(group.id) ? "chevron.right" : "chevron.down")
+                        }
+                        .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                    }
+                    .buttonStyle(.plain)
+                    .help(collapsedFileGroupIDs.contains(group.id) ? "Expand file" : "Collapse file")
+                    Spacer(minLength: 4)
+                    Menu("Assign all") {
+                        Button("New Commit") { assign(group, to: .newCommit) }
+                        Button("Original Commit") { assign(group, to: .originalCommit) }
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                    .accessibilityIdentifier("gg-split-file-assign-\(group.id)")
+                } else {
+                    Label(group.path, systemImage: "doc")
+                        .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 4)
+                    Text("Original only")
                         .font(.caption)
                         .foregroundStyle(theme.color("fg-dim"))
                 }
             }
+            .padding(12)
 
-            ForEach(group.hunks, id: \.id) { hunk in
-                Toggle(
-                    isOn: Binding(
-                        get: { model.selectedHunkIDs.contains(hunk.id) },
-                        set: { _ in
-                            model.toggleHunk(hunk.id)
-                            errorMessage = nil
-                            onDraftChange(model.draft)
-                        }
-                    )
-                ) {
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text(hunk.header)
-                            .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
-                            .foregroundStyle(theme.color("fg"))
-                        Text(hunk.patch)
-                            .font(CenterTypography.codeFont(family: codeFontFamily, size: max(9, codeFontSize - 2)))
-                            .foregroundStyle(theme.color("fg-dim"))
-                            .lineLimit(4)
-                            .textSelection(.enabled)
-                    }
+            if group.kind == .selectable, !collapsedFileGroupIDs.contains(group.id) {
+                ForEach(group.hunks, id: \.id) { hunk in
+                    splitHunkRow(hunk)
                 }
-                .toggleStyle(.checkbox)
             }
         }
-        .padding(12)
+        .overlay(Divider(), alignment: .bottom)
+    }
+
+    private func splitHunkRow(_ hunk: GGSplitHunk) -> some View {
+        let destination = model.destination(for: hunk.id) ?? .originalCommit
+        return HStack(alignment: .top, spacing: 8) {
+            Button {
+                focusPreview(destination: destination, path: hunk.path)
+            } label: {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(hunk.header)
+                        .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                        .foregroundStyle(theme.color("fg"))
+                        .lineLimit(1)
+                    Text(hunk.patch)
+                        .font(CenterTypography.codeFont(family: codeFontFamily, size: max(9, codeFontSize - 2)))
+                        .foregroundStyle(theme.color("fg-dim"))
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Show \(destination.title) preview for \(hunk.header)")
+
+            Button(destination.shortTitle) {
+                assign(hunk, to: destination.other)
+            }
+            .buttonStyle(.plain)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(destination == .newCommit ? theme.color("add") : theme.color("fg"))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(destination == .newCommit ? theme.color("add").opacity(0.14) : theme.color("bg-3"))
+            .clipShape(.capsule)
+            .help("Move to \(destination.other.title)")
+            .accessibilityLabel("Assigned to \(destination.title)")
+            .accessibilityHint("Moves this hunk to \(destination.other.title)")
+            .accessibilityIdentifier("gg-split-hunk-destination-\(hunk.id)")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-1").opacity(0.35))
         .overlay(Divider(), alignment: .bottom)
     }
 
     private var editorAndPreviews: some View {
         VStack(spacing: 0) {
-            messageEditor
+            commitCards
             Divider()
-            VSplitView {
-                previewPane(title: "First commit", preview: model.firstPreview)
-                    .frame(minHeight: 180)
-                previewPane(
-                    title: "Remainder",
-                    preview: model.remainderPreview,
-                    showsResultingImages: true
-                )
-                    .frame(minHeight: 180)
-            }
+            previewPane(
+                destination: activeDestination,
+                preview: activePreview,
+                showsResultingImages: activeDestination == .originalCommit
+            )
             Divider()
             actionBar
         }
     }
 
-    private var messageEditor: some View {
-        Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
-            GridRow {
-                Text("First commit")
-                    .foregroundStyle(theme.color("fg-dim"))
-                TextField("Commit message", text: $model.firstMessage)
-                    .textFieldStyle(.roundedBorder)
-                    .onChange(of: model.firstMessage) {
-                        errorMessage = nil
-                        onDraftChange(model.draft)
-                    }
-            }
-            GridRow {
-                Text("Remainder")
-                    .foregroundStyle(theme.color("fg-dim"))
-                TextField("Commit message", text: $model.remainderMessage)
-                    .textFieldStyle(.roundedBorder)
-                    .onChange(of: model.remainderMessage) {
-                        errorMessage = nil
-                        onDraftChange(model.draft)
-                    }
-            }
+    private var commitCards: some View {
+        HStack(spacing: 10) {
+            commitCard(
+                destination: .newCommit,
+                message: $model.firstMessage,
+                preview: model.firstPreview
+            )
+            commitCard(
+                destination: .originalCommit,
+                message: $model.remainderMessage,
+                preview: model.remainderPreview
+            )
         }
         .padding(12)
         .background(theme.color("bg-2"))
     }
 
+    private func commitCard(
+        destination: GGSplitCommitDestination,
+        message: Binding<String>,
+        preview: GGSplitPreview
+    ) -> some View {
+        let isActive = activeDestination == destination
+        return VStack(alignment: .leading, spacing: 8) {
+            Button {
+                activeDestination = destination
+                previewScrollRequest = nil
+            } label: {
+                HStack {
+                    Text(destination.title)
+                        .font(.headline)
+                    Spacer()
+                    Text(contentSummary(for: preview))
+                        .font(.caption)
+                        .foregroundStyle(theme.color("fg-dim"))
+                }
+                .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Show \(destination.title) preview")
+            .accessibilityValue(isActive ? "Selected" : "Not selected")
+            .accessibilityIdentifier("gg-split-commit-card-\(destination.previewID)")
+
+            TextField("Commit message", text: message)
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: message.wrappedValue) { draftDidChange() }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity)
+        .background(isActive ? theme.color("accent").opacity(0.09) : theme.color("bg-1"))
+        .clipShape(.rect(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isActive ? theme.color("accent") : theme.color("border"), lineWidth: isActive ? 2 : 1)
+        }
+    }
+
     private func previewPane(
-        title: String,
+        destination: GGSplitCommitDestination,
         preview: GGSplitPreview,
         showsResultingImages: Bool = false
     ) -> some View {
         return VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Text(title)
+                Text(destination.title)
                     .font(.headline)
                 Spacer()
                 Text("\(preview.files.flatMap(\.hunkIDs).count) hunk\(preview.files.flatMap(\.hunkIDs).count == 1 ? "" : "s")")
@@ -263,7 +348,7 @@ struct GGSplitCommitTabView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 previewScrollSubtree(
-                    previewID: title,
+                    previewID: destination.previewID,
                     preview: preview,
                     showsResultingImages: showsResultingImages
                 )
@@ -300,9 +385,13 @@ struct GGSplitCommitTabView: View {
                     imageStore: previewImageStore,
                     presentationStore: previewPresentationStore
                 )),
-                scrollRequest: nil,
+                scrollRequest: previewScrollRequest,
                 onActiveOwnerChange: { _ in },
-                onScrollRequestCompletion: { _ in }
+                onScrollRequestCompletion: { generation in
+                    if previewScrollRequest?.generation == generation {
+                        previewScrollRequest = nil
+                    }
+                }
             )
         } else {
             legacyPreviewScroll(preview: preview, showsResultingImages: showsResultingImages)
@@ -314,29 +403,40 @@ struct GGSplitCommitTabView: View {
         showsResultingImages: Bool
     ) -> some View {
         let partition = GGResultingImagePreview.partition(preview.nonTextualFiles)
-        return ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(preview.files) { file in splitPreviewFile(file) }
-                if showsResultingImages, let targetSHA = model.targetSHA {
-                    ForEach(partition.imagePaths, id: \.self) { path in
-                        let key = GGSplitPreviewImageKey(
-                            worktreePath: worktreePath, revision: targetSHA, relativePath: path
-                        )
-                        GGSplitResultingImagePreview(
-                            key: key,
-                            state: previewImageStore.state(for: key),
-                            codeFontFamily: codeFontFamily,
-                            codeFontSize: codeFontSize
-                        )
+        return ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(preview.files) { file in
+                        splitPreviewFile(file)
+                            .id(file.path)
+                    }
+                    if showsResultingImages, let targetSHA = model.targetSHA {
+                        ForEach(partition.imagePaths, id: \.self) { path in
+                            let key = GGSplitPreviewImageKey(
+                                worktreePath: worktreePath, revision: targetSHA, relativePath: path
+                            )
+                            GGSplitResultingImagePreview(
+                                key: key,
+                                state: previewImageStore.state(for: key),
+                                codeFontFamily: codeFontFamily,
+                                codeFontSize: codeFontSize
+                            )
+                            .id(path)
+                        }
+                    }
+                    ForEach(partition.otherPaths, id: \.self) { path in
+                        Label(path, systemImage: "doc")
+                            .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
+                            .foregroundStyle(theme.color("fg-dim"))
+                            .padding(12)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .id(path)
                     }
                 }
-                ForEach(partition.otherPaths, id: \.self) { path in
-                    Label(path, systemImage: "doc")
-                        .font(CenterTypography.codeFont(family: codeFontFamily, size: max(10, codeFontSize - 1)))
-                        .foregroundStyle(theme.color("fg-dim"))
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+            }
+            .onChange(of: legacyScrollGeneration) {
+                guard let legacyScrollPath else { return }
+                withAnimation { proxy.scrollTo(legacyScrollPath, anchor: .top) }
             }
         }
     }
@@ -390,6 +490,48 @@ struct GGSplitCommitTabView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .background(theme.color("bg-2"))
+    }
+
+    private var originalHunkCount: Int {
+        max(0, (model.description?.hunks.count ?? 0) - model.selectedHunkIDs.count)
+    }
+
+    private var activePreview: GGSplitPreview {
+        switch activeDestination {
+        case .newCommit: model.firstPreview
+        case .originalCommit: model.remainderPreview
+        }
+    }
+
+    private func contentSummary(for preview: GGSplitPreview) -> String {
+        let hunkCount = preview.files.flatMap(\.hunkIDs).count
+        let fileCount = Set(preview.files.map(\.path) + preview.nonTextualFiles).count
+        return "\(hunkCount) hunk\(hunkCount == 1 ? "" : "s") · \(fileCount) file\(fileCount == 1 ? "" : "s")"
+    }
+
+    private func assign(_ hunk: GGSplitHunk, to destination: GGSplitCommitDestination) {
+        model.assignHunk(hunk.id, to: destination)
+        draftDidChange()
+    }
+
+    private func assign(_ group: GGSplitCommitFileGroup, to destination: GGSplitCommitDestination) {
+        model.assignHunks(in: group, to: destination)
+        draftDidChange()
+    }
+
+    private func draftDidChange() {
+        errorMessage = nil
+        onDraftChange(model.draft)
+    }
+
+    private func focusPreview(destination: GGSplitCommitDestination, path: String) {
+        activeDestination = destination
+        previewScrollRequest = previewScrollCoordinator.request(
+            previewID: destination.previewID,
+            path: path
+        )
+        legacyScrollPath = path
+        legacyScrollGeneration += 1
     }
 
     private var loadFailure: some View {
@@ -447,6 +589,36 @@ struct GGSplitCommitTabView: View {
             } catch {
                 errorMessage = GGErrorPresentation.message(for: error)
             }
+        }
+    }
+}
+
+private extension GGSplitCommitDestination {
+    var title: String {
+        switch self {
+        case .newCommit: "New Commit"
+        case .originalCommit: "Original Commit"
+        }
+    }
+
+    var shortTitle: String {
+        switch self {
+        case .newCommit: "New"
+        case .originalCommit: "Original"
+        }
+    }
+
+    var previewID: String {
+        switch self {
+        case .newCommit: "new"
+        case .originalCommit: "original"
+        }
+    }
+
+    var other: Self {
+        switch self {
+        case .newCommit: .originalCommit
+        case .originalCommit: .newCommit
         }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
@@ -98,6 +98,10 @@ enum GGSplitPreviewRowID {
     static func fileHeader(previewID: String, path: String) -> String {
         "gg-preview:\(previewID):file:\(path):header"
     }
+
+    static func legacyFile(path: String) -> String { "gg-preview:legacy:file:\(path)" }
+    static func legacyImage(path: String) -> String { "gg-preview:legacy:image:\(path)" }
+    static func legacyOther(path: String) -> String { "gg-preview:legacy:other:\(path)" }
 }
 
 struct GGSplitPreviewScrollRequestCoordinator {
@@ -110,7 +114,8 @@ struct GGSplitPreviewScrollRequestCoordinator {
             fallbackID: nil,
             alignment: .top,
             animated: true,
-            generation: generation
+            generation: generation,
+            snapsWhenFar: true
         )
     }
 }

--- a/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitPreviewRowPlan.swift
@@ -94,6 +94,27 @@ struct GGSplitPreviewRowPlanInput {
     let presentationStore: GGSplitPreviewPresentationStore
 }
 
+enum GGSplitPreviewRowID {
+    static func fileHeader(previewID: String, path: String) -> String {
+        "gg-preview:\(previewID):file:\(path):header"
+    }
+}
+
+struct GGSplitPreviewScrollRequestCoordinator {
+    private var generation = 0
+
+    mutating func request(previewID: String, path: String) -> AppKitDiffScrollRequest {
+        generation += 1
+        return AppKitDiffScrollRequest(
+            targetID: GGSplitPreviewRowID.fileHeader(previewID: previewID, path: path),
+            fallbackID: nil,
+            alignment: .top,
+            animated: true,
+            generation: generation
+        )
+    }
+}
+
 private struct GGSplitPreviewHeaderToken: Equatable {
     let previewID: String
     let path: String
@@ -125,7 +146,7 @@ enum GGSplitPreviewRowPlanBuilder {
         for file in input.preview.files {
             let prefix = "gg-preview:\(input.previewID):file:\(file.path)"
             rows.append(.init(
-                id: "\(prefix):header",
+                id: GGSplitPreviewRowID.fileHeader(previewID: input.previewID, path: file.path),
                 ownerID: file.path,
                 equalityToken: .init(GGSplitPreviewHeaderToken(
                     previewID: input.previewID,

--- a/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
+++ b/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
@@ -70,6 +70,21 @@ struct GGSplitPreviewRowPlanTests {
         #expect(!GGSplitCommitTabView.usesAppKitPreviewScroller(flagEnabled: false))
     }
 
+    @Test("file navigation targets stable pane-scoped headers with fresh generations")
+    func fileNavigationRequests() {
+        var coordinator = GGSplitPreviewScrollRequestCoordinator()
+
+        let first = coordinator.request(previewID: "new", path: "Sources/App.swift")
+        let second = coordinator.request(previewID: "original", path: "Sources/App.swift")
+
+        #expect(first.targetID == "gg-preview:new:file:Sources/App.swift:header")
+        #expect(first.fallbackID == nil)
+        #expect(first.alignment == .top)
+        #expect(first.animated)
+        #expect(second.targetID == "gg-preview:original:file:Sources/App.swift:header")
+        #expect(second.generation == first.generation + 1)
+    }
+
     @Test("text hunk state survives a preview rebuild and is pruned with its file")
     func textStateRetentionAndPruning() {
         let imageStore = GGSplitPreviewImageStore()

--- a/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
+++ b/AlasTests/Integrations/GG/GGSplitPreviewRowPlanTests.swift
@@ -81,8 +81,17 @@ struct GGSplitPreviewRowPlanTests {
         #expect(first.fallbackID == nil)
         #expect(first.alignment == .top)
         #expect(first.animated)
+        #expect(first.snapsWhenFar)
         #expect(second.targetID == "gg-preview:original:file:Sources/App.swift:header")
         #expect(second.generation == first.generation + 1)
+    }
+
+    @Test("legacy navigation IDs distinguish a text file from same-path metadata")
+    func legacyNavigationIDsAreUnique() {
+        let path = "Sources/App.swift"
+
+        #expect(GGSplitPreviewRowID.legacyFile(path: path) != GGSplitPreviewRowID.legacyOther(path: path))
+        #expect(GGSplitPreviewRowID.legacyFile(path: path) != GGSplitPreviewRowID.legacyImage(path: path))
     }
 
     @Test("text hunk state survives a preview rebuild and is pruned with its file")

--- a/AlasTests/Integrations/GGSplitCommitModelTests.swift
+++ b/AlasTests/Integrations/GGSplitCommitModelTests.swift
@@ -66,6 +66,37 @@ struct GGSplitCommitModelTests {
         #expect(model.selectedHunkIDs.isEmpty)
     }
 
+    @Test func namedDestinationsMoveOnlyDescribedTextHunks() async throws {
+        let model = makeModel()
+        try await model.load()
+
+        #expect(model.destination(for: "h-2") == .originalCommit)
+        #expect(model.destination(for: "unknown") == nil)
+
+        model.assignHunk("h-2", to: .newCommit)
+        #expect(model.destination(for: "h-2") == .newCommit)
+        #expect(model.selectedHunkIDs == ["h-2"])
+
+        model.assignHunk("h-2", to: .originalCommit)
+        model.assignHunk("unknown", to: .newCommit)
+        #expect(model.destination(for: "h-2") == .originalCommit)
+        #expect(model.selectedHunkIDs.isEmpty)
+    }
+
+    @Test func assigningAFileMovesAllAndOnlyItsHunks() async throws {
+        let model = makeModel()
+        try await model.load()
+        let firstFile = try #require(model.fileGroups.first { $0.path == "Sources/A.swift" })
+
+        model.assignHunks(in: firstFile, to: .newCommit)
+        #expect(model.selectedHunkIDs == ["h-1", "h-2"])
+        #expect(model.firstPreview.files.map(\.path) == ["Sources/A.swift"])
+
+        model.assignHunks(in: firstFile, to: .originalCommit)
+        #expect(model.selectedHunkIDs.isEmpty)
+        #expect(model.remainderPreview.files.flatMap(\.hunkIDs) == ["h-1", "h-2", "h-3"])
+    }
+
     @Test func applyRequiresNonEmptyProperSubset() async throws {
         let model = GGSplitCommitModel(
             service: SplitServiceStub(description: .textualOnlyFixture),

--- a/docs/plans/2026-08-07-gg-split-pane-ux-design.md
+++ b/docs/plans/2026-08-07-gg-split-pane-ux-design.md
@@ -1,0 +1,25 @@
+# GG Split Pane UX Design
+
+## Goal
+
+Make split-commit hunk assignment faster and clearer while giving each resulting commit enough preview space to inspect comfortably.
+
+## Design
+
+The split editor uses a resizable horizontal split. Its left rail groups hunks by file, starts groups expanded, and replaces ambiguous checkboxes with a single pill naming the hunk's current destination: **New Commit** or **Original Commit**. Pressing the pill moves the hunk without changing preview focus. Each selectable file also has a menu to assign all of its hunks to either destination. Non-text files remain labeled **Original only**.
+
+The right side replaces the two equal-height previews and separate message grid with two compact commit cards above one full-height preview. Both cards keep their message and exact content counts visible. Selecting a card changes the preview. Clicking a hunk body selects its current destination and scrolls the preview to that file.
+
+Incomplete assignments and messages remain valid editing states. Existing validation disables **Apply Split** and explains what is missing. Existing draft and GG plan fields retain their current wire names; only user-facing copy changes from First/Remainder to New/Original.
+
+## Boundaries
+
+- Reuse SwiftUI split controls and the existing AppKit diff-scroller request API.
+- Keep expansion and selected-preview state local to the tab.
+- Navigate to the affected file, not an exact diff line.
+- Preserve equivalent file navigation in the legacy scroller fallback.
+- Do not add drag-and-drop, global assignment controls, dependencies, persistence changes, or a generalized rail component.
+
+## Verification
+
+Cover individual and per-file assignment, counts, validation, stable preview row targets, navigation requests, destination/card accessibility, narrow and wide layouts, reload, and existing failure states. Finish with `xcodegen`, the macOS build, and the full test suite.


### PR DESCRIPTION
## What changed

- Make the split pane's changes rail resizable, collapsible by file, and capable of per-file bulk assignment.
- Replace checkbox assignment with explicit `New` / `Original` hunk destinations.
- Replace the two half-height previews with compact commit cards and one focused, full-height preview.
- Scroll the selected destination preview to the hunk's file.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused split model and preview navigation tests
- Full suite: 7,744 passed; 5 unrelated existing failures in ACP launch, commit header, right-pane sync/base, and diff-review tests.