### PR TITLE
fix(acp): tool card scrolling

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1268,6 +1268,7 @@
 		D002012348D4DA7E124632BF /* SpacePagerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */; };
 		D02BB257817B709817CAB2B6 /* ACPRemoteMCPFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
+		D063240A6A5B8C4766B36F7B /* ACPToolCallCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869F008CBAF90B11A48EFD46 /* ACPToolCallCardTests.swift */; };
 		D0E9985350ECD64F1D042345 /* MermaidModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */; };
 		D0F370E528AA4D07814AEB15 /* ACPMCPStatusPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C051018EB105E225122750C /* ACPMCPStatusPolicy.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
@@ -2382,6 +2383,7 @@
 		85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerPlaceholderTests.swift; sourceTree = "<group>"; };
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
+		869F008CBAF90B11A48EFD46 /* ACPToolCallCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallCardTests.swift; sourceTree = "<group>"; };
 		86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStreamTests.swift; sourceTree = "<group>"; };
 		86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackModels.swift; sourceTree = "<group>"; };
 		86D12B948CADE546FFD3A54C /* DiffReviewImageStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewImageStateTests.swift; sourceTree = "<group>"; };
@@ -4212,6 +4214,7 @@
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
 				39B7BC45B64591618784F650 /* ACPSlashPickerTests.swift */,
 				B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */,
+				869F008CBAF90B11A48EFD46 /* ACPToolCallCardTests.swift */,
 				B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */,
 				729B5F3498FF7388142DB9DD /* ACPTranscriptLogicalScrollModelTests.swift */,
 				E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */,
@@ -6963,6 +6966,7 @@
 				11827C40372D7209868161C0 /* ACPTerminalHostTests.swift in Sources */,
 				89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */,
 				28710B18EF9FAE100B99E0A7 /* ACPThumbnailImageCacheTests.swift in Sources */,
+				D063240A6A5B8C4766B36F7B /* ACPToolCallCardTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
 				1C2C949642E10060172AB1BA /* ACPToolCallPresentationTests.swift in Sources */,
 				F3249EE6574B3C7FC9FED0B1 /* ACPTranscriptChangeLogTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -22,6 +22,18 @@ struct ACPToolCallCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.acpTerminalHost) private var terminalHost
 
+    init(
+        toolCall: ACPMessage.ToolCall,
+        trustedImageRoot: URL? = nil,
+        loadFullContent: ((String) async -> String?)? = nil,
+        initiallyExpanded: Bool = false
+    ) {
+        self.toolCall = toolCall
+        self.trustedImageRoot = trustedImageRoot
+        self.loadFullContent = loadFullContent
+        _expanded = State(initialValue: initiallyExpanded)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
@@ -144,15 +156,13 @@ struct ACPToolCallCard: View {
                 .background(theme.color("bg-0").opacity(0.55))
             } else {
                 if !displayContent.isEmpty {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        ACPSyntaxHighlightedText(
-                            text: displayContent,
-                            explicitLanguage: displayContentLanguage,
-                            fontSize: 11.5
-                        )
-                            .padding(.horizontal, 12).padding(.vertical, 10)
-                    }
-                    .background(theme.color("bg-0").opacity(0.55))
+                    ACPSyntaxHighlightedText(
+                        text: displayContent,
+                        explicitLanguage: displayContentLanguage,
+                        fontSize: 11.5
+                    )
+                        .padding(.horizontal, 12).padding(.vertical, 10)
+                        .background(theme.color("bg-0").opacity(0.55))
                 }
                 if !toolCall.assets.isEmpty {
                     assetBody

--- a/AlasTests/ACP/UI/ACPToolCallCardTests.swift
+++ b/AlasTests/ACP/UI/ACPToolCallCardTests.swift
@@ -1,0 +1,35 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct ACPToolCallCardTests {
+    @Test("expanded text output belongs to the transcript scroll surface")
+    func expandedTextOutputHasNoNestedScrollView() throws {
+        let card = ACPToolCallCard(toolCall: ACPMessage.ToolCall(
+            toolCallId: "tool-1",
+            title: "Run",
+            status: "completed",
+            content: String(repeating: "output line\n", count: 80)
+        ), initiallyExpanded: true)
+        .environment(\.theme, try ThemeStore().current)
+        let controller = NSHostingController(rootView: card)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 420, height: 80)
+        drainSwiftUI(controller.view)
+
+        #expect(descendants(of: controller.view).compactMap { $0 as? NSScrollView }.isEmpty)
+    }
+
+    private func drainSwiftUI(_ view: NSView) {
+        for _ in 0..<8 {
+            view.layoutSubtreeIfNeeded()
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.001))
+        }
+    }
+
+    private func descendants(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap(descendants)
+    }
+}


### PR DESCRIPTION
## Summary

- make expanded ACP tool output part of the transcript's scroll surface
- remove the nested horizontal scroll view that captured wheel and trackpad input
- add regression coverage for nested scroll views in expanded tool cards

## User impact

Scrolling over expanded tool output now moves the overall ACP transcript consistently.

## Root cause

Expanded text output was wrapped in its own SwiftUI `ScrollView`, so AppKit routed scroll events to that nested view instead of the transcript scroller.

## Validation

- `xcodegen`
- macOS build passes
- focused `ACPToolCallCardTests` passes
- full suite: 7,896 passing, 12 skipped, 4 unrelated existing failures
