### PR TITLE
fix(review): ellipsize review rail feedback

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownInlineRenderer.swift
@@ -92,6 +92,16 @@ enum ACPMarkdownInlineRenderer {
         ).string
     }
 
+    static func cleanAttributedString(_ source: String) -> AttributedString {
+        let plan = makePlan(source)
+        var text = plan.markdownSource
+        for image in plan.images {
+            text = text.replacingOccurrences(of: image.placeholder, with: image.alt)
+        }
+        text = removingSubscriptMarkers(from: text, markers: plan.subscriptMarkers)
+        return ACPMarkdownText.inlineMarkdown(text)
+    }
+
     static func makeAttributedString(
         source: String,
         theme: Theme,

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1782,19 +1782,24 @@ enum DiffReviewInlineFeedbackMarkdown {
 
     @MainActor
     static func inlineMarkdown(_ source: String) -> AttributedString {
-        let flattened = ACPMarkdownText.parse(source).map { block in
+        var result = AttributedString()
+        for block in ACPMarkdownText.parse(source) {
+            let (text, literal) = {
             switch block {
             case .heading(_, let text), .paragraph(let text), .quote(let text):
-                return text
+                return (text, false)
             case .taskList(let items):
-                return items.map(\.text).joined(separator: " ")
+                return (items.map { "[\($0.isChecked ? "x" : " ")] \($0.text)" }.joined(separator: " "), false)
             case .code(_, let body), .streamingCode(_, let body), .mermaid(let body):
-                return body
+                return (body, true)
             case .table(let header, let rows):
-                return ([header] + rows).map { $0.joined(separator: " ") }.joined(separator: " ")
+                return (([header] + rows).map { $0.joined(separator: " ") }.joined(separator: " "), false)
             }
-        }.joined(separator: "\n")
-        return ACPMarkdownInlineRenderer.cleanAttributedString(flattened)
+            }()
+            if !result.characters.isEmpty { result.append(AttributedString("\n")) }
+            result.append(literal ? AttributedString(text) : ACPMarkdownInlineRenderer.cleanAttributedString(text))
+        }
+        return result
     }
 
     @MainActor

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1780,8 +1780,9 @@ enum DiffReviewInlineFeedbackMarkdown {
         )
     }
 
+    @MainActor
     static func inlineMarkdown(_ source: String) -> AttributedString {
-        ACPMarkdownText.inlineMarkdown(source)
+        ACPMarkdownText.inlineMarkdown(plainText(source))
     }
 
     @MainActor

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1780,6 +1780,10 @@ enum DiffReviewInlineFeedbackMarkdown {
         )
     }
 
+    static func inlineMarkdown(_ source: String) -> NSAttributedString {
+        ACPMarkdownText.inlineMarkdown(source)
+    }
+
     @MainActor
     static func plainText(_ source: String) -> String {
         ACPMarkdownText.parse(source).compactMap { block -> String? in

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1782,7 +1782,19 @@ enum DiffReviewInlineFeedbackMarkdown {
 
     @MainActor
     static func inlineMarkdown(_ source: String) -> AttributedString {
-        ACPMarkdownText.inlineMarkdown(plainText(source))
+        let flattened = ACPMarkdownText.parse(source).map { block in
+            switch block {
+            case .heading(_, let text), .paragraph(let text), .quote(let text):
+                return text
+            case .taskList(let items):
+                return items.map(\.text).joined(separator: " ")
+            case .code(_, let body), .streamingCode(_, let body), .mermaid(let body):
+                return body
+            case .table(let header, let rows):
+                return ([header] + rows).map { $0.joined(separator: " ") }.joined(separator: " ")
+            }
+        }.joined(separator: "\n")
+        return ACPMarkdownText.inlineMarkdown(flattened)
     }
 
     @MainActor

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1794,7 +1794,7 @@ enum DiffReviewInlineFeedbackMarkdown {
                 return ([header] + rows).map { $0.joined(separator: " ") }.joined(separator: " ")
             }
         }.joined(separator: "\n")
-        return ACPMarkdownText.inlineMarkdown(flattened)
+        return ACPMarkdownInlineRenderer.cleanAttributedString(flattened)
     }
 
     @MainActor

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1780,7 +1780,7 @@ enum DiffReviewInlineFeedbackMarkdown {
         )
     }
 
