### PR TITLE
fix(editor): clear stale undo actions

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -117,6 +117,7 @@ struct ACPInputField: NSViewRepresentable {
         coordinator.flushPendingRestyleNow()
         if let tv = nsView.documentView as? ACPNSTextView {
             tv.dismissFloatingPanels()
+            tv.undoManager?.removeAllActions()
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -117,7 +117,7 @@ struct ACPInputField: NSViewRepresentable {
         coordinator.flushPendingRestyleNow()
         if let tv = nsView.documentView as? ACPNSTextView {
             tv.dismissFloatingPanels()
-            tv.undoManager?.removeAllActions()
+            coordinator.editorUndoManager.removeAllActions()
         }
     }
 
@@ -152,6 +152,7 @@ struct ACPInputField: NSViewRepresentable {
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
+        let editorUndoManager = UndoManager()
         let worktreeRoot: URL
         let initialDraft: ACPComposerDraft
         var isFocused: Binding<Bool>
@@ -178,6 +179,8 @@ struct ACPInputField: NSViewRepresentable {
         var onImageError: ((ACPImageStaging.StagingError) -> Void)?
         private var restoringDraft = false
         private var lastSyncedDraft: ACPComposerDraft
+
+        func undoManager(for view: NSTextView) -> UndoManager? { editorUndoManager }
         private var nextSubmitID = 0
         private var pendingSubmitID: Int?
         private var pendingImageFileInsertions = 0

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1151,6 +1151,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         guard let textView = scrollView.documentView as? ReviewDraftComposerNSTextView else { return }
         textView.onKeyboardAction = nil
         textView.onWindowChanged = nil
+        textView.undoManager?.removeAllActions()
         textView.delegate = nil
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1151,7 +1151,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         guard let textView = scrollView.documentView as? ReviewDraftComposerNSTextView else { return }
         textView.onKeyboardAction = nil
         textView.onWindowChanged = nil
-        textView.undoManager?.removeAllActions()
+        coordinator.editorUndoManager.removeAllActions()
         textView.delegate = nil
     }
 
@@ -1165,9 +1165,12 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
 
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
+        let editorUndoManager = UndoManager()
         var parent: ReviewDraftComposerTextEditor
         weak var textView: NSTextView?
         private var latestFulfilledFocusRequestGeneration = 0
+
+        func undoManager(for view: NSTextView) -> UndoManager? { editorUndoManager }
         private var scheduledFocusRequestGeneration: Int?
         private var scheduledFocusTask: Task<Void, Never>?
 

--- a/Alas/Sources/Center/Merge/MergeResultPane.swift
+++ b/Alas/Sources/Center/Merge/MergeResultPane.swift
@@ -139,12 +139,16 @@ struct MergeResultPane: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ scroll: NSScrollView, coordinator: Coordinator) {
-        (scroll.documentView as? NSTextView)?.undoManager?.removeAllActions()
+        coordinator.editorUndoManager.removeAllActions()
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
+        let editorUndoManager = UndoManager()
+
+        func undoManager(for view: NSTextView) -> UndoManager? { editorUndoManager }
+
         struct CacheKey: Equatable {
             let rows: [MergeRegionVisualLayout.VisualRow]
             let conflictRanges: [MergeRegionVisualLayout.VisualConflictRange]

--- a/Alas/Sources/Center/Merge/MergeResultPane.swift
+++ b/Alas/Sources/Center/Merge/MergeResultPane.swift
@@ -138,6 +138,10 @@ struct MergeResultPane: NSViewRepresentable {
         coordinator.contentTopInset = textView.textContainerInset.height
     }
 
+    static func dismantleNSView(_ scroll: NSScrollView, coordinator: Coordinator) {
+        (scroll.documentView as? NSTextView)?.undoManager?.removeAllActions()
+    }
+
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     final class Coordinator: NSObject, NSTextViewDelegate {

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -7,22 +7,31 @@ import Testing
 @MainActor
 @Suite("ACP composer draft bridge")
 struct ACPComposerDraftBridgeTests {
-    @Test("dismantling the composer clears stale AppKit undo actions")
-    func dismantlingComposerClearsUndoActions() {
+    @Test("dismantling the composer preserves window undo actions")
+    func dismantlingComposerPreservesWindowUndoActions() {
         let textView = ACPNSTextView()
         textView.allowsUndo = true
         let scrollView = NSScrollView()
         scrollView.documentView = textView
-        let undoOwner = ACPTestUndoOwner()
-        textView.delegate = undoOwner
         let coordinator = makeCoordinator(sendOnEnter: true) { _, _, _, _, _ in true }
+        textView.delegate = coordinator
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = scrollView
+        let windowUndoManager = window.undoManager!
 
         textView.undoManager?.registerUndo(withTarget: textView) { _ in }
+        windowUndoManager.registerUndo(withTarget: window) { _ in }
         #expect(textView.undoManager?.canUndo == true)
 
         ACPInputField.dismantleNSView(scrollView, coordinator: coordinator)
 
         #expect(textView.undoManager?.canUndo == false)
+        #expect(windowUndoManager.canUndo == true)
     }
 
     @Test("editing lifecycle updates composer focus binding")
@@ -1186,10 +1195,4 @@ struct ACPComposerDraftBridgeTests {
             .text("queued"),
         ]))
     }
-}
-
-@MainActor
-private final class ACPTestUndoOwner: NSObject, NSTextViewDelegate {
-    let manager = UndoManager()
-    func undoManager(for view: NSTextView) -> UndoManager? { manager }
 }

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -7,6 +7,24 @@ import Testing
 @MainActor
 @Suite("ACP composer draft bridge")
 struct ACPComposerDraftBridgeTests {
+    @Test("dismantling the composer clears stale AppKit undo actions")
+    func dismantlingComposerClearsUndoActions() {
+        let textView = ACPNSTextView()
+        textView.allowsUndo = true
+        let scrollView = NSScrollView()
+        scrollView.documentView = textView
+        let undoOwner = ACPTestUndoOwner()
+        textView.delegate = undoOwner
+        let coordinator = makeCoordinator(sendOnEnter: true) { _, _, _, _, _ in true }
+
+        textView.undoManager?.registerUndo(withTarget: textView) { _ in }
+        #expect(textView.undoManager?.canUndo == true)
+
+        ACPInputField.dismantleNSView(scrollView, coordinator: coordinator)
+
+        #expect(textView.undoManager?.canUndo == false)
+    }
+
     @Test("editing lifecycle updates composer focus binding")
     func editingLifecycleUpdatesFocusBinding() {
         var focused = false
@@ -1168,4 +1186,10 @@ struct ACPComposerDraftBridgeTests {
             .text("queued"),
         ]))
     }
+}
+
+@MainActor
+private final class ACPTestUndoOwner: NSObject, NSTextViewDelegate {
+    let manager = UndoManager()
+    func undoManager(for view: NSTextView) -> UndoManager? { manager }
 }


### PR DESCRIPTION
## Summary

Prevent crashes caused by AppKit undo managers retaining deallocated text views after SwiftUI dismantles an editor.

The ACP composer, diff-review draft editor, and merge result editor now use coordinator-owned undo managers and clear their native undo actions during teardown. A regression test verifies teardown removes editor undo without discarding unrelated window undo history.

## Validation

- `xcodegen`
- macOS build succeeds
- ACP composer regression suite: 46 tests pass
- Full local suite: 7,818 passed, 12 skipped, and 4 unrelated assertions failed reproducibly in isolation (AgentTerminalLaunch, CommitHeaderView, and two DiffReviewSurface layout tests)