### PR TITLE
feat(review): filter files in diff rail

### DIFF
--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -511,6 +511,29 @@ struct DiffReviewRailRow: Equatable, Identifiable {
     let kind: Kind
 }
 
+enum DiffReviewRailFilter {
+    static func session(
+        _ session: DiffReviewSessionModel,
+        matching query: String
+    ) -> DiffReviewSessionModel {
+        let query = normalizedQuery(query)
+        guard !query.isEmpty else { return session }
+
+        let files = session.files.filter { file in
+            FuzzyMatch.score(query: query, target: file.path) != nil
+        }
+        return DiffReviewSessionModel(files: files, groupsEnabled: session.groupsEnabled)
+    }
+
+    static func isActive(_ query: String) -> Bool {
+        !normalizedQuery(query).isEmpty
+    }
+
+    private static func normalizedQuery(_ query: String) -> String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
 enum DiffReviewRailRows {
     static func rows(for session: DiffReviewSessionModel) -> [DiffReviewRailRow] {
         if !session.groupsEnabled {

--- a/Alas/Sources/Center/DiffReview/DiffReviewRail.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRail.swift
@@ -1,6 +1,12 @@
 import AppKit
 import SwiftUI
 
+enum DiffReviewRailTooltip {
+    static func text(for file: DiffReviewFileSummary) -> String {
+        file.path
+    }
+}
+
 struct DiffReviewRail: View {
     let session: DiffReviewSessionModel
     @Binding var selectedFileID: DiffReviewFileID
@@ -10,6 +16,25 @@ struct DiffReviewRail: View {
     let onSelectFile: (DiffReviewFileID) -> Void
 
     @Environment(\.theme) private var theme
+    @State private var filterQuery = ""
+
+    init(
+        session: DiffReviewSessionModel,
+        selectedFileID: Binding<DiffReviewFileID>,
+        collapsed: Binding<Bool>,
+        displayControls: DiffReviewDisplayControlBindings? = nil,
+        threads: [ReviewThread] = [],
+        filterQuery: String = "",
+        onSelectFile: @escaping (DiffReviewFileID) -> Void
+    ) {
+        self.session = session
+        _selectedFileID = selectedFileID
+        _collapsed = collapsed
+        self.displayControls = displayControls
+        self.threads = threads
+        _filterQuery = State(initialValue: filterQuery)
+        self.onSelectFile = onSelectFile
+    }
 
     // MARK: - Thread counts
 
@@ -23,6 +48,10 @@ struct DiffReviewRail: View {
 
     private var resolvedThreadTotal: Int {
         threads.filter { $0.isResolved }.count
+    }
+
+    private var filteredSession: DiffReviewSessionModel {
+        DiffReviewRailFilter.session(session, matching: filterQuery)
     }
 
     var body: some View {
@@ -40,13 +69,28 @@ struct DiffReviewRail: View {
     }
 
     private var expandedBody: some View {
-        VStack(spacing: 0) {
+        let visibleSession = filteredSession
+        return VStack(spacing: 0) {
             expandedHeader
             ScrollViewReader { proxy in
                 ScrollView(.vertical) {
                     LazyVStack(alignment: .leading, spacing: 2) {
-                        ForEach(DiffReviewRailRows.rows(for: session)) { row in
-                            expandedRow(row)
+                        if DiffReviewRailFilter.isActive(filterQuery), visibleSession.files.isEmpty {
+                            Text("No matching files")
+                                .font(.system(size: 11))
+                                .foregroundStyle(theme.color("fg-faint"))
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 18)
+                                .background(
+                                    DiffReviewAccessibilityMarker(
+                                        identifier: "diff-review-rail-filter-empty",
+                                        label: "No matching files"
+                                    )
+                                )
+                        } else {
+                            ForEach(DiffReviewRailRows.rows(for: visibleSession)) { row in
+                                expandedRow(row)
+                            }
                         }
                     }
                     .padding(.horizontal, 8)
@@ -95,7 +139,8 @@ struct DiffReviewRail: View {
     }
 
     private var collapsedBody: some View {
-        VStack(spacing: 8) {
+        let visibleFiles = filteredSession.files
+        return VStack(spacing: 8) {
             collapseButton
                 .padding(.top, 8)
             Divider()
@@ -104,7 +149,7 @@ struct DiffReviewRail: View {
             ScrollViewReader { proxy in
                 ScrollView(.vertical) {
                     LazyVStack(spacing: 6) {
-                        ForEach(session.files) { file in
+                        ForEach(visibleFiles) { file in
                             collapsedMarker(for: file)
                                 .id(file.id.rawValue)
                         }
@@ -146,6 +191,8 @@ struct DiffReviewRail: View {
             if let displayControls {
                 DiffReviewDisplayControls(bindings: displayControls)
             }
+
+            DiffReviewRailFilterField(text: $filterQuery)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
@@ -313,7 +360,7 @@ struct DiffReviewRail: View {
                 }
             }
         )
-        .help(file.path)
+        .help(DiffReviewRailTooltip.text(for: file))
     }
 
     private func collapsedMarker(for file: DiffReviewFileSummary) -> some View {
@@ -360,7 +407,7 @@ struct DiffReviewRail: View {
                 }
             }
         )
-        .help(file.path)
+        .help(DiffReviewRailTooltip.text(for: file))
     }
 
     private func threadBadge(_ count: Int) -> some View {
@@ -397,6 +444,53 @@ struct DiffReviewRail: View {
         case .modified, .unknown:
             theme.color("fg-dim")
         }
+    }
+}
+
+private struct DiffReviewRailFilterField: View {
+    @Binding var text: String
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11))
+                .foregroundStyle(theme.color("fg-dim"))
+                .accessibilityHidden(true)
+            TextField("Filter files…", text: $text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11))
+                .foregroundStyle(theme.color("fg"))
+                .autocorrectionDisabled(true)
+                .accessibilityIdentifier("diff-review-rail-filter-field")
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(theme.color("fg-faint"))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear file filter")
+                .background(
+                    DiffReviewAccessibilityMarker(
+                        identifier: "diff-review-rail-filter-clear",
+                        label: "Clear file filter"
+                    )
+                )
+            }
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 26)
+        .background(theme.color("bg-1"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .compositingGroup()
+        .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 }
 

--- a/AlasTests/DiffReviewModelsTests.swift
+++ b/AlasTests/DiffReviewModelsTests.swift
@@ -117,6 +117,76 @@ struct DiffReviewModelsTests {
         #expect(ids.contains("file:staged:staged:Sources/App.swift"))
     }
 
+    @Test func railFilterFuzzyMatchesFullRelativePathsWithoutReorderingFiles() {
+        let firstMatch = summary(path: "Sources/Auth/LoginView.swift")
+        let skipped = summary(path: "Sources/EditorView.swift")
+        let secondMatch = summary(path: "Tests/Auth/LoginViewTests.swift")
+        let session = DiffReviewSessionModel(
+            files: [firstMatch, skipped, secondMatch],
+            groupsEnabled: false
+        )
+
+        let filtered = DiffReviewRailFilter.session(session, matching: "AUTHLOGIN")
+
+        #expect(filtered.files.map(\.id) == [firstMatch.id, secondMatch.id])
+    }
+
+    @Test func railFilterTreatsWhitespaceOnlyQueryAsInactive() {
+        let session = DiffReviewSessionModel(files: [
+            summary(path: "Sources/App.swift"),
+            summary(path: "Tests/AppTests.swift"),
+        ], groupsEnabled: false)
+
+        let filtered = DiffReviewRailFilter.session(session, matching: "  \n\t ")
+
+        #expect(filtered == session)
+        #expect(!DiffReviewRailFilter.isActive("  \n\t "))
+    }
+
+    @Test func railFilterPrunesEmptyGroupsDirectoriesAndDividers() {
+        let session = DiffReviewSessionModel(files: [
+            summary(
+                path: "Sources/Auth/LoginView.swift",
+                namespace: "unstaged",
+                groupID: "unstaged",
+                groupTitle: "Unstaged"
+            ),
+            summary(
+                path: "Sources/EditorView.swift",
+                namespace: "unstaged",
+                groupID: "unstaged",
+                groupTitle: "Unstaged"
+            ),
+            summary(
+                path: "Tests/Auth/LoginViewTests.swift",
+                namespace: "staged",
+                groupID: "staged",
+                groupTitle: "Staged"
+            ),
+            summary(
+                path: "Docs/ReleaseNotes.md",
+                namespace: "other",
+                groupID: "other",
+                groupTitle: "Other"
+            ),
+        ], groupsEnabled: true)
+
+        let filtered = DiffReviewRailFilter.session(session, matching: "authlogin")
+        let rows = DiffReviewRailRows.rows(for: filtered)
+
+        #expect(filtered.groups.map(\.id) == ["unstaged", "staged"])
+        #expect(filtered.groups.map(\.fileCount) == [1, 1])
+        #expect(rows.map(\.id) == [
+            "source:unstaged",
+            "directory:unstaged:Sources/Auth:0",
+            "file:unstaged:unstaged:Sources/Auth/LoginView.swift",
+            "divider:unstaged",
+            "source:staged",
+            "directory:staged:Tests/Auth:0",
+            "file:staged:staged:Tests/Auth/LoginViewTests.swift",
+        ])
+    }
+
     @Test func fileSummaryCodableRoundTripDerivesIdentityFromNamespaceAndPath() throws {
         let data = Data("""
         {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -580,6 +580,77 @@ struct DiffReviewSurfaceTests {
         #expect(subview(withAccessibilityIdentifier: "diff-review-rail-marker-selected-\(files[1].id.rawValue)", in: controller.view) != nil)
     }
 
+    @Test func railFilterNarrowsNavigationWithoutChangingSelectionAndPersistsAcrossCollapse() async {
+        let files = [
+            summary(path: "Sources/App/AlphaView.swift", additions: 4, deletions: 1),
+            summary(path: "Tests/BetaTests.swift", status: .added, additions: 12, deletions: 0),
+        ]
+        let model = DiffReviewRailHarnessModel(selectedFileID: files[0].id)
+        let controller = host(
+            DiffReviewRailHarness(
+                session: DiffReviewSessionModel(files: files, groupsEnabled: false),
+                model: model,
+                filterQuery: "beta"
+            )
+            .environment(\.theme, theme()),
+            width: 280,
+            height: 500
+        )
+        await drainSwiftUI(controller.view)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-row-\(files[0].id.rawValue)", in: controller.view) == nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-row-\(files[1].id.rawValue)", in: controller.view) != nil)
+        #expect(model.selectedFileID == files[0].id)
+
+        model.collapsed = true
+        await drainSwiftUI(controller.view)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-marker-\(files[0].id.rawValue)", in: controller.view) == nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-marker-\(files[1].id.rawValue)", in: controller.view) != nil)
+
+        model.collapsed = false
+        await drainSwiftUI(controller.view)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-row-\(files[0].id.rawValue)", in: controller.view) == nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-row-\(files[1].id.rawValue)", in: controller.view) != nil)
+    }
+
+    @Test func railFilterShowsEmptyStateAndUnfilteredRailRestoresAllFiles() async {
+        let files = [
+            summary(path: "Sources/App/AlphaView.swift"),
+            summary(path: "Tests/BetaTests.swift"),
+        ]
+        let model = DiffReviewRailHarnessModel(selectedFileID: files[0].id)
+        let controller = host(
+            DiffReviewRailHarness(
+                session: DiffReviewSessionModel(files: files, groupsEnabled: false),
+                model: model,
+                filterQuery: "missing"
+            )
+            .environment(\.theme, theme()),
+            width: 280,
+            height: 500
+        )
+        await drainSwiftUI(controller.view)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-filter-empty", in: controller.view) != nil)
+
+        let unfilteredController = host(
+            DiffReviewRailHarness(
+                session: DiffReviewSessionModel(files: files, groupsEnabled: false),
+                model: model
+            )
+            .environment(\.theme, theme()),
+            width: 280,
+            height: 500
+        )
+        await drainSwiftUI(unfilteredController.view)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-filter-empty", in: unfilteredController.view) == nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-row-\(files[0].id.rawValue)", in: unfilteredController.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "diff-review-rail-row-\(files[1].id.rawValue)", in: unfilteredController.view) != nil)
+    }
+
+    @Test func railFileTooltipUsesRelativePath() {
+        let file = summary(path: "Sources/Deeply/Nested/FeatureView.swift")
+        #expect(DiffReviewRailTooltip.text(for: file) == "Sources/Deeply/Nested/FeatureView.swift")
+    }
+
     @Test func railSelectedFileRowsUseSidebarSelectionTreatment() {
         #expect(DiffReviewRailSelectedRowStyle.backgroundToken == "bg-4")
         #expect(DiffReviewRailSelectedRowStyle.fileDepthIndent == 6)
@@ -4851,6 +4922,33 @@ struct DiffReviewSurfaceTests {
             return label
         }
         return view.subviews.lazy.compactMap { accessibilityLabel(in: $0, containing: text) }.first
+    }
+}
+
+@MainActor
+@Observable
+private final class DiffReviewRailHarnessModel {
+    var selectedFileID: DiffReviewFileID
+    var collapsed = false
+
+    init(selectedFileID: DiffReviewFileID) {
+        self.selectedFileID = selectedFileID
+    }
+}
+
+private struct DiffReviewRailHarness: View {
+    let session: DiffReviewSessionModel
+    @Bindable var model: DiffReviewRailHarnessModel
+    var filterQuery = ""
+
+    var body: some View {
+        DiffReviewRail(
+            session: session,
+            selectedFileID: $model.selectedFileID,
+            collapsed: $model.collapsed,
+            filterQuery: filterQuery,
+            onSelectFile: { model.selectedFileID = $0 }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- add fuzzy filtering for diff-review file rails
- show a compact filter field and empty state
- expose full relative paths through file-rail tooltips

## Verification
- focused rail filter and tooltip tests
- xcodebuild build
- SwiftFormat lint
- full suite: only three known unrelated failures remain