### PR TITLE
feat(mission): Mission deletion

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0081FC8497ADEC2FF4EF7D25 /* GGActionEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A25C83033616FE27526C945 /* GGActionEventsTests.swift */; };
 		00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */; };
 		00ED86F7E72AFBF6C8DD69C7 /* GitInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */; };
+		013A70CCBCEAD106485AEC1E /* MissionDeletionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F342E3DB9CF36E4A17452E /* MissionDeletionRequest.swift */; };
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
 		018E8980EAA0FA97A08A6EF6 /* RevisionSnapshotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */; };
 		018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */; };
@@ -3005,6 +3006,7 @@
 		F3A9FD2E7C30AA7C998FD071 /* BeautifulMermaidSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeautifulMermaidSmokeTests.swift; sourceTree = "<group>"; };
 		F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceCommitEditingTests.swift; sourceTree = "<group>"; };
 		F3BF7A5409A551E913EED82F /* MissionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionStore.swift; sourceTree = "<group>"; };
+		F3F342E3DB9CF36E4A17452E /* MissionDeletionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionDeletionRequest.swift; sourceTree = "<group>"; };
 		F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspectorTests.swift; sourceTree = "<group>"; };
 		F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabViewTests.swift; sourceTree = "<group>"; };
 		F4526714086C04ED5B472C90 /* DiffInlineCommentCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentCard.swift; sourceTree = "<group>"; };
@@ -4723,6 +4725,7 @@
 				B28CC0818EEC129C6CFE7A33 /* EditMissionSourceDialog.swift */,
 				D39349809C87AB2DA9CACF56 /* MissionController.swift */,
 				DE28FBD8A093452150901B6F /* MissionCoordinator.swift */,
+				F3F342E3DB9CF36E4A17452E /* MissionDeletionRequest.swift */,
 				F8393DE75ACFA27C6B581B5E /* MissionLegCoordinator.swift */,
 				FFDBC8F8504FF6C50FD070A2 /* MissionLegPresentation.swift */,
 				C9EF117AF22C11E37BB5B1F0 /* MissionLegPromptBuilder.swift */,
@@ -6492,6 +6495,7 @@
 				0BCDD4F3A4AE0B3944460D87 /* MermaidTextAttachment.swift in Sources */,
 				58BB9973486DACC65D7B8868 /* MissionController.swift in Sources */,
 				EE326CAD34D497B29C4601C6 /* MissionCoordinator.swift in Sources */,