-    static func inlineMarkdown(_ source: String) -> NSAttributedString {
+    static func inlineMarkdown(_ source: String) -> AttributedString {
         ACPMarkdownText.inlineMarkdown(source)
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -561,8 +561,9 @@ struct ReviewDraftSummaryRail: View {
             }
             .lineLimit(1)
 
-            Text(DiffReviewInlineFeedbackMarkdown.plainText(item.bodyPreview))
-                .font(.system(size: 11))
+            Text(AttributedString(
+                DiffReviewInlineFeedbackMarkdown.inlineMarkdown(item.bodyPreview)
+            ))
                 .lineLimit(6)
                 .truncationMode(.tail)
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -562,8 +562,8 @@ struct ReviewDraftSummaryRail: View {
             .lineLimit(1)
 
             DiffReviewInlineFeedbackMarkdown.view(item.bodyPreview)
-                .frame(maxHeight: 80, alignment: .top)
-                .clipped()
+                .lineLimit(6)
+                .truncationMode(.tail)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -561,9 +561,8 @@ struct ReviewDraftSummaryRail: View {
             }
             .lineLimit(1)
 
-            Text(AttributedString(
-                DiffReviewInlineFeedbackMarkdown.inlineMarkdown(item.bodyPreview)
-            ))
+            Text(DiffReviewInlineFeedbackMarkdown.inlineMarkdown(item.bodyPreview))
+                .font(.system(size: 11))
                 .lineLimit(6)
                 .truncationMode(.tail)
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -561,7 +561,8 @@ struct ReviewDraftSummaryRail: View {
             }
             .lineLimit(1)
 
-            DiffReviewInlineFeedbackMarkdown.view(item.bodyPreview)
+            Text(DiffReviewInlineFeedbackMarkdown.plainText(item.bodyPreview))
+                .font(.system(size: 11))
                 .lineLimit(6)
                 .truncationMode(.tail)
         }

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -4374,6 +4374,36 @@ struct DiffReviewSurfaceTests {
         #expect(accessibilityLabel(in: controller.view, containing: "Please fix this.") != nil)
     }
 
+    @Test func summaryRailEllipsizesMultiblockFeedbackPreview() {
+        let fileID = DiffReviewFileID(namespace: "github", path: "Sources/App.swift")
+        let feedback = DiffReviewInlineFeedback(
+            id: "thread-multiblock",
+            providerName: "GitHub",
+            author: "reviewer",
+            bodyPreview: "Paragraph one with enough text to wrap across lines.\n\nParagraph two with enough text to wrap across lines.",
+            status: .actionable,
+            providerURL: nil,
+            anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: 2, side: .new),
+            evidenceItemID: "thread-multiblock"
+        )
+        var collapsed = false
+        let view = ReviewDraftSummaryRail(
+            comments: [],
+            bundle: ReviewFeedbackBundle(
+                target: ReviewFeedbackTarget(title: "PR", repositoryPath: nil, providerDescription: nil, sourceDescription: "Diff review"),
+                comments: []
+            ),
+            collapsed: Binding(get: { collapsed }, set: { collapsed = $0 }),
+            inlineFeedbackByFileID: [fileID: [feedback]]
+        )
+        .environment(\.theme, theme())
+
+        let controller = host(view, width: 320, height: 500)
+
+        #expect(subview(withAccessibilityIdentifier: "review-summary-feedback-thread-multiblock", in: controller.view) != nil)
+        #expect(accessibilityLabel(in: controller.view, containing: "Paragraph two") != nil)
+    }
+
     @Test func summaryRailOmitsGitHubFeedbackSectionWhenEmpty() {
         var collapsed = false
         let view = ReviewDraftSummaryRail(


### PR DESCRIPTION
## Summary

Limit draft-review summary rail feedback previews to six tail-ellipsized lines while retaining inline Markdown styling and full accessibility/action text.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-ellipsize-derived-data -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-ellipsize-derived-data -quiet test`

## Notes

The compact rail preview intentionally renders inline Markdown only; rich block rendering remains available in the full review detail.