### PR TITLE
feat(drag): insert paths and SHAs into agents and terminals

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 		5806E3E41DA735380E33BF76 /* DiffReviewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D1ECA099BBDCB5BB2EEC67 /* DiffReviewModels.swift */; };
 		584066607B7E7E97A736213A /* AppQuitAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942B0DCA09E1297D9380C58C /* AppQuitAction.swift */; };
 		5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */; };
+		586FFC3F48E8E777ADD11DD4 /* ACPComposerDropRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458CE5FB9F4C19BE30643F39 /* ACPComposerDropRouter.swift */; };
 		588A1EB3D20EB2419A5A03B4 /* ACPStdioQuestionDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2015944331CE56AEEF534910 /* ACPStdioQuestionDispatchTests.swift */; };
 		58A58A64E7E10EC5A1CC60C5 /* FileDeviceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18E4AD4B92330FB085C821C /* FileDeviceStore.swift */; };
 		58B2E8C756F6D3CB08FB3B10 /* ReviewSessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */; };
@@ -1997,6 +1998,7 @@
 		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
 		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
 		457858DB2CF0B558A1A490BC /* AlasCLIWorktreeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIWorktreeResolver.swift; sourceTree = "<group>"; };
+		458CE5FB9F4C19BE30643F39 /* ACPComposerDropRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDropRouter.swift; sourceTree = "<group>"; };
 		45952C734DFE7E7F02B047E7 /* ACPThumbnailImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThumbnailImageCache.swift; sourceTree = "<group>"; };
 		45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreCRUDTests.swift; sourceTree = "<group>"; };
 		45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModelTests.swift; sourceTree = "<group>"; };
@@ -4586,6 +4588,7 @@
 				C496549308D5C3DD20E988AD /* ACPComposer.swift */,
 				E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */,
 				2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */,
+				458CE5FB9F4C19BE30643F39 /* ACPComposerDropRouter.swift */,
 				FF1494739C8FBECE52DAAAE3 /* ACPComposerFocusPolicy.swift */,
 				906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */,
 				DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */,
@@ -6038,6 +6041,7 @@
 				9CF6B43A0B19392A597A53EC /* ACPComposerActionButton.swift in Sources */,
 				1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */,
 				E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */,
+				586FFC3F48E8E777ADD11DD4 /* ACPComposerDropRouter.swift in Sources */,
 				B6B861A60445F450FB94A0CF /* ACPComposerFocusPolicy.swift in Sources */,
 				C04150547C17399FA9D7947C /* ACPComposerShell.swift in Sources */,
 				1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -804,6 +804,7 @@
 		85B8A8B929BD4ED4DC21FEDD /* ACPDelayedHoverVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3D3BB0A631D42AD22DBE0F /* ACPDelayedHoverVisibility.swift */; };
 		85C7E65296AB9500FF52060A /* session-update-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = 7094534860369BA79FC5A877 /* session-update-plan.json */; };
 		85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */; };
+		861DC3733D8F7A5339C3489E /* AlasDropPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CC75D28C2EE22D16E24964 /* AlasDropPayload.swift */; };
 		864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
 		86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */; };