+				013A70CCBCEAD106485AEC1E /* MissionDeletionRequest.swift in Sources */,
 				6C55D3C7C3916EB16F559F34 /* MissionLegCoordinator.swift in Sources */,
 				9466257C1D5E61A2674425B8 /* MissionLegPresentation.swift in Sources */,
 				1B68197F3766CF78E8FED978 /* MissionLegPromptBuilder.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4677,6 +4677,35 @@ final class AppState {
         }
     }
 
+    func deleteMission(id: MissionID) async {
+        await missions.delete(id)
+        guard missions.aggregate(id: id) == nil else { return }
+        discardMissionUI(id: id)
+    }
+
+    func deleteCompletedMissions(ids: [MissionID]) async {
+        await missions.deleteCompleted(ids: ids)
+        for id in ids where missions.aggregate(id: id) == nil {
+            discardMissionUI(id: id)
+        }
+    }
+
+    private func discardMissionUI(id: MissionID) {
+        if let tab = globalTabs.tabs.first(where: { tab in
+            guard case .mission(let state) = tab else { return false }
+            return state.missionID == id
+        }) {
+            // Deliberately not requestCloseGlobalTab: a deleted Mission must not
+            // land in closed-tab history where Reopen could resurrect it.
+            closeGlobalTab(tabId: tab.id)
+        }
+        if missingMissionTab?.missionID == id {
+            missingMissionTab = nil
+            missingMissionRecoveryTarget = nil
+        }
+        closedTabHistory.purge(missionID: id)
+    }
+
     func requestCloseGlobalTab(tabID: TabID) {
         guard let tab = globalTabs.tabs.first(where: { $0.id == tabID }) else { return }
         closedTabHistory.record(ClosedTabEntry(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4684,8 +4684,7 @@ final class AppState {
     }
 
     func deleteCompletedMissions(ids: [MissionID]) async {
-        await missions.deleteCompleted(ids: ids)
-        for id in ids where missions.aggregate(id: id) == nil {
+        for id in await missions.deleteCompleted(ids: ids) {
             discardMissionUI(id: id)
         }
     }

--- a/Alas/Sources/Center/ClosedTabHistory.swift
+++ b/Alas/Sources/Center/ClosedTabHistory.swift
@@ -86,6 +86,15 @@ struct ClosedTabHistory: Equatable {
     mutating func purge(worktreeID: String) {
         entries.removeAll { $0.snapshot.worktreeID == worktreeID }
     }
+
+    mutating func purge(missionID: MissionID) {
+        entries.removeAll { entry in
+            guard case .global(let tab) = entry.snapshot,
+                  case .mission(let state) = tab
+            else { return false }
+            return state.missionID == missionID
+        }
+    }
 }
 
 extension PaneNode {

--- a/Alas/Sources/Missions/MissionController.swift
+++ b/Alas/Sources/Missions/MissionController.swift
@@ -107,6 +107,13 @@ final class MissionController {
     private var lifecycleMutations: Set<MissionID> = []
     @ObservationIgnored
     private var lifecycleWaiters: [MissionID: [CheckedContinuation<Void, Never>]] = [:]
+    // Tombstones ids removed via delete/deleteCompleted so a `replace(_:)` call
+    // from a publisher that raced the deletion (already holding a stale
+    // aggregate read before the row was removed) cannot resurrect it in
+    // `aggregates`. MissionIDs are UUIDs minted once and never reused, so this
+    // set is safe to grow unbounded for the life of the app session.
+    @ObservationIgnored
+    private var deletedMissionIDs: Set<MissionID> = []
     @ObservationIgnored
     private var sourceRefreshGenerations: [MissionID: Int] = [:]
     @ObservationIgnored
@@ -1258,10 +1265,15 @@ final class MissionController {
     }
 
     private func remove(id: MissionID) {
+        deletedMissionIDs.insert(id)
         aggregates.removeAll { $0.mission.id == id }
     }
 
-    private func replace(_ aggregate: MissionAggregate) {
+    // Not private: MissionIntegrationTests calls this directly to exercise the
+    // tombstone guard against a real MissionController without fabricating
+    // real concurrency.
+    func replace(_ aggregate: MissionAggregate) {
+                guard !deletedMissionIDs.contains(aggregate.mission.id) else { return }
         if let index = aggregates.firstIndex(where: { $0.mission.id == aggregate.mission.id }) {
             aggregates[index] = aggregate
         } else {

--- a/Alas/Sources/Missions/MissionController.swift
+++ b/Alas/Sources/Missions/MissionController.swift
@@ -659,6 +659,33 @@ final class MissionController {
         }
     }
 
+    func delete(_ id: MissionID) async {
+        await withLifecycleMutation(id: id) { [weak self] in
+            guard let self else { return }
+            do {
+                try await persistence.delete(id: id)
+                remove(id: id)
+                loadError = nil
+            } catch {
+                loadError = error.localizedDescription
+            }
+        }
+    }
+
+    // Completed Missions have no in-flight setup work, so this deliberately
+    // skips the per-Mission lifecycle gate and deletes them in one transaction.
+    func deleteCompleted(ids: [MissionID]) async {
+        let completed = ids.filter { aggregate(id: $0)?.mission.state == .completed }
+        guard !completed.isEmpty else { return }
+        do {
+            try await persistence.delete(ids: completed)
+            for id in completed { remove(id: id) }
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
     func aggregate(id: MissionID) -> MissionAggregate? {
         aggregates.first { $0.mission.id == id }
     }
@@ -1225,6 +1252,10 @@ final class MissionController {
         // the same issue-scoped input instead of starting recovery empty.
         guard leg.ordinal == 0 else { return nil }
         return MissionPromptBuilder.build(source: source)
+    }
+
+    private func remove(id: MissionID) {
+        aggregates.removeAll { $0.mission.id == id }
     }
 
     private func replace(_ aggregate: MissionAggregate) {

--- a/Alas/Sources/Missions/MissionController.swift
+++ b/Alas/Sources/Missions/MissionController.swift
@@ -674,15 +674,18 @@ final class MissionController {
 
     // Completed Missions have no in-flight setup work, so this deliberately
     // skips the per-Mission lifecycle gate and deletes them in one transaction.
-    func deleteCompleted(ids: [MissionID]) async {
+    @discardableResult
+    func deleteCompleted(ids: [MissionID]) async -> [MissionID] {
         let completed = ids.filter { aggregate(id: $0)?.mission.state == .completed }
-        guard !completed.isEmpty else { return }
+        guard !completed.isEmpty else { return [] }
         do {
             try await persistence.delete(ids: completed)
             for id in completed { remove(id: id) }
             loadError = nil
+            return completed
         } catch {
             loadError = error.localizedDescription
+            return []
         }
     }
 

--- a/Alas/Sources/Missions/MissionController.swift
+++ b/Alas/Sources/Missions/MissionController.swift
@@ -1275,7 +1275,7 @@ final class MissionController {
     // tombstone guard against a real MissionController without fabricating
     // real concurrency.
     func replace(_ aggregate: MissionAggregate) {
-                guard !deletedMissionIDs.contains(aggregate.mission.id) else { return }
+        guard !deletedMissionIDs.contains(aggregate.mission.id) else { return }
         if let index = aggregates.firstIndex(where: { $0.mission.id == aggregate.mission.id }) {
             aggregates[index] = aggregate
         } else {

--- a/Alas/Sources/Missions/MissionController.swift
+++ b/Alas/Sources/Missions/MissionController.swift
@@ -177,7 +177,9 @@ final class MissionController {
         do {
             let loaded = try await persistence.list(includeCompleted: true)
             guard !Task.isCancelled else { return }
-            aggregates = Self.sorted(loaded)
+            // A delete(_:) that completes while this load is in flight must not have
+            // its result overwritten by a snapshot read before the deletion committed.
+            aggregates = Self.sorted(loaded.filter { !deletedMissionIDs.contains($0.mission.id) })
             loadState = .loaded
         } catch {
             guard !Task.isCancelled else { return }

--- a/Alas/Sources/Missions/MissionDeletionRequest.swift
+++ b/Alas/Sources/Missions/MissionDeletionRequest.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// A pending Mission deletion awaiting confirmation, together with its dialog copy.
+enum MissionDeletionRequest: Equatable, Identifiable {
+    case single(id: MissionID, title: String)
+    case completed([MissionID])
+
+    static let consequence = """
+    This removes the Mission and its history from Alas. Worktrees, branches, \
+    and running agents are left untouched.
+    """
+
+    var id: String {
+        switch self {
+        case .single(let id, _):
+            "single:\(id.rawValue)"
+        case .completed(let ids):
+            "completed:\(ids.map(\.rawValue).joined(separator: ","))"
+        }
+    }
+
+    var missionIDs: [MissionID] {
+        switch self {
+        case .single(let id, _): [id]
+        case .completed(let ids): ids
+        }
+    }
+
+    var confirmationTitle: String {
+        switch self {
+        case .single(_, let title):
+            "Delete \"\(title)\"?"
+        case .completed(let ids):
+            "Delete \(ids.count) completed \(Self.missionNoun(ids.count))?"
+        }
+    }
+
+    var confirmationButtonTitle: String {
+        switch self {
+        case .single:
+            "Delete Mission"
+        case .completed(let ids):
+            "Delete \(ids.count) \(Self.missionNoun(ids.count))"
+        }
+    }
+
+    private static func missionNoun(_ count: Int) -> String {
+        count == 1 ? "Mission" : "Missions"
+    }
+}

--- a/Alas/Sources/Missions/MissionLegCoordinator.swift
+++ b/Alas/Sources/Missions/MissionLegCoordinator.swift
@@ -384,6 +384,11 @@ final class MissionLegCoordinator {
             return true
         } catch MissionStore.Error.missionCompleted {
             return false
+        } catch MissionStore.Error.missionNotFound {
+            // The Mission was deleted while its setup was in flight. Any worktree
+            // already created survives as an ordinary worktree; there is nothing
+            // left to persist and nothing to report.
+            return false
         } catch {
             if let failureCheckpoint {
                 await persistFailure(

--- a/Alas/Sources/Missions/MissionPersistence.swift
+++ b/Alas/Sources/Missions/MissionPersistence.swift
@@ -128,4 +128,13 @@ actor MissionPersistence {
     func complete(id: MissionID, leg: MissionLeg? = nil, at: Date, event: MissionEvent) throws {
         try openedStore().complete(id: id, leg: leg, at: at, event: event)
     }
+
+    @discardableResult
+    func delete(id: MissionID) throws -> Bool {
+        try openedStore().delete(id: id)
+    }
+
+    func delete(ids: [MissionID]) throws {
+        try openedStore().delete(ids: ids)
+    }
 }

--- a/Alas/Sources/Missions/MissionSidebarSection.swift
+++ b/Alas/Sources/Missions/MissionSidebarSection.swift
@@ -186,11 +186,14 @@ struct MissionSidebarSection: View {
     let selectedMissionID: MissionID?
     let onOpenMission: (MissionID) -> Void
     let onNewMission: () -> Void
+    let onDeleteMission: (MissionID) -> Void
+    let onDeleteCompleted: ([MissionID]) -> Void
     @Environment(\.theme) private var theme
     @State private var collapsed = false
     @State private var completedCollapsed = true
     @State private var hoveringHeader = false
     @State private var plusHovering = false
+    @State private var pendingDeletion: MissionDeletionRequest?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -201,7 +204,8 @@ struct MissionSidebarSection: View {
                         MissionSidebarRowView(
                             row: row,
                             isSelected: selectedMissionID == row.id,
-                            onOpenMission: onOpenMission
+                            onOpenMission: onOpenMission,
+                            onDelete: { pendingDeletion = .single(id: row.id, title: row.title) }
                         )
                     }
                     if !model.completed.isEmpty {
@@ -211,7 +215,8 @@ struct MissionSidebarSection: View {
                                 MissionSidebarRowView(
                                     row: row,
                                     isSelected: selectedMissionID == row.id,
-                                    onOpenMission: onOpenMission
+                                    onOpenMission: onOpenMission,
+                                    onDelete: { pendingDeletion = .single(id: row.id, title: row.title) }
                                 )
                             }
                         }
@@ -219,6 +224,29 @@ struct MissionSidebarSection: View {
                 }
                 .padding(.horizontal, 6)
             }
+        }
+        .confirmationDialog(
+            pendingDeletion?.confirmationTitle ?? "",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let pendingDeletion {
+                Button(pendingDeletion.confirmationButtonTitle, role: .destructive) {
+                    switch pendingDeletion {
+                    case .single(let id, _):
+                        onDeleteMission(id)
+                    case .completed(let ids):
+                        onDeleteCompleted(ids)
+                    }
+                    self.pendingDeletion = nil
+                }
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: {
+            Text(MissionDeletionRequest.consequence)
         }
     }
 
@@ -293,6 +321,11 @@ struct MissionSidebarSection: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .contextMenu {
+            Button("Delete All Completed (\(model.completed.count))", role: .destructive) {
+                pendingDeletion = .completed(model.completedIDs)
+            }
+        }
     }
 }
 
@@ -300,6 +333,7 @@ private struct MissionSidebarRowView: View {
     let row: MissionSidebarRow
     let isSelected: Bool
     let onOpenMission: (MissionID) -> Void
+    let onDelete: () -> Void
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -355,6 +389,9 @@ private struct MissionSidebarRowView: View {
         .buttonStyle(.plain)
         .disabled(!row.isNavigationEnabled)
         .help(row.helpText)
+        .contextMenu {
+            Button("Delete Mission", role: .destructive, action: onDelete)
+        }
     }
 
     private var statusColor: Color {

--- a/Alas/Sources/Missions/MissionSidebarSection.swift
+++ b/Alas/Sources/Missions/MissionSidebarSection.swift
@@ -33,6 +33,10 @@ struct MissionSidebarModel: Equatable {
         .init(active: [], completed: [])
     }
 
+    var completedIDs: [MissionID] {
+        completed.map(\.id)
+    }
+
     nonisolated static func make(
         aggregates: [MissionAggregate],
         activeProjectIds: [String],

--- a/Alas/Sources/Missions/MissionStore.swift
+++ b/Alas/Sources/Missions/MissionStore.swift
@@ -538,6 +538,25 @@ final class MissionStore {
         }
     }
 
+    @discardableResult
+    func delete(id: MissionID) throws -> Bool {
+        try immediateTransaction {
+            try db.execChanges(
+                "DELETE FROM missions WHERE id = ?",
+                bindings: [id.rawValue]
+            ) > 0
+        }
+    }
+
+    func delete(ids: [MissionID]) throws {
+        guard !ids.isEmpty else { return }
+        try immediateTransaction {
+            for id in ids {
+                try db.exec("DELETE FROM missions WHERE id = ?", bindings: [id.rawValue])
+            }
+        }
+    }
+
     private func migrate() throws {
         try db.exec("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)")
         var current = try currentSchemaVersion()

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -41,7 +41,13 @@ struct SidebarView: View {
                             onOpenMission: { missionID in
                                 _ = state.openMission(id: missionID)
                             },
-                            onNewMission: onNewMission
+                            onNewMission: onNewMission,
+                            onDeleteMission: { missionID in
+                                Task { await state.deleteMission(id: missionID) }
+                            },
+                            onDeleteCompleted: { missionIDs in
+                                Task { await state.deleteCompletedMissions(ids: missionIDs) }
+                            }
                         )
                         ForEach(state.activeSpaceProjects) { project in
                             RepoGroupView(

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -487,4 +487,36 @@ struct ClosedTabAppStateTests {
         #expect(!fixture.state.canReopenClosedTab)
         #expect(fixture.state.closedTabHistory.entries.isEmpty)
     }
+
+    @Test func closedTabHistoryPurgesEntriesForOneMission() {
+        var history = ClosedTabHistory()
+        let kept = MissionID(rawValue: "kept-mission")
+        let removed = MissionID(rawValue: "removed-mission")
+        let placement = ClosedTabPlacement(previousID: nil, nextID: nil, ordinal: 0)
+        history.record(ClosedTabEntry(
+            snapshot: .global(.mission(MissionTabState(missionID: kept, title: "Kept"))),
+            placement: placement
+        ))
+        history.record(ClosedTabEntry(
+            snapshot: .global(.mission(MissionTabState(missionID: removed, title: "Removed"))),
+            placement: placement
+        ))
+
+        history.purge(missionID: removed)
+
+        #expect(history.count == 1)
+        #expect(history.last?.snapshot == .global(.mission(MissionTabState(missionID: kept, title: "Kept"))))
+    }
+
+    @Test func deletingAMissionClosesItsTabWithoutRecordingHistory() async {
+        let fixture = makeFixture()
+        let missionID = MissionID(rawValue: "closed-tabs-mission")
+        let tab = fixture.state.globalTabs.openOrFocusMission(missionID: missionID, title: "Mission")
+        #expect(fixture.state.globalTabs.tabs.map(\.id) == [tab.id])
+
+        await fixture.state.deleteMission(id: missionID)
+
+        #expect(fixture.state.globalTabs.tabs.isEmpty)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
 }

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -519,4 +519,60 @@ struct ClosedTabAppStateTests {
         #expect(fixture.state.globalTabs.tabs.isEmpty)
         #expect(!fixture.state.canReopenClosedTab)
     }
+
+    @Test func deletingCompletedMissionsClosesOnlyTheCompletedMissionsTab() async throws {
+        let completedID = MissionID(rawValue: "closed-tabs-completed-mission")
+        let runningID = MissionID(rawValue: "closed-tabs-running-mission")
+        let persistence = try Self.makeMixedMissionPersistence(completedID: completedID, runningID: runningID)
+        let state = AppState(store: MemoryStore(), missionPersistence: persistence)
+        let fixture = makeFixture(state: state)
+        await fixture.state.missions.load()
+
+        let completedTab = fixture.state.globalTabs.openOrFocusMission(missionID: completedID, title: "Completed Mission")
+        let runningTab = fixture.state.globalTabs.openOrFocusMission(missionID: runningID, title: "Running Mission")
+        #expect(fixture.state.globalTabs.tabs.map(\.id) == [completedTab.id, runningTab.id])
+
+        await fixture.state.deleteCompletedMissions(ids: [completedID, runningID])
+
+        #expect(fixture.state.globalTabs.tabs.map(\.id) == [runningTab.id])
+        #expect(!fixture.state.canReopenClosedTab)
+
+        // The running Mission's tab and its ordinary close/reopen behavior remain untouched.
+        fixture.state.requestCloseGlobalTab(tabID: runningTab.id)
+        #expect(fixture.state.canReopenClosedTab)
+
+        await fixture.state.reopenLastClosedTab()
+
+        #expect(fixture.state.globalTabs.tabs.map(\.id) == [runningTab.id])
+        #expect(fixture.state.globalTabs.activeTabId == runningTab.id)
+        #expect(!fixture.state.canReopenClosedTab)
+    }
+
+    private static func makeMixedMissionPersistence(
+        completedID: MissionID,
+        runningID: MissionID
+    ) throws -> MissionPersistence {
+        var completedAggregate = MissionFixtures.creatingMission(
+            id: completedID.rawValue,
+            issue: MissionFixtures.issue(number: 501)
+        )
+        completedAggregate.mission.state = .completed
+        completedAggregate.mission.setupCheckpoint = .running
+        completedAggregate.mission.completedAt = Date(timeIntervalSince1970: 200)
+
+        var runningAggregate = MissionFixtures.creatingMission(
+            id: runningID.rawValue,
+            issue: MissionFixtures.issue(number: 502)
+        )
+        runningAggregate.mission.state = .running
+        runningAggregate.mission.setupCheckpoint = .running
+
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("closed-tabs-missions-\(UUID().uuidString).sqlite")
+            .path
+        let store = try MissionStore(path: path)
+        try store.insert(completedAggregate)
+        try store.insert(runningAggregate)
+        return MissionPersistence(path: path)
+    }
 }

--- a/AlasTests/Missions/MissionCoordinatorTests.swift
+++ b/AlasTests/Missions/MissionCoordinatorTests.swift
@@ -231,6 +231,26 @@ struct MissionCoordinatorTests {
         #expect(!aggregate.events.contains { $0.kind == .attentionRequired })
     }
 
+    @Test("deletion during setup is silent cancellation")
+    func deletionDuringSetupIsSilentCancellation() async throws {
+        let fake = MissionCoordinatorFake(deleteWhenSessionReserved: true)
+        let coordinator = MissionCoordinator(environment: fake.environment)
+
+        let missionID = try await coordinator.create(Self.primaryDraft)
+        for _ in 0..<200 {
+            if try await fake.persistence.aggregate(id: missionID) == nil { break }
+            await Task.yield()
+        }
+        // The deletion above only tears down the Mission row; the coordinator's
+        // in-flight setup continuation (agent startup, then the final setup
+        // write) keeps running afterward. Give it room to settle before
+        // asserting nothing was reported.
+        for _ in 0..<50 { await Task.yield() }
+
+        #expect(try await fake.persistence.aggregate(id: missionID) == nil)
+        #expect(fake.reportedFailures.isEmpty)
+    }
+
     // Break caught: restart reconciliation awaits one creating leg to settle
     // before advancing the next, serializing otherwise independent Git work.
     @Test("restart advances creating legs independently")
@@ -1172,6 +1192,7 @@ private final class MissionCoordinatorFake {
     private let suspendWorktreePlanning: Bool
     private let suspendACPStartup: Bool
     private let completeWhenSessionReserved: Bool
+    private let deleteWhenSessionReserved: Bool
     private let completeAfterACPBeforeSetupPersistence: Bool
     private var completedAfterACP = false
     private var startedLegs: [MissionLegID: MissionLeg] = [:]
@@ -1197,6 +1218,7 @@ private final class MissionCoordinatorFake {
         suspendWorktreePlanning: Bool = false,
         suspendACPStartup: Bool = false,
         completeWhenSessionReserved: Bool = false,
+        deleteWhenSessionReserved: Bool = false,
         completeAfterACPBeforeSetupPersistence: Bool = false
     ) {
         let path = FileManager.default.temporaryDirectory
@@ -1214,6 +1236,7 @@ private final class MissionCoordinatorFake {
         self.suspendWorktreePlanning = suspendWorktreePlanning
         self.suspendACPStartup = suspendACPStartup
         self.completeWhenSessionReserved = completeWhenSessionReserved
+        self.deleteWhenSessionReserved = deleteWhenSessionReserved
         self.completeAfterACPBeforeSetupPersistence = completeAfterACPBeforeSetupPersistence
         if existing.contains(where: { $0.primaryLeg?.worktreeId != nil }) {
             worktreeAtDestination = worktree
@@ -1335,6 +1358,10 @@ private final class MissionCoordinatorFake {
                             createdAt: now.timeIntervalSince1970
                         )
                     )
+                }
+                if self.deleteWhenSessionReserved,
+                   aggregate.primaryLeg?.acpSessionId != nil {
+                    try! self.store.delete(id: aggregate.mission.id)
                 }
                 if aggregate.events.last?.kind == .created, aggregate.primaryLeg?.worktreeId == nil {
                     self.operations.append("insert:creatingWorktree")

--- a/AlasTests/Missions/MissionIntegrationTests.swift
+++ b/AlasTests/Missions/MissionIntegrationTests.swift
@@ -396,6 +396,28 @@ struct MissionIntegrationTests {
         #expect(harness.controller.aggregates.isEmpty)
     }
 
+    @Test("a full load cannot resurrect a Mission tombstoned by a concurrent delete")
+    func loadCannotResurrectATombstonedMission() async throws {
+        let harness = try MissionIntegrationHarness(running: true)
+        let id = MissionID(rawValue: "mission-1")
+
+        await harness.controller.load()
+        let staleAggregate = try #require(harness.controller.aggregate(id: id))
+
+        await harness.controller.delete(id)
+        #expect(harness.controller.aggregate(id: id) == nil)
+
+        // Simulate persistence.list() having captured this row from before the
+        // deletion committed — e.g. a load() in flight during startup legacy
+        // reconciliation. The tombstone left by delete(_:) must reject it even
+        // though the store itself would (in this simulation) return it.
+        try await harness.persistence.insert(staleAggregate, allowDuplicate: true)
+        await harness.controller.load()
+
+        #expect(harness.controller.aggregate(id: id) == nil)
+        #expect(!harness.controller.aggregates.contains { $0.mission.id == id })
+    }
+
     @Test("deleteCompleted only removes Missions that are actually completed")
     func deleteCompletedSkipsUnfinishedMissions() async throws {
         let harness = try MissionIntegrationHarness(running: true)

--- a/AlasTests/Missions/MissionIntegrationTests.swift
+++ b/AlasTests/Missions/MissionIntegrationTests.swift
@@ -372,9 +372,7 @@ struct MissionIntegrationTests {
         #expect(harness.controller.aggregate(id: id) == nil)
         #expect(harness.controller.aggregates.isEmpty)
         #expect(harness.controller.loadError == nil)
-        #expect(harness.providerMutations.isEmpty)
         #expect(harness.worktreeMutations.isEmpty)
-        #expect(harness.sessionStops.isEmpty)
     }
 
     @Test("deleteCompleted only removes Missions that are actually completed")
@@ -393,6 +391,34 @@ struct MissionIntegrationTests {
 
         #expect(try await harness.persistence.aggregate(id: id) == nil)
         #expect(harness.controller.aggregate(id: id) == nil)
+    }
+
+    @Test("deleteCompleted removes only the completed Mission from a mixed batch and returns exactly its id")
+    func deleteCompletedRemovesOnlyCompletedFromMixedBatch() async throws {
+        let harness = try MissionIntegrationHarness(running: true)
+        let completedID = MissionID(rawValue: "mission-1")
+        let runningID = MissionID(rawValue: "mission-2")
+        let unknownID = MissionID(rawValue: "mission-unknown")
+
+        var runningAggregate = MissionFixtures.creatingMission(
+            id: runningID.rawValue,
+            issue: MissionFixtures.issue(number: 43)
+        )
+        runningAggregate.mission.state = .running
+        runningAggregate.mission.setupCheckpoint = .running
+        try harness.insert(runningAggregate)
+
+        await harness.controller.load()
+        await harness.controller.complete(completedID)
+
+        let removed = await harness.controller.deleteCompleted(ids: [completedID, runningID, unknownID])
+
+        #expect(removed == [completedID])
+        #expect(try await harness.persistence.aggregate(id: completedID) == nil)
+        #expect(harness.controller.aggregate(id: completedID) == nil)
+        #expect(try await harness.persistence.aggregate(id: runningID) != nil)
+        #expect(harness.controller.aggregate(id: runningID) != nil)
+        #expect(harness.controller.aggregate(id: runningID)?.mission.state == .running)
     }
 }
 
@@ -647,6 +673,10 @@ private final class MissionIntegrationHarness {
 
     func failNextACPStart(forProjectID projectID: String) {
         recorder.failNextACPStart(forProjectID: projectID)
+    }
+
+    func insert(_ aggregate: MissionAggregate) throws {
+        try Self.insert(aggregate, at: path)
     }
 
     func markArchived(_ leg: MissionLeg) {

--- a/AlasTests/Missions/MissionIntegrationTests.swift
+++ b/AlasTests/Missions/MissionIntegrationTests.swift
@@ -375,6 +375,27 @@ struct MissionIntegrationTests {
         #expect(harness.worktreeMutations.isEmpty)
     }
 
+    @Test("a stale replace call after delete cannot resurrect the Mission")
+    func staleReplaceAfterDeleteCannotResurrectMission() async throws {
+        let harness = try MissionIntegrationHarness(running: true)
+        let id = MissionID(rawValue: "mission-1")
+
+        await harness.controller.load()
+        let staleAggregate = try #require(harness.controller.aggregate(id: id))
+
+        await harness.controller.delete(id)
+        #expect(harness.controller.aggregate(id: id) == nil)
+
+        // Simulate a publisher (coordinator notifyChanged, retry, or publish(id:))
+        // that had already read this aggregate before the delete landed and is
+        // only now calling replace(_:) with the stale value. The tombstone left
+        // by delete(_:) must reject this and keep the Mission gone.
+        harness.controller.replace(staleAggregate)
+
+        #expect(harness.controller.aggregate(id: id) == nil)
+        #expect(harness.controller.aggregates.isEmpty)
+    }
+
     @Test("deleteCompleted only removes Missions that are actually completed")
     func deleteCompletedSkipsUnfinishedMissions() async throws {
         let harness = try MissionIntegrationHarness(running: true)

--- a/AlasTests/Missions/MissionIntegrationTests.swift
+++ b/AlasTests/Missions/MissionIntegrationTests.swift
@@ -359,6 +359,41 @@ struct MissionIntegrationTests {
         #expect(harness.worktreeCreateCount == 1)
         #expect(harness.sessionIDs.count == 1)
     }
+
+    @Test("delete removes the Mission with no external side effects")
+    func deleteHasNoExternalSideEffects() async throws {
+        let harness = try MissionIntegrationHarness(running: true)
+        let id = MissionID(rawValue: "mission-1")
+
+        await harness.controller.load()
+        await harness.controller.delete(id)
+
+        #expect(try await harness.persistence.aggregate(id: id) == nil)
+        #expect(harness.controller.aggregate(id: id) == nil)
+        #expect(harness.controller.aggregates.isEmpty)
+        #expect(harness.controller.loadError == nil)
+        #expect(harness.providerMutations.isEmpty)
+        #expect(harness.worktreeMutations.isEmpty)
+        #expect(harness.sessionStops.isEmpty)
+    }
+
+    @Test("deleteCompleted only removes Missions that are actually completed")
+    func deleteCompletedSkipsUnfinishedMissions() async throws {
+        let harness = try MissionIntegrationHarness(running: true)
+        let id = MissionID(rawValue: "mission-1")
+
+        await harness.controller.load()
+        await harness.controller.deleteCompleted(ids: [id])
+
+        #expect(try await harness.persistence.aggregate(id: id) != nil)
+        #expect(harness.controller.aggregate(id: id) != nil)
+
+        await harness.controller.complete(id)
+        await harness.controller.deleteCompleted(ids: [id])
+
+        #expect(try await harness.persistence.aggregate(id: id) == nil)
+        #expect(harness.controller.aggregate(id: id) == nil)
+    }
 }
 
 private extension ReviewLoopSnapshot {

--- a/AlasTests/Missions/MissionSidebarTests.swift
+++ b/AlasTests/Missions/MissionSidebarTests.swift
@@ -189,6 +189,54 @@ struct MissionSidebarTests {
         #expect(row?.isNavigationEnabled == true)
     }
 
+    @Test func completedIdsCoverOnlyTheVisibleCompletedRows() {
+        let model = MissionSidebarModel.make(
+            aggregates: [
+                Self.mission(id: "visible-running", projectId: "alas", state: .running),
+                Self.mission(id: "visible-done", projectId: "alas", state: .completed),
+                Self.mission(id: "hidden-done", projectId: "other", state: .completed),
+            ],
+            activeProjectIds: ["alas"],
+            existingProjectIds: ["alas", "other"],
+            knownWorktreeIds: []
+        )
+
+        #expect(model.completedIDs == [MissionID(rawValue: "visible-done")])
+        #expect(model.completedIDs.count == model.completed.count)
+    }
+
+    @Test func singleDeletionCopyNamesTheMission() {
+        let request = MissionDeletionRequest.single(
+            id: MissionID(rawValue: "mission-1"),
+            title: "Fix parser crash"
+        )
+
+        #expect(request.confirmationTitle == "Delete \"Fix parser crash\"?")
+        #expect(request.confirmationButtonTitle == "Delete Mission")
+        #expect(request.missionIDs == [MissionID(rawValue: "mission-1")])
+    }
+
+    @Test func bulkDeletionCopyCountsTheMissions() {
+        let one = MissionDeletionRequest.completed([MissionID(rawValue: "a")])
+        let many = MissionDeletionRequest.completed([
+            MissionID(rawValue: "a"),
+            MissionID(rawValue: "b"),
+        ])
+
+        #expect(one.confirmationTitle == "Delete 1 completed Mission?")
+        #expect(one.confirmationButtonTitle == "Delete 1 Mission")
+        #expect(many.confirmationTitle == "Delete 2 completed Missions?")
+        #expect(many.confirmationButtonTitle == "Delete 2 Missions")
+        #expect(many.missionIDs.map(\.rawValue) == ["a", "b"])
+    }
+
+    @Test func deletionConsequenceSpellsOutWhatSurvives() {
+        #expect(MissionDeletionRequest.consequence == """
+        This removes the Mission and its history from Alas. Worktrees, branches, \
+        and running agents are left untouched.
+        """)
+    }
+
     private static func mission(
         id: String = "mission-1",
         projectId: String = "project-1",

--- a/AlasTests/Missions/MissionStoreTests.swift
+++ b/AlasTests/Missions/MissionStoreTests.swift
@@ -1199,6 +1199,74 @@ struct MissionStoreTests {
             MissionID(rawValue: "older-active"),
         ])
     }
+
+    @Test("deleting a Mission cascades to its legs, events and source")
+    func deleteCascadesToOwnedRows() throws {
+        let store = try MissionStore(path: temporaryPath())
+        try store.insert(MissionFixtures.creatingMission(id: "mission-1"))
+        try store.insert(MissionFixtures.creatingMission(id: "mission-2", issue: MissionFixtures.issue(number: 43)))
+
+        #expect(try store.delete(id: .init(rawValue: "mission-1")))
+
+        #expect(try store.aggregate(id: .init(rawValue: "mission-1")) == nil)
+        #expect(try store.aggregate(id: .init(rawValue: "mission-2")) != nil)
+        for table in ["mission_legs", "mission_events", "mission_sources"] {
+            let rows = try store.db.query(
+                "SELECT mission_id FROM \(table) WHERE mission_id = 'mission-1'"
+            )
+            #expect(rows.isEmpty, "\(table) still holds rows for the deleted Mission")
+        }
+    }
+
+    @Test("deleting an unknown Mission is a no-op rather than an error")
+    func deleteUnknownMissionIsANoOp() throws {
+        let store = try MissionStore(path: temporaryPath())
+        try store.insert(MissionFixtures.creatingMission(id: "mission-1"))
+
+        #expect(try store.delete(id: .init(rawValue: "missing")) == false)
+        #expect(try store.aggregate(id: .init(rawValue: "mission-1")) != nil)
+    }
+
+    @Test("bulk delete removes the named Missions and ignores unknown ids")
+    func bulkDeleteRemovesNamedMissions() throws {
+        let store = try MissionStore(path: temporaryPath())
+        try store.insert(MissionFixtures.creatingMission(id: "mission-1"))
+        try store.insert(MissionFixtures.creatingMission(id: "mission-2", issue: MissionFixtures.issue(number: 43)))
+        try store.insert(MissionFixtures.creatingMission(id: "mission-3", issue: MissionFixtures.issue(number: 44)))
+
+        try store.delete(ids: [
+            .init(rawValue: "mission-1"),
+            .init(rawValue: "missing"),
+            .init(rawValue: "mission-3"),
+        ])
+
+        #expect(try store.aggregate(id: .init(rawValue: "mission-1")) == nil)
+        #expect(try store.aggregate(id: .init(rawValue: "mission-2")) != nil)
+        #expect(try store.aggregate(id: .init(rawValue: "mission-3")) == nil)
+    }
+
+    @Test("bulk delete with no ids leaves the database untouched")
+    func bulkDeleteWithNoIdsIsANoOp() throws {
+        let store = try MissionStore(path: temporaryPath())
+        try store.insert(MissionFixtures.creatingMission(id: "mission-1"))
+
+        try store.delete(ids: [])
+
+        #expect(try store.aggregate(id: .init(rawValue: "mission-1")) != nil)
+    }
+
+    @Test("deleting the only Mission for a source frees that source identity")
+    func deleteFreesSourceIdentity() throws {
+        let store = try MissionStore(path: temporaryPath())
+        let aggregate = MissionFixtures.creatingMission(id: "mission-1")
+        try store.insert(aggregate)
+        let identity = aggregate.source.identity
+        #expect(try store.activeMission(sourceIdentity: identity) != nil)
+
+        #expect(try store.delete(id: .init(rawValue: "mission-1")))
+
+        #expect(try store.activeMission(sourceIdentity: identity) == nil)
+    }
 }
 
 private enum MissionStoreTestDatabase {


### PR DESCRIPTION
## Summary

- Adds a **Delete Mission** action (per-mission, from a sidebar row context menu) and a **Delete All Completed** bulk action (from the Completed group header), so abandoned, orphaned, and old completed Missions can be removed instead of accumulating forever.
- Deletion is a hard SQL delete of the mission and its owned rows (legs, events, source). It **never** stops an agent, deletes/archives a worktree, touches a branch, or mutates the Mission source — matching the same contract `Complete Mission` already advertises.
- `Delete All Completed` only ever operates on the Missions currently visible under the Completed group (post space-filtering), never on every completed Mission in the database.
- A deleted Mission's tab closes immediately and is scrubbed from closed-tab history, so `Reopen Closed Tab` can never resurrect it.
- Deleting a Mission mid-setup (worktree/agent still being created) now cancels silently instead of surfacing a spurious failure banner — the same treatment `Mission completed mid-setup` already gets.

### Why

Missions previously had only one exit: `Complete`, a soft terminal state that just relabels the mission into a collapsible "Completed" group. There was no way to remove a mistaken or abandoned Mission, no way to clear out an old Completed backlog, and no way to get rid of a Mission whose project no longer exists.

### Reviewer notes

- No schema migration was needed — `mission_legs`, `mission_events`, and `mission_sources` already declare `ON DELETE CASCADE`, and every SQLite connection already runs with `PRAGMA foreign_keys = ON`.
- `MissionController.deleteCompleted(ids:)` returns exactly the ids it removed; `AppState` uses that return value rather than inferring deletion from absence.
- Both confirmation dialogs share one `MissionDeletionRequest` value type for their copy, kept deliberately explicit about what does *not* change: "Worktrees, branches, and running agents are left untouched."
- Known, deliberately deferred follow-ups (none load-bearing): a narrow window where a source-refresh in flight during a delete can produce a spurious banner or a momentary ghost row; a couple of small polish items (an unused `Identifiable` conformance, a duplicated SQL literal). Happy to open follow-up issues if useful.

### Testing

- New coverage across the store, controller, coordinator, `AppState`, and sidebar-model layers (cascade delete, no-op on unknown id, bulk delete, mid-setup cancellation, tab teardown, closed-tab-history scrubbing, visible-only bulk scope).
- `xcodebuild test` green across `MissionStoreTests`, `MissionIntegrationTests`, `MissionCoordinatorTests`, `MissionSidebarTests`, `MissionTabTests`, `ClosedTabAppStateTests` (187 tests) at HEAD.
- Manual verification of the sidebar UI (context menus, dialog rendering/dismissal) is still outstanding and worth a quick pass before merge.