### PR TITLE
fix(gg): prevent post-sync refreshes from leaving actions loading

### DIFF
--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -213,7 +213,10 @@ final class GGMutationCoordinator {
         confirmedAgainst identity: GGStackIdentity?,
         confirmedWith confirmation: GGMutationConfirmation?
     ) async throws {
-        defer {
+        var didReleaseAction = false
+        func releaseAction() {
+            guard !didReleaseAction else { return }
+            didReleaseAction = true
             activeRequest = nil
             actionState.endAction(request.actionKind)
             if request == .sync,
@@ -222,6 +225,7 @@ final class GGMutationCoordinator {
                 actionState.clearSyncProgress()
             }
         }
+        defer { releaseAction() }
 
         let isRecoveryRequest = request == .continueOperation || request == .abortOperation
         let snapshot: GGStackSnapshot?
@@ -284,6 +288,7 @@ final class GGMutationCoordinator {
             )
             recordSummary(for: request, result: result)
             reconcilePausedState(after: request, error: nil)
+            releaseAction()
             await refresh(after: request, result: result)
             if request.isUndo {
                 undoCandidate = nil
@@ -304,6 +309,7 @@ final class GGMutationCoordinator {
                 }
                 if actionState.lastError == nil { actionState.setError(error.userMessage) }
             }
+            releaseAction()
             await refresh(after: request, result: .none)
             if toleratesMalformedRemoteOutput { return }
             throw error
@@ -311,6 +317,7 @@ final class GGMutationCoordinator {
             reconcilePausedState(after: request, error: error)
             if request == .sync { actionState.markSyncTerminalFailure() }
             actionState.setError(error.localizedDescription)
+            releaseAction()
             await refresh(after: request, result: .none)
             throw error
         }

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -128,6 +128,7 @@ final class GGMutationCoordinator {
         }
         do {
             let newest = try await service.listUndoOperations(worktreePath: worktreePath, limit: 1).first
+            guard undoMarkerStore.marker(worktreeId: worktreeId) == marker else { return }
             guard let newest,
                   newest.id == marker.operationID,
                   newest.matchesUndoScope(currentStackName: currentStackName, marker: marker),
@@ -144,6 +145,7 @@ final class GGMutationCoordinator {
             }
             undoCandidate = GGUndoCandidate(operation: newest)
         } catch {
+            guard undoMarkerStore.marker(worktreeId: worktreeId) == marker else { return }
             undoCandidate = nil
         }
     }

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -290,9 +290,8 @@ final class GGMutationCoordinator {
             reconcilePausedState(after: request, error: nil)
             releaseAction()
             await refresh(after: request, result: result)
-            if request.isUndo {
-                undoCandidate = nil
-                undoMarkerStore.clear(worktreeId: worktreeId)
+            if case .undo(let operationID) = request {
+                clearUndoCandidate(forOperationID: operationID)
             }
         } catch let error as GGServiceError {
             reconcilePausedState(after: request, error: error)
@@ -623,6 +622,15 @@ final class GGMutationCoordinator {
             worktreeId: worktreeId
         )
         undoCandidate = GGUndoCandidate(operation: newest)
+    }
+
+    private func clearUndoCandidate(forOperationID operationID: String) {
+        if undoCandidate?.operationID == operationID {
+            undoCandidate = nil
+        }
+        if undoMarkerStore.marker(worktreeId: worktreeId)?.operationID == operationID {
+            undoMarkerStore.clear(worktreeId: worktreeId)
+        }
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -78,9 +78,9 @@ struct ProcessGGCommandRunner: GGCommandRunning {
     }
 
     private static func isStackQuery(_ args: [String]) -> Bool {
-        args.indices.dropLast().contains { index in
-            args[index] == "ls" && args[args.index(after: index)] == "--json"
-        }
+        let commandIndex = args.first == "--client-operation-id" ? 2 : 0
+        guard args.indices.contains(commandIndex), args[commandIndex] == "ls" else { return false }
+        return args[args.index(after: commandIndex)...].contains("--json")
     }
 
     /// Pipe-lifecycle core of `runStreaming`, parameterized on the

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -37,20 +37,50 @@ extension GGCommandRunning {
 }
 
 struct ProcessGGCommandRunner: GGCommandRunning {
+    typealias ProcessLaunch = @Sendable (
+        _ executable: String,
+        _ args: [String],
+        _ cwd: URL?,
+        _ env: [String: String]?,
+        _ timeout: TimeInterval
+    ) async throws -> ProcessResult
+
     private static let commandTimeout: TimeInterval = 600
+    private let processLaunch: ProcessLaunch
+
+    init(
+        processLaunch: @escaping ProcessLaunch = { executable, args, cwd, env, timeout in
+            try await Process.run(
+                executable,
+                args: args,
+                cwd: cwd,
+                env: env,
+                timeout: timeout
+            )
+        }
+    ) {
+        self.processLaunch = processLaunch
+    }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
-        try await Process.run(
+        let timeout = Self.isStackQuery(args) ? Process.defaultTimeout : Self.commandTimeout
+        return try await processLaunch(
             "/usr/bin/env",
-            args: ["gg"] + args,
-            cwd: cwd,
-            env: Process.gitEnv(),
-            timeout: Self.commandTimeout
+            ["gg"] + args,
+            cwd,
+            Process.gitEnv(),
+            timeout
         )
     }
 
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
         Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv(), timeout: Self.commandTimeout)
+    }
+
+    private static func isStackQuery(_ args: [String]) -> Bool {
+        args.indices.dropLast().contains { index in
+            args[index] == "ls" && args[args.index(after: index)] == "--json"
+        }
     }
 
     /// Pipe-lifecycle core of `runStreaming`, parameterized on the

--- a/Alas/Sources/Integrations/GG/GGStackActionState.swift
+++ b/Alas/Sources/Integrations/GG/GGStackActionState.swift
@@ -31,6 +31,7 @@ final class GGStackActionState {
     private(set) var lastError: String?
     private(set) var pausedOperation: GGPausedOperation?
     private(set) var lastActionSummary: String?
+    @ObservationIgnored private(set) var actionGeneration: UInt = 0
 
     /// Returns false when another action is already running (one at a time).
     func beginAction(_ action: GGStackActionKind) -> Bool {
@@ -39,6 +40,7 @@ final class GGStackActionState {
         if syncHasTerminalFailure { syncHasTerminalFailure = false }
         if lastError != nil { lastError = nil }
         if lastActionSummary != nil { lastActionSummary = nil }
+        actionGeneration &+= 1
         inFlightAction = action
         return true
     }
@@ -52,6 +54,9 @@ final class GGStackActionState {
     func clearSyncProgress() { if !syncProgress.isEmpty { syncProgress = [] } }
     func markSyncTerminalFailure() {
         if inFlightAction == .sync, !syncHasTerminalFailure { syncHasTerminalFailure = true }
+    }
+    func shouldPublishError(forActionGeneration generation: UInt) -> Bool {
+        actionGeneration == generation && lastError == nil
     }
     func setError(_ message: String) { lastError = message }
     func clearError() { if lastError != nil { lastError = nil } }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -440,8 +440,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 },
                 refreshStack: { [weak self] in
                     guard let self else { return }
-                    self.ggStackCommitsKey = nil
-                    await self.refreshGGStack()
+                    await self.reevaluateGGGate().value
                 },
                 refreshGitChanges: { [weak self] in await self?.refresh() },
                 refreshProviderReviews: { [weak self] in await self?.refresh(forceReviewLoopRemote: true) },

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1579,13 +1579,17 @@ final class RightPaneState: GGSplitCommitServicing {
         runGGMutation(prepared.request, confirmedAgainst: prepared.snapshot)
     }
 
-    private func runGGMutation(_ request: GGMutationRequest, confirmedAgainst identity: GGStackIdentity? = nil) {
+    @discardableResult
+    func runGGMutation(
+        _ request: GGMutationRequest,
+        confirmedAgainst identity: GGStackIdentity? = nil
+    ) -> Task<Void, Never>? {
         guard let operation = ggMutationCoordinator.startApplying(
             request,
             confirmedAgainst: identity
-        ) else { return }
+        ) else { return nil }
         let actionGeneration = ggActionState.actionGeneration
-        Task { @MainActor in
+        return Task { @MainActor in
             do {
                 try await operation.value
             } catch {
@@ -1594,10 +1598,11 @@ final class RightPaneState: GGSplitCommitServicing {
         }
     }
 
-    private func runGGMutation(_ prepared: GGPreparedMutation) {
-        guard let operation = ggMutationCoordinator.startApplying(prepared) else { return }
+    @discardableResult
+    func runGGMutation(_ prepared: GGPreparedMutation) -> Task<Void, Never>? {
+        guard let operation = ggMutationCoordinator.startApplying(prepared) else { return nil }
         let actionGeneration = ggActionState.actionGeneration
-        Task { @MainActor in
+        return Task { @MainActor in
             do {
                 try await operation.value
             } catch {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1584,28 +1584,34 @@ final class RightPaneState: GGSplitCommitServicing {
             request,
             confirmedAgainst: identity
         ) else { return }
+        let actionGeneration = ggActionState.actionGeneration
         Task { @MainActor in
             do {
                 try await operation.value
             } catch {
-                if ggActionState.lastError == nil {
-                    ggActionState.setError(GGErrorPresentation.message(for: error))
-                }
+                publishGGMutationPresentationError(error, forActionGeneration: actionGeneration)
             }
         }
     }
 
     private func runGGMutation(_ prepared: GGPreparedMutation) {
         guard let operation = ggMutationCoordinator.startApplying(prepared) else { return }
+        let actionGeneration = ggActionState.actionGeneration
         Task { @MainActor in
             do {
                 try await operation.value
             } catch {
-                if ggActionState.lastError == nil {
-                    ggActionState.setError(GGErrorPresentation.message(for: error))
-                }
+                publishGGMutationPresentationError(error, forActionGeneration: actionGeneration)
             }
         }
+    }
+
+    private func publishGGMutationPresentationError(
+        _ error: Error,
+        forActionGeneration generation: UInt
+    ) {
+        guard ggActionState.shouldPublishError(forActionGeneration: generation) else { return }
+        ggActionState.setError(GGErrorPresentation.message(for: error))
     }
 
     func markSnapshotUnknown() {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -28,6 +28,7 @@ private final class RecordingGGMutationExecutor: GGMutationExecuting {
     var newestOperation: GGOperationSummary?
     var operationLists: [[GGOperationSummary]] = []
     var operationListCallCount = 0
+    var onListUndoOperations: (() async -> Void)?
     var restackPreview = GGRestackResult(
         stackName: "feature", totalEntries: 2, entriesRestacked: 1, entriesOK: 1,
         dryRun: true,
@@ -62,11 +63,15 @@ private final class RecordingGGMutationExecutor: GGMutationExecuting {
     }
 
     func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary] {
-        defer { operationListCallCount += 1 }
+        let operations: [GGOperationSummary]
         if !operationLists.isEmpty {
-            return operationLists[min(operationListCallCount, operationLists.count - 1)]
+            operations = operationLists[min(operationListCallCount, operationLists.count - 1)]
+        } else {
+            operations = newestOperation.map { [$0] } ?? []
         }
-        return newestOperation.map { [$0] } ?? []
+        operationListCallCount += 1
+        await onListUndoOperations?()
+        return operations
     }
 
     func previewRestack(worktreePath: String) async throws -> GGRestackResult {
@@ -137,6 +142,38 @@ private actor FirstRefreshSuspension {
 
     func suspend() async {
         guard !didSuspend else { return }
+        didSuspend = true
+        let waiters = suspensionWaiters
+        suspensionWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        await withCheckedContinuation { completion = $0 }
+    }
+
+    func waitUntilSuspended() async {
+        if didSuspend { return }
+        await withCheckedContinuation { suspensionWaiters.append($0) }
+    }
+
+    func resume() {
+        completion?.resume()
+        completion = nil
+    }
+}
+
+private actor UndoOperationListSuspension {
+    private let suspensionCall: Int
+    private var callCount = 0
+    private var didSuspend = false
+    private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var completion: CheckedContinuation<Void, Never>?
+
+    init(suspendOnCall suspensionCall: Int) {
+        self.suspensionCall = suspensionCall
+    }
+
+    func suspend() async {
+        callCount += 1
+        guard callCount == suspensionCall else { return }
         didSuspend = true
         let waiters = suspensionWaiters
         suspensionWaiters.removeAll()
@@ -1130,6 +1167,49 @@ struct GGMutationCoordinatorTests {
 
         #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: matching))
         #expect(harness.service.operationListCallCount == 1)
+    }
+
+    @Test func staleUndoRestoreDoesNotOverwriteNewerMutationCandidate() async throws {
+        let restoredOperation = GGOperationSummary(
+            id: "op_restored", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:restored", "reorder"],
+            stackName: "feature", touchedRemote: false, isUndoable: true
+        )
+        let newerOperation = GGOperationSummary(
+            id: "op_newer", kind: "squash", status: .completed, createdAtMs: 2,
+            args: ["--client-operation-id", "alas:test-1", "sc"],
+            stackName: "feature", touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+        harness.markers.set(operationID: restoredOperation.id, worktreeId: "wt")
+        harness.service.operationLists = [
+            [restoredOperation],
+            [restoredOperation],
+            [newerOperation],
+        ]
+        let listSuspension = UndoOperationListSuspension(suspendOnCall: 2)
+        harness.service.onListUndoOperations = { await listSuspension.suspend() }
+        harness.onRefreshStack = {
+            await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+        }
+
+        let undoTask = try #require(harness.coordinator.startApplying(
+            .undo(operationID: restoredOperation.id),
+            confirmedAgainst: nil
+        ))
+        await listSuspension.waitUntilSuspended()
+
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: newerOperation))
+        #expect(harness.markers.operationID(worktreeId: "wt") == newerOperation.id)
+
+        await listSuspension.resume()
+        try await undoTask.value
+
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: newerOperation))
+        #expect(harness.markers.operationID(worktreeId: "wt") == newerOperation.id)
     }
 
     @Test func relaunchClearsMarkerWhenNewestOperationDoesNotMatch() async {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -590,8 +590,12 @@ struct GGMutationCoordinatorTests {
             stack: try #require(harness.stacks[0].stack),
             action: harness.actionState
         )
-        #expect(model.syncProgress?.liveStatus == nil)
-        #expect(model.syncProgress?.showsSpinner == false)
+        #expect(harness.coordinator.activeRequest == nil)
+        #expect(harness.actionState.inFlightAction == nil)
+        #expect(harness.actionState.lastActionSummary == "Synced")
+        #expect(harness.actionState.syncProgress.isEmpty)
+        #expect(model.syncProgress == nil)
+        #expect(model.primaryActions.first(where: { $0.kind == .sync })?.isInFlight == false)
 
         resumeRefresh?.resume()
         try await task.value
@@ -618,8 +622,8 @@ struct GGMutationCoordinatorTests {
             stack: try #require(harness.stacks[0].stack),
             action: harness.actionState
         )
-        #expect(harness.coordinator.activeRequest == .sync)
-        #expect(harness.actionState.inFlightAction == .sync)
+        #expect(harness.coordinator.activeRequest == nil)
+        #expect(harness.actionState.inFlightAction == nil)
         #expect(harness.actionState.lastError == "sync failed")
         #expect(harness.actionState.syncHasTerminalFailure)
         #expect(model.syncProgress?.liveStatus == nil)

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -130,6 +130,31 @@ private final class RecordingUndoMarkerStore: GGUndoMarkerStoring, @unchecked Se
     }
 }
 
+private actor FirstRefreshSuspension {
+    private var didSuspend = false
+    private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var completion: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        guard !didSuspend else { return }
+        didSuspend = true
+        let waiters = suspensionWaiters
+        suspensionWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        await withCheckedContinuation { completion = $0 }
+    }
+
+    func waitUntilSuspended() async {
+        if didSuspend { return }
+        await withCheckedContinuation { suspensionWaiters.append($0) }
+    }
+
+    func resume() {
+        completion?.resume()
+        completion = nil
+    }
+}
+
 @MainActor
 private final class GGMutationHarness {
     enum Refresh: Equatable {
@@ -1411,6 +1436,47 @@ struct GGMutationCoordinatorTests {
         #expect(harness.service.requests == [.undo(operationID: candidate.id)])
         #expect(harness.coordinator.undoCandidate == nil)
         #expect(harness.markers.operationID(worktreeId: "wt") == nil)
+    }
+
+    @Test func completedUndoDoesNotClearNewerUndoCandidateAfterRefresh() async throws {
+        let undoneOperation = GGOperationSummary(
+            id: "op_undone", kind: "reorder", status: .completed, createdAtMs: 1,
+            args: ["--client-operation-id", "alas:undone", "reorder"],
+            stackName: "feature", touchedRemote: false, isUndoable: true
+        )
+        let newerOperation = GGOperationSummary(
+            id: "op_newer", kind: "squash", status: .completed, createdAtMs: 2,
+            args: ["--client-operation-id", "alas:test-1", "sc"],
+            stackName: "feature", touchedRemote: false, isUndoable: true
+        )
+        let harness = GGMutationHarness(
+            stacks: [stack(head: "a")], supportsClientOperationID: true
+        )
+        harness.markers.set(operationID: undoneOperation.id, worktreeId: "wt")
+        harness.service.operationLists = [
+            [undoneOperation],
+            [undoneOperation],
+            [newerOperation],
+        ]
+        await harness.coordinator.restoreUndoCandidate(currentStackName: "feature")
+        let refresh = FirstRefreshSuspension()
+        harness.onRefreshStack = { await refresh.suspend() }
+
+        let undoTask = try #require(harness.coordinator.startApplying(
+            .undo(operationID: undoneOperation.id),
+            confirmedAgainst: nil
+        ))
+        await refresh.waitUntilSuspended()
+
+        try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: newerOperation))
+        #expect(harness.markers.operationID(worktreeId: "wt") == newerOperation.id)
+
+        await refresh.resume()
+        try await undoTask.value
+
+        #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: newerOperation))
+        #expect(harness.markers.operationID(worktreeId: "wt") == newerOperation.id)
     }
 
     @Test func lastDropPersistsNoStackEvidenceBeforeRefreshReconcilesUndo() async throws {

--- a/AlasTests/Integrations/GGServiceTests.swift
+++ b/AlasTests/Integrations/GGServiceTests.swift
@@ -27,6 +27,36 @@ private struct FakeGGRunner: GGCommandRunning {
 }
 
 struct GGServiceTests {
+    @Test func processRunnerUsesShortTimeoutOnlyForStackQueries() async throws {
+        let cases: [([String], TimeInterval)] = [
+            (["ls", "--json"], Process.defaultTimeout),
+            (["--client-operation-id", "alas:1", "ls", "--json"], Process.defaultTimeout),
+            (["ls", "--json", "--client-operation-id", "alas:1"], Process.defaultTimeout),
+            (["sync", "--json"], 600),
+            (["sync", "--help"], 600),
+            (["ls"], 600)
+        ]
+
+        for (args, expectedTimeout) in cases {
+            let invocation = ProcessLaunchInvocation()
+            let runner = ProcessGGCommandRunner { executable, launchArgs, cwd, _, timeout in
+                invocation.record(
+                    executable: executable,
+                    args: launchArgs,
+                    cwd: cwd,
+                    timeout: timeout
+                )
+                return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+            }
+
+            _ = try await runner.run(args: args, cwd: nil)
+
+            #expect(invocation.executable == "/usr/bin/env")
+            #expect(invocation.args == ["gg"] + args)
+            #expect(invocation.timeout == expectedTimeout)
+        }
+    }
+
     @Test func probeVersionParsesOutput() async {
         let runner = FakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: "gg 0.9.8\n", stderr: "")
@@ -88,5 +118,28 @@ struct GGServiceTests {
         #expect(GGServiceError.map(exitCode: 127, stderr: "anything") == .cliMissing)
         #expect(GGServiceError.map(exitCode: 1, stderr: "  boom \n") == .commandFailed(stderr: "boom"))
         #expect(GGServiceError.map(exitCode: 2, stderr: "") == .commandFailed(stderr: ""))
+    }
+}
+
+private final class ProcessLaunchInvocation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: (executable: String, args: [String], cwd: URL?, timeout: TimeInterval)?
+
+    var executable: String? {
+        lock.withLock { value?.executable }
+    }
+
+    var args: [String]? {
+        lock.withLock { value?.args }
+    }
+
+    var timeout: TimeInterval? {
+        lock.withLock { value?.timeout }
+    }
+
+    func record(executable: String, args: [String], cwd: URL?, timeout: TimeInterval) {
+        lock.withLock {
+            value = (executable: executable, args: args, cwd: cwd, timeout: timeout)
+        }
     }
 }

--- a/AlasTests/Integrations/GGServiceTests.swift
+++ b/AlasTests/Integrations/GGServiceTests.swift
@@ -34,7 +34,9 @@ struct GGServiceTests {
             (["ls", "--json", "--client-operation-id", "alas:1"], Process.defaultTimeout),
             (["sync", "--json"], 600),
             (["sync", "--help"], 600),
-            (["ls"], 600)
+            (["ls"], 600),
+            (["land", "--until", "ls", "--json", "--no-clean"], 600),
+            (["--client-operation-id", "alas:1", "land", "--until", "ls", "--json", "--no-clean"], 600)
         ]
 
         for (args, expectedTimeout) in cases {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -226,6 +226,86 @@ private final class ReentrantSyncFakeGGRunner: GGCommandRunning, @unchecked Send
     }
 }
 
+/// Provides the three real calls made by a sync mutation: preflight stack
+/// read, sync output, and post-sync stack refresh. The post-sync refresh
+/// remains suspended until cancellation so a replacement gate refresh can
+/// prove it owns that work through `ggStackRefreshTask`.
+private actor PostMutationRefreshCancellationRunner: GGCommandRunning {
+    private let preflightResult = ProcessResult(
+        exitCode: 0,
+        stdout: GGStackModelsTests.fixture,
+        stderr: ""
+    )
+    private let replacementResult = ProcessResult(
+        exitCode: 0,
+        stdout: GGStackModelsTests.fixture.replacingOccurrences(
+            of: "agent-inbox",
+            with: "replacement-stack"
+        ),
+        stderr: ""
+    )
+    private let syncSummary = #"{"event":"summary"}"#
+
+    private var lsCallCount = 0
+    private var postSyncReadSuspended = false
+    private var postSyncReadCancellationObserved = false
+    private var postSyncReadWaiters: [CheckedContinuation<Void, Never>] = []
+    private var postSyncReadContinuation: CheckedContinuation<ProcessResult, Error>?
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["sync", "--help"] {
+            return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
+        }
+        if args == ["sync", "--json"] || args == ["sync", "--jsonl"] {
+            return ProcessResult(exitCode: 0, stdout: syncSummary, stderr: "")
+        }
+        guard args == ["ls", "--json"] else {
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected args: \(args)")
+        }
+        lsCallCount += 1
+        switch lsCallCount {
+        case 1:
+            return preflightResult
+        case 2:
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    postSyncReadSuspended = true
+                    postSyncReadContinuation = continuation
+                    let waiters = postSyncReadWaiters
+                    postSyncReadWaiters.removeAll()
+                    for waiter in waiters { waiter.resume() }
+                }
+            } onCancel: {
+                Task { await self.cancelPostSyncRead() }
+            }
+        case 3:
+            return replacementResult
+        default:
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected stack read")
+        }
+    }
+
+    func waitUntilPostSyncReadSuspends() async {
+        if postSyncReadSuspended { return }
+        await withCheckedContinuation { postSyncReadWaiters.append($0) }
+    }
+
+    func didObservePostSyncReadCancellation() -> Bool {
+        postSyncReadCancellationObserved
+    }
+
+    func releasePostSyncRead() {
+        postSyncReadContinuation?.resume(returning: replacementResult)
+        postSyncReadContinuation = nil
+    }
+
+    private func cancelPostSyncRead() {
+        postSyncReadCancellationObserved = true
+        postSyncReadContinuation?.resume(throwing: CancellationError())
+        postSyncReadContinuation = nil
+    }
+}
+
 private final class ConflictAfterSyncRunner: GGCommandRunning, @unchecked Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         if args == ["sync", "--help"] {
@@ -1843,6 +1923,30 @@ struct RightPaneGGStackTests {
 
         #expect(state.ggActionState.lastActionSummary == "Synced · 1 pushed")
         #expect(state.ggActionState.syncProgress.isEmpty)
+    }
+
+    @Test func postMutationStackRefreshIsCancelledByReplacementRefresh() async {
+        let worktree = makeWorktree()
+        let runner = PostMutationRefreshCancellationRunner()
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [
+            commit(sha: String(repeating: "s", count: 40), stackShaped: true),
+        ]
+
+        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        await runner.waitUntilPostSyncReadSuspends()
+
+        await state.reevaluateGGGate().value
+
+        #expect(await runner.didObservePostSyncReadCancellation())
+        #expect(state.ggStack?.name == "replacement-stack")
+        #expect(state.ggActionState.inFlightAction == nil)
+        #expect(state.ggActionState.lastActionSummary == "Synced")
+        #expect(state.ggActionState.syncProgress.isEmpty)
+
+        await runner.releasePostSyncRead()
     }
 
     @Test func repeatedSyncInvocationIsSilentlyIgnoredAtUIBoundary() async throws {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -250,6 +250,7 @@ private actor PostMutationRefreshCancellationRunner: GGCommandRunning {
     private var postSyncReadSuspended = false
     private var postSyncReadCancellationObserved = false
     private var postSyncReadWaiters: [CheckedContinuation<Void, Never>] = []
+    private var postSyncReadCancellationWaiters: [CheckedContinuation<Void, Never>] = []
     private var postSyncReadContinuation: CheckedContinuation<ProcessResult, Error>?
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
@@ -294,6 +295,11 @@ private actor PostMutationRefreshCancellationRunner: GGCommandRunning {
         postSyncReadCancellationObserved
     }
 
+    func waitUntilPostSyncReadCancellationIsObserved() async {
+        if postSyncReadCancellationObserved { return }
+        await withCheckedContinuation { postSyncReadCancellationWaiters.append($0) }
+    }
+
     func releasePostSyncRead() {
         postSyncReadContinuation?.resume(returning: replacementResult)
         postSyncReadContinuation = nil
@@ -301,8 +307,90 @@ private actor PostMutationRefreshCancellationRunner: GGCommandRunning {
 
     private func cancelPostSyncRead() {
         postSyncReadCancellationObserved = true
+        let waiters = postSyncReadCancellationWaiters
+        postSyncReadCancellationWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
         postSyncReadContinuation?.resume(throwing: CancellationError())
         postSyncReadContinuation = nil
+    }
+}
+
+/// Drives a failed mutation through its suspended post-mutation refresh while
+/// a replacement mutation is already running.
+private actor StaleMutationFailureRunner: GGCommandRunning {
+    private let stackResult = ProcessResult(
+        exitCode: 0,
+        stdout: GGStackModelsTests.fixture,
+        stderr: ""
+    )
+    private var stackReadCount = 0
+    private var syncCount = 0
+    private var firstRefreshSuspended = false
+    private var secondSyncSuspended = false
+    private var firstRefreshWaiters: [CheckedContinuation<Void, Never>] = []
+    private var secondSyncWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstRefreshContinuation: CheckedContinuation<ProcessResult, Error>?
+    private var secondSyncContinuation: CheckedContinuation<ProcessResult, Error>?
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        if args == ["sync", "--help"] {
+            return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
+        }
+        if args == ["sync", "--json"] || args == ["sync", "--jsonl"] {
+            syncCount += 1
+            if syncCount == 1 {
+                return ProcessResult(exitCode: 1, stdout: "", stderr: "mutation A failed")
+            }
+            return try await withCheckedThrowingContinuation { continuation in
+                secondSyncSuspended = true
+                secondSyncContinuation = continuation
+                let waiters = secondSyncWaiters
+                secondSyncWaiters.removeAll()
+                for waiter in waiters { waiter.resume() }
+            }
+        }
+        guard args == ["ls", "--json"] else {
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected args: \(args)")
+        }
+        stackReadCount += 1
+        switch stackReadCount {
+        case 1, 3, 4:
+            return stackResult
+        case 2:
+            return try await withCheckedThrowingContinuation { continuation in
+                firstRefreshSuspended = true
+                firstRefreshContinuation = continuation
+                let waiters = firstRefreshWaiters
+                firstRefreshWaiters.removeAll()
+                for waiter in waiters { waiter.resume() }
+            }
+        default:
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected stack read")
+        }
+    }
+
+    func waitUntilFirstRefreshSuspends() async {
+        if firstRefreshSuspended { return }
+        await withCheckedContinuation { firstRefreshWaiters.append($0) }
+    }
+
+    func waitUntilSecondSyncSuspends() async {
+        if secondSyncSuspended { return }
+        await withCheckedContinuation { secondSyncWaiters.append($0) }
+    }
+
+    func finishFirstRefresh() {
+        firstRefreshContinuation?.resume(returning: stackResult)
+        firstRefreshContinuation = nil
+    }
+
+    func finishSecondSync() {
+        secondSyncContinuation?.resume(returning: ProcessResult(
+            exitCode: 0,
+            stdout: #"{"event":"summary"}"#,
+            stderr: ""
+        ))
+        secondSyncContinuation = nil
     }
 }
 
@@ -1940,6 +2028,7 @@ struct RightPaneGGStackTests {
 
         await state.reevaluateGGGate().value
 
+        await runner.waitUntilPostSyncReadCancellationIsObserved()
         #expect(await runner.didObservePostSyncReadCancellation())
         #expect(state.ggStack?.name == "replacement-stack")
         #expect(state.ggActionState.inFlightAction == nil)
@@ -1947,6 +2036,46 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.syncProgress.isEmpty)
 
         await runner.releasePostSyncRead()
+    }
+
+    @Test func staleMutationFailureDoesNotOverwriteNewerActionState() async throws {
+        let worktree = makeWorktree()
+        let runner = StaleMutationFailureRunner()
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [
+            commit(sha: String(repeating: "s", count: 40), stackShaped: true),
+        ]
+
+        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        await runner.waitUntilFirstRefreshSuspends()
+
+        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        await runner.waitUntilSecondSyncSuspends()
+        #expect(state.ggActionState.inFlightAction == .sync)
+        #expect(state.ggActionState.lastActionSummary == nil)
+        #expect(state.ggActionState.syncProgress.isEmpty)
+        #expect(state.ggActionState.lastError == nil)
+
+        await runner.finishFirstRefresh()
+        for _ in 0..<100 where state.ggActionState.lastError == nil {
+            await Task.yield()
+        }
+
+        #expect(state.ggActionState.inFlightAction == .sync)
+        #expect(state.ggActionState.lastActionSummary == nil)
+        #expect(state.ggActionState.syncProgress.isEmpty)
+        #expect(state.ggActionState.lastError == nil)
+
+        await runner.finishSecondSync()
+        for _ in 0..<500 where state.ggActionState.inFlightAction != nil {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        #expect(state.ggActionState.lastActionSummary == "Synced")
+        #expect(state.ggActionState.syncProgress.isEmpty)
+        #expect(state.ggActionState.lastError == nil)
     }
 
     @Test func repeatedSyncInvocationIsSilentlyIgnoredAtUIBoundary() async throws {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -2048,10 +2048,10 @@ struct RightPaneGGStackTests {
             commit(sha: String(repeating: "s", count: 40), stackShaped: true),
         ]
 
-        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        let mutationA = try #require(state.runGGMutation(.sync))
         await runner.waitUntilFirstRefreshSuspends()
 
-        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        let mutationB = try #require(state.runGGMutation(.sync))
         await runner.waitUntilSecondSyncSuspends()
         #expect(state.ggActionState.inFlightAction == .sync)
         #expect(state.ggActionState.lastActionSummary == nil)
@@ -2059,9 +2059,7 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.lastError == nil)
 
         await runner.finishFirstRefresh()
-        for _ in 0..<100 where state.ggActionState.lastError == nil {
-            await Task.yield()
-        }
+        await mutationA.value
 
         #expect(state.ggActionState.inFlightAction == .sync)
         #expect(state.ggActionState.lastActionSummary == nil)
@@ -2069,9 +2067,7 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.lastError == nil)
 
         await runner.finishSecondSync()
-        for _ in 0..<500 where state.ggActionState.inFlightAction != nil {
-            try await Task.sleep(nanoseconds: 1_000_000)
-        }
+        await mutationB.value
 
         #expect(state.ggActionState.lastActionSummary == "Synced")
         #expect(state.ggActionState.syncProgress.isEmpty)

--- a/docs/superpowers/plans/2026-08-10-gg-post-sync-refresh-completion.md
+++ b/docs/superpowers/plans/2026-08-10-gg-post-sync-refresh-completion.md
@@ -1,0 +1,267 @@
+# GG Post-Sync Refresh Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Each task must follow superpowers:test-driven-development and receive a task-scoped review before the next task starts.
+
+**Goal:** Ensure a completed GG mutation never leaves its action spinner running while a follow-up stack refresh is slow, hung, cancelled, or failed.
+
+**Architecture:** Treat mutation execution and refresh reconciliation as two distinct phases. The coordinator publishes terminal mutation state before it awaits refresh work; `RightPaneState` routes that refresh through its existing cancellable `ggStackRefreshTask`; and the process runner applies a short timeout only to read-only `gg ls --json` calls while retaining the long mutation timeout.
+
+**Tech Stack:** Swift 5.9+, SwiftUI/Observation, Swift Concurrency, Swift Testing, XcodeGen/Xcode.
+
+## Global Constraints
+
+- Preserve the completed mutation result while refresh is pending or fails: success remains success, and a mutation error remains the terminal mutation error.
+- Clear `GGMutationCoordinator.activeRequest` and `GGStackActionState.inFlightAction` before any post-mutation refresh await.
+- Ending an old request must never clear a newer request, including a newer request with the same `GGMutationRequest` value.
+- Keep the returned mutation task awaitable through refresh completion for deterministic callers and tests.
+- Route post-mutation stack refreshes through the same tracked `ggStackRefreshTask` lifecycle used by `reevaluateGGGate()`.
+- Use `Process.defaultTimeout` (30 seconds) for buffered `gg ls --json` invocations, including invocations with client-operation arguments before or after the command tokens.
+- Keep the 600-second timeout for buffered mutations, capability probes, and streaming mutation commands.
+- A timed-out or otherwise failed stack refresh must surface through `ggStackLoadState` as a retryable failure without resurrecting an action spinner.
+- Keep the existing 0.14.4 cancellation recovery behavior and tests green.
+- Tests use Swift Testing (`import Testing`), not XCTest.
+- Keep code, comments, logs, and UI strings in English.
+- Do not edit `project.yml` or generated project files for this fix.
+
+---
+
+### Task 1: Publish terminal mutation state before refresh
+
+**Files:**
+
+- Modify: `AlasTests/Integrations/GGMutationCoordinatorTests.swift`
+- Modify: `Alas/Sources/Integrations/GG/GGMutationCoordinator.swift`
+
+**Step 1: Strengthen the suspended-refresh regression tests**
+
+Update `terminalSyncSummaryDoesNotRegressToPreparingDuringRefresh` so that, while `onRefreshStack` is suspended, it asserts all of these observable outcomes:
+
+```swift
+#expect(harness.coordinator.activeRequest == nil)
+#expect(harness.actionState.inFlightAction == nil)
+#expect(harness.actionState.lastActionSummary == "Synced")
+#expect(harness.actionState.syncProgress.isEmpty)
+#expect(model.syncProgress == nil)
+#expect(model.primaryActions.first(where: { $0.kind == .sync })?.isInFlight == false)
+```
+
+Update `syncCommandFailurePublishesTerminalStateBeforeSuspendedRefresh` so that the suspended refresh likewise observes `activeRequest == nil` and `inFlightAction == nil`, while preserving `lastError == "sync failed"` and `syncHasTerminalFailure == true`.
+
+These tests catch the original bug: moving action cleanup back behind `await refresh(...)` must make them fail.
+
+**Step 2: Run the focused tests and confirm RED**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGMutationCoordinatorTests/terminalSyncSummaryDoesNotRegressToPreparingDuringRefresh \
+  -only-testing:AlasTests/GGMutationCoordinatorTests/syncCommandFailurePublishesTerminalStateBeforeSuspendedRefresh
+```
+
+Expected: the new assertions fail because the coordinator still owns the action reservation during refresh.
+
+**Step 3: Release the observable action phase exactly once**
+
+Refactor `applyReserved` to use a synchronous local release path guarded by a per-invocation boolean. The fallback `defer` must release only if an earlier terminal path has not already released. The release path must:
+
+```swift
+activeRequest = nil
+actionState.endAction(request.actionKind)
+if request == .sync,
+   actionState.lastError == nil,
+   GGStackActionState.syncSummaryLine(from: actionState.syncProgress) != nil {
+    actionState.clearSyncProgress()
+}
+```
+
+Call it after `recordSummary` and `reconcilePausedState` on success but before `await refresh(...)`. In both error catches, publish the terminal error/failure state and then release before awaiting refresh. Set the per-invocation guard so the fallback defer cannot later clear a newer reservation.
+
+Do not detach the refresh and do not change refresh ordering or undo reconciliation.
+
+**Step 4: Run the focused tests and confirm GREEN**
+
+Run the command from Step 2. Expected: both tests pass, with their continuations still proving the returned task waits for refresh completion.
+
+**Step 5: Run the coordinator suite**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGMutationCoordinatorTests
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add Alas/Sources/Integrations/GG/GGMutationCoordinator.swift AlasTests/Integrations/GGMutationCoordinatorTests.swift
+git commit -m "fix(gg): end mutation state before stack refresh"
+```
+
+---
+
+### Task 2: Put post-mutation refreshes on the tracked refresh lifecycle
+
+**Files:**
+
+- Modify: `AlasTests/RightPaneGGStackTests.swift`
+- Modify: `Alas/Sources/Right/RightPaneState.swift`
+
+**Step 1: Add an integration regression test for replacement refresh cancellation**
+
+Add a purpose-built `GGCommandRunning` test double that can:
+
+- return a valid stack snapshot for the mutation preflight,
+- return a terminal JSONL sync summary,
+- suspend the post-sync `gg ls --json` call in a cancellation-sensitive await,
+- record when that suspended call is cancelled, and
+- let the next `gg ls --json` replacement complete successfully.
+
+Add `postMutationStackRefreshIsCancelledByReplacementRefresh`. Drive sync through `RightPaneState.onGGStackAction(.sync, appState:)`, wait for the post-sync stack read to suspend, then call and await `state.reevaluateGGGate()`. Assert the first post-sync read observed cancellation, the replacement read loaded the stack, and the action state remains terminal (`inFlightAction == nil`, summary retained, no sync progress).
+
+This catches routing the coordinator closure directly to `refreshGGStack()`: in that implementation the mutation refresh is not stored in `ggStackRefreshTask`, so replacement gate evaluation cannot cancel it.
+
+**Step 2: Run the new test and confirm RED**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/RightPaneGGStackTests/postMutationStackRefreshIsCancelledByReplacementRefresh
+```
+
+Expected: the suspended post-mutation refresh does not observe cancellation.
+
+**Step 3: Route the mutation context through `reevaluateGGGate()`**
+
+Replace the direct refresh body in `GGMutationContext.refreshStack` with the tracked path:
+
+```swift
+refreshStack: { [weak self] in
+    guard let self else { return }
+    await self.reevaluateGGGate().value
+},
+```
+
+Do not add another task property or duplicate the cancellation/generation logic. `reevaluateGGGate()` remains the single owner of `ggStackRefreshTask` replacement.
+
+**Step 4: Run the focused cancellation coverage and confirm GREEN**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/RightPaneGGStackTests/postMutationStackRefreshIsCancelledByReplacementRefresh \
+  -only-testing:AlasTests/RightPaneGGStackTests/cancelledSameKeyReloadRestoresPreviousStableStack \
+  -only-testing:AlasTests/RightPaneGGStackTests/cancelledFirstStackLoadBecomesRetryableFailure
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Alas/Sources/Right/RightPaneState.swift AlasTests/RightPaneGGStackTests.swift
+git commit -m "fix(gg): track post-mutation stack refreshes"
+```
+
+---
+
+### Task 3: Bound read-only stack query time without shortening mutations
+
+**Files:**
+
+- Modify: `AlasTests/Integrations/GGServiceTests.swift`
+- Modify: `Alas/Sources/Integrations/GG/GGService.swift`
+
+**Step 1: Add timeout policy tests**
+
+Add a table-driven test named `processRunnerUsesShortTimeoutOnlyForStackQueries` covering literal expectations:
+
+| Arguments | Expected timeout |
+|---|---:|
+| `["ls", "--json"]` | `Process.defaultTimeout` |
+| `["--client-operation-id", "alas:1", "ls", "--json"]` | `Process.defaultTimeout` |
+| `["ls", "--json", "--client-operation-id", "alas:1"]` | `Process.defaultTimeout` |
+| `["sync", "--json"]` | `600` |
+| `["sync", "--help"]` | `600` |
+| `["ls"]` | `600` |
+
+Exercise the timeout selected by `ProcessGGCommandRunner.run(args:cwd:)` through an injected process-launch closure that records the invocation and returns a successful `ProcessResult`. Assert the executable and command arguments remain `/usr/bin/env` and `["gg"] + args` as well as the timeout. Do not invoke a real `gg` subprocess.
+
+The test catches an over-broad short timeout, a suffix-only matcher that misses client-operation tokens, and accidental shortening of mutations.
+
+**Step 2: Run the new test and confirm RED**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGServiceTests/processRunnerUsesShortTimeoutOnlyForStackQueries
+```
+
+Expected: compilation or assertions fail until the runner exposes an injectable launch seam and selects the timeout by command tokens.
+
+**Step 3: Implement the narrow timeout policy**
+
+Keep `commandTimeout` at 600 seconds. Give `ProcessGGCommandRunner` an internal injected async process-launch closure whose default calls `Process.run`, and have `run(args:cwd:)` pass either `Process.defaultTimeout` or `commandTimeout` to it.
+
+Recognize the stack query by locating an adjacent `"ls", "--json"` pair anywhere in the GG argument list; do not classify a lone `ls`, a lone `--json`, or non-adjacent tokens as a stack query. Continue passing 600 seconds to `runStreaming`.
+
+**Step 4: Run service and streaming runner tests and confirm GREEN**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/GGServiceTests \
+  -only-testing:AlasTests/GGCommandRunningStreamingTests
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Alas/Sources/Integrations/GG/GGService.swift AlasTests/Integrations/GGServiceTests.swift
+git commit -m "fix(gg): bound stack query duration"
+```
+
+---
+
+### Task 4: Verify the complete fix and regression envelope
+
+**Files:**
+
+- Verify only; change files only if a verification failure exposes a defect in Tasks 1–3.
+
+**Step 1: Regenerate the Xcode project**
+
+```bash
+xcodegen
+```
+
+Expected: succeeds and produces no tracked diff because `project.yml` was not changed.
+
+**Step 2: Build the macOS app**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0.
+
+**Step 3: Run the full test suite**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: all tests pass.
+
+**Step 4: Inspect the final diff**
+
+```bash
+git status --short
+git diff --check
+git log --oneline --decorate -5
+```
+
+Expected: only the planned implementation, tests, design, and plan are present; no generated or unrelated changes remain.
+
+**Step 5: Record verification**
+
+Do not create an empty commit. Put command output and the final pass/fail summary in the subagent report so the controller can use it for final review and PR publication.

--- a/docs/superpowers/specs/2026-08-10-gg-post-sync-refresh-design.md
+++ b/docs/superpowers/specs/2026-08-10-gg-post-sync-refresh-design.md
@@ -1,0 +1,97 @@
+# GG Post-Sync Refresh Completion Design
+
+## Problem
+
+Alas keeps a GG mutation marked in flight while it refreshes stack, Git, and
+provider state after the GG command has already reached a terminal result. For
+`gg sync`, the first follow-up operation is a direct `gg ls --json` call. That
+call clears the visible stack into `.loading`, is not owned by the cancellable
+background stack-refresh task, and inherits the ten-minute timeout intended for
+mutating GG commands.
+
+If the forge lookup inside `gg ls` stalls, the completed sync continues to look
+active and the stack drawer can show a spinner for up to ten minutes. The 0.14.4
+recovery only handles a stack-refresh task that is cancelled and unwinds; it
+does not cover a live, un-cancelled read that is still waiting.
+
+## Design
+
+Treat mutation completion and follow-up presentation refresh as distinct
+lifecycle phases.
+
+When a GG command succeeds, Alas will record its summary, reconcile paused and
+undo state, release the mutation reservation, and clear the action's in-flight
+state before awaiting any follow-up refresh. When a GG command fails, Alas will
+publish its terminal error and likewise release the reservation before running
+the best-effort refresh. The returned mutation task may continue awaiting that
+refresh for deterministic callers, but the observable action state is already
+terminal and must not drive an action spinner.
+
+The post-mutation stack refresh will use `RightPaneState`'s tracked
+`ggStackRefreshTask` path. A watcher refresh or another explicit refresh can
+therefore supersede and cancel it through the existing generation-aware
+cancellation recovery instead of leaving an untracked `refreshGGStack` call
+alive.
+
+Read-only `gg ls --json` calls will use `Process.defaultTimeout` (30 seconds).
+All other buffered GG commands and all streaming mutation commands retain the
+existing 600-second timeout. Timeout selection belongs in
+`ProcessGGCommandRunner`, so every current-stack read receives the bound
+without changing the injectable `GGCommandRunning` protocol.
+
+## Data Flow
+
+1. Reserve the mutation and publish its action as in flight.
+2. Load the preflight stack and execute the GG command.
+3. Publish the command's terminal success, failure, summary, pause, and undo
+   state.
+4. Release `activeRequest` and clear `inFlightAction`.
+5. Start the stack refresh through the tracked task and await it only as
+   follow-up work.
+6. Refresh Git changes and, for remote mutations, provider review state.
+7. If `gg ls --json` exceeds 30 seconds, terminate it and publish the existing
+   retryable stack-load failure. Do not turn a successful sync into a sync
+   failure.
+
+Watcher-triggered refreshes remain single-flight. Stack refresh generations
+remain authoritative, so an older cancelled or delayed result cannot overwrite
+a newer result.
+
+## Error Handling
+
+- A sync command failure remains a sync failure and retains its existing
+  progress/error presentation.
+- A successful sync followed by a stack-refresh failure remains a successful
+  sync. The stack surface reports `Unavailable` with Retry.
+- A timed-out `gg ls --json` maps through the existing stack-load error path.
+- Cancellation recovery continues to restore a same-key stable stack or
+  publish an interrupted, retryable failure.
+- Releasing the mutation reservation is idempotent and must not clear a newer
+  mutation's state if follow-up work overlaps with it.
+
+## Testing
+
+Add regression coverage at the two responsible boundaries:
+
+1. Suspend the post-sync stack refresh after the sync summary arrives and
+   verify `activeRequest` and `inFlightAction` are already clear, the sync
+   summary is visible, and the action button no longer shows an in-flight
+   spinner.
+2. Resume the refresh and verify the mutation task completes and existing
+   refresh ordering remains intact.
+3. Verify `ProcessGGCommandRunner` selects 30 seconds for `gg ls --json`,
+   including a client-operation prefix if one is ever present, and 600 seconds
+   for mutating and streaming commands.
+4. Keep the 0.14.4 cancellation regressions green to prove the tracked refresh
+   still reaches a terminal state when superseded.
+
+Run the focused GG coordinator, right-pane stack, service, and process-runner
+tests before the full project build and test suite.
+
+## Scope
+
+This change does not alter GG's sync protocol, progress events, mutation
+timeouts, forge authentication, retry policy, or the drawer's visual design. It
+does not add automatic retry. It only separates terminal command state from
+best-effort refresh state, makes the refresh cancellable through its existing
+owner, and bounds read-only stack queries.


### PR DESCRIPTION
## Summary
- complete GG mutation UI state before post-mutation stack refreshes
- route those refreshes through the tracked cancellable refresh task and guard late errors by action generation
- bound buffered `gg ls --json` reads to 30 seconds while preserving 600-second mutation and streaming timeouts
- scope late undo cleanup and restoration to the operation state each waiter originally observed
- classify only the real GG command token when selecting the short read timeout

## Root cause
The 0.14.4 cancellation fix only covered tracked stack refreshes. Post-mutation refreshes bypassed that task, mutation state stayed in flight while awaiting them, and read-only stack queries inherited the 10-minute mutation timeout. Late mutation, undo-cleanup, and undo-restoration waiters could also write into newer action or recovery state after releasing their reservations.

## User impact
Completed syncs and other GG actions no longer leave the drawer spinner active while a stale refresh waits. Replacement refreshes can cancel post-mutation reads, stalled stack reads fail within 30 seconds without shortening mutation timeouts, and older waiters cannot erase or republish over newer recovery state.

## Validation
- `xcodegen`
- macOS build
- 142 combined GG tests passed
- stale-error RED/GREEN regression: pre-fix reproduced the stale `mutation A failed` write; fixed RightPane GG suite passed 58/58
- suspended-refresh undo cleanup and stale-restoration regressions; coordinator suite passed 69/69
- exact `land --until ls --json --no-clean` timeout regressions; service suite passed 8/8
- full macOS suite ran 7,870 tests: 7,855 passed, 12 skipped, and 3 unrelated tests failed in untouched AgentTerminal/DiffReviewSurface coverage
- final independent code reviews completed with no remaining findings
- GitHub Actions `build-test` passed on the final head