### PR TITLE
fix(acp): mention folder picker

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -217,7 +217,7 @@ enum MentionFuzzy {
         var result: [URL] = []
         var indices: [String: Int] = [:]
         for file in files {
-            let path = relativePath(for: file, root: root).lowercased()
+            let path = relativePath(for: file, root: root)
             if let index = indices[path] {
                 if file.hasDirectoryPath { result[index] = file }
             } else {

--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -19,6 +19,7 @@ struct ACPMentionPickerView: View {
     @State private var isIndexing: Bool = true
     @State private var rankTask: Task<Void, Never>?
     @State private var rankGeneration: Int = 0
+    @State private var scrollOnHighlightChange = false
 
     private let maxDisplay = 80
 
@@ -37,7 +38,6 @@ struct ACPMentionPickerView: View {
         )
         .shadow(color: .black.opacity(0.5), radius: 16, y: 8)
         .onAppear { populateFiles() }
-        .onKeyPress { press in handleKey(press) }
     }
 
     private var search: some View {
@@ -50,7 +50,9 @@ struct ACPMentionPickerView: View {
                 .font(.system(size: 12, design: .monospaced))
                 .focused($searchFocused)
                 .onAppear { searchFocused = true }
+                .onKeyPress { press in handleKey(press) }
                 .onChange(of: query) { _, _ in
+                    scrollOnHighlightChange = false
                     highlight = 0
                     rescheduleRank()
                 }
@@ -87,6 +89,8 @@ struct ACPMentionPickerView: View {
                 .padding(.vertical, 4)
             }
             .onChange(of: highlight) { _, new in
+                guard scrollOnHighlightChange else { return }
+                scrollOnHighlightChange = false
                 guard ranked.indices.contains(new) else { return }
                 proxy.scrollTo(ranked[new], anchor: .center)
             }
@@ -125,28 +129,37 @@ struct ACPMentionPickerView: View {
         }
         .buttonStyle(.plain)
         .onHover { hovering in
-            if hovering { highlight = idx }
+            if hovering {
+                scrollOnHighlightChange = false
+                highlight = idx
+            }
         }
     }
 
     private func handleKey(_ press: KeyPress) -> KeyPress.Result {
-        let count = ranked.count
         switch press.key {
         case .escape:
             onCancel()
             return .handled
         case .upArrow:
-            highlight = max(0, highlight - 1)
+            moveHighlight(by: -1)
             return .handled
         case .downArrow:
-            highlight = min(max(0, count - 1), highlight + 1)
+            moveHighlight(by: 1)
             return .handled
-        case .return:
+        case .return, .tab:
             if ranked.indices.contains(highlight) { onPick(ranked[highlight]) }
             return .handled
         default:
             return .ignored
         }
+    }
+
+    private func moveHighlight(by offset: Int) {
+        let next = MentionPickerNavigation.move(from: highlight, by: offset, count: ranked.count)
+        guard next != highlight else { return }
+        scrollOnHighlightChange = true
+        highlight = next
     }
 
     private func populateFiles() {
@@ -161,7 +174,7 @@ struct ACPMentionPickerView: View {
                     MentionFuzzy.collectFiles(under: root, limit: 5000)
                 }.value
             }
-            allFiles = files
+            allFiles = MentionFuzzy.deduplicated(files: files, relativeTo: worktreeRoot)
             isIndexing = false
             rescheduleRank()
         }
@@ -191,9 +204,30 @@ struct ACPMentionPickerView: View {
     }
 }
 
+enum MentionPickerNavigation {
+    static func move(from index: Int, by offset: Int, count: Int) -> Int {
+        min(max(0, count - 1), max(0, index + offset))
+    }
+}
+
 // MARK: - Fuzzy matching
 
 enum MentionFuzzy {
+    static func deduplicated(files: [URL], relativeTo root: URL) -> [URL] {
+        var result: [URL] = []
+        var indices: [String: Int] = [:]
+        for file in files {
+            let path = relativePath(for: file, root: root).lowercased()
+            if let index = indices[path] {
+                if file.hasDirectoryPath { result[index] = file }
+            } else {
+                indices[path] = result.count
+                result.append(file)
+            }
+        }
+        return result
+    }
+
     static func collectFiles(under root: URL, limit: Int) -> [URL] {
         var out: [URL] = []
         let skipDirs: Set<String> = [
@@ -269,15 +303,22 @@ enum MentionFuzzy {
             .map(String.init)
         guard !tokens.isEmpty else { return Array(files.prefix(limit)) }
 
-        var scored: [(url: URL, score: Double, relativePath: String)] = []
+        let normalizedQuery = query.lowercased()
+        var scored: [(url: URL, pathPriority: Int, score: Double, relativePath: String)] = []
         for f in files {
             let relativePath = relativePath(for: f, root: root)
             guard let score = score(file: f, relativePath: relativePath, tokens: tokens) else {
                 continue
             }
-            scored.append((f, score, relativePath))
+            let normalizedPath = relativePath.lowercased()
+            let pathPriority = normalizedPath == normalizedQuery ? 3
+                : normalizedPath.hasPrefix(normalizedQuery) ? 2
+                : normalizedPath.contains(normalizedQuery) ? 1
+                : 0
+            scored.append((f, pathPriority, score, relativePath))
         }
         scored.sort {
+            if $0.pathPriority != $1.pathPriority { return $0.pathPriority > $1.pathPriority }
             if $0.score != $1.score { return $0.score > $1.score }
             if $0.relativePath.count != $1.relativePath.count {
                 return $0.relativePath.count < $1.relativePath.count

--- a/AlasTests/ACP/UI/ACPMentionPickerTests.swift
+++ b/AlasTests/ACP/UI/ACPMentionPickerTests.swift
@@ -64,6 +64,17 @@ struct ACPMentionPickerTests {
         #expect(result.first?.hasDirectoryPath == true)
     }
 
+    @Test("keeps case-distinct candidates")
+    func keepsCaseDistinctCandidates() {
+        let root = URL(fileURLWithPath: "/tmp/project")
+        let uppercase = root.appendingPathComponent("Sources/Foo.swift")
+        let lowercase = root.appendingPathComponent("Sources/foo.swift")
+
+        let result = MentionFuzzy.deduplicated(files: [uppercase, lowercase], relativeTo: root)
+
+        #expect(result == [uppercase, lowercase])
+    }
+
     @Test("keyboard navigation stays within the available results")
     func keyboardNavigationClamps() {
         #expect(MentionPickerNavigation.move(from: 0, by: -1, count: 3) == 0)

--- a/AlasTests/ACP/UI/ACPMentionPickerTests.swift
+++ b/AlasTests/ACP/UI/ACPMentionPickerTests.swift
@@ -34,6 +34,44 @@ struct ACPMentionPickerTests {
         #expect(matches.first == root.appendingPathComponent("Sources/App.swift"))
     }
 
+    @Test("ranks an exact relative path ahead of a scattered fuzzy match")
+    func exactRelativePathWins() {
+        let root = URL(fileURLWithPath: "/tmp/project")
+        let expected = root.appendingPathComponent("ab/cd", isDirectory: true)
+        let files = [
+            root.appendingPathComponent("A_B/C_D", isDirectory: true),
+            expected,
+        ]
+
+        let matches = MentionFuzzy.rank(files: files, query: "ab/cd", limit: 10, relativeTo: root)
+
+        #expect(matches.first == expected)
+    }
+
+    @Test("deduplicates candidates by relative path and preserves directory URLs")
+    func deduplicatesCandidates() {
+        let root = URL(fileURLWithPath: "/tmp/project")
+        let fileShapedDirectory = root.appendingPathComponent("packages/common/core")
+        let directory = root.appendingPathComponent("packages/common/core", isDirectory: true)
+        let sibling = root.appendingPathComponent("packages/common/other", isDirectory: true)
+
+        let result = MentionFuzzy.deduplicated(
+            files: [fileShapedDirectory, sibling, directory],
+            relativeTo: root
+        )
+
+        #expect(result == [directory, sibling])
+        #expect(result.first?.hasDirectoryPath == true)
+    }
+
+    @Test("keyboard navigation stays within the available results")
+    func keyboardNavigationClamps() {
+        #expect(MentionPickerNavigation.move(from: 0, by: -1, count: 3) == 0)
+        #expect(MentionPickerNavigation.move(from: 0, by: 1, count: 3) == 1)
+        #expect(MentionPickerNavigation.move(from: 2, by: 1, count: 3) == 2)
+        #expect(MentionPickerNavigation.move(from: 0, by: 1, count: 0) == 0)
+    }
+
     @Test("collectFiles includes directories alongside files, flagged as directories")
     func collectFilesIncludesDirectories() throws {
         let root = try makeTempTree([


### PR DESCRIPTION
## Summary

- prioritize exact, prefix, and contiguous relative-path matches before fuzzy results
- deduplicate mention candidates while preserving directory URLs
- make arrow keys, Enter, Tab, and Escape work from the focused search field
- stop hover selection from programmatically recentering the scroll view

## Root cause

Folder candidates could be duplicated with file-shaped URLs, direct path matches had no priority over scattered fuzzy matches, and key handling sat outside the focused text field. Hover selection also shared the same scroll-to-highlight path as keyboard navigation, causing pointer movement to fight manual scrolling.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPMentionPickerTests -quiet`
- full test suite: 7,836 tests ran; three unrelated transient failures passed on isolated rerun
