### PR TITLE
fix(commit): description scroller width

### DIFF
--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -30,10 +30,11 @@ struct CommitHeaderView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     ScrollView(.vertical) {
                         expandedBlock
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .frame(maxHeight: Self.maxExpandedHeight)
+                .frame(maxWidth: .infinity, maxHeight: Self.maxExpandedHeight, alignment: .leading)
             }
         }
         .padding(.horizontal, 16).padding(.vertical, 10)


### PR DESCRIPTION
## Summary

The commit-description scrollbar stopped at the content’s intrinsic width instead of the right edge of the commit header.

## Change

Constrain both the overflowing scroll view and its content to the header width, keeping the scrollbar at the rightmost edge.

## Validation

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitHeaderViewTests test`
- Manual verification in a freshly built app (`open -n`)
