### PR TITLE
feat(gg): Add GG-ID copy action to commit menu

### DIFF
--- a/Alas/Sources/Integrations/GG/GGStackGate.swift
+++ b/Alas/Sources/Integrations/GG/GGStackGate.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+enum GGCommitMetadata {
+    static func ggID(in body: String) -> String? {
+        for line in body.split(whereSeparator: \.isNewline) {
+            let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+            guard trimmedLine.hasPrefix("GG-ID:") else { continue }
+
+            let value = trimmedLine.dropFirst("GG-ID:".count)
+                .trimmingCharacters(in: .whitespaces)
+            if !value.isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+}
+
 /// Pure gating logic for the stacked-diffs integration. UI renders only
 /// when every gate passes: master toggle → gg installed → per-project
 /// mode → the current branch is actually stack-shaped.
@@ -136,10 +152,6 @@ enum GGStackGate {
     /// Gate 4: any commit ahead of base carries a `GG-ID:` trailer line.
     /// Pure check over already-loaded commit bodies — no extra git call.
     static func isStackShaped(commits: [CommitInfo]) -> Bool {
-        commits.contains { commit in
-            commit.body.split(whereSeparator: \.isNewline).contains {
-                $0.trimmingCharacters(in: .whitespaces).hasPrefix("GG-ID:")
-            }
-        }
+        commits.contains { GGCommitMetadata.ggID(in: $0.body) != nil }
     }
 }

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -10,12 +10,19 @@ struct CommitRow: View {
         case review
     }
 
+    enum CopyContextMenuAction: Hashable {
+        case copySHA
+        case copyMessage
+        case copyGGID(String)
+    }
+
     let commit: CommitInfo
     let isLast: Bool
     var isHistorical: Bool = false
     let onSelect: () -> Void
     let onCopySHA: () -> Void
     var onCopyMessage: (() -> Void)? = nil
+    var ggID: String? = nil
     var onOpenRemote: (() -> Void)? = nil
     var onEdit: (() -> Void)? = nil
     var onReview: (() -> Void)? = nil
@@ -70,8 +77,16 @@ struct CommitRow: View {
             if onEdit != nil || onReview != nil {
                 Divider()
             }
-            Button("Copy Commit SHA") { copySHA() }
-            Button("Copy Commit Message") { copyMessage() }
+            ForEach(Self.copyContextMenuActions(ggID: ggID), id: \.self) { action in
+                switch action {
+                case .copySHA:
+                    Button("Copy Commit SHA") { copySHA() }
+                case .copyMessage:
+                    Button("Copy Commit Message") { copyMessage() }
+                case .copyGGID(let ggID):
+                    Button("Copy GG-ID") { copyGGID(ggID) }
+                }
+            }
             if let onOpenRemote {
                 Button("Open Commit on Remote") { onOpenRemote() }
             }
@@ -133,6 +148,14 @@ struct CommitRow: View {
         }
         if canReview {
             actions.append(.review)
+        }
+        return actions
+    }
+
+    static func copyContextMenuActions(ggID: String?) -> [CopyContextMenuAction] {
+        var actions: [CopyContextMenuAction] = [.copySHA, .copyMessage]
+        if let ggID {
+            actions.append(.copyGGID(ggID))
         }
         return actions
     }
@@ -282,5 +305,10 @@ struct CommitRow: View {
             Clipboard.copy(commit.fullMessage)
         }
         copyFeedback.show("Copied message")
+    }
+
+    private func copyGGID(_ ggID: String) {
+        Clipboard.copy(ggID)
+        copyFeedback.show("Copied GG-ID")
     }
 }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -200,6 +200,11 @@ struct CommitsSectionView: View {
         rps.ggCommitSelectionIsStale
     }
 