@@ -1771,6 +1772,7 @@
 		2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallProgressSheet.swift; sourceTree = "<group>"; };
 		239125BB939233233D405EB8 /* ACPChipStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipStateTests.swift; sourceTree = "<group>"; };
 		2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParser.swift; sourceTree = "<group>"; };
+		23CC75D28C2EE22D16E24964 /* AlasDropPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasDropPayload.swift; sourceTree = "<group>"; };
 		23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextView.swift; sourceTree = "<group>"; };
 		2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBindingTests.swift; sourceTree = "<group>"; };
 		2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostProviderTests.swift; sourceTree = "<group>"; };
@@ -5072,6 +5074,7 @@
 		B7F55BCF5A6A07CC612FB354 /* DragOut */ = {
 			isa = PBXGroup;
 			children = (
+				23CC75D28C2EE22D16E24964 /* AlasDropPayload.swift */,
 				38228AE1419253ADBC80E226 /* DragOutPayload.swift */,
 				4610C65B69BD08EF8DF12311 /* DragOutSession.swift */,
 				12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */,
@@ -6203,6 +6206,7 @@
 				29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */,
 				DC8458FA4C5FCC854BB46B96 /* AlasCLIReviewTargetResolver.swift in Sources */,
 				00D95534280A5CED2356D06D /* AlasCLIWorktreeResolver.swift in Sources */,
+				861DC3733D8F7A5339C3489E /* AlasDropPayload.swift in Sources */,
 				24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */,
 				9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */,
 				8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -16,6 +16,7 @@ struct ACPInputField: NSViewRepresentable {
     @ObservedObject var composer: ACPComposerState
     let worktreeRoot: URL
     let actions: ACPComposerActions
+    let dropRouter: ACPComposerDropRouter
     @Binding var isFocused: Bool
     let focusRequest: Int
     /// True when ⏎ should submit with `.auto` intent (the default mapping
@@ -52,6 +53,7 @@ struct ACPInputField: NSViewRepresentable {
         textView.textColor = NSColor(named: "fg") ?? NSColor.labelColor
         textView.insertionPointColor = NSColor.controlAccentColor
         context.coordinator.textView = textView
+        dropRouter.attach(textView)
         context.coordinator.onImageError = onImageError
         textView.registerForDraggedTypes([.fileURL, .png, .tiff])
         context.coordinator.restoreInitialDraft(into: textView)
@@ -116,6 +118,7 @@ struct ACPInputField: NSViewRepresentable {
         coordinator.isFocused.wrappedValue = false
         coordinator.flushPendingRestyleNow()
         if let tv = nsView.documentView as? ACPNSTextView {
+            coordinator.dropRouter.detach(tv)
             tv.dismissFloatingPanels()
         }
     }
@@ -146,7 +149,8 @@ struct ACPInputField: NSViewRepresentable {
             onDraftChange: onDraftChange,
             onDraftClear: onDraftClear,
             onSubmit: onSubmit,
-            filesProvider: filesProvider
+            filesProvider: filesProvider,
+            dropRouter: dropRouter
         )
     }
 
@@ -168,6 +172,7 @@ struct ACPInputField: NSViewRepresentable {
         let onDraftClear: () -> Void
         let onSubmit: ACPComposerSubmitHandler
         let filesProvider: (@Sendable () async -> [URL])?
+        let dropRouter: ACPComposerDropRouter
         var promptSuggestions: [ACPPromptSuggestion] = []
         /// Snapshotted at makeNSView time so the AppKit-only slash panel
         /// can render its SwiftUI content with our theme tokens.
@@ -208,7 +213,8 @@ struct ACPInputField: NSViewRepresentable {
             onDraftChange: @escaping (ACPComposerDraft) -> Void,
             onDraftClear: @escaping () -> Void,
             onSubmit: @escaping ACPComposerSubmitHandler,
-            filesProvider: (@Sendable () async -> [URL])? = nil
+            filesProvider: (@Sendable () async -> [URL])? = nil,
+            dropRouter: ACPComposerDropRouter = ACPComposerDropRouter()
         ) {
             self.worktreeRoot = worktreeRoot
             self.initialDraft = initialDraft
@@ -221,6 +227,7 @@ struct ACPInputField: NSViewRepresentable {
             self.onDraftClear = onDraftClear
             self.onSubmit = onSubmit
             self.filesProvider = filesProvider
+            self.dropRouter = dropRouter
         }
 
         func textDidBeginEditing(_ notification: Notification) {

--- a/Alas/Sources/ACP/UI/ACPComposerDropRouter.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerDropRouter.swift
@@ -1,0 +1,32 @@
+import AppKit
+
+/// Bridges a drop accepted by the whole chat surface to the currently mounted
+/// AppKit composer without replacing its selection, undo, or draft pipeline.
+@MainActor
+final class ACPComposerDropRouter: ObservableObject {
+    private weak var textView: ACPNSTextView?
+
+    var isAttached: Bool { textView != nil }
+
+    func attach(_ textView: ACPNSTextView) {
+        self.textView = textView
+    }
+
+    func detach(_ textView: ACPNSTextView) {
+        guard self.textView === textView else { return }
+        self.textView = nil
+    }
+
+    @discardableResult
+    func insert(encoded data: Data, enabled: Bool) -> Bool {
+        guard let payload = AlasDropPayload.decode(data) else { return false }
+        return insert(payload, enabled: enabled)
+    }
+
+    @discardableResult
+    func insert(_ payload: AlasDropPayload, enabled: Bool) -> Bool {
+        guard enabled, let textView else { return false }
+        textView.window?.makeFirstResponder(textView)
+        return textView.insertPlainText(payload.agentText)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -101,6 +101,7 @@ struct ACPComposer: View {
     /// triggers under the current mapping.
     let sendOnEnter: Bool
     let focusRequest: Int
+    let dropRouter: ACPComposerDropRouter
     let placement: ACPComposerPlacement
     let contentMaxWidth: CGFloat
     let typography: ACPChatTypography
@@ -120,6 +121,7 @@ struct ACPComposer: View {
         agentLookup: @escaping (String) -> AgentDefinition?,
         sendOnEnter: Bool,
         focusRequest: Int = 0,
+        dropRouter: ACPComposerDropRouter,
         placement: ACPComposerPlacement = .bottom,
         contentMaxWidth: CGFloat = ACPChatLayout.defaultContentMaxWidth,
         typography: ACPChatTypography = .default,
@@ -133,6 +135,7 @@ struct ACPComposer: View {
         self.agentLookup = agentLookup
         self.sendOnEnter = sendOnEnter
         self.focusRequest = focusRequest
+        self.dropRouter = dropRouter
         self.placement = placement
         self.contentMaxWidth = contentMaxWidth
         self.typography = typography
@@ -212,6 +215,7 @@ struct ACPComposer: View {
                 composer: composer,
                 worktreeRoot: worktreeRoot,
                 actions: actions,
+                dropRouter: dropRouter,
                 isFocused: $inputFocused,
                 focusRequest: focusRequest,
                 sendOnEnter: sendOnEnter,

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 enum ACPSessionAttachFreshness {
     static func isFresh(restoredFromPersistence: Bool, remoteSessionId: String?) -> Bool {
@@ -102,6 +103,7 @@ private struct ACPSessionView: View {
     @State private var dismissedLatest: String?
     @Environment(\.theme) private var theme
     @State private var composerFocusRequest: Int = 0
+    @StateObject private var composerDropRouter = ACPComposerDropRouter()
 
     private var adapterTarget: ACPAdapterTarget {
         guard let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path) else {
@@ -250,8 +252,31 @@ private struct ACPSessionView: View {
                 .frame(width: chatProxy.size.width, height: chatProxy.size.height)
                 .animation(emptyStateAnimation, value: isNewEmptySession)
                 .animation(emptyStateAnimation, value: isFirstRunConnecting)
+                .onDrop(of: [.alasDropPayload], isTargeted: nil, perform: handleDrop)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+        guard !isMirror,
+              composerDropRouter.isAttached,
+              let provider = providers.first(where: {
+                  $0.hasItemConformingToTypeIdentifier(UTType.alasDropPayload.identifier)
+              })
+        else { return false }
+
+        provider.loadDataRepresentation(
+            forTypeIdentifier: UTType.alasDropPayload.identifier
+        ) { data, _ in
+            guard let data else { return }
+            Task { @MainActor in
+                _ = composerDropRouter.insert(
+                    encoded: data,
+                    enabled: !manager.isMirror(sessionId: sessionId)
+                )
+            }
+        }
+        return true
     }
 
     private func chatSurface(contentMaxWidth: CGFloat) -> some View {
@@ -460,6 +485,7 @@ private struct ACPSessionView: View {
             agentLookup: { state.agent(id: $0) },
             sendOnEnter: state.config.harness.acpSendOnEnter,
             focusRequest: composerFocusRequest,
+            dropRouter: composerDropRouter,
             placement: placement,
             contentMaxWidth: contentMaxWidth,
             typography: typography ?? chatTypography,

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -67,6 +67,7 @@ struct CommitHeaderView: View {
                 }
                 .pointingHandCursor()
                 .help("Click to copy SHA")
+                .dragOut { .commitSHA(details.info.sha) }
             Text("·").foregroundColor(theme.color("fg-faint"))
             Text(details.info.author)
                 .font(.system(size: 11))
@@ -129,6 +130,7 @@ struct CommitHeaderView: View {
                                 }
                                 .pointingHandCursor()
                                 .help("Click to copy SHA")
+                                .dragOut { .commitSHA(parent) }
                             if index < details.parents.count - 1 {
                                 Text(" ")
                             }

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -124,7 +124,7 @@ struct CommitHeaderView: View {
                     HStack(spacing: 4) {
                         Text("parent" + (details.parents.count > 1 ? "s" : "") + ":")
                         ForEach(Array(details.parents.enumerated()), id: \.offset) { index, parent in
-                            Text(parent)
+                            Text(parent.prefix(7))
                                 .onTapGesture {
                                     copyToPasteboard(parent, feedback: "Copied SHA")
                                 }

--- a/Alas/Sources/DragOut/AlasDropPayload.swift
+++ b/Alas/Sources/DragOut/AlasDropPayload.swift
@@ -35,13 +35,26 @@ enum AlasDropPayload: Codable, Equatable, Sendable {
     }
 
     private var isValid: Bool {
-        guard case .commitSHA(let sha) = self else { return true }
-        return (sha.count == 40 || sha.count == 64)
-            && sha.unicodeScalars.allSatisfy { scalar in
-                (48 ... 57).contains(scalar.value)
-                    || (65 ... 70).contains(scalar.value)
-                    || (97 ... 102).contains(scalar.value)
-            }
+        switch self {
+        case .file(let relativePath, let absolutePath):
+            return !relativePath.containsTerminalControlCharacter
+                && !absolutePath.containsTerminalControlCharacter
+        case .commitSHA(let sha):
+            return (sha.count == 40 || sha.count == 64)
+                && sha.unicodeScalars.allSatisfy { scalar in
+                    (48 ... 57).contains(scalar.value)
+                        || (65 ... 70).contains(scalar.value)
+                        || (97 ... 102).contains(scalar.value)
+                }
+        }
+    }
+}
+
+private extension String {
+    var containsTerminalControlCharacter: Bool {
+        unicodeScalars.contains { scalar in
+            (0 ... 31).contains(scalar.value) || (127 ... 159).contains(scalar.value)
+        }
     }
 }
 

--- a/Alas/Sources/DragOut/AlasDropPayload.swift
+++ b/Alas/Sources/DragOut/AlasDropPayload.swift
@@ -23,6 +23,32 @@ enum AlasDropPayload: Codable, Equatable, Sendable {
         case .commitSHA(let sha): sha
         }
     }
+
+    var terminalText: String {
+        switch self {
+        case .file(_, let absolutePath): POSIXShellArgument.escape(absolutePath)
+        case .commitSHA(let sha): sha
+        }
+    }
+}
+
+enum POSIXShellArgument {
+    static func escape(_ value: String) -> String {
+        guard !value.isEmpty else { return "''" }
+        if value.unicodeScalars.allSatisfy(isSafe) {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private static func isSafe(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 48 ... 57, 65 ... 90, 97 ... 122:
+            return true
+        default:
+            return "_@%+=:,./-".unicodeScalars.contains(scalar)
+        }
+    }
 }
 
 extension NSPasteboard.PasteboardType {

--- a/Alas/Sources/DragOut/AlasDropPayload.swift
+++ b/Alas/Sources/DragOut/AlasDropPayload.swift
@@ -1,0 +1,34 @@
+import AppKit
+import Foundation
+
+/// Structured text that Alas drag sources can hand to Alas-owned input views.
+/// Public pasteboard flavors remain separate so internal targets never need to
+/// infer whether an arbitrary string is a path or a commit SHA.
+enum AlasDropPayload: Codable, Equatable, Sendable {
+    case file(relativePath: String, absolutePath: String)
+    case commitSHA(String)
+
+    func encoded() -> Data? {
+        try? JSONEncoder().encode(self)
+    }
+
+    static func decode(_ data: Data) -> AlasDropPayload? {
+        try? JSONDecoder().decode(Self.self, from: data)
+    }
+}
+
+extension NSPasteboard.PasteboardType {
+    static let alasDropPayload = NSPasteboard.PasteboardType("io.nlopez.alas.drop-payload")
+}
+
+/// All representations available when a drag lifts. `dropPayload` is private
+/// to Alas; the optional URL/text values are standard flavors for other apps.
+struct DragOutPreparedItem: Equatable, Sendable {
+    let dropPayload: AlasDropPayload?
+    let fileURL: URL?
+    let publicText: String?
+
+    var hasExternalRepresentation: Bool {
+        fileURL != nil || publicText != nil
+    }
+}

--- a/Alas/Sources/DragOut/AlasDropPayload.swift
+++ b/Alas/Sources/DragOut/AlasDropPayload.swift
@@ -14,7 +14,10 @@ enum AlasDropPayload: Codable, Equatable, Sendable {
     }
 
     static func decode(_ data: Data) -> AlasDropPayload? {
-        try? JSONDecoder().decode(Self.self, from: data)
+        guard let payload = try? JSONDecoder().decode(Self.self, from: data), payload.isValid else {
+            return nil
+        }
+        return payload
     }
 
     var agentText: String {
@@ -29,6 +32,16 @@ enum AlasDropPayload: Codable, Equatable, Sendable {
         case .file(_, let absolutePath): POSIXShellArgument.escape(absolutePath)
         case .commitSHA(let sha): sha
         }
+    }
+
+    private var isValid: Bool {
+        guard case .commitSHA(let sha) = self else { return true }
+        return (sha.count == 40 || sha.count == 64)
+            && sha.unicodeScalars.allSatisfy { scalar in
+                (48 ... 57).contains(scalar.value)
+                    || (65 ... 70).contains(scalar.value)
+                    || (97 ... 102).contains(scalar.value)
+            }
     }
 }
 

--- a/Alas/Sources/DragOut/AlasDropPayload.swift
+++ b/Alas/Sources/DragOut/AlasDropPayload.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import UniformTypeIdentifiers
 
 /// Structured text that Alas drag sources can hand to Alas-owned input views.
 /// Public pasteboard flavors remain separate so internal targets never need to
@@ -15,10 +16,21 @@ enum AlasDropPayload: Codable, Equatable, Sendable {
     static func decode(_ data: Data) -> AlasDropPayload? {
         try? JSONDecoder().decode(Self.self, from: data)
     }
+
+    var agentText: String {
+        switch self {
+        case .file(let relativePath, _): relativePath
+        case .commitSHA(let sha): sha
+        }
+    }
 }
 
 extension NSPasteboard.PasteboardType {
     static let alasDropPayload = NSPasteboard.PasteboardType("io.nlopez.alas.drop-payload")
+}
+
+extension UTType {
+    static let alasDropPayload = UTType(exportedAs: NSPasteboard.PasteboardType.alasDropPayload.rawValue)
 }
 
 /// All representations available when a drag lifts. `dropPayload` is private

--- a/Alas/Sources/DragOut/DragOutPayload.swift
+++ b/Alas/Sources/DragOut/DragOutPayload.swift
@@ -7,27 +7,63 @@ import Foundation
 enum DragOutPayload: Equatable, Sendable {
     /// A file or directory that exists in a local worktree. Dragging this hands
     /// over the live file, so edits in the receiving app land back in the repo.
-    case onDisk(URL)
+    case onDisk(URL, insertion: AlasDropPayload? = nil)
 
     /// A blob at a git revision, materialized to a temp file on demand.
     case revision(worktreePath: URL, ref: String, path: String)
 
+    /// Text with no corresponding file representation, such as a commit SHA.
+    case commitSHA(String)
+
     func resolve(using cache: RevisionSnapshotCache = .shared) async -> URL? {
         switch self {
-        case .onDisk(let url):
+        case .onDisk(let url, _):
             guard !url.isRemoteAlasPath else { return nil }
             guard FileManager.default.fileExists(atPath: url.path) else { return nil }
             return url
         case .revision(let worktreePath, let ref, let path):
             guard !worktreePath.isRemoteAlasPath else { return nil }
             return await cache.snapshot(worktreePath: worktreePath, ref: ref, path: path)
+        case .commitSHA:
+            return nil
+        }
+    }
+
+    func prepare(using cache: RevisionSnapshotCache = .shared) async -> DragOutPreparedItem? {
+        switch self {
+        case .onDisk(let url, let insertion):
+            guard !url.isRemoteAlasPath,
+                  FileManager.default.fileExists(atPath: url.path)
+            else {
+                return insertion.map {
+                    DragOutPreparedItem(dropPayload: $0, fileURL: nil, publicText: nil)
+                }
+            }
+            return DragOutPreparedItem(
+                dropPayload: insertion,
+                fileURL: url,
+                publicText: url.path
+            )
+        case .revision:
+            guard let url = await resolve(using: cache) else { return nil }
+            return DragOutPreparedItem(dropPayload: nil, fileURL: url, publicText: url.path)
+        case .commitSHA(let sha):
+            return DragOutPreparedItem(
+                dropPayload: .commitSHA(sha),
+                fileURL: nil,
+                publicText: sha
+            )
         }
     }
 }
 
 extension DragOutPayload {
     static func workingTreeFile(worktreePath: URL, relativePath: String) -> DragOutPayload {
-        .onDisk(worktreePath.appendingPathComponent(relativePath))
+        let absoluteURL = worktreePath.appendingPathComponent(relativePath)
+        return .onDisk(
+            absoluteURL,
+            insertion: .file(relativePath: relativePath, absolutePath: absoluteURL.path)
+        )
     }
 
     /// Untracked files live on the stash commit's third parent; tracked files

--- a/Alas/Sources/DragOut/DragOutSession.swift
+++ b/Alas/Sources/DragOut/DragOutSession.swift
@@ -12,20 +12,35 @@ final class DragOutSession: NSObject, NSDraggingSource {
     /// Drag image edge length, in points.
     private static let iconSize: CGFloat = 32
 
-    nonisolated static func operationMask(for context: NSDraggingContext) -> NSDragOperation {
+    nonisolated static func operationMask(
+        for context: NSDraggingContext,
+        hasInternalPayload: Bool,
+        hasExternalRepresentation: Bool
+    ) -> NSDragOperation {
         switch context {
-        case .outsideApplication: return .copy
-        case .withinApplication: return []
-        @unknown default: return .copy
+        case .outsideApplication:
+            return hasExternalRepresentation ? .copy : []
+        case .withinApplication:
+            return hasInternalPayload ? .copy : []
+        @unknown default:
+            return hasExternalRepresentation ? .copy : []
         }
     }
 
     /// Two flavors: the file URL for apps that open files, and the absolute
     /// POSIX path for terminals and text fields.
-    nonisolated static func pasteboardItem(for url: URL) -> NSPasteboardItem {
+    nonisolated static func pasteboardItem(for prepared: DragOutPreparedItem) -> NSPasteboardItem {
         let item = NSPasteboardItem()
-        item.setString(url.absoluteString, forType: .fileURL)
-        item.setString(url.path, forType: .string)
+        if let payload = prepared.dropPayload,
+           let data = payload.encoded() {
+            item.setData(data, forType: .alasDropPayload)
+        }
+        if let url = prepared.fileURL {
+            item.setString(url.absoluteString, forType: .fileURL)
+        }
+        if let text = prepared.publicText {
+            item.setString(text, forType: .string)
+        }
         return item
     }
 
@@ -33,12 +48,17 @@ final class DragOutSession: NSObject, NSDraggingSource {
         _ session: NSDraggingSession,
         sourceOperationMaskFor context: NSDraggingContext
     ) -> NSDragOperation {
-        Self.operationMask(for: context)
+        let pasteboard = session.draggingPasteboard
+        return Self.operationMask(
+            for: context,
+            hasInternalPayload: pasteboard.availableType(from: [.alasDropPayload]) != nil,
+            hasExternalRepresentation: pasteboard.availableType(from: [.fileURL, .string]) != nil
+        )
     }
 
-    func begin(url: URL, event: NSEvent, in view: NSView) {
-        let item = NSDraggingItem(pasteboardWriter: Self.pasteboardItem(for: url))
-        let icon = NSWorkspace.shared.icon(forFile: url.path)
+    func begin(prepared: DragOutPreparedItem, event: NSEvent, in view: NSView) {
+        let item = NSDraggingItem(pasteboardWriter: Self.pasteboardItem(for: prepared))
+        let icon = dragIcon(for: prepared)
         let size = NSSize(width: Self.iconSize, height: Self.iconSize)
         icon.size = size
         let origin = view.convert(event.locationInWindow, from: nil)
@@ -52,5 +72,18 @@ final class DragOutSession: NSObject, NSDraggingSource {
             contents: icon
         )
         view.beginDraggingSession(with: [item], event: event, source: self)
+    }
+
+    private func dragIcon(for prepared: DragOutPreparedItem) -> NSImage {
+        if let url = prepared.fileURL {
+            return NSWorkspace.shared.icon(forFile: url.path)
+        }
+        let symbolName: String
+        switch prepared.dropPayload {
+        case .commitSHA: symbolName = "number"
+        case .file: symbolName = "doc"
+        case nil: symbolName = "doc"
+        }
+        return NSImage(systemSymbolName: symbolName, accessibilityDescription: nil) ?? NSImage()
     }
 }

--- a/Alas/Sources/DragOut/ViewDragOut.swift
+++ b/Alas/Sources/DragOut/ViewDragOut.swift
@@ -36,7 +36,7 @@ extension View {
 private final class DragOutState: ObservableObject {
     var armed = false
     var began = false
-    var resolveTask: Task<URL?, Never>?
+    var resolveTask: Task<DragOutPreparedItem?, Never>?
     var beginTask: Task<Void, Never>?
 
     /// Called when the gesture ends without a drag ever lifting (a plain
@@ -67,7 +67,7 @@ private struct DragOutModifier: ViewModifier {
                     if !state.armed, travel >= DragOutActivation.prefetchDistance {
                         state.armed = true
                         if let payload = payload() {
-                            state.resolveTask = Task { await payload.resolve() }
+                            state.resolveTask = Task { await payload.prepare() }
                         }
                     }
                     guard !state.began,
@@ -77,12 +77,12 @@ private struct DragOutModifier: ViewModifier {
                     state.began = true
                     let state = state
                     state.beginTask = Task { @MainActor in
-                        guard let url = await resolveTask.value, !Task.isCancelled,
+                        guard let prepared = await resolveTask.value, !Task.isCancelled,
                               let event = NSApp.currentEvent,
                               event.type == .leftMouseDragged || event.type == .leftMouseDown,
                               let view = event.window?.contentView
                         else { return }        // no reset: onEnded will clean up
-                        DragOutSession.shared.begin(url: url, event: event, in: view)
+                        DragOutSession.shared.begin(prepared: prepared, event: event, in: view)
                         state.reset()          // only here — onEnded won't fire
                     }
                 }

--- a/Alas/Sources/Git/CommitDetails.swift
+++ b/Alas/Sources/Git/CommitDetails.swift
@@ -4,7 +4,7 @@ struct CommitDetails: Equatable {
     let info: CommitInfo
     let body: String          // commit message minus the subject line; "" if none
     let authorEmail: String
-    let parents: [String]     // short shas of parent commits, in git order
+    let parents: [String]     // full shas of parent commits, in git order
     let files: [CommitChangedFile]
 }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -950,7 +950,6 @@ extension GitService {
 
         let parents = parentsField
             .split(separator: " ")
-            .map { String($0).prefix(7) }
             .map(String.init)
 
         // Files: two separate diff-tree calls.

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -220,6 +220,7 @@ struct CommitRow: View {
                 }
                 .pointingHandCursor()
                 .help("Click to copy SHA")
+                .dragOut { .commitSHA(commit.sha) }
             avatar
             Text(relativeTime(commit.date))
                 .font(.system(size: 10.5))

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -157,7 +157,12 @@ struct FilesTabView: View {
                     .buttonStyle(.plain)
                     .contextMenu { contextMenu(for: terminal) }
                     .dragOut {
-                        worktreeRoot.map { DragOutPayload.onDisk($0.appendingPathComponent(terminal.path)) }
+                        worktreeRoot.map {
+                            DragOutPayload.workingTreeFile(
+                                worktreePath: $0,
+                                relativePath: terminal.path
+                            )
+                        }
                     }
                     if open && canExpand {
                         switch terminal.childrenState {
@@ -212,7 +217,12 @@ struct FilesTabView: View {
                 .buttonStyle(.plain)
                 .contextMenu { contextMenu(for: node) }
                 .dragOut {
-                    worktreeRoot.map { DragOutPayload.onDisk($0.appendingPathComponent(node.path)) }
+                    worktreeRoot.map {
+                        DragOutPayload.workingTreeFile(
+                            worktreePath: $0,
+                            relativePath: node.path
+                        )
+                    }
                 }
             )
         }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -148,6 +148,7 @@ extension AlasGhostty {
 
             // Enable layer-backed rendering. We'll configure the layer in makeBackingLayer().
             wantsLayer = true
+            registerForDraggedTypes([.alasDropPayload])
 
             // The surface config passes `self` as userdata so C callbacks can recover us.
             let selfPtr = Unmanaged.passUnretained(self).toOpaque()
@@ -173,6 +174,7 @@ extension AlasGhostty {
             self.app = nil
             super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
             wantsLayer = true
+            registerForDraggedTypes([.alasDropPayload])
             self.cSurface = nil
             self.surfaceIO = testIO
         }
@@ -281,6 +283,32 @@ extension AlasGhostty {
             ))
         }
 
+        override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+            canHandleAlasDrop(from: sender.draggingPasteboard) ? .copy : []
+        }
+
+        override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+            handleAlasDrop(from: sender.draggingPasteboard)
+        }
+
+        private func canHandleAlasDrop(from pasteboard: NSPasteboard) -> Bool {
+            guard surfaceIO != nil,
+                  let data = pasteboard.data(forType: .alasDropPayload)
+            else { return false }
+            return AlasDropPayload.decode(data) != nil
+        }
+
+        @discardableResult
+        func handleAlasDrop(from pasteboard: NSPasteboard) -> Bool {
+            guard let io = surfaceIO,
+                  let data = pasteboard.data(forType: .alasDropPayload),
+                  let payload = AlasDropPayload.decode(data)
+            else { return false }
+            window?.makeFirstResponder(self)
+            io.sendText(payload.terminalText)
+            return true
+        }
+
         // Ghostty performs its own Metal rendering; we just trigger a draw call.
         override func draw(_ dirtyRect: NSRect) {
             cSurface.map { ghostty_surface_draw($0) }
@@ -314,11 +342,7 @@ extension AlasGhostty {
 
         /// Inject text directly into the PTY (e.g. for paste or synthetic input).
         func sendText(_ text: String) {
-            guard let surface = cSurface else { return }
-            let bytes = text.utf8.count
-            text.withCString { ptr in
-                ghostty_surface_text(surface, ptr, UInt(bytes))
-            }
+            surfaceIO?.sendText(text)
         }
 
         /// Apply a cursor shape from a Ghostty mouse_shape action.
@@ -363,7 +387,7 @@ extension AlasGhostty {
         // MARK: - Keyboard events
 
         override func keyDown(with event: NSEvent) {
-            guard let surface = cSurface, let io = surfaceIO else { return }
+            guard let surface = cSurface, surfaceIO != nil else { return }
 
             let action: ghostty_input_action_e = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -779,6 +779,85 @@ struct ACPComposerDraftBridgeTests {
         #expect(textView.string == "before after")
     }
 
+    @Test("file drop router inserts the relative path at the retained selection")
+    func fileDropRouterInsertsRelativePathAtSelection() throws {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 40))
+        let window = NSWindow(contentRect: textView.frame, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = textView
+        let sink = NSTextField()
+        window.contentView?.addSubview(sink)
+        #expect(window.makeFirstResponder(sink))
+        textView.string = "Review old now"
+        textView.setSelectedRange(NSRange(location: 7, length: 3))
+        var changedDrafts: [ACPComposerDraft] = []
+        var submitCount = 0
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            focusRequest: 0,
+            sendOnEnter: true,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: {},
+            onSubmit: { _, _, _, _, _ in
+                submitCount += 1
+                return true
+            }
+        )
+        coordinator.textView = textView
+        textView.coordinator = coordinator
+        textView.delegate = coordinator
+        let router = ACPComposerDropRouter()
+        router.attach(textView)
+
+        let inserted = router.insert(.file(
+            relativePath: "Sources/App State.swift",
+            absolutePath: "/tmp/worktree/Sources/App State.swift"
+        ), enabled: true)
+
+        #expect(inserted)
+        #expect(textView.string == "Review Sources/App State.swift now")
+        #expect(textView.selectedRange() == NSRange(location: 30, length: 0))
+        #expect(window.firstResponder === textView)
+        #expect(changedDrafts.last == ACPComposerDraft(segments: [
+            .text("Review Sources/App State.swift now")
+        ]))
+        #expect(submitCount == 0)
+        let (_, attachments) = ACPInputField.Coordinator.extract(textView.attributedString())
+        #expect(attachments.isEmpty)
+    }
+
+    @Test("drop router inserts the full commit SHA")
+    func dropRouterInsertsFullCommitSHA() {
+        let sha = "0123456789abcdef0123456789abcdef01234567"
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 40))
+        textView.string = "Inspect "
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        let router = ACPComposerDropRouter()
+        router.attach(textView)
+
+        #expect(router.insert(.commitSHA(sha), enabled: true))
+        #expect(textView.string == "Inspect \(sha)")
+    }
+
+    @Test("disabled or malformed drops do not change the composer")
+    func disabledOrMalformedDropsAreRejected() {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 40))
+        textView.string = "Keep me"
+        textView.setSelectedRange(NSRange(location: 7, length: 0))
+        let router = ACPComposerDropRouter()
+        router.attach(textView)
+
+        #expect(!router.insert(.commitSHA("deadbeef"), enabled: false))
+        #expect(!router.insert(encoded: Data("not-json".utf8), enabled: true))
+        #expect(textView.string == "Keep me")
+    }
+
+    @Test("unmounted drop router rejects insertion")
+    func unmountedDropRouterRejectsInsertion() {
+        let router = ACPComposerDropRouter()
+        #expect(!router.insert(.commitSHA("deadbeef"), enabled: true))
+    }
+
     private final class EditingHookDelegate: NSObject, NSTextViewDelegate {
         struct Change: Equatable {
             let range: NSRange

--- a/AlasTests/CommitDetailsTests.swift
+++ b/AlasTests/CommitDetailsTests.swift
@@ -120,6 +120,7 @@ struct CommitDetailsTests {
 
         let details = try await GitService().commitDetails(at: repo, sha: sha)
         #expect(details.parents.count == 2)
+        #expect(details.parents.allSatisfy { $0.count == 40 })
         // First-parent diff: merging `side` into `main` brings b.txt from side.
         let paths = details.files.map(\.path).sorted()
         #expect(paths == ["b.txt"])

--- a/AlasTests/DragOutPayloadTests.swift
+++ b/AlasTests/DragOutPayloadTests.swift
@@ -41,6 +41,17 @@ struct DragOutPayloadTests {
         #expect(AlasDropPayload.decode(encoded) == nil)
     }
 
+    @Test func dropPayloadRejectsFilePathWithTerminalControlCharacters() throws {
+        let payload = AlasDropPayload.file(
+            relativePath: "Sources/unsafe.swift",
+            absolutePath: "/tmp/worktree/unsafe\u{03}.swift"
+        )
+
+        let encoded = try #require(payload.encoded())
+
+        #expect(AlasDropPayload.decode(encoded) == nil)
+    }
+
     @Test func missingWorkingTreeFileStillPreparesAnInternalPath() async throws {
         let dir = try makeTempDir("missing-internal")
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/AlasTests/DragOutPayloadTests.swift
+++ b/AlasTests/DragOutPayloadTests.swift
@@ -13,7 +13,65 @@ struct DragOutPayloadTests {
     @Test func workingTreeFileJoinsTheWorktreePath() {
         let root = URL(fileURLWithPath: "/tmp/wt")
         let payload = DragOutPayload.workingTreeFile(worktreePath: root, relativePath: "a/b.txt")
-        #expect(payload == .onDisk(URL(fileURLWithPath: "/tmp/wt/a/b.txt")))
+        #expect(payload == .onDisk(
+            URL(fileURLWithPath: "/tmp/wt/a/b.txt"),
+            insertion: .file(relativePath: "a/b.txt", absolutePath: "/tmp/wt/a/b.txt")
+        ))
+    }
+
+    @Test func dropPayloadRoundTripsWithoutLosingPathForms() throws {
+        let original = AlasDropPayload.file(
+            relativePath: "Sources/drag me.swift",
+            absolutePath: "/tmp/work tree/Sources/drag me.swift"
+        )
+
+        let encoded = try #require(original.encoded())
+        #expect(AlasDropPayload.decode(encoded) == original)
+    }
+
+    @Test func dropPayloadRejectsMalformedData() {
+        #expect(AlasDropPayload.decode(Data("not-json".utf8)) == nil)
+    }
+
+    @Test func missingWorkingTreeFileStillPreparesAnInternalPath() async throws {
+        let dir = try makeTempDir("missing-internal")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let payload = DragOutPayload.workingTreeFile(worktreePath: dir, relativePath: "gone.txt")
+
+        let prepared = try #require(await payload.prepare())
+        #expect(prepared.dropPayload == .file(
+            relativePath: "gone.txt",
+            absolutePath: dir.appendingPathComponent("gone.txt").path
+        ))
+        #expect(prepared.fileURL == nil)
+        #expect(prepared.publicText == nil)
+    }
+
+    @Test func remoteWorkingTreeFilePreparesAsInternalTextOnly() async throws {
+        let dir = try makeTempDir("remote-internal")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        RemoteHostRegistry.shared.register(root: dir.path, host: "example")
+        defer { RemoteHostRegistry.shared.unregister(root: dir.path) }
+
+        let payload = DragOutPayload.workingTreeFile(worktreePath: dir, relativePath: "a.txt")
+        let prepared = try #require(await payload.prepare())
+
+        #expect(prepared.dropPayload == .file(
+            relativePath: "a.txt",
+            absolutePath: dir.appendingPathComponent("a.txt").path
+        ))
+        #expect(prepared.fileURL == nil)
+        #expect(prepared.publicText == nil)
+    }
+
+    @Test func fullSHAHasInternalAndPublicTextRepresentations() async throws {
+        let sha = "0123456789abcdef0123456789abcdef01234567"
+
+        let prepared = try #require(await DragOutPayload.commitSHA(sha).prepare())
+
+        #expect(prepared.dropPayload == .commitSHA(sha))
+        #expect(prepared.fileURL == nil)
+        #expect(prepared.publicText == sha)
     }
 
     @Test func trackedStashFileUsesTheStashSHA() {

--- a/AlasTests/DragOutPayloadTests.swift
+++ b/AlasTests/DragOutPayloadTests.swift
@@ -74,6 +74,27 @@ struct DragOutPayloadTests {
         #expect(prepared.publicText == sha)
     }
 
+    @Test func terminalPathLeavesShellSafeAbsolutePathUnchanged() {
+        let payload = AlasDropPayload.file(
+            relativePath: "Sources/App.swift",
+            absolutePath: "/tmp/worktree/Sources/App.swift"
+        )
+        #expect(payload.terminalText == "/tmp/worktree/Sources/App.swift")
+    }
+
+    @Test func terminalPathQuotesSpacesAndEmbeddedSingleQuotes() {
+        let payload = AlasDropPayload.file(
+            relativePath: "Sources/it's here.swift",
+            absolutePath: "/tmp/work tree/Sources/it's here.swift"
+        )
+        #expect(payload.terminalText == "'/tmp/work tree/Sources/it'\\''s here.swift'")
+    }
+
+    @Test func terminalSHAIsInsertedVerbatim() {
+        let sha = "0123456789abcdef0123456789abcdef01234567"
+        #expect(AlasDropPayload.commitSHA(sha).terminalText == sha)
+    }
+
     @Test func trackedStashFileUsesTheStashSHA() {
         let root = URL(fileURLWithPath: "/tmp/wt")
         let stash = GitStash(ref: "stash@{0}", subject: "wip", relativeTime: "1m", sha: "abc")

--- a/AlasTests/DragOutPayloadTests.swift
+++ b/AlasTests/DragOutPayloadTests.swift
@@ -33,6 +33,14 @@ struct DragOutPayloadTests {
         #expect(AlasDropPayload.decode(Data("not-json".utf8)) == nil)
     }
 
+    @Test func dropPayloadRejectsCommitSHAWithTerminalControlCharacters() throws {
+        let payload = AlasDropPayload.commitSHA("0123456789abcdef0123456789abcdef01234567\nrm -rf /")
+
+        let encoded = try #require(payload.encoded())
+
+        #expect(AlasDropPayload.decode(encoded) == nil)
+    }
+
     @Test func missingWorkingTreeFileStillPreparesAnInternalPath() async throws {
         let dir = try makeTempDir("missing-internal")
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/AlasTests/DragOutSessionTests.swift
+++ b/AlasTests/DragOutSessionTests.swift
@@ -4,23 +4,59 @@ import Testing
 @testable import Alas
 
 struct DragOutSessionTests {
-    @Test func dragsOutsideTheAppAreCopyOnly() {
-        #expect(DragOutSession.operationMask(for: .outsideApplication) == .copy)
+    @Test func typedPayloadsCanBeCopiedInsideTheApp() {
+        #expect(DragOutSession.operationMask(
+            for: .withinApplication,
+            hasInternalPayload: true,
+            hasExternalRepresentation: false
+        ) == .copy)
     }
 
-    @Test func dragsInsideTheAppAreRefused() {
-        #expect(DragOutSession.operationMask(for: .withinApplication) == [])
+    @Test func externalOnlyFileDragsRemainRefusedInsideTheApp() {
+        #expect(DragOutSession.operationMask(
+            for: .withinApplication,
+            hasInternalPayload: false,
+            hasExternalRepresentation: true
+        ) == [])
     }
 
-    @Test func pasteboardItemCarriesTheFileURL() {
+    @Test func itemsWithPublicRepresentationsCanBeCopiedOutsideTheApp() {
+        #expect(DragOutSession.operationMask(
+            for: .outsideApplication,
+            hasInternalPayload: true,
+            hasExternalRepresentation: true
+        ) == .copy)
+    }
+
+    @Test func internalOnlyItemsAreRefusedOutsideTheApp() {
+        #expect(DragOutSession.operationMask(
+            for: .outsideApplication,
+            hasInternalPayload: true,
+            hasExternalRepresentation: false
+        ) == [])
+    }
+
+    @Test func pasteboardItemCarriesTheFileURLAndTypedPayload() throws {
         let url = URL(fileURLWithPath: "/tmp/alas drag/a b.txt")
-        let item = DragOutSession.pasteboardItem(for: url)
+        let payload = AlasDropPayload.file(relativePath: "a b.txt", absolutePath: url.path)
+        let item = DragOutSession.pasteboardItem(for: DragOutPreparedItem(
+            dropPayload: payload,
+            fileURL: url,
+            publicText: url.path
+        ))
+
         #expect(item.string(forType: .fileURL) == url.absoluteString)
+        let encoded = try #require(item.data(forType: .alasDropPayload))
+        #expect(AlasDropPayload.decode(encoded) == payload)
     }
 
     @Test func pasteboardItemCarriesThePOSIXPathAsText() {
         let url = URL(fileURLWithPath: "/tmp/alas drag/a b.txt")
-        let item = DragOutSession.pasteboardItem(for: url)
+        let item = DragOutSession.pasteboardItem(for: DragOutPreparedItem(
+            dropPayload: nil,
+            fileURL: url,
+            publicText: url.path
+        ))
         #expect(item.string(forType: .string) == "/tmp/alas drag/a b.txt")
     }
 }

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -428,6 +428,61 @@ struct SurfaceViewKeyboardTests {
         )])
     }
 
+    @Test @MainActor func alasPathDropTargetsOnlyTheReceivingPaneAndFocusesIt() throws {
+        let firstIO = FakeGhosttySurfaceIO()
+        let secondIO = FakeGhosttySurfaceIO()
+        let first = AlasGhostty.SurfaceView(testIO: firstIO)
+        let second = AlasGhostty.SurfaceView(testIO: secondIO)
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
+        let window = NSWindow(contentRect: container.frame, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        container.addSubview(first)
+        container.addSubview(second)
+        #expect(window.makeFirstResponder(first))
+        let pasteboard = NSPasteboard(name: .init("alas-terminal-drop-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        let payload = AlasDropPayload.file(
+            relativePath: "Sources/App State.swift",
+            absolutePath: "/tmp/work tree/Sources/App State.swift"
+        )
+        pasteboard.setData(try #require(payload.encoded()), forType: .alasDropPayload)
+
+        #expect(second.handleAlasDrop(from: pasteboard))
+        #expect(firstIO.calls.isEmpty)
+        #expect(secondIO.calls == [.text("'/tmp/work tree/Sources/App State.swift'")])
+        #expect(window.firstResponder === second)
+    }
+
+    @Test @MainActor func alasSHADropSendsFullSHAWithoutANewline() throws {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        let pasteboard = NSPasteboard(name: .init("alas-terminal-sha-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        let sha = "0123456789abcdef0123456789abcdef01234567"
+        pasteboard.setData(
+            try #require(AlasDropPayload.commitSHA(sha).encoded()),
+            forType: .alasDropPayload
+        )
+
+        #expect(view.handleAlasDrop(from: pasteboard))
+        #expect(io.calls == [.text(sha)])
+    }
+
+    @Test @MainActor func malformedOrUnrelatedTerminalDropsAreIgnored() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        let malformed = NSPasteboard(name: .init("alas-terminal-malformed-\(UUID().uuidString)"))
+        malformed.clearContents()
+        malformed.setData(Data("not-json".utf8), forType: .alasDropPayload)
+        let unrelated = NSPasteboard(name: .init("alas-terminal-unrelated-\(UUID().uuidString)"))
+        unrelated.clearContents()
+        unrelated.setString("do not inject", forType: .string)
+
+        #expect(!view.handleAlasDrop(from: malformed))
+        #expect(!view.handleAlasDrop(from: unrelated))
+        #expect(io.calls.isEmpty)
+    }
+
     // MARK: - Dead-key pipeline tests
 
     @Test @MainActor func keyDown_aggregatesInsertTextIntoAccumulator() {

--- a/docs/superpowers/plans/2026-08-10-drag-paths-and-shas.md
+++ b/docs/superpowers/plans/2026-08-10-drag-paths-and-shas.md
@@ -1,0 +1,54 @@
+# Drag Paths and Commit SHAs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Insert dragged worktree paths and commit SHAs into Alas agent composers and terminal panes.
+
+**Architecture:** Extend the existing AppKit drag pipeline with a private typed pasteboard payload while preserving public file and text representations. Route whole-agent drops through the live composer and terminal drops through the hovered Ghostty surface.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, AppKit drag and pasteboard APIs, GhosttyKit, Swift Testing.
+
+## Global Constraints
+
+- Preserve current external copy-only file dragging.
+- Agents receive repo-relative paths; terminals receive shell-escaped absolute paths.
+- Insert text without surrounding whitespace, newline, submission, execution, or attachments.
+- Remote and deleted files support internal text insertion only.
+- Scope file sources to Files, Working Tree, and conflicts; scope SHA sources to existing click-to-copy labels.
+
+---
+
+### Task 1: Typed drag payload and source policy
+
+- [ ] Add failing Swift Testing coverage for typed payload encoding, path/SHA text representations, operation masks, and remote/deleted internal-only items.
+- [ ] Run focused tests and confirm failures are caused by missing typed-payload behavior.
+- [ ] Implement the private payload, prepared drag item, public pasteboard fallbacks, and context-sensitive copy masks in the existing DragOut subsystem.
+- [ ] Run the focused DragOut tests and commit the independently green slice.
+
+### Task 2: Path and SHA drag sources
+
+- [ ] Add failing coverage for path payload factories and full-SHA source payloads.
+- [ ] Attach path payloads to Files-tab files/directories and Working Tree/conflict rows, including remote and deleted items.
+- [ ] Attach full-SHA payloads to commit-row, commit-header, and parent-SHA labels without changing click or row behavior.
+- [ ] Run focused source/model tests and commit the independently green slice.
+
+### Task 3: Agent drop routing
+
+- [ ] Add failing ACP tests for insertion at the retained selection, draft callbacks, focus, mirrored rejection, and no submission or attachment.
+- [ ] Add a whole-chat typed drop destination and a router to the mounted AppKit composer.
+- [ ] Preserve existing image drops and reject malformed or unrelated pasteboard data.
+- [ ] Run focused ACP and drag tests and commit the independently green slice.
+
+### Task 4: Terminal drop routing
+
+- [ ] Add failing tests for POSIX shell escaping and typed terminal drop decoding through fake Ghostty IO.
+- [ ] Register each Ghostty surface for the private payload, focus the hovered pane, and send exactly one formatted value through the existing IO seam.
+- [ ] Reject malformed and unrelated pasteboard data without sending input.
+- [ ] Run focused terminal and drag tests and commit the independently green slice.
+
+### Task 5: Integration verification
+
+- [ ] Run `xcodegen` and confirm generated project membership is current.
+- [ ] Run all focused DragOut, ACP, commit-header, and SurfaceView tests.
+- [ ] Run the required quiet macOS build and full test suite.
+- [ ] Inspect the final diff for scope, formatting, generated-file changes, and accidental attribution before branch handoff.

--- a/docs/superpowers/specs/2026-08-10-drag-paths-and-shas-design.md
+++ b/docs/superpowers/specs/2026-08-10-drag-paths-and-shas-design.md
@@ -1,0 +1,25 @@
+# Drag Paths and Commit SHAs Into Agents and Terminals
+
+## Summary
+
+Extend Alas's existing AppKit drag system so files from the Files and Changes tabs, plus copyable commit SHA labels, can insert text into agent composers and terminal panes. Keep existing external file dragging intact while allowing remote and deleted paths to work as internal text-only drags.
+
+## Interaction
+
+- Files-tab files and directories, Working Tree rows, and conflict rows provide a typed path drag containing repo-relative and worktree-absolute forms.
+- Copyable SHA labels in commit rows, commit-detail headers, and parent lists provide the full commit SHA.
+- Dropping anywhere in an agent chat focuses its composer and inserts a repo-relative path or full SHA at the retained selection.
+- Dropping on a terminal pane focuses that pane and inserts a POSIX-shell-escaped absolute path or full SHA.
+- Drops insert text only. They do not insert surrounding whitespace, send Enter, submit a prompt, run a command, or create an attachment.
+
+## Architecture
+
+Use a private codable Alas pasteboard payload with file-path and commit-SHA cases. Existing local file drags retain public file URL and absolute-text pasteboard representations. Full SHAs expose a public text representation. Remote and deleted paths expose only the private internal representation, so they cannot be dragged into external applications.
+
+Agent handling is split between a whole-chat drop destination and a small router to the live AppKit composer. Terminal handling lives on each Ghostty surface so split-pane routing follows the hovered pane. Both targets decode only the private Alas payload; existing agent image-drop behavior remains unchanged.
+
+Malformed payloads, mirrored or unavailable composers, and unavailable terminal input reject the drop without changing state. V1 uses the standard drag preview and copy cursor without a custom drop overlay.
+
+## Verification
+
+Cover payload encoding, public representations, operation masks, remote/deleted behavior, shell escaping, ACP selection and draft updates, mirrored-composer rejection, terminal pane routing, full-SHA insertion, and absence of implicit newline/submission. Retain regression coverage for existing drag activation, external file dragging, and agent image drops.


### PR DESCRIPTION
## Summary

- Add typed internal drag payloads for worktree paths and commit SHAs.
- Insert dropped paths into agent composers and shell-escaped absolute paths into the terminal pane under the pointer.
- Expose draggable file, conflict, working-tree, and commit-SHA sources while preserving public external-drag behavior.

## Validation

- Focused drag/drop, ACP composer, terminal, commit, and files tests
- `xcodebuild … build`
- SwiftFormat lint

The full local suite was attempted but stalled in an unrelated terminal-session shutdown wait; the focused coverage and build completed successfully.