### PR TITLE
fix(review): open restored comment editors

### DIFF
--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -137,21 +137,40 @@ final class AppKitDiffReviewFileState: ObservableObject {
     func bindingForInlineFeedbackReplyEditor(_ id: String) -> Binding<DiffReviewInlineFeedbackReplyEditorState> {
         Binding(
             get: { self.inlineFeedbackReplyEditors[id] ?? DiffReviewInlineFeedbackReplyEditorState() },
-            set: { self.inlineFeedbackReplyEditors[id] = $0 }
+            set: { newValue in
+                let previous = self.inlineFeedbackReplyEditors[id] ?? DiffReviewInlineFeedbackReplyEditorState()
+                self.inlineFeedbackReplyEditors[id] = newValue
+                if previous.isReplying != newValue.isReplying {
+                    self.structuralDidChange.send()
+                }
+            }
         )
     }
 
     func bindingForDraftCommentEditor(_ id: String) -> Binding<ReviewDraftCommentEditorState> {
         Binding(
             get: { self.draftCommentEditors[id] ?? ReviewDraftCommentEditorState() },
-            set: { self.draftCommentEditors[id] = $0 }
+            set: { newValue in
+                let previous = self.draftCommentEditors[id] ?? ReviewDraftCommentEditorState()
+                self.draftCommentEditors[id] = newValue
+                if previous.isEditing != newValue.isEditing {
+                    self.structuralDidChange.send()
+                }
+            }
         )
     }
 
     func bindingForThreadCommentEditor(_ id: String) -> Binding<DiffInlineCommentCardEditorState> {
         Binding(
             get: { self.threadCommentEditors[id] ?? DiffInlineCommentCardEditorState() },
-            set: { self.threadCommentEditors[id] = $0 }
+            set: { newValue in
+                let previous = self.threadCommentEditors[id] ?? DiffInlineCommentCardEditorState()
+                self.threadCommentEditors[id] = newValue
+                if previous.isComposerOpen != newValue.isComposerOpen
+                    || previous.editingCommentID != newValue.editingCommentID {
+                    self.structuralDidChange.send()
+                }
+            }
         )
     }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -71,6 +71,10 @@ struct AppKitDiffReviewRowToken: Equatable {
     let focusedFeedbackID: String?
     let focusedDraftCommentID: String?
     let activeThreadID: String?
+    let inlineFeedbackReplying: Bool
+    let draftCommentEditing: Bool
+    let threadReplying: Bool
+    let editingThreadCommentID: String?
     let draftComposerFocused: Bool
     let actionPresence: AppKitDiffReviewActionPresence
 }
@@ -505,7 +509,8 @@ enum AppKitDiffReviewRowPlanBuilder {
                         let threadID = AppKitDiffReviewRowID.thread(fileID: input.file.id, threadID: thread.id)
                         append(
                             &rows, id: threadID, input: input, signature: String(reflecting: thread).hashValue,
-                            height: 112, retention: input.state.activeThreadID == thread.id ? .pinned : .recyclable
+                            height: 112, retention: input.state.activeThreadID == thread.id ? .pinned : .recyclable,
+                            threadEditorState: input.state.threadCommentEditors[thread.id]
                         ) {
                             AnyView(AppKitDiffReviewThreadRowBody(thread: thread, rows: segment.rows, input: input))
                         }
@@ -579,7 +584,8 @@ enum AppKitDiffReviewRowPlanBuilder {
                 input: input,
                 signature: String(reflecting: thread).hashValue,
                 height: 112,
-                retention: input.state.activeThreadID == thread.id ? .pinned : .recyclable
+                retention: input.state.activeThreadID == thread.id ? .pinned : .recyclable,
+                threadEditorState: input.state.threadCommentEditors[thread.id]
             ) {
                 AnyView(AppKitDiffReviewImageThreadRowBody(thread: thread, input: input))
             }
@@ -634,6 +640,7 @@ enum AppKitDiffReviewRowPlanBuilder {
             &rows, id: id, input: input, signature: accessorySignature(item, contextRows: contextRows), height: 96,
             retention: input.state.activeInlineFeedbackEditorID == item.id ? .pinned : .recyclable,
             inlineAvailability: input.state.actionRelay.inlineFeedbackAvailability(for: item, file: input.file.summary),
+            inlineFeedbackReplying: input.state.inlineFeedbackReplyEditors[item.id]?.isReplying ?? false,
             contextRowCount: contextRows?.count
         ) {
             AnyView(AppKitDiffReviewInlineFeedbackRowBody(item: item, input: input, rows: contextRows))
@@ -657,6 +664,7 @@ enum AppKitDiffReviewRowPlanBuilder {
             draftAgentTargets: (input.draftCommentActions ?? input.state.actionRelay.draftCommentActionsForRow)
                 .agentTargets(),
             reviewFeedbackTarget: input.reviewFeedbackTarget,
+            draftCommentEditing: input.state.draftCommentEditors[comment.id]?.isEditing ?? false,
             contextRowCount: contextRows?.count
         ) {
             AnyView(AppKitDiffReviewDraftCommentRowBody(comment: comment, input: input, rows: contextRows))
@@ -700,6 +708,9 @@ enum AppKitDiffReviewRowPlanBuilder {
         draftAvailability: ReviewDraftCommentActionAvailability? = nil,
         draftAgentTargets: [ReviewFeedbackAgentTarget] = [],
         reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
+        inlineFeedbackReplying: Bool = false,
+        draftCommentEditing: Bool = false,
+        threadEditorState: DiffInlineCommentCardEditorState? = nil,
         includesActiveHighlight: Bool = false,
         contextRowCount: Int? = nil,
         build: @escaping () -> AnyView
@@ -721,6 +732,10 @@ enum AppKitDiffReviewRowPlanBuilder {
             focusedFeedbackID: input.focusedFeedbackID,
             focusedDraftCommentID: input.focusedDraftCommentID,
             activeThreadID: input.state.activeThreadID,
+            inlineFeedbackReplying: inlineFeedbackReplying,
+            draftCommentEditing: draftCommentEditing,
+            threadReplying: threadEditorState?.isComposerOpen ?? false,
+            editingThreadCommentID: threadEditorState?.editingCommentID,
             draftComposerFocused: input.state.isDraftComposerFocused,
             actionPresence: input.actionPresence
         )

--- a/AlasTests/AppKitDiffReviewPresentationStateTests.swift
+++ b/AlasTests/AppKitDiffReviewPresentationStateTests.swift
@@ -216,6 +216,25 @@ struct AppKitDiffReviewPresentationStateTests {
         _ = cancellable
     }
 
+    @Test func editorModeChangesAreStructuralButEditorTypingIsNot() {
+        let state = AppKitDiffReviewFileState()
+        var changes = 0
+        let cancellable = state.structuralDidChange.sink { changes += 1 }
+
+        state.bindingForDraftCommentEditor("draft").wrappedValue.editingBody = "draft body"
+        state.bindingForInlineFeedbackReplyEditor("feedback").wrappedValue.body = "reply body"
+        state.bindingForThreadCommentEditor("thread").wrappedValue.replyDraft = "thread reply"
+        state.bindingForThreadCommentEditor("thread").wrappedValue.editDraft = "thread edit"
+        #expect(changes == 0)
+
+        state.bindingForDraftCommentEditor("draft").wrappedValue.isEditing = true
+        state.bindingForInlineFeedbackReplyEditor("feedback").wrappedValue.isReplying = true
+        state.bindingForThreadCommentEditor("thread").wrappedValue.isComposerOpen = true
+        state.bindingForThreadCommentEditor("thread").wrappedValue.editingCommentID = "comment"
+        #expect(changes == 4)
+        _ = cancellable
+    }
+
     @Test func presentationStoreForwardsCopyFeedbackChanges() {
         let store = AppKitDiffReviewPresentationStore()
         let state = store.state(for: fileModel())

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -212,6 +212,36 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(plan.corePlan.rows.first { $0.id == threadID }?.retention == .pinned)
     }
 
+    @Test func editorModeChangesInvalidateTheirHostedRows() throws {
+        let file = textFile()
+        let feedback = feedback(line: 1)
+        let draft = draftComment(fileID: file.id)
+        let thread = DiffInlineCommentThread(
+            id: "thread", filePath: file.summary.path, newLine: 1, isOldSide: false,
+            isResolved: false, isOutdated: false, comments: []
+        )
+        let state = AppKitDiffReviewFileState()
+        let input = AppKitDiffReviewRowInput(
+            file: file, inlineFeedback: [feedback], draftComments: [draft], threads: [thread],
+            state: state, theme: theme
+        )
+        let feedbackID = AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: feedback.id, fileID: file.id))
+        let draftID = AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id))
+        let threadID = AppKitDiffReviewRowID.thread(fileID: file.id, threadID: thread.id)
+        let resting = AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan
+
+        state.bindingForInlineFeedbackReplyEditor(feedback.id).wrappedValue.isReplying = true
+        state.bindingForDraftCommentEditor(draft.id).wrappedValue.isEditing = true
+        state.bindingForThreadCommentEditor(thread.id).wrappedValue.editingCommentID = "comment"
+        let editing = AppKitDiffReviewRowPlanBuilder.build(inputs: [input]).corePlan
+
+        for rowID in [feedbackID, draftID, threadID] {
+            let restingRow = try #require(resting.rows.first { $0.id == rowID })
+            let editingRow = try #require(editing.rows.first { $0.id == rowID })
+            #expect(!restingRow.equalityToken.isEqual(to: editingRow.equalityToken))
+        }
+    }
+
     @Test func consolidatedHunkRowsArePinnedWhileContainedThreadEditorIsActive() throws {
         let file = textFile()
         let thread = DiffInlineCommentThread(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -272,6 +272,56 @@ struct DiffReviewSurfaceTests {
         }
     }
 
+    @Test func appKitReviewWindowOpensRestoredDraftCommentEditor() async throws {
+        let file = fileSection(
+            summary: summary(path: "Sources/RestoredDraft.swift"),
+            displayModel: displayModel()
+        )
+        let comment = draftComment(
+            id: "restored-draft",
+            fileID: file.id,
+            path: file.summary.path,
+            startLine: 2
+        )
+        let model = AppKitReviewSurfaceWindowModel(session: loadedSession(files: [file]))
+        model.draftCommentsByFileID = [file.id: [comment]]
+        model.draftCommentActions = ReviewDraftCommentActions(
+            availability: { _ in
+                ReviewDraftCommentActionAvailability(
+                    canEdit: true,
+                    canDelete: false,
+                    canResolve: false,
+                    canDismiss: false,
+                    canCopyPrompt: false,
+                    canShowSendToAgent: false,
+                    canSendToAgent: false
+                )
+            }
+        )
+
+        try await withAppKitReviewScroller {
+            let controller = host(
+                AppKitReviewSurfaceWindowHarness(model: model).environment(\.theme, theme()),
+                width: 1_000,
+                height: 500
+            )
+            let window = attachWindow(controller, width: 1_000, height: 500)
+            defer { ReviewDraftComposerFocusRetainer.retain(window, controller) }
+            await drainSwiftUI(controller.view)
+
+            #expect(pressAccessibilityElement(
+                withAccessibilityIdentifier: "diff-review-draft-comment-action-edit-restored-draft",
+                in: controller.view
+            ))
+            await drainSwiftUI(controller.view)
+
+            #expect(subview(
+                withAccessibilityIdentifier: "diff-review-draft-comment-action-save-restored-draft",
+                in: controller.view
+            ) != nil)
+        }
+    }
+
     @Test func appKitReviewWindowExpandsContextThroughRenderedControl() async throws {
         let summary = summary(path: "Sources/ContextControl.swift")
         let file = fileSection(
@@ -5099,6 +5149,7 @@ private final class AppKitReviewSurfaceWindowModel {
     var whitespace = false
     var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
     var draftCommentsByFileID: [DiffReviewFileID: [ReviewDraftComment]] = [:]
+    var draftCommentActions = ReviewDraftCommentActions()
     var inlineFeedbackCommand: DiffReviewInlineFeedbackScrollCommand?
     var draftCommentCommand: DiffReviewDraftCommentScrollCommand?
 
@@ -5125,7 +5176,8 @@ private struct AppKitReviewSurfaceWindowHarness: View {
             inlineFeedbackByFileID: model.inlineFeedbackByFileID,
             inlineFeedbackScrollCommand: model.inlineFeedbackCommand,
             draftCommentsByFileID: model.draftCommentsByFileID,
-            draftCommentScrollCommand: model.draftCommentCommand
+            draftCommentScrollCommand: model.draftCommentCommand,
+            draftCommentActions: model.draftCommentActions
         )
     }
 }


### PR DESCRIPTION
## Summary

- redraw AppKit-hosted review rows when restored comment edit or reply mode changes
- include editor mode in row equality while keeping text-entry updates non-structural
- cover restored-window editing plus presentation-state and row-token invalidation

## Root cause

After restoring review state, the shared editor mode changed when Edit was pressed, but the hosted row's equality token stayed unchanged. The fresh row therefore skipped its redraw until an unrelated invalidation occurred.

## Validation

- post-rebase focused regression suites: 48 passed, 0 failed
- SwiftFormat lint and diff check
- macOS app build
- full test run: 7,932 passed, 12 skipped, 4 pre-existing unrelated failures

The unrelated full-suite failures were in ACP terminal orphan release, ACP auth launch quoting, feedback file filtering, and cleared base-branch override refresh coverage.
