### PR TITLE
feat(gg): Show full GG stack in Changes

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */; };
 		2D63742A552F72DC6BEBF7DC /* WorktreeCreationCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CA4AD69CDACE0D41821742 /* WorktreeCreationCompletion.swift */; };
 		2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */; };
+		2DA2C2F546AF919D2DE4A41D /* GitService+StackCommits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCCB2F0B68844EA336A5433 /* GitService+StackCommits.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
 		2DDF8175D7490F505AED7DF4 /* WebSocketFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */; };
 		2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */; };
@@ -968,6 +969,7 @@
 		9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
 		9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */; };
+		9FE6B05DF450CFD427AD24A2 /* GitServiceStackCommitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1415E5F17DB2DF2038EE54 /* GitServiceStackCommitTests.swift */; };
 		A0012CF058E580908B5348BC /* AppKitDiffTilingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */; };
 		A00B9173561A37FD3B409BA9 /* GGCommandRunningStreamingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B58B29E5D4E497CEA3CE9BA /* GGCommandRunningStreamingTests.swift */; };
 		A01CDDEB7E0F6B2C1D3D0794 /* AddMissionLegDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C385F7CAAA65DB82ABC48F /* AddMissionLegDialogTests.swift */; };
@@ -1846,6 +1848,7 @@
 		2D904085EDE14D7C09A6BC9A /* AgentPathResolveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathResolveTests.swift; sourceTree = "<group>"; };
 		2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchPathResolverTests.swift; sourceTree = "<group>"; };
 		2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailure.swift; sourceTree = "<group>"; };
+		2DCCB2F0B68844EA336A5433 /* GitService+StackCommits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+StackCommits.swift"; sourceTree = "<group>"; };
 		2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnosticsTests.swift; sourceTree = "<group>"; };
 		2DDE190423707662BDC8E6EA /* RemoteRepoValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteRepoValidator.swift; sourceTree = "<group>"; };
 		2E14E781F0E1127387A06907 /* RemoteTerminalScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTerminalScriptTests.swift; sourceTree = "<group>"; };
@@ -2886,6 +2889,7 @@
 		DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRow.swift; sourceTree = "<group>"; };
 		DA89D4C70102BCF7B6B2450B /* ACPManagedAdapterDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagedAdapterDescriptor.swift; sourceTree = "<group>"; };
 		DAA7CD14A8FA2D335A59B062 /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
+		DB1415E5F17DB2DF2038EE54 /* GitServiceStackCommitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStackCommitTests.swift; sourceTree = "<group>"; };
 		DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRunScriptDialog.swift; sourceTree = "<group>"; };
 		DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetailsTests.swift; sourceTree = "<group>"; };
 		DB94BF97B7E1E0C78DDDE441 /* FileContextMenuActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileContextMenuActionsTests.swift; sourceTree = "<group>"; };
@@ -3509,6 +3513,7 @@
 				B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */,
 				1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */,
 				FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */,
+				DB1415E5F17DB2DF2038EE54 /* GitServiceStackCommitTests.swift */,
 				C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
 				1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */,
@@ -3851,6 +3856,7 @@
 				5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */,
 				764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */,
 				0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */,
+				2DCCB2F0B68844EA336A5433 /* GitService+StackCommits.swift */,
 				D2F90D03073708AA01531533 /* GitService+Staging.swift */,
 				8F3F67549BDACF73DFC2E477 /* GitService+Stash.swift */,
 				27A92711BC1D9A78D8A80561 /* GitTypes.swift */,
@@ -6455,6 +6461,7 @@
 				74F193BC4B2A1BD5AD58C6DA /* GitService+Pull.swift in Sources */,
 				5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */,
 				C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */,
+				2DA2C2F546AF919D2DE4A41D /* GitService+StackCommits.swift in Sources */,
 				0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */,
 				94FE17D9014F666C293EEFBE /* GitService+Stash.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
@@ -7237,6 +7244,7 @@
 				7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */,
 				B8BF059C5C2090AFBB56A5BC /* GitServicePullTests.swift in Sources */,
 				4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */,