+    static func contextMenuGGID(for commit: CommitInfo, ggModeEnabled: Bool) -> String? {
+        guard ggModeEnabled else { return nil }
+        return GGCommitMetadata.ggID(in: commit.body)
+    }
+
     @ViewBuilder
     private var expandedBody: some View {
         // 1. Worktree commits ("your work") OR today's empty placeholder.
@@ -213,6 +218,7 @@ struct CommitsSectionView: View {
                             onSelect: { onSelect(commit) },
                             onCopySHA: { onCopySHA(commit) },
                             onCopyMessage: { Clipboard.copy(commit.fullMessage) },
+                            ggID: Self.contextMenuGGID(for: commit, ggModeEnabled: rps.ggContext.isActive),
                             onOpenRemote: rps.commitsNeedPush ? nil : openRemoteAction(for: commit, remote: rps.primaryCommitRemote),
                             onEdit: { onEdit(commit) },
                             onReview: { onReview(commit) },
@@ -251,6 +257,7 @@ struct CommitsSectionView: View {
                             onSelect: { onSelect(commit) },
                             onCopySHA: { onCopySHA(commit) },
                             onCopyMessage: { Clipboard.copy(commit.fullMessage) },
+                            ggID: Self.contextMenuGGID(for: commit, ggModeEnabled: rps.ggContext.isActive),
                             onOpenRemote: openRemoteAction(for: commit, remote: rps.commitRemote),
                             onReview: { onReview(commit) },
                             onCherryPick: { rps.requestCherryPick(sha: commit.sha) },

--- a/AlasTests/CommitRowTests.swift
+++ b/AlasTests/CommitRowTests.swift
@@ -67,6 +67,37 @@ struct CommitRowTests {
         #expect(CommitRow.leadingContextMenuActions(canEdit: true, canReview: false) == [.edit])
     }
 
+    @Test func contextMenuPlacesGGIDAfterCommitMessage() {
+        #expect(CommitRow.copyContextMenuActions(ggID: "c-abc123") == [
+            .copySHA,
+            .copyMessage,
+            .copyGGID("c-abc123"),
+        ])
+        #expect(CommitRow.copyContextMenuActions(ggID: nil) == [
+            .copySHA,
+            .copyMessage,
+        ])
+    }
+
+    @Test func commitGGIDIsEligibleOnlyWhileGGModeIsActive() {
+        let commit = CommitInfo(
+            sha: "deadbeef1234567890abcdef1234567890abcdef",
+            shortSha: "deadbee",
+            author: "Nacho Lopez",
+            authorInitials: "NL",
+            date: Date(),
+            subject: "Wire stack identity copy",
+            body: "Details.\n\nGG-ID: c-abc123",
+            conventionalTag: nil,
+            filesChanged: 1,
+            insertions: 2,
+            deletions: 0
+        )
+
+        #expect(CommitsSectionView.contextMenuGGID(for: commit, ggModeEnabled: true) == "c-abc123")
+        #expect(CommitsSectionView.contextMenuGGID(for: commit, ggModeEnabled: false) == nil)
+    }
+
     @Test func ggContextMenuUsesStackedDiffsNameAndSharedIcon() {
         #expect(CommitRow.ggContextMenuTitle == "Stacked Diffs (GG)")
         #expect(CommitRow.ggContextMenuSystemImage == "square.stack.3d.up")

--- a/AlasTests/Integrations/GGStackGateTests.swift
+++ b/AlasTests/Integrations/GGStackGateTests.swift
@@ -101,6 +101,23 @@ struct GGStackGateTests {
         #expect(!GGStackGate.isStackShaped(commits: []))
     }
 
+    @Test func extractsFirstValidGGIDTrailerValue() {
+        let body = "Details.\n\n  GG-ID:   c-first   \nGG-ID: c-second"
+
+        #expect(GGCommitMetadata.ggID(in: body) == "c-first")
+    }
+
+    @Test func rejectsInvalidGGIDTrailerCandidates() {
+        #expect(GGCommitMetadata.ggID(in: "mentions GG-ID: inline") == nil)
+        #expect(GGCommitMetadata.ggID(in: "GG-ID:   ") == nil)
+        #expect(GGCommitMetadata.ggID(in: "gg-id: c-lowercase") == nil)
+        #expect(GGCommitMetadata.ggID(in: "") == nil)
+    }
+
+    @Test func emptyGGIDTrailerDoesNotMakeCommitStackShaped() {
+        #expect(!GGStackGate.isStackShaped(commits: [commit(body: "GG-ID:   ")]))
+    }
+
     private func makeRepo(rebaseInProgress: Bool) throws -> String {
         let dir = NSTemporaryDirectory() + "gg-op-" + UUID().uuidString
         let gitDir = dir + "/.git"


### PR DESCRIPTION
## Summary

- Parse `GG-ID:` trailers through shared GG commit metadata
- Show `Copy GG-ID` in commit context menus while GG mode is active, even while fetched stack data is unavailable
- Cover extraction, eligibility, and copy-menu ordering with focused tests

## Verification

- `git diff --check`
- `rtk swiftformat Alas AlasTests --lint --reporter github-actions-log`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-copy-ggid-review-verify -only-testing:AlasTests/CommitRowTests -only-testing:AlasTests/GGStackGateTests test`