+				9FE6B05DF450CFD427AD24A2 /* GitServiceStackCommitTests.swift in Sources */,
 				478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,
 				4135B5BC24856ED442E39069 /* GitServiceStashTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3207,6 +3207,7 @@ final class AppState {
     private func handleProjectRevisionChange(projectId: String) {
         bumpRevisionGenerationForProject(projectId: projectId)
         invalidateGGStackCacheAndRebumpGeneration(projectId: projectId)
+        rightPaneStore.refreshActiveGGPresentationForProjectRevision(projectId: projectId)
     }
 
     /// Invalidation itself is a fast, in-memory actor call, but it's still

--- a/Alas/Sources/Git/GitService+StackCommits.swift
+++ b/Alas/Sources/Git/GitService+StackCommits.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+enum StackCommitInfoError: Error, Equatable, LocalizedError {
+    case commandFailed(String)
+    case malformedRecord
+    case missingCommits([String])
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFailed(let message):
+            return message.isEmpty ? "Could not load the full GG stack." : message
+        case .malformedRecord:
+            return "Git returned commit metadata that Alas could not read."
+        case .missingCommits:
+            return "One or more GG stack commits are unavailable locally."
+        }
+    }
+}
+
+extension GitService {
+    func stackCommitInfos(at worktree: URL, shas: [String]) async throws -> [String: CommitInfo] {
+        guard !shas.isEmpty else { return [:] }
+        let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1f%b%x1d"
+        let result = try await Process.git(
+            ["log", "--no-walk=unsorted", "--stdin", "--pretty=tformat:\(format)", "--numstat"],
+            cwd: worktree,
+            stdin: shas.joined(separator: "\n") + "\n"
+        )
+        guard result.exitCode == 0 else {
+            throw StackCommitInfoError.commandFailed(
+                result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+
+        let infos = try Self.parseStackCommitInfoRecords(result.stdout)
+        let missing = shas.filter { requested in
+            !infos.keys.contains { full in full.hasPrefix(requested) || requested.hasPrefix(full) }
+        }
+        guard missing.isEmpty else { throw StackCommitInfoError.missingCommits(missing) }
+        return infos
+    }
+
+    static func parseStackCommitInfoRecords(_ stdout: String) throws -> [String: CommitInfo] {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        var infos: [String: CommitInfo] = [:]
+
+        for record in stdout.split(separator: "\u{1e}", omittingEmptySubsequences: true) {
+            let trimmed = record.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+
+            let sections = trimmed.split(separator: "\u{1d}", maxSplits: 1, omittingEmptySubsequences: false)
+            guard sections.count == 2 else { throw StackCommitInfoError.malformedRecord }
+
+            let fields = sections[0].split(separator: "\u{1f}", omittingEmptySubsequences: false)
+            guard fields.count == 6,
+                  let date = formatter.date(from: String(fields[3]))
+            else {
+                throw StackCommitInfoError.malformedRecord
+            }
+
+            let fullSHA = String(fields[0])
+            let shortSHA = String(fields[1])
+            let author = String(fields[2])
+            let rawSubject = String(fields[4])
+            let body = String(fields[5]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let (tag, subject) = CommitInfo.parseConventional(subject: rawSubject)
+
+            var filesChanged = 0
+            var insertions = 0
+            var deletions = 0
+            for line in sections[1].split(separator: "\n", omittingEmptySubsequences: false) {
+                let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+                guard !trimmedLine.isEmpty else { continue }
+
+                let numstat = trimmedLine.split(separator: "\t", omittingEmptySubsequences: false)
+                guard numstat.count >= 3,
+                      let additions = Self.stackCommitNumstatCount(numstat[0]),
+                      let removals = Self.stackCommitNumstatCount(numstat[1])
+                else {
+                    throw StackCommitInfoError.malformedRecord
+                }
+                filesChanged += 1
+                insertions += additions
+                deletions += removals
+            }
+
+            guard infos[fullSHA] == nil else { throw StackCommitInfoError.malformedRecord }
+            infos[fullSHA] = CommitInfo(
+                sha: fullSHA,
+                shortSha: shortSHA,
+                author: author,
+                authorInitials: CommitInfo.initials(for: author),
+                date: date,
+                subject: subject,
+                rawSubject: rawSubject,
+                body: body,
+                conventionalTag: tag,
+                filesChanged: filesChanged,
+                insertions: insertions,
+                deletions: deletions
+            )
+        }
+
+        return infos
+    }
+
+    private static func stackCommitNumstatCount(_ value: Substring) -> Int? {
+        if value == "-" { return 0 }
+        guard let count = Int(value), count >= 0 else { return nil }
+        return count
+    }
+}

--- a/Alas/Sources/Git/GitService+StackCommits.swift
+++ b/Alas/Sources/Git/GitService+StackCommits.swift
@@ -70,15 +70,28 @@ extension GitService {
             var insertions = 0
             var deletions = 0
             for line in sections[1].split(separator: "\n", omittingEmptySubsequences: false) {
-                let trimmedLine = line.trimmingCharacters(in: .whitespaces)
-                guard !trimmedLine.isEmpty else { continue }
+                guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
 
-                let numstat = trimmedLine.split(separator: "\t", omittingEmptySubsequences: false)
-                guard numstat.count == 3,
-                      let additions = Self.stackCommitNumstatCount(numstat[0]),
-                      let removals = Self.stackCommitNumstatCount(numstat[1])
-                else {
+                let numstat = line.split(separator: "\t", omittingEmptySubsequences: false)
+                guard numstat.count == 3, !numstat[2].isEmpty else {
                     throw StackCommitInfoError.malformedRecord
+                }
+                let additions: Int
+                let removals: Int
+                if numstat[0] == "-" || numstat[1] == "-" {
+                    guard numstat[0] == "-", numstat[1] == "-" else {
+                        throw StackCommitInfoError.malformedRecord
+                    }
+                    additions = 0
+                    removals = 0
+                } else {
+                    guard let parsedAdditions = Self.stackCommitNumstatCount(numstat[0]),
+                          let parsedRemovals = Self.stackCommitNumstatCount(numstat[1])
+                    else {
+                        throw StackCommitInfoError.malformedRecord
+                    }
+                    additions = parsedAdditions
+                    removals = parsedRemovals
                 }
                 filesChanged += 1
                 insertions += additions
@@ -106,7 +119,6 @@ extension GitService {
     }
 
     private static func stackCommitNumstatCount(_ value: Substring) -> Int? {
-        if value == "-" { return 0 }
         guard let count = Int(value), count >= 0 else { return nil }
         return count
     }

--- a/Alas/Sources/Git/GitService+StackCommits.swift
+++ b/Alas/Sources/Git/GitService+StackCommits.swift
@@ -74,7 +74,7 @@ extension GitService {
                 guard !trimmedLine.isEmpty else { continue }
 
                 let numstat = trimmedLine.split(separator: "\t", omittingEmptySubsequences: false)
-                guard numstat.count >= 3,
+                guard numstat.count == 3,
                       let additions = Self.stackCommitNumstatCount(numstat[0]),
                       let removals = Self.stackCommitNumstatCount(numstat[1])
                 else {

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -123,6 +123,59 @@ struct GGStack: Decodable, Equatable {
     func entry(matchingCommitSHA sha: String) -> GGStackEntry? {
         entries.first { sha.hasPrefix($0.sha) || $0.sha.hasPrefix(sha) }
     }
+
+    func projectCommits(_ infosBySHA: [String: CommitInfo]) throws -> [CommitInfo] {
+        try entries.sorted { $0.position > $1.position }.map { entry in
+            guard let info = infosBySHA.first(where: {
+                $0.key.hasPrefix(entry.sha) || entry.sha.hasPrefix($0.key)
+            })?.value else {
+                throw GGStackCommitProjectionError.missingCommit(sha: entry.sha)
+            }
+            return info
+        }
+    }
+
+    func relation(for entry: GGStackEntry) -> GGStackCommitRelation {
+        guard entries.contains(where: { $0.id == entry.id }),
+              let currentPosition,
+              entries.contains(where: { $0.position == currentPosition && $0.isCurrent })
+        else { return .unknown }
+        if entry.position > currentPosition { return .aboveCurrent }
+        if entry.position == currentPosition, entry.isCurrent { return .current }
+        return .belowCurrent
+    }
+
+    func currentPositionIndicator(for entry: GGStackEntry) -> GGCurrentPositionIndicator? {
+        guard relation(for: entry) == .current,
+              let currentPosition,
+              currentPosition < totalCommits,
+              totalCommits == entries.count
+        else { return nil }
+        return GGCurrentPositionIndicator(
+            text: "Current · \(currentPosition) of \(totalCommits)",
+            accessibilityLabel: "Current GG commit, position \(currentPosition) of \(totalCommits)"
+        )
+    }
+}
+
+enum GGStackCommitRelation: Equatable {
+    case aboveCurrent
+    case current
+    case belowCurrent
+    case unknown
+}
+
+struct GGCurrentPositionIndicator: Equatable {
+    let text: String
+    let accessibilityLabel: String
+}
+
+enum GGStackCommitProjectionError: Error, Equatable, LocalizedError {
+    case missingCommit(sha: String)
+
+    var errorDescription: String? {
+        "One or more GG stack commits are unavailable locally."
+    }
 }
 
 enum GGPRState: String, Equatable {

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -125,36 +125,72 @@ struct GGStack: Decodable, Equatable {
     }
 
     func projectCommits(_ infosBySHA: [String: CommitInfo]) throws -> [CommitInfo] {
-        try entries.sorted { $0.position > $1.position }.map { entry in
-            guard let info = infosBySHA.first(where: {
+        guard hasValidEntryShape,
+              infosBySHA.allSatisfy({ !$0.key.isEmpty && $0.key == $0.value.sha })
+        else {
+            throw GGStackCommitProjectionError.malformedStack
+        }
+
+        var resolvedSHAs: Set<String> = []
+        return try entries.sorted { $0.position > $1.position }.map { entry in
+            let matches = infosBySHA.filter {
                 $0.key.hasPrefix(entry.sha) || entry.sha.hasPrefix($0.key)
-            })?.value else {
+            }
+            guard !matches.isEmpty else {
                 throw GGStackCommitProjectionError.missingCommit(sha: entry.sha)
             }
+            guard matches.count == 1,
+                  let match = matches.first,
+                  resolvedSHAs.insert(match.key).inserted
+            else {
+                throw GGStackCommitProjectionError.malformedStack
+            }
+            let info = match.value
             return info
         }
     }
 
     func relation(for entry: GGStackEntry) -> GGStackCommitRelation {
-        guard entries.contains(where: { $0.id == entry.id }),
-              let currentPosition,
-              entries.contains(where: { $0.position == currentPosition && $0.isCurrent })
+        guard entries.contains(entry),
+              let currentEntry = validatedCurrentEntry
         else { return .unknown }
-        if entry.position > currentPosition { return .aboveCurrent }
-        if entry.position == currentPosition, entry.isCurrent { return .current }
+        if entry.position > currentEntry.position { return .aboveCurrent }
+        if entry == currentEntry { return .current }
         return .belowCurrent
     }
 
     func currentPositionIndicator(for entry: GGStackEntry) -> GGCurrentPositionIndicator? {
-        guard relation(for: entry) == .current,
-              let currentPosition,
-              currentPosition < totalCommits,
-              totalCommits == entries.count
+        guard let currentEntry = validatedCurrentEntry,
+              entry == currentEntry,
+              currentEntry.position < totalCommits
         else { return nil }
         return GGCurrentPositionIndicator(
-            text: "Current · \(currentPosition) of \(totalCommits)",
-            accessibilityLabel: "Current GG commit, position \(currentPosition) of \(totalCommits)"
+            text: "Current · \(currentEntry.position) of \(totalCommits)",
+            accessibilityLabel: "Current GG commit, position \(currentEntry.position) of \(totalCommits)"
         )
+    }
+
+    private var hasValidEntryShape: Bool {
+        guard totalCommits >= 0,
+              totalCommits == entries.count,
+              Set(entries.map(\.position)) == Set(entries.indices.map { $0 + 1 }),
+              entries.allSatisfy({ !$0.sha.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }),
+              Set(entries.map(\.sha)).count == entries.count
+        else { return false }
+        return true
+    }
+
+    private var validatedCurrentEntry: GGStackEntry? {
+        guard hasValidEntryShape,
+              let currentPosition,
+              currentPosition >= 1,
+              currentPosition <= totalCommits
+        else { return nil }
+        let currentEntries = entries.filter(\.isCurrent)
+        guard currentEntries.count == 1,
+              currentEntries[0].position == currentPosition
+        else { return nil }
+        return currentEntries[0]
     }
 }
 
@@ -172,9 +208,15 @@ struct GGCurrentPositionIndicator: Equatable {
 
 enum GGStackCommitProjectionError: Error, Equatable, LocalizedError {
     case missingCommit(sha: String)
+    case malformedStack
 
     var errorDescription: String? {
-        "One or more GG stack commits are unavailable locally."
+        switch self {
+        case .missingCommit:
+            return "One or more GG stack commits are unavailable locally."
+        case .malformedStack:
+            return "GG returned incomplete or inconsistent stack metadata."
+        }
     }
 }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -316,7 +316,7 @@ struct ChangesTabView: View {
                 commits: rps.commitsForDisplay,
                 olderCommits: rps.olderCommits,
                 comparisonRef: rps.comparisonRef,
-                hasMoreOlder: rps.hasMoreOlder,
+                hasMoreOlder: rps.hasMoreOlder && rps.ggStackLoadState != .loading,
                 isLoadingOlder: rps.isLoadingOlder,
                 behindBase: rps.showBehindBaseChip ? rps.behindBase : nil,
                 behindUpstream: rps.showBehindUpstreamChip ? rps.behindUpstream : nil,

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -313,7 +313,7 @@ struct ChangesTabView: View {
             )
             Divider().opacity(0.4)
             CommitsSectionView(
-                commits: rps.commits,
+                commits: rps.commitsForDisplay,
                 olderCommits: rps.olderCommits,
                 comparisonRef: rps.comparisonRef,
                 hasMoreOlder: rps.hasMoreOlder,

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -33,6 +33,7 @@ struct CommitRow: View {
     var onGGOpenPR: (() -> Void)? = nil
     /// Stack entry for this commit when the branch is a gg stack.
     var stackEntry: GGStackEntry? = nil
+    var currentPositionIndicator: GGCurrentPositionIndicator? = nil
     var codeHostKind: CodeHostKind? = nil
 
     @Environment(\.theme) private var theme
@@ -256,6 +257,18 @@ struct CommitRow: View {
                 Text("−\(commit.deletions)").foregroundColor(theme.color("del"))
             }
             Spacer(minLength: 0)
+            if let indicator = currentPositionIndicator {
+                Text(indicator.text)
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .foregroundColor(theme.color("accent"))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(theme.color("accent").opacity(0.12))
+                    .clipShape(Capsule())
+                    .accessibilityLabel(indicator.accessibilityLabel)
+            }
         }
         .font(.system(size: 10.5, design: .monospaced))
     }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -123,7 +123,7 @@ struct CommitsSectionView: View {
             SectionHeader(
                 role: ggStack == nil ? .commits : .stack,
                 title: Self.sectionTitle(ggStack: ggStack),
-                count: totalCount,
+                count: Self.sectionCount(primary: commits, older: olderCommits),
                 expanded: expanded,
                 onToggle: { expanded.toggle() }
             ) {
@@ -158,9 +158,9 @@ struct CommitsSectionView: View {
         }
     }
 
-    private var totalCount: Int? {
-        let n = commits.count + olderCommits.count
-        return n == 0 ? nil : n
+    static func sectionCount(primary: [CommitInfo], older: [CommitInfo]) -> Int? {
+        let count = primary.count + older.count
+        return count == 0 ? nil : count
     }
 
     /// A section's identity follows the active stack rather than the current
@@ -168,6 +168,11 @@ struct CommitsSectionView: View {
     /// or filtered-to-empty stacks.
     static func sectionTitle(ggStack: GGStack?) -> String {
         ggStack?.name ?? "Commits"
+    }
+
+    static func genericGitActionsAllowed(for entry: GGStackEntry?, in stack: GGStack?) -> Bool {
+        guard let entry, let stack else { return true }
+        return stack.relation(for: entry) != .aboveCurrent
     }
 
     static func rowBatches(count: Int) -> [Range<Int>] {
@@ -212,6 +217,11 @@ struct CommitsSectionView: View {
             ForEach(Self.rowBatches(for: commits)) { batch in
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(commits[batch.range]) { commit in
+                        let entry = ggStack?.entry(matchingCommitSHA: commit.sha)
+                        let allowsGenericGitActions = Self.genericGitActionsAllowed(for: entry, in: ggStack)
+                        let remote = entry == nil
+                            ? (rps.commitsNeedPush ? nil : rps.primaryCommitRemote)
+                            : rps.commitRemote
                         CommitRow(
                             commit: commit,
                             isLast: commit.id == commits.last?.id && olderCommits.isEmpty,
@@ -219,17 +229,18 @@ struct CommitsSectionView: View {
                             onCopySHA: { onCopySHA(commit) },
                             onCopyMessage: { Clipboard.copy(commit.fullMessage) },
                             ggID: Self.contextMenuGGID(for: commit, ggModeEnabled: rps.ggContext.isActive),
-                            onOpenRemote: rps.commitsNeedPush ? nil : openRemoteAction(for: commit, remote: rps.primaryCommitRemote),
-                            onEdit: { onEdit(commit) },
+                            onOpenRemote: openRemoteAction(for: commit, remote: remote),
+                            onEdit: allowsGenericGitActions ? { onEdit(commit) } : nil,
                             onReview: { onReview(commit) },
-                            onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
-                            onRevert: { rps.runRevert(sha: commit.sha) },
+                            onCherryPick: allowsGenericGitActions ? { rps.requestCherryPick(sha: commit.sha) } : nil,
+                            onRevert: allowsGenericGitActions ? { rps.runRevert(sha: commit.sha) } : nil,
                             ggMenu: ggMenu(for: commit),
                             onGGAction: { action in onGGAction(action, commit) },
                             onGGOpenPR: ggOpenReviewRequestAction(for: commit).map { action in
                                 { onGGAction(action, commit) }
                             },
-                            stackEntry: ggStack?.entry(matchingCommitSHA: commit.sha),
+                            stackEntry: entry,
+                            currentPositionIndicator: entry.flatMap { ggStack?.currentPositionIndicator(for: $0) },
                             codeHostKind: stackCodeHostKind
                         )
                     }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -129,6 +129,10 @@ final class RightPaneState: GGSplitCommitServicing {
     /// Current gg stack for this worktree's branch; nil when inactive or when
     /// gg reports that the active context has no stack metadata.
     var ggStack: GGStack? = nil
+    var ggStackDisplayCommits: [CommitInfo] = []
+    var commitsForDisplay: [CommitInfo] {
+        ggStackLoadState == .loaded ? ggStackDisplayCommits : commits
+    }
     var ggEffectiveConfig: GGEffectiveConfig = .defaults
     var ggContext: GGWorktreeContext = .inactive(reason: .policyOff)
     var ggStackLoadState: GGStackLoadState = .inactive
@@ -164,6 +168,11 @@ final class RightPaneState: GGSplitCommitServicing {
     /// .forReviewLoopBase`, computed in `performRefresh`), which never
     /// resolves to upstream and so always reflects true stack membership.
     @ObservationIgnored var ggStackSourceCommits: [CommitInfo] = []
+    @ObservationIgnored
+    var ggStackCommitLoader: @MainActor (URL, [String]) async throws -> [String: CommitInfo] = {
+        worktree, shas in
+        try await GitService().stackCommitInfos(at: worktree, shas: shas)
+    }
     /// SHA-set key of the last commits list gg was queried for. `gg ls
     /// --json` hits the forge API (best-effort PR-state refresh), and
     /// performRefresh fires continuously from the file watcher — so only
@@ -960,6 +969,7 @@ final class RightPaneState: GGSplitCommitServicing {
             ggStackCommitsKey = nil
             ggStackLoadState = .inactive
             if ggStack != nil { ggStack = nil }
+            if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
             }
@@ -983,6 +993,7 @@ final class RightPaneState: GGSplitCommitServicing {
             return
         }
         let previousStack = ggStack
+        let previousDisplayCommits = ggStackDisplayCommits
         let previousKey = ggStackCommitsKey
         let previousLoadState = ggStackLoadState
         let previousSummary = GGStackSummaryStore.shared.summaries[worktree.path.path]
@@ -996,11 +1007,13 @@ final class RightPaneState: GGSplitCommitServicing {
                     && (previousLoadState == .loaded || previousLoadState == .empty)
                 if canRestorePreviousSnapshot {
                     ggStack = previousStack
+                    ggStackDisplayCommits = previousDisplayCommits
                     ggStackCommitsKey = previousKey
                     ggStackLoadState = previousLoadState
                     GGStackSummaryStore.shared.summaries[worktree.path.path] = previousSummary
                 } else {
                     ggStack = nil
+                    ggStackDisplayCommits = []
                     ggStackCommitsKey = nil
                     ggStackLoadState = .failed(
                         "Stack refresh was interrupted. Retry to load it again."
@@ -1012,12 +1025,20 @@ final class RightPaneState: GGSplitCommitServicing {
         ggStackLoadState = .loading
         ggStackCommitsKey = nil
         if ggStack != nil { ggStack = nil }
+        if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
         if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
             GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
         }
         ggMutationCoordinator.suspendUndoCandidate()
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
+            let displayCommits: [CommitInfo]
+            if let stack, !stack.entries.isEmpty {
+                let infos = try await ggStackCommitLoader(worktree.path, stack.entries.map(\.sha))
+                displayCommits = try stack.projectCommits(infos)
+            } else {
+                displayCommits = []
+            }
             // A newer refresh, or a `markSnapshotUnknown()` invalidation,
             // superseded this one — its own `refreshGGStack` call (or the
             // invalidation's own reset) will write the current state;
@@ -1028,6 +1049,7 @@ final class RightPaneState: GGSplitCommitServicing {
             else { return }
             ggStackCommitsKey = key
             if ggStack != stack { ggStack = stack }
+            ggStackDisplayCommits = displayCommits
             let stackIsEmpty = stack.map { $0.totalCommits == 0 || $0.entries.isEmpty } ?? true
             ggStackLoadState = stackIsEmpty ? .empty : .loaded
             let summary = stackIsEmpty ? nil : stack?.summary
@@ -1058,6 +1080,7 @@ final class RightPaneState: GGSplitCommitServicing {
             else { return }
             ggStackCommitsKey = nil
             if ggStack != nil { ggStack = nil }
+            if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
             }
@@ -1642,6 +1665,7 @@ final class RightPaneState: GGSplitCommitServicing {
         ggStackSourceCommits = []
         ggStackCommitsKey = nil
         if ggStack != nil { ggStack = nil }
+        if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
         ggStackLoadState = ggContext.isActive ? .loading : .inactive
         if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
             GGStackSummaryStore.shared.summaries[worktree.path.path] = nil

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -125,6 +125,7 @@ final class RightPaneState: GGSplitCommitServicing {
     var olderCommits: [CommitInfo] = []
     var hasMoreOlder: Bool = true
     var isLoadingOlder: Bool = false
+    @ObservationIgnored private var commitDisplayGeneration: UInt = 0
 
     /// Current gg stack for this worktree's branch; nil when inactive or when
     /// gg reports that the active context has no stack metadata.
@@ -954,6 +955,9 @@ final class RightPaneState: GGSplitCommitServicing {
         }
         let context = ggContextProvider?(branch) ?? .inactive(reason: .policyOff)
         if ggContext != context { ggContext = context }
+        if ggStackLoadState == .loaded {
+            invalidateOlderHistoryForDisplaySourceChange()
+        }
         ggStackLoadState = context.isActive ? .loading : .inactive
     }
 
@@ -966,6 +970,9 @@ final class RightPaneState: GGSplitCommitServicing {
         if ggContext != context { ggContext = context }
         reconcilePausedOperation()
         guard context.isActive else {
+            if ggStackLoadState == .loaded {
+                invalidateOlderHistoryForDisplaySourceChange()
+            }
             ggStackCommitsKey = nil
             ggStackLoadState = .inactive
             if ggStack != nil { ggStack = nil }
@@ -1006,6 +1013,7 @@ final class RightPaneState: GGSplitCommitServicing {
                     && key == currentGGStackCommitsKey
                     && (previousLoadState == .loaded || previousLoadState == .empty)
                 if canRestorePreviousSnapshot {
+                    invalidateOlderHistoryForDisplaySourceChange()
                     ggStack = previousStack
                     ggStackDisplayCommits = previousDisplayCommits
                     ggStackCommitsKey = previousKey
@@ -1022,6 +1030,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 }
             }
         }
+        invalidateOlderHistoryForDisplaySourceChange()
         ggStackLoadState = .loading
         ggStackCommitsKey = nil
         if ggStack != nil { ggStack = nil }
@@ -1033,8 +1042,10 @@ final class RightPaneState: GGSplitCommitServicing {
         do {
             let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
             let displayCommits: [CommitInfo]
-            if let stack, !stack.entries.isEmpty {
-                let infos = try await ggStackCommitLoader(worktree.path, stack.entries.map(\.sha))
+            if let stack {
+                let infos = stack.entries.isEmpty
+                    ? [:]
+                    : try await ggStackCommitLoader(worktree.path, stack.entries.map(\.sha))
                 displayCommits = try stack.projectCommits(infos)
             } else {
                 displayCommits = []
@@ -1051,6 +1062,9 @@ final class RightPaneState: GGSplitCommitServicing {
             if ggStack != stack { ggStack = stack }
             ggStackDisplayCommits = displayCommits
             let stackIsEmpty = stack.map { $0.totalCommits == 0 || $0.entries.isEmpty } ?? true
+            if !stackIsEmpty {
+                invalidateOlderHistoryForDisplaySourceChange()
+            }
             ggStackLoadState = stackIsEmpty ? .empty : .loaded
             let summary = stackIsEmpty ? nil : stack?.summary
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
@@ -1656,7 +1670,7 @@ final class RightPaneState: GGSplitCommitServicing {
         indexFingerprint = ""
         fileTree = []
         commits = []
-        olderCommits = []
+        invalidateOlderHistoryForDisplaySourceChange()
         // gg stack state is derived from commits above — reset it here too,
         // and cancel any in-flight load, so a delayed or failed refresh
         // after this invalidation can't leave a stale "Stack · …"
@@ -2895,7 +2909,11 @@ final class RightPaneState: GGSplitCommitServicing {
     /// hides the tap target while a load is in flight.
     @MainActor
     func loadOlder() async {
-        guard !isLoadingOlder, hasMoreOlder else { return }
+        guard !isLoadingOlder,
+              hasMoreOlder,
+              ggStackLoadState != .loading
+        else { return }
+        let displayGeneration = commitDisplayGeneration
         let cursor: String
         if let last = olderCommits.last {
             cursor = last.sha
@@ -2915,7 +2933,9 @@ final class RightPaneState: GGSplitCommitServicing {
             let cursorStillValid = (olderCommits.last?.sha == cursor)
                 || (olderCommits.isEmpty && commitsForDisplay.last?.sha == cursor)
                 || (olderCommits.isEmpty && commitsForDisplay.isEmpty && cursor == "HEAD")
-            guard cursorStillValid else { return }
+            guard displayGeneration == commitDisplayGeneration,
+                  cursorStillValid
+            else { return }
             self.olderCommits.append(contentsOf: page)
             if page.count < 20 {
                 self.hasMoreOlder = false
@@ -2926,6 +2946,12 @@ final class RightPaneState: GGSplitCommitServicing {
             logger.error("loadOlder failed for worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             self.hasMoreOlder = false
         }
+    }
+
+    private func invalidateOlderHistoryForDisplaySourceChange() {
+        commitDisplayGeneration &+= 1
+        olderCommits = []
+        hasMoreOlder = true
     }
 
     // MARK: - Merge / rebase / cherry-pick operations

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -2899,7 +2899,7 @@ final class RightPaneState: GGSplitCommitServicing {
         let cursor: String
         if let last = olderCommits.last {
             cursor = last.sha
-        } else if let last = commits.last {
+        } else if let last = commitsForDisplay.last {
             cursor = last.sha
         } else {
             cursor = "HEAD"
@@ -2913,8 +2913,8 @@ final class RightPaneState: GGSplitCommitServicing {
                 count: 20
             )
             let cursorStillValid = (olderCommits.last?.sha == cursor)
-                || (olderCommits.isEmpty && commits.last?.sha == cursor)
-                || (olderCommits.isEmpty && commits.isEmpty && cursor == "HEAD")
+                || (olderCommits.isEmpty && commitsForDisplay.last?.sha == cursor)
+                || (olderCommits.isEmpty && commitsForDisplay.isEmpty && cursor == "HEAD")
             guard cursorStillValid else { return }
             self.olderCommits.append(contentsOf: page)
             if page.count < 20 {

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -341,12 +341,15 @@ final class RightPaneStore {
     func refreshActiveGGPresentationForProjectRevision(
         projectId: String
     ) -> Task<Void, Never>? {
+        let projectStates = states.values.filter { $0.worktree.projectId == projectId }
+        for state in projectStates {
+            state.ggStackCommitsKey = nil
+        }
         guard let activeId,
               let state = states[activeId],
               state.worktree.projectId == projectId,
               state.ggContext.isActive
         else { return nil }
-        state.ggStackCommitsKey = nil
         return Task { @MainActor in
             await state.refreshGGStack()
         }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -333,6 +333,25 @@ final class RightPaneStore {
         for state in states.values { state.reevaluateGGGate() }
     }
 
+    /// Branch-ref rewrites can change commits above the checked-out GG entry
+    /// without changing HEAD or its reachable commit set. Force the active
+    /// presentation to reload instead of letting its reachable-SHA cache key
+    /// preserve stale upper rows.
+    @discardableResult
+    func refreshActiveGGPresentationForProjectRevision(
+        projectId: String
+    ) -> Task<Void, Never>? {
+        guard let activeId,
+              let state = states[activeId],
+              state.worktree.projectId == projectId,
+              state.ggContext.isActive
+        else { return nil }
+        state.ggStackCommitsKey = nil
+        return Task { @MainActor in
+            await state.refreshGGStack()
+        }
+    }
+
     /// Re-evaluate the gg gate for one cached worktree after its override
     /// changes. Returns nil when that worktree has no cached pane state.
     @discardableResult

--- a/AlasTests/CommitRowTests.swift
+++ b/AlasTests/CommitRowTests.swift
@@ -105,6 +105,55 @@ struct CommitRowTests {
         #expect(GGCommitAction.checkout != .dropCommit)
     }
 
+    @Test func commitRowCarriesOffTipCurrentPositionIndicatorCopy() {
+        let indicator = GGCurrentPositionIndicator(
+            text: "Current · 2 of 4",
+            accessibilityLabel: "Current GG commit, position 2 of 4"
+        )
+        let row = CommitRow(
+            commit: commit(),
+            isLast: false,
+            onSelect: {},
+            onCopySHA: {},
+            currentPositionIndicator: indicator
+        )
+
+        #expect(row.currentPositionIndicator?.text == "Current · 2 of 4")
+        #expect(row.currentPositionIndicator?.accessibilityLabel == "Current GG commit, position 2 of 4")
+    }
+
+    @Test func aboveCurrentGGRowRetainsCheckoutAndGuardedMutations() {
+        let aboveCurrent = GGStackEntry(position: 4, sha: "four", title: "four")
+        let stack = GGStack(
+            name: "stack",
+            base: "main",
+            totalCommits: 4,
+            syncedCommits: 0,
+            currentPosition: 2,
+            behindBase: nil,
+            entries: [
+                GGStackEntry(position: 1, sha: "one", title: "one"),
+                GGStackEntry(position: 2, sha: "two", title: "two", isCurrent: true),
+                GGStackEntry(position: 3, sha: "three", title: "three"),
+                aboveCurrent,
+            ]
+        )
+        let menu = GGCommitMenuModel.make(context: GGCommitMenuContext(
+            entry: aboveCurrent,
+            stack: stack,
+            provider: nil,
+            capabilities: .init(structuredSplit: true, keepCurrentUnstack: true),
+            inFlightAction: nil,
+            pausedOperation: nil,
+            hasBlockingGitOperation: false,
+            selectionIsStale: false
+        ))
+
+        for action in [GGCommitAction.checkout, .splitCommit, .dropCommit, .unstackHere, .landThrough] {
+            #expect(menu.item(for: action) != nil)
+        }
+    }
+
     @Test func ggStackChipClickOpensProviderReviewWhenRemoteIsKnown() {
         let entry = GGStackEntry(
             position: 1,
@@ -175,5 +224,20 @@ struct CommitRowTests {
         #expect(feedback.message == "Copied title")
         try await waitUntil { feedback.message == nil }
         #expect(feedback.message == nil)
+    }
+
+    private func commit() -> CommitInfo {
+        CommitInfo(
+            sha: "deadbeef1234567890abcdef1234567890abcdef",
+            shortSha: "deadbee",
+            author: "Nacho Lopez",
+            authorInitials: "NL",
+            date: .now,
+            subject: "Show current stack position",
+            conventionalTag: nil,
+            filesChanged: 1,
+            insertions: 2,
+            deletions: 0
+        )
     }
 }

--- a/AlasTests/CommitsSectionTitleTests.swift
+++ b/AlasTests/CommitsSectionTitleTests.swift
@@ -86,4 +86,51 @@ struct CommitsSectionTitleTests {
             pausedGGOperation: GGPausedOperation(pausedBy: .sync)
         ))
     }
+
+    @Test func genericGitActionsAreHiddenOnlyAboveTheKnownCurrentStackPosition() {
+        let stack = GGStack(
+            name: "stack",
+            base: "main",
+            totalCommits: 4,
+            syncedCommits: 0,
+            currentPosition: 2,
+            behindBase: nil,
+            entries: [
+                GGStackEntry(position: 1, sha: "one", title: "one"),
+                GGStackEntry(position: 2, sha: "two", title: "two", isCurrent: true),
+                GGStackEntry(position: 3, sha: "three", title: "three"),
+                GGStackEntry(position: 4, sha: "four", title: "four"),
+            ]
+        )
+
+        #expect(!CommitsSectionView.genericGitActionsAllowed(for: stack.entries[3], in: stack))
+        #expect(!CommitsSectionView.genericGitActionsAllowed(for: stack.entries[2], in: stack))
+        #expect(CommitsSectionView.genericGitActionsAllowed(for: stack.entries[1], in: stack))
+        #expect(CommitsSectionView.genericGitActionsAllowed(for: stack.entries[0], in: stack))
+    }
+
+    @Test func unknownStackPositionKeepsGenericGitActionsAvailable() {
+        let entry = GGStackEntry(position: 1, sha: "one", title: "one")
+        let stack = GGStack(
+            name: "stack",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: nil,
+            behindBase: nil,
+            entries: [entry]
+        )
+
+        #expect(CommitsSectionView.genericGitActionsAllowed(for: entry, in: stack))
+        #expect(CommitsSectionView.genericGitActionsAllowed(for: nil, in: stack))
+        #expect(CommitsSectionView.genericGitActionsAllowed(for: entry, in: nil))
+    }
+
+    @Test func sectionCountIncludesPrimaryAndOlderRows() {
+        let primary = [commit(sha: "one"), commit(sha: "two"), commit(sha: "three"), commit(sha: "four")]
+        let older = [commit(sha: "five"), commit(sha: "six")]
+
+        #expect(CommitsSectionView.sectionCount(primary: primary, older: older) == 6)
+        #expect(CommitsSectionView.sectionCount(primary: [], older: []) == nil)
+    }
 }

--- a/AlasTests/GitServiceStackCommitTests.swift
+++ b/AlasTests/GitServiceStackCommitTests.swift
@@ -127,6 +127,24 @@ struct GitServiceStackCommitTests {
         #expect(infos[sha]?.deletions == 0)
     }
 
+    @Test func parserRejectsMixedBinaryAndNumericNumstatOrMissingPath() {
+        let sha = String(repeating: "f", count: 40)
+        let malformedNumstats = [
+            "-\t1\tfile.txt",
+            "1\t-\tfile.txt",
+            "1\t0\t",
+            "-\t-\t",
+        ]
+
+        for numstat in malformedNumstats {
+            #expect(throws: StackCommitInfoError.malformedRecord) {
+                try GitService.parseStackCommitInfoRecords(
+                    record(sha: sha, shortSHA: "fffffff", numstat: numstat)
+                )
+            }
+        }
+    }
+
     @Test func parserRejectsDuplicateResolvedSHAs() {
         let sha = String(repeating: "d", count: 40)
         let duplicate = record(sha: sha, shortSHA: "ddddddd") + record(sha: sha, shortSHA: "ddddddd")

--- a/AlasTests/GitServiceStackCommitTests.swift
+++ b/AlasTests/GitServiceStackCommitTests.swift
@@ -106,6 +106,16 @@ struct GitServiceStackCommitTests {
         }
     }
 
+    @Test func parserRejectsNumstatWithExtraTabSeparatedField() {
+        let sha = String(repeating: "e", count: 40)
+
+        #expect(throws: StackCommitInfoError.malformedRecord) {
+            try GitService.parseStackCommitInfoRecords(
+                record(sha: sha, shortSHA: "eeeeeee", numstat: "1\t0\tfile.txt\textra")
+            )
+        }
+    }
+
     @Test func parserCountsBinaryNumstatAsChangedFileWithoutLines() throws {
         let sha = String(repeating: "c", count: 40)
         let infos = try GitService.parseStackCommitInfoRecords(

--- a/AlasTests/GitServiceStackCommitTests.swift
+++ b/AlasTests/GitServiceStackCommitTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct GitServiceStackCommitTests {
+    private struct TwoCommitRepo {
+        let repo: URL
+        let base: String
+        let tip: String
+    }
+
+    private func makeTwoCommitRepo() async throws -> TwoCommitRepo {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-stack-commits-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "committer@example.com"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "Committer"], cwd: repo)
+
+        try "base\n".write(to: repo.appendingPathComponent("stack.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "stack.txt"], cwd: repo)
+        _ = try await Process.git(
+            ["commit", "-q", "--author", "Base Author <base@example.com>", "-m", "feat: base layer", "-m", "Base details."],
+            cwd: repo
+        )
+        let base = try await resolvedHead(in: repo)
+
+        try "base\ntip\n".write(to: repo.appendingPathComponent("stack.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "stack.txt"], cwd: repo)
+        _ = try await Process.git(
+            ["commit", "-q", "--author", "Tip Author <tip@example.com>", "-m", "fix: tip layer", "-m", "Tip details."],
+            cwd: repo
+        )
+        return TwoCommitRepo(repo: repo, base: base, tip: try await resolvedHead(in: repo))
+    }
+
+    private func resolvedHead(in repo: URL) async throws -> String {
+        let result = try await Process.git(["rev-parse", "HEAD"], cwd: repo)
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func record(
+        sha: String,
+        shortSHA: String,
+        author: String = "Test Author",
+        subject: String = "feat: test record",
+        body: String = "Details.",
+        numstat: String = "1\t0\tfile.txt"
+    ) -> String {
+        "\u{1e}\(sha)\u{1f}\(shortSHA)\u{1f}\(author)\u{1f}2024-01-02T03:04:05Z\u{1f}\(subject)\u{1f}\(body)\u{1d}\n\(numstat)"
+    }
+
+    @Test func loadsRequestedCommitsByFullResolvedSHA() async throws {
+        let fixture = try await makeTwoCommitRepo()
+        defer { try? FileManager.default.removeItem(at: fixture.repo) }
+
+        let infos = try await GitService().stackCommitInfos(
+            at: fixture.repo,
+            shas: [String(fixture.tip.prefix(7)), String(fixture.base.prefix(7))]
+        )
+
+        #expect(Set(infos.keys) == [fixture.base, fixture.tip])
+        #expect(infos[fixture.base]?.subject == "base layer")
+        #expect(infos[fixture.base]?.conventionalTag == "feat")
+        #expect(infos[fixture.tip]?.body == "Tip details.")
+        #expect(infos[fixture.tip]?.filesChanged == 1)
+    }
+
+    @Test func emptySHAListDoesNotInvokeGit() async throws {
+        #expect(try await GitService().stackCommitInfos(
+            at: URL(fileURLWithPath: "/missing"),
+            shas: [String]()
+        ) == [:])
+    }
+
+    @Test func unavailableSHAFailsTheWholeBatch() async throws {
+        let fixture = try await makeTwoCommitRepo()
+        defer { try? FileManager.default.removeItem(at: fixture.repo) }
+
+        await #expect(throws: StackCommitInfoError.self) {
+            _ = try await GitService().stackCommitInfos(at: fixture.repo, shas: [fixture.tip, "deadbeef"])
+        }
+    }
+
+    @Test func parserIndexesReversedRecordsByResolvedSHA() throws {
+        let base = String(repeating: "a", count: 40)
+        let tip = String(repeating: "b", count: 40)
+        let infos = try GitService.parseStackCommitInfoRecords(
+            record(sha: tip, shortSHA: "bbbbbbb", author: "Tip Author", subject: "fix: tip", numstat: "2\t1\ttip.txt")
+                + record(sha: base, shortSHA: "aaaaaaa", author: "Base Author", subject: "feat: base")
+        )
+
+        #expect(Set(infos.keys) == [base, tip])
+        #expect(infos[base]?.subject == "base")
+        #expect(infos[tip]?.subject == "tip")
+        #expect(infos[tip]?.insertions == 2)
+        #expect(infos[tip]?.deletions == 1)
+    }
+
+    @Test func parserRejectsMalformedHeaderFields() {
+        let malformed = "\u{1e}abc\u{1f}def\u{1f}Author\u{1f}2024-01-02T03:04:05Z\u{1f}subject\u{1d}\n1\t0\tfile.txt"
+
+        #expect(throws: StackCommitInfoError.malformedRecord) {
+            try GitService.parseStackCommitInfoRecords(malformed)
+        }
+    }
+
+    @Test func parserCountsBinaryNumstatAsChangedFileWithoutLines() throws {
+        let sha = String(repeating: "c", count: 40)
+        let infos = try GitService.parseStackCommitInfoRecords(
+            record(sha: sha, shortSHA: "ccccccc", numstat: "-\t-\tblob.bin")
+        )
+
+        #expect(infos[sha]?.filesChanged == 1)
+        #expect(infos[sha]?.insertions == 0)
+        #expect(infos[sha]?.deletions == 0)
+    }
+
+    @Test func parserRejectsDuplicateResolvedSHAs() {
+        let sha = String(repeating: "d", count: 40)
+        let duplicate = record(sha: sha, shortSHA: "ddddddd") + record(sha: sha, shortSHA: "ddddddd")
+
+        #expect(throws: StackCommitInfoError.malformedRecord) {
+            try GitService.parseStackCommitInfoRecords(duplicate)
+        }
+    }
+}

--- a/AlasTests/Integrations/GGStackModelsTests.swift
+++ b/AlasTests/Integrations/GGStackModelsTests.swift
@@ -167,6 +167,104 @@ struct GGStackModelsTests {
         #expect(tipStack.currentPositionIndicator(for: tip) == nil)
     }
 
+    @Test func projectionRejectsMalformedStackShapeBeforeHydration() {
+        let full1 = String(repeating: "a", count: 40)
+        let full2 = String(repeating: "b", count: 40)
+        let info = [
+            full1: commit(sha: full1),
+            full2: commit(sha: full2),
+        ]
+        let malformedEntries: [[GGStackEntry]] = [
+            [
+                GGStackEntry(position: 1, sha: "aaaaaaa", title: "one"),
+            ],
+            [
+                GGStackEntry(position: 1, sha: "aaaaaaa", title: "one"),
+                GGStackEntry(position: 1, sha: "bbbbbbb", title: "two"),
+            ],
+            [
+                GGStackEntry(position: 0, sha: "aaaaaaa", title: "one"),
+                GGStackEntry(position: 2, sha: "bbbbbbb", title: "two"),
+            ],
+            [
+                GGStackEntry(position: 1, sha: "", title: "one"),
+                GGStackEntry(position: 2, sha: "bbbbbbb", title: "two"),
+            ],
+            [
+                GGStackEntry(position: 1, sha: "aaaaaaa", title: "one"),
+                GGStackEntry(position: 2, sha: "aaaaaaa", title: "two"),
+            ],
+        ]
+
+        for (index, entries) in malformedEntries.enumerated() {
+            let total = index == 0 ? 2 : entries.count
+            let stack = GGStack(
+                name: "stack", base: "main", totalCommits: total, syncedCommits: 0,
+                currentPosition: nil, behindBase: nil, entries: entries
+            )
+            #expect(throws: GGStackCommitProjectionError.malformedStack) {
+                _ = try stack.projectCommits(info)
+            }
+        }
+    }
+
+    @Test func projectionRequiresOneDistinctResolvedCommitPerEntry() {
+        let full = String(repeating: "a", count: 40)
+        let ambiguous = GGStack(
+            name: "stack", base: "main", totalCommits: 2, syncedCommits: 0,
+            currentPosition: nil, behindBase: nil,
+            entries: [
+                GGStackEntry(position: 1, sha: "aaaaaaa", title: "one"),
+                GGStackEntry(position: 2, sha: "aaaaaaaa", title: "two"),
+            ]
+        )
+        #expect(throws: GGStackCommitProjectionError.malformedStack) {
+            _ = try ambiguous.projectCommits([full: commit(sha: full)])
+        }
+
+        let single = GGStack(
+            name: "stack", base: "main", totalCommits: 1, syncedCommits: 0,
+            currentPosition: nil, behindBase: nil,
+            entries: [GGStackEntry(position: 1, sha: "aaaaaaa", title: "one")]
+        )
+        #expect(throws: GGStackCommitProjectionError.malformedStack) {
+            _ = try single.projectCommits(["": commit(sha: full), full: commit(sha: full)])
+        }
+    }
+
+    @Test func indicatorRequiresValidPositionRangeAndOneMatchingCurrentEntry() {
+        let sha1 = String(repeating: "a", count: 7)
+        let sha2 = String(repeating: "b", count: 7)
+        let invalidCurrentPositions = [0, -1, 3]
+        for currentPosition in invalidCurrentPositions {
+            let current = GGStackEntry(position: 1, sha: sha1, title: "one", isCurrent: true)
+            let stack = GGStack(
+                name: "stack", base: "main", totalCommits: 2, syncedCommits: 0,
+                currentPosition: currentPosition, behindBase: nil,
+                entries: [current, GGStackEntry(position: 2, sha: sha2, title: "two")]
+            )
+            #expect(stack.relation(for: current) == .unknown)
+            #expect(stack.currentPositionIndicator(for: current) == nil)
+        }
+
+        let first = GGStackEntry(position: 1, sha: sha1, title: "one", isCurrent: true)
+        let duplicateCurrent = GGStack(
+            name: "stack", base: "main", totalCommits: 2, syncedCommits: 0,
+            currentPosition: 1, behindBase: nil,
+            entries: [first, GGStackEntry(position: 2, sha: sha2, title: "two", isCurrent: true)]
+        )
+        #expect(duplicateCurrent.relation(for: first) == .unknown)
+        #expect(duplicateCurrent.currentPositionIndicator(for: first) == nil)
+
+        let duplicatePosition = GGStack(
+            name: "stack", base: "main", totalCommits: 2, syncedCommits: 0,
+            currentPosition: 1, behindBase: nil,
+            entries: [first, GGStackEntry(position: 1, sha: sha2, title: "two")]
+        )
+        #expect(duplicatePosition.relation(for: first) == .unknown)
+        #expect(duplicatePosition.currentPositionIndicator(for: first) == nil)
+    }
+
     private func commit(sha: String) -> CommitInfo {
         CommitInfo(
             sha: sha,

--- a/AlasTests/Integrations/GGStackModelsTests.swift
+++ b/AlasTests/Integrations/GGStackModelsTests.swift
@@ -87,4 +87,98 @@ struct GGStackModelsTests {
         #expect(stack.entry(matchingCommitSHA: full)?.prNumber == 840)
         #expect(stack.entry(matchingCommitSHA: "ddddddd") == nil)
     }
+
+    @Test func projectsCompleteStackRowsInDescendingPositionOrder() throws {
+        let full1 = String(repeating: "a", count: 40)
+        let full2 = String(repeating: "b", count: 40)
+        let full3 = String(repeating: "c", count: 40)
+        let full4 = String(repeating: "d", count: 40)
+        let stack = GGStack(
+            name: "stack",
+            base: "main",
+            totalCommits: 4,
+            syncedCommits: 0,
+            currentPosition: 2,
+            behindBase: nil,
+            entries: [
+                GGStackEntry(position: 1, sha: String(full1.prefix(7)), title: "one"),
+                GGStackEntry(position: 2, sha: String(full2.prefix(7)), title: "two", isCurrent: true),
+                GGStackEntry(position: 3, sha: String(full3.prefix(7)), title: "three"),
+                GGStackEntry(position: 4, sha: String(full4.prefix(7)), title: "four"),
+            ]
+        )
+        let infosBySHA = [
+            full2: commit(sha: full2),
+            full4: commit(sha: full4),
+            full1: commit(sha: full1),
+            full3: commit(sha: full3),
+        ]
+
+        let projected = try stack.projectCommits(infosBySHA)
+
+        #expect(projected.map(\.sha) == [full4, full3, full2, full1])
+        #expect(stack.relation(for: stack.entries[3]) == .aboveCurrent)
+        #expect(stack.relation(for: stack.entries[1]) == .current)
+        #expect(stack.relation(for: stack.entries[0]) == .belowCurrent)
+        #expect(stack.currentPositionIndicator(for: stack.entries[1]) == GGCurrentPositionIndicator(
+            text: "Current · 2 of 4",
+            accessibilityLabel: "Current GG commit, position 2 of 4"
+        ))
+        #expect(stack.currentPositionIndicator(for: stack.entries[3]) == nil)
+    }
+
+    @Test func projectionRejectsMissingEntriesAndInconsistentCurrentPosition() throws {
+        let full = String(repeating: "a", count: 40)
+        let entry = GGStackEntry(position: 1, sha: String(full.prefix(7)), title: "one", isCurrent: true)
+        let missingStack = GGStack(
+            name: "stack", base: "main", totalCommits: 1, syncedCommits: 0,
+            currentPosition: 1, behindBase: nil, entries: [entry]
+        )
+        #expect(throws: GGStackCommitProjectionError.missingCommit(sha: entry.sha)) {
+            _ = try missingStack.projectCommits([:])
+        }
+
+        let inconsistentStack = GGStack(
+            name: "stack", base: "main", totalCommits: 1, syncedCommits: 0,
+            currentPosition: 1, behindBase: nil,
+            entries: [GGStackEntry(position: 1, sha: entry.sha, title: "one")]
+        )
+        #expect(inconsistentStack.relation(for: inconsistentStack.entries[0]) == .unknown)
+        #expect(inconsistentStack.currentPositionIndicator(for: inconsistentStack.entries[0]) == nil)
+
+        let nilPositionStack = GGStack(
+            name: "stack", base: "main", totalCommits: 1, syncedCommits: 0,
+            currentPosition: nil, behindBase: nil, entries: [entry]
+        )
+        #expect(nilPositionStack.relation(for: nilPositionStack.entries[0]) == .unknown)
+        #expect(nilPositionStack.currentPositionIndicator(for: nilPositionStack.entries[0]) == nil)
+
+        let tip = GGStackEntry(position: 4, sha: entry.sha, title: "tip", isCurrent: true)
+        let tipStack = GGStack(
+            name: "stack", base: "main", totalCommits: 4, syncedCommits: 0,
+            currentPosition: 4, behindBase: nil,
+            entries: [
+                GGStackEntry(position: 1, sha: "one", title: "one"),
+                GGStackEntry(position: 2, sha: "two", title: "two"),
+                GGStackEntry(position: 3, sha: "three", title: "three"),
+                tip,
+            ]
+        )
+        #expect(tipStack.currentPositionIndicator(for: tip) == nil)
+    }
+
+    private func commit(sha: String) -> CommitInfo {
+        CommitInfo(
+            sha: sha,
+            shortSha: String(sha.prefix(7)),
+            author: "Test",
+            authorInitials: "T",
+            date: .now,
+            subject: "subject",
+            conventionalTag: nil,
+            filesChanged: 0,
+            insertions: 0,
+            deletions: 0
+        )
+    }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -1414,6 +1414,48 @@ struct RightPaneGGStackTests {
         app.stopProjectGitWatcher(projectId: project.id)
     }
 
+    @Test func projectRevisionInvalidatesInactiveCachedGGPresentation() async throws {
+        let store = RightPaneStore()
+        let inactiveWorktree = makeWorktree()
+        let activeWorktree = makeWorktree()
+        let inactive = store.state(
+            for: inactiveWorktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        let active = store.state(
+            for: activeWorktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+
+        inactive.stop()
+        active.stop()
+        inactive.ggContext = .active(stackName: "agent-inbox")
+        inactive.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+        inactive.ggStackCommitsKey = inactive.currentGGStackCommitsKey
+        inactive.ggStackLoadState = .loaded
+        active.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        active.ggContext = .active(stackName: "agent-inbox")
+        active.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        active.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+        installFakeGGStackLoader(on: active)
+
+        let task = try #require(store.refreshActiveGGPresentationForProjectRevision(
+            projectId: inactiveWorktree.projectId
+        ))
+        await task.value
+
+        #expect(inactive.ggStackCommitsKey == nil)
+        #expect(store.ggStackSnapshotForWorktreePath(
+            inactiveWorktree.path.path,
+            effectiveContext: .active(stackName: "agent-inbox")
+        )?.loadState == .loading)
+        #expect(active.ggStackLoadState == .loaded)
+    }
+
     /// `reevaluateGGGate()` must clear stale stack state immediately when the
     /// gate flips closed (e.g. the Settings master toggle goes off), rather
     /// than waiting for the next watcher-driven refresh. `reevaluateGGGate()`

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -68,6 +68,9 @@ enum GGStackClassificationFixture: CaseIterable, Sendable {
 
     var isEmpty: Bool { self != .populated }
     var hasStack: Bool { self != .nilStack }
+    var isMalformed: Bool {
+        self == .zeroTotalWithEntry || self == .positiveTotalWithoutEntries
+    }
 
     var json: String {
         guard self != .nilStack else {
@@ -593,8 +596,18 @@ struct RightPaneGGStackErrorPresentationTests {
 @MainActor
 struct RightPaneGGStackTests {
     private struct MemoryStore: PersistenceStoreProtocol {
+        var projectsFile: ProjectsFile?
+
+        init(projectsFile: ProjectsFile? = nil) {
+            self.projectsFile = projectsFile
+        }
+
         func write<T: Encodable>(_: T, to _: URL) throws {}
-        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+        func readIfExists<T: Decodable>(_ type: T.Type, from _: URL) throws -> T? {
+            if type == ProjectsFile.self { return projectsFile as? T }
+            if type == AppConfig.self { return AppConfig.defaults as? T }
+            return nil
+        }
     }
 
     private func makeWorktree() -> Worktree {
@@ -1119,6 +1132,19 @@ struct RightPaneGGStackTests {
 
         await state.refreshGGStack()
 
+        if fixture.isMalformed {
+            #expect(state.ggStack == nil)
+            #expect(state.ggStackLoadState == .failed("GG returned incomplete or inconsistent stack metadata."))
+            #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
+            #expect(ChangesTabView.ggNewStackCommitDisabledReason(
+                contextIsActive: state.ggContext.isActive,
+                stackLoadState: state.ggStackLoadState,
+                stack: state.ggStack,
+                currentHeadSHA: state.currentHeadSHA
+            ) == "Retry loading the GG stack.")
+            return
+        }
+
         #expect((state.ggStack != nil) == fixture.hasStack)
         #expect((state.ggStackLoadState == .empty) == fixture.isEmpty)
         #expect((GGStackSummaryStore.shared.summaries[worktree.path.path] == nil) == fixture.isEmpty)
@@ -1311,6 +1337,81 @@ struct RightPaneGGStackTests {
         state.ggStackSourceCommits = [commit(sha: String(repeating: "d", count: 40), stackShaped: true)]
         await state.refreshGGStack()
         #expect(runner.callCount == 2)
+    }
+
+    @Test func projectRevisionWatcherReloadsAnUpperEntryWhenReachableCommitsAreUnchanged() async throws {
+        let project = ProjectConfig(
+            id: "test-project",
+            name: "Test",
+            path: "/repo",
+            color: "blue",
+            addedAt: .now
+        )
+        let worktree = makeWorktree()
+        let gitDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-upper-stack-watch-\(UUID().uuidString)/.git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent()) }
+        let watcher = ProjectGitWatcher(
+            repoPath: URL(fileURLWithPath: project.path),
+            resolvedGitDir: gitDir,
+            resolvedWorktreeRoot: worktree.path,
+            headDebounceInterval: 0.01,
+            headDebounceMaxWait: 0.05,
+            topologyDebounceInterval: 0.01,
+            topologyDebounceMaxWait: 0.05,
+            startStreamOverride: { _, _ in }
+        )
+        let app = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [project])),
+            projectGitWatcherFactory: { _ in watcher }
+        )
+        app.projectsManager.insertOptimisticWorktree(worktree)
+        app.projectsManager.setOperationState(id: worktree.id, state: nil)
+        let state = app.rightPaneStore.state(
+            for: worktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        state.stop()
+
+        let lowerSnapshot = GGStackModelsTests.fixture
+            .replacingOccurrences(of: #""current_position": 3"#, with: #""current_position": 1"#)
+            .replacingOccurrences(of: #""is_current": true"#, with: #""is_current": false"#)
+            .replacingOccurrences(
+                of: #""ci_status": "success", "is_current": false"#,
+                with: #""ci_status": "success", "is_current": true"#
+            )
+        let rewrittenUpperSnapshot = lowerSnapshot.replacingOccurrences(of: "ccccccc", with: "ddddddd")
+        let runner = ControlledStackGGRunner(
+            stackResults: [
+                ("agent-inbox", ProcessResult(exitCode: 0, stdout: lowerSnapshot, stderr: "")),
+                ("agent-inbox", ProcessResult(exitCode: 0, stdout: rewrittenUpperSnapshot, stderr: "")),
+            ],
+            suspendedCalls: []
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+        installFakeGGStackLoader(on: state)
+
+        await state.refreshGGStack()
+        #expect(state.ggStackDisplayCommits.first?.shortSha == "ccccccc")
+        let unchangedReachableKey = state.currentGGStackCommitsKey
+
+        app.startProjectGitWatcher(for: project)
+        watcher.processEvents([gitDir.appendingPathComponent("refs/remotes/origin/upper-entry").path])
+        for _ in 0..<500 where await runner.lsCallCount < 2 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        for _ in 0..<500 where state.ggStackDisplayCommits.first?.shortSha != "ddddddd" {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        #expect(state.currentGGStackCommitsKey == unchangedReachableKey)
+        #expect(await runner.lsCallCount == 2)
+        #expect(state.ggStackDisplayCommits.first?.shortSha == "ddddddd")
+        app.stopProjectGitWatcher(projectId: project.id)
     }
 
     /// `reevaluateGGGate()` must clear stale stack state immediately when the
@@ -2111,7 +2212,7 @@ struct RightPaneGGStackTests {
     @Test func postMutationStackRefreshIsCancelledByReplacementRefresh() async {
         let worktree = makeWorktree()
         let runner = PostMutationRefreshCancellationRunner()
-        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        let state = makeState(worktree: worktree)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
         state.ggStackSourceCommits = [

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -611,19 +611,76 @@ struct RightPaneGGStackTests {
         )
     }
 
-    private func commit(sha: String, stackShaped: Bool) -> CommitInfo {
+    private func commit(sha: String, stackShaped: Bool, subject: String = "subject") -> CommitInfo {
         CommitInfo(
             sha: sha, shortSha: String(sha.prefix(7)),
             author: "Test", authorInitials: "T", date: Date(),
-            subject: "subject",
+            subject: subject,
             body: stackShaped ? "Some detail.\n\nGG-ID: abc123\nGG-Parent: def456" : "Just a plain commit body.",
             conventionalTag: nil,
             filesChanged: 1, insertions: 1, deletions: 0
         )
     }
 
+    private func makeState(worktree: Worktree? = nil) -> RightPaneState {
+        let state = RightPaneState(worktree: worktree ?? makeWorktree(), baseBranch: "main")
+        installFakeGGStackLoader(on: state)
+        return state
+    }
+
+    private func installFakeGGStackLoader(on state: RightPaneState) {
+        state.ggStackCommitLoader = { _, shas in
+            Dictionary(uniqueKeysWithValues: shas.map { sha in
+                let fullSHA = sha.count == 40
+                    ? sha
+                    : sha + String(repeating: "0", count: 40 - sha.count)
+                return (fullSHA, self.commit(sha: fullSHA, stackShaped: true))
+            })
+        }
+    }
+
+    @Test func successfulRefreshPublishesFullStackRowsInPositionOrder() async {
+        let state = makeState()
+        let reachable = commit(sha: String(repeating: "f", count: 40), stackShaped: true)
+        state.commits = [reachable]
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStackDisplayCommits.map(\.shortSha) == ["ccccccc", "bbbbbbb", "aaaaaaa"])
+        #expect(state.commitsForDisplay == state.ggStackDisplayCommits)
+        #expect(state.commits == [reachable])
+    }
+
+    @Test func failedHydrationClearsStackAndKeepsPlainCommitRows() async {
+        let state = makeState()
+        let reachable = commit(sha: String(repeating: "f", count: 40), stackShaped: true)
+        state.commits = [reachable]
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+        state.ggStackCommitLoader = { _, shas in
+            throw StackCommitInfoError.missingCommits(shas)
+        }
+
+        await state.refreshGGStack()
+
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackDisplayCommits.isEmpty)
+        #expect(state.commitsForDisplay == state.commits)
+        #expect(state.ggStackCommitsKey == nil)
+        #expect(state.ggStackLoadState == .failed("One or more GG stack commits are unavailable locally."))
+    }
+
     @Test func seedingContextMakesEligibleFirstActivationLoadingImmediately() {
-        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let state = makeState()
         state.ggContextProvider = { branch in
             .active(stackName: String(branch.dropFirst("nacho/".count)))
         }
@@ -658,7 +715,7 @@ struct RightPaneGGStackTests {
         )
         defer { try? FileManager.default.removeItem(at: wt.path) }
         let runner = RecordingLifecycleGGRunner()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         state.ggStack = try GGStackSnapshot.decode(
             fromJSON: Data(GGStackModelsTests.fixture.utf8)
@@ -687,7 +744,7 @@ struct RightPaneGGStackTests {
         )
         defer { try? FileManager.default.removeItem(at: wt.path) }
         let runner = RecordingLifecycleGGRunner()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         let releaseFixture = GGStackModelsTests.fixture.replacingOccurrences(
             of: #""base": "main""#,
@@ -755,7 +812,7 @@ struct RightPaneGGStackTests {
 
     @Test func prepareFailurePresentsGGServiceUserMessage() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: ThrowingFakeGGRunner())
         let entry = try #require(try GGStackSnapshot.decode(
             fromJSON: Data(GGStackModelsTests.fixture.utf8)
@@ -771,7 +828,7 @@ struct RightPaneGGStackTests {
 
     @Test func applyPreflightFailurePresentsGGServiceUserMessage() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: ThrowingFakeGGRunner())
 
         state.requestGGCheckout(target: "change-1")
@@ -795,7 +852,7 @@ struct RightPaneGGStackTests {
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "q", count: 40), stackShaped: true)]
@@ -815,7 +872,7 @@ struct RightPaneGGStackTests {
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
-        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let state = makeState()
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "r", count: 40), stackShaped: true)]
@@ -839,7 +896,7 @@ struct RightPaneGGStackTests {
         let markerStore = GGUndoMarkerStore()
         markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
         let runner = AdvancingUndoGGRunner()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "u", count: 40), stackShaped: true)]
@@ -871,7 +928,7 @@ struct RightPaneGGStackTests {
             worktreeId: wt.id
         )
         let runner = NoCurrentStackUndoGGRunner()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [
@@ -899,7 +956,7 @@ struct RightPaneGGStackTests {
             snapshotOperationID: "op_paused",
             listedOperationID: "op_paused"
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         // Seed the gg gate and a stack-shaped commit set so the post-continue
         // refresh loads the `agent-inbox` stack and reconciles the undo
@@ -929,7 +986,7 @@ struct RightPaneGGStackTests {
             snapshotOperationID: nil,
             listedOperationID: "in-progress"
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         state.ggActionState.setPaused(GGPausedOperation(pausedBy: .restack))
 
@@ -1018,7 +1075,7 @@ struct RightPaneGGStackTests {
             status: .clean,
             lastActivity: Date()
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.comparisonMode = .branchUpstream
 
         await state.refresh()
@@ -1029,7 +1086,7 @@ struct RightPaneGGStackTests {
     }
 
     @Test func activeContextLoadsStackWithNoSourceCommits() async {
-        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let state = makeState()
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1048,7 +1105,7 @@ struct RightPaneGGStackTests {
     func stackClassificationKeepsEmptyUIConsistent(_ fixture: GGStackClassificationFixture) async {
         let worktree = makeWorktree()
         defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }
-        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        let state = makeState(worktree: worktree)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(
                 exitCode: 0,
@@ -1089,7 +1146,7 @@ struct RightPaneGGStackTests {
 
     @Test func inactiveContextSkipsGGAndClearsPublishedState() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1110,7 +1167,7 @@ struct RightPaneGGStackTests {
 
     @Test func gateClosedSkipsCLIAndClearsStack() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1127,7 +1184,7 @@ struct RightPaneGGStackTests {
 
     @Test func gateClosedClearsPausedOperation() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggContextProvider = { _ in .inactive(reason: .policyOff) }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
         state.ggActionState.setPaused(GGPausedOperation(pausedBy: .sync))
@@ -1142,7 +1199,7 @@ struct RightPaneGGStackTests {
         defer { GGUndoMarkerStore().clear(worktreeId: wt.id) }
         let markerStore = GGUndoMarkerStore()
         markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "n", count: 40), stackShaped: true)]
         state.ggService = GGService(runner: AdvancingUndoGGRunner())
@@ -1173,7 +1230,7 @@ struct RightPaneGGStackTests {
         let markerStore = GGUndoMarkerStore()
         markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
         let runner = FailSecondLsUndoGGRunner()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
@@ -1204,7 +1261,7 @@ struct RightPaneGGStackTests {
             id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
             branch: "feature", path: dir, status: .clean, lastActivity: Date()
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "o", count: 40), stackShaped: false)]
         _ = state.ggActionState.beginAction(.sync)
@@ -1217,7 +1274,7 @@ struct RightPaneGGStackTests {
 
     @Test func activeContextLoadsStackWithoutStackShapedCommits() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1234,7 +1291,7 @@ struct RightPaneGGStackTests {
 
     @Test func unchangedCommitSetDoesNotReinvokeCLI() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1263,7 +1320,7 @@ struct RightPaneGGStackTests {
     /// deterministically instead of racing the MainActor scheduler.
     @Test func reevaluateGGGateClearsStackWhenGateClosed() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1316,7 +1373,7 @@ struct RightPaneGGStackTests {
     /// underlying problem clears up.
     @Test func transientFailureDoesNotPoisonCommitsKeyCache() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let runner = ThrowingFakeGGRunner()
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
@@ -1338,7 +1395,7 @@ struct RightPaneGGStackTests {
         defer { GGUndoMarkerStore().clear(worktreeId: wt.id) }
         let markerStore = GGUndoMarkerStore()
         markerStore.set(GGUndoMarker(operationID: "op_1"), worktreeId: wt.id)
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: ThrowingFakeGGRunner())
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "f", count: 40), stackShaped: true)]
@@ -1358,7 +1415,16 @@ struct RightPaneGGStackTests {
             stderr: ""
         )
         let runner = DelayedStackGGRunner(staleResult: stale, freshResult: fresh)
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
+        var hydrationInvocation = 0
+        state.ggStackCommitLoader = { _, shas in
+            hydrationInvocation += 1
+            let subject = hydrationInvocation == 1 ? "fresh hydration" : "stale hydration"
+            return Dictionary(uniqueKeysWithValues: shas.map { sha in
+                let fullSHA = sha + String(repeating: "0", count: 40 - sha.count)
+                return (fullSHA, self.commit(sha: fullSHA, stackShaped: true, subject: subject))
+            })
+        }
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "z", count: 40), stackShaped: true)]
@@ -1372,9 +1438,11 @@ struct RightPaneGGStackTests {
         state.ggStackCommitsKey = nil
         await state.refreshGGStack()
         #expect(state.ggStack?.name == "fresh-stack")
+        #expect(state.ggStackDisplayCommits.allSatisfy { $0.subject == "fresh hydration" })
 
         await staleRefresh.value
         #expect(state.ggStack?.name == "fresh-stack")
+        #expect(state.ggStackDisplayCommits.allSatisfy { $0.subject == "fresh hydration" })
     }
 
     /// A stack loaded for one branch must not keep rendering after the user
@@ -1382,7 +1450,7 @@ struct RightPaneGGStackTests {
     /// fails transiently — the stale stack no longer matches `commits`.
     @Test func failedReloadClearsStaleStackFromDifferentBranch() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
 
         let okRunner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
@@ -1420,7 +1488,7 @@ struct RightPaneGGStackTests {
     /// leaving the UI stuck showing plain commits.
     @Test func failedReloadAllowsRefetchOnReturnToPriorBranch() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let commitsA = [commit(sha: String(repeating: "k", count: 40), stackShaped: true)]
 
         let firstRunner = CountingFakeGGRunner(
@@ -1460,7 +1528,7 @@ struct RightPaneGGStackTests {
     /// previous branch's cached stack via the unchanged-commits guard.
     @Test func branchChangeWithSameCommitsReinvokesCLI() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1478,7 +1546,7 @@ struct RightPaneGGStackTests {
     }
 
     @Test func activeContextNameChangeWithSameBranchAndCommitsReinvokesCLI() async {
-        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let state = makeState()
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1517,7 +1585,16 @@ struct RightPaneGGStackTests {
             stackResults: [("agent-inbox", result), ("cancelled-response", cancelledResult)],
             suspendedCalls: [2]
         )
-        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        let state = makeState(worktree: worktree)
+        var hydrationInvocation = 0
+        state.ggStackCommitLoader = { _, shas in
+            hydrationInvocation += 1
+            let subject = hydrationInvocation == 1 ? "stable hydration" : "cancelled hydration"
+            return Dictionary(uniqueKeysWithValues: shas.map { sha in
+                let fullSHA = sha + String(repeating: "0", count: 40 - sha.count)
+                return (fullSHA, self.commit(sha: fullSHA, stackShaped: true, subject: subject))
+            })
+        }
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
         state.ggStackSourceCommits = [
@@ -1527,6 +1604,7 @@ struct RightPaneGGStackTests {
         await state.refreshGGStack()
         let stableKey = try #require(state.ggStackCommitsKey)
         let stableSummary = try #require(GGStackSummaryStore.shared.summaries[worktree.path.path])
+        let stableDisplayCommits = state.ggStackDisplayCommits
 
         let refresh = Task { @MainActor in
             await state.refreshGGStack(forceRemote: true)
@@ -1542,6 +1620,9 @@ struct RightPaneGGStackTests {
         #expect(state.ggStack?.name == "agent-inbox")
         #expect(state.ggStack?.name != "cancelled-response")
         #expect(state.ggStackCommitsKey == stableKey)
+        #expect(state.ggStackDisplayCommits == stableDisplayCommits)
+        #expect(state.ggStackDisplayCommits.allSatisfy { $0.subject == "stable hydration" })
+        #expect(hydrationInvocation == 2)
         #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == stableSummary)
     }
 
@@ -1557,7 +1638,16 @@ struct RightPaneGGStackTests {
             stackResults: [("agent-inbox", result), ("agent-inbox", result)],
             suspendedCalls: [2]
         )
-        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        let state = makeState(worktree: worktree)
+        var hydrationInvocation = 0
+        state.ggStackCommitLoader = { _, shas in
+            hydrationInvocation += 1
+            let subject = hydrationInvocation == 1 ? "old hydration" : "changed hydration"
+            return Dictionary(uniqueKeysWithValues: shas.map { sha in
+                let fullSHA = sha + String(repeating: "0", count: 40 - sha.count)
+                return (fullSHA, self.commit(sha: fullSHA, stackShaped: true, subject: subject))
+            })
+        }
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
         state.currentBranch = "nacho/old-stack"
@@ -1583,6 +1673,8 @@ struct RightPaneGGStackTests {
 
         #expect(state.ggStackLoadState == .failed("Stack refresh was interrupted. Retry to load it again."))
         #expect(state.ggStack == nil)
+        #expect(state.ggStackDisplayCommits.isEmpty)
+        #expect(hydrationInvocation == 2)
         #expect(state.ggStackCommitsKey == nil)
         #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
     }
@@ -1598,7 +1690,7 @@ struct RightPaneGGStackTests {
             stackResults: [("agent-inbox", result)],
             suspendedCalls: [1]
         )
-        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        let state = makeState(worktree: worktree)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
         state.ggStackSourceCommits = [
@@ -1654,7 +1746,7 @@ struct RightPaneGGStackTests {
             ],
             suspendedCalls: [2, 4]
         )
-        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        let state = makeState(worktree: worktree)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.currentBranch = "nacho/old-stack"
@@ -1716,6 +1808,7 @@ struct RightPaneGGStackTests {
         let store = RightPaneStore()
         let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
         store.deactivate()
+        installFakeGGStackLoader(on: state)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggService = GGService(runner: CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
@@ -1739,6 +1832,7 @@ struct RightPaneGGStackTests {
         let store = RightPaneStore()
         let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
         store.deactivate()
+        installFakeGGStackLoader(on: state)
         state.ggContextProvider = { _ in .active(stackName: "old-stack") }
         state.ggService = GGService(runner: CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
@@ -1761,7 +1855,7 @@ struct RightPaneGGStackTests {
     /// commit list.
     @Test func markSnapshotUnknownClearsStackState() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -1776,13 +1870,14 @@ struct RightPaneGGStackTests {
         state.markSnapshotUnknown()
 
         #expect(state.ggStack == nil)
+        #expect(state.ggStackDisplayCommits.isEmpty)
         #expect(state.ggStackCommitsKey == nil)
         #expect(state.ggStackLoadState == .loading)
         #expect(GGStackSummaryStore.shared.summaries[wt.path.path] == nil)
     }
 
     @Test func markSnapshotUnknownKeepsInactiveLoadStateInactive() {
-        let state = RightPaneState(worktree: makeWorktree(), baseBranch: "main")
+        let state = makeState()
         state.ggContext = .inactive(reason: .policyOff)
         state.ggStackLoadState = .inactive
 
@@ -1802,7 +1897,7 @@ struct RightPaneGGStackTests {
             id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
             branch: "feature", path: dir, status: .clean, lastActivity: Date()
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         ))
@@ -1836,7 +1931,7 @@ struct RightPaneGGStackTests {
             id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
             branch: "feature", path: dir, status: .clean, lastActivity: Date()
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         ))
@@ -1865,7 +1960,7 @@ struct RightPaneGGStackTests {
             snapshotOperationID: nil,
             listedOperationID: "in-progress"
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")) }
         state.currentBranch = ""
@@ -1898,7 +1993,7 @@ struct RightPaneGGStackTests {
             id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
             branch: "feature", path: dir, status: .clean, lastActivity: Date()
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         ))
@@ -1920,7 +2015,7 @@ struct RightPaneGGStackTests {
             id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
             branch: "feature", path: dir, status: .clean, lastActivity: Date()
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: ThrowingFakeGGRunner())
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "m", count: 40), stackShaped: true)]
@@ -1941,7 +2036,7 @@ struct RightPaneGGStackTests {
             id: Worktree.makeId(path: dir), projectId: "p", name: "feature",
             branch: "feature", path: dir, status: .clean, lastActivity: Date()
         )
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: ConflictAfterSyncRunner())
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
@@ -1962,7 +2057,7 @@ struct RightPaneGGStackTests {
         )
         defer { try? FileManager.default.removeItem(at: wt.path) }
         let runner = CleanMutationFakeGGRunner()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         var didRefreshProjectTopology = false
         state.refreshProjectTopologyAfterGGMutation = {
@@ -1984,7 +2079,7 @@ struct RightPaneGGStackTests {
 
     @Test func syncActionLeavesSummaryAndClearsProgress() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let ndjson = [
             #"{"event":"start","total_entries":1}"#,
             #"{"event":"push_done","position":1,"forced":false}"#,
@@ -2077,7 +2172,7 @@ struct RightPaneGGStackTests {
     @Test func repeatedSyncInvocationIsSilentlyIgnoredAtUIBoundary() async throws {
         let wt = makeWorktree()
         let runner = ReentrantSyncFakeGGRunner()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "stack") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "s", count: 40), stackShaped: true)]
@@ -2099,7 +2194,7 @@ struct RightPaneGGStackTests {
 
     @Test func syncErrorSuppressesSuccessSummary() async throws {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let ndjson = [
             #"{"event":"start","total_entries":1}"#,
             #"{"event":"push_done","position":1,"forced":false}"#,
@@ -2121,7 +2216,7 @@ struct RightPaneGGStackTests {
 
     @Test func commitMenuSelectionStalenessTracksStackSnapshotSourceKey() {
         let wt = makeWorktree()
-        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        let state = makeState(worktree: wt)
         let source = commit(sha: String(repeating: "a", count: 40), stackShaped: true)
         state.ggStackSourceCommits = [source]
         state.ggStack = GGStack(

--- a/AlasTests/RightPaneStateLoadOlderTests.swift
+++ b/AlasTests/RightPaneStateLoadOlderTests.swift
@@ -2,6 +2,51 @@ import Testing
 import Foundation
 @testable import Alas
 
+private final class LoadOlderStackRunner: GGCommandRunning, @unchecked Sendable {
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+    }
+}
+
+private actor DelayedStackHydration {
+    private var started = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func waitUntilStarted() async {
+        if started { return }
+        await withCheckedContinuation { startWaiters.append($0) }
+    }
+
+    func load(_ shas: [String]) async -> [String: CommitInfo] {
+        started = true
+        let waiters = startWaiters
+        startWaiters = []
+        for waiter in waiters { waiter.resume() }
+        await withCheckedContinuation { releaseContinuation = $0 }
+        return Dictionary(uniqueKeysWithValues: shas.map { sha in
+            let fullSHA = sha + String(repeating: "0", count: 40 - sha.count)
+            return (fullSHA, CommitInfo(
+                sha: fullSHA,
+                shortSha: sha,
+                author: "Test",
+                authorInitials: "T",
+                date: .now,
+                subject: sha,
+                conventionalTag: nil,
+                filesChanged: 0,
+                insertions: 0,
+                deletions: 0
+            ))
+        })
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
 @MainActor
 @Suite(.serialized)
 struct RightPaneStateLoadOlderTests {
@@ -93,6 +138,34 @@ struct RightPaneStateLoadOlderTests {
         #expect(state.olderCommits.first?.subject == "c25")
         #expect(displayedSHAs.intersection(olderSHAs).isEmpty)
         #expect(displayedSHAs.union(olderSHAs).count == 23)
+    }
+
+    @Test func loadingGGPresentationDisablesPaginationAndDropsRowsFromThePreviousSource() async throws {
+        let repo = try await makeBranchAhead(base: 25, ahead: 3)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(worktree: makeWorktree(at: repo, branch: "feature"), baseBranch: "main")
+        await state.refresh()
+        await state.loadOlder()
+        #expect(state.olderCommits.count == 20)
+
+        let hydration = DelayedStackHydration()
+        state.ggService = GGService(runner: LoadOlderStackRunner())
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = state.commits
+        state.ggStackCommitLoader = { _, shas in await hydration.load(shas) }
+
+        let refresh = Task { @MainActor in await state.refreshGGStack() }
+        await hydration.waitUntilStarted()
+        #expect(state.ggStackLoadState == .loading)
+
+        await state.loadOlder()
+
+        #expect(state.olderCommits.isEmpty)
+        #expect(state.hasMoreOlder)
+        await hydration.release()
+        await refresh.value
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.olderCommits.isEmpty)
     }
 
     @Test func branchFetchMarksLoadingAndPublishesCompleteInitialList() async throws {

--- a/AlasTests/RightPaneStateLoadOlderTests.swift
+++ b/AlasTests/RightPaneStateLoadOlderTests.swift
@@ -75,6 +75,26 @@ struct RightPaneStateLoadOlderTests {
         #expect(state.olderCommits[0].subject == "c25")
     }
 
+    @Test func hydratedGGDisplayRowsProvideTheFirstOlderHistoryCursor() async throws {
+        let repo = try await makeBranchAhead(base: 25, ahead: 3)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(worktree: makeWorktree(at: repo, branch: "feature"), baseBranch: "main")
+        await state.refresh()
+        let displayedStack = state.commits
+        state.ggStackDisplayCommits = displayedStack
+        state.ggStackLoadState = .loaded
+        state.commits = []
+
+        await state.loadOlder()
+
+        let displayedSHAs = Set(state.commitsForDisplay.map(\.sha))
+        let olderSHAs = Set(state.olderCommits.map(\.sha))
+        #expect(state.olderCommits.count == 20)
+        #expect(state.olderCommits.first?.subject == "c25")
+        #expect(displayedSHAs.intersection(olderSHAs).isEmpty)
+        #expect(displayedSHAs.union(olderSHAs).count == 23)
+    }
+
     @Test func branchFetchMarksLoadingAndPublishesCompleteInitialList() async throws {
         let fixture = try await makeRepoWithRemoteBranches()
         defer {

--- a/docs/superpowers/plans/2026-08-10-full-gg-stack-commits.md
+++ b/docs/superpowers/plans/2026-08-10-full-gg-stack-commits.md
@@ -1,0 +1,518 @@
+# Full GG Stack in Changes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Always show every commit in the active GG stack in Changes and identify an off-tip checkout with a compact current-position row label.
+
+**Architecture:** Keep `gg ls --json` as stack truth, batch-hydrate its SHAs into full `CommitInfo` values with one local Git command, and publish the ordered rows atomically with the existing GG refresh generation. Preserve `RightPaneState.commits` for ordinary Git/business logic and expose a separate GG-only display list to the Commits section.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Observation, Foundation `Process`, git-gud JSON schema 1, Swift Testing, XcodeGen.
+
+## Global Constraints
+
+- Implement this entirely in Alas; do not change git-gud commands, output, or minimum version.
+- Keep all code, comments, logs, tests, and UI copy in English.
+- Use Swift Testing (`import Testing`), not XCTest.
+- Keep `RightPaneState.commits` authoritative for ahead counts, push/preparation decisions, comparison logic, and initial-tab selection.
+- Never publish a partial or mixed-generation GG commit list.
+- Keep the existing SHA-derived `CommitRowBatch` identity and batches of eight.
+- Order GG stack rows by descending `position`, with the stack tip first.
+- Show `Current · X of N` only when the current entry is below the stack tip.
+- Keep GG-native guarded mutations available for all entries; hide generic Edit, Cherry-pick, and Revert only above the current position.
+- Preserve current non-GG rows, older-history paging/divider behavior, stack chips, merged opacity, and row selection.
+- Prefix repository commands with `rtk`; run Xcode builds/tests serially.
+- Do not add agent attribution to commits or documentation.
+
+---
+
+## File Map
+
+- Create `Alas/Sources/Git/GitService+StackCommits.swift`: batch-load arbitrary stack SHAs into `CommitInfo` values keyed by full resolved SHA.
+- Create `AlasTests/GitServiceStackCommitTests.swift`: real temporary-repository coverage for batch hydration, empty input, missing objects, and malformed parser records.
+- Modify `Alas/Sources/Integrations/GG/GGStackModels.swift`: project hydrated commit metadata into stack order and derive current/above/below presentation state.
+- Modify `Alas/Sources/Right/RightPaneState.swift`: own the GG display rows, injectable loader seam, atomic refresh publication, failure clearing, and cancellation restoration.
+- Modify `Alas/Sources/Right/ChangesTabView.swift`: pass GG display rows to the Commits section without replacing ordinary commits.
+- Modify `Alas/Sources/Right/CommitsSectionView.swift`: classify upper rows, suppress only unsafe generic callbacks, and pass the current-position badge model.
+- Modify `Alas/Sources/Right/CommitRow.swift`: render and expose accessibility for the selected compact row badge.
+- Modify `AlasTests/Integrations/GGStackModelsTests.swift`: pure ordering, missing-commit, relation, and position-badge coverage.
+- Modify `AlasTests/RightPaneGGStackTests.swift`: stub hydration for existing fake GG snapshots and cover atomic publication, fallback, cancellation, and stale generations.
+- Modify `AlasTests/CommitsSectionTitleTests.swift` and `AlasTests/CommitRowTests.swift`: count/action policy and indicator/accessibility regressions.
+- Regenerate `Alas.xcodeproj/project.pbxproj` after adding the two new files.
+
+---
+
+### Task 1: Batch-hydrate GG entry SHAs with one Git command
+
+**Files:**
+- Create: `Alas/Sources/Git/GitService+StackCommits.swift`
+- Create: `AlasTests/GitServiceStackCommitTests.swift`
+- Regenerate: `Alas.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: `Process.git(_:cwd:stdin:timeout:)`, `CommitInfo`, and the established `%x1e`/`%x1f`/`%x1d` commit-log record format.
+- Produces: `GitService.stackCommitInfos(at:shas:) async throws -> [String: CommitInfo]`, keyed by each commit's full resolved SHA; Task 2 injects and consumes this method.
+- Produces: `StackCommitInfoError.commandFailed(String)`, `.malformedRecord`, and `.missingCommits([String])` with stable localized descriptions for the existing GG failed-state presentation.
+
+- [ ] **Step 1: Add a compiling test target and a deliberately incomplete loader**
+
+Create `GitService+StackCommits.swift` with the public-to-module interface and empty-input behavior:
+
+```swift
+import Foundation
+
+enum StackCommitInfoError: Error, Equatable, LocalizedError {
+    case commandFailed(String)
+    case malformedRecord
+    case missingCommits([String])
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFailed(let message):
+            return message.isEmpty ? "Could not load the full GG stack." : message
+        case .malformedRecord:
+            return "Git returned commit metadata that Alas could not read."
+        case .missingCommits:
+            return "One or more GG stack commits are unavailable locally."
+        }
+    }
+}
+
+extension GitService {
+    func stackCommitInfos(at worktree: URL, shas: [String]) async throws -> [String: CommitInfo] {
+        guard !shas.isEmpty else { return [:] }
+        throw StackCommitInfoError.malformedRecord
+    }
+}
+```
+
+Create `GitServiceStackCommitTests.swift` as `@Suite(.serialized)`. Its helper must initialize a temporary `main` repository, configure a test identity, and create two commits with distinct authors, bodies, conventional subjects, and numstat. Add these assertions:
+
+```swift
+@Test func loadsRequestedCommitsByFullResolvedSHA() async throws {
+    let fixture = try await makeTwoCommitRepo()
+    defer { try? FileManager.default.removeItem(at: fixture.repo) }
+
+    let infos = try await GitService().stackCommitInfos(
+        at: fixture.repo,
+        shas: [String(fixture.tip.prefix(7)), String(fixture.base.prefix(7))]
+    )
+
+    #expect(Set(infos.keys) == [fixture.base, fixture.tip])
+    #expect(infos[fixture.base]?.subject == "base layer")
+    #expect(infos[fixture.base]?.conventionalTag == "feat")
+    #expect(infos[fixture.tip]?.body == "Tip details.")
+    #expect(infos[fixture.tip]?.filesChanged == 1)
+}
+
+@Test func emptySHAListDoesNotInvokeGit() async throws {
+    #expect(try await GitService().stackCommitInfos(
+        at: URL(fileURLWithPath: "/missing"),
+        shas: [String]()
+    ) == [:])
+}
+
+@Test func unavailableSHAFailsTheWholeBatch() async throws {
+    let fixture = try await makeTwoCommitRepo()
+    defer { try? FileManager.default.removeItem(at: fixture.repo) }
+
+    await #expect(throws: StackCommitInfoError.self) {
+        _ = try await GitService().stackCommitInfos(at: fixture.repo, shas: [fixture.tip, "deadbeef"])
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate project membership and run the new suite RED**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-task1 test -only-testing:AlasTests/GitServiceStackCommitTests
+```
+
+Expected: `loadsRequestedCommitsByFullResolvedSHA` fails with `StackCommitInfoError.malformedRecord`; empty input passes.
+
+- [ ] **Step 3: Implement the single-command loader and strict parser**
+
+Replace the incomplete method with one `git log` call:
+
+```swift
+func stackCommitInfos(at worktree: URL, shas: [String]) async throws -> [String: CommitInfo] {
+    guard !shas.isEmpty else { return [:] }
+    let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1f%b%x1d"
+    let result = try await Process.git(
+        ["log", "--no-walk=unsorted", "--stdin", "--pretty=tformat:\(format)", "--numstat"],
+        cwd: worktree,
+        stdin: shas.joined(separator: "\n") + "\n"
+    )
+    guard result.exitCode == 0 else {
+        throw StackCommitInfoError.commandFailed(
+            result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    let infos = try Self.parseStackCommitInfoRecords(result.stdout)
+    let missing = shas.filter { requested in
+        !infos.keys.contains { full in full.hasPrefix(requested) || requested.hasPrefix(full) }
+    }
+    guard missing.isEmpty else { throw StackCommitInfoError.missingCommits(missing) }
+    return infos
+}
+```
+
+Implement `static func parseStackCommitInfoRecords(_ stdout: String) throws -> [String: CommitInfo]` in the same extension. Split on `\u{1e}`, require six header fields split on `\u{1f}`, split the body from numstat on `\u{1d}`, require an ISO-8601 author date parsed with `.withInternetDateTime`, call `CommitInfo.parseConventional(subject:)`, and aggregate every non-empty tab-separated numstat line. Count binary `-` values as a changed file with zero additions/deletions. Throw `.malformedRecord` for any non-empty record with the wrong field count, invalid date, malformed numstat line, or duplicate resolved SHA key rather than trapping in `Dictionary(uniqueKeysWithValues:)`.
+
+The produced value must populate every field used by existing rows:
+
+```swift
+let info = CommitInfo(
+    sha: fullSHA,
+    shortSha: shortSHA,
+    author: author,
+    authorInitials: CommitInfo.initials(for: author),
+    date: date,
+    subject: subject,
+    rawSubject: rawSubject,
+    body: body.trimmingCharacters(in: .whitespacesAndNewlines),
+    conventionalTag: tag,
+    filesChanged: filesChanged,
+    insertions: insertions,
+    deletions: deletions
+)
+```
+
+- [ ] **Step 4: Extend parser edge coverage and run GREEN**
+
+Add direct parser tests for deliberately reversed records, malformed header fields, binary numstat, and duplicate SHA records. Assert the dictionary is correct regardless of record order and malformed/duplicate records throw `.malformedRecord`.
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-task1 test -only-testing:AlasTests/GitServiceStackCommitTests
+```
+
+Expected: all `GitServiceStackCommitTests` pass.
+
+- [ ] **Step 5: Commit the batch loader**
+
+```bash
+git add Alas/Sources/Git/GitService+StackCommits.swift AlasTests/GitServiceStackCommitTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(gg): batch load stack commit metadata"
+```
+
+---
+
+### Task 2: Publish complete GG rows atomically from `RightPaneState`
+
+**Files:**
+- Modify: `Alas/Sources/Integrations/GG/GGStackModels.swift:105-198`
+- Modify: `Alas/Sources/Right/RightPaneState.swift:114-198, 938-1075, 1615-1638`
+- Modify: `AlasTests/Integrations/GGStackModelsTests.swift:1-95`
+- Modify: `AlasTests/RightPaneGGStackTests.swift:393-1921`
+
+**Interfaces:**
+- Consumes: `GitService.stackCommitInfos(at:shas:)` from Task 1.
+- Produces: `GGStackCommitRelation`, `GGCurrentPositionIndicator`, `GGStack.projectCommits(_:)`, `GGStack.relation(for:)`, and `GGStack.currentPositionIndicator(for:)` for Task 3.
+- Produces: `RightPaneState.ggStackDisplayCommits`, `RightPaneState.commitsForDisplay`, and injectable `RightPaneState.ggStackCommitLoader` for the view and state tests.
+
+- [ ] **Step 1: Write pure projection tests RED**
+
+Extend `GGStackModelsTests` with a four-entry stack whose current position is 2 and a full-SHA `CommitInfo` dictionary inserted in a deliberately unrelated order. Assert:
+
+```swift
+let projected = try stack.projectCommits(infosBySHA)
+#expect(projected.map(\.sha) == [full4, full3, full2, full1])
+#expect(stack.relation(for: stack.entries[3]) == .aboveCurrent)
+#expect(stack.relation(for: stack.entries[1]) == .current)
+#expect(stack.relation(for: stack.entries[0]) == .belowCurrent)
+#expect(stack.currentPositionIndicator(for: stack.entries[1]) == GGCurrentPositionIndicator(
+    text: "Current · 2 of 4",
+    accessibilityLabel: "Current GG commit, position 2 of 4"
+))
+```
+
+Add separate expectations that `projectCommits` throws `GGStackCommitProjectionError.missingCommit(sha:)` when any entry is absent, the tip gets no indicator at `4 of 4`, and a nil/inconsistent `currentPosition` returns `.unknown` relation and no indicator.
+
+- [ ] **Step 2: Run model tests RED**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-task2 test -only-testing:AlasTests/GGStackModelsTests
+```
+
+Expected: compilation fails because the projection types and methods do not exist.
+
+- [ ] **Step 3: Add the pure stack projection model**
+
+Add these module-internal types beside `GGStack`:
+
+```swift
+enum GGStackCommitRelation: Equatable {
+    case aboveCurrent
+    case current
+    case belowCurrent
+    case unknown
+}
+
+struct GGCurrentPositionIndicator: Equatable {
+    let text: String
+    let accessibilityLabel: String
+}
+
+enum GGStackCommitProjectionError: Error, Equatable, LocalizedError {
+    case missingCommit(sha: String)
+
+    var errorDescription: String? {
+        "One or more GG stack commits are unavailable locally."
+    }
+}
+```
+
+Implement the methods with prefix-safe SHA matching and no inferred position:
+
+```swift
+func projectCommits(_ infosBySHA: [String: CommitInfo]) throws -> [CommitInfo] {
+    try entries.sorted { $0.position > $1.position }.map { entry in
+        guard let info = infosBySHA.first(where: {
+            $0.key.hasPrefix(entry.sha) || entry.sha.hasPrefix($0.key)
+        })?.value else {
+            throw GGStackCommitProjectionError.missingCommit(sha: entry.sha)
+        }
+        return info
+    }
+}
+
+func relation(for entry: GGStackEntry) -> GGStackCommitRelation {
+    guard entries.contains(where: { $0.id == entry.id }),
+          let currentPosition,
+          entries.contains(where: { $0.position == currentPosition && $0.isCurrent })
+    else { return .unknown }
+    if entry.position > currentPosition { return .aboveCurrent }
+    if entry.position == currentPosition, entry.isCurrent { return .current }
+    return .belowCurrent
+}
+
+func currentPositionIndicator(for entry: GGStackEntry) -> GGCurrentPositionIndicator? {
+    guard relation(for: entry) == .current,
+          let currentPosition,
+          currentPosition < totalCommits,
+          totalCommits == entries.count
+    else { return nil }
+    return GGCurrentPositionIndicator(
+        text: "Current · \(currentPosition) of \(totalCommits)",
+        accessibilityLabel: "Current GG commit, position \(currentPosition) of \(totalCommits)"
+    )
+}
+```
+
+Run `GGStackModelsTests` and confirm GREEN before editing state.
+
+- [ ] **Step 4: Add failing state tests for complete, failed, and superseded hydration**
+
+In `RightPaneGGStackTests`, add a `makeState(worktree:)` helper that creates `RightPaneState` and installs a deterministic loader returning a full `CommitInfo` per requested SHA. Replace direct state construction in this file with that helper so existing fake GG snapshots continue testing GG behavior rather than a nonexistent on-disk repository.
+
+Add focused tests:
+
+```swift
+@Test func successfulRefreshPublishesFullStackRowsInPositionOrder() async {
+    let state = makeState()
+    let reachable = commit(sha: String(repeating: "f", count: 40), stackShaped: true)
+    state.commits = [reachable]
+    state.ggService = GGService(runner: CountingFakeGGRunner(
+        result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+    ))
+    state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+    state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+
+    await state.refreshGGStack()
+
+    #expect(state.ggStackLoadState == .loaded)
+    #expect(state.ggStackDisplayCommits.map(\.shortSha) == ["ccccccc", "bbbbbbb", "aaaaaaa"])
+    #expect(state.commitsForDisplay == state.ggStackDisplayCommits)
+    #expect(state.commits == [reachable])
+}
+```
+
+Add one test whose loader throws `StackCommitInfoError.missingCommits`, asserting `ggStack == nil`, `ggStackDisplayCommits.isEmpty`, `commitsForDisplay == commits`, `ggStackCommitsKey == nil`, and `.failed("One or more GG stack commits are unavailable locally.")`.
+
+Extend the existing stale/cancellation tests to use distinct hydrated subjects per loader invocation. Assert a cancelled same-key refresh restores the previous display rows, a changed-key cancellation clears them, and a delayed stale refresh cannot overwrite the newer display rows.
+
+- [ ] **Step 5: Run state tests RED**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-task2 test -only-testing:AlasTests/RightPaneGGStackTests -only-testing:AlasTests/RightPaneGGStackErrorPresentationTests
+```
+
+Expected: compilation fails because the display state and loader seam do not exist.
+
+- [ ] **Step 6: Add GG display state and atomic hydration**
+
+Add state fields near `ggStack`:
+
+```swift
+var ggStackDisplayCommits: [CommitInfo] = []
+var commitsForDisplay: [CommitInfo] {
+    ggStackLoadState == .loaded ? ggStackDisplayCommits : commits
+}
+@ObservationIgnored
+var ggStackCommitLoader: @MainActor (URL, [String]) async throws -> [String: CommitInfo] = {
+    worktree, shas in
+    try await GitService().stackCommitInfos(at: worktree, shas: shas)
+}
+```
+
+In `refreshGGStack`, capture `previousDisplayCommits` with the existing previous stack/key/load state. Clear `ggStackDisplayCommits` when entering a changed-key load. After `currentStack` returns, hydrate before the publication guards:
+
+```swift
+let displayCommits: [CommitInfo]
+if let stack, !stack.entries.isEmpty {
+    let infos = try await ggStackCommitLoader(worktree.path, stack.entries.map(\.sha))
+    displayCommits = try stack.projectCommits(infos)
+} else {
+    displayCommits = []
+}
+```
+
+After cancellation and generation guards pass, publish `ggStack`, `ggStackDisplayCommits`, key, load state, and summary in one synchronous main-actor block. Restore `previousDisplayCommits` only in the same-key cancellation branch that restores `previousStack`; clear display rows in every inactive, empty, changed-key cancellation, error, and `markSnapshotUnknown()` path that clears the stack. Convert `LocalizedError.errorDescription` through `error.localizedDescription`, preserving the existing special handling for `GGServiceError.userMessage`.
+
+Do not assign hydrated rows to `commits` or `ggStackSourceCommits`.
+
+- [ ] **Step 7: Run model and state suites GREEN**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-task2 test -only-testing:AlasTests/GGStackModelsTests -only-testing:AlasTests/RightPaneGGStackTests -only-testing:AlasTests/RightPaneGGStackErrorPresentationTests
+```
+
+Expected: all focused tests pass, including the existing cancellation/cache/undo regressions.
+
+- [ ] **Step 8: Commit state publication**
+
+```bash
+git add Alas/Sources/Integrations/GG/GGStackModels.swift Alas/Sources/Right/RightPaneState.swift AlasTests/Integrations/GGStackModelsTests.swift AlasTests/RightPaneGGStackTests.swift
+git commit -m "feat(gg): hydrate full stack commit presentation"
+```
+
+---
+
+### Task 3: Render the selected position label and safe upper-row actions
+
+**Files:**
+- Modify: `Alas/Sources/Right/ChangesTabView.swift:315-352`
+- Modify: `Alas/Sources/Right/CommitsSectionView.swift:82-338`
+- Modify: `Alas/Sources/Right/CommitRow.swift:19-261`
+- Modify: `AlasTests/CommitsSectionTitleTests.swift:4-88`
+- Modify: `AlasTests/CommitRowTests.swift:64-153`
+
+**Interfaces:**
+- Consumes: `RightPaneState.commitsForDisplay`, `GGStack.relation(for:)`, and `GGStack.currentPositionIndicator(for:)` from Task 2.
+- Produces: `CommitsSectionView.genericGitActionsAllowed(for:in:) -> Bool` and `CommitRow.currentPositionIndicator` rendering.
+
+- [ ] **Step 1: Write failing action, count, and badge tests**
+
+In `CommitsSectionTitleTests`, add a four-entry stack with current position 2 and assert:
+
+```swift
+#expect(!CommitsSectionView.genericGitActionsAllowed(for: stack.entries[3], in: stack))
+#expect(!CommitsSectionView.genericGitActionsAllowed(for: stack.entries[2], in: stack))
+#expect(CommitsSectionView.genericGitActionsAllowed(for: stack.entries[1], in: stack))
+#expect(CommitsSectionView.genericGitActionsAllowed(for: stack.entries[0], in: stack))
+#expect(CommitsSectionView.sectionCount(primary: fourCommits, older: twoCommits) == 6)
+```
+
+Also assert an unknown current position permits generic actions rather than hiding them on a guess, and `sectionCount(primary: [], older: []) == nil`.
+
+In `CommitRowTests`, construct the off-tip indicator and assert its exact text/accessibility copy. Keep existing context-menu tests proving `canEdit: false, canReview: true` yields only `.review`; add a test that GG menu construction still includes Checkout and existing guarded mutations for an above-current entry.
+
+- [ ] **Step 2: Run UI-model suites RED**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-task3 test -only-testing:AlasTests/CommitsSectionTitleTests -only-testing:AlasTests/CommitRowTests -only-testing:AlasTests/GGCommitMenuModelTests
+```
+
+Expected: compilation fails because the action/count helpers and row indicator input do not exist.
+
+- [ ] **Step 3: Route full display rows and classify callbacks**
+
+Change the `ChangesTabView` call site to `commits: rps.commitsForDisplay`.
+
+In `CommitsSectionView`, expose pure helpers:
+
+```swift
+static func sectionCount(primary: [CommitInfo], older: [CommitInfo]) -> Int? {
+    let count = primary.count + older.count
+    return count == 0 ? nil : count
+}
+
+static func genericGitActionsAllowed(for entry: GGStackEntry?, in stack: GGStack?) -> Bool {
+    guard let entry, let stack else { return true }
+    return stack.relation(for: entry) != .aboveCurrent
+}
+```
+
+Use `sectionCount` for the header. For each primary row, resolve `entry` once, derive `allowsGenericGitActions`, and pass:
+
+```swift
+onEdit: allowsGenericGitActions ? { onEdit(commit) } : nil,
+onReview: { onReview(commit) },
+onCherryPick: allowsGenericGitActions ? { rps.requestCherryPick(sha: commit.sha) } : nil,
+onRevert: allowsGenericGitActions ? { rps.runRevert(sha: commit.sha) } : nil,
+ggMenu: ggMenu(for: commit),
+currentPositionIndicator: entry.flatMap { ggStack?.currentPositionIndicator(for: $0) },
+stackEntry: entry
+```
+
+Keep `ggMenu` independent of `allowsGenericGitActions`, so stable-ID GG Checkout/Split/Drop/Unstack/Land continue through their existing guards and confirmation flows. For GG primary rows, use `rps.commitRemote` for commit URLs; retain today's `commitsNeedPush`/`primaryCommitRemote` behavior when no GG stack is loaded. Do not change older-history row actions.
+
+- [ ] **Step 4: Render the compact metadata-line badge**
+
+Add `var currentPositionIndicator: GGCurrentPositionIndicator? = nil` to `CommitRow`. In `metaLine`, keep the existing metadata and trailing spacer, then render:
+
+```swift
+if let indicator = currentPositionIndicator {
+    Text(indicator.text)
+        .font(.system(size: 9.5, weight: .semibold))
+        .foregroundColor(theme.color("accent"))
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(theme.color("accent").opacity(0.12))
+        .clipShape(Capsule())
+        .accessibilityLabel(indicator.accessibilityLabel)
+}
+```
+
+Do not move the badge into `subjectLine`; the commit subject retains its current width and two-line behavior. Keep the existing blue leading rail driven by `stackEntry.isCurrent`.
+
+- [ ] **Step 5: Run focused UI and full GG regressions GREEN**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-task3 test -only-testing:AlasTests/CommitsSectionTitleTests -only-testing:AlasTests/CommitRowTests -only-testing:AlasTests/GGCommitMenuModelTests -only-testing:AlasTests/GGStackModelsTests -only-testing:AlasTests/RightPaneGGStackTests -only-testing:AlasTests/RightPaneStateLoadOlderTests
+```
+
+Expected: all focused suites pass; the existing batching, title, GG menu, cancellation, and older-history tests remain green.
+
+- [ ] **Step 6: Run formatting, generation, build, and full tests serially**
+
+```bash
+rtk swiftformat Alas AlasTests --lint --reporter github-actions-log
+rtk git diff --check
+rtk xcodegen
+rtk git diff --check
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: formatting and diff checks report no issues, XcodeGen is deterministic, the macOS build succeeds, and the full test suite passes. If the full suite exposes a pre-existing failure, rerun the failing test unchanged on `main` before classifying it as unrelated; do not describe an incomplete or stalled run as passing.
+
+- [ ] **Step 7: Perform focused manual QA**
+
+In a disposable multi-commit GG stack, check out a non-tip entry and open Changes. Verify the entire stack is visible tip-first, the correct row shows the rail and `Current · X of N`, upper rows open details/reviews and expose GG Checkout but omit Edit/Cherry-pick/Revert, lower/current rows retain those generic actions, and selecting a row does not navigate the stack. Return to the tip and verify the rail remains while the position capsule disappears. Trigger Retry after a deliberately unavailable local stack object and confirm ordinary reachable commits remain visible without partial GG rows.
+
+- [ ] **Step 8: Commit the UI and regression coverage**
+
+```bash
+git add Alas/Sources/Right/ChangesTabView.swift Alas/Sources/Right/CommitsSectionView.swift Alas/Sources/Right/CommitRow.swift AlasTests/CommitsSectionTitleTests.swift AlasTests/CommitRowTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(gg): show full stack position in Changes"
+```
+
+Verify the final tree contains exactly the three implementation commits after the design/plan documentation commits, with no generated or temporary files staged.

--- a/docs/superpowers/specs/2026-08-10-full-gg-stack-commits-design.md
+++ b/docs/superpowers/specs/2026-08-10-full-gg-stack-commits-design.md
@@ -1,0 +1,48 @@
+# Full GG Stack in Changes
+
+## Summary
+
+When a GG-managed worktree is checked out below the stack tip, the Changes tab currently shows only commits reachable from `HEAD`. Always show the complete GG stack in the Commits section while preserving the ordinary Git list for non-GG repositories and for non-presentation logic.
+
+The current stack entry keeps the existing blue leading rail. When it is not the tip, its metadata line also shows a compact `Current · X of N` capsule. The capsule is omitted at `N of N` because the rail already identifies the current commit.
+
+## Data Flow
+
+`gg ls --json` remains the canonical stack source. It already provides every entry's SHA, position, and `isCurrent` state, so this feature requires no git-gud command or schema change.
+
+Add a focused Git batch loader that accepts the stack-entry SHAs and runs one `git log --no-walk=unsorted --stdin` query using the existing commit record format. Parse the results into full `CommitInfo` values keyed by resolved SHA; do not depend on Git's output order.
+
+After the current-stack query succeeds, `RightPaneState` hydrates every reported entry, then projects the rows in descending GG position. This keeps the stack tip at the top and the base-most entry at the bottom, matching the existing history direction. Stack metadata and hydrated rows publish together under the existing snapshot-generation, GG-refresh-generation, and cancellation guards so stale or partial generations never render.
+
+Keep the ordinary reachable `commits` collection unchanged. Ahead counts, push/preparation decisions, initial-tab selection, comparison logic, and non-GG behavior continue to use it. The hydrated full-stack collection is a GG-specific presentation source used by the Commits section only. Existing older-history rows remain below the comparison-base divider and retain the current Load Older behavior.
+
+If the GG query or batch hydration fails, produces malformed records, or cannot resolve every reported entry, do not publish a partial stack. Preserve the ordinary reachable commit rows and route the GG presentation through the existing failed-state Retry path. A newer refresh always supersedes an older hydration result.
+
+## Row Presentation and Actions
+
+The Commits section count and primary rows use the complete hydrated stack whenever that GG presentation is loaded. Existing entry-derived PR/CI chips, merged-row opacity, batching, selection, and details continue to work through the entry-to-SHA association.
+
+The entry whose GG metadata reports `isCurrent` receives the blue rail. When its position is less than the stack's total, add `Current · X of N` to the metadata line. The label must remain compact without reducing the commit subject's available width and must expose accessibility text identifying the current GG commit and its position. If the current position is absent or inconsistent, omit the numeric label rather than inventing a position.
+
+Rows above the current position remain selectable and expose safe read/navigation actions: commit details, review, copy SHA/message/GG-ID, remote commit and review-request links, and GG Checkout. GG-native mutations remain available through the existing stable-entry targeting, guards, and confirmation flows. Hide generic Git Edit Commit, Cherry-pick, and Revert actions for upper entries because those paths assume or act on commits reachable from the current `HEAD`. Current and lower reachable entries retain today's actions.
+
+## Verification
+
+Add Swift Testing coverage for:
+
+- Batch-loading arbitrary commit SHAs and mapping records correctly regardless of Git output order.
+- Full-stack projection in descending position, exact entry-to-commit matching, and complete section counts.
+- Current-row classification, off-tip `Current · X of N` visibility, tip-label omission, inconsistent-position fallback, and accessibility text.
+- Safe, generic, and GG-native action availability for entries above, at, and below the current position.
+- Older-history divider/load behavior and existing merged-entry styling with full-stack primary rows.
+- Hydration failure, missing objects, malformed output, cancellation, and stale-generation suppression without mixed partial rows.
+- Unchanged non-GG commit lists, ahead counts, preparation/push behavior, and existing stack-tip presentation.
+
+Run focused suites first, followed by SwiftFormat lint and `git diff --check`. Run `rtk xcodegen` only if source/test membership changes require project regeneration. Finish with the repository's required macOS build and test commands, serially.
+
+## Out of Scope
+
+- Changing git-gud output or stack semantics.
+- Navigating or checking out a commit merely by selecting its row.
+- Changing the ordering of ordinary non-GG history.
+- Redesigning GG chips, the stack drawer, or generic commit details.


### PR DESCRIPTION
## Summary
- show the full GG stack in Changes/Commits, including off-tip current-position display
- hydrate GG-only stack commits with strict parser/model validation
- preserve GG actions while hiding generic rewrite actions above the current commit
- keep older-history paging and refresh invalidation aligned with the displayed stack

## Testing
- `rtk xcodegen`
- `rtk swiftformat Alas/Sources/App/AppState.swift Alas/Sources/Git/GitService+StackCommits.swift Alas/Sources/Integrations/GG/GGStackModels.swift Alas/Sources/Right/ChangesTabView.swift Alas/Sources/Right/RightPaneState.swift Alas/Sources/Right/RightPaneStore.swift AlasTests/GitServiceStackCommitTests.swift AlasTests/Integrations/GGStackModelsTests.swift AlasTests/RightPaneGGStackTests.swift AlasTests/RightPaneStateLoadOlderTests.swift --lint`
- `git diff --check`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-rebased-focused-direct test -only-testing:AlasTests/GGStackModelsTests -only-testing:AlasTests/GitServiceStackCommitTests -only-testing:AlasTests/RightPaneGGStackTests -only-testing:AlasTests/RightPaneStateLoadOlderTests`\n- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-full-gg-stack-rebased-build -quiet build`